### PR TITLE
ContextualPolicy: add async support; bind more tightly with (extend) Policy

### DIFF
--- a/src/Polly.Shared/Context.cs
+++ b/src/Polly.Shared/Context.cs
@@ -13,7 +13,7 @@ namespace Polly
     /// </summary>
     public class Context : ReadOnlyDictionary<string, object>
     {
-        internal static Context Empty = new Context(new Dictionary<string, object>());
+        internal static readonly Context Empty = new Context(new Dictionary<string, object>());
 
         internal Context(IDictionary<string, object> values) : base(values)
         {

--- a/src/Polly.Shared/ContextualPolicy.cs
+++ b/src/Polly.Shared/ContextualPolicy.cs
@@ -8,15 +8,11 @@ namespace Polly
     /// Transient exception handling policies that can be applied to delegates.
     /// These policies can be called with arbitrary context data.
     /// </summary>
-    public class ContextualPolicy
+    public class ContextualPolicy : Policy
     {
-         private readonly Action<Action, Context> _exceptionPolicy;
-
-         internal ContextualPolicy(Action<Action, Context> exceptionPolicy)
+        internal ContextualPolicy(Action<Action, Context> exceptionPolicy, IEnumerable<ExceptionPredicate> exceptionPredicates) 
+            : base(exceptionPolicy, exceptionPredicates)
         {
-            if (exceptionPolicy == null) throw new ArgumentNullException("exceptionPolicy");
-            
-            _exceptionPolicy = exceptionPolicy;
         }
 
          /// <summary>
@@ -30,29 +26,13 @@ namespace Polly
          {
              if (contextData == null) throw new ArgumentNullException("contextData");
 
-             Execute(action, new Context(contextData));
+             base.Execute(action, new Context(contextData));
          }
 
         /// <summary>
-        /// Executes the specified action within the policy.
+        /// Executes the specified action within the policy and returns the result.
         /// </summary>
-        /// <param name="action">The action to perform.</param>
-        [DebuggerStepThrough]
-        public void Execute(Action action)
-        {
-            Execute(action, Context.Empty);
-        }
-
-        [DebuggerStepThrough]
-        private void Execute(Action action, Context context)
-        {
-            _exceptionPolicy(action, context);
-        }
-
-        /// <summary>
-        /// Executes the specified action within the policy and returns the Result.
-        /// </summary>
-        /// <typeparam name="TResult">The type of the Result.</typeparam>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
         /// <param name="action">The action to perform.</param>
         /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
         /// <returns>
@@ -64,29 +44,7 @@ namespace Polly
         {
             if (contextData == null) throw new ArgumentNullException("contextData");
 
-            return Execute(action, new Context(contextData));
+            return base.Execute(action, new Context(contextData));
         }
-
-        /// <summary>
-        /// Executes the specified action within the policy and returns the Result.
-        /// </summary>
-        /// <typeparam name="TResult">The type of the Result.</typeparam>
-        /// <param name="action">The action to perform.</param>
-        /// <returns>
-        /// The value returned by the action
-        /// </returns>
-        [DebuggerStepThrough]
-        public TResult Execute<TResult>(Func<TResult> action)
-        {
-            return Execute(action, Context.Empty);
-        }
-
-        [DebuggerStepThrough]
-        private TResult Execute<TResult>(Func<TResult> action, Context context)
-        {
-            var result = default(TResult);
-            _exceptionPolicy(() => { result = action(); }, context);
-            return result;
-        } 
     }
 }

--- a/src/Polly.Shared/ContextualPolicy.cs
+++ b/src/Polly.Shared/ContextualPolicy.cs
@@ -8,7 +8,7 @@ namespace Polly
     /// Transient exception handling policies that can be applied to delegates.
     /// These policies can be called with arbitrary context data.
     /// </summary>
-    public class ContextualPolicy : Policy
+    public partial class ContextualPolicy : Policy
     {
         internal ContextualPolicy(Action<Action, Context> exceptionPolicy, IEnumerable<ExceptionPredicate> exceptionPredicates) 
             : base(exceptionPolicy, exceptionPredicates)

--- a/src/Polly.Shared/ContextualPolicyAsync.cs
+++ b/src/Polly.Shared/ContextualPolicyAsync.cs
@@ -1,0 +1,126 @@
+﻿#if SUPPORTS_ASYNC
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Polly
+{
+    public partial class ContextualPolicy
+    {
+        internal ContextualPolicy(Func<Func<CancellationToken, Task>, Context, CancellationToken, bool, Task> asyncExceptionPolicy, IEnumerable<ExceptionPredicate> exceptionPredicates)
+           : base(asyncExceptionPolicy, exceptionPredicates)
+        {
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
+        [DebuggerStepThrough]
+        public Task ExecuteAsync(Func<Task> action, IDictionary<string, object> contextData)
+        {
+            return ExecuteAsync(ct => action(), contextData, CancellationToken.None, false);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        [DebuggerStepThrough]
+        public Task ExecuteAsync(Func<Task> action, IDictionary<string, object> contextData, bool continueOnCapturedContext)
+        {
+            return ExecuteAsync(ct => action(), contextData, CancellationToken.None, continueOnCapturedContext);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+        [DebuggerStepThrough]
+        public Task ExecuteAsync(Func<CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken)
+        {
+            return ExecuteAsync(action, contextData, cancellationToken, false);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <exception cref="System.ArgumentNullException">contextData</exception>
+        [DebuggerStepThrough]
+        public Task ExecuteAsync(Func<CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        {
+            if (contextData == null) throw new ArgumentNullException("contextData");
+
+            return base.ExecuteAsync(action, new Context(contextData), cancellationToken, continueOnCapturedContext);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
+        /// <returns>The value returned by the action</returns>
+        [DebuggerStepThrough]
+        public Task<TResult> ExecuteAsync<TResult>(Func<Task<TResult>> action, IDictionary<string, object> contextData)
+        {
+            return ExecuteAsync(ct => action(), contextData, CancellationToken.None, false);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <returns>The value returned by the action</returns>
+        [DebuggerStepThrough]
+        public Task<TResult> ExecuteAsync<TResult>(Func<Task<TResult>> action, IDictionary<string, object> contextData, bool continueOnCapturedContext)
+        {
+            return ExecuteAsync(ct => action(), contextData, CancellationToken.None, continueOnCapturedContext);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+        /// <returns>The value returned by the action</returns>
+        [DebuggerStepThrough]
+        public Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken)
+        {
+            return ExecuteAsync(action, contextData, cancellationToken, false);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <returns>The value returned by the action</returns>
+        /// <exception cref="System.ArgumentNullException">contextData</exception>
+        [DebuggerStepThrough]
+        public Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        {
+            if (contextData == null) throw new ArgumentNullException("contextData");
+
+            return base.ExecuteAsync(action, new Context(contextData), cancellationToken, continueOnCapturedContext);
+        }
+    }
+}
+
+#endif

--- a/src/Polly.Shared/Policy.cs
+++ b/src/Polly.Shared/Policy.cs
@@ -11,15 +11,21 @@ namespace Polly
     /// </summary>
     public partial class Policy
     {
-        private readonly Action<Action> _exceptionPolicy;
+        private readonly Action<Action, Context> _exceptionPolicy;
         private readonly IEnumerable<ExceptionPredicate> _exceptionPredicates;
 
-        internal Policy(Action<Action> exceptionPolicy, IEnumerable<ExceptionPredicate> exceptionPredicates)
+        internal Policy(Action<Action, Context> exceptionPolicy, IEnumerable<ExceptionPredicate> exceptionPredicates)
         {
             if (exceptionPolicy == null) throw new ArgumentNullException("exceptionPolicy");
 
             _exceptionPolicy = exceptionPolicy;
             _exceptionPredicates = exceptionPredicates ?? Enumerable.Empty<ExceptionPredicate>();
+
+        }
+
+        internal Policy(Action<Action> exceptionPolicy, IEnumerable<ExceptionPredicate> exceptionPredicates)
+            : this((action, ctx) => exceptionPolicy(action), exceptionPredicates)
+        {
         }
 
         /// <summary>
@@ -29,10 +35,21 @@ namespace Polly
         [DebuggerStepThrough]
         public void Execute(Action action)
         {
+            Execute(action, Context.Empty);
+        }
+
+        /// <summary>
+        /// Executes the specified action within the policy.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
+        [DebuggerStepThrough]
+        protected void Execute(Action action, Context context)
+        {
             if (_exceptionPolicy == null) throw new InvalidOperationException(
                 "Please use the synchronous Retry, RetryForever, WaitAndRetry or CircuitBreaker methods when calling the synchronous Execute method.");
 
-            _exceptionPolicy(action);
+            _exceptionPolicy(action, context);
         }
 
         /// <summary>
@@ -43,12 +60,18 @@ namespace Polly
         [DebuggerStepThrough]
         public PolicyResult ExecuteAndCapture(Action action)
         {
+            return ExecuteAndCapture(action, Context.Empty);
+        }
+
+        [DebuggerStepThrough]
+        private PolicyResult ExecuteAndCapture(Action action, Context context)
+        {
             if (_exceptionPolicy == null) throw new InvalidOperationException(
-                "Please use the synchronous Retry, RetryForever, WaitAndRetry or CircuitBreaker methods when calling the synchronous Execute method.");
+                "Please use the synchronous Retry, RetryForever, WaitAndRetry or CircuitBreaker methods when calling the synchronous ExecuteAndCapture method.");
 
             try
             {
-                _exceptionPolicy(action);
+                _exceptionPolicy(action, context);
                 return PolicyResult.Successful();
             }
             catch (Exception exception)
@@ -62,16 +85,29 @@ namespace Polly
         /// </summary>
         /// <typeparam name="TResult">The type of the result.</typeparam>
         /// <param name="action">The action to perform.</param>
+        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
         /// <returns>The value returned by the action</returns>
         [DebuggerStepThrough]
-        public TResult Execute<TResult>(Func<TResult> action)
+        protected TResult Execute<TResult>(Func<TResult> action, Context context)
         {
             if (_exceptionPolicy == null) throw new InvalidOperationException(
                 "Please use the synchronous Retry, RetryForever, WaitAndRetry or CircuitBreaker methods when calling the synchronous Execute method.");
 
             var result = default(TResult);
-            _exceptionPolicy(() => { result = action(); });
+            _exceptionPolicy(() => { result = action(); }, context);
             return result;
+        }
+
+        /// <summary>
+        /// Executes the specified action within the policy and returns the Result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the Result.</typeparam>
+        /// <param name="action">The action to perform.</param>
+        /// <returns>The value returned by the action</returns>
+        [DebuggerStepThrough]
+        public TResult Execute<TResult>(Func<TResult> action)
+        {
+            return Execute(action, Context.Empty);
         }
 
         /// <summary>
@@ -82,13 +118,20 @@ namespace Polly
         [DebuggerStepThrough]
         public PolicyResult<TResult> ExecuteAndCapture<TResult>(Func<TResult> action)
         {
+            return ExecuteAndCapture(action, Context.Empty);
+        }
+
+        [DebuggerStepThrough]
+        private PolicyResult<TResult> ExecuteAndCapture<TResult>(Func<TResult> action, Context context)
+        {
+
             if (_exceptionPolicy == null) throw new InvalidOperationException(
-                "Please use the synchronous Retry, RetryForever, WaitAndRetry or CircuitBreaker methods when calling the synchronous Execute method.");
+                "Please use the synchronous Retry, RetryForever, WaitAndRetry or CircuitBreaker methods when calling the synchronous ExecuteAndCapture method.");
 
             try
             {
                 var result = default(TResult);
-                _exceptionPolicy(() => { result = action(); });
+                _exceptionPolicy(() => { result = action(); }, context);
                 return PolicyResult<TResult>.Successful(result);
             }
             catch (Exception exception)

--- a/src/Polly.Shared/Policy.cs
+++ b/src/Polly.Shared/Policy.cs
@@ -14,6 +14,11 @@ namespace Polly
         private readonly Action<Action, Context> _exceptionPolicy;
         private readonly IEnumerable<ExceptionPredicate> _exceptionPredicates;
 
+        internal Policy(Action<Action> exceptionPolicy, IEnumerable<ExceptionPredicate> exceptionPredicates)
+            : this((action, ctx) => exceptionPolicy(action), exceptionPredicates)
+        {
+        }
+
         internal Policy(Action<Action, Context> exceptionPolicy, IEnumerable<ExceptionPredicate> exceptionPredicates)
         {
             if (exceptionPolicy == null) throw new ArgumentNullException("exceptionPolicy");
@@ -21,11 +26,6 @@ namespace Polly
             _exceptionPolicy = exceptionPolicy;
             _exceptionPredicates = exceptionPredicates ?? Enumerable.Empty<ExceptionPredicate>();
 
-        }
-
-        internal Policy(Action<Action> exceptionPolicy, IEnumerable<ExceptionPredicate> exceptionPredicates)
-            : this((action, ctx) => exceptionPolicy(action), exceptionPredicates)
-        {
         }
 
         /// <summary>

--- a/src/Polly.Shared/PolicyAsync.cs
+++ b/src/Polly.Shared/PolicyAsync.cs
@@ -11,9 +11,13 @@ namespace Polly
 {
     public partial class Policy
     {
-        private readonly Func<Func<CancellationToken, Task>, CancellationToken, bool, Task> _asyncExceptionPolicy;
+        private readonly Func<Func<CancellationToken, Task>, Context, CancellationToken, bool, Task> _asyncExceptionPolicy;
 
         internal Policy(Func<Func<CancellationToken, Task>, CancellationToken, bool, Task> asyncExceptionPolicy, IEnumerable<ExceptionPredicate> exceptionPredicates)
+            : this((action, context, cancellationToken, continueOnCapturedContext) => asyncExceptionPolicy(action, cancellationToken, continueOnCapturedContext), exceptionPredicates)
+        { }
+
+        internal Policy(Func<Func<CancellationToken, Task>, Context, CancellationToken, bool, Task> asyncExceptionPolicy, IEnumerable<ExceptionPredicate> exceptionPredicates)
         {
             if (asyncExceptionPolicy == null) throw new ArgumentNullException("asyncExceptionPolicy");
 
@@ -28,7 +32,18 @@ namespace Polly
         [DebuggerStepThrough]
         public Task ExecuteAsync(Func<Task> action)
         {
-            return ExecuteAsync(action, false);
+            return ExecuteAsync(action, Context.Empty, false);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
+        [DebuggerStepThrough]
+        protected Task ExecuteAsync(Func<Task> action, Context context)
+        {
+            return ExecuteAsync(action, context, false);
         }
 
         /// <summary>
@@ -39,7 +54,19 @@ namespace Polly
         [DebuggerStepThrough]
         public Task ExecuteAsync(Func<Task> action, bool continueOnCapturedContext)
         {
-            return ExecuteAsync(ct => action(), CancellationToken.None, continueOnCapturedContext);
+            return ExecuteAsync(ct => action(), Context.Empty, CancellationToken.None, continueOnCapturedContext);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        [DebuggerStepThrough]
+        protected Task ExecuteAsync(Func<Task> action, Context context, bool continueOnCapturedContext)
+        {
+            return ExecuteAsync(ct => action(), context, CancellationToken.None, continueOnCapturedContext);
         }
 
         /// <summary>
@@ -50,7 +77,19 @@ namespace Polly
         [DebuggerStepThrough]
         public Task ExecuteAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken)
         {
-            return ExecuteAsync(action, cancellationToken, false);
+            return ExecuteAsync(action, Context.Empty, cancellationToken, false);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+        [DebuggerStepThrough]
+        protected Task ExecuteAsync(Func<CancellationToken, Task> action, Context context, CancellationToken cancellationToken)
+        {
+            return ExecuteAsync(action, context, cancellationToken, false);
         }
 
         /// <summary>
@@ -61,12 +100,26 @@ namespace Polly
         /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
         /// <exception cref="System.InvalidOperationException">Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.</exception>
         [DebuggerStepThrough]
-        public async Task ExecuteAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        public Task ExecuteAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        {
+            return ExecuteAsync(action, Context.Empty, cancellationToken, continueOnCapturedContext);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+        /// <exception cref="System.InvalidOperationException">Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.</exception>
+        [DebuggerStepThrough]
+        protected async Task ExecuteAsync(Func<CancellationToken, Task> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
             if (_asyncExceptionPolicy == null) throw new InvalidOperationException
                 ("Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.");
 
-            await _asyncExceptionPolicy(action, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
+            await _asyncExceptionPolicy(action, context, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
         }
 
         /// <summary>
@@ -76,7 +129,18 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Task> action)
         {
-            return ExecuteAndCaptureAsync(action, false);
+            return ExecuteAndCaptureAsync(action, Context.Empty, false);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the captured result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
+        [DebuggerStepThrough]
+        private Task<PolicyResult> ExecuteAndCaptureAsync(Func<Task> action, Context context)
+        {
+            return ExecuteAndCaptureAsync(action, context, false);
         }
 
         /// <summary>
@@ -87,7 +151,19 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Task> action, bool continueOnCapturedContext)
         {
-            return ExecuteAndCaptureAsync(ct => action(), CancellationToken.None, continueOnCapturedContext);
+            return ExecuteAndCaptureAsync(ct => action(), Context.Empty, CancellationToken.None, continueOnCapturedContext);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the captured result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        [DebuggerStepThrough]
+        private Task<PolicyResult> ExecuteAndCaptureAsync(Func<Task> action, Context context, bool continueOnCapturedContext)
+        {
+            return ExecuteAndCaptureAsync(ct => action(), context, CancellationToken.None, continueOnCapturedContext);
         }
 
         /// <summary>
@@ -98,7 +174,19 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult> ExecuteAndCaptureAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken)
         {
-            return ExecuteAndCaptureAsync(action, cancellationToken, false);
+            return ExecuteAndCaptureAsync(action, Context.Empty, cancellationToken, false);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the captured result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+        [DebuggerStepThrough]
+        private Task<PolicyResult> ExecuteAndCaptureAsync(Func<CancellationToken, Task> action, Context context, CancellationToken cancellationToken)
+        {
+            return ExecuteAndCaptureAsync(action, context, cancellationToken, false);
         }
 
         /// <summary>
@@ -109,14 +197,28 @@ namespace Polly
         /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
         /// <exception cref="System.InvalidOperationException">Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.</exception>
         [DebuggerStepThrough]
-        public async Task<PolicyResult> ExecuteAndCaptureAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        public Task<PolicyResult> ExecuteAndCaptureAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        {
+            return ExecuteAndCaptureAsync(action, Context.Empty, cancellationToken, continueOnCapturedContext);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the captured result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+        /// <exception cref="System.InvalidOperationException">Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.</exception>
+        [DebuggerStepThrough]
+        private async Task<PolicyResult> ExecuteAndCaptureAsync(Func<CancellationToken, Task> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
             if (_asyncExceptionPolicy == null) throw new InvalidOperationException
                 ("Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.");
 
             try
             {
-                await _asyncExceptionPolicy(action, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
+                await _asyncExceptionPolicy(action, context, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
                 return PolicyResult.Successful();
             }
             catch (Exception exception)
@@ -134,7 +236,20 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<TResult> ExecuteAsync<TResult>(Func<Task<TResult>> action)
         {
-            return ExecuteAsync(action, false);
+            return ExecuteAsync(action, Context.Empty, false);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
+        /// <returns>The value returned by the action</returns>
+        [DebuggerStepThrough]
+        protected Task<TResult> ExecuteAsync<TResult>(Func<Task<TResult>> action, Context context)
+        {
+            return ExecuteAsync(action, context, false);
         }
 
         /// <summary>
@@ -147,7 +262,21 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken)
         {
-            return ExecuteAsync(action, cancellationToken, false);
+            return ExecuteAsync(action, Context.Empty, cancellationToken, false);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
+        /// <returns>The value returned by the action</returns>
+        [DebuggerStepThrough]
+        protected Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken)
+        {
+            return ExecuteAsync(action, context, cancellationToken, false);
         }
 
         /// <summary>
@@ -160,7 +289,21 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<TResult> ExecuteAsync<TResult>(Func<Task<TResult>> action, bool continueOnCapturedContext)
         {
-            return ExecuteAsync(ct => action(), CancellationToken.None, continueOnCapturedContext);
+            return ExecuteAsync(ct => action(), Context.Empty, CancellationToken.None, continueOnCapturedContext);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <returns>The value returned by the action</returns>
+        [DebuggerStepThrough]
+        protected Task<TResult> ExecuteAsync<TResult>(Func<Task<TResult>> action, Context context, bool continueOnCapturedContext)
+        {
+            return ExecuteAsync(ct => action(), context, CancellationToken.None, continueOnCapturedContext);
         }
 
         /// <summary>
@@ -173,7 +316,23 @@ namespace Polly
         /// <returns>The value returned by the action</returns>
         /// <exception cref="System.InvalidOperationException">Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.</exception>
         [DebuggerStepThrough]
-        public async Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        public Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        {
+            return ExecuteAsync(action, Context.Empty, cancellationToken, continueOnCapturedContext);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
+        /// <returns>The value returned by the action</returns>
+        /// <exception cref="System.InvalidOperationException">Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.</exception>
+        [DebuggerStepThrough]
+        protected async Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
             if (_asyncExceptionPolicy == null) throw new InvalidOperationException(
                 "Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.");
@@ -182,7 +341,7 @@ namespace Polly
             await _asyncExceptionPolicy(async ct =>
             {
                 result = await action(ct).ConfigureAwait(continueOnCapturedContext);
-            }, cancellationToken, continueOnCapturedContext)
+            }, context, cancellationToken, continueOnCapturedContext)
             .ConfigureAwait(continueOnCapturedContext);
             return result;
         }
@@ -198,7 +357,22 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Task<TResult>> action)
         {
-            return ExecuteAndCaptureAsync(action, false);
+            return ExecuteAndCaptureAsync(action, Context.Empty, false);
+        }
+
+        /// <summary>
+        /// Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
+        /// <returns>
+        /// The value returned by the action
+        /// </returns>
+        [DebuggerStepThrough]
+        private Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Task<TResult>> action, Context context)
+        {
+            return ExecuteAndCaptureAsync(action, context, false);
         }
 
         /// <summary>
@@ -213,7 +387,23 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Task<TResult>> action, bool continueOnCapturedContext)
         {
-            return ExecuteAndCaptureAsync(ct => action(), CancellationToken.None, continueOnCapturedContext);
+            return ExecuteAndCaptureAsync(ct => action(), Context.Empty, CancellationToken.None, continueOnCapturedContext);
+        }
+
+        /// <summary>
+        /// Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <returns>
+        /// The value returned by the action
+        /// </returns>
+        [DebuggerStepThrough]
+        private Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Task<TResult>> action, Context context, bool continueOnCapturedContext)
+        {
+            return ExecuteAndCaptureAsync(ct => action(), context, CancellationToken.None, continueOnCapturedContext);
         }
 
         /// <summary>
@@ -226,7 +416,21 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Task<TResult>> action, CancellationToken cancellationToken)
         {
-            return ExecuteAndCaptureAsync(ct => action(), cancellationToken, false);
+            return ExecuteAndCaptureAsync(ct => action(), Context.Empty, cancellationToken, false);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+        /// <returns>The value returned by the action</returns>
+        [DebuggerStepThrough]
+        private Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Task<TResult>> action, Context context, CancellationToken cancellationToken)
+        {
+            return ExecuteAndCaptureAsync(ct => action(), context, cancellationToken, false);
         }
 
         /// <summary>
@@ -239,7 +443,23 @@ namespace Polly
         /// <returns>The value returned by the action</returns>
         /// <exception cref="System.InvalidOperationException">Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.</exception>
         [DebuggerStepThrough]
-        public async Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        {
+            return ExecuteAndCaptureAsync(action, Context.Empty, cancellationToken, continueOnCapturedContext);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+        /// <returns>The value returned by the action</returns>
+        /// <exception cref="System.InvalidOperationException">Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.</exception>
+        [DebuggerStepThrough]
+        private async Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
             if (_asyncExceptionPolicy == null) throw new InvalidOperationException(
                 "Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.");
@@ -250,7 +470,7 @@ namespace Polly
                 await _asyncExceptionPolicy(async ct =>
                 {
                     result = await action(ct).ConfigureAwait(continueOnCapturedContext);
-                }, cancellationToken, continueOnCapturedContext)
+                }, context, cancellationToken, continueOnCapturedContext)
                 .ConfigureAwait(continueOnCapturedContext);
 
                 return PolicyResult<TResult>.Successful(result);

--- a/src/Polly.Shared/Polly.Shared.projitems
+++ b/src/Polly.Shared/Polly.Shared.projitems
@@ -18,6 +18,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CircuitBreaker\ICircuitBreakerState.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Context.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ContextualPolicy.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ContextualPolicyAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExceptionPredicate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)OrSyntax.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Policy.cs" />

--- a/src/Polly.Shared/RetrySyntax.cs
+++ b/src/Polly.Shared/RetrySyntax.cs
@@ -107,7 +107,7 @@ namespace Polly
                 action, 
                 policyBuilder.ExceptionPredicates, 
                 () => new RetryPolicyStateWithCount(retryCount, onRetry, context)
-            ));
+            ), policyBuilder.ExceptionPredicates);
         }
 
         /// <summary>
@@ -161,7 +161,7 @@ namespace Polly
                 action, 
                 policyBuilder.ExceptionPredicates,
                 () => new RetryPolicyState(onRetry, context)
-            ));
+            ), policyBuilder.ExceptionPredicates);
         }
 
         /// <summary>
@@ -247,7 +247,7 @@ namespace Polly
                 action, 
                 policyBuilder.ExceptionPredicates, 
                 () => new RetryPolicyStateWithSleep(sleepDurations, onRetry, context)
-            ));
+            ), policyBuilder.ExceptionPredicates);
         }
 
         /// <summary>
