### PR TITLE
Allowed policies with a retry count of zero

### DIFF
--- a/src/Polly.Shared/RetrySyntax.cs
+++ b/src/Polly.Shared/RetrySyntax.cs
@@ -59,7 +59,7 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">onRetry</exception>
         public static Policy Retry(this PolicyBuilder policyBuilder, int retryCount, Action<Exception, int> onRetry)
         {
-            if (retryCount <= 0) throw new ArgumentOutOfRangeException("retryCount", "Value must be greater than zero.");
+            if (retryCount < 0) throw new ArgumentOutOfRangeException("retryCount", "Value must be equal to or greater than zero.");
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
             return new Policy(
@@ -100,7 +100,7 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">onRetry</exception>
         public static ContextualPolicy Retry(this PolicyBuilder policyBuilder, int retryCount, Action<Exception, int, Context> onRetry)
         {
-            if (retryCount <= 0) throw new ArgumentOutOfRangeException("retryCount", "Value must be greater than zero.");
+            if (retryCount < 0) throw new ArgumentOutOfRangeException("retryCount", "Value must be equal to or greater than zero.");
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
             return new ContextualPolicy((action, context) => RetryPolicy.Implementation(
@@ -199,7 +199,7 @@ namespace Polly
         /// </exception>
         public static Policy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan> onRetry)
         {
-            if (retryCount <= 0) throw new ArgumentOutOfRangeException("retryCount", "Value must be greater than zero.");
+            if (retryCount < 0) throw new ArgumentOutOfRangeException("retryCount", "Value must be equal to or greater than zero.");
             if (sleepDurationProvider == null) throw new ArgumentNullException("sleepDurationProvider");
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
@@ -236,7 +236,7 @@ namespace Polly
         /// </exception>
         public static ContextualPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, Context> onRetry)
         {
-            if (retryCount <= 0) throw new ArgumentOutOfRangeException("retryCount", "Value must be greater than zero.");
+            if (retryCount < 0) throw new ArgumentOutOfRangeException("retryCount", "Value must be equal to or greater than zero.");
             if (sleepDurationProvider == null) throw new ArgumentNullException("sleepDurationProvider");
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 

--- a/src/Polly.Shared/RetrySyntaxAsync.cs
+++ b/src/Polly.Shared/RetrySyntaxAsync.cs
@@ -61,8 +61,8 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">onRetry</exception>
         public static Policy RetryAsync(this PolicyBuilder policyBuilder, int retryCount, Action<Exception, int> onRetry)
         {
-            if (retryCount <= 0)
-                throw new ArgumentOutOfRangeException("retryCount", "Value must be greater than zero.");
+            if (retryCount < 0)
+                throw new ArgumentOutOfRangeException("retryCount", "Value must be equal to or greater than zero.");
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
             return new Policy(
@@ -160,8 +160,8 @@ namespace Polly
         public static Policy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
             Func<int, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan> onRetry)
         {
-            if (retryCount <= 0)
-                throw new ArgumentOutOfRangeException("retryCount", "Value must be greater than zero.");
+            if (retryCount < 0)
+                throw new ArgumentOutOfRangeException("retryCount", "Value must be equal to or greater than zero.");
             if (sleepDurationProvider == null) throw new ArgumentNullException("sleepDurationProvider");
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 

--- a/src/Polly.SharedSpecs/RetryAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/RetryAsyncSpecs.cs
@@ -224,5 +224,22 @@ namespace Polly.Specs
             policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
                   .ShouldNotThrow();
         }
+
+        [Fact]
+        public void Should_not_call_onretry_when_retry_count_is_zero()
+        {
+            string onRetrySideEffect = "original_value";
+
+            Action<Exception, int> onRetryWithSideEffect = (_, __) => { onRetrySideEffect = "new_value"; };
+
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .RetryAsync(0, onRetryWithSideEffect);
+
+            policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
+                  .ShouldThrow<DivideByZeroException>();
+
+            onRetrySideEffect.Should().Be("original_value");
+        }
     }
 }

--- a/src/Polly.SharedSpecs/RetryAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/RetryAsyncSpecs.cs
@@ -228,18 +228,18 @@ namespace Polly.Specs
         [Fact]
         public void Should_not_call_onretry_when_retry_count_is_zero()
         {
-            string onRetrySideEffect = "original_value";
+            bool retryInvoked = false;
 
-            Action<Exception, int> onRetryWithSideEffect = (_, __) => { onRetrySideEffect = "new_value"; };
+            Action<Exception, int> onRetry = (_, __) => { retryInvoked = true; };
 
             var policy = Policy
                 .Handle<DivideByZeroException>()
-                .RetryAsync(0, onRetryWithSideEffect);
+                .RetryAsync(0, onRetry);
 
             policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
                   .ShouldThrow<DivideByZeroException>();
 
-            onRetrySideEffect.Should().Be("original_value");
+            retryInvoked.Should().BeFalse();
         }
     }
 }

--- a/src/Polly.SharedSpecs/RetryAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/RetryAsyncSpecs.cs
@@ -11,13 +11,13 @@ namespace Polly.Specs
     public class RetryAsyncSpecs
     {
         [Fact]
-        public void Should_throw_when_retry_count_is_less_than_one_without_context()
+        public void Should_throw_when_retry_count_is_less_than_zero_without_context()
         {
             Action<Exception, int> onRetry = (_, __) => { };
 
             Action policy = () => Policy
                                       .Handle<DivideByZeroException>()
-                                      .RetryAsync(0, onRetry);
+                                      .RetryAsync(-1, onRetry);
         
             policy.ShouldThrow<ArgumentOutOfRangeException>().And
                   .ParamName.Should().Be("retryCount");

--- a/src/Polly.SharedSpecs/RetrySpecs.cs
+++ b/src/Polly.SharedSpecs/RetrySpecs.cs
@@ -363,5 +363,39 @@ namespace Polly.Specs
 
             contextValue.Should().Be("new_value");
         }
+
+        [Fact]
+        public void Should_not_call_onretry_when_retry_count_is_zero_without_context()
+        {
+            string onRetrySideEffect = "original_value";
+
+            Action<Exception, int> onRetryWithSideEffect = (_, __) => { onRetrySideEffect = "new_value"; };
+
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .Retry(0, onRetryWithSideEffect);
+
+            policy.Invoking(x => x.RaiseException<DivideByZeroException>())
+                  .ShouldThrow<DivideByZeroException>();
+
+            onRetrySideEffect.Should().Be("original_value");
+        }
+
+        [Fact]
+        public void Should_not_call_onretry_when_retry_count_is_zero_with_context()
+        {
+            string onRetrySideEffect = "original_value";
+
+            Action<Exception, int, Context> onRetryWithSideEffect = (_, __, ___) => { onRetrySideEffect = "new_value"; };
+
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .Retry(0, onRetryWithSideEffect);
+
+            policy.Invoking(x => x.RaiseException<DivideByZeroException>())
+                  .ShouldThrow<DivideByZeroException>();
+
+            onRetrySideEffect.Should().Be("original_value");
+        }
     }
 }

--- a/src/Polly.SharedSpecs/RetrySpecs.cs
+++ b/src/Polly.SharedSpecs/RetrySpecs.cs
@@ -367,35 +367,35 @@ namespace Polly.Specs
         [Fact]
         public void Should_not_call_onretry_when_retry_count_is_zero_without_context()
         {
-            string onRetrySideEffect = "original_value";
+            bool retryInvoked = false;
 
-            Action<Exception, int> onRetryWithSideEffect = (_, __) => { onRetrySideEffect = "new_value"; };
+            Action<Exception, int> onRetry = (_, __) => { retryInvoked = true; };
 
             var policy = Policy
                 .Handle<DivideByZeroException>()
-                .Retry(0, onRetryWithSideEffect);
+                .Retry(0, onRetry);
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>())
                   .ShouldThrow<DivideByZeroException>();
 
-            onRetrySideEffect.Should().Be("original_value");
+            retryInvoked.Should().BeFalse();
         }
 
         [Fact]
         public void Should_not_call_onretry_when_retry_count_is_zero_with_context()
         {
-            string onRetrySideEffect = "original_value";
+            bool retryInvoked = false;
 
-            Action<Exception, int, Context> onRetryWithSideEffect = (_, __, ___) => { onRetrySideEffect = "new_value"; };
+            Action<Exception, int, Context> onRetry = (_, __, ___) => { retryInvoked = true; };
 
             var policy = Policy
                 .Handle<DivideByZeroException>()
-                .Retry(0, onRetryWithSideEffect);
+                .Retry(0, onRetry);
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>())
                   .ShouldThrow<DivideByZeroException>();
 
