### PR TITLE
Add NetStandard 1.0 target to v5.0-alpha branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,17 @@
+## 5.0.1
+
+- Add .NET Standard 1.0 project and target.
+
 ## 5.0.0
 
 - Discontinue .NET3.5 support
 - Provide .NET4.0 support uniquely through Polly.NET40Async package
 - Retire ContextualPolicy (not part of documented API; support now in Policy base class)
 - Add some missing ExecuteAndCapture/Async overloads. Thanks to [@reisenberger](https://github.com/reisenberger)
-- Add CancellationToken support to synchronous executions (to support TimeoutPolicy).  Thanks to [@brunolauze](https://github.com/brunolauze) and [@reisenberger](https://github.com/reisenberger)
+- Add CancellationToken support to synchronous executions.  Thanks to [@brunolauze](https://github.com/brunolauze) and [@reisenberger](https://github.com/reisenberger)
 - Add PolicyWrap. Thanks to [@reisenberger](https://github.com/reisenberger)
 - Add Fallback policy. Thanks to [@reisenberger](https://github.com/reisenberger)
-- Add PolicyKeys and context to all policy executions, as bedrock for policy events and metrics tracking executions. Thanks to [@reisenberger](https://github.com/reisenberger) 
+- Add PolicyKeys and context to all policy executions, to enrich logging and to support later introduction of policy events and metrics. Thanks to [@reisenberger](https://github.com/reisenberger) 
 - Add Bulkhead Isolation policy.  Thanks to [@reisenberger](https://github.com/reisenberger) and contributions from  [@brunolauze](https://github.com/brunolauze).
 - Add Timeout policy.  Thanks to [@reisenberger](https://github.com/reisenberger).
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Polly is a .NET resilience and transient-fault-handling library that allows developers to express policies such as Retry, Circuit Breaker, Timeout, Bulkhead Isolation and Fallback in a fluent and thread-safe manner.  
 
-Polly targets .NET 4.0, 4.5, PCL (Profile 259) and .NET CORE via .NET Standard **1.[TBC]**.
+Polly targets .NET 4.0, 4.5, PCL (Profile 259) and .NET CORE via .NET Standard 1.0.
 
 **Keep up to date with new feature announcements, tips & tricks, and other news through [www.thepollyproject.org](http://www.thepollyproject.org)**
 

--- a/build.cake
+++ b/build.cake
@@ -47,12 +47,13 @@ var nupkgDestDir = artifactsDir + Directory("nuget-package");
 var snkFile = srcDir + File(keyName);
 
 var projectToNugetFolderMap = new Dictionary<string, string[]>() {
-    { "Net45", new [] {"net45"} },
-    { "Pcl"  , new [] {"portable-net45+netcore45+wpa81+wp8", "dotnet"} }
+    { "Net45"        , new [] {"net45"} },
+    { "Pcl"          , new [] {"portable-net45+netcore45+wpa81+wp8"} },
+    { "NetStandard10", new [] {"netstandard1.0"} },
 };
 
 var net40AsyncProjectToNugetFolderMap = new Dictionary<string, string[]>() {
-    { "Net40Async", new [] {"net40"} },
+    { "Net40Async"   , new [] {"net40"} },
 };
 
 // Gitversion

--- a/src/Polly.Net40Async.nuspec
+++ b/src/Polly.Net40Async.nuspec
@@ -4,7 +4,7 @@
     <owners>App vNext</owners>
     <authors>Michael Wolfenden, App vNext</authors>
     <description>
-     Polly is a .NET 4.0 / 4.5 / PCL library (Profile 259) / .NET Standard 1.0 library that allows developers to express resilience and transient fault handling policies such as Retry, Circuit Breaker, Timeout, Bulkhead Isolation and Fallback in a fluent and thread-safe manner.
+     Polly.Net40Async is a version of the Polly library specifically for for .NET 4.0 with async support via Microsoft.Bcl.Async.  Polly allows developers to express resilience and transient fault handling policies such as Retry, Circuit Breaker, Timeout, Bulkhead Isolation and Fallback in a fluent and thread-safe manner.
    </description>
     <language>en-US</language>
     <licenseUrl>https://raw.github.com/App-vNext/Polly/master/LICENSE.txt</licenseUrl>

--- a/src/Polly.Net40Async.nuspec
+++ b/src/Polly.Net40Async.nuspec
@@ -4,27 +4,32 @@
     <owners>App vNext</owners>
     <authors>Michael Wolfenden, App vNext</authors>
     <description>
-     Polly.Net40Async is a version of the Polly library specifically for for .NET 4.0 with async support via Microsoft.Bcl.Async.  Allows developers to express transient exception and fault handling policies such as Retry, Retry Forever, Wait and Retry or Circuit Breaker in a fluent manner.
+     Polly is a .NET 4.0 / 4.5 / PCL library (Profile 259) / .NET Standard 1.0 library that allows developers to express resilience and transient fault handling policies such as Retry, Circuit Breaker, Timeout, Bulkhead Isolation and Fallback in a fluent and thread-safe manner.
    </description>
     <language>en-US</language>
     <licenseUrl>https://raw.github.com/App-vNext/Polly/master/LICENSE.txt</licenseUrl>
     <iconUrl>https://raw.github.com/App-vNext/Polly/master/Polly.png</iconUrl>
     <projectUrl>https://github.com/App-vNext/Polly</projectUrl>
-    <tags>Exception Handling Policy Retry Wait Circuit Breaker</tags>
+    <tags>Exception Handling Policy Retry Wait Circuit Breaker Bulkhead Fallback Timeout Resilience</tags>
     <copyright>Copyright © 2016, App vNext</copyright>
     <releaseNotes>
+     5.0.1
+     ---------------------
+     Add a .NETStandard1.0 project and target to main Nuget package.
+
      5.0.0
      ---------------------
      A major release, adding significant new resilience policies:
-     - Timeout policy: allows timing out any execution (for both co-operative and unco-operative underlying delegates)
-     - Bulkhead isolation policy: limits the resources consumable by governed actions, such that a faulting channel cannot cause cascading failures, also bringing down other operations.
-     - Fallback policy: provides for a fallback execution or substitute value, in case of overall failure
-     - PolicyWrap: allows flexibly combining any Policy instances in the Polly armoury, to form an overall resilience strategy.
+     - Timeout policy: allows timing out any execution
+     - Bulkhead isolation policy: limits the resources consumable by governed actions, such that a faulting channel cannot cause cascading failures.
+     - Fallback policy: provides for a fallback execution or value, in case of overall failure
+     - PolicyWrap: allows flexibly combining Policy instances of any type, to form an overall resilience strategy.
 
      Other changes include:
-     - Add PolicyKeys and context to all policy executions, as bedrock for forthcoming introduction of policy events and metrics tracking executions. 
-     - Add CancellationToken support to synchronous executions (to support TimeoutPolicy).
+     - Add PolicyKeys and context to all policy executions, for logging and to support later introduction of policy events and metrics. 
+     - Add CancellationToken support to synchronous executions.
      - Add some missing ExecuteAndCapture/Async overloads. 
+     - Remove invalid ExecuteAsync overloads taking (but not making use of) a CancellationToken
      - Provide .NET4.0 support uniquely through Polly.NET40Async package
      - Retire ContextualPolicy (not part of documented API; support now in Policy base class)
      - Discontinue .NET3.5 support

--- a/src/Polly.NetStandard10/Polly.NetStandard10.csproj
+++ b/src/Polly.NetStandard10/Polly.NetStandard10.csproj
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{5017174E-DAC5-4408-AB15-1F902F40C612}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Polly</RootNamespace>
+    <AssemblyName>Polly</AssemblyName>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
+    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;PORTABLE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\Polly.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;PORTABLE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\Polly.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\Polly.Net45\Polly.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <NuSpecFile Include="$(SolutionDir)Polly.nuspec">
+      <Visible>False</Visible>
+    </NuSpecFile>
+    <!-- A reference to the entire .NET Framework is automatically included -->
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="..\Polly.Shared\Polly.Shared.projitems" Label="Shared" />
+</Project>

--- a/src/Polly.NetStandard10/Properties/AssemblyInfo.cs
+++ b/src/Polly.NetStandard10/Properties/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+﻿using System.Reflection;
+[assembly: AssemblyTitle("Polly")]

--- a/src/Polly.NetStandard10/project.json
+++ b/src/Polly.NetStandard10/project.json
@@ -1,0 +1,10 @@
+﻿{
+  "supports": {},
+  "dependencies": {
+    "GitVersionTask": "3.1.2",
+    "NETStandard.Library": "1.6.0"
+  },
+  "frameworks": {
+    "netstandard1.0": {}
+  }
+}

--- a/src/Polly.Shared/Bulkhead/BulkheadRejectedException.cs
+++ b/src/Polly.Shared/Bulkhead/BulkheadRejectedException.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+#if !PORTABLE
 using System.Runtime.Serialization;
+#endif
 
 namespace Polly.Bulkhead
 {

--- a/src/Polly.Shared/CircuitBreaker/BrokenCircuitException.cs
+++ b/src/Polly.Shared/CircuitBreaker/BrokenCircuitException.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+#if !PORTABLE
 using System.Runtime.Serialization;
+#endif
 
 namespace Polly.CircuitBreaker
 {

--- a/src/Polly.Shared/CircuitBreaker/IsolatedCircuitException.cs
+++ b/src/Polly.Shared/CircuitBreaker/IsolatedCircuitException.cs
@@ -1,8 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
+#if !PORTABLE
 using System.Runtime.Serialization;
-using System.Text;
-using Polly.CircuitBreaker;
+#endif
 
 namespace Polly.CircuitBreaker
 {

--- a/src/Polly.Shared/ExecutionRejectedException.cs
+++ b/src/Polly.Shared/ExecutionRejectedException.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+#if !PORTABLE
 using System.Runtime.Serialization;
+#endif
 
 namespace Polly
 {

--- a/src/Polly.Shared/Timeout/TimeoutRejectedException.cs
+++ b/src/Polly.Shared/Timeout/TimeoutRejectedException.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+#if !PORTABLE
 using System.Runtime.Serialization;
+#endif
 
 namespace Polly.Timeout
 {

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -4,27 +4,32 @@
     <owners>App vNext</owners>
     <authors>Michael Wolfenden, App vNext</authors>
     <description>
-      Polly is a .NET 4.0 / 4.5 / PCL library (Profile 259) that allows developers to express transient exception and fault handling policies such as Retry, Retry Forever, Wait and Retry or Circuit Breaker in a fluent manner.
+      Polly is a .NET 4.0 / 4.5 / PCL library (Profile 259) / .NET Standard 1.0 library that allows developers to express resilience and transient fault handling policies such as Retry, Circuit Breaker, Timeout, Bulkhead Isolation and Fallback in a fluent and thread-safe manner.
     </description>
     <language>en-US</language>
     <licenseUrl>https://raw.github.com/App-vNext/Polly/master/LICENSE.txt</licenseUrl>
     <iconUrl>https://raw.github.com/App-vNext/Polly/master/Polly.png</iconUrl>
     <projectUrl>https://github.com/App-vNext/Polly</projectUrl>
-    <tags>Exception Handling Policy Retry Wait Circuit Breaker</tags>
+    <tags>Exception Handling Policy Retry Wait Circuit Breaker Bulkhead Fallback Timeout Resilience</tags>
     <copyright>Copyright © 2016, App vNext</copyright>
     <releaseNotes>
+     5.0.1
+     ---------------------
+     Add a .NETStandard1.0 project and target to Nuget package.
+
      5.0.0
      ---------------------
      A major release, adding significant new resilience policies:
-     - Timeout policy: allows timing out any execution (for both co-operative and unco-operative underlying delegates)
-     - Bulkhead isolation policy: limits the resources consumable by governed actions, such that a faulting channel cannot cause cascading failures, also bringing down other operations.
-     - Fallback policy: provides for a fallback execution or substitute value, in case of overall failure
-     - PolicyWrap: allows flexibly combining any Policy instances in the Polly armoury, to form an overall resilience strategy.
+     - Timeout policy: allows timing out any execution
+     - Bulkhead isolation policy: limits the resources consumable by governed actions, such that a faulting channel cannot cause cascading failures.
+     - Fallback policy: provides for a fallback execution or value, in case of overall failure
+     - PolicyWrap: allows flexibly combining Policy instances of any type, to form an overall resilience strategy.
 
      Other changes include:
-     - Add PolicyKeys and context to all policy executions, as bedrock for forthcoming introduction of policy events and metrics tracking executions. 
-     - Add CancellationToken support to synchronous executions (to support TimeoutPolicy).
+     - Add PolicyKeys and context to all policy executions, for logging and to support later introduction of policy events and metrics. 
+     - Add CancellationToken support to synchronous executions.
      - Add some missing ExecuteAndCapture/Async overloads. 
+     - Remove invalid ExecuteAsync overloads taking (but not making use of) a CancellationToken
      - Provide .NET4.0 support uniquely through Polly.NET40Async package
      - Retire ContextualPolicy (not part of documented API; support now in Policy base class)
      - Discontinue .NET3.5 support

--- a/src/Polly.sln
+++ b/src/Polly.sln
@@ -24,11 +24,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Polly.Pcl.Specs", "Polly.Pc
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Polly.Net40Async", "Polly.Net40Async\Polly.Net40Async.csproj", "{D6A676C2-982D-42D1-AD21-FA53582A1C31}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Polly.NetStandard10", "Polly.NetStandard10\Polly.NetStandard10.csproj", "{5017174E-DAC5-4408-AB15-1F902F40C612}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Polly.Shared\Polly.Shared.projitems*{23fa87f9-c77d-4c67-a0b0-2901de51b3ff}*SharedItemsImports = 13
 		Polly.Shared\Polly.Shared.projitems*{29265540-f724-4324-9321-643a0fcb133f}*SharedItemsImports = 4
 		Polly.SharedSpecs\Polly.SharedSpecs.projitems*{4ab46d16-0806-4f51-8677-d849ba87cb05}*SharedItemsImports = 4
+		Polly.Shared\Polly.Shared.projitems*{5017174e-dac5-4408-ab15-1f902f40c612}*SharedItemsImports = 4
 		Polly.SharedSpecs\Polly.SharedSpecs.projitems*{5f2bd87d-a7ed-433d-b7e3-f3072d07c1dc}*SharedItemsImports = 4
 		Polly.SharedSpecs\Polly.SharedSpecs.projitems*{8d537c37-a4a2-4be1-84bc-34f1afb51ca8}*SharedItemsImports = 13
 		Polly.Shared\Polly.Shared.projitems*{905cf38a-be90-4234-bf15-2fcfd1973a9c}*SharedItemsImports = 4
@@ -59,6 +62,10 @@ Global
 		{D6A676C2-982D-42D1-AD21-FA53582A1C31}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D6A676C2-982D-42D1-AD21-FA53582A1C31}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D6A676C2-982D-42D1-AD21-FA53582A1C31}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5017174E-DAC5-4408-AB15-1F902F40C612}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5017174E-DAC5-4408-AB15-1F902F40C612}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5017174E-DAC5-4408-AB15-1F902F40C612}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5017174E-DAC5-4408-AB15-1F902F40C612}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
* Add NetStandard 1.0 target and nupkg

Add NetStandard 1.0 target and nupkg.  Update readme and nuspec files, to reflect NetStandard 1.0 target.  Update nuspec documentation and search keys for new resilience policies.  Update also ChangeLog.