### PR TITLE
Add Polly.Net40Async.specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Mark Polly.dll as CLSCompliant.
 - Tidy build around GitVersionTask and ReferenceGenerator.
 - Update FluentAssertions dependency.
+- Added Polly.Net40Async specs project.
 
 ## 5.0.1
 

--- a/src/Polly.Net40Async.Specs/Polly.Net40Async.Specs.csproj
+++ b/src/Polly.Net40Async.Specs/Polly.Net40Async.Specs.csproj
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{65062661-9E19-4FC6-859C-8B7811553E13}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Polly.Net40Async.Specs</RootNamespace>
+    <AssemblyName>Polly.Net40Async.Specs</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="FluentAssertions, Version=4.17.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.17.0\lib\net45\FluentAssertions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentAssertions.Core, Version=4.17.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.17.0\lib\net45\FluentAssertions.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Polly.Net40Async\Polly.Net40Async.csproj">
+      <Project>{29265540-f724-4324-9321-643a0fcb133f}</Project>
+      <Name>Polly.Net40Async</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="..\Polly.SharedSpecs\Polly.SharedSpecs.projitems" Label="Shared" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\GitVersionTask.3.1.2\build\dotnet\GitVersionTask.targets" Condition="Exists('..\packages\GitVersionTask.3.1.2\build\dotnet\GitVersionTask.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\GitVersionTask.3.1.2\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitVersionTask.3.1.2\build\dotnet\GitVersionTask.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Polly.Net40Async.Specs/Properties/AssemblyInfo.cs
+++ b/src/Polly.Net40Async.Specs/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+﻿using System.Reflection;
+using Xunit;
+
+[assembly: AssemblyTitle("Polly.Net40Async.Specs")]
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/src/Polly.Net40Async.Specs/packages.config
+++ b/src/Polly.Net40Async.Specs/packages.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="FluentAssertions" version="4.17.0" targetFramework="net45" />
+  <package id="GitVersionTask" version="3.1.2" targetFramework="net45" developmentDependency="true" />
+  <package id="xunit" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
+</packages>

--- a/src/Polly.Net40Async.Specs/readme.txt
+++ b/src/Polly.Net40Async.Specs/readme.txt
@@ -1,0 +1,3 @@
+This project exists to test Polly.Net40Async.csproj.  
+
+Polly.Net40Async.csproj is compiled against .NET4.5, and has to be, to use XUnit version 2.0, on which we depend.  This is however a valid way of xunit-testing a .NET40 assembly.  See https://github.com/xunit/xunit/issues/241#issuecomment-67725679

--- a/src/Polly.Net40Async.nuspec
+++ b/src/Polly.Net40Async.nuspec
@@ -21,7 +21,8 @@
      - Mark Polly.dll as CLSCompliant.
      - Tidy build around GitVersionTask and ReferenceGenerator.
      - Update FluentAssertions dependency.
-
+     - Add full specs support for .NET40.
+      
      5.0.1
      ---------------------
      - (Add a .NETStandard1.0 project and target to main Nuget package).

--- a/src/Polly.sln
+++ b/src/Polly.sln
@@ -24,6 +24,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Polly.Net40Async", "Polly.N
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Polly.NetStandard10", "Polly.NetStandard10\Polly.NetStandard10.csproj", "{5017174E-DAC5-4408-AB15-1F902F40C612}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Polly.Net40Async.Specs", "Polly.Net40Async.Specs\Polly.Net40Async.Specs.csproj", "{65062661-9E19-4FC6-859C-8B7811553E13}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Polly.Shared\Polly.Shared.projitems*{23fa87f9-c77d-4c67-a0b0-2901de51b3ff}*SharedItemsImports = 13
@@ -31,6 +33,7 @@ Global
 		Polly.SharedSpecs\Polly.SharedSpecs.projitems*{4ab46d16-0806-4f51-8677-d849ba87cb05}*SharedItemsImports = 4
 		Polly.Shared\Polly.Shared.projitems*{5017174e-dac5-4408-ab15-1f902f40c612}*SharedItemsImports = 4
 		Polly.SharedSpecs\Polly.SharedSpecs.projitems*{5f2bd87d-a7ed-433d-b7e3-f3072d07c1dc}*SharedItemsImports = 4
+		Polly.SharedSpecs\Polly.SharedSpecs.projitems*{65062661-9e19-4fc6-859c-8b7811553e13}*SharedItemsImports = 4
 		Polly.SharedSpecs\Polly.SharedSpecs.projitems*{8d537c37-a4a2-4be1-84bc-34f1afb51ca8}*SharedItemsImports = 13
 		Polly.Shared\Polly.Shared.projitems*{d6a676c2-982d-42d1-ad21-fa53582a1c31}*SharedItemsImports = 4
 	EndGlobalSection
@@ -59,6 +62,10 @@ Global
 		{5017174E-DAC5-4408-AB15-1F902F40C612}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5017174E-DAC5-4408-AB15-1F902F40C612}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5017174E-DAC5-4408-AB15-1F902F40C612}.Release|Any CPU.Build.0 = Release|Any CPU
+		{65062661-9E19-4FC6-859C-8B7811553E13}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{65062661-9E19-4FC6-859C-8B7811553E13}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{65062661-9E19-4FC6-859C-8B7811553E13}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{65062661-9E19-4FC6-859C-8B7811553E13}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Add a test assembly against Polly.Net40Async

Although XUnit 2.0 (on which Polly's tests depend) is not .NET40 compatible, it turns out there is a (relatively obvious) workround for testing .NET40 dlls: compile the _test_ project against .NET45, but it can still validly test the underlying .NET40 dll.  

See https://github.com/xunit/xunit/issues/241#issuecomment-67725679