@@ -317,7 +317,7 @@ namespace Polly
                 action, 
                 policyBuilder.ExceptionPredicates, 
                 () => new RetryPolicyStateWithSleep(sleepDurations, onRetry, context)
-            ));
+            ), policyBuilder.ExceptionPredicates);
         }
     }
 }

--- a/src/Polly.Shared/RetrySyntax.cs
+++ b/src/Polly.Shared/RetrySyntax.cs
@@ -40,7 +40,6 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than zero.</exception>
         /// <exception cref="System.ArgumentNullException">onRetry</exception>
         public static Policy Retry(this PolicyBuilder policyBuilder, Action<Exception, int> onRetry)
         {
@@ -55,11 +54,11 @@ namespace Polly
         /// <param name="retryCount">The retry count.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="System.ArgumentNullException">onRetry</exception>
         public static Policy Retry(this PolicyBuilder policyBuilder, int retryCount, Action<Exception, int> onRetry)
         {
-            if (retryCount < 0) throw new ArgumentOutOfRangeException("retryCount", "Value must be equal to or greater than zero.");
+            if (retryCount < 0) throw new ArgumentOutOfRangeException("retryCount", "Value must be greater than or equal to zero.");
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
             return new Policy(
@@ -74,13 +73,11 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will retry once
-        /// calling <paramref name="onRetry"/> on retry with the raised exception, retry count and 
-        /// execution context.
+        /// calling <paramref name="onRetry"/> on retry with the raised exception, retry count and context data.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than zero.</exception>
         /// <exception cref="System.ArgumentNullException">onRetry</exception>
         public static ContextualPolicy Retry(this PolicyBuilder policyBuilder, Action<Exception, int, Context> onRetry)
         {
@@ -89,18 +86,17 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will retry <paramref name="retryCount"/> times
-        /// calling <paramref name="onRetry"/> on each retry with the raised exception, retry count and 
-        /// execution context.
+        /// calling <paramref name="onRetry"/> on each retry with the raised exception, retry count and context data.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="System.ArgumentNullException">onRetry</exception>
         public static ContextualPolicy Retry(this PolicyBuilder policyBuilder, int retryCount, Action<Exception, int, Context> onRetry)
         {
-            if (retryCount < 0) throw new ArgumentOutOfRangeException("retryCount", "Value must be equal to or greater than zero.");
+            if (retryCount < 0) throw new ArgumentOutOfRangeException("retryCount", "Value must be greater than or equal to zero.");
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
             return new ContextualPolicy((action, context) => RetryPolicy.Implementation(
@@ -146,8 +142,7 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will retry indefinitely
-        /// calling <paramref name="onRetry"/> on each retry with the raised exception and
-        /// execution context.
+        /// calling <paramref name="onRetry"/> on each retry with the raised exception and context data.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
@@ -191,7 +186,7 @@ namespace Polly
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="System.ArgumentNullException">
         /// timeSpanProvider
         /// or
@@ -199,7 +194,7 @@ namespace Polly
         /// </exception>
         public static Policy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan> onRetry)
         {
-            if (retryCount < 0) throw new ArgumentOutOfRangeException("retryCount", "Value must be equal to or greater than zero.");
+            if (retryCount < 0) throw new ArgumentOutOfRangeException("retryCount", "Value must be greater than or equal to zero.");
             if (sleepDurationProvider == null) throw new ArgumentNullException("sleepDurationProvider");
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
@@ -218,8 +213,7 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
-        /// calling <paramref name="onRetry"/> on each retry with the raised exception, current sleep duration and
-        /// execution context.
+        /// calling <paramref name="onRetry"/> on each retry with the raised exception, current sleep duration and context data.
         /// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
         /// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
         /// </summary>
@@ -228,7 +222,7 @@ namespace Polly
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="System.ArgumentNullException">
         /// timeSpanProvider
         /// or
@@ -236,7 +230,7 @@ namespace Polly
         /// </exception>
         public static ContextualPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, Context> onRetry)
         {
-            if (retryCount < 0) throw new ArgumentOutOfRangeException("retryCount", "Value must be equal to or greater than zero.");
+            if (retryCount < 0) throw new ArgumentOutOfRangeException("retryCount", "Value must be greater than or equal to zero.");
             if (sleepDurationProvider == null) throw new ArgumentNullException("sleepDurationProvider");
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
@@ -295,8 +289,7 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry as many times as there are provided <paramref name="sleepDurations"/>
-        /// calling <paramref name="onRetry"/> on each retry with the raised exception, current sleep duration and
-        /// execution context.
+        /// calling <paramref name="onRetry"/> on each retry with the raised exception, current sleep duration and context data.
         /// On each retry, the duration to wait is the current <paramref name="sleepDurations"/> item.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>

--- a/src/Polly.Shared/RetrySyntaxAsync.cs
+++ b/src/Polly.Shared/RetrySyntaxAsync.cs
@@ -111,21 +111,6 @@ namespace Polly
         }
 
         /// <summary>
-        ///     Builds a <see cref="Policy" /> that will wait and retry as many times as there are provided
-        ///     <paramref name="sleepDurations" />
-        ///     On each retry, the duration to wait is the current <paramref name="sleepDurations" /> item.
-        /// </summary>
-        /// <param name="policyBuilder">The policy builder.</param>
-        /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
-        /// <returns>The policy instance.</returns>
-        public static Policy WaitAndRetryAsync(this PolicyBuilder policyBuilder, IEnumerable<TimeSpan> sleepDurations)
-        {
-            Action<Exception, TimeSpan> doNothing = (_, __) => { };
-
-            return policyBuilder.WaitAndRetryAsync(sleepDurations, doNothing);
-        }
-
-        /// <summary>
         ///     Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times.
         ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
         ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
@@ -177,7 +162,22 @@ namespace Polly
                     () => new RetryPolicyStateWithSleep(sleepDurations, onRetry), 
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates
-            );
+                );
+        }
+
+        /// <summary>
+        ///     Builds a <see cref="Policy" /> that will wait and retry as many times as there are provided
+        ///     <paramref name="sleepDurations" />
+        ///     On each retry, the duration to wait is the current <paramref name="sleepDurations" /> item.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        public static Policy WaitAndRetryAsync(this PolicyBuilder policyBuilder, IEnumerable<TimeSpan> sleepDurations)
+        {
+            Action<Exception, TimeSpan> doNothing = (_, __) => { };
+
+            return policyBuilder.WaitAndRetryAsync(sleepDurations, doNothing);
         }
 
         /// <summary>
@@ -209,7 +209,7 @@ namespace Polly
                     () => new RetryPolicyStateWithSleep(sleepDurations, onRetry), 
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates
-            );
+                );
         }
     }
 }

