### PR TITLE
Add Optimistic/Pessimistic modes for TimeoutPolicy

### DIFF
--- a/src/Polly.Shared/CircuitBreaker/BrokenCircuitException.cs
+++ b/src/Polly.Shared/CircuitBreaker/BrokenCircuitException.cs
@@ -52,7 +52,7 @@ namespace Polly.CircuitBreaker
     /// <summary>
     /// Exception thrown when a circuit is broken.
     /// </summary>
-    /// <typeparam name="TResult">The TResult type being handled by the policy.</typeparam>
+    /// <typeparam name="TResult">The type of returned results being handled by the policy.</typeparam>
 #if !PORTABLE
     [Serializable]
 #endif

--- a/src/Polly.Shared/ContextualPolicy.cs
+++ b/src/Polly.Shared/ContextualPolicy.cs
@@ -230,7 +230,7 @@ namespace Polly
         /// <summary>
         /// Executes the specified action within the policy and returns the captured result.
         /// </summary>
-        /// <typeparam name="TResult">The type of the t result.</typeparam>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
         /// <param name="action">The action to perform.</param>
         /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
         /// <param name="cancellationToken">The cancellation token.</param>

--- a/src/Polly.Shared/PolicyWrapSyntax.cs
+++ b/src/Polly.Shared/PolicyWrapSyntax.cs
@@ -25,7 +25,7 @@ namespace Polly
         /// Wraps the specified inner policy.
         /// </summary>
         /// <param name="innerPolicy">The inner policy.</param>
