### PR TITLE
Add PolicyKeys which feed to execution Context

### DIFF
--- a/src/Polly.Shared/CircuitBreaker/CircuitStateController.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitStateController.cs
@@ -85,7 +85,7 @@ namespace Polly.CircuitBreaker
             using (TimedLock.Lock(_lock))
             {
                 _lastOutcome = new DelegateResult<TResult>(new IsolatedCircuitException("The circuit is manually held open and is not allowing calls."));
-                BreakFor_NeedsLock(TimeSpan.MaxValue, Context.Empty);
+                BreakFor_NeedsLock(TimeSpan.MaxValue, Context.None);
                 _circuitState = CircuitState.Isolated;
             }
         }
@@ -103,12 +103,12 @@ namespace Polly.CircuitBreaker
                 : SystemClock.UtcNow() + durationOfBreak;
             _circuitState = CircuitState.Open;
 
-            _onBreak(_lastOutcome, durationOfBreak, context ?? Context.Empty);
+            _onBreak(_lastOutcome, durationOfBreak, context);
         }
 
         public void Reset()
         {
-            OnCircuitReset(Context.Empty);
+            OnCircuitReset(Context.None);
         }
 
         protected void ResetInternal_NeedsLock(Context context)
@@ -120,7 +120,7 @@ namespace Polly.CircuitBreaker
             _circuitState = CircuitState.Closed;
             if (priorState != CircuitState.Closed)
             {
-                _onReset(context ?? Context.Empty);
+                _onReset(context);
             }
         }
 

--- a/src/Polly.Shared/Context.cs
+++ b/src/Polly.Shared/Context.cs
@@ -52,12 +52,20 @@ namespace Polly
         /// <summary>
         /// A key unique to the outermost <see cref="PolicyWrap"/> instance involved in the current PolicyWrap execution.
         /// </summary>
-        public String PolicyWrapKey => _policyWrapKey;
+        public String PolicyWrapKey
+        {
+            get { return _policyWrapKey; }
+            internal set { _policyWrapKey = value; }
+        }
 
         /// <summary>
         /// A key unique to the <see cref="Policy"/> instance executing the current delegate.
         /// </summary>
-        public String PolicyKey => _policyKey;
+        public String PolicyKey
+        {
+            get { return _policyKey; }
+            internal set { _policyKey = value; }
+        }
 
         /// <summary>
         /// A key unique to the call site of the current execution. 
@@ -72,29 +80,10 @@ namespace Polly
         {
             get
             {
-                if (_executionGuid == null) { _executionGuid = Guid.NewGuid(); }
+                if (!_executionGuid.HasValue) { _executionGuid = Guid.NewGuid(); }
                 return _executionGuid.Value;
             }
         }
-
-        internal void SetPolicyContext(Policy executingPolicy)
-        {
-            _policyKey = executingPolicy.PolicyKey;
-
-            if (PolicyWrapKey == null && executingPolicy is PolicyWrap)
-            {
-                _policyWrapKey = executingPolicy.PolicyKey;
-            }
-        }
-
-        internal void SetPolicyContext<TResult>(Policy<TResult> executingPolicy)
-        {
-            _policyKey = executingPolicy.PolicyKey;
-
-            if (PolicyWrapKey == null && executingPolicy is PolicyWrap<TResult>)
-            {
-                _policyWrapKey = executingPolicy.PolicyKey;
-            }
-        }
+        
     }
 }

--- a/src/Polly.Shared/Context.cs
+++ b/src/Polly.Shared/Context.cs
@@ -1,5 +1,6 @@
-﻿using System.Collections.Generic;
-
+﻿using System;
+using System.Collections.Generic;
+using Polly.Wrap;
 #if SUPPORTS_READONLY_COLLECTION
 using System.Collections.ObjectModel;
 #else
@@ -13,10 +14,87 @@ namespace Polly
     /// </summary>
     public class Context : ReadOnlyDictionary<string, object>
     {
-        internal static readonly Context Empty = new Context(new Dictionary<string, object>());
+        private static readonly IDictionary<string, object> emptyDictionary = new Dictionary<string, object>();
+        internal static readonly Context None = new Context(emptyDictionary);
 
-        internal Context(IDictionary<string, object> values) : base(values)
+        private string _policyKey;
+        private string _policyWrapKey;
+        private readonly string _executionKey;
+        private Guid? _executionGuid;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Context"/> class, with the specified <paramref name="executionKey"/>.
+        /// </summary>
+        /// <param name="executionKey">The execution key.</param>
+        public Context(String executionKey) : this(executionKey, emptyDictionary)
         {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Context"/> class, with the specified <paramref name="executionKey" /> and the supplied <paramref name="contextData"/>.
+        /// </summary>
+        /// <param name="executionKey">The execution key.</param>
+        /// <param name="contextData">The context data.</param>
+        public Context(String executionKey, IDictionary<string, object> contextData) : this(contextData)
+        {
+            _executionKey = executionKey;
+        }
+
+        internal Context() : this(emptyDictionary)
+        {
+        }
+
+        internal Context(IDictionary<string, object> contextData) : base(contextData)
+        {
+            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
+        }
+
+        /// <summary>
+        /// A key unique to the outermost <see cref="PolicyWrap"/> instance involved in the current PolicyWrap execution.
+        /// </summary>
+        public String PolicyWrapKey => _policyWrapKey;
+
+        /// <summary>
+        /// A key unique to the <see cref="Policy"/> instance executing the current delegate.
+        /// </summary>
+        public String PolicyKey => _policyKey;
+
+        /// <summary>
+        /// A key unique to the call site of the current execution. 
+        /// <remarks>The value is set </remarks>
+        /// </summary>
+        public String ExecutionKey => _executionKey;
+
+        /// <summary>
+        /// A Guid guaranteed to be unique to each execution.
+        /// </summary>
+        public Guid ExecutionGuid
+        {
+            get
+            {
+                if (_executionGuid == null) { _executionGuid = Guid.NewGuid(); }
+                return _executionGuid.Value;
+            }
+        }
+
+        internal void SetPolicyContext(Policy executingPolicy)
+        {
+            _policyKey = executingPolicy.PolicyKey;
+
+            if (PolicyWrapKey == null && executingPolicy is PolicyWrap)
+            {
+                _policyWrapKey = executingPolicy.PolicyKey;
+            }
+        }
+
+        internal void SetPolicyContext<TResult>(Policy<TResult> executingPolicy)
+        {
+            _policyKey = executingPolicy.PolicyKey;
+
+            if (PolicyWrapKey == null && executingPolicy is PolicyWrap<TResult>)
+            {
+                _policyWrapKey = executingPolicy.PolicyKey;
+            }
         }
     }
 }

--- a/src/Polly.Shared/ContextualPolicy.cs
+++ b/src/Polly.Shared/ContextualPolicy.cs
@@ -59,7 +59,7 @@ namespace Polly
                 "Please use the synchronous-defined policies when calling the synchronous Execute (and similar) methods.");
             if (context == null) throw new ArgumentNullException(nameof(context));
 
-            context.SetPolicyContext(this);
+            SetPolicyContext(context);
 
             _exceptionPolicy(action, context, cancellationToken);
         }
@@ -192,7 +192,7 @@ namespace Polly
                 "Please use the synchronous-defined policies when calling the synchronous Execute (and similar) methods.");
             if (context == null) throw new ArgumentNullException(nameof(context));
 
-            context.SetPolicyContext(this);
+            SetPolicyContext(context);
 
             var result = default(TResult);
             _exceptionPolicy(ct => { result = action(ct); }, context, cancellationToken);
@@ -333,7 +333,7 @@ namespace Polly
                 "Please use the synchronous-defined policies when calling the synchronous Execute (and similar) methods.");
             if (context == null) throw new ArgumentNullException(nameof(context));
 
-            context.SetPolicyContext(this);
+            SetPolicyContext(context);
 
             return _executionPolicy(action, context, cancellationToken);
         }

--- a/src/Polly.Shared/ContextualPolicyAsync.cs
+++ b/src/Polly.Shared/ContextualPolicyAsync.cs
@@ -1,8 +1,7 @@
-﻿
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -18,7 +17,18 @@ namespace Polly
         [DebuggerStepThrough]
         public Task ExecuteAsync(Func<Task> action, IDictionary<string, object> contextData)
         {
-            return ExecuteAsync(ct => action(), contextData, CancellationToken.None, false);
+            return ExecuteAsync(ct => action(), new Context(contextData), CancellationToken.None, false);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Context data that is passed to the exception policy.</param>
+        [DebuggerStepThrough]
+        public Task ExecuteAsync(Func<Task> action, Context context)
+        {
+            return ExecuteAsync(ct => action(), context, CancellationToken.None, false);
         }
 
         /// <summary>
@@ -30,7 +40,19 @@ namespace Polly
         [DebuggerStepThrough]
         public Task ExecuteAsync(Func<Task> action, IDictionary<string, object> contextData, bool continueOnCapturedContext)
         {
-            return ExecuteAsync(ct => action(), contextData, CancellationToken.None, continueOnCapturedContext);
+            return ExecuteAsync(ct => action(), new Context(contextData), CancellationToken.None, continueOnCapturedContext);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Context data that is passed to the exception policy.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        [DebuggerStepThrough]
+        public Task ExecuteAsync(Func<Task> action, Context context, bool continueOnCapturedContext)
+        {
+            return ExecuteAsync(ct => action(), context, CancellationToken.None, continueOnCapturedContext);
         }
 
         /// <summary>
@@ -42,7 +64,19 @@ namespace Polly
         [DebuggerStepThrough]
         public Task ExecuteAsync(Func<CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken)
         {
-            return ExecuteAsync(action, contextData, cancellationToken, false);
+            return ExecuteAsync(action, new Context(contextData), cancellationToken, false);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Context data that is passed to the exception policy.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+        [DebuggerStepThrough]
+        public Task ExecuteAsync(Func<CancellationToken, Task> action, Context context, CancellationToken cancellationToken)
+        {
+            return ExecuteAsync(action, context, cancellationToken, false);
         }
 
         /// <summary>
@@ -56,9 +90,27 @@ namespace Polly
         [DebuggerStepThrough]
         public Task ExecuteAsync(Func<CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
-            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
-
             return ExecuteAsync(action, new Context(contextData), cancellationToken, continueOnCapturedContext);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Context data that is passed to the exception policy.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+        /// <exception cref="System.InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
+        [DebuggerStepThrough]
+        public async Task ExecuteAsync(Func<CancellationToken, Task> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        {
+            if (_asyncExceptionPolicy == null) throw new InvalidOperationException
+                ("Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.");
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            context.SetPolicyContext(this);
+
+            await _asyncExceptionPolicy(action, context, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
         }
 
 
@@ -72,9 +124,19 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Task> action, IDictionary<string, object> contextData)
         {
-            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
-
             return ExecuteAndCaptureAsync(action, new Context(contextData));
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the captured result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Context data that is passed to the exception policy.</param>
+        /// <returns>The captured result</returns>
+        [DebuggerStepThrough]
+        public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Task> action, Context context)
+        {
+            return ExecuteAndCaptureAsync(action, context, false);
         }
 
         /// <summary>
@@ -88,10 +150,22 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Task> action, IDictionary<string, object> contextData, bool continueOnCapturedContext)
         {
-            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
-
             return ExecuteAndCaptureAsync(action, new Context(contextData), continueOnCapturedContext);
         }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the captured result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Context data that is passed to the exception policy.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <returns>The captured result</returns>
+        [DebuggerStepThrough]
+        public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Task> action, Context context, bool continueOnCapturedContext)
+        {
+            return ExecuteAndCaptureAsync(ct => action(), context, CancellationToken.None, continueOnCapturedContext);
+        }
+
         /// <summary>
         ///     Executes the specified asynchronous action within the policy and returns the captured result.
         /// </summary>
@@ -103,8 +177,6 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult> ExecuteAndCaptureAsync(Func<CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken)
         {
-            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
-
             return ExecuteAndCaptureAsync(action, new Context(contextData), cancellationToken);
         }
 
@@ -112,18 +184,55 @@ namespace Polly
         ///     Executes the specified asynchronous action within the policy and returns the captured result.
         /// </summary>
         /// <param name="action">The action to perform.</param>
-        /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <param name="context">Context data that is passed to the exception policy.</param>
         /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+        [DebuggerStepThrough]
+        public Task<PolicyResult> ExecuteAndCaptureAsync(Func<CancellationToken, Task> action, Context context, CancellationToken cancellationToken)
+        {
+            return ExecuteAndCaptureAsync(action, context, cancellationToken, false);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the captured result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
         /// <exception cref="System.ArgumentNullException">contextData</exception>
         /// <returns>The captured result</returns>
         [DebuggerStepThrough]
         public Task<PolicyResult> ExecuteAndCaptureAsync(Func<CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
-            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
-
             return ExecuteAndCaptureAsync(action, new Context(contextData), cancellationToken,
                 continueOnCapturedContext);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the captured result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Context data that is passed to the exception policy.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+        /// <exception cref="System.InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
+        [DebuggerStepThrough]
+        public async Task<PolicyResult> ExecuteAndCaptureAsync(Func<CancellationToken, Task> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        {
+            if (_asyncExceptionPolicy == null) throw new InvalidOperationException
+                ("Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.");
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            try
+            {
+                await ExecuteAsync(action, context, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
+                return PolicyResult.Successful();
+            }
+            catch (Exception exception)
+            {
+                return PolicyResult.Failure(exception, GetExceptionType(_exceptionPredicates, exception));
+            }
+
         }
 
         /// <summary>
@@ -135,7 +244,20 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<TResult> ExecuteAsync<TResult>(Func<Task<TResult>> action, IDictionary<string, object> contextData)
         {
-            return ExecuteAsync(ct => action(), contextData, CancellationToken.None, false);
+            return ExecuteAsync(ct => action(), new Context(contextData), CancellationToken.None, false);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Context data that is passed to the exception policy.</param>
+        /// <returns>The value returned by the action</returns>
+        [DebuggerStepThrough]
+        public Task<TResult> ExecuteAsync<TResult>(Func<Task<TResult>> action, Context context)
+        {
+            return ExecuteAsync(ct => action(), context, CancellationToken.None, false);
         }
 
         /// <summary>
@@ -148,9 +270,23 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<TResult> ExecuteAsync<TResult>(Func<Task<TResult>> action, IDictionary<string, object> contextData, bool continueOnCapturedContext)
         {
-            return ExecuteAsync(ct => action(), contextData, CancellationToken.None, continueOnCapturedContext);
+            return ExecuteAsync(ct => action(), new Context(contextData), CancellationToken.None, continueOnCapturedContext);
         }
 
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Context data that is passed to the exception policy.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <returns>The value returned by the action</returns>
+        [DebuggerStepThrough]
+        public Task<TResult> ExecuteAsync<TResult>(Func<Task<TResult>> action, Context context, bool continueOnCapturedContext)
+        {
+            return ExecuteAsync(ct => action(), context, CancellationToken.None, continueOnCapturedContext);
+        }
+        
         /// <summary>
         ///     Executes the specified asynchronous action within the policy and returns the result.
         /// </summary>
@@ -161,7 +297,21 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken)
         {
-            return ExecuteAsync(action, contextData, cancellationToken, false);
+            return ExecuteAsync(action, new Context(contextData), cancellationToken, false);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Context data that is passed to the exception policy.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
+        /// <returns>The value returned by the action</returns>
+        [DebuggerStepThrough]
+        public Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken)
+        {
+            return ExecuteAsync(action, context, cancellationToken, false);
         }
 
         /// <summary>
@@ -176,9 +326,35 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
-            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
-
             return ExecuteAsync(action, new Context(contextData), cancellationToken, continueOnCapturedContext);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Context data that is passed to the exception policy.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
+        /// <returns>The value returned by the action</returns>
+        /// <exception cref="System.InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
+        [DebuggerStepThrough]
+        public async Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        {
+            if (_asyncExceptionPolicy == null) throw new InvalidOperationException(
+                "Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.");
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            context.SetPolicyContext(this);
+
+            var result = default(TResult);
+            await _asyncExceptionPolicy(async ct =>
+            {
+                result = await action(ct).ConfigureAwait(continueOnCapturedContext);
+            }, context, cancellationToken, continueOnCapturedContext)
+            .ConfigureAwait(continueOnCapturedContext);
+            return result;
         }
 
         /// <summary>
@@ -192,9 +368,20 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Task<TResult>> action, IDictionary<string, object> contextData)
         {
-            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
-
             return ExecuteAndCaptureAsync(action, new Context(contextData));
+        }
+
+        /// <summary>
+        /// Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Context data that is passed to the exception policy.</param>
+        /// <returns>The captured result</returns>
+        [DebuggerStepThrough]
+        public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Task<TResult>> action, Context context)
+        {
+            return ExecuteAndCaptureAsync(ct => action(), context, CancellationToken.None, false);
         }
 
         /// <summary>
@@ -209,9 +396,21 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Task<TResult>> action, IDictionary<string, object> contextData, bool continueOnCapturedContext)
         {
-            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
-
             return ExecuteAndCaptureAsync(action, new Context(contextData), continueOnCapturedContext);
+        }
+
+        /// <summary>
+        /// Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Context data that is passed to the exception policy.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <returns>The captured result</returns>
+        [DebuggerStepThrough]
+        public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Task<TResult>> action, Context context, bool continueOnCapturedContext)
+        {
+            return ExecuteAndCaptureAsync(ct => action(), context, CancellationToken.None, continueOnCapturedContext);
         }
 
         /// <summary>
@@ -226,9 +425,21 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken)
         {
-            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
-
             return ExecuteAndCaptureAsync(action, new Context(contextData), cancellationToken, false);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+        /// <returns>The captured result</returns>
+        [DebuggerStepThrough]
+        public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken)
+        {
+            return ExecuteAndCaptureAsync(action, context, cancellationToken, false);
         }
 
         /// <summary>
@@ -244,9 +455,34 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
-            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
-
             return ExecuteAndCaptureAsync(action, new Context(contextData), cancellationToken, continueOnCapturedContext);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Context data that is passed to the exception policy.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <returns>The captured result</returns>
+        /// <exception cref="System.InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
+        [DebuggerStepThrough]
+        public async Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        {
+            if (_asyncExceptionPolicy == null) throw new InvalidOperationException(
+                "Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.");
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            try
+            {
+                return PolicyResult<TResult>.Successful(await ExecuteAsync(action, context, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext));
+            }
+            catch (Exception exception)
+            {
+                return PolicyResult<TResult>.Failure(exception, GetExceptionType(_exceptionPredicates, exception));
+            }
         }
     }
 
@@ -261,7 +497,19 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<TResult> ExecuteAsync(Func<Task<TResult>> action, IDictionary<string, object> contextData)
         {
-            return ExecuteAsync(ct => action(), contextData, CancellationToken.None, false);
+            return ExecuteAsync(ct => action(), new Context(contextData), CancellationToken.None, false);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Context data that is passed to the exception policy.</param>
+        /// <returns>The value returned by the action</returns>
+        [DebuggerStepThrough]
+        public Task<TResult> ExecuteAsync(Func<Task<TResult>> action, Context context)
+        {
+            return ExecuteAsync(ct => action(), context, CancellationToken.None, false);
         }
 
         /// <summary>
@@ -274,7 +522,20 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<TResult> ExecuteAsync(Func<Task<TResult>> action, IDictionary<string, object> contextData, bool continueOnCapturedContext)
         {
-            return ExecuteAsync(ct => action(), contextData, CancellationToken.None, continueOnCapturedContext);
+            return ExecuteAsync(ct => action(), new Context(contextData), CancellationToken.None, continueOnCapturedContext);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Context data that is passed to the exception policy.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <returns>The value returned by the action</returns>
+        [DebuggerStepThrough]
+        public Task<TResult> ExecuteAsync(Func<Task<TResult>> action, Context context, bool continueOnCapturedContext)
+        {
+            return ExecuteAsync(ct => action(), context, CancellationToken.None, continueOnCapturedContext);
         }
 
         /// <summary>
@@ -287,7 +548,20 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<TResult> ExecuteAsync(Func<CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken)
         {
-            return ExecuteAsync(action, contextData, cancellationToken, false);
+            return ExecuteAsync(action, new Context(contextData), cancellationToken, false);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Context data that is passed to the exception policy.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
+        /// <returns>The value returned by the action</returns>
+        [DebuggerStepThrough]
+        public Task<TResult> ExecuteAsync(Func<CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken)
+        {
+            return ExecuteAsync(action, context, cancellationToken, false);
         }
 
         /// <summary>
@@ -302,9 +576,35 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<TResult> ExecuteAsync(Func<CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
-            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
-
             return ExecuteAsync(action, new Context(contextData), cancellationToken, continueOnCapturedContext);
+        }
+
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Context data that is passed to the exception policy.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
+        /// <returns>The value returned by the action</returns>
+        /// <exception cref="System.InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
+        [DebuggerStepThrough]
+        public async Task<TResult> ExecuteAsync(Func<CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        {
+            if (_asyncExecutionPolicy == null) throw new InvalidOperationException(
+                "Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.");
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            context.SetPolicyContext(this);
+
+            TResult result = await _asyncExecutionPolicy(
+                action,
+                context,
+                cancellationToken,
+                continueOnCapturedContext)
+            .ConfigureAwait(continueOnCapturedContext);
+            return result;
         }
 
         /// <summary>
@@ -317,9 +617,19 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Task<TResult>> action, IDictionary<string, object> contextData)
         {
-            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
+            return ExecuteAndCaptureAsync(ct => action(), new Context(contextData), CancellationToken.None, false);
+        }
 
-            return ExecuteAndCaptureAsync(action, new Context(contextData));
+        /// <summary>
+        /// Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Context data that is passed to the exception policy.</param>
+        /// <returns>The captured result</returns>
+        [DebuggerStepThrough]
+        public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Task<TResult>> action, Context context)
+        {
+            return ExecuteAndCaptureAsync(ct => action(), context, CancellationToken.None, false);
         }
 
         /// <summary>
@@ -333,9 +643,21 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Task<TResult>> action, IDictionary<string, object> contextData, bool continueOnCapturedContext)
         {
-            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
+            return ExecuteAndCaptureAsync(ct => action(), new Context(contextData), CancellationToken.None, continueOnCapturedContext);
+        }
 
-            return ExecuteAndCaptureAsync(action, new Context(contextData), continueOnCapturedContext);
+
+        /// <summary>
+        /// Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Context data that is passed to the exception policy.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <returns>The captured result</returns>
+        [DebuggerStepThrough]
+        public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Task<TResult>> action, Context context, bool continueOnCapturedContext)
+        {
+            return ExecuteAndCaptureAsync(ct => action(), context, CancellationToken.None, continueOnCapturedContext);
         }
 
         /// <summary>
@@ -349,9 +671,20 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken)
         {
-            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
-
             return ExecuteAndCaptureAsync(action, new Context(contextData), cancellationToken, false);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Context data that is passed to the exception policy.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+        /// <returns>The captured result</returns>
+        [DebuggerStepThrough]
+        public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken)
+        {
+            return ExecuteAndCaptureAsync(action, context, cancellationToken, false);
         }
 
         /// <summary>