--- a/src/Polly.Shared/RetrySyntaxAsync.cs
+++ b/src/Polly.Shared/RetrySyntaxAsync.cs
@@ -56,12 +56,12 @@ namespace Polly
         /// <param name="retryCount">The retry count.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be equal to or greater than zero.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="System.ArgumentNullException">onRetry</exception>
         public static Policy RetryAsync(this PolicyBuilder policyBuilder, int retryCount, Action<Exception, int> onRetry)
         {
             if (retryCount < 0)
-                throw new ArgumentOutOfRangeException("retryCount", "Value must be equal to or greater than zero.");
+                throw new ArgumentOutOfRangeException("retryCount", "Value must be greater than or equal to zero.");
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
             return new Policy(
@@ -73,6 +73,43 @@ namespace Polly
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates
             );
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will retry once
+        /// calling <paramref name="onRetry"/> on retry with the raised exception, retry count and context data.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">onRetry</exception>
+        public static ContextualPolicy RetryAsync(this PolicyBuilder policyBuilder, Action<Exception, int, Context> onRetry)
+        {
+            return RetryAsync(policyBuilder, 1, onRetry);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will retry <paramref name="retryCount"/> times
+        /// calling <paramref name="onRetry"/> on each retry with the raised exception, retry count and context data.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="retryCount">The retry count.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentNullException">onRetry</exception>
+        public static ContextualPolicy RetryAsync(this PolicyBuilder policyBuilder, int retryCount, Action<Exception, int, Context> onRetry)
+        {
+            if (retryCount < 0) throw new ArgumentOutOfRangeException("retryCount", "Value must be greater than or equal to zero.");
+            if (onRetry == null) throw new ArgumentNullException("onRetry");
+
+            return new ContextualPolicy((action, context, cancellationToken, continueOnCapturedContext) => RetryPolicy.ImplementationAsync(
+                action, 
+                cancellationToken,
+                policyBuilder.ExceptionPredicates,
+                () => new RetryPolicyStateWithCount(retryCount, onRetry, context),
+                continueOnCapturedContext
+            ), policyBuilder.ExceptionPredicates);
         }
 
         /// <summary>
@@ -111,6 +148,27 @@ namespace Polly
         }
 
         /// <summary>
+        /// Builds a <see cref="Policy"/> that will retry indefinitely
+        /// calling <paramref name="onRetry"/> on each retry with the raised exception and context data.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">onRetry</exception>
+        public static ContextualPolicy RetryForeverAsync(this PolicyBuilder policyBuilder, Action<Exception, Context> onRetry)
+        {
+            if (onRetry == null) throw new ArgumentNullException("onRetry");
+
+            return new ContextualPolicy((action, context, cancellationToken, continueOnCapturedContext) => RetryPolicy.ImplementationAsync(
+                action, 
+                cancellationToken,
+                policyBuilder.ExceptionPredicates,
+                () => new RetryPolicyState(onRetry, context),
+                continueOnCapturedContext
+            ), policyBuilder.ExceptionPredicates);
+        }
+
+        /// <summary>
         ///     Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times.
         ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
         ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
@@ -137,7 +195,7 @@ namespace Polly
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be equal to or greater than zero.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="System.ArgumentNullException">
         ///     timeSpanProvider
         ///     or
@@ -147,7 +205,7 @@ namespace Polly
             Func<int, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan> onRetry)
         {
             if (retryCount < 0)
-                throw new ArgumentOutOfRangeException("retryCount", "Value must be equal to or greater than zero.");
+                throw new ArgumentOutOfRangeException("retryCount", "Value must be greater than or equal to zero.");
             if (sleepDurationProvider == null) throw new ArgumentNullException("sleepDurationProvider");
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
@@ -162,7 +220,46 @@ namespace Polly
                     () => new RetryPolicyStateWithSleep(sleepDurations, onRetry), 
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates
-                );
+            );
+        }
+
+
+        /// <summary>
+        ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
+        ///     calling <paramref name="onRetry" /> on each retry with the raised exception, the current sleep duration and context data.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
+        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="retryCount">The retry count.</param>
+        /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        /// <exception cref="System.ArgumentNullException">
+        ///     timeSpanProvider
+        ///     or
+        ///     onRetry
+        /// </exception>
+        public static ContextualPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
+            Func<int, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, Context> onRetry)
+        {
+            if (retryCount < 0) throw new ArgumentOutOfRangeException("retryCount", "Value must be greater than or equal to zero.");
+            if (sleepDurationProvider == null) throw new ArgumentNullException("sleepDurationProvider");
+            if (onRetry == null) throw new ArgumentNullException("onRetry");
+
+            IEnumerable<TimeSpan> sleepDurations = Enumerable.Range(1, retryCount)
+                .Select(sleepDurationProvider);
+
+            return new ContextualPolicy(
+                (action, context, cancellationToken, continueOnCapturedContext) => RetryPolicy.ImplementationAsync(
+                    action,
+                    cancellationToken,
+                    policyBuilder.ExceptionPredicates,
+                    () => new RetryPolicyStateWithSleep(sleepDurations, onRetry, context),
+                    continueOnCapturedContext),
+                policyBuilder.ExceptionPredicates
+            );
         }
 
         /// <summary>
