### PR TITLE
Provide contextual execution support through base class, from v5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Discontinue .NET3.5 support
 - Provide .NET4.0 support uniquely through Polly.NET40Async package
+- Retire ContextualPolicy (not part of documented API; support now in Policy base class)
+- Add some missing ExecuteAndCapture/Async overloads
 
 ## 4.3.0
 

--- a/src/Polly.Shared/CircuitBreaker/CircuitBreakerPolicy.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitBreakerPolicy.cs
@@ -7,7 +7,7 @@ namespace Polly.CircuitBreaker
     /// <summary>
     /// A circuit-breaker policy that can be applied to delegates.
     /// </summary>
-    public partial class CircuitBreakerPolicy : ContextualPolicy
+    public partial class CircuitBreakerPolicy : Policy
     {
         private readonly ICircuitController<EmptyStruct> _breakerController;
 
@@ -56,7 +56,7 @@ namespace Polly.CircuitBreaker
     /// <summary>
     /// A circuit-breaker policy that can be applied to delegates returning a value of type <typeparam name="TResult"/>.
     /// </summary>
-    public partial class CircuitBreakerPolicy<TResult> : ContextualPolicy<TResult>
+    public partial class CircuitBreakerPolicy<TResult> : Policy<TResult>
     {
         private readonly ICircuitController<TResult> _breakerController;
 

--- a/src/Polly.Shared/ContextualPolicy.cs
+++ b/src/Polly.Shared/ContextualPolicy.cs
@@ -1,22 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 
 namespace Polly
 {
     /// <summary>
     /// Transient exception handling policies that can be applied to delegates.
-    /// These policies can be called with arbitrary context data.
     /// </summary>
-    public partial class ContextualPolicy : Policy
+    public partial class Policy
     {
-        internal ContextualPolicy(
-            Action<Action, Context> exceptionPolicy, 
-            IEnumerable<ExceptionPredicate> exceptionPredicates
-            ) : base(exceptionPolicy, exceptionPredicates)
-        {
-        }
-
         /// <summary>
         /// Executes the specified action within the policy.
         /// </summary>
@@ -26,9 +19,9 @@ namespace Polly
         [DebuggerStepThrough]
         public void Execute(Action action, IDictionary<string, object> contextData)
         {
-            if (contextData == null) throw new ArgumentNullException("contextData");
+            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
 
-            base.Execute(action, new Context(contextData));
+            Execute(action, new Context(contextData));
         }
 
         /// <summary>
@@ -41,11 +34,11 @@ namespace Polly
         [DebuggerStepThrough]
         public PolicyResult ExecuteAndCapture(Action action, IDictionary<string, object> contextData)
         {
-            if (contextData == null) throw new ArgumentNullException("contextData");
+            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
 
-            return base.ExecuteAndCapture(action, new Context(contextData));
+            return ExecuteAndCapture(action, new Context(contextData));
         }
-
+        
         /// <summary>
         /// Executes the specified action within the policy and returns the result.
         /// </summary>
@@ -60,9 +53,9 @@ namespace Polly
         [DebuggerStepThrough]
         public TResult Execute<TResult>(Func<TResult> action, IDictionary<string, object> contextData)
         {
-            if (contextData == null) throw new ArgumentNullException("contextData");
+            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
 
-            return base.Execute(action, new Context(contextData));
+            return Execute(action, new Context(contextData));
         }
 
         /// <summary>
@@ -75,26 +68,18 @@ namespace Polly
         [DebuggerStepThrough]
         public PolicyResult<TResult> ExecuteAndCapture<TResult>(Func<TResult> action, IDictionary<string, object> contextData)
         {
-            if (contextData == null) throw new ArgumentNullException("contextData");
+            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
 
-            return base.ExecuteAndCapture(action, new Context(contextData));
+            return ExecuteAndCapture(action, new Context(contextData));
         }
     }
 
     /// <summary>
-    /// Transient fault handling policies that can be applied to delegates returning results of type <typeparam name="TResult"/>
+    /// Transient fault handling policies that can be applied to delegates returning results of type <typeparamref name="TResult"/>
     /// These policies can be called with arbitrary context data.
     /// </summary>
-    public partial class ContextualPolicy<TResult> : Policy<TResult>
+    public partial class Policy<TResult>
     {
-        internal ContextualPolicy(
-            Func<Func<TResult>, Context, TResult> executionPolicy, 
-            IEnumerable<ExceptionPredicate> exceptionPredicates, 
-            IEnumerable<ResultPredicate<TResult>> resultPredicates
-            ) : base(executionPolicy, exceptionPredicates, resultPredicates)
-        {
-        }
-
         /// <summary>
         /// Executes the specified action within the policy and returns the result.
         /// </summary>
@@ -108,9 +93,9 @@ namespace Polly
         [DebuggerStepThrough]
         public TResult Execute(Func<TResult> action, IDictionary<string, object> contextData)
         {
-            if (contextData == null) throw new ArgumentNullException("contextData");
+            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
 
-            return base.Execute(action, new Context(contextData));
+            return Execute(action, new Context(contextData));
         }
 
         /// <summary>
@@ -123,9 +108,9 @@ namespace Polly
         [DebuggerStepThrough]
         public PolicyResult<TResult> ExecuteAndCapture(Func<TResult> action, IDictionary<string, object> contextData)
         {
-            if (contextData == null) throw new ArgumentNullException("contextData");
+            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
 
-            return base.ExecuteAndCapture(action, new Context(contextData));
+            return ExecuteAndCapture(action, new Context(contextData));
         }
     }
 }

--- a/src/Polly.Shared/ContextualPolicyAsync.cs
+++ b/src/Polly.Shared/ContextualPolicyAsync.cs
@@ -8,15 +8,8 @@ using System.Threading.Tasks;
 
 namespace Polly
 {
-    public partial class ContextualPolicy
+    public partial class Policy
     {
-        internal ContextualPolicy(
-            Func<Func<CancellationToken, Task>, Context, CancellationToken, bool, Task> asyncExceptionPolicy, 
-            IEnumerable<ExceptionPredicate> exceptionPredicates
-            ) : base(asyncExceptionPolicy, exceptionPredicates)
-        {
-        }
-
         /// <summary>
         ///     Executes the specified asynchronous action within the policy.
         /// </summary>
@@ -63,9 +56,9 @@ namespace Polly
         [DebuggerStepThrough]
         public Task ExecuteAsync(Func<CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
-            if (contextData == null) throw new ArgumentNullException("contextData");
+            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
 
-            return base.ExecuteAsync(action, new Context(contextData), cancellationToken, continueOnCapturedContext);
+            return ExecuteAsync(action, new Context(contextData), cancellationToken, continueOnCapturedContext);
         }
 
 
@@ -79,9 +72,9 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Task> action, IDictionary<string, object> contextData)
         {
-            if (contextData == null) throw new ArgumentNullException("contextData");
+            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
 
-            return base.ExecuteAndCaptureAsync(action, new Context(contextData));
+            return ExecuteAndCaptureAsync(action, new Context(contextData));
         }
 
         /// <summary>
@@ -95,9 +88,9 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Task> action, IDictionary<string, object> contextData, bool continueOnCapturedContext)
         {
-            if (contextData == null) throw new ArgumentNullException("contextData");
+            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
 
-            return base.ExecuteAndCaptureAsync(action, new Context(contextData), continueOnCapturedContext);
+            return ExecuteAndCaptureAsync(action, new Context(contextData), continueOnCapturedContext);
         }
         /// <summary>
         ///     Executes the specified asynchronous action within the policy and returns the captured result.
@@ -110,9 +103,9 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult> ExecuteAndCaptureAsync(Func<CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken)
         {
-            if (contextData == null) throw new ArgumentNullException("contextData");
+            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
 
-            return base.ExecuteAndCaptureAsync(action, new Context(contextData), cancellationToken);
+            return ExecuteAndCaptureAsync(action, new Context(contextData), cancellationToken);
         }
 
         /// <summary>
@@ -127,9 +120,9 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult> ExecuteAndCaptureAsync(Func<CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
-            if (contextData == null) throw new ArgumentNullException("contextData");
+            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
 
-            return base.ExecuteAndCaptureAsync(action, new Context(contextData), cancellationToken,
+            return ExecuteAndCaptureAsync(action, new Context(contextData), cancellationToken,
                 continueOnCapturedContext);
         }
 
@@ -183,9 +176,9 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
-            if (contextData == null) throw new ArgumentNullException("contextData");
+            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
 
-            return base.ExecuteAsync(action, new Context(contextData), cancellationToken, continueOnCapturedContext);
+            return ExecuteAsync(action, new Context(contextData), cancellationToken, continueOnCapturedContext);
         }
 
         /// <summary>
@@ -199,9 +192,9 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Task<TResult>> action, IDictionary<string, object> contextData)
         {
-            if (contextData == null) throw new ArgumentNullException("contextData");
+            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
 
-            return base.ExecuteAndCaptureAsync(action, new Context(contextData));
+            return ExecuteAndCaptureAsync(action, new Context(contextData));
         }
 
         /// <summary>
@@ -214,11 +207,11 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">contextData</exception>
         /// <returns>The captured result</returns>
         [DebuggerStepThrough]
-        protected Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Task<TResult>> action, IDictionary<string, object> contextData, bool continueOnCapturedContext)
+        public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Task<TResult>> action, IDictionary<string, object> contextData, bool continueOnCapturedContext)
         {
-            if (contextData == null) throw new ArgumentNullException("contextData");
+            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
 
-            return base.ExecuteAndCaptureAsync(action, new Context(contextData), continueOnCapturedContext);
+            return ExecuteAndCaptureAsync(action, new Context(contextData), continueOnCapturedContext);
         }
 
         /// <summary>
