### PR TITLE
Added Noop policy method

### DIFF
--- a/src/Polly.Net35/Policy.cs
+++ b/src/Polly.Net35/Policy.cs
@@ -68,5 +68,14 @@ namespace Polly
 
             return new PolicyBuilder(predicate);
         }
+
+        /// <summary>
+        /// Builds a void policy without behaviour.
+        /// </summary>
+        /// <returns>A policy instance</returns>
+        public static Policy Empty()
+        {
+            return new Policy(x => x());
+        }
     }
 }


### PR DESCRIPTION
In a large application it is sometimes nice to be able to pass exception policies around. When doing so, it is necessary to have a policy equivalent to not wrapping the call in a policy. 

This is my first public pull request ever, so comments and critique is welcome.