### PR TITLE
Scrub time limit on circuit state-change delegates

### DIFF
--- a/src/Polly.Shared/Utilities/TimedLock.cs
+++ b/src/Polly.Shared/Utilities/TimedLock.cs
@@ -3,7 +3,10 @@ using System.Threading;
 
 namespace Polly.Utilities
 {
+    // Adapted from the link below, with slight modifications.
+
     // http://www.interact-sw.co.uk/iangblog/2004/04/26/yetmoretimedlocking
+    // Ian Griffiths (original TimedLock author) wrote:
     // Thanks to Eric Gunnerson for recommending this be a struct rather
     // than a class - avoids a heap allocation.
     // Thanks to Change Gillespie and Jocelyn Coulmance for pointing out
@@ -13,12 +16,19 @@ namespace Polly.Utilities
     // without losing the debug leak tracking.
     internal struct TimedLock : IDisposable
     {
+
+#if DEBUG
+        private static readonly TimeSpan LockTimeout = TimeSpan.FromSeconds(5);
+#else
+        private static readonly TimeSpan LockTimeout = TimeSpan.MaxValue;
+#endif
+
         public static TimedLock Lock(object o)
         {
-            return Lock(o, TimeSpan.FromSeconds(5));
+            return Lock(o, LockTimeout);
         }
 
-        public static TimedLock Lock(object o, TimeSpan timeout)
+        private static TimedLock Lock(object o, TimeSpan timeout)
         {
             TimedLock tl = new TimedLock(o);
             if (!Monitor.TryEnter(o, timeout))

--- a/src/Polly.Shared/Utilities/TimedLock.cs
+++ b/src/Polly.Shared/Utilities/TimedLock.cs
@@ -16,11 +16,13 @@ namespace Polly.Utilities
     // without losing the debug leak tracking.
     internal struct TimedLock : IDisposable
     {
-
+        // The TimedLock class throws a LockTimeoutException if a lock cannot be obtained within the LockTimeout.  This allows the easier discovery and debugging of deadlocks during Polly development, than if using a pure lock.
+        // We do not however ever want to throw a LockTimeoutException in production - hence the forked LockTimeout value below for DEBUG versus RELEASE builds.  
+        // This applies particularly because CircuitBreakerPolicy runs state-change delegates during the lock, in order that the state change holds true (cannot be superseded by activity on other threads) while the delegate runs.  
 #if DEBUG
         private static readonly TimeSpan LockTimeout = TimeSpan.FromSeconds(5);
 #else
-        private static readonly TimeSpan LockTimeout = TimeSpan.MaxValue;
+        private static readonly TimeSpan LockTimeout = TimeSpan.FromMilliseconds(int.MaxValue);
 #endif
 
         public static TimedLock Lock(object o)


### PR DESCRIPTION
Circuit-breaker V4 runs state-change delegates within locks, to ensure state change holds during delegate (see wiki).  While slow-running state-change delegates are not recommended, this change prevents unexpected LockTimeoutExceptions arising should users author 'slow' delegates.

`TimedLock` is intended to help spot potential deadlocks during development, but a `LockTimeoutException` should never be thrown in production.  DEBUG/RELEASE distinction introduced in this PR reflects that.