@@ -231,11 +224,11 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">contextData</exception>
         /// <returns>The captured result</returns>
         [DebuggerStepThrough]
-        public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken)
+        public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken)
         {
-            if (contextData == null) throw new ArgumentNullException("contextData");
+            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
 
-            return base.ExecuteAndCaptureAsync(action, new Context(contextData), cancellationToken);
+            return ExecuteAndCaptureAsync(action, new Context(contextData), cancellationToken, false);
         }
 
         /// <summary>
@@ -251,22 +244,14 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
-            if (contextData == null) throw new ArgumentNullException("contextData");
+            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
 
-            return base.ExecuteAndCaptureAsync(action, new Context(contextData), cancellationToken, continueOnCapturedContext);
+            return ExecuteAndCaptureAsync(action, new Context(contextData), cancellationToken, continueOnCapturedContext);
         }
     }
 
-    public partial class ContextualPolicy<TResult>
+    public partial class Policy<TResult>
     {
-        internal ContextualPolicy(
-            Func<Func<CancellationToken, Task<TResult>>, Context, CancellationToken, bool, Task<TResult>> asyncExecutionPolicy, 
-            IEnumerable<ExceptionPredicate> exceptionPredicates, 
-            IEnumerable<ResultPredicate<TResult>> resultPredicates
-            ) : base(asyncExecutionPolicy, exceptionPredicates, resultPredicates)
-        {
-        }
-
         /// <summary>
         ///     Executes the specified asynchronous action within the policy and returns the result.
         /// </summary>
@@ -317,9 +302,9 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<TResult> ExecuteAsync(Func<CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
-            if (contextData == null) throw new ArgumentNullException("contextData");
+            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
 
-            return base.ExecuteAsync(action, new Context(contextData), cancellationToken, continueOnCapturedContext);
+            return ExecuteAsync(action, new Context(contextData), cancellationToken, continueOnCapturedContext);
         }
 
         /// <summary>
@@ -332,9 +317,9 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Task<TResult>> action, IDictionary<string, object> contextData)
         {
-            if (contextData == null) throw new ArgumentNullException("contextData");
+            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
 
-            return base.ExecuteAndCaptureAsync(action, new Context(contextData));
+            return ExecuteAndCaptureAsync(action, new Context(contextData));
         }
 
         /// <summary>