@@ -209,7 +306,39 @@ namespace Polly
                     () => new RetryPolicyStateWithSleep(sleepDurations, onRetry), 
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates
-                );
+            );
+        }
+
+        /// <summary>
+        ///     Builds a <see cref="Policy" /> that will wait and retry as many times as there are provided
+        ///     <paramref name="sleepDurations" />
+        ///     calling <paramref name="onRetry" /> on each retry with the raised exception, the current sleep duration and context data.
+        ///     On each retry, the duration to wait is the current <paramref name="sleepDurations" /> item.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">
+        ///     sleepDurations
+        ///     or
+        ///     onRetry
+        /// </exception>
+        public static ContextualPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, IEnumerable<TimeSpan> sleepDurations,
+            Action<Exception, TimeSpan, Context> onRetry)
+        {
+            if (sleepDurations == null) throw new ArgumentNullException("sleepDurations");
+            if (onRetry == null) throw new ArgumentNullException("onRetry");
+
+            return new ContextualPolicy(
+                (action, context, cancellationToken, continueOnCapturedContext) => RetryPolicy.ImplementationAsync(
+                    action,
+                    cancellationToken,
+                    policyBuilder.ExceptionPredicates,
+                    () => new RetryPolicyStateWithSleep(sleepDurations, onRetry, context),
+                    continueOnCapturedContext),
+                policyBuilder.ExceptionPredicates
+            );
         }
     }
 }

