### PR TITLE
Performance refinement - reduce allocations

### DIFF
--- a/src/Polly.Shared/AdvancedCircuitBreakerSyntax.cs
+++ b/src/Polly.Shared/AdvancedCircuitBreakerSyntax.cs
@@ -215,7 +215,7 @@ namespace Polly
                     context,
                     cancellationToken,
                     policyBuilder.ExceptionPredicates, 
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(), 
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates, 
                     breakerController), 
                 policyBuilder.ExceptionPredicates, 
                 breakerController

--- a/src/Polly.Shared/AdvancedCircuitBreakerSyntaxAsync.cs
+++ b/src/Polly.Shared/AdvancedCircuitBreakerSyntaxAsync.cs
@@ -220,7 +220,7 @@ namespace Polly
                     async ct => { await action(ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                     context,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(), 
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates, 
                     breakerController,
                     cancellationToken,
                     continueOnCapturedContext),

--- a/src/Polly.Shared/CircuitBreakerSyntax.cs
+++ b/src/Polly.Shared/CircuitBreakerSyntax.cs
@@ -187,7 +187,7 @@ namespace Polly
                     context,
                     cancellationToken,
                     policyBuilder.ExceptionPredicates, 
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(), 
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates, 
                     breakerController), 
                 policyBuilder.ExceptionPredicates, 
                 breakerController

--- a/src/Polly.Shared/CircuitBreakerSyntaxAsync.cs
+++ b/src/Polly.Shared/CircuitBreakerSyntaxAsync.cs
@@ -188,7 +188,7 @@ namespace Polly
                     async ct => { await action(ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                       context, 
                       policyBuilder.ExceptionPredicates, 
-                      Enumerable.Empty<ResultPredicate<EmptyStruct>>(), 
+                      PredicateHelper<EmptyStruct>.EmptyResultPredicates, 
                       breakerController, 
                       cancellationToken, 
                       continueOnCapturedContext),

--- a/src/Polly.Shared/FallbackSyntax.cs
+++ b/src/Polly.Shared/FallbackSyntax.cs
@@ -114,7 +114,7 @@ namespace Polly
                     context,
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
                     (outcome, ctx) => onFallback(outcome.Exception, ctx),
                     ct => { fallbackAction(ct); return EmptyStruct.Instance; }),
                 policyBuilder.ExceptionPredicates);