@@ -366,9 +699,40 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
-            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
-
             return ExecuteAndCaptureAsync(action, new Context(contextData), cancellationToken, continueOnCapturedContext);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Context data that is passed to the exception policy.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+        /// <returns>The captured result</returns>
+        /// <exception cref="System.InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
+        [DebuggerStepThrough]
+        public async Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        {
+            if (_asyncExecutionPolicy == null) throw new InvalidOperationException(
+                "Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.");
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            try
+            {
+                TResult result = await ExecuteAsync(action, context, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
+
+                if (_resultPredicates.Any(predicate => predicate(result)))
+                {
+                    return PolicyResult<TResult>.Failure(result);
+                }
+
+                return PolicyResult<TResult>.Successful(result);
+            }
+            catch (Exception exception)
+            {
+                return PolicyResult<TResult>.Failure(exception, GetExceptionType(_exceptionPredicates, exception));
+            }
         }
     }
 

--- a/src/Polly.Shared/ContextualPolicyAsync.cs
+++ b/src/Polly.Shared/ContextualPolicyAsync.cs
@@ -108,7 +108,7 @@ namespace Polly
                 ("Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.");
             if (context == null) throw new ArgumentNullException(nameof(context));
 
-            context.SetPolicyContext(this);
+            SetPolicyContext(context);
 
             await _asyncExceptionPolicy(action, context, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
         }
@@ -346,7 +346,7 @@ namespace Polly
                 "Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.");
             if (context == null) throw new ArgumentNullException(nameof(context));
 
-            context.SetPolicyContext(this);
+            SetPolicyContext(context);
 
             var result = default(TResult);
             await _asyncExceptionPolicy(async ct =>
@@ -596,7 +596,7 @@ namespace Polly
                 "Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.");
             if (context == null) throw new ArgumentNullException(nameof(context));
 
-            context.SetPolicyContext(this);
+            SetPolicyContext(context);
 
             TResult result = await _asyncExecutionPolicy(
                 action,

--- a/src/Polly.Shared/Policy.ContextAndKeys.cs
+++ b/src/Polly.Shared/Policy.ContextAndKeys.cs
@@ -24,6 +24,15 @@ namespace Polly
             _policyKey = policyKey;
             return this;
         }
+
+        /// <summary>
+        /// Updates the execution <see cref="Context"/> with context from the executing <see cref="Policy"/>.
+        /// </summary>
+        /// <param name="executionContext">The execution <see cref="Context"/>.</param>
+        internal virtual void SetPolicyContext(Context executionContext)
+        {
+            executionContext.PolicyKey = PolicyKey;
+        }
     }
 
     public partial class Policy<TResult>
@@ -46,6 +55,15 @@ namespace Polly
 
             _policyKey = policyKey;
             return this;
+        }
+
+        /// <summary>
+        /// Updates the execution <see cref="Context"/> with context from the executing <see cref="Policy{TResult}"/>.
+        /// </summary>
+        /// <param name="executionContext">The execution <see cref="Context"/>.</param>
+        internal virtual void SetPolicyContext(Context executionContext)
+        {
+            executionContext.PolicyKey = PolicyKey;
         }
     }
 }

--- a/src/Polly.Shared/Policy.Key.cs
+++ b/src/Polly.Shared/Policy.Key.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Polly.Utilities;
+
+namespace Polly
+{
+    public partial class Policy
+    {
+        private String _policyKey;
+
+        /// <summary>
+        /// A key intended to be unique to each <see cref="Policy"/> instance, which is passed with executions as the <see cref="M:Context.PolicyKey"/> property.
+        /// </summary>
+        public String PolicyKey => _policyKey ?? (_policyKey = GetType().Name + "-" + KeyHelper.GuidPart());
+
+        /// <summary>
+        /// Sets the PolicyKey for this <see cref="Policy"/> instance.
+        /// <remarks>Must be called before the policy is first used.  Can only be set once.</remarks>
+        /// </summary>
+        /// <param name="policyKey">The unique, used-definable key to assign to this <see cref="Policy"/> instance.</param>
+        public Policy WithPolicyKey(String policyKey)
+        {
+            if (_policyKey != null) throw new ArgumentException("For thread-safety reasons, PolicyKey cannot be set more than once on a Policy instance; or if the default value is being used, cannot be set after the PolicyKey property has been accessed.", nameof(policyKey));
+
+            _policyKey = policyKey;
+            return this;
+        }
+    }
+
+    public partial class Policy<TResult>
+    {
+        private String _policyKey;
+
+        /// <summary>
+        /// A key intended to be unique to each <see cref="Policy"/> instance, which is passed with executions as the <see cref="M:Context.PolicyKey"/> property.
+        /// </summary>
+        public String PolicyKey => _policyKey ?? (_policyKey = GetType().Name + "-" + KeyHelper.GuidPart());
+
+        /// <summary>
+        /// Sets the PolicyKey for this <see cref="Policy"/> instance.
+        /// <remarks>Must be called before the policy is first used.  Can only be set once.</remarks>
+        /// </summary>
+        /// <param name="policyKey">The unique, used-definable key to assign to this <see cref="Policy"/> instance.</param>
+        public Policy<TResult> WithPolicyKey(String policyKey)
+        {
+            if (_policyKey != null) throw new ArgumentException("For thread-safety reasons, PolicyKey cannot be set more than once on a Policy instance; or if the default value is being used, cannot be set after the PolicyKey property has been accessed.", nameof(policyKey));
+
+            _policyKey = policyKey;
+            return this;
+        }
+    }
+}