--- a/src/Polly.SharedSpecs/ContextualPolicyAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/ContextualPolicyAsyncSpecs.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace Polly.Specs
+{
+    public class ContextualPolicyAsyncSpecs
+    {
+        [Fact]
+        public async Task Executing_the_policy_action_should_execute_the_specified_async_action()
+        {
+            bool executed = false;
+
+            ContextualPolicy policy = Policy
+                .Handle<DivideByZeroException>()
+                .RetryAsync((_, __, ___) => { });
+
+            await policy.ExecuteAsync(() =>
+            {
+                executed = true;
+                return Task.FromResult(true) as Task;
+            });
+
+            executed.Should()
+                .BeTrue();
+        }
+
+        [Fact]
+        public async Task Executing_the_policy_function_should_execute_the_specified_async_function_and_return_the_result()
+        {
+            ContextualPolicy policy = Policy
+                .Handle<DivideByZeroException>()
+                .RetryAsync((_, __, ___) => { });
+
+            int result = await policy.ExecuteAsync(() => Task.FromResult(2));
+
+            result.Should()
+                .Be(2);
+        }
+
+        [Fact]
+        public void Executing_the_policy_action_should_should_throw_when_context_data_is_null()
+        {
+            ContextualPolicy policy = Policy
+                .Handle<DivideByZeroException>()
+                .RetryAsync((_, __, ___) => { });
+
+            policy.Invoking(p => p.ExecuteAsync(async () => { }, null))
+                  .ShouldThrow<ArgumentNullException>().And
+                  .ParamName.Should().Be("contextData");
+        }
+
+        [Fact]
+        public void Executing_the_policy_function_should_should_throw_when_context_data_is_null()
+        {
+            ContextualPolicy policy = Policy
+                .Handle<DivideByZeroException>()
+                .RetryAsync((_, __, ___) => { });
+
+            policy.Invoking(p => p.ExecuteAsync(() => Task.FromResult(2), null))
+                  .ShouldThrow<ArgumentNullException>().And
+                  .ParamName.Should().Be("contextData");
+        }
+    }
+}

