### PR TITLE
Allow tracking of current CircuitControllers and output hystrix style…

### DIFF
--- a/src/Polly.Shared/CircuitBreaker/AdvancedCircuitController.cs
+++ b/src/Polly.Shared/CircuitBreaker/AdvancedCircuitController.cs
@@ -30,6 +30,14 @@ namespace Polly.CircuitBreaker
             _minimumThroughput = minimumThroughput;
         }
 
+        public override HealthCount HealthCount
+        {
+            get
+            {
+                return _metrics.GetHealthCount_NeedsLock();
+            }
+        }
+
         public override void OnCircuitReset(Context context)
         {
             using (TimedLock.Lock(_lock))

--- a/src/Polly.Shared/CircuitBreaker/CircuitBreakerPolicy.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitBreakerPolicy.cs
@@ -29,6 +29,14 @@ namespace Polly.CircuitBreaker
         }
 
         /// <summary>
+        /// Gets the state of the underlying circuit.
+        /// </summary>
+        public IHealthCount HealthCount
+        {
+            get { return _breakerController.HealthCount; }
+        }
+
+        /// <summary>
         /// Gets the last exception handled by the circuit-breaker.
         /// </summary>
         public Exception LastException

--- a/src/Polly.Shared/CircuitBreaker/CircuitStateController.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitStateController.cs
@@ -15,9 +15,9 @@ namespace Polly.CircuitBreaker
         protected readonly object _lock = new object();
 
         protected CircuitStateController(
-            TimeSpan durationOfBreak, 
-            Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, 
-            Action<Context> onReset, 
+            TimeSpan durationOfBreak,
+            Action<DelegateResult<TResult>, TimeSpan, Context> onBreak,
+            Action<Context> onReset,
             Action onHalfOpen)
         {
             _durationOfBreak = durationOfBreak;
@@ -147,6 +147,8 @@ namespace Polly.CircuitBreaker
         public abstract void OnActionFailure(DelegateResult<TResult> outcome, Context context);
 
         public abstract void OnCircuitReset(Context context);
+
+        public abstract HealthCount HealthCount { get; }
     }
 }
 

--- a/src/Polly.Shared/CircuitBreaker/ConsecutiveCountCircuitController.cs
+++ b/src/Polly.Shared/CircuitBreaker/ConsecutiveCountCircuitController.cs
@@ -19,6 +19,14 @@ namespace Polly.CircuitBreaker
             _exceptionsAllowedBeforeBreaking = exceptionsAllowedBeforeBreaking;
         }
 