--- a/src/Polly.Shared/Policy.cs
+++ b/src/Polly.Shared/Policy.cs
@@ -20,7 +20,7 @@ namespace Polly
             Action<Action<CancellationToken>, Context, CancellationToken> exceptionPolicy,
             IEnumerable<ExceptionPredicate> exceptionPredicates)
         {
-            if (exceptionPolicy == null) throw new ArgumentNullException("exceptionPolicy");
+            if (exceptionPolicy == null) throw new ArgumentNullException(nameof(exceptionPolicy));
 
             _exceptionPolicy = exceptionPolicy;
             _exceptionPredicates = exceptionPredicates ?? PredicateHelper.EmptyExceptionPredicates;
@@ -33,7 +33,7 @@ namespace Polly
         [DebuggerStepThrough]
         public void Execute(Action action)
         {
-            Execute(ct => action(), Context.Empty, CancellationToken.None);
+            Execute(ct => action(), new Context(), CancellationToken.None);
         }
         
         /// <summary>
@@ -44,24 +44,9 @@ namespace Polly
         [DebuggerStepThrough]
         public void Execute(Action<CancellationToken> action, CancellationToken cancellationToken)
         {
-            Execute(action, Context.Empty, cancellationToken);
+            Execute(action, new Context(), cancellationToken);
         }
-
-        /// <summary>
-        /// Executes the specified action within the policy.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        [DebuggerStepThrough]
-        internal void Execute(Action<CancellationToken> action, Context context, CancellationToken cancellationToken)
-        {
-            if (_exceptionPolicy == null) throw new InvalidOperationException(
-                "Please use the synchronous Retry, RetryForever, WaitAndRetry or CircuitBreaker methods when calling the synchronous Execute method.");
-
-            _exceptionPolicy(action, context, cancellationToken);
-        }
-
+        
         /// <summary>
         /// Executes the specified action within the policy and returns the captured result
         /// </summary>
@@ -70,7 +55,7 @@ namespace Polly
         [DebuggerStepThrough]
         public PolicyResult ExecuteAndCapture(Action action)
         {
-            return ExecuteAndCapture(ct => action(), Context.Empty, CancellationToken.None);
+            return ExecuteAndCapture(ct => action(), new Context(), CancellationToken.None);
         }
 
         /// <summary>
@@ -82,33 +67,9 @@ namespace Polly
         [DebuggerStepThrough]
         public PolicyResult ExecuteAndCapture(Action<CancellationToken> action, CancellationToken cancellationToken)
         {
-            return ExecuteAndCapture(action, Context.Empty, cancellationToken);
+            return ExecuteAndCapture(action, new Context(), cancellationToken);
         }
-
-        /// <summary>
-        /// Executes the specified action within the policy and returns the captured result
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The captured result</returns>
-        [DebuggerStepThrough]
-        internal PolicyResult ExecuteAndCapture(Action<CancellationToken> action, Context context, CancellationToken cancellationToken)
-        {
-            if (_exceptionPolicy == null) throw new InvalidOperationException(
-                "Please use the synchronous Retry, RetryForever, WaitAndRetry or CircuitBreaker methods when calling the synchronous ExecuteAndCapture method.");
-
-            try
-            {
-                _exceptionPolicy(action, context, cancellationToken);
-                return PolicyResult.Successful();
-            }
-            catch (Exception exception)
-            {
-                return PolicyResult.Failure(exception, GetExceptionType(_exceptionPredicates, exception));
-            }
-        }
-
+        
         /// <summary>
         /// Executes the specified action within the policy and returns the Result.
         /// </summary>
@@ -118,7 +79,7 @@ namespace Polly
         [DebuggerStepThrough]
         public TResult Execute<TResult>(Func<TResult> action)
         {
-            return Execute(ct => action(), Context.Empty, CancellationToken.None);
+            return Execute(ct => action(), new Context(), CancellationToken.None);
         }
 
         /// <summary>
@@ -131,28 +92,9 @@ namespace Polly
         [DebuggerStepThrough]
         public TResult Execute<TResult>(Func<CancellationToken, TResult> action, CancellationToken cancellationToken)
         {
-            return Execute(action, Context.Empty, cancellationToken);
+            return Execute(action, new Context(), cancellationToken);
         }
-
-        /// <summary>
-        /// Executes the specified action within the policy and returns the result.
-        /// </summary>
-        /// <typeparam name="TResult">The type of the result.</typeparam>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The value returned by the action</returns>
-        [DebuggerStepThrough]
-        internal TResult Execute<TResult>(Func<CancellationToken, TResult> action, Context context, CancellationToken cancellationToken)
-        {
-            if (_exceptionPolicy == null) throw new InvalidOperationException(
-                "Please use the synchronous Retry, RetryForever, WaitAndRetry or CircuitBreaker methods when calling the synchronous Execute method.");
-
-            var result = default(TResult);
-            _exceptionPolicy(ct => { result = action(ct); }, context, cancellationToken);
-            return result;
-        }
-
+        
         /// <summary>
         /// Executes the specified action within the policy and returns the captured result
         /// </summary>
@@ -161,7 +103,7 @@ namespace Polly
         [DebuggerStepThrough]
         public PolicyResult<TResult> ExecuteAndCapture<TResult>(Func<TResult> action)
         {
-            return ExecuteAndCapture(ct => action(), Context.Empty, CancellationToken.None);
+            return ExecuteAndCapture(ct => action(), new Context(), CancellationToken.None);
         }
 
         /// <summary>
@@ -173,36 +115,9 @@ namespace Polly
         /// <returns>The captured result</returns>
         public PolicyResult<TResult> ExecuteAndCapture<TResult>(Func<CancellationToken, TResult> action, CancellationToken cancellationToken)
         {
-            return ExecuteAndCapture(action, Context.Empty, cancellationToken);
+            return ExecuteAndCapture(action, new Context(), cancellationToken);
         }
-
-        /// <summary>
-        /// Executes the specified action within the policy and returns the captured result.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The captured result</returns>
-        [DebuggerStepThrough]
-        internal PolicyResult<TResult> ExecuteAndCapture<TResult>(Func<CancellationToken, TResult> action, Context context, CancellationToken cancellationToken)
-        {
-
-            if (_exceptionPolicy == null) throw new InvalidOperationException(
-                "Please use the synchronous Retry, RetryForever, WaitAndRetry or CircuitBreaker methods when calling the synchronous ExecuteAndCapture method.");
-
-            try
-            {
-                var result = default(TResult);
-                _exceptionPolicy(ct => { result = action(ct); }, context, cancellationToken);
-                return PolicyResult<TResult>.Successful(result);
-            }
-            catch (Exception exception)
-            {
-                return PolicyResult<TResult>.Failure(exception, GetExceptionType(_exceptionPredicates, exception));
-            }
-        }
-
-
+        
         internal static ExceptionType GetExceptionType(IEnumerable<ExceptionPredicate> exceptionPredicates, Exception exception)
         {
             var isExceptionTypeHandledByThisPolicy = exceptionPredicates.Any(predicate => predicate(exception));
@@ -216,7 +131,7 @@ namespace Polly
     /// <summary>
     /// Transient fault handling policies that can be applied to delegates returning results of type <typeparam name="TResult"/>
     /// </summary>
-    public partial class Policy<TResult>
+    public partial class Policy<TResult> 
     {
         private readonly Func<Func<CancellationToken, TResult>, Context, CancellationToken, TResult> _executionPolicy;
         private readonly IEnumerable<ExceptionPredicate> _exceptionPredicates;
@@ -243,7 +158,7 @@ namespace Polly
         [DebuggerStepThrough]
         public TResult Execute(Func<TResult> action)
         {
-            return Execute(ct => action(), Context.Empty, CancellationToken.None);
+            return Execute(ct => action(), new Context(), CancellationToken.None);
         }
 
         /// <summary>
@@ -253,25 +168,9 @@ namespace Polly
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The value returned by the action</returns>
         [DebuggerStepThrough]
-        public TResult Execute(Func<CancellationToken, TResult> action,  CancellationToken cancellationToken)
+        public TResult Execute(Func<CancellationToken, TResult> action, CancellationToken cancellationToken)
         {
-            return Execute(action, Context.Empty, cancellationToken);
-        }
-
-        /// <summary>
-        /// Executes the specified action within the policy and returns the result.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The value returned by the action</returns>
-        [DebuggerStepThrough]
-        internal TResult Execute(Func<CancellationToken, TResult> action, Context context, CancellationToken cancellationToken)
-        {
-            if (_executionPolicy == null) throw new InvalidOperationException(
-                "Please use the synchronous Retry, RetryForever, WaitAndRetry or CircuitBreaker methods when calling the synchronous Execute method.");
-
-            return _executionPolicy(action, context, cancellationToken);
+            return Execute(action, new Context(), cancellationToken);
         }
 
         /// <summary>
@@ -282,7 +181,7 @@ namespace Polly
         [DebuggerStepThrough]
         public PolicyResult<TResult> ExecuteAndCapture(Func<TResult> action)
         {
-            return ExecuteAndCapture(ct => action(), Context.Empty, CancellationToken.None);
+            return ExecuteAndCapture(ct => action(), new Context(), CancellationToken.None);
         }
 
         /// <summary>
@@ -294,38 +193,7 @@ namespace Polly
         [DebuggerStepThrough]
         public PolicyResult<TResult> ExecuteAndCapture(Func<CancellationToken, TResult> action, CancellationToken cancellationToken)
         {
-            return ExecuteAndCapture(action, Context.Empty, cancellationToken);
-        }
-
-        /// <summary>
-        /// Executes the specified action within the policy and returns the captured result.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The captured result</returns>
-        [DebuggerStepThrough]
-        internal PolicyResult<TResult> ExecuteAndCapture(Func<CancellationToken, TResult> action, Context context, CancellationToken cancellationToken)
-        {
-
-            if (_executionPolicy == null) throw new InvalidOperationException(
-                "Please use the synchronous Retry, RetryForever, WaitAndRetry or CircuitBreaker methods when calling the synchronous ExecuteAndCapture method.");
-
-            try
-            {
-                TResult result = _executionPolicy(action, context, cancellationToken);
-
-                if (_resultPredicates.Any(predicate => predicate(result)))
-                {
-                    return PolicyResult<TResult>.Failure(result);
-                }
-
-                return PolicyResult<TResult>.Successful(result);
-            }
-            catch (Exception exception)
-            {
-                return PolicyResult<TResult>.Failure(exception, GetExceptionType(_exceptionPredicates, exception));
-            }
+            return ExecuteAndCapture(action, new Context(), cancellationToken);
         }
 
         /// <summary>

--- a/src/Polly.Shared/PolicyAsync.cs
+++ b/src/Polly.Shared/PolicyAsync.cs
@@ -29,18 +29,7 @@ namespace Polly
         [DebuggerStepThrough]
         public Task ExecuteAsync(Func<Task> action)
         {
-            return ExecuteAsync(action, Context.Empty, false);
-        }
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        [DebuggerStepThrough]
-        protected Task ExecuteAsync(Func<Task> action, Context context)
-        {
-            return ExecuteAsync(action, context, false);
+            return ExecuteAsync(ct => action(), new Context(), CancellationToken.None, false);
         }
 
         /// <summary>
@@ -51,19 +40,7 @@ namespace Polly
         [DebuggerStepThrough]
         public Task ExecuteAsync(Func<Task> action, bool continueOnCapturedContext)
         {
-            return ExecuteAsync(ct => action(), Context.Empty, CancellationToken.None, continueOnCapturedContext);
-        }
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-        [DebuggerStepThrough]
-        protected Task ExecuteAsync(Func<Task> action, Context context, bool continueOnCapturedContext)
-        {
-            return ExecuteAsync(ct => action(), context, CancellationToken.None, continueOnCapturedContext);
+            return ExecuteAsync(ct => action(), new Context(), CancellationToken.None, continueOnCapturedContext);
         }
 
         /// <summary>
@@ -74,19 +51,7 @@ namespace Polly
         [DebuggerStepThrough]
         public Task ExecuteAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken)
         {
-            return ExecuteAsync(action, Context.Empty, cancellationToken, false);
-        }
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-        [DebuggerStepThrough]
-        protected Task ExecuteAsync(Func<CancellationToken, Task> action, Context context, CancellationToken cancellationToken)
-        {
-            return ExecuteAsync(action, context, cancellationToken, false);
+            return ExecuteAsync(action, new Context(), cancellationToken, false);
         }
 
         /// <summary>
@@ -95,28 +60,11 @@ namespace Polly
         /// <param name="action">The action to perform.</param>
         /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
         /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-        /// <exception cref="System.InvalidOperationException">Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.</exception>
+        /// <exception cref="System.InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
         [DebuggerStepThrough]
         public Task ExecuteAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
-            return ExecuteAsync(action, Context.Empty, cancellationToken, continueOnCapturedContext);
-        }
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-        /// <exception cref="System.InvalidOperationException">Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.</exception>
-        [DebuggerStepThrough]
-        internal async Task ExecuteAsync(Func<CancellationToken, Task> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
-        {
-            if (_asyncExceptionPolicy == null) throw new InvalidOperationException
-                ("Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.");
-
-            await _asyncExceptionPolicy(action, context, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
+            return ExecuteAsync(action, new Context(), cancellationToken, continueOnCapturedContext);
         }
 
         /// <summary>
@@ -127,30 +75,7 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Task> action)
         {
-            return ExecuteAndCaptureAsync(action, Context.Empty, false);
-        }
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy and returns the captured result.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <returns>The captured result</returns>
-        [DebuggerStepThrough]
-        public Task<PolicyResult> ExecuteAndCaptureAsync(Func<CancellationToken, Task> action)
-        {
-            return ExecuteAndCaptureAsync(action, Context.Empty, false);
-        }
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy and returns the captured result.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <returns>The captured result</returns>
-        [DebuggerStepThrough]
-        protected Task<PolicyResult> ExecuteAndCaptureAsync(Func<Task> action, Context context)
-        {
-            return ExecuteAndCaptureAsync(action, context, false);
+            return ExecuteAndCaptureAsync(ct => action(), new Context(), CancellationToken.None, false);
         }
 
         /// <summary>
@@ -162,33 +87,7 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Task> action, bool continueOnCapturedContext)
         {
-            return ExecuteAndCaptureAsync(ct => action(), Context.Empty, CancellationToken.None, continueOnCapturedContext);
-        }
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy and returns the captured result.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-        /// <returns>The captured result</returns>
-        [DebuggerStepThrough]
-        protected Task<PolicyResult> ExecuteAndCaptureAsync(Func<Task> action, Context context, bool continueOnCapturedContext)
-        {
-            return ExecuteAndCaptureAsync(ct => action(), context, CancellationToken.None, continueOnCapturedContext);
-        }
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy and returns the captured result.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-        /// <returns>The captured result</returns>
-        [DebuggerStepThrough]
-        protected Task<PolicyResult> ExecuteAndCaptureAsync(Func<CancellationToken, Task> action, Context context, bool continueOnCapturedContext)
-        {
-            return ExecuteAndCaptureAsync(action, context, CancellationToken.None, continueOnCapturedContext);
+            return ExecuteAndCaptureAsync(ct => action(), new Context(), CancellationToken.None, continueOnCapturedContext);
         }
 
         /// <summary>
@@ -199,58 +98,22 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult> ExecuteAndCaptureAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken)
         {
-            return ExecuteAndCaptureAsync(action, Context.Empty, cancellationToken, false);
+            return ExecuteAndCaptureAsync(action, new Context(), cancellationToken, false);
         }
 
         /// <summary>
         ///     Executes the specified asynchronous action within the policy and returns the captured result.
         /// </summary>
         /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
         /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-        [DebuggerStepThrough]
-        protected Task<PolicyResult> ExecuteAndCaptureAsync(Func<CancellationToken, Task> action, Context context, CancellationToken cancellationToken)
-        {
-            return ExecuteAndCaptureAsync(action, context, cancellationToken, false);
-        }
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy and returns the captured result.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
         /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-        /// <exception cref="System.InvalidOperationException">Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.</exception>
+        /// <exception cref="System.InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
         [DebuggerStepThrough]
         public Task<PolicyResult> ExecuteAndCaptureAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
-            return ExecuteAndCaptureAsync(action, Context.Empty, cancellationToken, continueOnCapturedContext);
+            return ExecuteAndCaptureAsync(action, new Context(), cancellationToken, continueOnCapturedContext);
         }
 
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy and returns the captured result.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-        /// <exception cref="System.InvalidOperationException">Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.</exception>
-        [DebuggerStepThrough]
-        internal async Task<PolicyResult> ExecuteAndCaptureAsync(Func<CancellationToken, Task> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
-        {
-            if (_asyncExceptionPolicy == null) throw new InvalidOperationException
-                ("Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.");
-
-            try
-            {
-                await _asyncExceptionPolicy(action, context, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
-                return PolicyResult.Successful();
-            }
-            catch (Exception exception)
-            {
-                return PolicyResult.Failure(exception, GetExceptionType(_exceptionPredicates, exception));
-            }
-        }
 
         /// <summary>
         ///     Executes the specified asynchronous action within the policy and returns the result.
@@ -261,60 +124,7 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<TResult> ExecuteAsync<TResult>(Func<Task<TResult>> action)
         {
-            return ExecuteAsync(action, Context.Empty, false);
-        }
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <typeparam name="TResult">The type of the result.</typeparam>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <returns>The value returned by the action</returns>
-        [DebuggerStepThrough]
-        protected Task<TResult> ExecuteAsync<TResult>(Func<Task<TResult>> action, Context context)
-        {
-            return ExecuteAsync(action, context, false);
-        }
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <typeparam name="TResult">The type of the result.</typeparam>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <returns>The value returned by the action</returns>
-        [DebuggerStepThrough]
-        protected Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, Context context)
-        {
-            return ExecuteAsync(action, context, false);
-        }
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <typeparam name="TResult">The type of the result.</typeparam>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
-        /// <returns>The value returned by the action</returns>
-        [DebuggerStepThrough]
-        public Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken)
-        {
-            return ExecuteAsync(action, Context.Empty, cancellationToken, false);
-        }
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <typeparam name="TResult">The type of the result.</typeparam>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
-        /// <returns>The value returned by the action</returns>
-        [DebuggerStepThrough]
-        protected Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken)
-        {
-            return ExecuteAsync(action, context, cancellationToken, false);
+            return ExecuteAsync(ct => action(), new Context(), CancellationToken.None, false);
         }
 
         /// <summary>
@@ -327,7 +137,7 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<TResult> ExecuteAsync<TResult>(Func<Task<TResult>> action, bool continueOnCapturedContext)
         {
-            return ExecuteAsync(ct => action(), Context.Empty, CancellationToken.None, continueOnCapturedContext);
+            return ExecuteAsync(ct => action(), new Context(), CancellationToken.None, continueOnCapturedContext);
         }
 
         /// <summary>
@@ -335,27 +145,12 @@ namespace Polly
         /// </summary>
         /// <typeparam name="TResult">The type of the result.</typeparam>
         /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
         /// <returns>The value returned by the action</returns>
         [DebuggerStepThrough]
-        protected Task<TResult> ExecuteAsync<TResult>(Func<Task<TResult>> action, Context context, bool continueOnCapturedContext)
+        public Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken)
         {
-            return ExecuteAsync(ct => action(), context, CancellationToken.None, continueOnCapturedContext);
-        }
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <typeparam name="TResult">The type of the result.</typeparam>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-        /// <returns>The value returned by the action</returns>
-        [DebuggerStepThrough]
-        protected Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, Context context, bool continueOnCapturedContext)
-        {
-            return ExecuteAsync(action, context, CancellationToken.None, continueOnCapturedContext);
+            return ExecuteAsync(action, new Context(), cancellationToken, false);
         }
 
         /// <summary>