-            onRetrySideEffect.Should().Be("original_value");
+            retryInvoked.Should().BeFalse();
         }
     }
 }

--- a/src/Polly.SharedSpecs/RetrySpecs.cs
+++ b/src/Polly.SharedSpecs/RetrySpecs.cs
@@ -10,13 +10,13 @@ namespace Polly.Specs
     public class RetrySpecs
     {
         [Fact]
-        public void Should_throw_when_retry_count_is_less_than_one_without_context()
+        public void Should_throw_when_retry_count_is_less_than_zero_without_context()
         {
             Action<Exception, int> onRetry = (_, __) => { };
 
             Action policy = () => Policy
                                       .Handle<DivideByZeroException>()
-                                      .Retry(0, onRetry);
+                                      .Retry(-1, onRetry);
         
             policy.ShouldThrow<ArgumentOutOfRangeException>().And
                   .ParamName.Should().Be("retryCount");
@@ -36,13 +36,13 @@ namespace Polly.Specs
         }
 
         [Fact]
-        public void Should_throw_when_retry_count_is_less_than_one_with_context()
+        public void Should_throw_when_retry_count_is_less_than_zero_with_context()
         {
             Action<Exception, int, Context> onRetry = (_, __, ___) => { };
 
             Action policy = () => Policy
                                       .Handle<DivideByZeroException>()
-                                      .Retry(0, onRetry);
+                                      .Retry(-1, onRetry);
 
             policy.ShouldThrow<ArgumentOutOfRangeException>().And
                   .ParamName.Should().Be("retryCount");

--- a/src/Polly.SharedSpecs/WaitAndRetryAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/WaitAndRetryAsyncSpecs.cs
@@ -453,18 +453,18 @@ namespace Polly.Specs
         [Fact]
         public void Should_not_call_onretry_when_retry_count_is_zero()
         {
-            string onRetrySideEffect = "original_value";
+            bool retryInvoked = false;
 
-            Action<Exception, TimeSpan> onRetryWithSideEffect = (_, __) => { onRetrySideEffect = "new_value"; };
+            Action<Exception, TimeSpan> onRetry = (_, __) => { retryInvoked = true; };
 
             var policy = Policy
                 .Handle<DivideByZeroException>()
-                .WaitAndRetryAsync(0, retryAttempt => TimeSpan.FromSeconds(1), onRetryWithSideEffect);
+                .WaitAndRetryAsync(0, retryAttempt => TimeSpan.FromSeconds(1), onRetry);
 
             policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
                   .ShouldThrow<DivideByZeroException>();
 
-            onRetrySideEffect.Should().Be("original_value");
+            retryInvoked.Should().BeFalse();
         }
 
         public void Dispose()

--- a/src/Polly.SharedSpecs/WaitAndRetryAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/WaitAndRetryAsyncSpecs.cs
@@ -385,13 +385,13 @@ namespace Polly.Specs
         }
 
         [Fact]
-        public void Should_throw_when_retry_count_is_less_than_one_without_context()
+        public void Should_throw_when_retry_count_is_less_than_zero_without_context()
         {
             Action<Exception, TimeSpan> onRetry = (_, __) => { };
 
             Action policy = () => Policy
                                       .Handle<DivideByZeroException>()
-                                      .WaitAndRetryAsync(0, _ => new TimeSpan(), onRetry);
+                                      .WaitAndRetryAsync(-1, _ => new TimeSpan(), onRetry);
                                            
             policy.ShouldThrow<ArgumentOutOfRangeException>().And                  
                   .ParamName.Should().Be("retryCount");

--- a/src/Polly.SharedSpecs/WaitAndRetryAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/WaitAndRetryAsyncSpecs.cs
@@ -450,6 +450,23 @@ namespace Polly.Specs
                        .ContainInOrder(expectedRetryCounts);
         }
 
+        [Fact]
+        public void Should_not_call_onretry_when_retry_count_is_zero()
+        {
+            string onRetrySideEffect = "original_value";
+
+            Action<Exception, TimeSpan> onRetryWithSideEffect = (_, __) => { onRetrySideEffect = "new_value"; };
+
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .WaitAndRetryAsync(0, retryAttempt => TimeSpan.FromSeconds(1), onRetryWithSideEffect);
+
+            policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
+                  .ShouldThrow<DivideByZeroException>();
+
+            onRetrySideEffect.Should().Be("original_value");
+        }
+
         public void Dispose()
         {
             SystemClock.Reset();

--- a/src/Polly.SharedSpecs/WaitAndRetrySpecs.cs
+++ b/src/Polly.SharedSpecs/WaitAndRetrySpecs.cs
@@ -658,35 +658,35 @@ namespace Polly.Specs
         [Fact]
         public void Should_not_call_onretry_when_retry_count_is_zero_without_context()
         {
-            string onRetrySideEffect = "original_value";
+            bool retryInvoked = false;
 
-            Action<Exception, TimeSpan> onRetryWithSideEffect = (_, __) => { onRetrySideEffect = "new_value"; };
+            Action<Exception, TimeSpan> onRetry = (_, __) => { retryInvoked = true; };
 
             var policy = Policy
                 .Handle<DivideByZeroException>()
-                .WaitAndRetry(0, retryAttempt => TimeSpan.FromSeconds(1), onRetryWithSideEffect);
+                .WaitAndRetry(0, retryAttempt => TimeSpan.FromSeconds(1), onRetry);
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>())
                   .ShouldThrow<DivideByZeroException>();
 
-            onRetrySideEffect.Should().Be("original_value");
+            retryInvoked.Should().BeFalse();
         }
 
         [Fact]
         public void Should_not_call_onretry_when_retry_count_is_zero_with_context()
         {
-            string onRetrySideEffect = "original_value";
+            bool retryInvoked = false;
 
-            Action<Exception, TimeSpan, Context> onRetryWithSideEffect = (_, __, ___) => { onRetrySideEffect = "new_value"; };
+            Action<Exception, TimeSpan, Context> onRetry = (_, __, ___) => { retryInvoked = true; };
 
             var policy = Policy
                 .Handle<DivideByZeroException>()
-                .WaitAndRetry(0, retryAttempt => TimeSpan.FromSeconds(1), onRetryWithSideEffect);
+                .WaitAndRetry(0, retryAttempt => TimeSpan.FromSeconds(1), onRetry);
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>())
                   .ShouldThrow<DivideByZeroException>();
 
-            onRetrySideEffect.Should().Be("original_value");
+            retryInvoked.Should().BeFalse();
         }
 
         public void Dispose()