@@ -346,11 +331,11 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">contextData</exception>
         /// <returns>The captured result</returns>
         [DebuggerStepThrough]
-        protected Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Task<TResult>> action, IDictionary<string, object> contextData, bool continueOnCapturedContext)
+        public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Task<TResult>> action, IDictionary<string, object> contextData, bool continueOnCapturedContext)
         {
-            if (contextData == null) throw new ArgumentNullException("contextData");
+            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
 
-            return base.ExecuteAndCaptureAsync(action, new Context(contextData), continueOnCapturedContext);
+            return ExecuteAndCaptureAsync(action, new Context(contextData), continueOnCapturedContext);
         }
 
         /// <summary>
@@ -362,11 +347,11 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">contextData</exception>
         /// <returns>The captured result</returns>
         [DebuggerStepThrough]
-        public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken)
+        public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken)
         {
-            if (contextData == null) throw new ArgumentNullException("contextData");
+            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
 
-            return base.ExecuteAndCaptureAsync(action, new Context(contextData), cancellationToken);
+            return ExecuteAndCaptureAsync(action, new Context(contextData), cancellationToken, false);
         }
 
         /// <summary>
@@ -381,9 +366,9 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
-            if (contextData == null) throw new ArgumentNullException("contextData");
+            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
 
-            return base.ExecuteAndCaptureAsync(action, new Context(contextData), cancellationToken, continueOnCapturedContext);
+            return ExecuteAndCaptureAsync(action, new Context(contextData), cancellationToken, continueOnCapturedContext);
         }
     }
 

--- a/src/Polly.Shared/PolicyAsync.cs
+++ b/src/Polly.Shared/PolicyAsync.cs
@@ -1,6 +1,4 @@
-﻿
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -12,15 +10,6 @@ namespace Polly
     public partial class Policy
     {
         private readonly Func<Func<CancellationToken, Task>, Context, CancellationToken, bool, Task> _asyncExceptionPolicy;
-
-        internal Policy(
-            Func<Func<CancellationToken, Task>, CancellationToken, bool, Task> asyncExceptionPolicy, 
-            IEnumerable<ExceptionPredicate> exceptionPredicates
-            ) : this(
-                (action, context, cancellationToken, continueOnCapturedContext) => asyncExceptionPolicy(action, cancellationToken, continueOnCapturedContext), 
-                exceptionPredicates
-                )
-        { }
 
         internal Policy(
             Func<Func<CancellationToken, Task>, Context, CancellationToken, bool, Task> asyncExceptionPolicy, 
@@ -144,6 +133,17 @@ namespace Polly
         ///     Executes the specified asynchronous action within the policy and returns the captured result.
         /// </summary>
         /// <param name="action">The action to perform.</param>
+        /// <returns>The captured result</returns>
+        [DebuggerStepThrough]
+        public Task<PolicyResult> ExecuteAndCaptureAsync(Func<CancellationToken, Task> action)
+        {
+            return ExecuteAndCaptureAsync(action, Context.Empty, false);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the captured result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
         /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
         /// <returns>The captured result</returns>
         [DebuggerStepThrough]
@@ -175,6 +175,19 @@ namespace Polly
         protected Task<PolicyResult> ExecuteAndCaptureAsync(Func<Task> action, Context context, bool continueOnCapturedContext)
         {
             return ExecuteAndCaptureAsync(ct => action(), context, CancellationToken.None, continueOnCapturedContext);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the captured result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <returns>The captured result</returns>
+        [DebuggerStepThrough]
+        protected Task<PolicyResult> ExecuteAndCaptureAsync(Func<CancellationToken, Task> action, Context context, bool continueOnCapturedContext)
+        {
+            return ExecuteAndCaptureAsync(action, context, CancellationToken.None, continueOnCapturedContext);
         }
 
         /// <summary>
@@ -268,6 +281,19 @@ namespace Polly
         /// </summary>
         /// <typeparam name="TResult">The type of the result.</typeparam>
         /// <param name="action">The action to perform.</param>
+        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
+        /// <returns>The value returned by the action</returns>
+        [DebuggerStepThrough]
+        protected Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, Context context)
+        {
+            return ExecuteAsync(action, context, false);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="action">The action to perform.</param>
         /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
         /// <returns>The value returned by the action</returns>
         [DebuggerStepThrough]
@@ -315,6 +341,20 @@ namespace Polly
         protected Task<TResult> ExecuteAsync<TResult>(Func<Task<TResult>> action, Context context, bool continueOnCapturedContext)
         {
             return ExecuteAsync(ct => action(), context, CancellationToken.None, continueOnCapturedContext);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <returns>The value returned by the action</returns>
+        [DebuggerStepThrough]
+        protected Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, Context context, bool continueOnCapturedContext)
+        {
+            return ExecuteAsync(action, context, CancellationToken.None, continueOnCapturedContext);
         }
 
         /// <summary>
@@ -374,6 +414,18 @@ namespace Polly
         /// </summary>
         /// <typeparam name="TResult">The type of the result.</typeparam>
         /// <param name="action">The action to perform.</param>
+        /// <returns>The captured result</returns>
+        [DebuggerStepThrough]
+        public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<CancellationToken, Task<TResult>> action)
+        {
+            return ExecuteAndCaptureAsync(action, Context.Empty, false);
+        }
+
+        /// <summary>
+        /// Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="action">The action to perform.</param>
         /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
         /// <returns>The captured result</returns>
         [DebuggerStepThrough]
@@ -410,6 +462,20 @@ namespace Polly
         }
 
         /// <summary>
+        /// Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <returns>The captured result</returns>
+        [DebuggerStepThrough]
+        protected Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<CancellationToken, Task<TResult>> action, Context context, bool continueOnCapturedContext)
+        {
+            return ExecuteAndCaptureAsync(action, context, CancellationToken.None, continueOnCapturedContext);
+        }
+
+        /// <summary>
         ///     Executes the specified asynchronous action within the policy and returns the result.
         /// </summary>
         /// <typeparam name="TResult">The type of the result.</typeparam>
@@ -420,6 +486,33 @@ namespace Polly
         public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Task<TResult>> action, CancellationToken cancellationToken)
         {
             return ExecuteAndCaptureAsync(ct => action(), Context.Empty, cancellationToken, false);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+        /// <returns>The captured result</returns>
+        [DebuggerStepThrough]
+        public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken)
+        {
+            return ExecuteAndCaptureAsync(action, Context.Empty, cancellationToken, false);
+        }
+
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+        /// <returns>The captured result</returns>
+        [DebuggerStepThrough]
+        protected Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<CancellationToken, Task<TResult>> action, Context context)
+        {
+            return ExecuteAndCaptureAsync(action, context, CancellationToken.None, false);
         }
 
         /// <summary>
