### PR TITLE
Defend timeout specs against timing issues

### DIFF
--- a/src/Polly.SharedSpecs/TimeoutSpecs.cs
+++ b/src/Polly.SharedSpecs/TimeoutSpecs.cs
@@ -270,7 +270,7 @@ namespace Polly.Specs
 
             var policy = Policy.Timeout(timeoutPassedToConfiguration, TimeoutStrategy.Pessimistic, onTimeout);
 
-            policy.Invoking(p => p.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(1), CancellationToken.None)))
+            policy.Invoking(p => p.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None)))
                 .ShouldThrow<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutPassedToConfiguration);

--- a/src/Polly.SharedSpecs/TimeoutTResultSpecs.cs
+++ b/src/Polly.SharedSpecs/TimeoutTResultSpecs.cs
@@ -306,7 +306,7 @@ namespace Polly.Specs
 
             policy.Invoking(p => p.Execute(() =>
             {
-                SystemClock.Sleep(TimeSpan.FromSeconds(1), CancellationToken.None);
+                SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None);
                 return ResultPrimitive.WhateverButTooLate;
             }))
             .ShouldThrow<TimeoutRejectedException>();


### PR DESCRIPTION
Defend specs against timing issues (slower running on AppVeyor)