### PR TITLE
Simplify continueOnCapturedContext API, fixes #70

### DIFF
--- a/src/Polly.Shared/CircuitBreaker/CircuitBreakerPolicyAsync.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitBreakerPolicyAsync.cs
@@ -9,7 +9,7 @@ namespace Polly.CircuitBreaker
 {
     internal partial class CircuitBreakerPolicy
     {
-        internal static async Task ImplementationAsync(bool continueOnCapturedContext, Func<Task> action, IEnumerable<ExceptionPredicate> shouldRetryPredicates, ICircuitBreakerState breakerState)
+        internal static async Task ImplementationAsync(Func<Task> action, IEnumerable<ExceptionPredicate> shouldRetryPredicates, ICircuitBreakerState breakerState, bool continueOnCapturedContext)
         {
             if (breakerState.IsBroken)
             {

--- a/src/Polly.Shared/CircuitBreakerSyntaxAsync.cs
+++ b/src/Polly.Shared/CircuitBreakerSyntaxAsync.cs
@@ -30,35 +30,11 @@ namespace Polly
         /// <exception cref="System.ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
         public static Policy CircuitBreakerAsync(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak)
         {
-            return CircuitBreakerAsync(policyBuilder, exceptionsAllowedBeforeBreaking, durationOfBreak, false);
-        }
-
-        /// <summary>
-        /// <para> Builds a <see cref="Policy"/> that will function like a Circuit Breaker.</para>
-        /// <para>The circuit will break after <paramref name="exceptionsAllowedBeforeBreaking"/>
-        /// exceptions that are handled by this policy are raised. The circuit will stay
-        /// broken for the <paramref name="durationOfBreak"/>. Any attempt to execute this policy
-        /// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException"/> containing the exception 
-        /// that broke the cicuit.
-        /// </para>
-        /// <para>If the first action after the break duration period results in an exception, the circuit will break
-        /// again for another <paramref name="durationOfBreak"/>, otherwise it will reset.
-        /// </para>
-        /// </summary>
-        /// <param name="policyBuilder">The policy builder.</param>
-        /// <param name="exceptionsAllowedBeforeBreaking">The number of exceptions that are allowed before opening the circuit.</param>
-        /// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-        /// <returns>The policy instance.</returns>
-        /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
-        /// <exception cref="System.ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        public static Policy CircuitBreakerAsync(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, bool continueOnCapturedContext)
-        {
             if (exceptionsAllowedBeforeBreaking <= 0) throw new ArgumentOutOfRangeException("exceptionsAllowedBeforeBreaking", "Value must be greater than zero.");
 
             var policyState = new CircuitBreakerState(exceptionsAllowedBeforeBreaking, durationOfBreak);
             return new Policy(
-                action => CircuitBreakerPolicy.ImplementationAsync(continueOnCapturedContext, action, policyBuilder.ExceptionPredicates, policyState),
+                (action, continueOnCapturedContext) => CircuitBreakerPolicy.ImplementationAsync(action, policyBuilder.ExceptionPredicates, policyState, continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates
             );
         }

--- a/src/Polly.Shared/RetrySyntaxAsync.cs
+++ b/src/Polly.Shared/RetrySyntaxAsync.cs
@@ -19,18 +19,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static Policy RetryAsync(this PolicyBuilder policyBuilder)
         {
-            return RetryAsync(policyBuilder, false);
-        }
-
-        /// <summary>
-        /// Builds a <see cref="Policy"/> that will retry once.
-        /// </summary>
-        /// <param name="policyBuilder">The policy builder.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-        /// <returns>The policy instance.</returns>
-        public static Policy RetryAsync(this PolicyBuilder policyBuilder, bool continueOnCapturedContext)
-        {
-            return policyBuilder.RetryAsync(1, continueOnCapturedContext);
+            return policyBuilder.RetryAsync(1);
         }
 
         /// <summary>
@@ -41,21 +30,9 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static Policy RetryAsync(this PolicyBuilder policyBuilder, int retryCount)
         {
-            return RetryAsync(policyBuilder, retryCount, false);
-        }
-
-        /// <summary>
-        ///     Builds a <see cref="Policy" /> that will retry <paramref name="retryCount" /> times.
-        /// </summary>
-        /// <param name="policyBuilder">The policy builder.</param>
-        /// <param name="retryCount">The retry count.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-        /// <returns>The policy instance.</returns>
-        public static Policy RetryAsync(this PolicyBuilder policyBuilder, int retryCount, bool continueOnCapturedContext)
-        {
             Action<Exception, int> doNothing = (_, __) => { };
 
-            return policyBuilder.RetryAsync(retryCount, continueOnCapturedContext, doNothing);
+            return policyBuilder.RetryAsync(retryCount, doNothing);
         }
 
         /// <summary>
@@ -65,26 +42,10 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than zero.</exception>
         /// <exception cref="System.ArgumentNullException">onRetry</exception>
         public static Policy RetryAsync(this PolicyBuilder policyBuilder, Action<Exception, int> onRetry)
         {
-            return RetryAsync(policyBuilder, false, onRetry);
-        }
-
-        /// <summary>
-        ///     Builds a <see cref="Policy" /> that will retry once
-        ///     calling <paramref name="onRetry" /> on retry with the raised exception and retry count.
-        /// </summary>
-        /// <param name="policyBuilder">The policy builder.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-        /// <param name="onRetry">The action to call on each retry.</param>
-        /// <returns>The policy instance.</returns>
-        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than zero.</exception>
-        /// <exception cref="System.ArgumentNullException">onRetry</exception>
-        public static Policy RetryAsync(this PolicyBuilder policyBuilder, bool continueOnCapturedContext, Action<Exception, int> onRetry)
-        {
-            return policyBuilder.RetryAsync(1, continueOnCapturedContext, onRetry);
+            return policyBuilder.RetryAsync(1, onRetry);
         }
 
         /// <summary>
@@ -95,32 +56,16 @@ namespace Polly
         /// <param name="retryCount">The retry count.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be equal to or greater than zero.</exception>
         /// <exception cref="System.ArgumentNullException">onRetry</exception>
         public static Policy RetryAsync(this PolicyBuilder policyBuilder, int retryCount, Action<Exception, int> onRetry)
-        {
-            return RetryAsync(policyBuilder, retryCount, false, onRetry);
-        }
-
-        /// <summary>
-        ///     Builds a <see cref="Policy" /> that will retry <paramref name="retryCount" /> times
-        ///     calling <paramref name="onRetry" /> on each retry with the raised exception and retry count.
-        /// </summary>
-        /// <param name="policyBuilder">The policy builder.</param>
-        /// <param name="retryCount">The retry count.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-        /// <param name="onRetry">The action to call on each retry.</param>
-        /// <returns>The policy instance.</returns>
-        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than zero.</exception>
-        /// <exception cref="System.ArgumentNullException">onRetry</exception>
-        public static Policy RetryAsync(this PolicyBuilder policyBuilder, int retryCount, bool continueOnCapturedContext, Action<Exception, int> onRetry)
         {
             if (retryCount < 0)
                 throw new ArgumentOutOfRangeException("retryCount", "Value must be equal to or greater than zero.");
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
             return new Policy(
-                action => RetryPolicy.ImplementationAsync(
+                (action, continueOnCapturedContext) => RetryPolicy.ImplementationAsync(
                     action,
                     policyBuilder.ExceptionPredicates,
                     () => new RetryPolicyStateWithCount(retryCount, onRetry), 
@@ -136,20 +81,9 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static Policy RetryForeverAsync(this PolicyBuilder policyBuilder)
         {
-            return RetryForeverAsync(policyBuilder, false);
-        }
-
-        /// <summary>
-        ///     Builds a <see cref="Policy" /> that will retry indefinitely.
-        /// </summary>
-        /// <param name="policyBuilder">The policy builder.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-        /// <returns>The policy instance.</returns>
-        public static Policy RetryForeverAsync(this PolicyBuilder policyBuilder, bool continueOnCapturedContext)
-        {
             Action<Exception> doNothing = _ => { };
 
-            return policyBuilder.RetryForeverAsync(continueOnCapturedContext, doNothing);
+            return policyBuilder.RetryForeverAsync(doNothing);
         }
 
         /// <summary>
@@ -162,24 +96,10 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">onRetry</exception>
         public static Policy RetryForeverAsync(this PolicyBuilder policyBuilder, Action<Exception> onRetry)
         {
-            return RetryForeverAsync(policyBuilder, false, onRetry);
-        }
-
-        /// <summary>
-        ///     Builds a <see cref="Policy" /> that will retry indefinitely
-        ///     calling <paramref name="onRetry" /> on each retry with the raised exception.
-        /// </summary>
-        /// <param name="policyBuilder">The policy builder.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-        /// <param name="onRetry">The action to call on each retry.</param>
-        /// <returns>The policy instance.</returns>
-        /// <exception cref="System.ArgumentNullException">onRetry</exception>
-        public static Policy RetryForeverAsync(this PolicyBuilder policyBuilder, bool continueOnCapturedContext, Action<Exception> onRetry)
-        {
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
             return new Policy(
-                action => RetryPolicy.ImplementationAsync(
+                (action, continueOnCapturedContext) => RetryPolicy.ImplementationAsync(
                     action,
                     policyBuilder.ExceptionPredicates,
                     () => new RetryPolicyState(onRetry), 
@@ -198,23 +118,9 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static Policy WaitAndRetryAsync(this PolicyBuilder policyBuilder, IEnumerable<TimeSpan> sleepDurations)
         {
-            return WaitAndRetryAsync(policyBuilder, sleepDurations, false);
-        }
-
-        /// <summary>
-        ///     Builds a <see cref="Policy" /> that will wait and retry as many times as there are provided
-        ///     <paramref name="sleepDurations" />
-        ///     On each retry, the duration to wait is the current <paramref name="sleepDurations" /> item.
-        /// </summary>
-        /// <param name="policyBuilder">The policy builder.</param>
-        /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-        /// <returns>The policy instance.</returns>
-        public static Policy WaitAndRetryAsync(this PolicyBuilder policyBuilder, IEnumerable<TimeSpan> sleepDurations, bool continueOnCapturedContext)
-        {
             Action<Exception, TimeSpan> doNothing = (_, __) => { };
 
-            return policyBuilder.WaitAndRetryAsync(sleepDurations, continueOnCapturedContext, doNothing);
+            return policyBuilder.WaitAndRetryAsync(sleepDurations, doNothing);
         }
 
         /// <summary>
@@ -228,24 +134,9 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static Policy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider)
         {
-            return WaitAndRetryAsync(policyBuilder, retryCount, sleepDurationProvider, false);
-        }
-
-        /// <summary>
-        ///     Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times.
-        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
-        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
-        /// </summary>
-        /// <param name="policyBuilder">The policy builder.</param>
-        /// <param name="retryCount">The retry count.</param>
-        /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-        /// <returns>The policy instance.</returns>
-        public static Policy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, bool continueOnCapturedContext)
-        {
             Action<Exception, TimeSpan> doNothing = (_, __) => { };
 
-            return policyBuilder.WaitAndRetryAsync(retryCount, sleepDurationProvider, continueOnCapturedContext, doNothing);
+            return policyBuilder.WaitAndRetryAsync(retryCount, sleepDurationProvider, doNothing);
         }
 
         /// <summary>
@@ -259,36 +150,14 @@ namespace Polly
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be equal to or greater than zero.</exception>
         /// <exception cref="System.ArgumentNullException">
         ///     timeSpanProvider
         ///     or
         ///     onRetry
         /// </exception>
-        public static Policy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan> onRetry)
-        {
-            return WaitAndRetryAsync(policyBuilder, retryCount, sleepDurationProvider, false, onRetry);
-        }
-
-        /// <summary>
-        ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
-        ///     calling <paramref name="onRetry" /> on each retry with the raised exception and the current sleep duration.
-        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
-        /// </summary>
-        /// <param name="policyBuilder">The policy builder.</param>
-        /// <param name="retryCount">The retry count.</param>
-        /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-        /// <param name="onRetry">The action to call on each retry.</param>
-        /// <returns>The policy instance.</returns>
-        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than zero.</exception>
-        /// <exception cref="System.ArgumentNullException">
-        ///     timeSpanProvider
-        ///     or
-        ///     onRetry
-        /// </exception>
-        public static Policy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, bool continueOnCapturedContext, Action<Exception, TimeSpan> onRetry)
+        public static Policy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
+            Func<int, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan> onRetry)
         {
             if (retryCount < 0)
                 throw new ArgumentOutOfRangeException("retryCount", "Value must be equal to or greater than zero.");
@@ -299,7 +168,7 @@ namespace Polly
                 .Select(sleepDurationProvider);
 
             return new Policy(
-                action => RetryPolicy.ImplementationAsync(
+                (action, continueOnCapturedContext) => RetryPolicy.ImplementationAsync(
                     action,
                     policyBuilder.ExceptionPredicates,
                     () => new RetryPolicyStateWithSleep(sleepDurations, onRetry), 
@@ -323,34 +192,14 @@ namespace Polly
         ///     or
         ///     onRetry
         /// </exception>
-        public static Policy WaitAndRetryAsync(this PolicyBuilder policyBuilder, IEnumerable<TimeSpan> sleepDurations, Action<Exception, TimeSpan> onRetry)
-        {
-            return WaitAndRetryAsync(policyBuilder, sleepDurations, false, onRetry);
-        }
-
-        /// <summary>
-        ///     Builds a <see cref="Policy" /> that will wait and retry as many times as there are provided
-        ///     <paramref name="sleepDurations" />
-        ///     calling <paramref name="onRetry" /> on each retry with the raised exception and the current sleep duration.
-        ///     On each retry, the duration to wait is the current <paramref name="sleepDurations" /> item.
-        /// </summary>
-        /// <param name="policyBuilder">The policy builder.</param>
-        /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-        /// <param name="onRetry">The action to call on each retry.</param>
-        /// <returns>The policy instance.</returns>
-        /// <exception cref="System.ArgumentNullException">
-        ///     sleepDurations
-        ///     or
-        ///     onRetry
-        /// </exception>
-        public static Policy WaitAndRetryAsync(this PolicyBuilder policyBuilder, IEnumerable<TimeSpan> sleepDurations, bool continueOnCapturedContext, Action<Exception, TimeSpan> onRetry)
+        public static Policy WaitAndRetryAsync(this PolicyBuilder policyBuilder, IEnumerable<TimeSpan> sleepDurations,
+            Action<Exception, TimeSpan> onRetry)
         {
             if (sleepDurations == null) throw new ArgumentNullException("sleepDurations");
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
             return new Policy(
-                action => RetryPolicy.ImplementationAsync(
+                (action, continueOnCapturedContext) => RetryPolicy.ImplementationAsync(
                     action,
                     policyBuilder.ExceptionPredicates,
                     () => new RetryPolicyStateWithSleep(sleepDurations, onRetry), 


### PR DESCRIPTION
This PR fixes #70, so that continueOnCapturedContext need only be specified in one place (on action execution but not also on Policy configuration), when wanting to flow async action execution on the captured context.

With this change, the syntax:

```Policy.Handle<Exception>.RetryOrWhatever().ExecuteAsync(delegate, true);```

suffices to flow async operations on captured contexts.

In addition, this greatly reduces the number of `RetryAsync(...)`, `WaitAndRetryAsync(...)`, `CircuitBreakerAsync()` etc overloads for library users to navigate.