### PR TITLE
Fixed Simple Code Sample Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Policy
 // Multiple exception types with condition
 Policy
   .Handle<SqlException>(ex => ex.Number == 1205)
-  .Or<ArgumentException>(ex => x.ParamName == "example")
+  .Or<ArgumentException>(ex => ex.ParamName == "example")
 ```
 
 ## Step 2 : Specify how the policy should handle those exceptions


### PR DESCRIPTION
```csharp    
Or<ArgumentException>(ex => x.ParamName == "example")
```
to
```csharp 
    Or<ArgumentException>(ex => ex.ParamName == "example")
```