--- a/src/Polly.Shared/FallbackSyntaxAsync.cs
+++ b/src/Polly.Shared/FallbackSyntaxAsync.cs
@@ -69,7 +69,7 @@ namespace Polly
                     async ct => { await action(ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                     context,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
                     (outcome, ctx) => onFallbackAsync(outcome.Exception, ctx),
                     async ct => { await fallbackAction(ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                     cancellationToken,

--- a/src/Polly.Shared/Policy.cs
+++ b/src/Polly.Shared/Policy.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using Polly.Utilities;
 
 namespace Polly
 {
@@ -22,7 +23,7 @@ namespace Polly
             if (exceptionPolicy == null) throw new ArgumentNullException("exceptionPolicy");
 
             _exceptionPolicy = exceptionPolicy;
-            _exceptionPredicates = exceptionPredicates ?? Enumerable.Empty<ExceptionPredicate>();
+            _exceptionPredicates = exceptionPredicates ?? PredicateHelper.EmptyExceptionPredicates;
         }
 
         /// <summary>
@@ -230,8 +231,8 @@ namespace Polly
             if (executionPolicy == null) throw new ArgumentNullException("executionPolicy");
 
             _executionPolicy = executionPolicy;
-            _exceptionPredicates = exceptionPredicates ?? Enumerable.Empty<ExceptionPredicate>();
-            _resultPredicates = resultPredicates ?? Enumerable.Empty<ResultPredicate<TResult>>();
+            _exceptionPredicates = exceptionPredicates ?? PredicateHelper.EmptyExceptionPredicates;
+            _resultPredicates = resultPredicates ?? PredicateHelper<TResult>.EmptyResultPredicates;
         }
 
         /// <summary>

--- a/src/Polly.Shared/PolicyAsync.cs
+++ b/src/Polly.Shared/PolicyAsync.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Polly.Utilities;
 
 namespace Polly
 {
@@ -18,7 +19,7 @@ namespace Polly
             if (asyncExceptionPolicy == null) throw new ArgumentNullException("asyncExceptionPolicy");
 
             _asyncExceptionPolicy = asyncExceptionPolicy;
-            _exceptionPredicates = exceptionPredicates ?? Enumerable.Empty<ExceptionPredicate>();
+            _exceptionPredicates = exceptionPredicates ?? PredicateHelper.EmptyExceptionPredicates;
         }
 
         /// <summary>
@@ -590,8 +591,8 @@ namespace Polly
             if (asyncExecutionPolicy == null) throw new ArgumentNullException("asyncExecutionPolicy");
 
             _asyncExecutionPolicy = asyncExecutionPolicy;
-            _exceptionPredicates = exceptionPredicates ?? Enumerable.Empty<ExceptionPredicate>();
-            _resultPredicates = resultPredicates ?? Enumerable.Empty<ResultPredicate<TResult>>();
+            _exceptionPredicates = exceptionPredicates ?? PredicateHelper.EmptyExceptionPredicates;
+            _resultPredicates = resultPredicates ?? PredicateHelper<TResult>.EmptyResultPredicates;
         }
 
         /// <summary>

--- a/src/Polly.Shared/Polly.Shared.projitems
+++ b/src/Polly.Shared/Polly.Shared.projitems
@@ -70,6 +70,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)AdvancedCircuitBreakerSyntax.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AdvancedCircuitBreakerSyntaxAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\EmptyStruct.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Utilities\PredicateHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\ReadOnlyDictionary.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\SystemClock.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\TaskHelper.cs" />

--- a/src/Polly.Shared/RetrySyntax.cs
+++ b/src/Polly.Shared/RetrySyntax.cs
@@ -67,7 +67,7 @@ namespace Polly
                     ct => { action(ct); return EmptyStruct.Instance; }, 
                     cancellationToken,
                     policyBuilder.ExceptionPredicates, 
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
                     () => new RetryPolicyStateWithCount<EmptyStruct>(retryCount, (outcome, i) => onRetry(outcome.Exception, i))
                 ),
                 policyBuilder.ExceptionPredicates
@@ -107,7 +107,7 @@ namespace Polly
                     ct => { action(ct); return EmptyStruct.Instance; },
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
                 () => new RetryPolicyStateWithCount<EmptyStruct>(retryCount, (outcome, i, ctx) => onRetry(outcome.Exception, i, ctx), context)
             ), policyBuilder.ExceptionPredicates);
         }
@@ -141,7 +141,7 @@ namespace Polly
                     ct => { action(ct); return EmptyStruct.Instance; },
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(), 
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates, 
                     () => new RetryPolicyState<EmptyStruct>(outcome => onRetry(outcome.Exception))
                 ),
                 policyBuilder.ExceptionPredicates
@@ -164,7 +164,7 @@ namespace Polly
                 ct => { action(ct); return EmptyStruct.Instance; },
                 cancellationToken,
                 policyBuilder.ExceptionPredicates,
-                Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                PredicateHelper<EmptyStruct>.EmptyResultPredicates,
                 () => new RetryPolicyState<EmptyStruct>((outcome, ctx) => onRetry(outcome.Exception, ctx), context)
             ), policyBuilder.ExceptionPredicates);
         }
@@ -216,7 +216,7 @@ namespace Polly
                     ct => { action(ct); return EmptyStruct.Instance; },
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
                     () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, (outcome, timespan) => onRetry(outcome.Exception, timespan))
                 ),
                 policyBuilder.ExceptionPredicates
@@ -253,7 +253,7 @@ namespace Polly
                 ct => { action(ct); return EmptyStruct.Instance; },
                 cancellationToken,
                 policyBuilder.ExceptionPredicates,
-                Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                PredicateHelper<EmptyStruct>.EmptyResultPredicates,
                 () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, (outcome, timespan, ctx) => onRetry(outcome.Exception, timespan, ctx), context)
             ), policyBuilder.ExceptionPredicates);
         }