--- a/src/Polly.SharedSpecs/WaitAndRetrySpecs.cs
+++ b/src/Polly.SharedSpecs/WaitAndRetrySpecs.cs
@@ -551,26 +551,26 @@ namespace Polly.Specs
         }
 
         [Fact]
-        public void Should_throw_when_retry_count_is_less_than_one_without_context()
+        public void Should_throw_when_retry_count_is_less_than_zero_without_context()
         {
             Action<Exception, TimeSpan> onRetry = (_, __) => { };
 
             Action policy = () => Policy
                                       .Handle<DivideByZeroException>()
-                                      .WaitAndRetry(0, _ => new TimeSpan(), onRetry);
+                                      .WaitAndRetry(-1, _ => new TimeSpan(), onRetry);
                                            
             policy.ShouldThrow<ArgumentOutOfRangeException>().And                  
                   .ParamName.Should().Be("retryCount");
         }
 
         [Fact]
-        public void Should_throw_when_retry_count_is_less_than_one_with_context()
+        public void Should_throw_when_retry_count_is_less_than_zero_with_context()
         {
             Action<Exception, TimeSpan, Context> onRetry = (_, __, ___) => { };
 
             Action policy = () => Policy
                                       .Handle<DivideByZeroException>()
-                                      .WaitAndRetry(0, _ => new TimeSpan(), onRetry);
+                                      .WaitAndRetry(-1, _ => new TimeSpan(), onRetry);
 
             policy.ShouldThrow<ArgumentOutOfRangeException>().And
                   .ParamName.Should().Be("retryCount");

--- a/src/Polly.SharedSpecs/WaitAndRetrySpecs.cs
+++ b/src/Polly.SharedSpecs/WaitAndRetrySpecs.cs
@@ -655,6 +655,40 @@ namespace Polly.Specs
                        .ContainInOrder(expectedRetryCounts);
         }
 