@@ -366,36 +161,11 @@ namespace Polly
         /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
         /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
         /// <returns>The value returned by the action</returns>
-        /// <exception cref="System.InvalidOperationException">Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.</exception>
+        /// <exception cref="System.InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
         [DebuggerStepThrough]
         public Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
-            return ExecuteAsync(action, Context.Empty, cancellationToken, continueOnCapturedContext);
-        }
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <typeparam name="TResult">The type of the result.</typeparam>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
-        /// <returns>The value returned by the action</returns>
-        /// <exception cref="System.InvalidOperationException">Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.</exception>
-        [DebuggerStepThrough]
-        internal async Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
-        {
-            if (_asyncExceptionPolicy == null) throw new InvalidOperationException(
-                "Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.");
-
-            var result = default(TResult);
-            await _asyncExceptionPolicy(async ct =>
-            {
-                result = await action(ct).ConfigureAwait(continueOnCapturedContext);
-            }, context, cancellationToken, continueOnCapturedContext)
-            .ConfigureAwait(continueOnCapturedContext);
-            return result;
+            return ExecuteAsync(action, new Context(), cancellationToken, continueOnCapturedContext);
         }
 
         /// <summary>
@@ -407,32 +177,7 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Task<TResult>> action)
         {
-            return ExecuteAndCaptureAsync(action, Context.Empty, false);
-        }
-
-        /// <summary>
-        /// Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <typeparam name="TResult">The type of the result.</typeparam>
-        /// <param name="action">The action to perform.</param>
-        /// <returns>The captured result</returns>
-        [DebuggerStepThrough]
-        public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<CancellationToken, Task<TResult>> action)
-        {
-            return ExecuteAndCaptureAsync(action, Context.Empty, false);
-        }
-
-        /// <summary>
-        /// Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <typeparam name="TResult">The type of the result.</typeparam>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <returns>The captured result</returns>
-        [DebuggerStepThrough]
-        protected Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Task<TResult>> action, Context context)
-        {
-            return ExecuteAndCaptureAsync(action, context, false);
+            return ExecuteAndCaptureAsync(ct => action(), new Context(), CancellationToken.None, false);
         }
 
         /// <summary>
@@ -445,48 +190,7 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Task<TResult>> action, bool continueOnCapturedContext)
         {
-            return ExecuteAndCaptureAsync(ct => action(), Context.Empty, CancellationToken.None, continueOnCapturedContext);
-        }
-
-        /// <summary>
-        /// Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <typeparam name="TResult">The type of the result.</typeparam>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-        /// <returns>The captured result</returns>
-        [DebuggerStepThrough]
-        protected Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Task<TResult>> action, Context context, bool continueOnCapturedContext)
-        {
-            return ExecuteAndCaptureAsync(ct => action(), context, CancellationToken.None, continueOnCapturedContext);
-        }
-
-        /// <summary>
-        /// Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <typeparam name="TResult">The type of the result.</typeparam>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-        /// <returns>The captured result</returns>
-        [DebuggerStepThrough]
-        protected Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<CancellationToken, Task<TResult>> action, Context context, bool continueOnCapturedContext)
-        {
-            return ExecuteAndCaptureAsync(action, context, CancellationToken.None, continueOnCapturedContext);
-        }
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <typeparam name="TResult">The type of the result.</typeparam>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-        /// <returns>The captured result</returns>
-        [DebuggerStepThrough]
-        public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Task<TResult>> action, CancellationToken cancellationToken)
-        {
-            return ExecuteAndCaptureAsync(ct => action(), Context.Empty, cancellationToken, false);
+            return ExecuteAndCaptureAsync(ct => action(), new Context(), CancellationToken.None, continueOnCapturedContext);
         }
 
         /// <summary>
@@ -499,21 +203,7 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken)
         {
-            return ExecuteAndCaptureAsync(action, Context.Empty, cancellationToken, false);
-        }
-
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <typeparam name="TResult">The type of the result.</typeparam>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-        /// <returns>The captured result</returns>
-        [DebuggerStepThrough]
-        protected Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<CancellationToken, Task<TResult>> action, Context context)
-        {
-            return ExecuteAndCaptureAsync(action, context, CancellationToken.None, false);
+            return ExecuteAndCaptureAsync(action, new Context(), cancellationToken, false);
         }
 
         /// <summary>
@@ -521,62 +211,16 @@ namespace Polly
         /// </summary>
         /// <typeparam name="TResult">The type of the result.</typeparam>
         /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
         /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-        /// <returns>The captured result</returns>
-        [DebuggerStepThrough]
-        protected Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Task<TResult>> action, Context context, CancellationToken cancellationToken)
-        {
-            return ExecuteAndCaptureAsync(ct => action(), context, cancellationToken, false);
-        }
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <typeparam name="TResult">The type of the result.</typeparam>
-        /// <param name="action">The action to perform.</param>
         /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
         /// <returns>The captured result</returns>
-        /// <exception cref="System.InvalidOperationException">Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.</exception>
+        /// <exception cref="System.InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
         [DebuggerStepThrough]
         public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
-            return ExecuteAndCaptureAsync(action, Context.Empty, cancellationToken, continueOnCapturedContext);
+            return ExecuteAndCaptureAsync(action, new Context(), cancellationToken, continueOnCapturedContext);
         }
 
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <typeparam name="TResult">The type of the result.</typeparam>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-        /// <returns>The captured result</returns>
-        /// <exception cref="System.InvalidOperationException">Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.</exception>
-        [DebuggerStepThrough]
-        internal async Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
-        {
-            if (_asyncExceptionPolicy == null) throw new InvalidOperationException(
-                "Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.");
-
-            try
-            {
-                var result = default(TResult);
-                await _asyncExceptionPolicy(async ct =>
-                {
-                    result = await action(ct).ConfigureAwait(continueOnCapturedContext);
-                }, context, cancellationToken, continueOnCapturedContext)
-                .ConfigureAwait(continueOnCapturedContext);
-
-                return PolicyResult<TResult>.Successful(result);
-            }
-            catch (Exception exception)
-            {
-                return PolicyResult<TResult>.Failure(exception, GetExceptionType(_exceptionPredicates, exception));
-            }
-        }
     }
 
     public partial class Policy<TResult>
@@ -603,67 +247,7 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<TResult> ExecuteAsync(Func<Task<TResult>> action)
         {
-            return ExecuteAsync(action, Context.Empty, false);
-        }
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <returns>The value returned by the action</returns>
-        [DebuggerStepThrough]
-        public Task<TResult> ExecuteAsync(Func<CancellationToken, Task<TResult>> action)
-        {
-            return ExecuteAsync(action, Context.Empty, false);
-        }
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <returns>The value returned by the action</returns>
-        [DebuggerStepThrough]
-        protected Task<TResult> ExecuteAsync(Func<Task<TResult>> action, Context context)
-        {
-            return ExecuteAsync(action, context, false);
-        }
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <returns>The value returned by the action</returns>
-        [DebuggerStepThrough]
-        protected Task<TResult> ExecuteAsync(Func<CancellationToken, Task<TResult>> action, Context context)
-        {
-            return ExecuteAsync(action, context, false);
-        }
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
-        /// <returns>The value returned by the action</returns>
-        [DebuggerStepThrough]
-        public Task<TResult> ExecuteAsync(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken)
-        {
-            return ExecuteAsync(action, Context.Empty, cancellationToken, false);
-        }
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
-        /// <returns>The value returned by the action</returns>
-        [DebuggerStepThrough]
-        protected Task<TResult> ExecuteAsync(Func<CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken)
-        {
-            return ExecuteAsync(action, context, cancellationToken, false);
+            return ExecuteAsync(ct => action(), new Context(), CancellationToken.None, false);
         }
 
         /// <summary>
@@ -675,47 +259,21 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<TResult> ExecuteAsync(Func<Task<TResult>> action, bool continueOnCapturedContext)
         {
-            return ExecuteAsync(ct => action(), Context.Empty, CancellationToken.None, continueOnCapturedContext);
+            return ExecuteAsync(ct => action(), new Context(), CancellationToken.None, continueOnCapturedContext);
         }
 
         /// <summary>
         ///     Executes the specified asynchronous action within the policy and returns the result.
         /// </summary>
         /// <param name="action">The action to perform.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
         /// <returns>The value returned by the action</returns>
         [DebuggerStepThrough]
-        public Task<TResult> ExecuteAsync(Func<CancellationToken, Task<TResult>> action, bool continueOnCapturedContext)
+        public Task<TResult> ExecuteAsync(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken)
         {
-            return ExecuteAsync(action, Context.Empty, CancellationToken.None, continueOnCapturedContext);
+            return ExecuteAsync(action, new Context(), cancellationToken, false);
         }
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-        /// <returns>The value returned by the action</returns>
-        [DebuggerStepThrough]
-        protected Task<TResult> ExecuteAsync(Func<Task<TResult>> action, Context context, bool continueOnCapturedContext)
-        {
-            return ExecuteAsync(ct => action(), context, CancellationToken.None, continueOnCapturedContext);
-        }
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-        /// <returns>The value returned by the action</returns>
-        [DebuggerStepThrough]
-        protected Task<TResult> ExecuteAsync(Func<CancellationToken, Task<TResult>> action, Context context, bool continueOnCapturedContext)
-        {
-            return ExecuteAsync(action, context, CancellationToken.None, continueOnCapturedContext);
-        }
-
+        
         /// <summary>
         ///     Executes the specified asynchronous action within the policy and returns the result.
         /// </summary>
@@ -723,35 +281,11 @@ namespace Polly
         /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
         /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
         /// <returns>The value returned by the action</returns>
-        /// <exception cref="System.InvalidOperationException">Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.</exception>
+        /// <exception cref="System.InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
         [DebuggerStepThrough]
         public Task<TResult> ExecuteAsync(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
-            return ExecuteAsync(action, Context.Empty, cancellationToken, continueOnCapturedContext);
-        }
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
-        /// <returns>The value returned by the action</returns>
-        /// <exception cref="System.InvalidOperationException">Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.</exception>
-        [DebuggerStepThrough]
-        internal async Task<TResult> ExecuteAsync(Func<CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
-        {
-            if (_asyncExecutionPolicy == null) throw new InvalidOperationException(
-                "Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.");
-
-            TResult result = await _asyncExecutionPolicy(
-                action,
-                context,
-                cancellationToken,
-                continueOnCapturedContext)
-            .ConfigureAwait(continueOnCapturedContext);
-            return result;
+            return ExecuteAsync(action, new Context(), cancellationToken, continueOnCapturedContext);
         }
 
         /// <summary>
@@ -762,30 +296,7 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Task<TResult>> action)
         {
-            return ExecuteAndCaptureAsync(action, Context.Empty, false);
-        }
-
-        /// <summary>
-        /// Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <returns>The captured result</returns>
-        [DebuggerStepThrough]
-        public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<CancellationToken, Task<TResult>> action)
-        {
-            return ExecuteAndCaptureAsync(action, Context.Empty, false);
-        }
-
-        /// <summary>
-        /// Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <returns>The captured result</returns>
-        [DebuggerStepThrough]
-        protected Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Task<TResult>> action, Context context)
-        {
-            return ExecuteAndCaptureAsync(action, context, false);
+            return ExecuteAndCaptureAsync(ct => action(), new Context(), CancellationToken.None, false);
         }
 
         /// <summary>
@@ -797,47 +308,9 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Task<TResult>> action, bool continueOnCapturedContext)
         {
-            return ExecuteAndCaptureAsync(ct => action(), Context.Empty, CancellationToken.None, continueOnCapturedContext);
+            return ExecuteAndCaptureAsync(ct => action(), new Context(), CancellationToken.None, continueOnCapturedContext);
         }
-
-        /// <summary>
-        /// Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-        /// <returns>The captured result</returns>
-        [DebuggerStepThrough]
-        protected Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Task<TResult>> action, Context context, bool continueOnCapturedContext)
-        {
-            return ExecuteAndCaptureAsync(ct => action(), context, CancellationToken.None, continueOnCapturedContext);
-        }
-
-        /// <summary>
-        /// Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-        /// <returns>The captured result</returns>
-        [DebuggerStepThrough]
-        protected Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<CancellationToken, Task<TResult>> action, Context context, bool continueOnCapturedContext)
-        {
-            return ExecuteAndCaptureAsync(action, context, CancellationToken.None, continueOnCapturedContext);
-        }
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-        /// <returns>The captured result</returns>
-        [DebuggerStepThrough]
-        public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Task<TResult>> action, CancellationToken cancellationToken)
-        {
-            return ExecuteAndCaptureAsync(ct => action(), Context.Empty, cancellationToken, false);
-        }
-
+        
         /// <summary>
         ///     Executes the specified asynchronous action within the policy and returns the result.
         /// </summary>
@@ -847,33 +320,7 @@ namespace Polly
         [DebuggerStepThrough]
         public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken)
         {
-            return ExecuteAndCaptureAsync(action, Context.Empty, cancellationToken, false);
-        }
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-        /// <returns>The captured result</returns>
-        [DebuggerStepThrough]
-        protected Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Task<TResult>> action, Context context, CancellationToken cancellationToken)
-        {
-            return ExecuteAndCaptureAsync(ct => action(), context, cancellationToken, false);
-        }
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-        /// <returns>The captured result</returns>
-        [DebuggerStepThrough]
-        protected Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken)
-        {
-            return ExecuteAndCaptureAsync(action, context, cancellationToken, false);
+            return ExecuteAndCaptureAsync(action, new Context(), cancellationToken, false);
         }
 
         /// <summary>
@@ -883,48 +330,11 @@ namespace Polly
         /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
         /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
         /// <returns>The captured result</returns>
-        /// <exception cref="System.InvalidOperationException">Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.</exception>
+        /// <exception cref="System.InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
         [DebuggerStepThrough]
         public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
-            return ExecuteAndCaptureAsync(action, Context.Empty, cancellationToken, continueOnCapturedContext);
-        }
-
-        /// <summary>
-        ///     Executes the specified asynchronous action within the policy and returns the result.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        /// <param name="context">Arbitrary data that is passed to the exception policy.</param>
-        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-        /// <returns>The captured result</returns>
-        /// <exception cref="System.InvalidOperationException">Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.</exception>
-        [DebuggerStepThrough]
-        internal async Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
-        {
-            if (_asyncExecutionPolicy == null) throw new InvalidOperationException(
-                "Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.");
-
-            try
-            {
-                TResult result = await _asyncExecutionPolicy(
-                    action,
-                    context,
-                    cancellationToken,
-                    continueOnCapturedContext)
-                .ConfigureAwait(continueOnCapturedContext);
-
-                if (_resultPredicates.Any(predicate => predicate(result)))
-                {
-                    return PolicyResult<TResult>.Failure(result);
-                }
-
-                return PolicyResult<TResult>.Successful(result);
-            }
-            catch (Exception exception)
-            {
-                return PolicyResult<TResult>.Failure(exception, GetExceptionType(_exceptionPredicates, exception));
-            }
+            return ExecuteAndCaptureAsync(action, new Context(), cancellationToken, continueOnCapturedContext);
         }
     }
 

--- a/src/Polly.Shared/Polly.Shared.projitems
+++ b/src/Polly.Shared/Polly.Shared.projitems
@@ -43,6 +43,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Fallback\FallbackPolicyAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Policy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Policy.HandleSyntax.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Policy.Key.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PolicyAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PolicyBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PolicyBuilder.OrSyntax.cs" />
@@ -70,6 +71,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)AdvancedCircuitBreakerSyntax.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AdvancedCircuitBreakerSyntaxAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\EmptyStruct.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Utilities\KeyHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\PredicateHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\ReadOnlyDictionary.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\SystemClock.cs" />

--- a/src/Polly.Shared/Polly.Shared.projitems
+++ b/src/Polly.Shared/Polly.Shared.projitems
@@ -43,7 +43,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Fallback\FallbackPolicyAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Policy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Policy.HandleSyntax.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Policy.Key.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Policy.ContextAndKeys.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PolicyAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PolicyBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PolicyBuilder.OrSyntax.cs" />
@@ -78,6 +78,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\TaskHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\TimedLock.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PolicyWrapSyntax.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Wrap\PolicyWrap.ContextAndKeys.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Wrap\PolicyWrap.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Wrap\PolicyWrapAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Wrap\PolicyWrapEngine.cs" />