-        /// <typeparam name="TResult">The type of the results returned by delegates which may be executed through the policy.</typeparam>
+        /// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
         /// <returns>PolicyWrap.PolicyWrap.</returns>
         public PolicyWrap<TResult> Wrap<TResult>(Policy<TResult> innerPolicy)
         {
@@ -93,7 +93,7 @@ namespace Polly
         /// Creates a <see cref="PolicyWrap" /> of the given policies governing delegates returning values of type <typeparamref name="TResult" />.
         /// </summary>
         /// <param name="policies">The policies to place in the wrap, outermost (at left) to innermost (at right).</param>
-        /// <typeparam name="TResult">The type of the results returned by delegates which may be executed through the policy.</typeparam>
+        /// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
         /// <returns>The PolicyWrap.</returns>
         /// <exception cref="System.ArgumentException">The enumerable of policies to form the wrap must contain at least two policies.</exception>
         public static PolicyWrap<TResult> Wrap<TResult>(params Policy<TResult>[] policies)

--- a/src/Polly.Shared/PolicyWrapSyntaxAsync.cs
+++ b/src/Polly.Shared/PolicyWrapSyntaxAsync.cs
@@ -25,7 +25,7 @@ namespace Polly
         /// Wraps the specified inner policy.
         /// </summary>
         /// <param name="innerPolicy">The inner policy.</param>
-        /// <typeparam name="TResult">The type of the results returned by delegates which may be executed through the policy.</typeparam>
+        /// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
         /// <returns>PolicyWrap.PolicyWrap.</returns>
         public PolicyWrap<TResult> WrapAsync<TResult>(Policy<TResult> innerPolicy)
         {
@@ -93,7 +93,7 @@ namespace Polly
         /// Creates a <see cref="PolicyWrap" /> of the given policies governing delegates returning values of type <typeparamref name="TResult" />.
         /// </summary>
         /// <param name="policies">The policies to place in the wrap, outermost (at left) to innermost (at right).</param>
-        /// <typeparam name="TResult">The type of the results returned by delegates which may be executed through the policy.</typeparam>
+        /// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
         /// <returns>The PolicyWrap.</returns>
         /// <exception cref="System.ArgumentException">The enumerable of policies to form the wrap must contain at least two policies.</exception>
         public static PolicyWrap<TResult> WrapAsync<TResult>(params Policy<TResult>[] policies)

--- a/src/Polly.Shared/Polly.Shared.projitems
+++ b/src/Polly.Shared/Polly.Shared.projitems
@@ -89,6 +89,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Timeout\TimeoutPolicy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Timeout\TimeoutPolicyAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Timeout\TimeoutRejectedException.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Timeout\TimeoutStrategy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\EmptyStruct.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\KeyHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\PredicateHelper.cs" />

--- a/src/Polly.Shared/Timeout/TimeoutStrategy.cs
+++ b/src/Polly.Shared/Timeout/TimeoutStrategy.cs
@@ -1,0 +1,19 @@
+﻿using System.Threading;
+
+namespace Polly.Timeout
+{
+    /// <summary>
+    /// Defines strategies used by <see cref="TimeoutPolicy"/>s to enforce timeouts.
+    /// </summary>
+    public enum TimeoutStrategy
+    {
+        /// <summary>
+        /// An optimistic <see cref="TimeoutStrategy"/>.  The <see cref="TimeoutPolicy"/> relies on a timing-out <see cref="CancellationToken"/> to cancel executed delegates by co-operative cancellation.
+        /// </summary>
+        Optimistic,
+        /// <summary>
+        /// An pessimistic <see cref="TimeoutStrategy"/>.  The <see cref="TimeoutPolicy"/> will assume the delegates passed to be executed will not necessarily honor any timing-out <see cref="CancellationToken"/>, but the policy will still guarantee timing out (and returning to the caller) by other means.
+        /// </summary>
+        Pessimistic
+    }
+}

--- a/src/Polly.Shared/TimeoutSyntax.cs
+++ b/src/Polly.Shared/TimeoutSyntax.cs
@@ -18,7 +18,22 @@ namespace Polly
             if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
             Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
 
-            return Timeout(() => TimeSpan.FromSeconds(seconds), doNothing);
+            return Timeout(() => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, doNothing);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="seconds">The number of seconds after which to timeout.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
+        public static TimeoutPolicy Timeout(int seconds, TimeoutStrategy timeoutStrategy)
+        {
+            if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
+            Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
+
+            return Timeout(() => TimeSpan.FromSeconds(seconds), timeoutStrategy, doNothing);
         }
 
         /// <summary>
@@ -33,9 +48,25 @@ namespace Polly
         public static TimeoutPolicy Timeout(int seconds, Action<Context, TimeSpan, Task> onTimeout)
         {
             if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
-            if (onTimeout == null) throw new ArgumentNullException(nameof(onTimeout));
 
-            return Timeout(() => TimeSpan.FromSeconds(seconds), onTimeout);
+            return Timeout(() => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, onTimeout);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="seconds">The number of seconds after which to timeout.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task" /> capturing the abandoned, timed-out action.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeout</exception>
+        public static TimeoutPolicy Timeout(int seconds, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task> onTimeout)
+        {
+            if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
+
+            return Timeout(() => TimeSpan.FromSeconds(seconds), timeoutStrategy, onTimeout);
         }
 
         /// <summary>
@@ -48,7 +79,22 @@ namespace Polly
             if (timeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
             Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
 
-            return Timeout(() => timeout, doNothing);
+            return Timeout(() => timeout, TimeoutStrategy.Optimistic, doNothing);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeout">The timeout.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException"></exception>
+        public static TimeoutPolicy Timeout(TimeSpan timeout, TimeoutStrategy timeoutStrategy)
+        {
+            if (timeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
+            Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
+
+            return Timeout(() => timeout, timeoutStrategy, doNothing);
         }
 
         /// <summary>
@@ -63,9 +109,25 @@ namespace Polly
         public static TimeoutPolicy Timeout(TimeSpan timeout, Action<Context, TimeSpan, Task> onTimeout)
         {
             if (timeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
-            if (onTimeout == null) throw new ArgumentNullException(nameof(onTimeout));
 
-            return Timeout(() => timeout, onTimeout);
+            return Timeout(() => timeout, TimeoutStrategy.Optimistic, onTimeout);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeout">The timeout.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task" /> capturing the abandoned, timed-out action.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">timeout;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeout</exception>
+        public static TimeoutPolicy Timeout(TimeSpan timeout, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task> onTimeout)
+        {
+            if (timeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
+
+            return Timeout(() => timeout, timeoutStrategy, onTimeout);
         }
 
         /// <summary>
@@ -77,19 +139,47 @@ namespace Polly
         public static TimeoutPolicy Timeout(Func<TimeSpan> timeoutProvider)
         {
             Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
-            return Timeout(timeoutProvider, doNothing);
+            return Timeout(timeoutProvider, TimeoutStrategy.Optimistic, doNothing);
         }
 
         /// <summary>
-        /// Builds a <see cref="Policy"/> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
+        /// Builds a <see cref="Policy" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
         /// </summary>
         /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
-        /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task"/> capturing the abandoned, timed-out action. 
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
+        public static TimeoutPolicy Timeout(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy)
+        {
+            Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
+            return Timeout(timeoutProvider, timeoutStrategy, doNothing);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
+        /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task" /> capturing the abandoned, timed-out action.
         /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
         /// <exception cref="System.ArgumentNullException">onTimeout</exception>
         public static TimeoutPolicy Timeout(Func<TimeSpan> timeoutProvider, Action<Context, TimeSpan, Task> onTimeout)
+        {
+            return Timeout(timeoutProvider, TimeoutStrategy.Optimistic, onTimeout);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task" /> capturing the abandoned, timed-out action.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeout</exception>
+        public static TimeoutPolicy Timeout(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task> onTimeout)
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
             if (onTimeout == null) throw new ArgumentNullException(nameof(onTimeout));
@@ -100,6 +190,7 @@ namespace Polly
                     context,
                     cancellationToken,
                     timeoutProvider,
+                    timeoutStrategy,
                     onTimeout)
                 );
         }

--- a/src/Polly.Shared/TimeoutSyntaxAsync.cs
+++ b/src/Polly.Shared/TimeoutSyntaxAsync.cs
@@ -18,7 +18,22 @@ namespace Polly
             if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
             Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.EmptyTask;
 
-            return TimeoutAsync(() => TimeSpan.FromSeconds(seconds), doNothingAsync);
+            return TimeoutAsync(() => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, doNothingAsync);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy" /> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="seconds">The number of seconds after which to timeout.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
+        public static TimeoutPolicy TimeoutAsync(int seconds, TimeoutStrategy timeoutStrategy)
+        {
+            if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
+            Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.EmptyTask;
+
+            return TimeoutAsync(() => TimeSpan.FromSeconds(seconds), timeoutStrategy, doNothingAsync);
         }
 
         /// <summary>
@@ -30,12 +45,30 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
         /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
-        public static TimeoutPolicy TimeoutAsync(int seconds,Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
+        public static TimeoutPolicy TimeoutAsync(int seconds, Func<Context
+            , TimeSpan, Task, Task> onTimeoutAsync)
         {
             if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
             if (onTimeoutAsync == null) throw new ArgumentNullException(nameof(onTimeoutAsync));
 
-            return TimeoutAsync(() => TimeSpan.FromSeconds(seconds), onTimeoutAsync);
+            return TimeoutAsync(() => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, onTimeoutAsync);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy" /> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="seconds">The number of seconds after which to timeout.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task" /> capturing the abandoned, timed-out action.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentNullException">seconds;Value must be greater than zero.</exception>
+        public static TimeoutPolicy TimeoutAsync(int seconds, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
+        {
+            if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
+
+            return TimeoutAsync(() => TimeSpan.FromSeconds(seconds), timeoutStrategy, onTimeoutAsync);
         }
 
         /// <summary>
@@ -48,7 +81,22 @@ namespace Polly
             if (timeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
             Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.EmptyTask;
 
-            return TimeoutAsync(() => timeout, doNothingAsync);
+            return TimeoutAsync(() => timeout, TimeoutStrategy.Optimistic, doNothingAsync);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy" /> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeout">The timeout.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException"></exception>
+        public static TimeoutPolicy TimeoutAsync(TimeSpan timeout, TimeoutStrategy timeoutStrategy)
+        {
+            if (timeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
+            Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.EmptyTask;
+
+            return TimeoutAsync(() => timeout, timeoutStrategy, doNothingAsync);
         }
 
         /// <summary>
@@ -60,12 +108,28 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">timeout;Value must be greater than zero.</exception>
         /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
-        public static TimeoutPolicy TimeoutAsync(TimeSpan timeout,Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
+        public static TimeoutPolicy TimeoutAsync(TimeSpan timeout, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
         {
             if (timeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
-            if (onTimeoutAsync == null) throw new ArgumentNullException(nameof(onTimeoutAsync));
 
-            return TimeoutAsync(() => timeout, onTimeoutAsync);
+            return TimeoutAsync(() => timeout, TimeoutStrategy.Optimistic, onTimeoutAsync);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy" /> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeout">The timeout.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task" /> capturing the abandoned, timed-out action.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">timeout;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
+        public static TimeoutPolicy TimeoutAsync(TimeSpan timeout, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
+        {
+            if (timeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
+
+            return TimeoutAsync(() => timeout, timeoutStrategy, onTimeoutAsync);
         }
 
         /// <summary>
@@ -78,7 +142,21 @@ namespace Polly
         {
             Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.EmptyTask;
 
-            return TimeoutAsync(timeoutProvider, doNothingAsync);
+            return TimeoutAsync(timeoutProvider, TimeoutStrategy.Optimistic, doNothingAsync);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy" /> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
+        public static TimeoutPolicy TimeoutAsync(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy)
+        {
+            Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.EmptyTask;
+
+            return TimeoutAsync(timeoutProvider, timeoutStrategy, doNothingAsync);
         }
 
         /// <summary>
@@ -92,6 +170,21 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
         public static TimeoutPolicy TimeoutAsync(Func<TimeSpan> timeoutProvider, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
         {
+            return TimeoutAsync(timeoutProvider, TimeoutStrategy.Optimistic, onTimeoutAsync);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy" /> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task" /> capturing the abandoned, timed-out action.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
+        public static TimeoutPolicy TimeoutAsync(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
+        {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
             if (onTimeoutAsync == null) throw new ArgumentNullException(nameof(onTimeoutAsync));
 
@@ -100,6 +193,7 @@ namespace Polly
                     async ct => { await action(ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                     context,
                     timeoutProvider,
+                    timeoutStrategy,
                     onTimeoutAsync,
                     cancellationToken, 
                     continueOnCapturedContext)

--- a/src/Polly.Shared/TimeoutTResultSyntax.cs
+++ b/src/Polly.Shared/TimeoutTResultSyntax.cs
@@ -9,6 +9,7 @@ namespace Polly
         /// <summary>
         /// Builds a <see cref="Policy{TResult}"/> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
         /// </summary>
+        /// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
         /// <param name="seconds">The number of seconds after which to timeout.</param>
         /// <exception cref="System.ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
         /// <returns>The policy instance.</returns>
@@ -17,7 +18,23 @@ namespace Polly
             if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
             Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
 
-            return Timeout<TResult>(() => TimeSpan.FromSeconds(seconds), doNothing);
+            return Timeout<TResult>(() => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, doNothing);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy{TResult}" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
+        /// <param name="seconds">The number of seconds after which to timeout.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
+        public static TimeoutPolicy<TResult> Timeout<TResult>(int seconds, TimeoutStrategy timeoutStrategy)
+        {
+            if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
+            Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
+
+            return Timeout<TResult>(() => TimeSpan.FromSeconds(seconds), timeoutStrategy, doNothing);
         }
 
         /// <summary>
@@ -32,8 +49,25 @@ namespace Polly
         public static TimeoutPolicy<TResult> Timeout<TResult>(int seconds, Action<Context, TimeSpan, Task> onTimeout)
         {
             if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
-            if (onTimeout == null) throw new ArgumentNullException(nameof(onTimeout));
-            return Timeout<TResult>(() => TimeSpan.FromSeconds(seconds), onTimeout);
+            return Timeout<TResult>(() => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, onTimeout);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy{TResult}" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
+        /// <param name="seconds">The number of seconds after which to timeout.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task{TResult}" /> capturing the abandoned, timed-out action.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeout</exception>
+        public static TimeoutPolicy<TResult> Timeout<TResult>(int seconds, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task> onTimeout)
+        {
+            if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
+
+            return Timeout<TResult>(() => TimeSpan.FromSeconds(seconds), timeoutStrategy, onTimeout);
         }
 
         /// <summary>
@@ -46,7 +80,23 @@ namespace Polly
             if (timeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
             Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
 
-            return Timeout<TResult>(() => timeout, doNothing);
+            return Timeout<TResult>(() => timeout, TimeoutStrategy.Optimistic, doNothing);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy{TResult}" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
+        /// <param name="timeout">The timeout.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">timeout</exception>
+        public static TimeoutPolicy<TResult> Timeout<TResult>(TimeSpan timeout, TimeoutStrategy timeoutStrategy)
+        {
+            if (timeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
+            Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
+
+            return Timeout<TResult>(() => timeout, timeoutStrategy, doNothing);
         }
 
         /// <summary>
@@ -61,8 +111,24 @@ namespace Polly
         public static TimeoutPolicy<TResult> Timeout<TResult>(TimeSpan timeout, Action<Context, TimeSpan, Task> onTimeout)
         {
             if (timeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
-            if (onTimeout == null) throw new ArgumentNullException(nameof(onTimeout));
-            return Timeout<TResult>(() => timeout, onTimeout);
+            return Timeout<TResult>(() => timeout, TimeoutStrategy.Optimistic, onTimeout);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy{TResult}" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
+        /// <param name="timeout">The timeout.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task{TResult}" /> capturing the abandoned, timed-out action.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">timeout;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeout</exception>
+        public static TimeoutPolicy<TResult> Timeout<TResult>(TimeSpan timeout, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task> onTimeout)
+        {
+            if (timeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
+            return Timeout<TResult>(() => timeout, timeoutStrategy, onTimeout);
         }
 
         /// <summary>
@@ -74,7 +140,21 @@ namespace Polly
         public static TimeoutPolicy<TResult> Timeout<TResult>(Func<TimeSpan> timeoutProvider)
         {
             Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
-            return Timeout<TResult>(timeoutProvider, doNothing);
+            return Timeout<TResult>(timeoutProvider, TimeoutStrategy.Optimistic, doNothing);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy{TResult}" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
+        /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
+        public static TimeoutPolicy<TResult> Timeout<TResult>(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy)
+        {
+            Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
+            return Timeout<TResult>(timeoutProvider, timeoutStrategy, doNothing);
         }
 
         /// <summary>
@@ -88,6 +168,22 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">onTimeout</exception>
         public static TimeoutPolicy<TResult> Timeout<TResult>(Func<TimeSpan> timeoutProvider, Action<Context, TimeSpan, Task> onTimeout)
         {
+            return Timeout<TResult>(timeoutProvider, TimeoutStrategy.Optimistic, onTimeout);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy{TResult}" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
+        /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task{TResult}" /> capturing the abandoned, timed-out action.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeout</exception>
+        public static TimeoutPolicy<TResult> Timeout<TResult>(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task> onTimeout)
+        {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
             if (onTimeout == null) throw new ArgumentNullException(nameof(onTimeout));
 
@@ -97,9 +193,10 @@ namespace Polly
                     context,
                     cancellationToken,
                     timeoutProvider,
+                    timeoutStrategy,
                     onTimeout)
                 );
         }
-        
+
     }
 }

--- a/src/Polly.Shared/TimeoutTResultSyntaxAsync.cs
+++ b/src/Polly.Shared/TimeoutTResultSyntaxAsync.cs
@@ -18,7 +18,22 @@ namespace Polly
             if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
 
             Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.FromResult(default(TResult));
-            return TimeoutAsync<TResult>(() => TimeSpan.FromSeconds(seconds), doNothingAsync);
+            return TimeoutAsync<TResult>(() => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, doNothingAsync);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy{TResult}"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="seconds">The number of seconds after which to timeout.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <exception cref="System.ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
+        /// <returns>The policy instance.</returns>
+        public static TimeoutPolicy<TResult> TimeoutAsync<TResult>(int seconds, TimeoutStrategy timeoutStrategy)
+        {
+            if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
+
+            Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.FromResult(default(TResult));
+            return TimeoutAsync<TResult>(() => TimeSpan.FromSeconds(seconds), timeoutStrategy, doNothingAsync);
         }
 
         /// <summary>
@@ -33,9 +48,25 @@ namespace Polly
         public static TimeoutPolicy<TResult> TimeoutAsync<TResult>(int seconds, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
         {
             if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
-            if (onTimeoutAsync == null) throw new ArgumentNullException(nameof(onTimeoutAsync));
 
-            return TimeoutAsync<TResult>(() => TimeSpan.FromSeconds(seconds), onTimeoutAsync);
+            return TimeoutAsync<TResult>(() => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, onTimeoutAsync);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy{TResult}"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="seconds">The number of seconds after which to timeout.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task"/> capturing the abandoned, timed-out action. 
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
+        public static TimeoutPolicy<TResult> TimeoutAsync<TResult>(int seconds, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
+        {
+            if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
+
+            return TimeoutAsync<TResult>(() => TimeSpan.FromSeconds(seconds), timeoutStrategy, onTimeoutAsync);
         }
 
         /// <summary>
@@ -48,7 +79,21 @@ namespace Polly
             if (timeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
 
             Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.FromResult(default(TResult));
-            return TimeoutAsync<TResult>(() => timeout, doNothingAsync);
+            return TimeoutAsync<TResult>(() => timeout, TimeoutStrategy.Optimistic, doNothingAsync);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy{TResult}"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeout">The timeout.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <returns>The policy instance.</returns>
+        public static TimeoutPolicy<TResult> TimeoutAsync<TResult>(TimeSpan timeout, TimeoutStrategy timeoutStrategy)
+        {
+            if (timeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
+
+            Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.FromResult(default(TResult));
+            return TimeoutAsync<TResult>(() => timeout, timeoutStrategy, doNothingAsync);
         }
 
         /// <summary>
@@ -65,7 +110,24 @@ namespace Polly
             if (timeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
             if (onTimeoutAsync == null) throw new ArgumentNullException(nameof(onTimeoutAsync));
 
-            return TimeoutAsync<TResult>(() => timeout, onTimeoutAsync);
+            return TimeoutAsync<TResult>(() => timeout, TimeoutStrategy.Optimistic, onTimeoutAsync);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy{TResult}"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeout">The timeout.</param>
+        /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task"/> capturing the abandoned, timed-out action. 
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">timeout;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
+        public static TimeoutPolicy<TResult> TimeoutAsync<TResult>(TimeSpan timeout, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
+        {
+            if (timeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
+
+            return TimeoutAsync<TResult>(() => timeout, timeoutStrategy, onTimeoutAsync);
         }
 
         /// <summary>
@@ -77,7 +139,20 @@ namespace Polly
         public static TimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<TimeSpan> timeoutProvider)
         {
             Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.FromResult(default(TResult));
-            return TimeoutAsync<TResult>(timeoutProvider, doNothingAsync);
+            return TimeoutAsync<TResult>(timeoutProvider, TimeoutStrategy.Optimistic, doNothingAsync);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy{TResult}"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
+        /// <returns>The policy instance.</returns>
+        public static TimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy)
+        {
+            Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.FromResult(default(TResult));
+            return TimeoutAsync<TResult>(timeoutProvider, timeoutStrategy, doNothingAsync);
         }
 
         /// <summary>
@@ -91,6 +166,21 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
         public static TimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<TimeSpan> timeoutProvider, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
         {
+            return TimeoutAsync<TResult>(timeoutProvider, TimeoutStrategy.Optimistic, onTimeoutAsync);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy{TResult}"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task"/> capturing the abandoned, timed-out action. 
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
+        public static TimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
+        {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
             if (onTimeoutAsync == null) throw new ArgumentNullException(nameof(onTimeoutAsync));
 
@@ -99,6 +189,7 @@ namespace Polly
                     action,
                     context,
                     timeoutProvider,
+                    timeoutStrategy,
                     onTimeoutAsync,
                     cancellationToken, 
                     continueOnCapturedContext)

--- a/src/Polly.Shared/Wrap/PolicyWrap.cs
+++ b/src/Polly.Shared/Wrap/PolicyWrap.cs
@@ -21,7 +21,7 @@ namespace Polly.Wrap
     /// <summary>
     /// A policy that allows two (and by recursion more) Polly policies to wrap executions of delegates.
     /// </summary>
-    /// <typeparam name="TResult">The type of the results returned by delegates which may be executed through the policy.</typeparam>
+    /// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
     public partial class PolicyWrap<TResult> : Policy<TResult>
     {
         internal PolicyWrap(Func<Func<CancellationToken, TResult>, Context, CancellationToken, TResult> policyAction)

--- a/src/Polly.SharedSpecs/TimeoutSpecs.cs
+++ b/src/Polly.SharedSpecs/TimeoutSpecs.cs
@@ -127,38 +127,81 @@ namespace Polly.Specs
 
         #endregion
 
-        #region Timeout operation
+        #region Timeout operation - pessimistic
 
         [Fact]
-        public void Should_throw_when_timeout_is_less_than_execution_duration()
+        public void Should_throw_when_timeout_is_less_than_execution_duration__pessimistic()
         {
-            var policy = Policy.Timeout(TimeSpan.FromMilliseconds(50));
+            var policy = Policy.Timeout(TimeSpan.FromMilliseconds(50), TimeoutStrategy.Pessimistic);
 
             policy.Invoking(p => p.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None)))
                 .ShouldThrow<TimeoutRejectedException>();
         }
 
         [Fact]
-        public void Should_not_throw_when_timeout_is_greater_than_execution_duration()
+        public void Should_not_throw_when_timeout_is_greater_than_execution_duration__pessimistic()
         {
             var policy = Policy
-                .Timeout(TimeSpan.FromSeconds(1));
+                .Timeout(TimeSpan.FromSeconds(1), TimeoutStrategy.Pessimistic);
 
             policy.Invoking(p => p.Execute(() => { })).ShouldNotThrow();
         }
 
         [Fact]
-        public void Should_throw_timeout_after_correct_duration()
+        public void Should_throw_timeout_after_correct_duration__pessimistic()
         {
             Stopwatch watch = new Stopwatch();
 
             TimeSpan timeout = TimeSpan.FromSeconds(1);
-            var policy = Policy.Timeout(timeout);
+            var policy = Policy.Timeout(timeout, TimeoutStrategy.Pessimistic);
 
             TimeSpan tolerance = TimeSpan.FromSeconds(1); // Consider increasing tolerance, if test fails transiently in different test/build environments.
 
             watch.Start();
             policy.Invoking(p => p.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(5), CancellationToken.None)))
+                .ShouldThrow<TimeoutRejectedException>();
+            watch.Stop();
+
+            watch.Elapsed.Should().BeCloseTo(timeout, ((int)tolerance.TotalMilliseconds));
+        }
+
+        #endregion
+
+        #region Timeout operation - optimistic
+
+        [Fact]
+        public void Should_throw_when_timeout_is_less_than_execution_duration__optimistic()
+        {
+            var policy = Policy.Timeout(TimeSpan.FromMilliseconds(50), TimeoutStrategy.Optimistic);
+            var userCancellationToken = CancellationToken.None;
+
+            policy.Invoking(p => p.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(3), ct), userCancellationToken)) // Delegate observes cancellation token, so permitting optimistic cancellation. 
+                .ShouldThrow<TimeoutRejectedException>();
+        }
+
+        [Fact]
+        public void Should_not_throw_when_timeout_is_greater_than_execution_duration__optimistic()
+        {
+            var policy = Policy
+                .Timeout(TimeSpan.FromSeconds(1));
+            var userCancellationToken = CancellationToken.None;
+
+            policy.Invoking(p => p.Execute(ct => { }, userCancellationToken)).ShouldNotThrow();
+        }
+
+        [Fact]
+        public void Should_throw_timeout_after_correct_duration__optimistic()
+        {
+            Stopwatch watch = new Stopwatch();
+
+            TimeSpan timeout = TimeSpan.FromSeconds(1);
+            var policy = Policy.Timeout(timeout);
+            var userCancellationToken = CancellationToken.None;
+
+            TimeSpan tolerance = TimeSpan.FromSeconds(1); // Consider increasing tolerance, if test fails transiently in different test/build environments.
+
+            watch.Start();
+            policy.Invoking(p => p.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(5), ct), userCancellationToken)) // Delegate observes cancellation token, so permitting optimistic cancellation. 
                 .ShouldThrow<TimeoutRejectedException>();
             watch.Stop();
 
@@ -215,17 +258,17 @@ namespace Polly.Specs
 
         #endregion
 
-        #region onTimeout overload
+        #region onTimeout overload - pessimistic
 
         [Fact]
-        public void Should_call_ontimeout_with_configured_timeout()
+        public void Should_call_ontimeout_with_configured_timeout__pessimistic()
         {
             TimeSpan timeoutPassedToConfiguration = TimeSpan.FromMilliseconds(250);
 
             TimeSpan? timeoutPassedToOnTimeout = null;
             Action<Context, TimeSpan, Task> onTimeout = (ctx, span, task) => { timeoutPassedToOnTimeout = span; };
 
-            var policy = Policy.Timeout(timeoutPassedToConfiguration, onTimeout);
+            var policy = Policy.Timeout(timeoutPassedToConfiguration, TimeoutStrategy.Pessimistic, onTimeout);
 
             policy.Invoking(p => p.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(1), CancellationToken.None)))
                 .ShouldThrow<TimeoutRejectedException>();
@@ -234,7 +277,7 @@ namespace Polly.Specs
         }
 
         [Fact]
-        public void Should_call_ontimeout_with_timeout_supplied_different_for_each_execution_by_evaluating_func()
+        public void Should_call_ontimeout_with_timeout_supplied_different_for_each_execution_by_evaluating_func__pessimistic()
         {
             for (int i = 1; i <= 3; i++)
             {
@@ -243,7 +286,7 @@ namespace Polly.Specs
                 TimeSpan? timeoutPassedToOnTimeout = null;
                 Action<Context, TimeSpan, Task> onTimeout = (ctx, span, task) => { timeoutPassedToOnTimeout = span; };
 
-                var policy = Policy.Timeout(timeoutFunc, onTimeout);
+                var policy = Policy.Timeout(timeoutFunc, TimeoutStrategy.Pessimistic, onTimeout);
 
                 policy.Invoking(p => p.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None)))
                     .ShouldThrow<TimeoutRejectedException>();
@@ -253,7 +296,7 @@ namespace Polly.Specs
         }
 
         [Fact]
-        public void Should_call_ontimeout_with_passed_context()
+        public void Should_call_ontimeout_with_passed_context__pessimistic()
         {
             string executionKey = Guid.NewGuid().ToString();
             Context contextPassedToExecute = new Context(executionKey);
@@ -262,7 +305,7 @@ namespace Polly.Specs
             Action<Context, TimeSpan, Task> onTimeout = (ctx, span, task) => { contextPassedToOnTimeout = ctx; };
 
             TimeSpan timeout = TimeSpan.FromMilliseconds(250);
-            var policy = Policy.Timeout(timeout, onTimeout);
+            var policy = Policy.Timeout(timeout, TimeoutStrategy.Pessimistic, onTimeout);
 
             policy.Invoking(p => p.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None), contextPassedToExecute))
                 .ShouldThrow<TimeoutRejectedException>();
@@ -273,13 +316,13 @@ namespace Polly.Specs
         }
 
         [Fact]
-        public void Should_call_ontimeout_with_task_wrapping_abandoned_action()
+        public void Should_call_ontimeout_with_task_wrapping_abandoned_action__pessimistic()
         {
             Task taskPassedToOnTimeout = null;
             Action<Context, TimeSpan, Task> onTimeout = (ctx, span, task) => { taskPassedToOnTimeout = task; };
 
             TimeSpan timeout = TimeSpan.FromMilliseconds(250);
-            var policy = Policy.Timeout(timeout, onTimeout);
+            var policy = Policy.Timeout(timeout, TimeoutStrategy.Pessimistic, onTimeout);
 
             policy.Invoking(p => p.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None)))
                 .ShouldThrow<TimeoutRejectedException>();
@@ -288,7 +331,7 @@ namespace Polly.Specs
         }
 
         [Fact]
-        public void Should_call_ontimeout_with_task_wrapping_abandoned_action_allowing_capture_of_otherwise_unobserved_exception()
+        public void Should_call_ontimeout_with_task_wrapping_abandoned_action_allowing_capture_of_otherwise_unobserved_exception__pessimistic()
         {
             Exception exceptionToThrow = new DivideByZeroException();
 
@@ -300,7 +343,7 @@ namespace Polly.Specs
 
             TimeSpan shimTimespan = TimeSpan.FromSeconds(1);
             TimeSpan thriceShimTimeSpan = shimTimespan + shimTimespan + shimTimespan;
-            var policy = Policy.Timeout(shimTimespan, onTimeout);
+            var policy = Policy.Timeout(shimTimespan, TimeoutStrategy.Pessimistic, onTimeout);
 
             policy.Invoking(p => p.Execute(() =>
             {
@@ -314,6 +357,85 @@ namespace Polly.Specs
             exceptionObservedFromTaskPassedToOnTimeout.Should().Be(exceptionToThrow);
 
         }
+
+        #endregion
+
+        #region onTimeout overload - optimistic
+
+        [Fact]
+        public void Should_call_ontimeout_with_configured_timeout__optimistic()
+        {
+            TimeSpan timeoutPassedToConfiguration = TimeSpan.FromMilliseconds(250);
+
+            TimeSpan? timeoutPassedToOnTimeout = null;
+            Action<Context, TimeSpan, Task> onTimeout = (ctx, span, task) => { timeoutPassedToOnTimeout = span; };
+
+            var policy = Policy.Timeout(timeoutPassedToConfiguration, TimeoutStrategy.Optimistic, onTimeout);
+            var userCancellationToken = CancellationToken.None;
+
+            policy.Invoking(p => p.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(1), ct), userCancellationToken))
+                .ShouldThrow<TimeoutRejectedException>();
+
+            timeoutPassedToOnTimeout.Should().Be(timeoutPassedToConfiguration);
+        }
+
+        [Fact]
+        public void Should_call_ontimeout_with_timeout_supplied_different_for_each_execution_by_evaluating_func__optimistic()
+        {
+            for (int i = 1; i <= 3; i++)
+            {
+                Func<TimeSpan> timeoutFunc = () => TimeSpan.FromMilliseconds(25 * i);
+
+                TimeSpan? timeoutPassedToOnTimeout = null;
+                Action<Context, TimeSpan, Task> onTimeout = (ctx, span, task) => { timeoutPassedToOnTimeout = span; };
+
+                var policy = Policy.Timeout(timeoutFunc, TimeoutStrategy.Optimistic, onTimeout);
+                var userCancellationToken = CancellationToken.None;
+
+                policy.Invoking(p => p.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(3), ct), userCancellationToken))
+                    .ShouldThrow<TimeoutRejectedException>();
+
+                timeoutPassedToOnTimeout.Should().Be(timeoutFunc());
+            }
+        }
+
+        [Fact]
+        public void Should_call_ontimeout_with_passed_context__optimistic()
+        {
+            string executionKey = Guid.NewGuid().ToString();
+            Context contextPassedToExecute = new Context(executionKey);
+
+            Context contextPassedToOnTimeout = null;
+            Action<Context, TimeSpan, Task> onTimeout = (ctx, span, task) => { contextPassedToOnTimeout = ctx; };
+
+            TimeSpan timeout = TimeSpan.FromMilliseconds(250);
+            var policy = Policy.Timeout(timeout, TimeoutStrategy.Optimistic, onTimeout);
+            var userCancellationToken = CancellationToken.None;
+
+            policy.Invoking(p => p.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(3), ct), contextPassedToExecute, userCancellationToken))
+                .ShouldThrow<TimeoutRejectedException>();
+
+            contextPassedToOnTimeout.Should().NotBeNull();
+            contextPassedToOnTimeout.ExecutionKey.Should().Be(executionKey);
+            contextPassedToOnTimeout.Should().BeSameAs(contextPassedToExecute);
+        }
+
+        [Fact]
+        public void Should_call_ontimeout_but_not_with_task_wrapping_abandoned_action__optimistic()
+        {
+            Task taskPassedToOnTimeout = null;
+            Action<Context, TimeSpan, Task> onTimeout = (ctx, span, task) => { taskPassedToOnTimeout = task; };
+
+            TimeSpan timeout = TimeSpan.FromMilliseconds(250);
+            var policy = Policy.Timeout(timeout, TimeoutStrategy.Optimistic, onTimeout);
+            var userCancellationToken = CancellationToken.None;
+
+            policy.Invoking(p => p.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(3), ct), userCancellationToken))
+                .ShouldThrow<TimeoutRejectedException>();
+
+            taskPassedToOnTimeout.Should().BeNull();
+        }
+        
 
         #endregion
     }

--- a/src/Polly.SharedSpecs/TimeoutTResultAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/TimeoutTResultAsyncSpecs.cs
@@ -128,14 +128,14 @@ namespace Polly.Specs
 
         #endregion
 
-        #region Timeout operation
+        #region Timeout operation - pessimistic
 
         [Fact]
-        public void Should_throw_when_timeout_is_less_than_execution_duration()
+        public void Should_throw_when_timeout_is_less_than_execution_duration__pessimistic()
         {
             TimeSpan timeout = TimeSpan.FromMilliseconds(50);
 
-            var policy = Policy.TimeoutAsync<ResultPrimitive>(timeout);
+            var policy = Policy.TimeoutAsync<ResultPrimitive>(timeout, TimeoutStrategy.Pessimistic);
 
             policy.Awaiting(async p => await p.ExecuteAsync(async () =>
             {
@@ -145,9 +145,9 @@ namespace Polly.Specs
         }
 
         [Fact]
-        public async void Should_not_throw_when_timeout_is_greater_than_execution_duration()
+        public async void Should_not_throw_when_timeout_is_greater_than_execution_duration__pessimistic()
         {
-            var policy = Policy.TimeoutAsync<ResultPrimitive>(TimeSpan.FromSeconds(1));
+            var policy = Policy.TimeoutAsync<ResultPrimitive>(TimeSpan.FromSeconds(1), TimeoutStrategy.Pessimistic);
 
             ResultPrimitive result = ResultPrimitive.Undefined;
             Exception ex = null;
@@ -167,12 +167,12 @@ namespace Polly.Specs
         }
 
         [Fact]
-        public void Should_throw_timeout_after_correct_duration()
+        public void Should_throw_timeout_after_correct_duration__pessimistic()
         {
             Stopwatch watch = new Stopwatch();
 
             TimeSpan timeout = TimeSpan.FromSeconds(1);
-            var policy = Policy.TimeoutAsync<ResultPrimitive>(timeout);
+            var policy = Policy.TimeoutAsync<ResultPrimitive>(timeout, TimeoutStrategy.Pessimistic);
 
             TimeSpan tolerance = TimeSpan.FromSeconds(1); // Consider increasing tolerance, if test fails transiently in different test/build environments.
 
@@ -182,6 +182,69 @@ namespace Polly.Specs
                 await SystemClock.SleepAsync(TimeSpan.FromSeconds(5), CancellationToken.None).ConfigureAwait(false);
                 return ResultPrimitive.WhateverButTooLate;
             }))
+                .ShouldThrow<TimeoutRejectedException>();
+            watch.Stop();
+
+            watch.Elapsed.Should().BeCloseTo(timeout, ((int)tolerance.TotalMilliseconds));
+        }
+
+        #endregion
+
+        #region Timeout operation - optimistic
+
+        [Fact]
+        public void Should_throw_when_timeout_is_less_than_execution_duration__optimistic()
+        {
+            var policy = Policy.TimeoutAsync<ResultPrimitive>(TimeSpan.FromMilliseconds(50), TimeoutStrategy.Optimistic);
+            var userCancellationToken = CancellationToken.None;
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async ct =>
+            {
+                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+                return ResultPrimitive.WhateverButTooLate;
+            }, userCancellationToken).ConfigureAwait(false)).ShouldThrow<TimeoutRejectedException>();
+        }
+
+        [Fact]
+        public async void Should_not_throw_when_timeout_is_greater_than_execution_duration__optimistic()
+        {
+            var policy = Policy.TimeoutAsync<ResultPrimitive>(TimeSpan.FromSeconds(1), TimeoutStrategy.Optimistic);
+
+            ResultPrimitive result = ResultPrimitive.Undefined;
+            Exception ex = null;
+            var userCancellationToken = CancellationToken.None;
+
+            try
+            {
+                result = await policy.ExecuteAsync(ct => TaskHelper.FromResult(ResultPrimitive.Good), userCancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                ex = e;
+            }
+
+            ex.Should().BeNull();
+            result.Should().Be(ResultPrimitive.Good);
+        }
+
+        [Fact]
+        public void Should_throw_timeout_after_correct_duration__optimistic()
+        {
+            Stopwatch watch = new Stopwatch();
+
+            TimeSpan timeout = TimeSpan.FromSeconds(1);
+            var policy = Policy.TimeoutAsync<ResultPrimitive>(timeout, TimeoutStrategy.Optimistic);
+            var userCancellationToken = CancellationToken.None;
+
+            TimeSpan tolerance = TimeSpan.FromSeconds(1); // Consider increasing tolerance, if test fails transiently in different test/build environments.
+
+            watch.Start();
+            policy.Awaiting(async p => await p.ExecuteAsync(async ct =>
+            {
+                await SystemClock.SleepAsync(TimeSpan.FromSeconds(5), ct).ConfigureAwait(false);
+                return ResultPrimitive.WhateverButTooLate;
+            }, userCancellationToken).ConfigureAwait(false))
                 .ShouldThrow<TimeoutRejectedException>();
             watch.Stop();
 
@@ -245,10 +308,10 @@ namespace Polly.Specs
 
         #endregion
 
-        #region onTimeout overload
+        #region onTimeout overload - pessimistic
 
         [Fact]
-        public void Should_call_ontimeout_with_configured_timeout()
+        public void Should_call_ontimeout_with_configured_timeout__pessimistic()
         {
             TimeSpan timeoutPassedToConfiguration = TimeSpan.FromMilliseconds(250);
 
@@ -259,7 +322,7 @@ namespace Polly.Specs
                 return TaskHelper.EmptyTask;
             };
 
-            var policy = Policy.TimeoutAsync<ResultPrimitive>(timeoutPassedToConfiguration, onTimeoutAsync);
+            var policy = Policy.TimeoutAsync<ResultPrimitive>(timeoutPassedToConfiguration, TimeoutStrategy.Pessimistic, onTimeoutAsync);
 
             policy.Awaiting(async p => await p.ExecuteAsync(async () =>
             {
@@ -272,7 +335,7 @@ namespace Polly.Specs
         }
 
         [Fact]
-        public void Should_call_ontimeout_with_timeout_supplied_different_for_each_execution_by_evaluating_func()
+        public void Should_call_ontimeout_with_timeout_supplied_different_for_each_execution_by_evaluating_func__pessimistic()
         {
             for (int i = 1; i <= 3; i++)
             {
@@ -285,7 +348,7 @@ namespace Polly.Specs
                     return TaskHelper.EmptyTask;
                 };
 
-                var policy = Policy.TimeoutAsync<ResultPrimitive>(timeoutFunc, onTimeoutAsync);
+                var policy = Policy.TimeoutAsync<ResultPrimitive>(timeoutFunc, TimeoutStrategy.Pessimistic, onTimeoutAsync);
 
                 policy.Awaiting(async p => await p.ExecuteAsync(async () =>
                 {
@@ -299,7 +362,7 @@ namespace Polly.Specs
         }
 
         [Fact]
-        public void Should_call_ontimeout_with_passed_context()
+        public void Should_call_ontimeout_with_passed_context__pessimistic()
         {
             string executionKey = Guid.NewGuid().ToString();
             Context contextPassedToExecute = new Context(executionKey);
@@ -312,7 +375,7 @@ namespace Polly.Specs
             };
 
             TimeSpan timeout = TimeSpan.FromMilliseconds(250);
-            var policy = Policy.TimeoutAsync<ResultPrimitive>(timeout, onTimeoutAsync);
+            var policy = Policy.TimeoutAsync<ResultPrimitive>(timeout, TimeoutStrategy.Pessimistic, onTimeoutAsync);
 
             policy.Awaiting(async p => await p.ExecuteAsync(async () =>
             {
@@ -327,7 +390,7 @@ namespace Polly.Specs
         }
 
         [Fact]
-        public void Should_call_ontimeout_with_task_wrapping_abandoned_action()
+        public void Should_call_ontimeout_with_task_wrapping_abandoned_action__pessimistic()
         {
             Task taskPassedToOnTimeout = null;
             Func<Context, TimeSpan, Task, Task> onTimeoutAsync = (ctx, span, task) =>
@@ -337,7 +400,7 @@ namespace Polly.Specs
             };
 
             TimeSpan timeout = TimeSpan.FromMilliseconds(250);
-            var policy = Policy.TimeoutAsync<ResultPrimitive>(timeout, onTimeoutAsync);
+            var policy = Policy.TimeoutAsync<ResultPrimitive>(timeout, TimeoutStrategy.Pessimistic, onTimeoutAsync);
 
             policy.Awaiting(async p => await p.ExecuteAsync(async () =>
             {
@@ -350,7 +413,7 @@ namespace Polly.Specs
         }
 
         [Fact]
-        public async void Should_call_ontimeout_with_task_wrapping_abandoned_action_allowing_capture_of_otherwise_unobserved_exception()
+        public async void Should_call_ontimeout_with_task_wrapping_abandoned_action_allowing_capture_of_otherwise_unobserved_exception__pessimistic()
         {
             Exception exceptionToThrow = new DivideByZeroException();
 
@@ -363,7 +426,7 @@ namespace Polly.Specs
 
             TimeSpan shimTimespan = TimeSpan.FromSeconds(1);
             TimeSpan thriceShimTimeSpan = shimTimespan + shimTimespan + shimTimespan;
-            var policy = Policy.TimeoutAsync<ResultPrimitive>(shimTimespan, onTimeoutAsync);
+            var policy = Policy.TimeoutAsync<ResultPrimitive>(shimTimespan, TimeoutStrategy.Pessimistic, onTimeoutAsync);
 
             policy.Awaiting(async p => await p.ExecuteAsync(async () =>
             {
@@ -377,6 +440,117 @@ namespace Polly.Specs
             exceptionObservedFromTaskPassedToOnTimeout.Should().Be(exceptionToThrow);
 
         }
+
+        #endregion
+
+        #region onTimeout overload - optimistic
+
+        [Fact]
+        public void Should_call_ontimeout_with_configured_timeout__optimistic()
+        {
+            TimeSpan timeoutPassedToConfiguration = TimeSpan.FromMilliseconds(250);
+
+            TimeSpan? timeoutPassedToOnTimeout = null;
+            Func<Context, TimeSpan, Task, Task> onTimeoutAsync = (ctx, span, task) =>
+            {
+                timeoutPassedToOnTimeout = span;
+                return TaskHelper.EmptyTask;
+            };
+
+            var policy = Policy.TimeoutAsync<ResultPrimitive>(timeoutPassedToConfiguration, TimeoutStrategy.Optimistic, onTimeoutAsync);
+            var userCancellationToken = CancellationToken.None;
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async ct =>
+            {
+                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+                return ResultPrimitive.WhateverButTooLate;
+            }, userCancellationToken).ConfigureAwait(false))
+            .ShouldThrow<TimeoutRejectedException>();
+
+            timeoutPassedToOnTimeout.Should().Be(timeoutPassedToConfiguration);
+        }
+
+        [Fact]
+        public void Should_call_ontimeout_with_timeout_supplied_different_for_each_execution_by_evaluating_func__optimistic()
+        {
+            for (int i = 1; i <= 3; i++)
+            {
+                Func<TimeSpan> timeoutFunc = () => TimeSpan.FromMilliseconds(25 * i);
+
+                TimeSpan? timeoutPassedToOnTimeout = null;
+                Func<Context, TimeSpan, Task, Task> onTimeoutAsync = (ctx, span, task) =>
+                {
+                    timeoutPassedToOnTimeout = span;
+                    return TaskHelper.EmptyTask;
+                };
+
+                var policy = Policy.TimeoutAsync<ResultPrimitive>(timeoutFunc, TimeoutStrategy.Optimistic, onTimeoutAsync);
+                var userCancellationToken = CancellationToken.None;
+
+                policy.Awaiting(async p => await p.ExecuteAsync(async ct =>
+                {
+                    await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+                    return ResultPrimitive.WhateverButTooLate;
+                }, userCancellationToken).ConfigureAwait(false))
+                .ShouldThrow<TimeoutRejectedException>();
+
+                timeoutPassedToOnTimeout.Should().Be(timeoutFunc());
+            }
+        }
+
+        [Fact]
+        public void Should_call_ontimeout_with_passed_context__optimistic()
+        {
+            string executionKey = Guid.NewGuid().ToString();
+            Context contextPassedToExecute = new Context(executionKey);
+
+            Context contextPassedToOnTimeout = null;
+            Func<Context, TimeSpan, Task, Task> onTimeoutAsync = (ctx, span, task) =>
+            {
+                contextPassedToOnTimeout = ctx;
+                return TaskHelper.EmptyTask;
+            };
+
+            TimeSpan timeout = TimeSpan.FromMilliseconds(250);
+            var policy = Policy.TimeoutAsync<ResultPrimitive>(timeout, TimeoutStrategy.Optimistic, onTimeoutAsync);
+            var userCancellationToken = CancellationToken.None;
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async ct =>
+            {
+                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+                return ResultPrimitive.WhateverButTooLate;
+            }, contextPassedToExecute, userCancellationToken).ConfigureAwait(false))
+                .ShouldThrow<TimeoutRejectedException>();
+
+            contextPassedToOnTimeout.Should().NotBeNull();
+            contextPassedToOnTimeout.ExecutionKey.Should().Be(executionKey);
+            contextPassedToOnTimeout.Should().BeSameAs(contextPassedToExecute);
+        }
+
+        [Fact]
+        public void Should_call_ontimeout_but_not_with_task_wrapping_abandoned_action__optimistic()
+        {
+            Task taskPassedToOnTimeout = null;
+            Func<Context, TimeSpan, Task, Task> onTimeoutAsync = (ctx, span, task) =>
+            {
+                taskPassedToOnTimeout = task;
+                return TaskHelper.EmptyTask;
+            };
+
+            TimeSpan timeout = TimeSpan.FromMilliseconds(250);
+            var policy = Policy.TimeoutAsync<ResultPrimitive>(timeout, TimeoutStrategy.Optimistic, onTimeoutAsync);
+            var userCancellationToken = CancellationToken.None;
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async ct =>
+            {
+                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+                return ResultPrimitive.WhateverButTooLate;
+            }, userCancellationToken).ConfigureAwait(false))
+            .ShouldThrow<TimeoutRejectedException>();
+
+            taskPassedToOnTimeout.Should().BeNull();
+        }
+
 
         #endregion
 


### PR DESCRIPTION
Adds Optimistic/Pessimistic modes for TimeoutPolicy; and all related specs.

+ **Optimistic** mode relies on co-operative cancellation via `CancellationToken`s to time out governed actions.
+ **Pessimistic** mode guarantees to return to the caller on timeout, even for actions having no in-built timeout and not honouring `CancellationToken`s.

Make `TResult` documentation more consistent.