--- a/src/Polly.SharedSpecs/ContextualPolicySpecs.cs
+++ b/src/Polly.SharedSpecs/ContextualPolicySpecs.cs
@@ -11,7 +11,7 @@ namespace Polly.Specs
         {
             var executed = false;
 
-            var policy = Policy
+            ContextualPolicy policy = Policy
                           .Handle<DivideByZeroException>()
                           .Retry((_, __, ___) => { });
 
@@ -24,7 +24,7 @@ namespace Polly.Specs
         [Fact]
         public void Executing_the_policy_function_should_execute_the_specified_function_and_return_the_result()
         {
-            var policy = Policy
+            ContextualPolicy policy = Policy
                           .Handle<DivideByZeroException>()
                           .Retry((_, __, ___) => { });
 
@@ -37,7 +37,7 @@ namespace Polly.Specs
         [Fact]
         public void Executing_the_policy_action_should_should_throw_when_context_data_is_null()
         {
-            var policy = Policy
+            ContextualPolicy policy = Policy
                 .Handle<DivideByZeroException>()
                 .Retry((_, __, ___) => { });
 
@@ -49,7 +49,7 @@ namespace Polly.Specs
         [Fact]
         public void Executing_the_policy_function_should_should_throw_when_context_data_is_null()
         {
-            var policy = Policy
+            ContextualPolicy policy = Policy
                 .Handle<DivideByZeroException>()
                 .Retry((_, __, ___) => { });
 

--- a/src/Polly.SharedSpecs/Helpers/ContextualPolicyExtensions.cs
+++ b/src/Polly.SharedSpecs/Helpers/ContextualPolicyExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Polly.Specs.Helpers
 {
@@ -68,5 +70,34 @@ namespace Polly.Specs.Helpers
         {
             policy.RaiseException(1, contextData, configureException);
         }
+
+        public static Task RaiseExceptionAsync<TException>(this ContextualPolicy policy, int numberOfTimesToRaiseException, IDictionary<string, object> contextData, Action<TException, int> configureException = null, CancellationToken cancellationToken = default(CancellationToken)) where TException : Exception, new()
+        {
+            int counter = 0;
+
+            return policy.ExecuteAsync(ct =>
+            {
+                if (counter < numberOfTimesToRaiseException)
+                {
+                    counter++;
+
+                    var exception = new TException();
+
+                    if (configureException != null)
+                    {
+                        configureException(exception, counter);
+                    }
+
+                    throw exception;
+                }
+                return Task.FromResult(true) as Task;
+            }, contextData, cancellationToken);
+        }
+
+        public static Task RaiseExceptionAsync<TException>(this ContextualPolicy policy, IDictionary<string, object> contextData, Action<TException, int> configureException = null, CancellationToken cancellationToken = default(CancellationToken)) where TException : Exception, new()
+        {
+            return policy.RaiseExceptionAsync(1, contextData, configureException, cancellationToken);
+        }
+
     }
 }

--- a/src/Polly.SharedSpecs/PolicySpecs.cs
+++ b/src/Polly.SharedSpecs/PolicySpecs.cs
@@ -170,7 +170,7 @@ namespace Polly.Specs
             Action action = () => asyncPolicy.ExecuteAndCapture(() => { });
 
             action.ShouldThrow<InvalidOperationException>()
-                .WithMessage("Please use the synchronous Retry, RetryForever, WaitAndRetry or CircuitBreaker methods when calling the synchronous Execute method.");
+                .WithMessage("Please use the synchronous Retry, RetryForever, WaitAndRetry or CircuitBreaker methods when calling the synchronous ExecuteAndCapture method.");
         }
 
         public static IEnumerable<object[]> AsyncPolicies

--- a/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
+++ b/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)CircuitBreakerAsyncSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CircuitBreakerSpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ContextualPolicyAsyncSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ContextualPolicySpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ContextualPolicyExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ObjectExtensions.cs" />

--- a/src/Polly.SharedSpecs/RetryForeverAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/RetryForeverAsyncSpecs.cs
@@ -125,6 +125,61 @@ namespace Polly.Specs
         }
 
         [Fact]