--- a/src/Polly.Shared/Retry/RetryPolicyState.cs
+++ b/src/Polly.Shared/Retry/RetryPolicyState.cs
@@ -14,11 +14,6 @@ namespace Polly.Retry
             _context = context;
         }
 
-        public RetryPolicyState(Action<DelegateResult<TResult>> onRetry) :
-            this((delegateResult, context) => onRetry(delegateResult), Context.Empty)
-        {
-        }
-
         public bool CanRetry(DelegateResult<TResult> delegateResult, CancellationToken cancellationToken)
         {
             _onRetry(delegateResult, _context);

--- a/src/Polly.Shared/Retry/RetryPolicyStateAsync.cs
+++ b/src/Polly.Shared/Retry/RetryPolicyStateAsync.cs
@@ -16,11 +16,6 @@ namespace Polly.Retry
             _context = context;
         }
 
-        public RetryPolicyState(Func<DelegateResult<TResult>, Task> onRetryAsync) :
-            this((delegateResult, context) => onRetryAsync(delegateResult), Context.Empty)
-        {
-        }
-
         public async Task<bool> CanRetryAsync(DelegateResult<TResult> delegateResult, CancellationToken ct, bool continueOnCapturedContext)
         {
             await _onRetryAsync(delegateResult, _context).ConfigureAwait(continueOnCapturedContext);

--- a/src/Polly.Shared/Retry/RetryPolicyStateWithCount.cs
+++ b/src/Polly.Shared/Retry/RetryPolicyStateWithCount.cs
@@ -17,11 +17,6 @@ namespace Polly.Retry
             _context = context;
         }
 
-        public RetryPolicyStateWithCount(int retryCount, Action<DelegateResult<TResult>, int> onRetry) :
-            this(retryCount, (delegateResult, i, context) => onRetry(delegateResult, i), Context.Empty)
-        {
-        }
-
         public bool CanRetry(DelegateResult<TResult> delegateResult, CancellationToken cancellationToken)
         {
             _errorCount += 1;

--- a/src/Polly.Shared/Retry/RetryPolicyStateWithCountAsync.cs
+++ b/src/Polly.Shared/Retry/RetryPolicyStateWithCountAsync.cs
@@ -17,11 +17,6 @@ namespace Polly.Retry
             _context = context;
         }
 
-        public RetryPolicyStateWithCount(int retryCount, Func<DelegateResult<TResult>, int, Task> onRetryAsync) :
-            this(retryCount, (delegateResult, i, context) => onRetryAsync(delegateResult, i), Context.Empty)
-        {
-        }
-
         public async Task<bool> CanRetryAsync(DelegateResult<TResult> delegateResult, CancellationToken ct, bool continueOnCapturedContext)
         {
             _errorCount += 1;

--- a/src/Polly.Shared/Retry/RetryPolicyStateWithSleep.cs
+++ b/src/Polly.Shared/Retry/RetryPolicyStateWithSleep.cs
@@ -24,11 +24,6 @@ namespace Polly.Retry
         {
         }
 
-        public RetryPolicyStateWithSleep(IEnumerable<TimeSpan> sleepDurations, Action<DelegateResult<TResult>, TimeSpan> onRetry) :
-            this(sleepDurations, (delegateResult, span, context) => onRetry(delegateResult, span), Context.Empty)
-        {
-        }
-
         public bool CanRetry(DelegateResult<TResult> delegateResult, CancellationToken cancellationToken)
         {
             if (!_sleepDurationsEnumerator.MoveNext()) return false;

--- a/src/Polly.Shared/Retry/RetryPolicyStateWithSleepAsync.cs
+++ b/src/Polly.Shared/Retry/RetryPolicyStateWithSleepAsync.cs
@@ -25,11 +25,6 @@ namespace Polly.Retry
         {
         }
 
-        public RetryPolicyStateWithSleep(IEnumerable<TimeSpan> sleepDurations, Func<DelegateResult<TResult>, TimeSpan, Task> onRetryAsync) :
-            this(sleepDurations, (delegateResult, span, context) => onRetryAsync(delegateResult, span), Context.Empty)
-        {
-        }
-
         public async Task<bool> CanRetryAsync(DelegateResult<TResult> delegateResult, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
             if (!_sleepDurationsEnumerator.MoveNext()) return false;

--- a/src/Polly.Shared/Retry/RetryPolicyStateWithSleepDurationProvider.cs
+++ b/src/Polly.Shared/Retry/RetryPolicyStateWithSleepDurationProvider.cs
@@ -18,11 +18,6 @@ namespace Polly.Retry
             _context = context;
         }
 
-        public RetryPolicyStateWithSleepDurationProvider(Func<int, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan> onRetry) :
-            this(sleepDurationProvider, (delegateResult, timespan, context) => onRetry(delegateResult, timespan), Context.Empty)
-        {
-        }
-
         public bool CanRetry(DelegateResult<TResult> delegateResult, CancellationToken cancellationToken)
         {
             if (_errorCount < int.MaxValue)

--- a/src/Polly.Shared/Retry/RetryPolicyStateWithSleepDurationProviderAsync.cs
+++ b/src/Polly.Shared/Retry/RetryPolicyStateWithSleepDurationProviderAsync.cs
@@ -17,11 +17,6 @@ namespace Polly.Retry
             _onRetryAsync = onRetryAsync;
             _context = context;
         }
-
-        public RetryPolicyStateWithSleepDurationProvider(Func<int, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, Task> onRetryAsync) :
-            this(sleepDurationProvider, (delegateResult, timespan, context) => onRetryAsync(delegateResult, timespan), Context.Empty)
-        {
-        }
         
         public async Task<bool> CanRetryAsync(DelegateResult<TResult> delegateResult, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {

--- a/src/Polly.Shared/RetrySyntax.cs
+++ b/src/Polly.Shared/RetrySyntax.cs
@@ -68,7 +68,7 @@ namespace Polly
                     cancellationToken,
                     policyBuilder.ExceptionPredicates, 
                     PredicateHelper<EmptyStruct>.EmptyResultPredicates,
-                    () => new RetryPolicyStateWithCount<EmptyStruct>(retryCount, (outcome, i) => onRetry(outcome.Exception, i))
+                    () => new RetryPolicyStateWithCount<EmptyStruct>(retryCount, (outcome, i, ctx) => onRetry(outcome.Exception, i), context)
                 ),
                 policyBuilder.ExceptionPredicates
             );
@@ -142,7 +142,7 @@ namespace Polly
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     PredicateHelper<EmptyStruct>.EmptyResultPredicates, 
-                    () => new RetryPolicyState<EmptyStruct>(outcome => onRetry(outcome.Exception))
+                    () => new RetryPolicyState<EmptyStruct>((outcome, ctx) => onRetry(outcome.Exception), context)
                 ),
                 policyBuilder.ExceptionPredicates
             );
@@ -217,7 +217,7 @@ namespace Polly
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     PredicateHelper<EmptyStruct>.EmptyResultPredicates,
-                    () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, (outcome, timespan) => onRetry(outcome.Exception, timespan))
+                    () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, (outcome, timespan, ctx) => onRetry(outcome.Exception, timespan), context)
                 ),
                 policyBuilder.ExceptionPredicates
             );
@@ -333,7 +333,7 @@ namespace Polly
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     PredicateHelper<EmptyStruct>.EmptyResultPredicates,
-                    () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, (outcome, timespan) => onRetry(outcome.Exception, timespan))
+                    () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, (outcome, timespan, ctx) => onRetry(outcome.Exception, timespan), context)
                 ),
                 policyBuilder.ExceptionPredicates
             );
@@ -434,7 +434,7 @@ namespace Polly
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     PredicateHelper<EmptyStruct>.EmptyResultPredicates,
-                    () => new RetryPolicyStateWithSleepDurationProvider<EmptyStruct>(sleepDurationProvider, (outcome, timespan) => onRetry(outcome.Exception, timespan))
+                    () => new RetryPolicyStateWithSleepDurationProvider<EmptyStruct>(sleepDurationProvider, (outcome, timespan, ctx) => onRetry(outcome.Exception, timespan), context)
                 ),
                 policyBuilder.ExceptionPredicates
             );

--- a/src/Polly.Shared/RetrySyntaxAsync.cs
+++ b/src/Polly.Shared/RetrySyntaxAsync.cs
@@ -87,7 +87,7 @@ namespace Polly
                     policyBuilder.ExceptionPredicates,
                     PredicateHelper<EmptyStruct>.EmptyResultPredicates,
 #pragma warning disable 1998
-                    () => new RetryPolicyStateWithCount<EmptyStruct>(retryCount, async (outcome, i) => onRetry(outcome.Exception, i)),
+                    () => new RetryPolicyStateWithCount<EmptyStruct>(retryCount, async (outcome, i, ctx) => onRetry(outcome.Exception, i), context),
 #pragma warning restore 1998
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates
@@ -117,7 +117,7 @@ namespace Polly
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     PredicateHelper<EmptyStruct>.EmptyResultPredicates,
-                    () => new RetryPolicyStateWithCount<EmptyStruct>(retryCount, (outcome, i) => onRetryAsync(outcome.Exception, i)), 
+                    () => new RetryPolicyStateWithCount<EmptyStruct>(retryCount, (outcome, i, ctx) => onRetryAsync(outcome.Exception, i), context), 
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates
             );
@@ -237,7 +237,7 @@ namespace Polly
                     policyBuilder.ExceptionPredicates,
                     PredicateHelper<EmptyStruct>.EmptyResultPredicates,
 #pragma warning disable 1998
-                    () => new RetryPolicyState<EmptyStruct>(async outcome => onRetry(outcome.Exception)), 
+                    () => new RetryPolicyState<EmptyStruct>(async (outcome, ctx) => onRetry(outcome.Exception), context), 
 #pragma warning restore 1998
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates
@@ -263,7 +263,7 @@ namespace Polly
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     PredicateHelper<EmptyStruct>.EmptyResultPredicates,
-                    () => new RetryPolicyState<EmptyStruct>(outcome => onRetryAsync(outcome.Exception)),
+                    () => new RetryPolicyState<EmptyStruct>((outcome, ctx) => onRetryAsync(outcome.Exception), context),
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates
             );
@@ -370,7 +370,7 @@ namespace Polly
                     policyBuilder.ExceptionPredicates,
                     PredicateHelper<EmptyStruct>.EmptyResultPredicates,
 #pragma warning disable 1998
-                    () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, async (outcome, timespan) => onRetry(outcome.Exception, timespan)), 
+                    () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, async (outcome, timespan, ctx) => onRetry(outcome.Exception, timespan), context), 
 #pragma warning restore 1998
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates
@@ -412,7 +412,7 @@ namespace Polly
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     PredicateHelper<EmptyStruct>.EmptyResultPredicates,
-                    () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, (outcome, timespan) => onRetryAsync(outcome.Exception, timespan)),
+                    () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, (outcome, timespan, ctx) => onRetryAsync(outcome.Exception, timespan), context),
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates
             );
@@ -625,7 +625,7 @@ namespace Polly
                     policyBuilder.ExceptionPredicates,
                     PredicateHelper<EmptyStruct>.EmptyResultPredicates,
 #pragma warning disable 1998
-                    () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, async (outcome, timespan) => onRetry(outcome.Exception, timespan)), 
+                    () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, async (outcome, timespan, ctx) => onRetry(outcome.Exception, timespan), context), 
 #pragma warning restore 1998
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates
@@ -659,7 +659,7 @@ namespace Polly
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     PredicateHelper<EmptyStruct>.EmptyResultPredicates,
-                    () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, (outcome, timespan) => onRetryAsync(outcome.Exception, timespan)),
+                    () => new RetryPolicyStateWithSleep<EmptyStruct>(sleepDurations, (outcome, timespan, ctx) => onRetryAsync(outcome.Exception, timespan), context),
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates
             );
@@ -840,7 +840,7 @@ namespace Polly
                     policyBuilder.ExceptionPredicates,
                     PredicateHelper<EmptyStruct>.EmptyResultPredicates,
 #pragma warning disable 1998
-                    () => new RetryPolicyStateWithSleepDurationProvider<EmptyStruct>(sleepDurationProvider, async (outcome, timespan) => onRetry(outcome.Exception, timespan)),
+                    () => new RetryPolicyStateWithSleepDurationProvider<EmptyStruct>(sleepDurationProvider, async (outcome, timespan, ctx) => onRetry(outcome.Exception, timespan), context),
 #pragma warning restore 1998
                     continueOnCapturedContext
                 ),
@@ -870,7 +870,7 @@ namespace Polly
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     PredicateHelper<EmptyStruct>.EmptyResultPredicates,
-                    () => new RetryPolicyStateWithSleepDurationProvider<EmptyStruct>(sleepDurationProvider, (outcome, timespan) => onRetryAsync(outcome.Exception, timespan)),
+                    () => new RetryPolicyStateWithSleepDurationProvider<EmptyStruct>(sleepDurationProvider, (outcome, timespan, ctx) => onRetryAsync(outcome.Exception, timespan), context),
                     continueOnCapturedContext
                 ),
                 policyBuilder.ExceptionPredicates

--- a/src/Polly.Shared/RetryTResultSyntax.cs
+++ b/src/Polly.Shared/RetryTResultSyntax.cs
@@ -67,7 +67,7 @@ namespace Polly
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
-                    () => new RetryPolicyStateWithCount<TResult>(retryCount, onRetry)
+                    () => new RetryPolicyStateWithCount<TResult>(retryCount, (outcome, i, ctx) => onRetry(outcome, i), context)
                 ),
                 policyBuilder.ExceptionPredicates,
                 policyBuilder.ResultPredicates
@@ -144,7 +144,7 @@ namespace Polly
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
-                    () => new RetryPolicyState<TResult>(outcome => onRetry(outcome.Exception))
+                    () => new RetryPolicyState<TResult>((outcome, ctx) => onRetry(outcome.Exception), context)
                 ),
                 policyBuilder.ExceptionPredicates,
                 policyBuilder.ResultPredicates
@@ -223,7 +223,7 @@ namespace Polly
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
-                    () => new RetryPolicyStateWithSleep<TResult>(sleepDurations, onRetry)
+                    () => new RetryPolicyStateWithSleep<TResult>(sleepDurations, (outcome, span, ctx) => onRetry(outcome, span), context)
                 ),
                 policyBuilder.ExceptionPredicates,
                 policyBuilder.ResultPredicates
@@ -345,7 +345,7 @@ namespace Polly
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
-                    () => new RetryPolicyStateWithSleep<TResult>(sleepDurations, onRetry)
+                    () => new RetryPolicyStateWithSleep<TResult>(sleepDurations, (outcome, span, ctx) => onRetry(outcome, span), context)
                 ),
                 policyBuilder.ExceptionPredicates,
                 policyBuilder.ResultPredicates
@@ -453,7 +453,7 @@ namespace Polly
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
-                    () => new RetryPolicyStateWithSleepDurationProvider<TResult>(sleepDurationProvider, onRetry)
+                    () => new RetryPolicyStateWithSleepDurationProvider<TResult>(sleepDurationProvider, (outcome, timespan, ctx) => onRetry(outcome, timespan), context)
                 ),
                 policyBuilder.ExceptionPredicates,
                 policyBuilder.ResultPredicates

--- a/src/Polly.Shared/RetryTResultSyntaxAsync.cs
+++ b/src/Polly.Shared/RetryTResultSyntaxAsync.cs
@@ -86,7 +86,7 @@ namespace Polly
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
 #pragma warning disable 1998
-                    () => new RetryPolicyStateWithCount<TResult>(retryCount, async (outcome, i) => onRetry(outcome, i)),
+                    () => new RetryPolicyStateWithCount<TResult>(retryCount, async (outcome, i, ctx) => onRetry(outcome, i), context),
 #pragma warning restore 1998
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates, 
@@ -117,7 +117,7 @@ namespace Polly
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
-                    () => new RetryPolicyStateWithCount<TResult>(retryCount, onRetryAsync),
+                    () => new RetryPolicyStateWithCount<TResult>(retryCount, (outcome, i, ctx) => onRetryAsync(outcome, i), context),
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates,
                 policyBuilder.ResultPredicates