+        public override HealthCount HealthCount
+        {
+            get
+            {
+                return new HealthCount() { Failures = _count };
+            }
+        }
+
         public override void OnCircuitReset(Context context)
         {
             using (TimedLock.Lock(_lock))

--- a/src/Polly.Shared/CircuitBreaker/HealthCount.cs
+++ b/src/Polly.Shared/CircuitBreaker/HealthCount.cs
@@ -1,6 +1,6 @@
 ﻿namespace Polly.CircuitBreaker
 {
-    internal class HealthCount
+    internal class HealthCount : IHealthCount
     {
         public int Successes { get; set; }
 

--- a/src/Polly.Shared/CircuitBreaker/ICircuitController.cs
+++ b/src/Polly.Shared/CircuitBreaker/ICircuitController.cs
@@ -5,6 +5,7 @@ namespace Polly.CircuitBreaker
     internal interface ICircuitController<TResult>
     {
         CircuitState CircuitState { get; }
+        HealthCount HealthCount { get; }
         Exception LastException { get; }
         TResult LastHandledResult { get; }
         void Isolate();

--- a/src/Polly.Shared/CircuitBreaker/IHealthCount.cs
+++ b/src/Polly.Shared/CircuitBreaker/IHealthCount.cs
@@ -1,0 +1,28 @@
+﻿namespace Polly.CircuitBreaker
+{
+    /// <summary>
+    /// Store and report health metrics
+    /// </summary>
+    public interface IHealthCount
+    {
+        /// <summary>
+        /// Success count
+        /// </summary>
+        int Successes { get; }
+
+        /// <summary>
+        /// Failure count
+        /// </summary>
+        int Failures { get; }
+
+        /// <summary>
+        /// Total count (probably success + failure)
+        /// </summary>
+        int Total { get; }
+
+        /// <summary>
+        /// Start time for metric collection
+        /// </summary>
+        long StartedAt { get; }
+    }
+}

--- a/src/Polly.Shared/CollectMetricsSyntax.cs
+++ b/src/Polly.Shared/CollectMetricsSyntax.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Linq;
+using Polly.CircuitBreaker;
+using Polly.Utilities;
+using Polly.Shared;
+
+namespace Polly
+{
+    /// <summary>
+    /// Fluent API for adding a policy to metrics. 
+    /// </summary>
+    public static class CollectMetricsSyntax
+    {
+        /// <summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <para> Adds policy to metrics collection</para>
+        /// </summary>
+        /// <param name="name">The policy name.</param>
+        /// <returns>The policy instance.</returns>
+        public static CircuitBreakerPolicy CollectMetrics(this CircuitBreakerPolicy policyBuilder, string name)
+        {
+            CollectedPolicies.Add(name, policyBuilder);
+
+            return policyBuilder;
+        }
+    }
+}

--- a/src/Polly.Shared/CollectedPolicies.cs
+++ b/src/Polly.Shared/CollectedPolicies.cs
@@ -1,0 +1,36 @@
+﻿using Polly.CircuitBreaker;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Polly.Shared
+{
+    /// <summary>
+    /// Static storage for the current collection of policies to report metrics on.
+    /// </summary>
+    public class CollectedPolicies
+    {
+        private static WeakDictionary<string, CircuitBreakerPolicy> _policies;
+        static CollectedPolicies() {
+            _policies = new WeakDictionary<string, CircuitBreakerPolicy>();
+        }
+
+        /// <summary>
+        /// Return the current list of policies
+        /// </summary>
+        public static IEnumerable<KeyValuePair<string, CircuitBreakerPolicy>> All
+        {
+            get { return _policies.All(); }
+        }
+
+        /// <summary>
+        /// Add a policy to the collection
+        /// </summary>
+        /// <param name="name">Unique name for this policy</param>
+        /// <param name="policy">The policy to record</param>
+        public static void Add(string name, CircuitBreakerPolicy policy)
+        {
+            _policies.Add(name, policy);
+        }
+    }
+}

--- a/src/Polly.Shared/HystrixCommand.cs
+++ b/src/Polly.Shared/HystrixCommand.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Polly.Shared
+{
+    /// <summary>
+    /// Data class for output to be consumed by Hystrix Dashboard (https://github.com/Netflix/Hystrix/tree/master/hystrix-dashboard)
+    /// </summary>
+    public class HystrixCommand
+    {
+        private static readonly DateTime Jan1St1970 = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        public HystrixCommand()
+        {
+            currentTime = (long)((DateTime.UtcNow - Jan1St1970).TotalMilliseconds);
+            rollingCountTimeout = -1;
+        }
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+        public string type { get { return "HystrixCommand"; } }
+        public string name { get; set; }
+        public string group { get; set; }
+        public long currentTime { get; set; }
+        public bool isCircuitBreakerOpen { get; set; }
+        public int errorPercentage { get; set; }
+        public int errorCount { get; set; }
+        public int requestCount { get; set; }
+        public int rollingCountBadRequests { get; set; }
+        public int rollingCountCollapsedRequests { get; set; }
+        public int rollingCountEmit { get; set; }
+        public int rollingCountExceptionsThrown { get; set; }
+        public int rollingCountFailure { get; set; }
+        public int rollingCountFallbackEmit { get; set; }
+        public int rollingCountFallbackFailure { get; set; }
+        public int rollingCountFallbackMissing { get; set; }
+        public int rollingCountFallbackRejection { get; set; }
+        public int rollingCountFallbackSuccess { get; set; }
+        public int rollingCountResponsesFromCache { get; set; }
+        public int rollingCountSemaphoreRejected { get; set; }
+        public int rollingCountShortCircuited { get; set; }
+        public int rollingCountSuccess { get; set; }
+        public int rollingCountThreadPoolRejected { get; set; }
+        public int rollingCountTimeout { get; set; }
+        public int currentConcurrentExecutionCount { get; set; }
+        public int rollingMaxConcurrentExecutionCount { get; set; }
+        public int latencyExecute_mean { get; set; }
+        public Dictionary<string, int> latencyExecute { get; set; }
+        public int latencyTotal_mean { get; set; }
+        public Dictionary<string, int> latencyTotal { get; set; }
+        public int propertyValue_circuitBreakerRequestVolumeThreshold { get; set; }
+        public int propertyValue_circuitBreakerSleepWindowInMilliseconds { get; set; }
+        public int propertyValue_circuitBreakerErrorThresholdPercentage { get; set; }
+        public bool propertyValue_circuitBreakerForceOpen { get; set; }
+        public bool propertyValue_circuitBreakerForceClosed { get; set; }
+        public bool propertyValue_circuitBreakerEnabled { get; set; }
+        public string propertyValue_executionIsolationStrategy { get; set; }
+        public int propertyValue_executionIsolationThreadTimeoutInMilliseconds { get; set; }
+        public int propertyValue_executionTimeoutInMilliseconds { get; set; }
+        public bool propertyValue_executionIsolationThreadInterruptOnTimeout { get; set; }
+        public object propertyValue_executionIsolationThreadPoolKeyOverride { get; set; }
+        public int propertyValue_executionIsolationSemaphoreMaxConcurrentRequests { get; set; }
+        public int propertyValue_fallbackIsolationSemaphoreMaxConcurrentRequests { get; set; }
+        public int propertyValue_metricsRollingStatisticalWindowInMilliseconds { get; set; }
+        public bool propertyValue_requestCacheEnabled { get; set; }
+        public bool propertyValue_requestLogEnabled { get; set; }
+        public int reportingHosts { get; set; }
+        public string threadPool { get; set; }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+    }
+}

--- a/src/Polly.Shared/MetricStream.cs
+++ b/src/Polly.Shared/MetricStream.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Polly.Shared
+{
+    /// Find and return the current metrics for the system (in Hystrix format)
+    public class MetricStream
+    {
+        /// an infinite stream of all metrics
+        /// <param name="sleepFunc">The method will be called between each set of outputs to slow the stream down. We suggest "() => Thread.Sleep(1000)"</param>
+        public static IEnumerable<object> All(Action sleepFunc)
+        {
+            while (true)
+            {
+                foreach (var policy in CollectedPolicies.All)
+                {
+                    yield return new HystrixCommand
+                    {
+                        rollingCountSuccess = policy.Value.HealthCount.Successes,
+                        rollingCountFailure = policy.Value.HealthCount.Failures,
+                        isCircuitBreakerOpen = (policy.Value.CircuitState != CircuitBreaker.CircuitState.Closed),
+                        name = policy.Key,
+                        group = "Group",
+                        latencyExecute = new Dictionary<string, int>() { { "0", 0 }, { "25", 0 }, { "50", 0 }, { "75", 0 }, { "90", 0 }, { "95", 0 }, { "99", 0 }, { "99.5", 0 }, { "100", 0 } },
+                        latencyTotal = new Dictionary<string, int>() { { "0", 0 }, { "25", 0 }, { "50", 0 }, { "75", 0 }, { "90", 0 }, { "95", 0 }, { "99", 0 }, { "99.5", 0 }, { "100", 0 } },
+                        propertyValue_executionIsolationStrategy = "THREAD",
+                        threadPool = "ThreadPool"
+                    };
+                }
+
+                // yield return new HystrixThreadPool { type = "HystrixThreadPool", name = "Order" };
+
+                sleepFunc.Invoke();
+            }
+        }
+    }
+}

--- a/src/Polly.Shared/Polly.Shared.projitems
+++ b/src/Polly.Shared/Polly.Shared.projitems
@@ -9,6 +9,9 @@
     <Import_RootNamespace>Polly.Shared</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)CircuitBreaker\IHealthCount.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CollectedPolicies.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CollectMetricsSyntax.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AdvancedCircuitBreakerTResultSyntax.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AdvancedCircuitBreakerTResultSyntaxAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CircuitBreakerSyntax.cs" />
@@ -35,6 +38,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)ContextualPolicyAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExceptionPredicate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DelegateResult.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HystrixCommand.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)MetricStream.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Policy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Policy.HandleSyntax.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PolicyAsync.cs" />
@@ -66,5 +71,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\ReadOnlyDictionary.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\SystemClock.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\TimedLock.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)WeakDictionary.cs" />
   </ItemGroup>
 </Project>