@@ -490,16 +583,6 @@ namespace Polly
         private readonly Func<Func<CancellationToken, Task<TResult>>, Context, CancellationToken, bool, Task<TResult>> _asyncExecutionPolicy;
 
         internal Policy(
-            Func<Func<CancellationToken, Task<TResult>>, CancellationToken, bool, Task<TResult>> asyncExceptionPolicy, 
-            IEnumerable<ExceptionPredicate> exceptionPredicates, 
-            IEnumerable<ResultPredicate<TResult>> resultPredicates
-            ) : this(
-                (action, context, cancellationToken, continueOnCapturedContext) => asyncExceptionPolicy(action, cancellationToken, continueOnCapturedContext),
-                exceptionPredicates, 
-                resultPredicates)
-        { }
-
-        internal Policy(
             Func<Func<CancellationToken, Task<TResult>>, Context, CancellationToken, bool, Task<TResult>> asyncExecutionPolicy, 
             IEnumerable<ExceptionPredicate> exceptionPredicates, 
             IEnumerable<ResultPredicate<TResult>> resultPredicates)
@@ -526,10 +609,33 @@ namespace Polly
         ///     Executes the specified asynchronous action within the policy and returns the result.
         /// </summary>
         /// <param name="action">The action to perform.</param>
+        /// <returns>The value returned by the action</returns>
+        [DebuggerStepThrough]
+        public Task<TResult> ExecuteAsync(Func<CancellationToken, Task<TResult>> action)
+        {
+            return ExecuteAsync(action, Context.Empty, false);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
         /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
         /// <returns>The value returned by the action</returns>
         [DebuggerStepThrough]
         protected Task<TResult> ExecuteAsync(Func<Task<TResult>> action, Context context)
+        {
+            return ExecuteAsync(action, context, false);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
+        /// <returns>The value returned by the action</returns>
+        [DebuggerStepThrough]
+        protected Task<TResult> ExecuteAsync(Func<CancellationToken, Task<TResult>> action, Context context)
         {
             return ExecuteAsync(action, context, false);
         }
@@ -575,6 +681,18 @@ namespace Polly
         ///     Executes the specified asynchronous action within the policy and returns the result.
         /// </summary>
         /// <param name="action">The action to perform.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <returns>The value returned by the action</returns>
+        [DebuggerStepThrough]
+        public Task<TResult> ExecuteAsync(Func<CancellationToken, Task<TResult>> action, bool continueOnCapturedContext)
+        {
+            return ExecuteAsync(action, Context.Empty, CancellationToken.None, continueOnCapturedContext);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
         /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
         /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
         /// <returns>The value returned by the action</returns>
@@ -582,6 +700,19 @@ namespace Polly
         protected Task<TResult> ExecuteAsync(Func<Task<TResult>> action, Context context, bool continueOnCapturedContext)
         {
             return ExecuteAsync(ct => action(), context, CancellationToken.None, continueOnCapturedContext);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <returns>The value returned by the action</returns>
+        [DebuggerStepThrough]
+        protected Task<TResult> ExecuteAsync(Func<CancellationToken, Task<TResult>> action, Context context, bool continueOnCapturedContext)
+        {
+            return ExecuteAsync(action, context, CancellationToken.None, continueOnCapturedContext);
         }
 
         /// <summary>
@@ -637,6 +768,17 @@ namespace Polly
         /// Executes the specified asynchronous action within the policy and returns the result.
         /// </summary>
         /// <param name="action">The action to perform.</param>
+        /// <returns>The captured result</returns>
+        [DebuggerStepThrough]
+        public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<CancellationToken, Task<TResult>> action)
+        {
+            return ExecuteAndCaptureAsync(action, Context.Empty, false);
+        }
+
+        /// <summary>
+        /// Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
         /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
         /// <returns>The captured result</returns>
         [DebuggerStepThrough]
@@ -671,6 +813,19 @@ namespace Polly
         }
 
         /// <summary>
+        /// Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <returns>The captured result</returns>
+        [DebuggerStepThrough]
+        protected Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<CancellationToken, Task<TResult>> action, Context context, bool continueOnCapturedContext)
+        {
+            return ExecuteAndCaptureAsync(action, context, CancellationToken.None, continueOnCapturedContext);
+        }
+
+        /// <summary>
         ///     Executes the specified asynchronous action within the policy and returns the result.
         /// </summary>
         /// <param name="action">The action to perform.</param>
@@ -686,6 +841,18 @@ namespace Polly
         ///     Executes the specified asynchronous action within the policy and returns the result.
         /// </summary>
         /// <param name="action">The action to perform.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+        /// <returns>The captured result</returns>
+        [DebuggerStepThrough]
+        public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken)
+        {
+            return ExecuteAndCaptureAsync(action, Context.Empty, cancellationToken, false);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
         /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
         /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
         /// <returns>The captured result</returns>
@@ -693,6 +860,19 @@ namespace Polly
         protected Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Task<TResult>> action, Context context, CancellationToken cancellationToken)
         {
             return ExecuteAndCaptureAsync(ct => action(), context, cancellationToken, false);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+        /// <returns>The captured result</returns>
+        [DebuggerStepThrough]
+        protected Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken)
+        {
+            return ExecuteAndCaptureAsync(action, context, cancellationToken, false);
         }
 
         /// <summary>