@@ -242,7 +242,7 @@ namespace Polly
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
 #pragma warning disable 1998
-                    () => new RetryPolicyState<TResult>(async outcome => onRetry(outcome.Exception)),
+                    () => new RetryPolicyState<TResult>(async (outcome, ctx) => onRetry(outcome.Exception), context),
 #pragma warning restore 1998
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates,
@@ -269,7 +269,7 @@ namespace Polly
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
-                    () => new RetryPolicyState<TResult>(onRetryAsync),
+                    () => new RetryPolicyState<TResult>((outcome, ctx) => onRetryAsync(outcome), context),
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates,
                 policyBuilder.ResultPredicates
@@ -297,7 +297,7 @@ namespace Polly
                     policyBuilder.ResultPredicates,
 #pragma warning disable 1998
                     () => new RetryPolicyState<TResult>(async (outcome, c) => onRetry(outcome, c), context),
-    #pragma warning restore 1998
+#pragma warning restore 1998
                     continueOnCapturedContext
                 ), 
                 policyBuilder.ExceptionPredicates,
@@ -381,7 +381,7 @@ namespace Polly
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
 #pragma warning disable 1998
-                    () => new RetryPolicyStateWithSleep<TResult>(sleepDurations, async (outcome, timespan) => onRetry(outcome, timespan)),
+                    () => new RetryPolicyStateWithSleep<TResult>(sleepDurations, async (outcome, timespan, ctx) => onRetry(outcome, timespan), context),
 #pragma warning restore 1998
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates,
@@ -424,7 +424,7 @@ namespace Polly
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
-                    () => new RetryPolicyStateWithSleep<TResult>(sleepDurations, onRetryAsync),
+                    () => new RetryPolicyStateWithSleep<TResult>(sleepDurations, (outcome, timespan, ctx) => onRetryAsync(outcome, timespan), context),
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates,
                 policyBuilder.ResultPredicates
@@ -642,7 +642,7 @@ namespace Polly
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
 #pragma warning disable 1998
-                    () => new RetryPolicyStateWithSleep<TResult>(sleepDurations, async (outcome, timespan) => onRetry(outcome, timespan)),
+                    () => new RetryPolicyStateWithSleep<TResult>(sleepDurations, async (outcome, timespan, ctx) => onRetry(outcome, timespan), context),
 #pragma warning restore 1998
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates,
@@ -677,7 +677,7 @@ namespace Polly
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
-                    () => new RetryPolicyStateWithSleep<TResult>(sleepDurations, onRetryAsync),
+                    () => new RetryPolicyStateWithSleep<TResult>(sleepDurations, (outcome, timespan, ctx) => onRetryAsync(outcome, timespan), context),
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates,
                 policyBuilder.ResultPredicates
@@ -863,7 +863,7 @@ namespace Polly
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
 #pragma warning disable 1998
-                    () => new RetryPolicyStateWithSleepDurationProvider<TResult>(sleepDurationProvider, async (outcome, timespan) => onRetry(outcome, timespan)),
+                    () => new RetryPolicyStateWithSleepDurationProvider<TResult>(sleepDurationProvider, async (outcome, timespan, ctx) => onRetry(outcome, timespan), context),
 #pragma warning restore 1998
                     continueOnCapturedContext
                 ),
@@ -894,7 +894,7 @@ namespace Polly
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
-                    () => new RetryPolicyStateWithSleepDurationProvider<TResult>(sleepDurationProvider, onRetryAsync),
+                    () => new RetryPolicyStateWithSleepDurationProvider<TResult>(sleepDurationProvider, (outcome, timespan, ctx) =>  onRetryAsync(outcome, timespan), context),
                     continueOnCapturedContext
                 ),
                 policyBuilder.ExceptionPredicates,

--- a/src/Polly.Shared/Utilities/KeyHelper.cs
+++ b/src/Polly.Shared/Utilities/KeyHelper.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Polly.Utilities
+{
+    internal static class KeyHelper
+    {
+        public static String GuidPart()
+        {
+            return Guid.NewGuid().ToString().Substring(0, 8);
+        }
+    }
+}

--- a/src/Polly.Shared/Wrap/PolicyWrap.ContextAndKeys.cs
+++ b/src/Polly.Shared/Wrap/PolicyWrap.ContextAndKeys.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Polly.Wrap
+{
+    public partial class PolicyWrap
+    {
+        /// <summary>
+        /// Updates the execution <see cref="Context"/> with context from the executing <see cref="PolicyWrap"/>.
+        /// </summary>
+        /// <param name="executionContext">The execution <see cref="Context"/>.</param>
+        internal override void SetPolicyContext(Context executionContext)
+        {
+            if (executionContext.PolicyWrapKey == null) executionContext.PolicyWrapKey = PolicyKey;
+
+            base.SetPolicyContext(executionContext);
+        }
+    }
+
+    public partial class PolicyWrap<TResult>
+    {
+        /// <summary>
+        /// Updates the execution <see cref="Context"/> with context from the executing <see cref="PolicyWrap{TResult}"/>.
+        /// </summary>
+        /// <param name="executionContext">The execution <see cref="Context"/>.</param>
+        internal override void SetPolicyContext(Context executionContext)
+        {
+            if (executionContext.PolicyWrapKey == null) executionContext.PolicyWrapKey = PolicyKey;
+
+            base.SetPolicyContext(executionContext);
+        }
+    }
+}

--- a/src/Polly.Shared/Wrap/PolicyWrapAsync.cs
+++ b/src/Polly.Shared/Wrap/PolicyWrapAsync.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Polly.Utilities;

--- a/src/Polly.SharedSpecs/ContextSpecs.cs
+++ b/src/Polly.SharedSpecs/ContextSpecs.cs
@@ -5,7 +5,7 @@ using FluentAssertions;
 using Polly.Specs.Helpers;
 using Xunit;
 
-namespace Polly.SharedSpecs
+namespace Polly.Specs
 {
     public class ContextSpecs
     {

--- a/src/Polly.SharedSpecs/ContextSpecs.cs
+++ b/src/Polly.SharedSpecs/ContextSpecs.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using FluentAssertions;
+using Polly.Specs.Helpers;
+using Xunit;
+
+namespace Polly.SharedSpecs
+{
+    public class ContextSpecs
+    {
+        [Fact]
+        public void Should_assign_ExecutionKey_from_constructor()
+        {
+            Context context = new Context("SomeKey");
+
+            context.ExecutionKey.Should().Be("SomeKey");
+
+            context.Keys.Count.Should().Be(0);
+        }
+
+        [Fact]
+        public void Should_assign_ExecutionKey_and_context_data_from_constructor()
+        {
+            Context context = new Context("SomeKey", new { key1 = "value1", key2 = "value2" }.AsDictionary());
+
+            context.ExecutionKey.Should().Be("SomeKey");
+            context["key1"].Should().Be("value1");
+            context["key2"].Should().Be("value2");
+        }
+
+        [Fact]
+        public void Should_assign_ExecutionGuid_when_accessed()
+        {
+            Context context = new Context("SomeKey");
+
+            context.ExecutionGuid.Should().NotBeEmpty();
+        }
+
+        [Fact]
+        public void Should_return_consistent_ExecutionGuid()
+        {
+            Context context = new Context("SomeKey");
+
+            Guid retrieved1 = context.ExecutionGuid;
+            Guid retrieved2 = context.ExecutionGuid;
+
+            retrieved1.ShouldBeEquivalentTo(retrieved2);
+        }
+    }
+}

--- a/src/Polly.SharedSpecs/ContextualPolicyAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/ContextualPolicyAsyncSpecs.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Polly.Specs.Helpers;
 using Xunit;
 
 namespace Polly.Specs
@@ -17,9 +19,8 @@ namespace Polly.Specs
                 .Handle<DivideByZeroException>()
                 .RetryAsync((_, __, ___) => { });
 
-            policy.Invoking(p => p.ExecuteAsync(() => Task.FromResult(true), null))
-                  .ShouldThrow<ArgumentNullException>().And
-                  .ParamName.Should().Be("contextData");
+            policy.Awaiting(p => p.ExecuteAsync(() => Task.FromResult(true), (IDictionary<string, object>) null))
+                  .ShouldThrow<ArgumentNullException>();
         }
 
         [Fact]
@@ -29,9 +30,32 @@ namespace Polly.Specs
                 .Handle<DivideByZeroException>()
                 .RetryAsync((_, __, ___) => { });
 
-            policy.Invoking(p => p.ExecuteAsync(() => Task.FromResult(2), null))
+            policy.Awaiting(p => p.ExecuteAsync(() => Task.FromResult(2), (IDictionary<string, object>) null))
+                  .ShouldThrow<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Executing_the_policy_action_should_throw_when_context_is_null()
+        {
+            Policy policy = Policy
+                .Handle<DivideByZeroException>()
+                .RetryAsync((_, __, ___) => { });
+
+            policy.Awaiting(p => p.ExecuteAsync(() => Task.FromResult(true), (Context) null))
                   .ShouldThrow<ArgumentNullException>().And
-                  .ParamName.Should().Be("contextData");
+                  .ParamName.Should().Be("context");
+        }
+
+        [Fact]
+        public void Executing_the_policy_function_should_throw_when_context_is_null()
+        {
+            Policy policy = Policy
+                .Handle<DivideByZeroException>()
+                .RetryAsync((_, __, ___) => { });
+
+            policy.Awaiting(p => p.ExecuteAsync(() => Task.FromResult(2), (Context)null))
+                  .ShouldThrow<ArgumentNullException>().And
+                  .ParamName.Should().Be("context");
         }
 
         [Fact]
@@ -41,9 +65,8 @@ namespace Polly.Specs
                 .Handle<DivideByZeroException>()
                 .RetryAsync((_, __, ___) => { });
 
-            policy.Invoking(p => p.ExecuteAndCaptureAsync(() => Task.FromResult(true), null))
-                  .ShouldThrow<ArgumentNullException>().And
-                  .ParamName.Should().Be("contextData");
+            policy.Awaiting(p => p.ExecuteAndCaptureAsync(() => Task.FromResult(true), (IDictionary<string, object>)null))
+                  .ShouldThrow<ArgumentNullException>();
         }
 
         [Fact]
@@ -53,9 +76,32 @@ namespace Polly.Specs
                 .Handle<DivideByZeroException>()
                 .RetryAsync((_, __, ___) => { });
 
-            policy.Invoking(p => p.ExecuteAndCaptureAsync(() => Task.FromResult(2), null))
+            policy.Awaiting(p => p.ExecuteAndCaptureAsync(() => Task.FromResult(2), (IDictionary<string, object>)null))
+                  .ShouldThrow<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Execute_and_capturing_the_policy_action_should_throw_when_context_is_null()
+        {
+            Policy policy = Policy
+                .Handle<DivideByZeroException>()
+                .RetryAsync((_, __, ___) => { });
+
+            policy.Awaiting(p => p.ExecuteAndCaptureAsync(() => Task.FromResult(true), (Context)null))
                   .ShouldThrow<ArgumentNullException>().And
-                  .ParamName.Should().Be("contextData");
+                  .ParamName.Should().Be("context");
+        }
+
+        [Fact]
+        public void Execute_and_capturing_the_policy_function_should_throw_when_context_is_null()
+        {
+            Policy policy = Policy
+                .Handle<DivideByZeroException>()
+                .RetryAsync((_, __, ___) => { });
+
+            policy.Awaiting(p => p.ExecuteAndCaptureAsync(() => Task.FromResult(2), (Context)null))
+                  .ShouldThrow<ArgumentNullException>().And
+                  .ParamName.Should().Be("context");
         }
     }
 }

--- a/src/Polly.SharedSpecs/ContextualPolicySpecs.cs
+++ b/src/Polly.SharedSpecs/ContextualPolicySpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using Xunit;
 
@@ -6,7 +7,6 @@ namespace Polly.Specs
 {
     public class ContextualPolicySpecs
     {
-
         [Fact]
         public void Executing_the_policy_action_should_throw_when_context_data_is_null()
         {
@@ -14,9 +14,8 @@ namespace Polly.Specs
                 .Handle<DivideByZeroException>()
                 .Retry((_, __, ___) => { });
 
-            policy.Invoking(p => p.Execute(() => { }, null))
-                  .ShouldThrow<ArgumentNullException>().And
-                  .ParamName.Should().Be("contextData");
+            policy.Invoking(p => p.Execute(() => { }, (IDictionary<string, object>)null))
+                  .ShouldThrow<ArgumentNullException>();
         }
         
         [Fact]
@@ -26,9 +25,8 @@ namespace Polly.Specs
                 .Handle<DivideByZeroException>()
                 .Retry((_, __, ___) => { });
 
-            policy.Invoking(p => p.ExecuteAndCapture(() => { }, null))
-                  .ShouldThrow<ArgumentNullException>().And
-                  .ParamName.Should().Be("contextData");
+            policy.Invoking(p => p.ExecuteAndCapture(() => { }, (IDictionary<string, object>)null))
+                  .ShouldThrow<ArgumentNullException>();
         }
 
         [Fact]
@@ -38,9 +36,8 @@ namespace Polly.Specs
                 .Handle<DivideByZeroException>()
                 .Retry((_, __, ___) => { });
 
-            policy.Invoking(p => p.Execute(() => 2, null))
-                  .ShouldThrow<ArgumentNullException>().And
-                  .ParamName.Should().Be("contextData");
+            policy.Invoking(p => p.Execute(() => 2, (IDictionary<string, object>)null))
+                  .ShouldThrow<ArgumentNullException>();
         }
 
         [Fact]
@@ -50,9 +47,55 @@ namespace Polly.Specs
                 .Handle<DivideByZeroException>()
                 .Retry((_, __, ___) => { });
 
-            policy.Invoking(p => p.ExecuteAndCapture(() => 2, null))
+            policy.Invoking(p => p.ExecuteAndCapture(() => 2, (IDictionary<string, object>)null))
+                  .ShouldThrow<ArgumentNullException>();
+        }
+        [Fact]
+        public void Executing_the_policy_action_should_throw_when_context_is_null()
+        {
+            Policy policy = Policy
+                .Handle<DivideByZeroException>()
+                .Retry((_, __, ___) => { });
+
+            policy.Invoking(p => p.Execute(() => { }, (Context)null))
                   .ShouldThrow<ArgumentNullException>().And
-                  .ParamName.Should().Be("contextData");
+                  .ParamName.Should().Be("context");
+        }
+
+        [Fact]
+        public void Execute_and_capturing_the_policy_action_should_throw_when_context_is_null()
+        {
+            Policy policy = Policy
+                .Handle<DivideByZeroException>()
+                .Retry((_, __, ___) => { });
+
+            policy.Invoking(p => p.ExecuteAndCapture(() => { }, (Context)null))
+                  .ShouldThrow<ArgumentNullException>().And
+                  .ParamName.Should().Be("context");
+        }
+
+        [Fact]
+        public void Executing_the_policy_function_should_throw_when_context_is_null()
+        {
+            Policy policy = Policy
+                .Handle<DivideByZeroException>()
+                .Retry((_, __, ___) => { });
+
+            policy.Invoking(p => p.Execute(() => 2, (Context)null))
+                  .ShouldThrow<ArgumentNullException>().And
+                  .ParamName.Should().Be("context");
+        }
+
+        [Fact]
+        public void Execute_and_capturing_the_policy_function_should_throw_when_context_is_null()
+        {
+            Policy policy = Policy
+                .Handle<DivideByZeroException>()
+                .Retry((_, __, ___) => { });
+
+            policy.Invoking(p => p.ExecuteAndCapture(() => 2, (Context)null))
+                  .ShouldThrow<ArgumentNullException>().And
+                  .ParamName.Should().Be("context");
         }
     }
 }

--- a/src/Polly.SharedSpecs/PolicyAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/PolicyAsyncSpecs.cs
@@ -174,7 +174,7 @@ namespace Polly.Specs
             syncPolicy
                 .Awaiting(x => x.ExecuteAsync(() => CompletedTask))
                 .ShouldThrow<InvalidOperationException>()