--- a/src/Polly.Shared/WeakDictionary.cs
+++ b/src/Polly.Shared/WeakDictionary.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Polly.Shared
+{
+    internal class WeakDictionary<K, V>
+    {
+        private HashSet<KeyValuePair<K, WeakReference>> list;
+
+        public WeakDictionary()
+        {
+            list = new HashSet<KeyValuePair<K, WeakReference>>();
+        }
+
+        public void Add(K k, V v)
+        {
+            list.Add(new KeyValuePair<K, WeakReference>(k, new WeakReference(v)));
+        }
+
+        public IEnumerable<KeyValuePair<K, V>> All()
+        {
+            var cloneList = new HashSet<KeyValuePair<K, WeakReference>>(list);
+            foreach (var pair in cloneList)
+            {
+                object value = pair.Value.Target;
+                if (value != null)
+                {
+                    yield return new KeyValuePair<K,V>(pair.Key, (V)value);
+                }
+                else
+                {
+                    list.Remove(pair);
+                }
+            }
+        }
+    }
+}

--- a/src/Polly.SharedSpecs/AdvancedCircuitBreakerSpecs.cs
+++ b/src/Polly.SharedSpecs/AdvancedCircuitBreakerSpecs.cs
@@ -151,6 +151,16 @@ namespace Polly.Specs
             breaker.CircuitState.Should().Be(CircuitState.Closed);
         }
 