+        public void Should_call_onretry_on_each_retry_with_the_passed_context()
+        {
+            IDictionary<string, object> contextData = null;
+
+            ContextualPolicy policy = Policy
+                .Handle<DivideByZeroException>()
+                .RetryForeverAsync((_, context) => contextData = context);
+
+            policy.RaiseExceptionAsync<DivideByZeroException>(
+                new { key1 = "value1", key2 = "value2" }.AsDictionary()
+            );
+
+            contextData.Should()
+                       .ContainKeys("key1", "key2").And
+                       .ContainValues("value1", "value2");
+        }
+
+        [Fact]
+        public void Context_should_be_empty_if_execute_not_called_with_any_data()
+        {
+            Context capturedContext = null;
+
+            ContextualPolicy policy = Policy
+                .Handle<DivideByZeroException>()
+                .RetryForeverAsync((_, context) => capturedContext = context);
+
+            policy.RaiseExceptionAsync<DivideByZeroException>();
+
+            capturedContext.Should()
+                           .BeEmpty();
+        }
+
+        [Fact]
+        public void Should_create_new_context_for_each_call_to_policy()
+        {
+            string contextValue = null;
+
+            ContextualPolicy policy = Policy
+                .Handle<DivideByZeroException>()
+                .RetryForeverAsync((_, context) => contextValue = context["key"].ToString());
+
+            policy.RaiseExceptionAsync<DivideByZeroException>(
+                new { key = "original_value" }.AsDictionary()
+            );
+
+            contextValue.Should().Be("original_value");
+
+            policy.RaiseExceptionAsync<DivideByZeroException>(
+                new { key = "new_value" }.AsDictionary()
+            );
+
+            contextValue.Should().Be("new_value");
+        }
+
+        [Fact]
         public void Should_not_call_onretry_when_no_retries_are_performed()
         {
             var retryExceptions = new List<Exception>();

--- a/src/Polly.SharedSpecs/RetrySpecs.cs
+++ b/src/Polly.SharedSpecs/RetrySpecs.cs
@@ -280,29 +280,45 @@ namespace Polly.Specs
         }
 
         [Fact]