-                .WithMessage("Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.");
+                .WithMessage("Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.");
         }
 
         [Theory, MemberData("SyncPolicies")]
@@ -183,7 +183,7 @@ namespace Polly.Specs
             syncPolicy
                 .Awaiting(x => x.ExecuteAndCaptureAsync(() => CompletedTask))
                 .ShouldThrow<InvalidOperationException>()
-                .WithMessage("Please use the asynchronous RetryAsync, RetryForeverAsync, WaitAndRetryAsync or CircuitBreakerAsync methods when calling the asynchronous Execute method.");
+                .WithMessage("Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.");
         }
 
         public static IEnumerable<object[]> SyncPolicies

--- a/src/Polly.SharedSpecs/PolicyKeyAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/PolicyKeyAsyncSpecs.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using FluentAssertions;
+using Polly.Retry;
+using Xunit;
+
+namespace Polly.Specs
+{
+    public class PolicyKeyAsyncSpecs
+    {
+        [Fact]
+        public void Should_be_able_fluently_to_configure_the_policy_key()
+        {
+            var policy = Policy.Handle<Exception>().RetryAsync().WithPolicyKey(Guid.NewGuid().ToString());
+
+            policy.Should().BeAssignableTo<Policy>();
+        }
+
+        [Fact]
+        public void PolicyKey_property_should_be_the_fluently_configured_policy_key()
+        {
+            const string key = "SomePolicyKey";
+
+            var policy = Policy.Handle<Exception>().RetryAsync().WithPolicyKey(key);
+
+            policy.PolicyKey.Should().Be(key);
+        }
+
+        [Fact]
+        public void Should_not_be_able_to_configure_the_policy_key_explicitly_more_than_once()
+        {
+            var policy = Policy.Handle<Exception>().RetryAsync();
+
+            Action configure = () => policy.WithPolicyKey(Guid.NewGuid().ToString());
+
+            configure.ShouldNotThrow();
+
+            configure.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("policyKey");
+        }
+
+        [Fact]
+        public void PolicyKey_property_should_be_non_null_or_empty_if_not_explicitly_configured()
+        {
+            var policy = Policy.Handle<Exception>().RetryAsync();
+
+            policy.PolicyKey.Should().NotBeNullOrEmpty();
+        }
+
+        [Fact]
+        public void PolicyKey_property_should_start_with_policy_type_if_not_explicitly_configured()
+        {
+            var policy = Policy.Handle<Exception>().RetryAsync();
+            
+            policy.PolicyKey.Should().StartWith("Retry");
+        }
+
+        [Fact]
+        public void PolicyKey_property_should_be_unique_for_different_instances_if_not_explicitly_configured()
+        {
+            var policy1 = Policy.Handle<Exception>().RetryAsync();
+            var policy2 = Policy.Handle<Exception>().RetryAsync();
+
+            policy1.PolicyKey.Should().NotBe(policy2.PolicyKey);
+        }
+
+        [Fact]
+        public void PolicyKey_property_should_return_consistent_value_for_same_policy_instance_if_not_explicitly_configured()
+        {
+            var policy = Policy.Handle<Exception>().RetryAsync();
+
+            var keyRetrievedFirst = policy.PolicyKey;
+            var keyRetrievedSecond = policy.PolicyKey;
+
+            keyRetrievedSecond.Should().Be(keyRetrievedFirst);
+        }
+
+
+        [Fact]
+        public void Should_not_be_able_to_configure_the_policy_key_explicitly_after_retrieving_default_value()
+        {
+            var policy = Policy.Handle<Exception>().RetryAsync();
+
+            string retrieveKeyWhenNotExplicitlyConfigured = policy.PolicyKey;
+
+            Action configure = () => policy.WithPolicyKey(Guid.NewGuid().ToString());
+
+            configure.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("policyKey");
+        }
+    }
+
+
+    public class PolicyTResultKeyAsyncSpecs
+    {
+        [Fact]
+        public void Should_be_able_fluently_to_configure_the_policy_key()
+        {
+            var policy = Policy.HandleResult<int>(0).RetryAsync().WithPolicyKey(Guid.NewGuid().ToString());
+
+            policy.Should().BeAssignableTo<Policy<int>>();
+        }
+
+        [Fact]
+        public void PolicyKey_property_should_be_the_fluently_configured_policy_key()
+        {
+            const string key = "SomePolicyKey";
+
+            var policy = Policy.HandleResult(0).RetryAsync().WithPolicyKey(key);
+
+            policy.PolicyKey.Should().Be(key);
+        }
+
+        [Fact]
+        public void Should_not_be_able_to_configure_the_policy_key_explicitly_more_than_once()
+        {
+            var policy = Policy.HandleResult(0).RetryAsync();
+
+            Action configure = () => policy.WithPolicyKey(Guid.NewGuid().ToString());
+
+            configure.ShouldNotThrow();
+
+            configure.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("policyKey");
+        }
+
+        [Fact]
+        public void PolicyKey_property_should_be_non_null_or_empty_if_not_explicitly_configured()
+        {
+            var policy = Policy.HandleResult(0).RetryAsync();
+
+            policy.PolicyKey.Should().NotBeNullOrEmpty();
+        }
+
+        [Fact]
+        public void PolicyKey_property_should_start_with_policy_type_if_not_explicitly_configured()
+        {
+            var policy = Policy.HandleResult(0).RetryAsync();
+
+            policy.PolicyKey.Should().StartWith("Retry");
+        }
+
+        [Fact]
+        public void PolicyKey_property_should_be_unique_for_different_instances_if_not_explicitly_configured()
+        {
+            var policy1 = Policy.HandleResult(0).RetryAsync();
+            var policy2 = Policy.HandleResult(0).RetryAsync();
+
+            policy1.PolicyKey.Should().NotBe(policy2.PolicyKey);
+        }
+
+        [Fact]
+        public void PolicyKey_property_should_return_consistent_value_for_same_policy_instance_if_not_explicitly_configured()
+        {
+            var policy = Policy.HandleResult(0).RetryAsync();
+
+            var keyRetrievedFirst = policy.PolicyKey;
+            var keyRetrievedSecond = policy.PolicyKey;
+
+            keyRetrievedSecond.Should().Be(keyRetrievedFirst);
+        }
+
+
+        [Fact]
+        public void Should_not_be_able_to_configure_the_policy_key_explicitly_after_retrieving_default_value()
+        {
+            var policy = Policy.HandleResult(0).RetryAsync();
+
+            string retrieveKeyWhenNotExplicitlyConfigured = policy.PolicyKey;
+
+            Action configure = () => policy.WithPolicyKey(Guid.NewGuid().ToString());
+
+            configure.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("policyKey");
+        }
+    }
+}

--- a/src/Polly.SharedSpecs/PolicyKeySpecs.cs
+++ b/src/Polly.SharedSpecs/PolicyKeySpecs.cs
@@ -1,0 +1,171 @@
+﻿using System;
+using FluentAssertions;
+using Xunit;
+
+namespace Polly.Specs
+{
+    public class PolicyKeySpecs
+    {
+        [Fact]
+        public void Should_be_able_fluently_to_configure_the_policy_key()
+        {
+            var policy = Policy.Handle<Exception>().Retry().WithPolicyKey(Guid.NewGuid().ToString());
+
+            policy.Should().BeAssignableTo<Policy>();
+        }
+
+        [Fact]
+        public void PolicyKey_property_should_be_the_fluently_configured_policy_key()
+        {
+            const string key = "SomePolicyKey";
+
+            var policy = Policy.Handle<Exception>().Retry().WithPolicyKey(key);
+
+            policy.PolicyKey.Should().Be(key);
+        }
+
+        [Fact]
+        public void Should_not_be_able_to_configure_the_policy_key_explicitly_more_than_once()
+        {
+            var policy = Policy.Handle<Exception>().Retry();
+
+            Action configure = () => policy.WithPolicyKey(Guid.NewGuid().ToString());
+
+            configure.ShouldNotThrow();
+
+            configure.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("policyKey");
+        }
+
+        [Fact]
+        public void PolicyKey_property_should_be_non_null_or_empty_if_not_explicitly_configured()
+        {
+            var policy = Policy.Handle<Exception>().Retry();
+
+            policy.PolicyKey.Should().NotBeNullOrEmpty();
+        }
+
+        [Fact]
+        public void PolicyKey_property_should_start_with_policy_type_if_not_explicitly_configured()
+        {
+            var policy = Policy.Handle<Exception>().Retry();
+
+            policy.PolicyKey.Should().StartWith("Retry");
+        }
+
+        [Fact]
+        public void PolicyKey_property_should_be_unique_for_different_instances_if_not_explicitly_configured()
+        {
+            var policy1 = Policy.Handle<Exception>().Retry();
+            var policy2 = Policy.Handle<Exception>().Retry();
+
+            policy1.PolicyKey.Should().NotBe(policy2.PolicyKey);
+        }
+
+        [Fact]
+        public void PolicyKey_property_should_return_consistent_value_for_same_policy_instance_if_not_explicitly_configured()
+        {
+            var policy = Policy.Handle<Exception>().Retry();
+
+            var keyRetrievedFirst = policy.PolicyKey;
+            var keyRetrievedSecond = policy.PolicyKey;
+
+            keyRetrievedSecond.Should().Be(keyRetrievedFirst);
+        }
+
+
+        [Fact]
+        public void Should_not_be_able_to_configure_the_policy_key_explicitly_after_retrieving_default_value()
+        {
+            var policy = Policy.Handle<Exception>().Retry();
+
+            string retrieveKeyWhenNotExplicitlyConfigured = policy.PolicyKey;
+
+            Action configure = () => policy.WithPolicyKey(Guid.NewGuid().ToString());
+
+            configure.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("policyKey");
+        }
+    }
+
+
+    public class PolicyTResultKeySpecs
+    {
+        [Fact]
+        public void Should_be_able_fluently_to_configure_the_policy_key()
+        {
+            var policy = Policy.HandleResult<int>(0).Retry().WithPolicyKey(Guid.NewGuid().ToString());
+
+            policy.Should().BeAssignableTo<Policy<int>>();
+        }
+
+        [Fact]
+        public void PolicyKey_property_should_be_the_fluently_configured_policy_key()
+        {
+            const string key = "SomePolicyKey";
+
+            var policy = Policy.HandleResult(0).Retry().WithPolicyKey(key);
+
+            policy.PolicyKey.Should().Be(key);
+        }
+
+        [Fact]
+        public void Should_not_be_able_to_configure_the_policy_key_explicitly_more_than_once()
+        {
+            var policy = Policy.HandleResult(0).Retry();
+
+            Action configure = () => policy.WithPolicyKey(Guid.NewGuid().ToString());
+
+            configure.ShouldNotThrow();
+
+            configure.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("policyKey");
+        }
+
+        [Fact]
+        public void PolicyKey_property_should_be_non_null_or_empty_if_not_explicitly_configured()
+        {
+            var policy = Policy.HandleResult(0).Retry();
+
+            policy.PolicyKey.Should().NotBeNullOrEmpty();
+        }
+
+        [Fact]
+        public void PolicyKey_property_should_start_with_policy_type_if_not_explicitly_configured()
+        {
+            var policy = Policy.HandleResult(0).Retry();
+
+            policy.PolicyKey.Should().StartWith("Retry");
+        }
+
+        [Fact]
+        public void PolicyKey_property_should_be_unique_for_different_instances_if_not_explicitly_configured()
+        {
+            var policy1 = Policy.HandleResult(0).Retry();
+            var policy2 = Policy.HandleResult(0).Retry();
+
+            policy1.PolicyKey.Should().NotBe(policy2.PolicyKey);
+        }
+
+        [Fact]
+        public void PolicyKey_property_should_return_consistent_value_for_same_policy_instance_if_not_explicitly_configured()
+        {
+            var policy = Policy.HandleResult(0).Retry();
+
+            var keyRetrievedFirst = policy.PolicyKey;
+            var keyRetrievedSecond = policy.PolicyKey;
+
+            keyRetrievedSecond.Should().Be(keyRetrievedFirst);
+        }
+
+
+        [Fact]
+        public void Should_not_be_able_to_configure_the_policy_key_explicitly_after_retrieving_default_value()
+        {
+            var policy = Policy.HandleResult(0).Retry();
+
+            string retrieveKeyWhenNotExplicitlyConfigured = policy.PolicyKey;
+
+            Action configure = () => policy.WithPolicyKey(Guid.NewGuid().ToString());
+
+            configure.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("policyKey");
+        }
+    }
+}

--- a/src/Polly.SharedSpecs/PolicySpecs.cs
+++ b/src/Polly.SharedSpecs/PolicySpecs.cs
@@ -167,7 +167,7 @@ namespace Polly.Specs
             Action action = () => asyncPolicy.Execute(() => { });
 
             action.ShouldThrow<InvalidOperationException>()
-                .WithMessage("Please use the synchronous Retry, RetryForever, WaitAndRetry or CircuitBreaker methods when calling the synchronous Execute method.");
+                .WithMessage("Please use the synchronous-defined policies when calling the synchronous Execute (and similar) methods.");
         }
 
         [Theory, MemberData("AsyncPolicies")]
@@ -176,7 +176,7 @@ namespace Polly.Specs
             Action action = () => asyncPolicy.ExecuteAndCapture(() => { });
 
             action.ShouldThrow<InvalidOperationException>()
-                .WithMessage("Please use the synchronous Retry, RetryForever, WaitAndRetry or CircuitBreaker methods when calling the synchronous ExecuteAndCapture method.");
+                .WithMessage("Please use the synchronous-defined policies when calling the synchronous Execute (and similar) methods.");
         }
 
         public static IEnumerable<object[]> AsyncPolicies