@@ -289,7 +289,7 @@ namespace Polly
                 ct => { action(ct); return EmptyStruct.Instance; },
                 cancellationToken,
                 policyBuilder.ExceptionPredicates,
-                Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                PredicateHelper<EmptyStruct>.EmptyResultPredicates,
                 () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, (outcome, timespan, i, ctx) => onRetry(outcome.Exception, timespan, i, ctx), context)
             ), policyBuilder.ExceptionPredicates);
         }
@@ -332,7 +332,7 @@ namespace Polly
                     ct => { action(ct); return EmptyStruct.Instance; },
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
                     () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, (outcome, timespan) => onRetry(outcome.Exception, timespan))
                 ),
                 policyBuilder.ExceptionPredicates
@@ -363,7 +363,7 @@ namespace Polly
                 ct => { action(ct); return EmptyStruct.Instance; },
                 cancellationToken,
                 policyBuilder.ExceptionPredicates,
-                Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                PredicateHelper<EmptyStruct>.EmptyResultPredicates,
                 () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, (outcome, timespan, ctx) => onRetry(outcome.Exception, timespan, ctx), context)
             ), policyBuilder.ExceptionPredicates);
         }
@@ -392,7 +392,7 @@ namespace Polly
                 ct => { action(ct); return EmptyStruct.Instance; },
                 cancellationToken,
                 policyBuilder.ExceptionPredicates,
-                Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                PredicateHelper<EmptyStruct>.EmptyResultPredicates,
                 () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, (outcome, timespan, i, ctx) => onRetry(outcome.Exception, timespan, i, ctx), context)
             ), policyBuilder.ExceptionPredicates);
         }
@@ -433,7 +433,7 @@ namespace Polly
                     ct => { action(ct); return EmptyStruct.Instance; },
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
                     () => new RetryPolicyStateWithSleepDurationProvider<EmptyStruct>(sleepDurationProvider, (outcome, timespan) => onRetry(outcome.Exception, timespan))
                 ),
                 policyBuilder.ExceptionPredicates
@@ -460,7 +460,7 @@ namespace Polly
                 ct => { action(ct); return EmptyStruct.Instance; },
                 cancellationToken,
                 policyBuilder.ExceptionPredicates,
-                Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                PredicateHelper<EmptyStruct>.EmptyResultPredicates,
                 () => new RetryPolicyStateWithSleepDurationProvider<EmptyStruct>(sleepDurationProvider, (outcome, timespan, ctx) => onRetry(outcome.Exception, timespan, ctx), context)
             ), policyBuilder.ExceptionPredicates);
         }