+        [Fact]
+        public void Should_return_health_count()
+        {
+            CircuitBreakerPolicy breaker = Policy
+                .Handle<DivideByZeroException>()
+                .AdvancedCircuitBreaker(0.5, TimeSpan.FromSeconds(10), 4, TimeSpan.FromSeconds(30));
+
+            breaker.HealthCount.StartedAt.Should().BeGreaterThan(0);
+        }
+
         #endregion
 
         #region Circuit-breaker threshold-to-break tests

--- a/src/Polly.SharedSpecs/CollectMetricsSpec.cs
+++ b/src/Polly.SharedSpecs/CollectMetricsSpec.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Polly.CircuitBreaker;
+using Polly.Specs.Helpers;
+using Polly.Utilities;
+using Xunit;
+using Polly.Shared;
+using System.Linq;
+
+namespace Polly.Specs
+{
+    public class CollectMetricsSpecs : IDisposable
+    {
+        [Fact]
+        public void Should_be_able_to_be_called_on_advanced_circuit_breaker()
+        {
+            CircuitBreakerPolicy policy = Policy
+                .Handle<DivideByZeroException>()
+                .AdvancedCircuitBreaker(0.5, TimeSpan.FromSeconds(10), 4, TimeSpan.MaxValue)
+                .CollectMetrics("BreakerTest");
+        }
+
+        [Fact]
+        public void Should_be_able_to_enumerate_collected_metric_policies()
+        {
+            CircuitBreakerPolicy policyMetrics1 = Policy
+                .Handle<DivideByZeroException>()
+                .AdvancedCircuitBreaker(0.5, TimeSpan.FromSeconds(10), 4, TimeSpan.MaxValue)
+                .CollectMetrics("Test 1");
+
+            CircuitBreakerPolicy policyNoMetrics = Policy
+                .Handle<DivideByZeroException>()
+                .AdvancedCircuitBreaker(0.5, TimeSpan.FromSeconds(10), 4, TimeSpan.MaxValue);
+
+            CircuitBreakerPolicy policyMetrics2 = Policy
+                .Handle<DivideByZeroException>()
+                .AdvancedCircuitBreaker(0.5, TimeSpan.FromSeconds(10), 4, TimeSpan.MaxValue)
+                .CollectMetrics("Test 3");
+
+            var actual = CollectedPolicies.All.Select(x => x.Value);
+            Assert.Contains(policyMetrics1, actual);
+            Assert.DoesNotContain(policyNoMetrics, actual);
+            Assert.Contains(policyMetrics2, actual);
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
+++ b/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
@@ -9,6 +9,8 @@
     <Import_RootNamespace>Polly.SharedSpecs</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)CollectMetricsSpec.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)WeakDictionarySpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CircuitBreakerAsyncSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AdvancedCircuitBreakerSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CircuitBreakerSpecs.cs" />

--- a/src/Polly.SharedSpecs/WeakDictionarySpecs.cs
+++ b/src/Polly.SharedSpecs/WeakDictionarySpecs.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Polly.Specs
+{
+    public class WeakDictionarySpecs
+    {
+        [Fact]
+        public void Enumerable()
+        {
+            var dict = new Shared.WeakDictionary<string, object>();
+            var fred = new object();
+            dict.Add("fred", fred);
+
+            var count = 0;
+            foreach(var entry in dict.All())
+            {
+                Assert.Equal(entry.Key, "fred");
+                count++;
+            }
+            Assert.Equal(count, 1);
+        }
+
+        [Fact]
+        public void DoesNotHaveAStrongReference()
+        {
+            var dict = new Shared.WeakDictionary<string, object>();
+            var fred = new object();
+            dict.Add("fred", fred);
+
+            Assert.Equal(dict.All().Count(), 1);
+
+            fred = null;
+            GC.Collect();
+
+            var list = dict.All().ToArray();
+            Assert.Equal(list.Count(), 0);
+        }
+
+        [Fact]
+        public void CanReAddKeys()
+        {
+            var dict = new Shared.WeakDictionary<string, object>();
+            var fred = new object();
+            dict.Add("fred", fred);
+            Assert.Equal(dict.All().Count(), 1);
+
+            fred = null;
+            GC.Collect();
+            Assert.Equal(dict.All().Count(), 0);
+
+            fred = new object();
+            dict.Add("fred", fred);
+            Assert.Equal(dict.All().Count(), 1);
+        }
+
+        [Fact]
+        public void CanHaveMultipleKeyValues()
+        {
+            var dict = new Shared.WeakDictionary<string, object>();
+            var obj = new object();
+            dict.Add("fred", obj);
+            dict.Add("jane", obj);
+            dict.Add("jim", obj);
+
+            var actual = dict.All().Select(pair => pair.Key);
+            Assert.Contains("fred", actual);
+            Assert.Contains("jane", actual);
+            Assert.Contains("jim", actual);
+            Assert.Equal(3, actual.Count());
+        }
+    }
+}


### PR DESCRIPTION
This commit is considered less than an MVP and is hoped to be useful to start a conversation

I noticed that #90 mentions metrics. I a part of a team (steeltoe.io) looking to increase the interaction between java spring and .net applications. As part of that, we would like to help with efforts to add metrics to Polly, and specifically output them in a feed consumable by Hystrix.

We have investigated how we believe to be a sensible starting point to add metrics to Polly (and specifically circuit breaker), and would like feedback on whether this is a good approach and interest from the team to have us continue with this work.

I include a sample image of the hystrix dashboard with success / failure counts and circuit open / closed streaming in.

![image](https://cloud.githubusercontent.com/assets/126285/18178354/04c37d34-704c-11e6-81f5-e0a65d27cb9f.png)

We would love to chat in any way you prefer (eg. hangout etc....) 