@@ -748,4 +928,3 @@ namespace Polly
     }
 
 }
-

--- a/src/Polly.Shared/Retry/RetryPolicy.cs
+++ b/src/Polly.Shared/Retry/RetryPolicy.cs
@@ -6,7 +6,7 @@ namespace Polly.Retry
     /// <summary>
     /// A retry policy that can be applied to delegates.
     /// </summary>
-    public partial class RetryPolicy : ContextualPolicy
+    public partial class RetryPolicy : Policy
     {
         internal RetryPolicy(Action<Action, Context> exceptionPolicy, IEnumerable<ExceptionPredicate> exceptionPredicates) 
             : base(exceptionPolicy, exceptionPredicates)
@@ -17,7 +17,7 @@ namespace Polly.Retry
     /// <summary>
     /// A retry policy that can be applied to delegates returning a value of type <typeparam name="TResult"/>.
     /// </summary>
-    public partial class RetryPolicy<TResult> : ContextualPolicy<TResult>
+    public partial class RetryPolicy<TResult> : Policy<TResult>
     {
         internal RetryPolicy(
             Func<Func<TResult>, Context, TResult> executionPolicy,

--- a/src/Polly.SharedSpecs/ContextualPolicyAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/ContextualPolicyAsyncSpecs.cs
@@ -9,42 +9,11 @@ namespace Polly.Specs
 {
     public class ContextualPolicyAsyncSpecs
     {
-        [Fact]
-        public async Task Executing_the_policy_action_should_execute_the_specified_async_action()
-        {
-            bool executed = false;
-
-            ContextualPolicy policy = Policy
-                .Handle<DivideByZeroException>()
-                .RetryAsync((_, __, ___) => { });
-
-            await policy.ExecuteAsync(() =>
-            {
-                executed = true;
-                return Task.FromResult(true) as Task;
-            });
-
-            executed.Should()
-                .BeTrue();
-        }
-
-        [Fact]
-        public async Task Executing_the_policy_function_should_execute_the_specified_async_function_and_return_the_result()
-        {
-            ContextualPolicy policy = Policy
-                .Handle<DivideByZeroException>()
-                .RetryAsync((_, __, ___) => { });
-
-            int result = await policy.ExecuteAsync(() => Task.FromResult(2));
-
-            result.Should()
-                .Be(2);
-        }
 
         [Fact]
         public void Executing_the_policy_action_should_throw_when_context_data_is_null()
         {
-            ContextualPolicy policy = Policy
+            Policy policy = Policy
                 .Handle<DivideByZeroException>()
                 .RetryAsync((_, __, ___) => { });
 
@@ -56,7 +25,7 @@ namespace Polly.Specs
         [Fact]
         public void Executing_the_policy_function_should_throw_when_context_data_is_null()
         {
-            ContextualPolicy policy = Policy
+            Policy policy = Policy
                 .Handle<DivideByZeroException>()
                 .RetryAsync((_, __, ___) => { });
 
@@ -68,7 +37,7 @@ namespace Polly.Specs
         [Fact]
         public void Execute_and_capturing_the_policy_action_should_throw_when_context_data_is_null()
         {
-            ContextualPolicy policy = Policy
+            Policy policy = Policy
                 .Handle<DivideByZeroException>()
                 .RetryAsync((_, __, ___) => { });
 
@@ -80,7 +49,7 @@ namespace Polly.Specs
         [Fact]
         public void Execute_and_capturing_the_policy_function_should_throw_when_context_data_is_null()
         {
-            ContextualPolicy policy = Policy
+            Policy policy = Policy
                 .Handle<DivideByZeroException>()
                 .RetryAsync((_, __, ___) => { });
 

--- a/src/Polly.SharedSpecs/ContextualPolicySpecs.cs
+++ b/src/Polly.SharedSpecs/ContextualPolicySpecs.cs
@@ -6,38 +6,11 @@ namespace Polly.Specs
 {
     public class ContextualPolicySpecs
     {
-        [Fact]
-        public void Executing_the_policy_action_should_execute_the_specified_action()
-        {
-            var executed = false;
-
-            ContextualPolicy policy = Policy
-                          .Handle<DivideByZeroException>()
-                          .Retry((_, __, ___) => { });
-
-            policy.Execute(() => executed = true);
-
-            executed.Should()
-                    .BeTrue();
-        } 
-
-        [Fact]
-        public void Executing_the_policy_function_should_execute_the_specified_function_and_return_the_result()
-        {
-            ContextualPolicy policy = Policy
-                          .Handle<DivideByZeroException>()
-                          .Retry((_, __, ___) => { });
-
-            var result = policy.Execute(() => 2);
-
-            result.Should()
-                  .Be(2);
-        } 
 
         [Fact]
         public void Executing_the_policy_action_should_throw_when_context_data_is_null()
         {
-            ContextualPolicy policy = Policy
+            Policy policy = Policy
                 .Handle<DivideByZeroException>()
                 .Retry((_, __, ___) => { });
 
@@ -49,7 +22,7 @@ namespace Polly.Specs
         [Fact]
         public void Execute_and_capturing_the_policy_action_should_throw_when_context_data_is_null()
         {
-            ContextualPolicy policy = Policy
+            Policy policy = Policy
                 .Handle<DivideByZeroException>()
                 .Retry((_, __, ___) => { });
 
@@ -61,7 +34,7 @@ namespace Polly.Specs
         [Fact]
         public void Executing_the_policy_function_should_throw_when_context_data_is_null()
         {
-            ContextualPolicy policy = Policy
+            Policy policy = Policy
                 .Handle<DivideByZeroException>()
                 .Retry((_, __, ___) => { });
 
@@ -73,7 +46,7 @@ namespace Polly.Specs
         [Fact]
         public void Execute_and_capturing_the_policy_function_should_throw_when_context_data_is_null()
         {
-            ContextualPolicy policy = Policy
+            Policy policy = Policy
                 .Handle<DivideByZeroException>()
                 .Retry((_, __, ___) => { });
 

--- a/src/Polly.SharedSpecs/Helpers/ContextualPolicyExtensions.cs
+++ b/src/Polly.SharedSpecs/Helpers/ContextualPolicyExtensions.cs
@@ -5,39 +5,8 @@ namespace Polly.Specs.Helpers
 {
     public static class ContextualPolicyExtensions
     {
-        public static void RaiseException<TException>(this ContextualPolicy policy,
-                   int numberOfTimesToRaiseException,
-                   Action<TException, int> configureException = null) where TException : Exception, new()
-        {
-            int counter = 0;
-
-            policy.Execute(() =>
-            {
-                if (counter < numberOfTimesToRaiseException)
-                {
-                    counter++;
-
-                    var exception = new TException();
-
-                    if (configureException != null)
-                    {
-                        configureException(exception, counter);
-                    }
-
-                    throw exception;
-                }
-            });
-        }
-
-        public static void RaiseException<TException>(
-            this ContextualPolicy policy,
-            Action<TException, int> configureException = null) where TException : Exception, new()
-        {
-            policy.RaiseException(1, configureException);
-        }
-
-        public static void RaiseException<TException>(this ContextualPolicy policy, 
-            int numberOfTimesToRaiseException, 
+        public static void RaiseException<TException>(this Policy policy,
+            int numberOfTimesToRaiseException,
             IDictionary<string, object> contextData,
             Action<TException, int> configureException = null) where TException : Exception, new()
         {
@@ -50,7 +19,7 @@ namespace Polly.Specs.Helpers
                     counter++;
 
                     var exception = new TException();
-                    
+
                     if (configureException != null)
                     {
                         configureException(exception, counter);
@@ -62,12 +31,12 @@ namespace Polly.Specs.Helpers
         }
 
         public static void RaiseException<TException>(
-            this ContextualPolicy policy,
+            this Policy policy,
             IDictionary<string, object> contextData,
             Action<TException, int> configureException = null) where TException : Exception, new()
         {
             policy.RaiseException(1, contextData, configureException);
         }
-        
+
     }
 }

--- a/src/Polly.SharedSpecs/Helpers/ContextualPolicyExtensionsAsync.cs
+++ b/src/Polly.SharedSpecs/Helpers/ContextualPolicyExtensionsAsync.cs
@@ -8,7 +8,7 @@ namespace Polly.Specs.Helpers
     public static class ContextualPolicyExtensionsAsync
     {
 
-        public static Task RaiseExceptionAsync<TException>(this ContextualPolicy policy, int numberOfTimesToRaiseException, IDictionary<string, object> contextData, Action<TException, int> configureException = null, CancellationToken cancellationToken = default(CancellationToken)) where TException : Exception, new()
+        public static Task RaiseExceptionAsync<TException>(this Policy policy, int numberOfTimesToRaiseException, IDictionary<string, object> contextData, Action<TException, int> configureException = null, CancellationToken cancellationToken = default(CancellationToken)) where TException : Exception, new()
         {
             int counter = 0;
 
@@ -31,7 +31,7 @@ namespace Polly.Specs.Helpers
             }, contextData, cancellationToken);
         }
 
-        public static Task RaiseExceptionAsync<TException>(this ContextualPolicy policy, IDictionary<string, object> contextData, Action<TException, int> configureException = null, CancellationToken cancellationToken = default(CancellationToken)) where TException : Exception, new()
+        public static Task RaiseExceptionAsync<TException>(this Policy policy, IDictionary<string, object> contextData, Action<TException, int> configureException = null, CancellationToken cancellationToken = default(CancellationToken)) where TException : Exception, new()
         {
             return policy.RaiseExceptionAsync(1, contextData, configureException, cancellationToken);
         }

--- a/src/Polly.SharedSpecs/Helpers/ContextualPolicyTResultExtensions.cs
+++ b/src/Polly.SharedSpecs/Helpers/ContextualPolicyTResultExtensions.cs
@@ -6,14 +6,14 @@ namespace Polly.Specs.Helpers
 {
     public static class ContextualPolicyTResultExtensions
     {
-        public static TResult RaiseResultSequence<TResult>(this ContextualPolicy<TResult> policy,
+        public static TResult RaiseResultSequence<TResult>(this Policy<TResult> policy,
             IDictionary<string, object> contextData,
             params TResult[] resultsToRaise)
         {
             return policy.RaiseResultSequence(contextData, resultsToRaise.ToList());
         }
 
-        public static TResult RaiseResultSequence<TResult>(this ContextualPolicy<TResult> policy,
+        public static TResult RaiseResultSequence<TResult>(this Policy<TResult> policy,
             IDictionary<string, object> contextData,
             IEnumerable<TResult> resultsToRaise)
         {
@@ -30,14 +30,14 @@ namespace Polly.Specs.Helpers
             }, contextData);
         }
 
-        public static PolicyResult<TResult> RaiseResultSequenceOnExecuteAndCapture<TResult>(this ContextualPolicy<TResult> policy,
+        public static PolicyResult<TResult> RaiseResultSequenceOnExecuteAndCapture<TResult>(this Policy<TResult> policy,
           IDictionary<string, object> contextData,
           params TResult[] resultsToRaise)
         {
             return policy.RaiseResultSequenceOnExecuteAndCapture(contextData, resultsToRaise.ToList());
         }
 
-        public static PolicyResult<TResult> RaiseResultSequenceOnExecuteAndCapture<TResult>(this ContextualPolicy<TResult> policy,
+        public static PolicyResult<TResult> RaiseResultSequenceOnExecuteAndCapture<TResult>(this Policy<TResult> policy,
             IDictionary<string, object> contextData,
             IEnumerable<TResult> resultsToRaise)
         {

--- a/src/Polly.SharedSpecs/Helpers/ContextualPolicyTResultExtensionsAsync.cs
+++ b/src/Polly.SharedSpecs/Helpers/ContextualPolicyTResultExtensionsAsync.cs
@@ -10,14 +10,14 @@ namespace Polly.Specs.Helpers
     public static class ContextualPolicyTResultExtensionsAsync
     {
 
-        public static Task<TResult> RaiseResultSequenceAsync<TResult>(this ContextualPolicy<TResult> policy,
+        public static Task<TResult> RaiseResultSequenceAsync<TResult>(this Policy<TResult> policy,
     IDictionary<string, object> contextData,
     params TResult[] resultsToRaise)
         {
             return policy.RaiseResultSequenceAsync(contextData, CancellationToken.None, resultsToRaise.ToList());
         }
 
-        public static Task<TResult> RaiseResultSequenceAsync<TResult>(this ContextualPolicy<TResult> policy, IDictionary<string, object> contextData, CancellationToken cancellationToken, IEnumerable<TResult> resultsToRaise)
+        public static Task<TResult> RaiseResultSequenceAsync<TResult>(this Policy<TResult> policy, IDictionary<string, object> contextData, CancellationToken cancellationToken, IEnumerable<TResult> resultsToRaise)
         {
             var enumerator = resultsToRaise.GetEnumerator();
 
@@ -32,12 +32,12 @@ namespace Polly.Specs.Helpers
             }, contextData, cancellationToken);
         }
 
-        public static Task<PolicyResult<TResult>> RaiseResultSequenceOnExecuteAndCaptureAsync<TResult>(this ContextualPolicy<TResult> policy, IDictionary<string, object> contextData, params TResult[] resultsToRaise)
+        public static Task<PolicyResult<TResult>> RaiseResultSequenceOnExecuteAndCaptureAsync<TResult>(this Policy<TResult> policy, IDictionary<string, object> contextData, params TResult[] resultsToRaise)
         {
             return policy.RaiseResultSequenceOnExecuteAndCaptureAsync(contextData, resultsToRaise.ToList());
         }
 
-        public static Task<PolicyResult<TResult>> RaiseResultSequenceOnExecuteAndCaptureAsync<TResult>(this ContextualPolicy<TResult> policy, IDictionary<string, object> contextData, IEnumerable<TResult> resultsToRaise)
+        public static Task<PolicyResult<TResult>> RaiseResultSequenceOnExecuteAndCaptureAsync<TResult>(this Policy<TResult> policy, IDictionary<string, object> contextData, IEnumerable<TResult> resultsToRaise)
         {
             var enumerator = resultsToRaise.GetEnumerator();
 

--- a/src/Polly.SharedSpecs/Helpers/PolicyExtensionsAsync.cs
+++ b/src/Polly.SharedSpecs/Helpers/PolicyExtensionsAsync.cs
@@ -83,20 +83,11 @@ namespace Polly.Specs.Helpers
         {
             return (Func<Task>)(() => action(policy));
         }
-
-        public static Func<Task> Awaiting(this ContextualPolicy policy, Func<ContextualPolicy, Task> action)
-        {
-            return (Func<Task>)(() => action(policy));
-        }
-
+        
         public static Func<Task<TResult>> Awaiting<TResult>(this Policy<TResult> policy, Func<Policy<TResult>, Task<TResult>> action)
         {
             return (Func<Task<TResult>>)(() => action(policy));
         }
-
-        public static Func<Task<TResult>> Awaiting<TResult>(this ContextualPolicy<TResult> policy, Func<ContextualPolicy<TResult>, Task<TResult>> action)
-        {
-            return (Func<Task<TResult>>)(() => action(policy));
-        }
+        
     }
 }

--- a/src/Polly.SharedSpecs/RetryAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/RetryAsyncSpecs.cs
@@ -233,7 +233,7 @@ namespace Polly.Specs
         {
             IDictionary<string, object> contextData = null;
 
-            ContextualPolicy policy = Policy
+            Policy policy = Policy
                 .Handle<DivideByZeroException>()
                 .RetryAsync((_, __, context) => contextData = context);
 
@@ -251,7 +251,7 @@ namespace Polly.Specs
         {
             IDictionary<string, object> contextData = null;
 
-            ContextualPolicy policy = Policy
+            Policy policy = Policy
                 .Handle<DivideByZeroException>()
                 .RetryAsync((_, __, context) => contextData = context);
 
@@ -269,7 +269,7 @@ namespace Polly.Specs
         {
             Context capturedContext = null;
 
-            ContextualPolicy policy = Policy
+            Policy policy = Policy
                 .Handle<DivideByZeroException>()
                 .RetryAsync((_, __, context) => capturedContext = context);
 

--- a/src/Polly.SharedSpecs/RetryForeverAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/RetryForeverAsyncSpecs.cs
@@ -129,7 +129,7 @@ namespace Polly.Specs
         {
             IDictionary<string, object> contextData = null;
 
-            ContextualPolicy policy = Policy
+            Policy policy = Policy
                 .Handle<DivideByZeroException>()
                 .RetryForeverAsync((_, context) => contextData = context);
 
@@ -147,7 +147,7 @@ namespace Polly.Specs
         {
             Context capturedContext = null;
 
-            ContextualPolicy policy = Policy
+            Policy policy = Policy
                 .Handle<DivideByZeroException>()
                 .RetryForeverAsync((_, context) => capturedContext = context);
 
@@ -162,7 +162,7 @@ namespace Polly.Specs
         {
             string contextValue = null;
 
-            ContextualPolicy policy = Policy
+            Policy policy = Policy
                 .Handle<DivideByZeroException>()
                 .RetryForeverAsync((_, context) => contextValue = context["key"].ToString());
 

--- a/src/Polly.SharedSpecs/RetrySpecs.cs
+++ b/src/Polly.SharedSpecs/RetrySpecs.cs
@@ -300,7 +300,7 @@ namespace Polly.Specs
         {
             IDictionary<string, object> contextData = null;
 
-            ContextualPolicy policy = Policy
+            Policy policy = Policy
                 .Handle<DivideByZeroException>()
                 .Retry((_, __, context) => contextData = context);
 
@@ -318,7 +318,7 @@ namespace Polly.Specs
         {
             IDictionary<string, object> contextData = null;
 
-            ContextualPolicy policy = Policy
+            Policy policy = Policy
                 .Handle<DivideByZeroException>()
                 .Retry((_, __, context) => contextData = context);
 
@@ -336,7 +336,7 @@ namespace Polly.Specs
         {
             Context capturedContext = null;
 
-            ContextualPolicy policy = Policy
+            Policy policy = Policy
                 .Handle<DivideByZeroException>()
                 .Retry((_, __, context) => capturedContext = context);
 
@@ -351,7 +351,7 @@ namespace Polly.Specs
         {
             string contextValue = null;
 
-            ContextualPolicy policy = Policy
+            Policy policy = Policy
                 .Handle<DivideByZeroException>()
                 .Retry((_, __, context) => contextValue = context["key"].ToString());
 
@@ -373,7 +373,7 @@ namespace Polly.Specs
         {
             string contextValue = null;
 
-            ContextualPolicy policy = Policy
+            Policy policy = Policy
                 .Handle<DivideByZeroException>()
                 .Retry((_, __, context) => contextValue = context["key"].ToString());
 

--- a/src/Polly.SharedSpecs/WaitAndRetryAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/WaitAndRetryAsyncSpecs.cs
@@ -430,7 +430,7 @@ namespace Polly.Specs
         {
             IDictionary<string, object> contextData = null;
 
-            ContextualPolicy policy = Policy
+            Policy policy = Policy
                 .Handle<DivideByZeroException>()
                 .WaitAndRetryAsync(new[]
                 {
@@ -453,7 +453,7 @@ namespace Polly.Specs
         {
             Context capturedContext = null;
 
-            ContextualPolicy policy = Policy
+            Policy policy = Policy
                 .Handle<DivideByZeroException>()
                 .WaitAndRetryAsync(new[]
                 {
@@ -472,7 +472,7 @@ namespace Polly.Specs
         {
             string contextValue = null;
 
-            ContextualPolicy policy = Policy
+            Policy policy = Policy
                 .Handle<DivideByZeroException>()
                 .WaitAndRetryAsync(new[]
                 {

--- a/src/Polly.SharedSpecs/WaitAndRetrySpecs.cs
+++ b/src/Polly.SharedSpecs/WaitAndRetrySpecs.cs
@@ -727,7 +727,7 @@ namespace Polly.Specs
 
             Action<Exception, TimeSpan, Context> onRetry = (_, __, ___) => { retryInvoked = true; };
 
-            ContextualPolicy policy = Policy
+            Policy policy = Policy
                 .Handle<DivideByZeroException>()
                 .WaitAndRetry(0, retryAttempt => TimeSpan.FromSeconds(1), onRetry);
 
@@ -744,7 +744,7 @@ namespace Polly.Specs
 
             Action<Exception, TimeSpan, int, Context> onRetry = (_, __, ___, ____) => { retryInvoked = true; };
 
-            ContextualPolicy policy = Policy
+            Policy policy = Policy
                 .Handle<DivideByZeroException>()
                 .WaitAndRetry(0, retryAttempt => TimeSpan.FromSeconds(1), onRetry);
 


### PR DESCRIPTION
Remove `ContextualPolicy` class for v5.0 onwards.  Support for execution with context will now be provided via the `Policy` base class.  From Polly v5.0, all executions will be contextual, to carry execution keys and allow binding together of policies via the `PolicyWrap`.  

This will constitute a (minor/edge-case) breaking change to enable v5.0 functionality.  The `ContextualPolicy` class is currently public but has never been part of the publicly-quoted API.  It will be removed.  All existing functionality continues to be supported: any user who has coded using the non-publicly-described `ContextualPolicy` class will be able to replace with `Policy`.

Add some missing ExecuteAndCapture/Async overloads.