--- a/src/Polly.SharedSpecs/PolicyWrapContextAndKeySpecs.cs
+++ b/src/Polly.SharedSpecs/PolicyWrapContextAndKeySpecs.cs
@@ -1,0 +1,186 @@
+﻿using System;
+using FluentAssertions;
+using Polly.Specs.Helpers;
+using Xunit;
+
+namespace Polly.Specs
+{
+    public class PolicyWrapContextAndKeySpecs
+    {
+        #region PolicyKey and execution Context tests
+
+        [Fact]
+        public void Should_pass_PolicyKey_to_execution_context_of_outer_policy_as_PolicyWrapKey()
+        {
+            string retryKey = Guid.NewGuid().ToString();
+            string breakerKey = Guid.NewGuid().ToString();
+            string wrapKey = Guid.NewGuid().ToString();
+
+            string policyWrapKeySetOnExecutionContext = null;
+            Action<Exception, int, Context> onRetry = (e, i, context) =>
+            {
+                policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
+            };
+
+            var retry = Policy.Handle<Exception>().Retry(1, onRetry).WithPolicyKey(retryKey);
+            var breaker = Policy.Handle<Exception>().CircuitBreaker(1, TimeSpan.Zero).WithPolicyKey(breakerKey);
+            var wrap = retry.Wrap(breaker).WithPolicyKey(wrapKey);
+
+            wrap.RaiseException<Exception>(1);
+
+            policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
+            policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
+            policyWrapKeySetOnExecutionContext.Should().Be(wrapKey);
+        }
+
+        [Fact]
+        public void Should_pass_PolicyKey_to_execution_context_of_inner_policy_as_PolicyWrapKey()
+        {
+            string retryKey = Guid.NewGuid().ToString();
+            string breakerKey = Guid.NewGuid().ToString();
+            string wrapKey = Guid.NewGuid().ToString();
+
+            string policyWrapKeySetOnExecutionContext = null;
+            Action<Exception, TimeSpan, Context> onBreak = (e, t, context) =>
+            {
+                policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
+            };
+            Action<Context> onReset = _ => {};
+
+            var retry = Policy.Handle<Exception>().Retry(1).WithPolicyKey(retryKey);
+            var breaker = Policy.Handle<Exception>().CircuitBreaker(1, TimeSpan.Zero, onBreak, onReset).WithPolicyKey(breakerKey);
+            var wrap = retry.Wrap(breaker).WithPolicyKey(wrapKey);
+
+            wrap.RaiseException<Exception>(1);
+
+            policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
+            policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
+            policyWrapKeySetOnExecutionContext.Should().Be(wrapKey);
+        }
+
+        [Fact]
+        public void Should_pass_outmost_PolicyWrap_Key_as_PolicyWrapKey_ignoring_inner_PolicyWrap_keys_even_when_executing_policies_in_inner_wrap()
+        {
+            string retryKey = Guid.NewGuid().ToString();
+            string breakerKey = Guid.NewGuid().ToString();
+            string fallbackKey = Guid.NewGuid().ToString();
+            string innerWrapKey = Guid.NewGuid().ToString();
+            string outerWrapKey = Guid.NewGuid().ToString();
+
+            string policyWrapKeySetOnExecutionContext = null;
+            Action<Exception, TimeSpan, Context> onBreak = (e, t, context) =>
+            {
+                policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
+            };
+            Action<Context> doNothingOnReset = _ => { };
+
+            var retry = Policy.Handle<Exception>().Retry(1).WithPolicyKey(retryKey);
+            var breaker = Policy.Handle<Exception>().CircuitBreaker(1, TimeSpan.Zero, onBreak, doNothingOnReset).WithPolicyKey(breakerKey);
+            var fallback = Policy.Handle<Exception>().Fallback(() => { }).WithPolicyKey(fallbackKey);
+
+            var innerWrap = retry.Wrap(breaker).WithPolicyKey(innerWrapKey);
+            var outerWrap = fallback.Wrap(innerWrap).WithPolicyKey(outerWrapKey);
+
+            outerWrap.RaiseException<Exception>(1);
+
+            policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
+            policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
+            policyWrapKeySetOnExecutionContext.Should().NotBe(fallbackKey);
+            policyWrapKeySetOnExecutionContext.Should().NotBe(innerWrapKey);
+            policyWrapKeySetOnExecutionContext.Should().Be(outerWrapKey);
+        }
+
+        #endregion
+
+    }
+
+    public class PolicyWrapTResultContextAndKeySpecs
+    {
+        #region PolicyKey and execution Context tests
+
+        [Fact]
+        public void Should_pass_PolicyKey_to_execution_context_of_outer_policy_as_PolicyWrapKey()
+        {
+            string retryKey = Guid.NewGuid().ToString();
+            string breakerKey = Guid.NewGuid().ToString();
+            string wrapKey = Guid.NewGuid().ToString();
+
+            string policyWrapKeySetOnExecutionContext = null;
+            Action<DelegateResult<ResultPrimitive>, int, Context> onRetry = (e, i, context) =>
+            {
+                policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
+            };
+
+            var retry = Policy.HandleResult(ResultPrimitive.Fault).Retry(1, onRetry).WithPolicyKey(retryKey);
+            var breaker = Policy.HandleResult(ResultPrimitive.Fault).CircuitBreaker(1, TimeSpan.Zero).WithPolicyKey(breakerKey);
+            var wrap = retry.Wrap(breaker).WithPolicyKey(wrapKey);
+
+            wrap.RaiseResultSequence(ResultPrimitive.Fault, ResultPrimitive.Good);
+
+            policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
+            policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
+            policyWrapKeySetOnExecutionContext.Should().Be(wrapKey);
+        }
+
+        [Fact]
+        public void Should_pass_PolicyKey_to_execution_context_of_inner_policy_as_PolicyWrapKey()
+        {
+            string retryKey = Guid.NewGuid().ToString();
+            string breakerKey = Guid.NewGuid().ToString();
+            string wrapKey = Guid.NewGuid().ToString();
+
+            string policyWrapKeySetOnExecutionContext = null;
+            Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (e, t, context) =>
+            {
+                policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
+            };
+            Action<Context> onReset = _ => { };
+
+            var retry = Policy.HandleResult(ResultPrimitive.Fault).Retry(1).WithPolicyKey(retryKey);
+            var breaker = Policy.HandleResult(ResultPrimitive.Fault).CircuitBreaker(1, TimeSpan.Zero, onBreak, onReset).WithPolicyKey(breakerKey);
+            var wrap = retry.Wrap(breaker).WithPolicyKey(wrapKey);
+
+            wrap.RaiseResultSequence(ResultPrimitive.Fault, ResultPrimitive.Good);
+
+            policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
+            policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
+            policyWrapKeySetOnExecutionContext.Should().Be(wrapKey);
+        }
+
+        [Fact]
+        public void Should_pass_outmost_PolicyWrap_Key_as_PolicyWrapKey_ignoring_inner_PolicyWrap_keys_even_when_executing_policies_in_inner_wrap()
+        {
+            string retryKey = Guid.NewGuid().ToString();
+            string breakerKey = Guid.NewGuid().ToString();
+            string fallbackKey = Guid.NewGuid().ToString();
+            string innerWrapKey = Guid.NewGuid().ToString();
+            string outerWrapKey = Guid.NewGuid().ToString();
+
+            string policyWrapKeySetOnExecutionContext = null;
+            Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (e, t, context) =>
+            {
+                policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
+            };
+            Action<Context> doNothingOnReset = _ => { };
+
+            var retry = Policy.HandleResult(ResultPrimitive.Fault).Retry(1).WithPolicyKey(retryKey);
+            var breaker = Policy.HandleResult(ResultPrimitive.Fault).CircuitBreaker(1, TimeSpan.Zero, onBreak, doNothingOnReset).WithPolicyKey(breakerKey);
+            var fallback = Policy.HandleResult(ResultPrimitive.Fault).Fallback(ResultPrimitive.Substitute).WithPolicyKey(fallbackKey);
+
+            var innerWrap = retry.Wrap(breaker).WithPolicyKey(innerWrapKey);
+            var outerWrap = fallback.Wrap(innerWrap).WithPolicyKey(outerWrapKey);
+
+            outerWrap.RaiseResultSequence(ResultPrimitive.Fault, ResultPrimitive.Good);
+
+            policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
+            policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
+            policyWrapKeySetOnExecutionContext.Should().NotBe(fallbackKey);
+            policyWrapKeySetOnExecutionContext.Should().NotBe(innerWrapKey);
+            policyWrapKeySetOnExecutionContext.Should().Be(outerWrapKey);
+        }
+
+        #endregion
+
+    }
+
+}

--- a/src/Polly.SharedSpecs/PolicyWrapContextAndKeySpecsAsync.cs
+++ b/src/Polly.SharedSpecs/PolicyWrapContextAndKeySpecsAsync.cs
@@ -1,0 +1,187 @@
+﻿using System;
+using FluentAssertions;
+using Polly.Specs.Helpers;
+using Polly.Utilities;
+using Xunit;
+
+namespace Polly.Specs
+{
+    public class PolicyWrapContextAndKeySpecsAsync
+    {
+        #region PolicyKey and execution Context tests
+
+        [Fact]
+        public void Should_pass_PolicyKey_to_execution_context_of_outer_policy_as_PolicyWrapKey()
+        {
+            string retryKey = Guid.NewGuid().ToString();
+            string breakerKey = Guid.NewGuid().ToString();
+            string wrapKey = Guid.NewGuid().ToString();
+
+            string policyWrapKeySetOnExecutionContext = null;
+            Action<Exception, int, Context> onRetry = (e, i, context) =>
+            {
+                policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
+            };
+
+            var retry = Policy.Handle<Exception>().RetryAsync(1, onRetry).WithPolicyKey(retryKey);
+            var breaker = Policy.Handle<Exception>().CircuitBreakerAsync(1, TimeSpan.Zero).WithPolicyKey(breakerKey);
+            var wrap = retry.WrapAsync(breaker).WithPolicyKey(wrapKey);
+
+            wrap.RaiseExceptionAsync<Exception>(1);
+
+            policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
+            policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
+            policyWrapKeySetOnExecutionContext.Should().Be(wrapKey);
+        }
+
+        [Fact]
+        public void Should_pass_PolicyKey_to_execution_context_of_inner_policy_as_PolicyWrapKey()
+        {
+            string retryKey = Guid.NewGuid().ToString();
+            string breakerKey = Guid.NewGuid().ToString();
+            string wrapKey = Guid.NewGuid().ToString();
+
+            string policyWrapKeySetOnExecutionContext = null;
+            Action<Exception, TimeSpan, Context> onBreak = (e, t, context) =>
+            {
+                policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
+            };
+            Action<Context> onReset = _ => { };
+
+            var retry = Policy.Handle<Exception>().RetryAsync(1).WithPolicyKey(retryKey);
+            var breaker = Policy.Handle<Exception>().CircuitBreakerAsync(1, TimeSpan.Zero, onBreak, onReset).WithPolicyKey(breakerKey);
+            var wrap = retry.WrapAsync(breaker).WithPolicyKey(wrapKey);
+
+            wrap.RaiseExceptionAsync<Exception>(1);
+
+            policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
+            policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
+            policyWrapKeySetOnExecutionContext.Should().Be(wrapKey);
+        }
+
+        [Fact]
+        public void Should_pass_outmost_PolicyWrap_Key_as_PolicyWrapKey_ignoring_inner_PolicyWrap_keys_even_when_executing_policies_in_inner_WrapAsync()
+        {
+            string retryKey = Guid.NewGuid().ToString();
+            string breakerKey = Guid.NewGuid().ToString();
+            string fallbackKey = Guid.NewGuid().ToString();
+            string innerWrapKey = Guid.NewGuid().ToString();
+            string outerWrapKey = Guid.NewGuid().ToString();
+
+            string policyWrapKeySetOnExecutionContext = null;
+            Action<Exception, TimeSpan, Context> onBreak = (e, t, context) =>
+            {
+                policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
+            };
+            Action<Context> doNothingOnReset = _ => { };
+
+            var retry = Policy.Handle<Exception>().RetryAsync(1).WithPolicyKey(retryKey);
+            var breaker = Policy.Handle<Exception>().CircuitBreakerAsync(1, TimeSpan.Zero, onBreak, doNothingOnReset).WithPolicyKey(breakerKey);
+            var fallback = Policy.Handle<Exception>().FallbackAsync(_ => TaskHelper.EmptyTask).WithPolicyKey(fallbackKey);
+
+            var innerWrap = retry.WrapAsync(breaker).WithPolicyKey(innerWrapKey);
+            var outerWrap = fallback.WrapAsync(innerWrap).WithPolicyKey(outerWrapKey);
+
+            outerWrap.RaiseExceptionAsync<Exception>(1);
+
+            policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
+            policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
+            policyWrapKeySetOnExecutionContext.Should().NotBe(fallbackKey);
+            policyWrapKeySetOnExecutionContext.Should().NotBe(innerWrapKey);
+            policyWrapKeySetOnExecutionContext.Should().Be(outerWrapKey);
+        }
+
+        #endregion
+
+    }
+
+    public class PolicyWrapTResultContextAndKeySpecsAsync
+    {
+        #region PolicyKey and execution Context tests
+
+        [Fact]
+        public void Should_pass_PolicyKey_to_execution_context_of_outer_policy_as_PolicyWrapKey()
+        {
+            string retryKey = Guid.NewGuid().ToString();
+            string breakerKey = Guid.NewGuid().ToString();
+            string wrapKey = Guid.NewGuid().ToString();
+
+            string policyWrapKeySetOnExecutionContext = null;
+            Action<DelegateResult<ResultPrimitive>, int, Context> onRetry = (e, i, context) =>
+            {
+                policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
+            };
+
+            var retry = Policy.HandleResult(ResultPrimitive.Fault).RetryAsync(1, onRetry).WithPolicyKey(retryKey);
+            var breaker = Policy.HandleResult(ResultPrimitive.Fault).CircuitBreakerAsync(1, TimeSpan.Zero).WithPolicyKey(breakerKey);
+            var wrap = retry.WrapAsync(breaker).WithPolicyKey(wrapKey);
+
+            wrap.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Good);
+
+            policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
+            policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
+            policyWrapKeySetOnExecutionContext.Should().Be(wrapKey);
+        }
+
+        [Fact]
+        public void Should_pass_PolicyKey_to_execution_context_of_inner_policy_as_PolicyWrapKey()
+        {
+            string retryKey = Guid.NewGuid().ToString();
+            string breakerKey = Guid.NewGuid().ToString();
+            string wrapKey = Guid.NewGuid().ToString();
+
+            string policyWrapKeySetOnExecutionContext = null;
+            Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (e, t, context) =>
+            {
+                policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
+            };
+            Action<Context> onReset = _ => { };
+
+            var retry = Policy.HandleResult(ResultPrimitive.Fault).RetryAsync(1).WithPolicyKey(retryKey);
+            var breaker = Policy.HandleResult(ResultPrimitive.Fault).CircuitBreakerAsync(1, TimeSpan.Zero, onBreak, onReset).WithPolicyKey(breakerKey);
+            var wrap = retry.WrapAsync(breaker).WithPolicyKey(wrapKey);
+
+            wrap.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Good);
+
+            policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
+            policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
+            policyWrapKeySetOnExecutionContext.Should().Be(wrapKey);
+        }
+
+        [Fact]
+        public void Should_pass_outmost_PolicyWrap_Key_as_PolicyWrapKey_ignoring_inner_PolicyWrap_keys_even_when_executing_policies_in_inner_WrapAsync()
+        {
+            string retryKey = Guid.NewGuid().ToString();
+            string breakerKey = Guid.NewGuid().ToString();
+            string fallbackKey = Guid.NewGuid().ToString();
+            string innerWrapKey = Guid.NewGuid().ToString();
+            string outerWrapKey = Guid.NewGuid().ToString();
+
+            string policyWrapKeySetOnExecutionContext = null;
+            Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (e, t, context) =>
+            {
+                policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
+            };
+            Action<Context> doNothingOnReset = _ => { };
+
+            var retry = Policy.HandleResult(ResultPrimitive.Fault).RetryAsync(1).WithPolicyKey(retryKey);
+            var breaker = Policy.HandleResult(ResultPrimitive.Fault).CircuitBreakerAsync(1, TimeSpan.Zero, onBreak, doNothingOnReset).WithPolicyKey(breakerKey);
+            var fallback = Policy.HandleResult(ResultPrimitive.Fault).FallbackAsync(ResultPrimitive.Substitute).WithPolicyKey(fallbackKey);
+
+            var innerWrap = retry.WrapAsync(breaker).WithPolicyKey(innerWrapKey);
+            var outerWrap = fallback.WrapAsync(innerWrap).WithPolicyKey(outerWrapKey);
+
+            outerWrap.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Good);
+
+            policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
+            policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
+            policyWrapKeySetOnExecutionContext.Should().NotBe(fallbackKey);
+            policyWrapKeySetOnExecutionContext.Should().NotBe(innerWrapKey);
+            policyWrapKeySetOnExecutionContext.Should().Be(outerWrapKey);
+        }
+
+        #endregion
+
+    }
+
+}

--- a/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
+++ b/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
@@ -37,6 +37,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)PolicyContextAndKeyAsyncSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PolicyContextAndKeySpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PolicySpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)PolicyWrapContextAndKeySpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)PolicyWrapContextAndKeySpecsAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PolicyWrapSpecsAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RetryAsyncSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RetryForeverAsyncSpecs.cs" />

--- a/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
+++ b/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
@@ -34,8 +34,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ResultClass.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ResultPrimitive.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PolicyAsyncSpecs.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)PolicyKeyAsyncSpecs.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)PolicyKeySpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)PolicyContextAndKeyAsyncSpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)PolicyContextAndKeySpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PolicySpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PolicyWrapSpecsAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RetryAsyncSpecs.cs" />

--- a/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
+++ b/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
@@ -15,6 +15,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CircuitBreakerTResultAsyncSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CircuitBreakerTResultMixedResultExceptionSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CircuitBreakerTResultSpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ContextSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ContextualPolicyAsyncSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ContextualPolicySpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FallbackAsyncSpecs.cs" />
@@ -33,6 +34,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ResultClass.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ResultPrimitive.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PolicyAsyncSpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)PolicyKeyAsyncSpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)PolicyKeySpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PolicySpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PolicyWrapSpecsAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RetryAsyncSpecs.cs" />


### PR DESCRIPTION
Implementation for issue 139.
Add PolicyKeys to Context, Policy and PolicyWrap.
Ensure keys feed to the Context of each execution.
Ensure all executions carry a Context.
Specs for all same.