+        public void Should_not_call_onretry_when_no_retries_are_performed()
+        {
+            var retryCounts = new List<int>();
+
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .Retry((_, retyCount) => retryCounts.Add(retyCount));
+
+            policy.Invoking(x => x.RaiseException<ArgumentException>())
+                .ShouldThrow<ArgumentException>();
+
+            retryCounts.Should()
+                .BeEmpty();
+        }
+
+        [Fact]
         public void Should_call_onretry_with_the_passed_context()
         {
             IDictionary<string, object> contextData = null;
 
-            var policy = Policy
+            ContextualPolicy policy = Policy
                 .Handle<DivideByZeroException>()
                 .Retry((_, __, context) => contextData = context);
 
             policy.RaiseException<DivideByZeroException>(
                 new { key1 = "value1", key2 = "value2" }.AsDictionary()
-            );
+                );
 
             contextData.Should()
-                       .ContainKeys("key1", "key2").And
-                       .ContainValues("value1", "value2");
+                .ContainKeys("key1", "key2").And
+                .ContainValues("value1", "value2");
         }
 
         [Fact]
-        public void Context_should_be_empty_if_policy_not_initialised_with_any_data()
+        public void Context_should_be_empty_if_execute_not_called_with_any_context_data()
         {
             Context capturedContext = null;
 
-            var policy = Policy
+            ContextualPolicy policy = Policy
                 .Handle<DivideByZeroException>()
                 .Retry((_, __, context) => capturedContext = context);
 
@@ -313,41 +329,11 @@ namespace Polly.Specs
         }
 
         [Fact]
-        public void Should_not_call_onretry_when_no_retries_are_performed()
-        {
-            var retryCounts = new List<int>();
-
-            var policy = Policy
-                .Handle<DivideByZeroException>()
-                .Retry((_, retyCount) => retryCounts.Add(retyCount));
-
-            policy.Invoking(x => x.RaiseException<ArgumentException>())
-                  .ShouldThrow<ArgumentException>();
-
-            retryCounts.Should()
-                       .BeEmpty();
-        }
-
-        [Fact]
-        public void Should_create_new_state_for_each_call_to_policy()
-        {
-            var policy = Policy
-                .Handle<DivideByZeroException>()
-                .Retry();
-
-            policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldNotThrow();
-
-            policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldNotThrow();
-        }
-
-        [Fact]
         public void Should_create_new_context_for_each_call_to_policy()
         {
             string contextValue = null;
 
-            var policy = Policy
+            ContextualPolicy policy = Policy
                 .Handle<DivideByZeroException>()
                 .Retry((_, __, context) => contextValue = context["key"].ToString());
 
@@ -362,6 +348,20 @@ namespace Polly.Specs
             );
 
             contextValue.Should().Be("new_value");
+        }
+
+        [Fact]
+        public void Should_create_new_state_for_each_call_to_policy()
+        {
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .Retry();
+
+            policy.Invoking(x => x.RaiseException<DivideByZeroException>())
+                .ShouldNotThrow();
+
+            policy.Invoking(x => x.RaiseException<DivideByZeroException>())
+                .ShouldNotThrow();
         }
 
         [Fact]

--- a/src/Polly.SharedSpecs/WaitAndRetrySpecs.cs
+++ b/src/Polly.SharedSpecs/WaitAndRetrySpecs.cs
@@ -431,29 +431,6 @@ namespace Polly.Specs
         }
 
         [Fact]
-        public void Should_call_onretry_with_the_passed_context()
-        {
-            IDictionary<string, object> contextData = null;
-
-            var policy = Policy
-                .Handle<DivideByZeroException>()
-                .WaitAndRetry(new[]
-                {
-                   1.Seconds(),
-                   2.Seconds(),
-                   3.Seconds()
-                }, (_, __, context) => contextData = context);
-
-            policy.RaiseException<DivideByZeroException>(
-                new { key1 = "value1", key2 = "value2" }.AsDictionary()
-            );
-
-            contextData.Should()
-                       .ContainKeys("key1", "key2").And
-                       .ContainValues("value1", "value2");
-        }
-
-        [Fact]
         public void Should_not_call_onretry_when_no_retries_are_performed()
         {
             var retryCounts = new List<int>();
@@ -484,6 +461,29 @@ namespace Polly.Specs
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>())
                   .ShouldNotThrow();
+        }
+
+        [Fact]
+        public void Should_call_onretry_with_the_passed_context()
+        {
+            IDictionary<string, object> contextData = null;
+
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .WaitAndRetry(new[]
+                {
+                    1.Seconds(),
+                    2.Seconds(),
+                    3.Seconds()
+                }, (_, __, context) => contextData = context);
+
+            policy.RaiseException<DivideByZeroException>(
+                new { key1 = "value1", key2 = "value2" }.AsDictionary()
+                );
+
+            contextData.Should()
+                .ContainKeys("key1", "key2").And
+                .ContainValues("value1", "value2");
         }
 
         [Fact]
@@ -641,7 +641,7 @@ namespace Polly.Specs
 
             Action<Exception, TimeSpan, Context> onRetry = (_, __, ___) => { retryInvoked = true; };
 
-            var policy = Policy
+            ContextualPolicy policy = Policy
                 .Handle<DivideByZeroException>()
                 .WaitAndRetry(0, retryAttempt => TimeSpan.FromSeconds(1), onRetry);
 


### PR DESCRIPTION
Adds async support to `ContextualPolicy` - closes #81 .  

(Lays ground also for later addressing 78 : Add `ExecuteAndCapture/Async()` support for `ContextualPolicy`)

Closes #64 (cannot combine `ContextualPolicy` and `Policy`).

Tidies by moving certain async tests which were in sync test classes, into async test classes.