--- a/src/Polly.Shared/RetrySyntaxAsync.cs
+++ b/src/Polly.Shared/RetrySyntaxAsync.cs
@@ -85,7 +85,7 @@ namespace Polly
                     async ct => { await action(ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
 #pragma warning disable 1998
                     () => new RetryPolicyStateWithCount<EmptyStruct>(retryCount, async (outcome, i) => onRetry(outcome.Exception, i)),
 #pragma warning restore 1998
@@ -116,7 +116,7 @@ namespace Polly
                     async ct => { await action(ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
                     () => new RetryPolicyStateWithCount<EmptyStruct>(retryCount, (outcome, i) => onRetryAsync(outcome.Exception, i)), 
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates
@@ -170,7 +170,7 @@ namespace Polly
                     async ct => { await action(ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
 #pragma warning disable 1998
                 () => new RetryPolicyStateWithCount<EmptyStruct>(retryCount, async (outcome, i, c) => onRetry(outcome.Exception, i, c), context),
 #pragma warning restore 1998
@@ -199,7 +199,7 @@ namespace Polly
                     async ct => { await action(ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
                 () => new RetryPolicyStateWithCount<EmptyStruct>(retryCount, (outcome, i, ctx) => onRetryAsync(outcome.Exception, i, ctx), context),
                 continueOnCapturedContext
             ), policyBuilder.ExceptionPredicates);
@@ -235,7 +235,7 @@ namespace Polly
                     async ct => { await action(ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
 #pragma warning disable 1998
                     () => new RetryPolicyState<EmptyStruct>(async outcome => onRetry(outcome.Exception)), 
 #pragma warning restore 1998
@@ -262,7 +262,7 @@ namespace Polly
                     async ct => { await action(ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
                     () => new RetryPolicyState<EmptyStruct>(outcome => onRetryAsync(outcome.Exception)),
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates
@@ -287,7 +287,7 @@ namespace Polly
                     async ct => { await action(ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
 #pragma warning disable 1998
                 () => new RetryPolicyState<EmptyStruct>(async (outcome, c) => onRetry(outcome.Exception, c), context),
 #pragma warning restore 1998
@@ -313,7 +313,7 @@ namespace Polly
                     async ct => { await action(ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
                 () => new RetryPolicyState<EmptyStruct>((outcome, ctx) => onRetryAsync(outcome.Exception, ctx), context),
                 continueOnCapturedContext
             ), policyBuilder.ExceptionPredicates);
@@ -368,7 +368,7 @@ namespace Polly
                     async ct => { await action(ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
 #pragma warning disable 1998
                     () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, async (outcome, timespan) => onRetry(outcome.Exception, timespan)), 
 #pragma warning restore 1998
@@ -411,7 +411,7 @@ namespace Polly
                     async ct => { await action(ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
                     () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, (outcome, timespan) => onRetryAsync(outcome.Exception, timespan)),
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates
@@ -451,7 +451,7 @@ namespace Polly
                     async ct => { await action(ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
 #pragma warning disable 1998
                     () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, async (outcome, timespan, ctx) => onRetry(outcome.Exception, timespan, ctx), context),
 #pragma warning restore 1998
@@ -493,7 +493,7 @@ namespace Polly
                     async ct => { await action(ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
 #pragma warning disable 1998
                     () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, async (outcome, timespan, i, ctx) => onRetry(outcome.Exception, timespan, i, ctx), context),
 #pragma warning restore 1998
@@ -535,7 +535,7 @@ namespace Polly
                     async ct => { await action(ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
                     () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, (outcome, timespan, ctx) => onRetryAsync(outcome.Exception, timespan, ctx), context),
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates
@@ -575,7 +575,7 @@ namespace Polly
                     async ct => { await action(ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
                     () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, (outcome, timespan, i, ctx) => onRetryAsync(outcome.Exception, timespan, i, ctx), context),
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates
@@ -623,7 +623,7 @@ namespace Polly
                     async ct => { await action(ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
 #pragma warning disable 1998
                     () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, async (outcome, timespan) => onRetry(outcome.Exception, timespan)), 
 #pragma warning restore 1998
@@ -658,7 +658,7 @@ namespace Polly
                     async ct => { await action(ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
                     () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, (outcome, timespan) => onRetryAsync(outcome.Exception, timespan)),
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates
@@ -691,7 +691,7 @@ namespace Polly
                     async ct => { await action(ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
 #pragma warning disable 1998
                     () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, async (outcome, timespan, ctx) => onRetry(outcome.Exception, timespan, ctx), context),
 #pragma warning restore 1998
@@ -726,7 +726,7 @@ namespace Polly
                     async ct => { await action(ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
 #pragma warning disable 1998
                     () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, async (outcome, timespan, i, ctx) => onRetry(outcome.Exception, timespan, i, ctx), context),
 #pragma warning restore 1998
@@ -761,7 +761,7 @@ namespace Polly
                     async ct => { await action(ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
                     () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, (outcome, timespan, ctx) => onRetryAsync(outcome.Exception, timespan, ctx), context),
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates
@@ -794,7 +794,7 @@ namespace Polly
                     async ct => { await action(ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
                     () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, (outcome, timespan, i, ctx) => onRetryAsync(outcome.Exception, timespan, i, ctx), context),
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates
@@ -838,7 +838,7 @@ namespace Polly
                     async ct => { await action(ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
 #pragma warning disable 1998
                     () => new RetryPolicyStateWithSleepDurationProvider<EmptyStruct>(sleepDurationProvider, async (outcome, timespan) => onRetry(outcome.Exception, timespan)),
 #pragma warning restore 1998
@@ -869,7 +869,7 @@ namespace Polly
                     async ct => { await action(ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
                     () => new RetryPolicyStateWithSleepDurationProvider<EmptyStruct>(sleepDurationProvider, (outcome, timespan) => onRetryAsync(outcome.Exception, timespan)),
                     continueOnCapturedContext
                 ),
@@ -899,7 +899,7 @@ namespace Polly
                     async ct => { await action(ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
 #pragma warning disable 1998
                 () => new RetryPolicyStateWithSleepDurationProvider<EmptyStruct>(sleepDurationProvider, async (outcome, timespan, ctx) => onRetry(outcome.Exception, timespan, ctx), context),
 #pragma warning restore 1998
@@ -929,7 +929,7 @@ namespace Polly
                     async ct => { await action(ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
-                    Enumerable.Empty<ResultPredicate<EmptyStruct>>(),
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
                 () => new RetryPolicyStateWithSleepDurationProvider<EmptyStruct>(sleepDurationProvider, (outcome, timespan, ctx) => onRetryAsync(outcome.Exception, timespan, ctx), context),
                 continueOnCapturedContext
             ), policyBuilder.ExceptionPredicates);

--- a/src/Polly.Shared/Utilities/PredicateHelper.cs
+++ b/src/Polly.Shared/Utilities/PredicateHelper.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Polly.Utilities
+{
+    internal class PredicateHelper
+    {
+        public static readonly IEnumerable<ExceptionPredicate> EmptyExceptionPredicates = Enumerable.Empty<ExceptionPredicate>();
+    }
+
+    internal class PredicateHelper<TResult>
+    {
+        public static readonly IEnumerable<ResultPredicate<TResult>> EmptyResultPredicates = Enumerable.Empty<ResultPredicate<TResult>>();
+    }
+}

--- a/src/Polly.Shared/Wrap/PolicyWrap.cs
+++ b/src/Polly.Shared/Wrap/PolicyWrap.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using Polly.Utilities;
 
 namespace Polly.Wrap
 {
@@ -12,7 +13,7 @@ namespace Polly.Wrap
     public partial class PolicyWrap : Policy
     {
         internal PolicyWrap(Action<Action<CancellationToken>, Context, CancellationToken> policyAction) 
-            : base(policyAction, Enumerable.Empty<ExceptionPredicate>())
+            : base(policyAction, PredicateHelper.EmptyExceptionPredicates)
         {
         }
     }
@@ -24,7 +25,7 @@ namespace Polly.Wrap
     public partial class PolicyWrap<TResult> : Policy<TResult>
     {
         internal PolicyWrap(Func<Func<CancellationToken, TResult>, Context, CancellationToken, TResult> policyAction)
-            : base(policyAction, Enumerable.Empty<ExceptionPredicate>(), Enumerable.Empty<ResultPredicate<TResult>>())
+            : base(policyAction, PredicateHelper.EmptyExceptionPredicates, PredicateHelper<TResult>.EmptyResultPredicates)
         {
         }
     }

--- a/src/Polly.Shared/Wrap/PolicyWrapAsync.cs
+++ b/src/Polly.Shared/Wrap/PolicyWrapAsync.cs
@@ -4,13 +4,14 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Polly.Utilities;
 
 namespace Polly.Wrap
 {
     public partial class PolicyWrap
     {
         internal PolicyWrap(Func<Func<CancellationToken, Task>, Context, CancellationToken, bool, Task> policyAction)
-            : base(policyAction, Enumerable.Empty<ExceptionPredicate>())
+            : base(policyAction, PredicateHelper.EmptyExceptionPredicates)
         {
         }
     }
@@ -18,7 +19,7 @@ namespace Polly.Wrap
     public partial class PolicyWrap<TResult>
     {
         internal PolicyWrap(Func<Func<CancellationToken, Task<TResult>>, Context, CancellationToken, bool, Task<TResult>> policyAction)
-            : base(policyAction, Enumerable.Empty<ExceptionPredicate>(), Enumerable.Empty<ResultPredicate<TResult>>())
+            : base(policyAction, PredicateHelper.EmptyExceptionPredicates, PredicateHelper<TResult>.EmptyResultPredicates)
         {
         }
     }


### PR DESCRIPTION
Reduce allocations by sharing single static allocation for policies where some predicates may be irrelevant