+        [Fact]
+        public void Should_not_call_onretry_when_retry_count_is_zero_without_context()
+        {
+            string onRetrySideEffect = "original_value";
+
+            Action<Exception, TimeSpan> onRetryWithSideEffect = (_, __) => { onRetrySideEffect = "new_value"; };
+
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .WaitAndRetry(0, retryAttempt => TimeSpan.FromSeconds(1), onRetryWithSideEffect);
+
+            policy.Invoking(x => x.RaiseException<DivideByZeroException>())
+                  .ShouldThrow<DivideByZeroException>();
+
+            onRetrySideEffect.Should().Be("original_value");
+        }
+
+        [Fact]
+        public void Should_not_call_onretry_when_retry_count_is_zero_with_context()
+        {
+            string onRetrySideEffect = "original_value";
+
+            Action<Exception, TimeSpan, Context> onRetryWithSideEffect = (_, __, ___) => { onRetrySideEffect = "new_value"; };
+
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .WaitAndRetry(0, retryAttempt => TimeSpan.FromSeconds(1), onRetryWithSideEffect);
+
+            policy.Invoking(x => x.RaiseException<DivideByZeroException>())
+                  .ShouldThrow<DivideByZeroException>();
+
+            onRetrySideEffect.Should().Be("original_value");
+        }
+
         public void Dispose()
         {
             SystemClock.Reset();


### PR DESCRIPTION
The change is useful when you want to setup a policy to be non-retryable (as for now, PolicyBuilder requires you to specify a retry strategy).

This allows more transparent code in cases where the same Policy needs to be used, but the retry count comes as a parameter to the method in which it's defined.

As I want the Policy to retry in some cases but not in others, allowing zero as a value for the Retry methods family becomes a handy default.