### PR TITLE
Add Cancellation support for sync executions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Provide .NET4.0 support uniquely through Polly.NET40Async package
 - Retire ContextualPolicy (not part of documented API; support now in Policy base class)
 - Add some missing ExecuteAndCapture/Async overloads
-- Add CancellationToken support to synchronous executions (to support TimeoutPolicy)
+- Add CancellationToken support to synchronous executions (to support TimeoutPolicy).  Thanks to [@brunolauze](https://github.com/brunolauze) and [@reisenberger](https://github.com/reisenberger)
 
 ## 4.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Provide .NET4.0 support uniquely through Polly.NET40Async package
 - Retire ContextualPolicy (not part of documented API; support now in Policy base class)
 - Add some missing ExecuteAndCapture/Async overloads
+- Add CancellationToken support to synchronous executions (to support TimeoutPolicy)
 
 ## 4.3.0
 

--- a/src/Polly.Shared/AdvancedCircuitBreakerSyntax.cs
+++ b/src/Polly.Shared/AdvancedCircuitBreakerSyntax.cs
@@ -210,9 +210,10 @@ namespace Polly
                 onReset, 
                 onHalfOpen);
             return new CircuitBreakerPolicy(
-                (action, context) => CircuitBreakerEngine.Implementation<EmptyStruct>(
-                    () => { action(); return EmptyStruct.Instance; },
-                    context, 
+                (action, context, cancellationToken) => CircuitBreakerEngine.Implementation<EmptyStruct>(
+                    (ct) => { action(ct); return EmptyStruct.Instance; },
+                    context,
+                    cancellationToken,
                     policyBuilder.ExceptionPredicates, 
                     Enumerable.Empty<ResultPredicate<EmptyStruct>>(), 
                     breakerController), 

--- a/src/Polly.Shared/AdvancedCircuitBreakerTResultSyntax.cs
+++ b/src/Polly.Shared/AdvancedCircuitBreakerTResultSyntax.cs
@@ -211,9 +211,10 @@ namespace Polly
                 onReset,
                 onHalfOpen);
             return new CircuitBreakerPolicy<TResult>(
-                (action, context) => CircuitBreakerEngine.Implementation(
+                (action, context, cancellationToken) => CircuitBreakerEngine.Implementation(
                     action,
                     context,
+                    cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
                     breakerController),

--- a/src/Polly.Shared/CircuitBreaker/CircuitBreakerEngine.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitBreakerEngine.cs
@@ -15,11 +15,15 @@ namespace Polly.CircuitBreaker
             IEnumerable<ResultPredicate<TResult>> shouldHandleResultPredicates, 
             ICircuitController<TResult> breakerController)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             breakerController.OnActionPreExecute();
 
             try
             {
                 DelegateResult<TResult> delegateOutcome = new DelegateResult<TResult>(action(cancellationToken));
+
+                cancellationToken.ThrowIfCancellationRequested();
 
                 if (shouldHandleResultPredicates.Any(predicate => predicate(delegateOutcome.Result)))
                 {
@@ -34,6 +38,15 @@ namespace Polly.CircuitBreaker
             }
             catch (Exception ex)
             {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    if (ex is OperationCanceledException && ((OperationCanceledException)ex).CancellationToken == cancellationToken)
+                    {
+                        throw;
+                    }
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+
                 if (!shouldHandleExceptionPredicates.Any(predicate => predicate(ex)))
                 {
                     throw;

--- a/src/Polly.Shared/CircuitBreaker/CircuitBreakerEngine.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitBreakerEngine.cs
@@ -1,14 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace Polly.CircuitBreaker
 {
     internal partial class CircuitBreakerEngine
     {
         internal static TResult Implementation<TResult>(
-            Func<TResult> action,
+            Func<CancellationToken, TResult> action,
             Context context,
+            CancellationToken cancellationToken,
             IEnumerable<ExceptionPredicate> shouldHandleExceptionPredicates, 
             IEnumerable<ResultPredicate<TResult>> shouldHandleResultPredicates, 
             ICircuitController<TResult> breakerController)
@@ -17,7 +19,7 @@ namespace Polly.CircuitBreaker
 
             try
             {
-                DelegateResult<TResult> delegateOutcome = new DelegateResult<TResult>(action());
+                DelegateResult<TResult> delegateOutcome = new DelegateResult<TResult>(action(cancellationToken));
 
                 if (shouldHandleResultPredicates.Any(predicate => predicate(delegateOutcome.Result)))
                 {

--- a/src/Polly.Shared/CircuitBreaker/CircuitBreakerPolicy.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitBreakerPolicy.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Polly.Utilities;
+using System.Threading;
 
 namespace Polly.CircuitBreaker
 {
@@ -12,7 +13,7 @@ namespace Polly.CircuitBreaker
         private readonly ICircuitController<EmptyStruct> _breakerController;
 
         internal CircuitBreakerPolicy(
-            Action<Action, Context> exceptionPolicy, 
+            Action<Action<CancellationToken>, Context, CancellationToken> exceptionPolicy, 
             IEnumerable<ExceptionPredicate> exceptionPredicates,
             ICircuitController<EmptyStruct> breakerController
             ) : base(exceptionPolicy, exceptionPredicates)
@@ -61,7 +62,7 @@ namespace Polly.CircuitBreaker
         private readonly ICircuitController<TResult> _breakerController;
 
         internal CircuitBreakerPolicy(
-            Func<Func<TResult>, Context, TResult> executionPolicy, 
+            Func<Func<CancellationToken, TResult>, Context, CancellationToken, TResult> executionPolicy, 
             IEnumerable<ExceptionPredicate> exceptionPredicates, 
             IEnumerable<ResultPredicate<TResult>> resultPredicates, 
             ICircuitController<TResult> breakerController

--- a/src/Polly.Shared/CircuitBreakerSyntax.cs
+++ b/src/Polly.Shared/CircuitBreakerSyntax.cs
@@ -182,9 +182,10 @@ namespace Polly
                 onReset, 
                 onHalfOpen);
             return new CircuitBreakerPolicy(
-                (action, context) => CircuitBreakerEngine.Implementation(
-                    () => { action(); return EmptyStruct.Instance; },
-                    context, 
+                (action, context, cancellationToken) => CircuitBreakerEngine.Implementation(
+                    (ct) => { action(ct); return EmptyStruct.Instance; },
+                    context,
+                    cancellationToken,
                     policyBuilder.ExceptionPredicates, 
                     Enumerable.Empty<ResultPredicate<EmptyStruct>>(), 
                     breakerController), 

--- a/src/Polly.Shared/CircuitBreakerTResultSyntax.cs
+++ b/src/Polly.Shared/CircuitBreakerTResultSyntax.cs
@@ -180,9 +180,10 @@ namespace Polly
                 onReset,
                 onHalfOpen);
             return new CircuitBreakerPolicy<TResult>(
-                (action, context) => CircuitBreakerEngine.Implementation(
+                (action, context, cancellationToken) => CircuitBreakerEngine.Implementation(
                     action,
                     context,
+                    cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
                     breakerController),

--- a/src/Polly.Shared/ContextualPolicy.cs
+++ b/src/Polly.Shared/ContextualPolicy.cs
@@ -21,7 +21,22 @@ namespace Polly
         {
             if (contextData == null) throw new ArgumentNullException(nameof(contextData));
 
-            Execute(action, new Context(contextData));
+            Execute(ct => action(), new Context(contextData), CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Executes the specified action within the policy.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <exception cref="System.ArgumentNullException">contextData</exception>
+        [DebuggerStepThrough]
+        public void Execute(Action<CancellationToken> action, IDictionary<string, object> contextData, CancellationToken cancellationToken)
+        {
+            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
+
+            Execute(action, new Context(contextData), cancellationToken);
         }
 
         /// <summary>
@@ -36,9 +51,25 @@ namespace Polly
         {
             if (contextData == null) throw new ArgumentNullException(nameof(contextData));
 
-            return ExecuteAndCapture(action, new Context(contextData));
+            return ExecuteAndCapture(ct => action(), new Context(contextData), CancellationToken.None);
         }
-        
+
+        /// <summary>
+        /// Executes the specified action within the policy and returns the captured result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The captured result</returns>
+        /// <exception cref="System.ArgumentNullException">contextData</exception>
+        [DebuggerStepThrough]
+        public PolicyResult ExecuteAndCapture(Action<CancellationToken> action, IDictionary<string, object> contextData, CancellationToken cancellationToken)
+        {
+            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
+
+            return ExecuteAndCapture(action, new Context(contextData), cancellationToken);
+        }
+
         /// <summary>
         /// Executes the specified action within the policy and returns the result.
         /// </summary>
@@ -55,8 +86,26 @@ namespace Polly
         {
             if (contextData == null) throw new ArgumentNullException(nameof(contextData));
 
-            return Execute(action, new Context(contextData));
+            return Execute(ct => action(), new Context(contextData), CancellationToken.None);
         }
+        
+        /// <summary>
+        /// Executes the specified action within the policy and returns the result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The value returned by the action</returns>
+        /// <exception cref="System.ArgumentNullException">contextData</exception>
+        [DebuggerStepThrough]
+        public TResult Execute<TResult>(Func<CancellationToken, TResult> action, IDictionary<string, object> contextData, CancellationToken cancellationToken)
+        {
+            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
+
+            return Execute(action, new Context(contextData), cancellationToken);
+        }
+
 
         /// <summary>
         /// Executes the specified action within the policy and returns the captured result.
@@ -70,8 +119,27 @@ namespace Polly
         {
             if (contextData == null) throw new ArgumentNullException(nameof(contextData));
 
-            return ExecuteAndCapture(action, new Context(contextData));
+            return ExecuteAndCapture(ct => action(), new Context(contextData), CancellationToken.None);
         }
+
+
+        /// <summary>
+        /// Executes the specified action within the policy and returns the captured result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the t result.</typeparam>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The captured result</returns>
+        /// <exception cref="System.ArgumentNullException">contextData</exception>
+        [DebuggerStepThrough]
+        public PolicyResult<TResult> ExecuteAndCapture<TResult>(Func<CancellationToken, TResult> action, IDictionary<string, object> contextData, CancellationToken cancellationToken)
+        {
+            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
+
+            return ExecuteAndCapture(action, new Context(contextData), cancellationToken);
+        }
+
     }
 
     /// <summary>
@@ -95,7 +163,24 @@ namespace Polly
         {
             if (contextData == null) throw new ArgumentNullException(nameof(contextData));
 
-            return Execute(action, new Context(contextData));
+            return Execute(ct => action(), new Context(contextData), CancellationToken.None);
+        }
+
+
+        /// <summary>
+        /// Executes the specified action within the policy and returns the result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The value returned by the action</returns>
+        /// <exception cref="System.ArgumentNullException">contextData</exception>
+        [DebuggerStepThrough]
+        public TResult Execute(Func<CancellationToken, TResult> action, IDictionary<string, object> contextData, CancellationToken cancellationToken)
+        {
+            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
+
+            return Execute(action, new Context(contextData), cancellationToken);
         }
 
         /// <summary>
@@ -110,7 +195,23 @@ namespace Polly
         {
             if (contextData == null) throw new ArgumentNullException(nameof(contextData));
 
-            return ExecuteAndCapture(action, new Context(contextData));
+            return ExecuteAndCapture(ct => action(), new Context(contextData), CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Executes the specified action within the policy and returns the captured result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The captured result</returns>
+        /// <exception cref="System.ArgumentNullException">contextData</exception>
+        [DebuggerStepThrough]
+        public PolicyResult<TResult> ExecuteAndCapture(Func<CancellationToken, TResult> action, IDictionary<string, object> contextData, CancellationToken cancellationToken)
+        {
+            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
+
+            return ExecuteAndCapture(action, new Context(contextData), cancellationToken);
         }
     }
 }

--- a/src/Polly.Shared/Retry/IRetryPolicyState.cs
+++ b/src/Polly.Shared/Retry/IRetryPolicyState.cs
@@ -1,9 +1,10 @@
 ﻿using System;
+using System.Threading;
 
 namespace Polly.Retry
 {
     internal partial interface IRetryPolicyState<TResult>
     {
-        bool CanRetry(DelegateResult<TResult> delegateResult);
+        bool CanRetry(DelegateResult<TResult> delegateResult, CancellationToken cancellationToken);
     }
 }

--- a/src/Polly.Shared/Retry/RetryEngine.cs
+++ b/src/Polly.Shared/Retry/RetryEngine.cs
@@ -18,28 +18,41 @@ namespace Polly.Retry
 
             while (true)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 try
                 {
                     DelegateResult<TResult> delegateOutcome = new DelegateResult<TResult>(action(cancellationToken));
+
+                    cancellationToken.ThrowIfCancellationRequested();
 
                     if (!shouldRetryResultPredicates.Any(predicate => predicate(delegateOutcome.Result)))
                     {
                         return delegateOutcome.Result;
                     }
 
-                    if (!policyState.CanRetry(delegateOutcome))
+                    if (!policyState.CanRetry(delegateOutcome, cancellationToken))
                     {
                         return delegateOutcome.Result;
                     }
                 }
                 catch (Exception ex)
                 {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        if (ex is OperationCanceledException && ((OperationCanceledException)ex).CancellationToken == cancellationToken)
+                        {
+                            throw;
+                        }
+                        cancellationToken.ThrowIfCancellationRequested();
+                    }
+
                     if (!shouldRetryExceptionPredicates.Any(predicate => predicate(ex)))
                     {
                         throw;
                     }
 
-                    if (!policyState.CanRetry(new DelegateResult<TResult>(ex)))
+                    if (!policyState.CanRetry(new DelegateResult<TResult>(ex), cancellationToken))
                     {
                         throw;
                     }

--- a/src/Polly.Shared/Retry/RetryEngine.cs
+++ b/src/Polly.Shared/Retry/RetryEngine.cs
@@ -1,13 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace Polly.Retry
 {
     internal static partial class RetryEngine
     {
         internal static TResult Implementation<TResult>(
-            Func<TResult> action,
+            Func<CancellationToken, TResult> action,
+            CancellationToken cancellationToken,
             IEnumerable<ExceptionPredicate> shouldRetryExceptionPredicates,
             IEnumerable<ResultPredicate<TResult>> shouldRetryResultPredicates,
             Func<IRetryPolicyState<TResult>> policyStateFactory)
@@ -18,7 +20,7 @@ namespace Polly.Retry
             {
                 try
                 {
-                    DelegateResult<TResult> delegateOutcome = new DelegateResult<TResult>(action());
+                    DelegateResult<TResult> delegateOutcome = new DelegateResult<TResult>(action(cancellationToken));
 
                     if (!shouldRetryResultPredicates.Any(predicate => predicate(delegateOutcome.Result)))
                     {

--- a/src/Polly.Shared/Retry/RetryPolicy.cs
+++ b/src/Polly.Shared/Retry/RetryPolicy.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace Polly.Retry
 {
@@ -8,7 +9,7 @@ namespace Polly.Retry
     /// </summary>
     public partial class RetryPolicy : Policy
     {
-        internal RetryPolicy(Action<Action, Context> exceptionPolicy, IEnumerable<ExceptionPredicate> exceptionPredicates) 
+        internal RetryPolicy(Action<Action<CancellationToken>, Context, CancellationToken> exceptionPolicy, IEnumerable<ExceptionPredicate> exceptionPredicates) 
             : base(exceptionPolicy, exceptionPredicates)
         {
         }
@@ -20,7 +21,7 @@ namespace Polly.Retry
     public partial class RetryPolicy<TResult> : Policy<TResult>
     {
         internal RetryPolicy(
-            Func<Func<TResult>, Context, TResult> executionPolicy,
+            Func<Func<CancellationToken, TResult>, Context, CancellationToken, TResult> executionPolicy,
             IEnumerable<ExceptionPredicate> exceptionPredicates,
             IEnumerable<ResultPredicate<TResult>> resultPredicates
             ) : base(executionPolicy, exceptionPredicates, resultPredicates)

--- a/src/Polly.Shared/Retry/RetryPolicyState.cs
+++ b/src/Polly.Shared/Retry/RetryPolicyState.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 
 namespace Polly.Retry
 {
@@ -18,7 +19,7 @@ namespace Polly.Retry
         {
         }
 
-        public bool CanRetry(DelegateResult<TResult> delegateResult)
+        public bool CanRetry(DelegateResult<TResult> delegateResult, CancellationToken cancellationToken)
         {
             _onRetry(delegateResult, _context);
             return true;

--- a/src/Polly.Shared/Retry/RetryPolicyStateWithCount.cs
+++ b/src/Polly.Shared/Retry/RetryPolicyStateWithCount.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 
 namespace Polly.Retry
 {
@@ -21,7 +22,7 @@ namespace Polly.Retry
         {
         }
 
-        public bool CanRetry(DelegateResult<TResult> delegateResult)
+        public bool CanRetry(DelegateResult<TResult> delegateResult, CancellationToken cancellationToken)
         {
             _errorCount += 1;
 

--- a/src/Polly.Shared/Retry/RetryPolicyStateWithSleep.cs
+++ b/src/Polly.Shared/Retry/RetryPolicyStateWithSleep.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using Polly.Utilities;
 
 namespace Polly.Retry
@@ -28,7 +29,7 @@ namespace Polly.Retry
         {
         }
 
-        public bool CanRetry(DelegateResult<TResult> delegateResult)
+        public bool CanRetry(DelegateResult<TResult> delegateResult, CancellationToken cancellationToken)
         {
             if (!_sleepDurationsEnumerator.MoveNext()) return false;
 
@@ -37,7 +38,7 @@ namespace Polly.Retry
             var currentTimeSpan = _sleepDurationsEnumerator.Current;
             _onRetry(delegateResult, currentTimeSpan, _errorCount, _context);
                 
-            SystemClock.Sleep(currentTimeSpan);
+            SystemClock.Sleep(currentTimeSpan, cancellationToken);
 
             return true;
         }

--- a/src/Polly.Shared/Retry/RetryPolicyStateWithSleepDurationProvider.cs
+++ b/src/Polly.Shared/Retry/RetryPolicyStateWithSleepDurationProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using Polly.Utilities;
 
 namespace Polly.Retry
@@ -22,7 +23,7 @@ namespace Polly.Retry
         {
         }
 
-        public bool CanRetry(DelegateResult<TResult> delegateResult)
+        public bool CanRetry(DelegateResult<TResult> delegateResult, CancellationToken cancellationToken)
         {
             if (_errorCount < int.MaxValue)
             {
@@ -32,7 +33,7 @@ namespace Polly.Retry
             var currentTimeSpan = _sleepDurationProvider(_errorCount);
             _onRetry(delegateResult, currentTimeSpan, _context);
 
-            SystemClock.Sleep(currentTimeSpan);
+            SystemClock.Sleep(currentTimeSpan, cancellationToken);
             
             return true;
         }        

--- a/src/Polly.Shared/RetrySyntax.cs
+++ b/src/Polly.Shared/RetrySyntax.cs
@@ -63,8 +63,9 @@ namespace Polly
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
             return new RetryPolicy(
-                (action, context) => RetryEngine.Implementation(
-                    () => { action(); return EmptyStruct.Instance; }, 
+                (action, context, cancellationToken) => RetryEngine.Implementation(
+                    ct => { action(ct); return EmptyStruct.Instance; }, 
+                    cancellationToken,
                     policyBuilder.ExceptionPredicates, 
                     Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
                     () => new RetryPolicyStateWithCount<EmptyStruct>(retryCount, (outcome, i) => onRetry(outcome.Exception, i))
@@ -101,8 +102,10 @@ namespace Polly
             if (retryCount < 0) throw new ArgumentOutOfRangeException("retryCount", "Value must be greater than or equal to zero.");
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
-            return new RetryPolicy((action, context) => RetryEngine.Implementation(
-                    () => { action(); return EmptyStruct.Instance; },
+            return new RetryPolicy(
+                (action, context, cancellationToken) => RetryEngine.Implementation(
+                    ct => { action(ct); return EmptyStruct.Instance; },
+                    cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
                 () => new RetryPolicyStateWithCount<EmptyStruct>(retryCount, (outcome, i, ctx) => onRetry(outcome.Exception, i, ctx), context)
@@ -134,8 +137,9 @@ namespace Polly
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
             return new RetryPolicy(
-                (action, context) => RetryEngine.Implementation(
-                    () => { action(); return EmptyStruct.Instance; },
+                (action, context, cancellationToken) => RetryEngine.Implementation(
+                    ct => { action(ct); return EmptyStruct.Instance; },
+                    cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     Enumerable.Empty<ResultPredicate<EmptyStruct>>(), 
                     () => new RetryPolicyState<EmptyStruct>(outcome => onRetry(outcome.Exception))
@@ -156,8 +160,9 @@ namespace Polly
         {
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
-            return new RetryPolicy((action, context) => RetryEngine.Implementation(
-                () => { action(); return EmptyStruct.Instance; },
+            return new RetryPolicy((action, context, cancellationToken) => RetryEngine.Implementation(
+                ct => { action(ct); return EmptyStruct.Instance; },
+                cancellationToken,
                 policyBuilder.ExceptionPredicates,
                 Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
                 () => new RetryPolicyState<EmptyStruct>((outcome, ctx) => onRetry(outcome.Exception, ctx), context)
@@ -207,8 +212,9 @@ namespace Polly
                                            .Select(sleepDurationProvider);
 
             return new RetryPolicy(
-                (action, context) => RetryEngine.Implementation(
-                    () => { action(); return EmptyStruct.Instance; },
+                (action, context, cancellationToken) => RetryEngine.Implementation(
+                    ct => { action(ct); return EmptyStruct.Instance; },
+                    cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
                     () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, (outcome, timespan) => onRetry(outcome.Exception, timespan))
@@ -243,8 +249,9 @@ namespace Polly
             var sleepDurations = Enumerable.Range(1, retryCount)
                                            .Select(sleepDurationProvider);
 
-            return new RetryPolicy((action, context) => RetryEngine.Implementation(
-                () => { action(); return EmptyStruct.Instance; },
+            return new RetryPolicy((action, context, cancellationToken) => RetryEngine.Implementation(
+                ct => { action(ct); return EmptyStruct.Instance; },
+                cancellationToken,
                 policyBuilder.ExceptionPredicates,
                 Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
                 () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, (outcome, timespan, ctx) => onRetry(outcome.Exception, timespan, ctx), context)
@@ -277,8 +284,10 @@ namespace Polly
             var sleepDurations = Enumerable.Range(1, retryCount)
                                            .Select(sleepDurationProvider);
 
-            return new RetryPolicy((action, context) => RetryEngine.Implementation(
-                () => { action(); return EmptyStruct.Instance; },
+            return new RetryPolicy(
+                (action, context, cancellationToken) => RetryEngine.Implementation(
+                ct => { action(ct); return EmptyStruct.Instance; },
+                cancellationToken,
                 policyBuilder.ExceptionPredicates,
                 Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
                 () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, (outcome, timespan, i, ctx) => onRetry(outcome.Exception, timespan, i, ctx), context)
@@ -319,8 +328,9 @@ namespace Polly
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
             return new RetryPolicy(
-                (action, context) => RetryEngine.Implementation(
-                    () => { action(); return EmptyStruct.Instance; },
+                (action, context, cancellationToken) => RetryEngine.Implementation(
+                    ct => { action(ct); return EmptyStruct.Instance; },
+                    cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
                     () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, (outcome, timespan) => onRetry(outcome.Exception, timespan))
@@ -348,8 +358,10 @@ namespace Polly
             if (sleepDurations == null) throw new ArgumentNullException("sleepDurations");
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
-            return new RetryPolicy((action, context) => RetryEngine.Implementation(
-                () => { action(); return EmptyStruct.Instance; },
+            return new RetryPolicy(
+                (action, context, cancellationToken) => RetryEngine.Implementation(
+                ct => { action(ct); return EmptyStruct.Instance; },
+                cancellationToken,
                 policyBuilder.ExceptionPredicates,
                 Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
                 () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, (outcome, timespan, ctx) => onRetry(outcome.Exception, timespan, ctx), context)
@@ -375,8 +387,10 @@ namespace Polly
             if (sleepDurations == null) throw new ArgumentNullException("sleepDurations");
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
-            return new RetryPolicy((action, context) => RetryEngine.Implementation(
-                () => { action(); return EmptyStruct.Instance; },
+            return new RetryPolicy(
+                (action, context, cancellationToken) => RetryEngine.Implementation(
+                ct => { action(ct); return EmptyStruct.Instance; },
+                cancellationToken,
                 policyBuilder.ExceptionPredicates,
                 Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
                 () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, (outcome, timespan, i, ctx) => onRetry(outcome.Exception, timespan, i, ctx), context)
@@ -415,8 +429,9 @@ namespace Polly
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
             return new RetryPolicy(
-                (action, context) => RetryEngine.Implementation(
-                    () => { action(); return EmptyStruct.Instance; },
+                (action, context, cancellationToken) => RetryEngine.Implementation(
+                    ct => { action(ct); return EmptyStruct.Instance; },
+                    cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
                     () => new RetryPolicyStateWithSleepDurationProvider<EmptyStruct>(sleepDurationProvider, (outcome, timespan) => onRetry(outcome.Exception, timespan))
@@ -441,8 +456,9 @@ namespace Polly
             if (sleepDurationProvider == null) throw new ArgumentNullException("sleepDurationProvider");
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
-            return new RetryPolicy((action, context) => RetryEngine.Implementation(
-                () => { action(); return EmptyStruct.Instance; },
+            return new RetryPolicy((action, context, cancellationToken) => RetryEngine.Implementation(
+                ct => { action(ct); return EmptyStruct.Instance; },
+                cancellationToken,
                 policyBuilder.ExceptionPredicates,
                 Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
                 () => new RetryPolicyStateWithSleepDurationProvider<EmptyStruct>(sleepDurationProvider, (outcome, timespan, ctx) => onRetry(outcome.Exception, timespan, ctx), context)

--- a/src/Polly.Shared/RetryTResultSyntax.cs
+++ b/src/Polly.Shared/RetryTResultSyntax.cs
@@ -62,8 +62,9 @@ namespace Polly
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
             return new RetryPolicy<TResult>(
-                (action, context) => RetryEngine.Implementation<TResult>(
+                (action, context, cancellationToken) => RetryEngine.Implementation<TResult>(
                     action,
+                    cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
                     () => new RetryPolicyStateWithCount<TResult>(retryCount, onRetry)
@@ -101,8 +102,10 @@ namespace Polly
             if (retryCount < 0) throw new ArgumentOutOfRangeException("retryCount", "Value must be greater than or equal to zero.");
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
-            return new RetryPolicy<TResult>((action, context) => RetryEngine.Implementation(
+            return new RetryPolicy<TResult>(
+                (action, context, cancellationToken) => RetryEngine.Implementation(
                     action,
+                    cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
                     () => new RetryPolicyStateWithCount<TResult>(retryCount, onRetry, context)
@@ -136,8 +139,9 @@ namespace Polly
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
             return new RetryPolicy<TResult>(
-                (action, context) => RetryEngine.Implementation(
+                (action, context, cancellationToken) => RetryEngine.Implementation(
                     action,
+                    cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
                     () => new RetryPolicyState<TResult>(outcome => onRetry(outcome.Exception))
@@ -160,8 +164,9 @@ namespace Polly
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
             return new RetryPolicy<TResult>(
-                (action, context) => RetryEngine.Implementation(
+                (action, context, cancellationToken) => RetryEngine.Implementation(
                     action,
+                    cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
                     () => new RetryPolicyState<TResult>(onRetry, context)
@@ -213,8 +218,9 @@ namespace Polly
                                            .Select(sleepDurationProvider);
 
             return new RetryPolicy<TResult>(
-                (action, context) => RetryEngine.Implementation(
+                (action, context, cancellationToken) => RetryEngine.Implementation(
                     action,
+                    cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
                     () => new RetryPolicyStateWithSleep<TResult>(sleepDurations, onRetry)
@@ -251,8 +257,9 @@ namespace Polly
                                            .Select(sleepDurationProvider);
 
             return new RetryPolicy<TResult>(
-                (action, context) => RetryEngine.Implementation(
+                (action, context, cancellationToken) => RetryEngine.Implementation(
                     action,
+                    cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
                     () => new RetryPolicyStateWithSleep<TResult>(sleepDurations, onRetry, context)
@@ -288,8 +295,9 @@ namespace Polly
                                            .Select(sleepDurationProvider);
 
             return new RetryPolicy<TResult>(
-                (action, context) => RetryEngine.Implementation(
+                (action, context, cancellationToken) => RetryEngine.Implementation(
                     action,
+                    cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
                     () => new RetryPolicyStateWithSleep<TResult>(sleepDurations, onRetry, context)
@@ -332,8 +340,9 @@ namespace Polly
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
             return new RetryPolicy<TResult>(
-                (action, context) => RetryEngine.Implementation(
+                (action, context, cancellationToken) => RetryEngine.Implementation(
                     action,
+                    cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
                     () => new RetryPolicyStateWithSleep<TResult>(sleepDurations, onRetry)
@@ -363,8 +372,9 @@ namespace Polly
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
             return new RetryPolicy<TResult>(
-                (action, context) => RetryEngine.Implementation(
+                (action, context, cancellationToken) => RetryEngine.Implementation(
                     action,
+                    cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
                     () => new RetryPolicyStateWithSleep<TResult>(sleepDurations, onRetry, context)
@@ -394,8 +404,9 @@ namespace Polly
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
             return new RetryPolicy<TResult>(
-                (action, context) => RetryEngine.Implementation(
+                (action, context, cancellationToken) => RetryEngine.Implementation(
                     action,
+                    cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
                     () => new RetryPolicyStateWithSleep<TResult>(sleepDurations, onRetry, context)
@@ -437,8 +448,9 @@ namespace Polly
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
             return new RetryPolicy<TResult>(
-                (action, context) => RetryEngine.Implementation(
+                (action, context, cancellationToken) => RetryEngine.Implementation(
                     action,
+                    cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
                     () => new RetryPolicyStateWithSleepDurationProvider<TResult>(sleepDurationProvider, onRetry)
@@ -465,8 +477,9 @@ namespace Polly
             if (onRetry == null) throw new ArgumentNullException("onRetry");
 
             return new RetryPolicy<TResult>(
-                (action, context) => RetryEngine.Implementation(
+                (action, context, cancellationToken) => RetryEngine.Implementation(
                     action,
+                    cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
                     () => new RetryPolicyStateWithSleepDurationProvider<TResult>(sleepDurationProvider, onRetry, context)

--- a/src/Polly.Shared/Utilities/SystemClock.cs
+++ b/src/Polly.Shared/Utilities/SystemClock.cs
@@ -9,19 +9,19 @@ namespace Polly.Utilities
     /// </summary>
     public static class SystemClock
     {
-#if !PORTABLE
         /// <summary>
         /// Allows the setting of a custom Thread.Sleep implementation for testing.
-        /// By default this will be a call to <see cref="M:Thread.Sleep"/>
+        /// By default this will be a call to <see cref="M:Task.Delay"/> taking a <see cref="CancellationToken"/>
         /// </summary>
-        public static Action<TimeSpan> Sleep = Thread.Sleep;
+        public static Action<TimeSpan, CancellationToken> Sleep = (timeSpan, cancellationToken) =>
+        {
+#if NET40
+            TaskEx 
 #else
-        /// <summary>
-        /// Allows the setting of a custom Thread.Sleep implementation for testing.
-        /// By default this will be a call to <see cref="M:ManualResetEvent.WaitOne"/>
-        /// </summary>
-        public static Action<TimeSpan> Sleep = timespan => new ManualResetEvent(false).WaitOne(timespan);
-#endif
+            Task 
+#endif 
+            .Delay(timeSpan, cancellationToken).Wait(cancellationToken);
+        };
 
         /// <summary>
         /// Allows the setting of a custom async Sleep implementation for testing.
@@ -44,11 +44,13 @@ namespace Polly.Utilities
         /// </summary>
         public static void Reset()
         {
-#if !PORTABLE
-            Sleep = Thread.Sleep;
+            Sleep = (timeSpan, cancellationToken) =>
+#if NET40
+            TaskEx 
 #else
-            Sleep = timeSpan => new ManualResetEvent(false).WaitOne(timeSpan);
+            Task
 #endif
+            .Delay(timeSpan, cancellationToken).Wait(cancellationToken);
 
 #if NET40
             SleepAsync = TaskEx.Delay;

--- a/src/Polly.SharedSpecs/CircuitBreakerSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreakerSpecs.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Polly.CircuitBreaker;
 using Polly.Specs.Helpers;
@@ -895,6 +897,279 @@ namespace Polly.Specs
         #endregion
 
         #endregion
+
+        #region Cancellation support
+
+        [Fact]
+        public void Should_execute_action_when_non_faulting_and_cancellationtoken_not_cancelled()
+        {
+            var durationOfBreak = TimeSpan.FromMinutes(1);
+            CircuitBreakerPolicy breaker = Policy
+                            .Handle<DivideByZeroException>()
+                            .CircuitBreaker(2, durationOfBreak);
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+
+            int attemptsInvoked = 0;
+            Action onExecute = () => attemptsInvoked++;
+
+            PolicyExtensions.ExceptionAndOrCancellationScenario scenario = new PolicyExtensions.ExceptionAndOrCancellationScenario
+            {
+                NumberOfTimesToRaiseException = 0,
+                AttemptDuringWhichToCancel = null,
+            };
+
+            breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .ShouldNotThrow();
+
+            attemptsInvoked.Should().Be(1);
+        }
+
+        [Fact]
+        public void Should_not_execute_action_when_cancellationtoken_cancelled_before_execute()
+        {
+            var durationOfBreak = TimeSpan.FromMinutes(1);
+            CircuitBreakerPolicy breaker = Policy
+                            .Handle<DivideByZeroException>()
+                            .CircuitBreaker(2, durationOfBreak);
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+
+            int attemptsInvoked = 0;
+            Action onExecute = () => attemptsInvoked++;
+
+            PolicyExtensions.ExceptionAndOrCancellationScenario scenario = new PolicyExtensions.ExceptionAndOrCancellationScenario
+            {
+                NumberOfTimesToRaiseException = 0,
+                AttemptDuringWhichToCancel = null, // Cancellation token cancelled manually below - before any scenario execution.
+            };
+
+            cancellationTokenSource.Cancel();
+
+            breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .ShouldThrow<OperationCanceledException>()
+                .And.CancellationToken.Should().Be(cancellationToken);
+
+            attemptsInvoked.Should().Be(0);
+        }
+
+        [Fact]
+        public void Should_report_cancellation_during_otherwise_non_faulting_action_execution_when_user_delegate_observes_cancellationtoken()
+        {
+            var durationOfBreak = TimeSpan.FromMinutes(1);
+            CircuitBreakerPolicy breaker = Policy
+                            .Handle<DivideByZeroException>()
+                            .CircuitBreaker(2, durationOfBreak);
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+
+            int attemptsInvoked = 0;
+            Action onExecute = () => attemptsInvoked++;
+
+            PolicyExtensions.ExceptionAndOrCancellationScenario scenario = new PolicyExtensions.ExceptionAndOrCancellationScenario
+            {
+                NumberOfTimesToRaiseException = 0,
+                AttemptDuringWhichToCancel = 1,
+                ActionObservesCancellation = true
+            };
+
+            breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .ShouldThrow<OperationCanceledException>()
+                .And.CancellationToken.Should().Be(cancellationToken);
+
+            attemptsInvoked.Should().Be(1);
+        }
+
+        [Fact]
+        public void Should_report_cancellation_during_faulting_action_execution_when_user_delegate_observes_cancellationtoken()
+        {
+            var durationOfBreak = TimeSpan.FromMinutes(1);
+            CircuitBreakerPolicy breaker = Policy
+                            .Handle<DivideByZeroException>()
+                            .CircuitBreaker(2, durationOfBreak);
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+
+            int attemptsInvoked = 0;
+            Action onExecute = () => attemptsInvoked++;
+
+            PolicyExtensions.ExceptionAndOrCancellationScenario scenario = new PolicyExtensions.ExceptionAndOrCancellationScenario
+            {
+                NumberOfTimesToRaiseException = 1,
+                AttemptDuringWhichToCancel = 1,
+                ActionObservesCancellation = true
+            };
+
+            breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .ShouldThrow<OperationCanceledException>()
+                .And.CancellationToken.Should().Be(cancellationToken);
+
+            attemptsInvoked.Should().Be(1);
+        }
+
+        [Fact]
+        public void Should_report_cancellation_during_faulting_action_execution_when_user_delegate_does_not_observe_cancellationtoken()
+        {
+            var durationOfBreak = TimeSpan.FromMinutes(1);
+            CircuitBreakerPolicy breaker = Policy
+                            .Handle<DivideByZeroException>()
+                            .CircuitBreaker(2, durationOfBreak);
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+
+            int attemptsInvoked = 0;
+            Action onExecute = () => attemptsInvoked++;
+
+            PolicyExtensions.ExceptionAndOrCancellationScenario scenario = new PolicyExtensions.ExceptionAndOrCancellationScenario
+            {
+                NumberOfTimesToRaiseException = 1,
+                AttemptDuringWhichToCancel = 1,
+                ActionObservesCancellation = false
+            };
+
+            breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .ShouldThrow<OperationCanceledException>()
+                .And.CancellationToken.Should().Be(cancellationToken);
+
+            attemptsInvoked.Should().Be(1);
+        }
+
+        [Fact]
+        public void Should_report_cancellation_when_both_open_circuit_and_cancellation()
+        {
+            CircuitBreakerPolicy breaker = Policy
+                .Handle<DivideByZeroException>()
+                .CircuitBreaker(1, TimeSpan.FromMinutes(1));
+
+            breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
+                .ShouldThrow<DivideByZeroException>();
+
+            breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
+                .ShouldThrow<BrokenCircuitException>()
+                .WithMessage("The circuit is now open and is not allowing calls.")
+                .WithInnerException<DivideByZeroException>();
+            // Circuit is now broken.
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+
+            int attemptsInvoked = 0;
+            Action onExecute = () => attemptsInvoked++;
+
+            cancellationTokenSource.Cancel();
+
+            PolicyExtensions.ExceptionAndOrCancellationScenario scenario = new PolicyExtensions.ExceptionAndOrCancellationScenario
+            {
+                NumberOfTimesToRaiseException = 1,
+                AttemptDuringWhichToCancel = null, // Cancelled manually instead - see above.
+                ActionObservesCancellation = false
+            };
+
+            breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .ShouldThrow<OperationCanceledException>()
+                .And.CancellationToken.Should().Be(cancellationToken);
+
+            attemptsInvoked.Should().Be(0);
+        }
+
+        [Fact]
+        public void Should_honour_different_cancellationtoken_captured_implicitly_by_action()
+        {
+            // Before CancellationToken support was built in to Polly, users of the library may have implicitly captured a CancellationToken and used it to cancel actions.  For backwards compatibility, Polly should not confuse these with its own CancellationToken; it should distinguish OperationCanceledExceptions thrown with different CancellationTokens.
+
+            var durationOfBreak = TimeSpan.FromMinutes(1);
+            CircuitBreakerPolicy breaker = Policy
+                            .Handle<DivideByZeroException>()
+                            .CircuitBreaker(2, durationOfBreak);
+
+            CancellationTokenSource policyCancellationTokenSource = new CancellationTokenSource();
+            CancellationToken policyCancellationToken = policyCancellationTokenSource.Token;
+
+            CancellationTokenSource implicitlyCapturedActionCancellationTokenSource = new CancellationTokenSource();
+            CancellationToken implicitlyCapturedActionCancellationToken = implicitlyCapturedActionCancellationTokenSource.Token;
+
+            implicitlyCapturedActionCancellationTokenSource.Cancel();
+
+            int attemptsInvoked = 0;
+
+            breaker.Invoking(x => x.Execute(ct =>
+            {
+                attemptsInvoked++;
+                implicitlyCapturedActionCancellationToken.ThrowIfCancellationRequested();
+            }, policyCancellationToken))
+                .ShouldThrow<OperationCanceledException>()
+                .And.CancellationToken.Should().Be(implicitlyCapturedActionCancellationToken);
+
+            attemptsInvoked.Should().Be(1);
+        }
+
+        [Fact]
+        public void Should_execute_func_returning_value_when_cancellationtoken_not_cancelled()
+        {
+            var durationOfBreak = TimeSpan.FromMinutes(1);
+            CircuitBreakerPolicy breaker = Policy
+                            .Handle<DivideByZeroException>()
+                            .CircuitBreaker(2, durationOfBreak);
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+
+            int attemptsInvoked = 0;
+            Action onExecute = () => attemptsInvoked++;
+
+            bool? result = null;
+
+            PolicyExtensions.ExceptionAndOrCancellationScenario scenario = new PolicyExtensions.ExceptionAndOrCancellationScenario
+            {
+                NumberOfTimesToRaiseException = 0,
+                AttemptDuringWhichToCancel = null,
+            };
+
+            breaker.Invoking(x => result = x.RaiseExceptionAndOrCancellation<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true))
+                .ShouldNotThrow();
+
+            result.Should().BeTrue();
+
+            attemptsInvoked.Should().Be(1);
+        }
+
+        [Fact]
+        public void Should_honour_and_report_cancellation_during_func_execution()
+        {
+            CircuitBreakerPolicy breaker = Policy
+                             .Handle<DivideByZeroException>()
+                             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+
+            int attemptsInvoked = 0;
+            Action onExecute = () => attemptsInvoked++;
+
+            bool? result = null;
+
+            PolicyExtensions.ExceptionAndOrCancellationScenario scenario = new PolicyExtensions.ExceptionAndOrCancellationScenario
+            {
+                NumberOfTimesToRaiseException = 0,
+                AttemptDuringWhichToCancel = 1,
+                ActionObservesCancellation = true
+            };
+
+            breaker.Invoking(x => result = x.RaiseExceptionAndOrCancellation<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true))
+                .ShouldThrow<OperationCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
+
+            result.Should().Be(null);
+
+            attemptsInvoked.Should().Be(1);
+        }
+
+        #endregion
+
 
         public void Dispose()
         {

--- a/src/Polly.SharedSpecs/RetrySpecs.cs
+++ b/src/Polly.SharedSpecs/RetrySpecs.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using FluentAssertions;
 using Polly.Specs.Helpers;
 using Xunit;
@@ -94,18 +95,7 @@ namespace Polly.Specs
             policy.Invoking(x => x.RaiseException<DivideByZeroException>())
                   .ShouldNotThrow();
         }
-
-        [Fact]
-        public void Should_not_throw_when_specified_exception_thrown_less_number_of_times_than_retry_count_async()
-        {
-            var policy = Policy
-                .Handle<DivideByZeroException>()
-                .RetryAsync(3);
-
-            policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldNotThrow();
-        }
-
+        
         [Fact]
         public void Should_not_throw_when_one_of_the_specified_exceptions_thrown_less_number_of_times_than_retry_count()
         {
@@ -117,19 +107,7 @@ namespace Polly.Specs
             policy.Invoking(x => x.RaiseException<ArgumentException>())
                   .ShouldNotThrow();
         }
-
-        [Fact]
-        public void Should_not_throw_when_one_of_the_specified_exceptions_thrown_less_number_of_times_than_retry_count_async()
-        {
-            var policy = Policy
-                .Handle<DivideByZeroException>()
-                .Or<ArgumentException>()
-                .RetryAsync(3);
-
-            policy.Awaiting(x => x.RaiseExceptionAsync<ArgumentException>())
-                  .ShouldNotThrow();
-        }
-
+        
         [Fact]
         public void Should_throw_when_specified_exception_thrown_more_times_then_retry_count()
         {
@@ -140,18 +118,7 @@ namespace Polly.Specs
             policy.Invoking(x => x.RaiseException<DivideByZeroException>(3 + 1))
                   .ShouldThrow<DivideByZeroException>();
         }
-
-        [Fact]
-        public void Should_throw_when_specified_exception_thrown_more_times_then_retry_count_async()
-        {
-            var policy = Policy
-                .Handle<DivideByZeroException>()
-                .RetryAsync(3);
-
-            policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>(3 + 1))
-                  .ShouldThrow<DivideByZeroException>();
-        }
-
+        
         [Fact]
         public void Should_throw_when_one_of_the_specified_exceptions_are_thrown_more_times_then_retry_count()
         {
@@ -163,19 +130,7 @@ namespace Polly.Specs
             policy.Invoking(x => x.RaiseException<ArgumentException>(3 + 1))
                   .ShouldThrow<ArgumentException>();
         }
-
-        [Fact]
-        public void Should_throw_when_one_of_the_specified_exceptions_are_thrown_more_times_then_retry_count_async()
-        {
-            var policy = Policy
-                .Handle<DivideByZeroException>()
-                .Or<ArgumentException>()
-                .RetryAsync(3);
-
-            policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>(3 + 1))
-                  .ShouldThrow<DivideByZeroException>();
-        }
-
+        
         [Fact]
         public void Should_throw_when_exception_thrown_is_not_the_specified_exception_type()
         {
@@ -437,5 +392,341 @@ namespace Polly.Specs
 
             retryInvoked.Should().BeFalse();
         }
+
+
+        #region Sync cancellation tests
+
+        [Fact]
+        public void Should_execute_action_when_non_faulting_and_cancellationtoken_not_cancelled()
+        {
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .Retry(3);
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+
+            int attemptsInvoked = 0;
+            Action onExecute = () => attemptsInvoked++;
+
+            PolicyExtensions.ExceptionAndOrCancellationScenario scenario = new PolicyExtensions.ExceptionAndOrCancellationScenario
+            {
+                NumberOfTimesToRaiseException = 0,
+                AttemptDuringWhichToCancel = null,
+            };
+
+            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .ShouldNotThrow();
+
+            attemptsInvoked.Should().Be(1);
+        }
+
+        [Fact]
+        public void Should_execute_all_tries_when_faulting_and_cancellationtoken_not_cancelled()
+        {
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .Retry(3);
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+
+            int attemptsInvoked = 0;
+            Action onExecute = () => attemptsInvoked++;
+
+            PolicyExtensions.ExceptionAndOrCancellationScenario scenario = new PolicyExtensions.ExceptionAndOrCancellationScenario
+            {
+                NumberOfTimesToRaiseException = 1 + 3,
+                AttemptDuringWhichToCancel = null,
+            };
+
+            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .ShouldThrow<DivideByZeroException>();
+
+            attemptsInvoked.Should().Be(1 + 3);
+        }
+
+        [Fact]
+        public void Should_not_execute_action_when_cancellationtoken_cancelled_before_execute()
+        {
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .Retry(3);
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+
+            int attemptsInvoked = 0;
+            Action onExecute = () => attemptsInvoked++;
+
+            PolicyExtensions.ExceptionAndOrCancellationScenario scenario = new PolicyExtensions.ExceptionAndOrCancellationScenario
+            {
+                NumberOfTimesToRaiseException = 1 + 3,
+                AttemptDuringWhichToCancel = null, // Cancellation token cancelled manually below - before any scenario execution.
+            };
+
+            cancellationTokenSource.Cancel();
+
+            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .ShouldThrow<OperationCanceledException>()
+                .And.CancellationToken.Should().Be(cancellationToken);
+
+            attemptsInvoked.Should().Be(0);
+        }
+
+        [Fact]
+        public void Should_report_cancellation_during_otherwise_non_faulting_action_execution_and_cancel_further_retries_when_user_delegate_observes_cancellationtoken()
+        {
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .Retry(3);
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+
+            int attemptsInvoked = 0;
+            Action onExecute = () => attemptsInvoked++;
+
+            PolicyExtensions.ExceptionAndOrCancellationScenario scenario = new PolicyExtensions.ExceptionAndOrCancellationScenario
+            {
+                NumberOfTimesToRaiseException = 0,
+                AttemptDuringWhichToCancel = 1,
+                ActionObservesCancellation = true
+            };
+
+            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .ShouldThrow<OperationCanceledException>()
+                .And.CancellationToken.Should().Be(cancellationToken);
+
+            attemptsInvoked.Should().Be(1);
+        }
+
+        [Fact]
+        public void Should_report_cancellation_during_faulting_initial_action_execution_and_cancel_further_retries_when_user_delegate_observes_cancellationtoken()
+        {
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .Retry(3);
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+
+            int attemptsInvoked = 0;
+            Action onExecute = () => attemptsInvoked++;
+
+            PolicyExtensions.ExceptionAndOrCancellationScenario scenario = new PolicyExtensions.ExceptionAndOrCancellationScenario
+            {
+                NumberOfTimesToRaiseException = 1 + 3,
+                AttemptDuringWhichToCancel = 1,
+                ActionObservesCancellation = true
+            };
+
+            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .ShouldThrow<OperationCanceledException>()
+                .And.CancellationToken.Should().Be(cancellationToken);
+
+            attemptsInvoked.Should().Be(1);
+        }
+
+        [Fact]
+        public void Should_report_cancellation_during_faulting_initial_action_execution_and_cancel_further_retries_when_user_delegate_does_not_observe_cancellationtoken()
+        {
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .Retry(3);
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+
+            int attemptsInvoked = 0;
+            Action onExecute = () => attemptsInvoked++;
+
+            PolicyExtensions.ExceptionAndOrCancellationScenario scenario = new PolicyExtensions.ExceptionAndOrCancellationScenario
+            {
+                NumberOfTimesToRaiseException = 1 + 3,
+                AttemptDuringWhichToCancel = 1,
+                ActionObservesCancellation = false
+            };
+
+            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .ShouldThrow<OperationCanceledException>()
+                .And.CancellationToken.Should().Be(cancellationToken);
+
+            attemptsInvoked.Should().Be(1);
+        }
+
+        [Fact]
+        public void Should_report_cancellation_during_faulting_retried_action_execution_and_cancel_further_retries_when_user_delegate_observes_cancellationtoken()
+        {
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .Retry(3);
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+
+            int attemptsInvoked = 0;
+            Action onExecute = () => attemptsInvoked++;
+
+            PolicyExtensions.ExceptionAndOrCancellationScenario scenario = new PolicyExtensions.ExceptionAndOrCancellationScenario
+            {
+                NumberOfTimesToRaiseException = 1 + 3,
+                AttemptDuringWhichToCancel = 2,
+                ActionObservesCancellation = true
+            };
+
+            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .ShouldThrow<OperationCanceledException>()
+                .And.CancellationToken.Should().Be(cancellationToken);
+
+            attemptsInvoked.Should().Be(2);
+        }
+
+        [Fact]
+        public void Should_report_cancellation_during_faulting_retried_action_execution_and_cancel_further_retries_when_user_delegate_does_not_observe_cancellationtoken()
+        {
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .Retry(3);
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+
+            int attemptsInvoked = 0;
+            Action onExecute = () => attemptsInvoked++;
+
+            PolicyExtensions.ExceptionAndOrCancellationScenario scenario = new PolicyExtensions.ExceptionAndOrCancellationScenario
+            {
+                NumberOfTimesToRaiseException = 1 + 3,
+                AttemptDuringWhichToCancel = 2,
+                ActionObservesCancellation = false
+            };
+
+            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .ShouldThrow<OperationCanceledException>()
+                .And.CancellationToken.Should().Be(cancellationToken);
+
+            attemptsInvoked.Should().Be(2);
+        }
+
+        [Fact]
+        public void Should_report_cancellation_during_faulting_last_retry_execution_when_user_delegate_does_not_observe_cancellationtoken()
+        {
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .Retry(3);
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+
+            int attemptsInvoked = 0;
+            Action onExecute = () => attemptsInvoked++;
+
+            PolicyExtensions.ExceptionAndOrCancellationScenario scenario = new PolicyExtensions.ExceptionAndOrCancellationScenario
+            {
+                NumberOfTimesToRaiseException = 1 + 3,
+                AttemptDuringWhichToCancel = 1 + 3,
+                ActionObservesCancellation = false
+            };
+
+            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .ShouldThrow<OperationCanceledException>()
+                .And.CancellationToken.Should().Be(cancellationToken);
+
+            attemptsInvoked.Should().Be(1 + 3);
+        }
+
+        [Fact]
+        public void Should_report_cancellation_after_faulting_action_execution_and_cancel_further_retries_if_onRetry_invokes_cancellation()
+        {
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .Retry(3, (_, __) =>
+                {
+                    cancellationTokenSource.Cancel();
+                });
+
+            int attemptsInvoked = 0;
+            Action onExecute = () => attemptsInvoked++;
+
+            PolicyExtensions.ExceptionAndOrCancellationScenario scenario = new PolicyExtensions.ExceptionAndOrCancellationScenario
+            {
+                NumberOfTimesToRaiseException = 1 + 3,
+                AttemptDuringWhichToCancel = null, // Cancellation during onRetry instead - see above.
+                ActionObservesCancellation = false
+            };
+
+            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .ShouldThrow<OperationCanceledException>()
+                .And.CancellationToken.Should().Be(cancellationToken);
+
+            attemptsInvoked.Should().Be(1);
+        }
+
+        [Fact]
+        public void Should_execute_func_returning_value_when_cancellationtoken_not_cancelled()
+        {
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .Retry(3);
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+
+            int attemptsInvoked = 0;
+            Action onExecute = () => attemptsInvoked++;
+
+            bool? result = null;
+
+            PolicyExtensions.ExceptionAndOrCancellationScenario scenario = new PolicyExtensions.ExceptionAndOrCancellationScenario
+            {
+                NumberOfTimesToRaiseException = 0,
+                AttemptDuringWhichToCancel = null,
+            };
+
+            policy.Invoking(x => result = x.RaiseExceptionAndOrCancellation<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true))
+                .ShouldNotThrow();
+
+            result.Should().BeTrue();
+
+            attemptsInvoked.Should().Be(1);
+        }
+
+        [Fact]
+        public void Should_honour_and_report_cancellation_during_func_execution()
+        {
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .Retry(3);
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+
+            int attemptsInvoked = 0;
+            Action onExecute = () => attemptsInvoked++;
+
+            bool? result = null;
+
+            PolicyExtensions.ExceptionAndOrCancellationScenario scenario = new PolicyExtensions.ExceptionAndOrCancellationScenario
+            {
+                NumberOfTimesToRaiseException = 0,
+                AttemptDuringWhichToCancel = 1,
+                ActionObservesCancellation = true
+            };
+
+            policy.Invoking(x => result = x.RaiseExceptionAndOrCancellation<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true))
+                .ShouldThrow<OperationCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
+
+            result.Should().Be(null);
+
+            attemptsInvoked.Should().Be(1);
+        }
+
+        #endregion
+
+
     }
 }

--- a/src/Polly.SharedSpecs/WaitAndRetryForeverAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/WaitAndRetryForeverAsyncSpecs.cs
@@ -189,7 +189,7 @@ namespace Polly.Specs
                 .Handle<DivideByZeroException>()
                 .WaitAndRetryForeverAsync(provider);
 
-            SystemClock.Sleep = span => totalTimeSlept += span.Seconds;
+            SystemClock.Sleep = (span, ct) => totalTimeSlept += span.Seconds;
 
             policy.Awaiting(x => x.RaiseExceptionAsync<NullReferenceException>())
                   .ShouldThrow<NullReferenceException>();

--- a/src/Polly.SharedSpecs/WaitAndRetryForeverSpecs.cs
+++ b/src/Polly.SharedSpecs/WaitAndRetryForeverSpecs.cs
@@ -13,7 +13,7 @@ namespace Polly.Specs
         public WaitAndRetryForeverSpecs()
         {
             // do nothing on call to sleep
-            SystemClock.Sleep = (_) => { };
+            SystemClock.Sleep = (_, __) => { };
         }
 
         [Fact]
@@ -185,7 +185,7 @@ namespace Polly.Specs
                 .Handle<DivideByZeroException>()
                 .WaitAndRetryForever(provider);
 
-            SystemClock.Sleep = span => totalTimeSlept += span.Seconds;
+            SystemClock.Sleep = (span, ct) => totalTimeSlept += span.Seconds;
 
             policy.Invoking(x => x.RaiseException<NullReferenceException>())
                   .ShouldThrow<NullReferenceException>();


### PR DESCRIPTION
Add Cancellation support for sync executions.  Thanks to @brunolauze for the initial implementation. 

Cancellation support on sync executions will support using the forthcoming `TimeoutPolicy` in Polly v5.0 as part of `PolicyWrap`s.