### PR TITLE
Add ttl strategy pattern to cache architecture spike

### DIFF
--- a/src/Polly.Shared/CacheSyntax.cs
+++ b/src/Polly.Shared/CacheSyntax.cs
@@ -11,30 +11,72 @@ namespace Polly
         /// If the <paramref name="cacheProvider"/> contains a value, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider"/> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider"/>, then returns the value.
         /// </para>
         /// </summary>
+        /// <param name="cacheProvider">The cache provider.</param>
+        /// <param name="ttl">Duration (ttl) for which to cache values.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
-        public static CachePolicy Cache(ICacheProvider cacheProvider)
+        public static CachePolicy Cache(ICacheProvider cacheProvider, TimeSpan ttl)
         {
-            return Cache(cacheProvider, DefaultCacheKeyStrategy.Instance);
+            return Cache(cacheProvider, new TimeSpanTtl(ttl), DefaultCacheKeyStrategy.Instance);
         }
 
         /// <summary>
         /// <para>Builds a <see cref="Policy" /> that will function like a result cache for delegate executions returning a result.</para>
-        /// <para>Before executing a delegate returning a result, checks whether the <paramref name="cacheProvider" /> holds a value for the cache key determined by applying the <paramref name="cacheKeyStrategy"/> to the execution <see cref="Context"/>.
-        /// If the <paramref name="cacheProvider" /> contains a value, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider" /> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider" />, then returns the value.
+        /// <para>Before executing a delegate returning a result, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="M:Context.ExecutionKey"/>.
+        /// If the <paramref name="cacheProvider"/> contains a value, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider"/> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider"/>, then returns the value.
         /// </para>
         /// </summary>
         /// <param name="cacheProvider">The cache provider.</param>
-        /// <param name="cacheKeyStrategy">The cache key strategy.</param>
+        /// <param name="ttlStrategy">A strategy for specifying ttl for values to be cached.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
+        /// <exception cref="ArgumentNullException">ttlStrategy</exception>
+        public static CachePolicy Cache(ICacheProvider cacheProvider, ITtlStrategy ttlStrategy)
+        {
+            return Cache(cacheProvider, ttlStrategy, DefaultCacheKeyStrategy.Instance);
+        }
+
+        /// <summary>
+        /// <para>Builds a <see cref="Policy"/> that will function like a result cache for delegate executions returning a result.</para>
+        /// <para>Before executing a delegate returning a result, checks whether the <paramref name="cacheProvider" /> holds a value for the cache key determined by applying the <paramref name="cacheKeyStrategy"/> to the execution <see cref="Context"/>.
+        /// If the <paramref name="cacheProvider "/> contains a value, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider" /> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider" />, then returns the value.
+        /// </para>
+        /// </summary>
+        /// <param name="cacheProvider">The cache provider.</param>
+        /// <param name="ttl">Duration (ttl) for which to cache values.</param>
+        /// <param name="cacheKeyStrategy">The cache key strategy.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">
+        /// </exception>
+        /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        public static CachePolicy Cache(ICacheProvider cacheProvider, ICacheKeyStrategy cacheKeyStrategy)
+        public static CachePolicy Cache(ICacheProvider cacheProvider, TimeSpan ttl, ICacheKeyStrategy cacheKeyStrategy)
+        {
+            return Cache(cacheProvider, new TimeSpanTtl(ttl), cacheKeyStrategy);
+        }
+
+        /// <summary>
+        /// <para>Builds a <see cref="Policy"/> that will function like a result cache for delegate executions returning a result.</para>
+        /// <para>Before executing a delegate returning a result, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key determined by applying the <paramref name="cacheKeyStrategy"/> to the execution <see cref="Context"/>.
+        /// If the <paramref name="cacheProvider"/> contains a value, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider"/> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider"/>, then returns the value.
+        /// </para>
+        /// </summary>
+        /// <param name="cacheProvider">The cache provider.</param>
+        /// <param name="ttlStrategy">A strategy for specifying ttl for values to be cached.</param>
+        /// <param name="cacheKeyStrategy">The cache key strategy.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">
+        /// </exception>
+        /// <exception cref="ArgumentNullException">cacheProvider</exception>
+        /// <exception cref="ArgumentNullException">ttlStrategy</exception>
+        /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+        public static CachePolicy Cache(ICacheProvider cacheProvider, ITtlStrategy ttlStrategy, ICacheKeyStrategy cacheKeyStrategy)
         {
             if (cacheProvider == null) throw new ArgumentNullException(nameof(cacheProvider));
+            if (ttlStrategy == null) throw new ArgumentNullException(nameof(ttlStrategy));
             if (cacheKeyStrategy == null) throw new ArgumentNullException(nameof(cacheKeyStrategy));
 
-            return new CachePolicy(cacheProvider, cacheKeyStrategy);
+            return new CachePolicy(cacheProvider, ttlStrategy, cacheKeyStrategy);
         }
     }
 }

--- a/src/Polly.Shared/CacheSyntaxAsync.cs
+++ b/src/Polly.Shared/CacheSyntaxAsync.cs
@@ -11,11 +11,46 @@ namespace Polly
         /// If the <paramref name="cacheProvider"/> provides a value, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider"/> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider"/>, then returns the value.
         /// </para>
         /// </summary>
+        /// <param name="cacheProvider">The cache provider.</param>
+        /// <param name="ttl">Duration (ttl) for which to cache values.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
-        public static CachePolicy CacheAsync(ICacheProviderAsync cacheProvider)
+        public static CachePolicy CacheAsync(ICacheProviderAsync cacheProvider, TimeSpan ttl)
         {
-            return CacheAsync(cacheProvider, DefaultCacheKeyStrategy.Instance);
+            return CacheAsync(cacheProvider, new TimeSpanTtl(ttl), DefaultCacheKeyStrategy.Instance);
+        }
+
+        /// <summary>
+        /// <para>Builds a <see cref="Policy"/> that will function like a result cache for delegate executions returning a result.</para>
+        /// <para>Before executing a delegate returning a result, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="M:Context.ExecutionKey"/>
+        /// If the <paramref name="cacheProvider"/> provides a value, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider"/> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider"/>, then returns the value.
+        /// </para>
+        /// </summary>
+        /// <param name="cacheProvider">The cache provider.</param>
+        /// <param name="ttlStrategy">A strategy for specifying ttl for values to be cached.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="ArgumentNullException">cacheProvider</exception>
+        /// <exception cref="ArgumentNullException">ttlStrategy</exception>
+        public static CachePolicy CacheAsync(ICacheProviderAsync cacheProvider, ITtlStrategy ttlStrategy)
+        {
+            return CacheAsync(cacheProvider, ttlStrategy, DefaultCacheKeyStrategy.Instance);
+        }
+
+        /// <summary>
+        /// <para>Builds a <see cref="Policy"/> that will function like a result cache for delegate executions returning a result.</para>
+        /// <para>Before executing a delegate returning a result, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key determined by applying the <paramref name="cacheKeyStrategy"/> to the execution <see cref="Context"/>.
+        /// If the <paramref name="cacheProvider"/> provides a value, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider"/> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider"/>, then returns the value.
+        /// </para>
+        /// </summary>
+        /// <param name="cacheProvider">The cache provider.</param>
+        /// <param name="ttl">Duration (ttl) for which to cache values.</param>
+        /// <param name="cacheKeyStrategy">The cache key strategy.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="ArgumentNullException">cacheProvider</exception>
+        /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+        public static CachePolicy CacheAsync(ICacheProviderAsync cacheProvider, TimeSpan ttl, ICacheKeyStrategy cacheKeyStrategy)
+        {
+            return CacheAsync(cacheProvider, new TimeSpanTtl(ttl), cacheKeyStrategy);
         }
 
         /// <summary>
@@ -25,16 +60,19 @@ namespace Polly
         /// </para>
         /// </summary>
         /// <param name="cacheProvider">The cache provider.</param>
+        /// <param name="ttlStrategy">A strategy for specifying ttl for values to be cached.</param>
         /// <param name="cacheKeyStrategy">The cache key strategy.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
+        /// <exception cref="ArgumentNullException">ttlStrategy</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        public static CachePolicy CacheAsync(ICacheProviderAsync cacheProvider, ICacheKeyStrategy cacheKeyStrategy)
+        public static CachePolicy CacheAsync(ICacheProviderAsync cacheProvider, ITtlStrategy ttlStrategy, ICacheKeyStrategy cacheKeyStrategy)
         {
             if (cacheProvider == null) throw new ArgumentNullException(nameof(cacheProvider));
+            if (ttlStrategy == null) throw new ArgumentNullException(nameof(ttlStrategy));
             if (cacheKeyStrategy == null) throw new ArgumentNullException(nameof(cacheKeyStrategy));
 
-            return new CachePolicy(cacheProvider, cacheKeyStrategy);
+            return new CachePolicy(cacheProvider, ttlStrategy, cacheKeyStrategy);
         }
 
     }

--- a/src/Polly.Shared/CacheTResultSyntax.cs
+++ b/src/Polly.Shared/CacheTResultSyntax.cs
@@ -11,13 +11,15 @@ namespace Polly
         /// If the <paramref name="cacheProvider"/> contains a value, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider"/> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider"/>, then returns the value.
         /// </para>
         /// </summary>
+        /// <param name="cacheProvider">The cache provider.</param>
+        /// <param name="ttl">Duration (ttl) for which to cache values.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
-        public static CachePolicy<TResult> Cache<TResult>(ICacheProvider cacheProvider)
+        public static CachePolicy<TResult> Cache<TResult>(ICacheProvider cacheProvider, TimeSpan ttl)
         {
             if (cacheProvider == null) throw new ArgumentNullException(nameof(cacheProvider));
 
-            return Cache<TResult>(cacheProvider.As<TResult>(), DefaultCacheKeyStrategy.Instance);
+            return Cache<TResult>(cacheProvider.As<TResult>(), new TimeSpanTtl(ttl), DefaultCacheKeyStrategy.Instance);
         }
 
         /// <summary>
@@ -26,11 +28,47 @@ namespace Polly
         /// If the <paramref name="cacheProvider"/> contains a value, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider"/> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider"/>, then returns the value.
         /// </para>
         /// </summary>
+        /// <param name="cacheProvider">The cache provider.</param>
+        /// <param name="ttlStrategy">A strategy for specifying ttl for values to be cached.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
-        public static CachePolicy<TResult> Cache<TResult>(ICacheProvider<TResult> cacheProvider)
+        /// <exception cref="ArgumentNullException">ttlStrategy</exception>
+        public static CachePolicy<TResult> Cache<TResult>(ICacheProvider cacheProvider, ITtlStrategy ttlStrategy)
         {
-            return Cache<TResult>(cacheProvider, DefaultCacheKeyStrategy.Instance);
+            if (cacheProvider == null) throw new ArgumentNullException(nameof(cacheProvider));
+
+            return Cache<TResult>(cacheProvider.As<TResult>(), ttlStrategy, DefaultCacheKeyStrategy.Instance);
+        }
+
+        /// <summary>
+        /// <para>Builds a <see cref="Policy"/> that will function like a result cache for delegate executions returning a <typeparamref name="TResult"/>.</para>
+        /// <para>Before executing a delegate, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="M:Context.ExecutionKey"/>.
+        /// If the <paramref name="cacheProvider"/> contains a value, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider"/> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider"/>, then returns the value.
+        /// </para>
+        /// </summary>
+        /// <param name="cacheProvider">The cache provider.</param>
+        /// <param name="ttl">Duration (ttl) for which to cache values.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="ArgumentNullException">cacheProvider</exception>
+        public static CachePolicy<TResult> Cache<TResult>(ICacheProvider<TResult> cacheProvider, TimeSpan ttl)
+        {
+            return Cache<TResult>(cacheProvider, new TimeSpanTtl(ttl), DefaultCacheKeyStrategy.Instance);
+        }
+
+        /// <summary>
+        /// <para>Builds a <see cref="Policy"/> that will function like a result cache for delegate executions returning a <typeparamref name="TResult"/>.</para>
+        /// <para>Before executing a delegate, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="M:Context.ExecutionKey"/>.
+        /// If the <paramref name="cacheProvider"/> contains a value, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider"/> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider"/>, then returns the value.
+        /// </para>
+        /// </summary>
+        /// <param name="cacheProvider">The cache provider.</param>
+        /// <param name="ttlStrategy">A strategy for specifying ttl for values to be cached.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="ArgumentNullException">cacheProvider</exception>
+        /// <exception cref="ArgumentNullException">ttlStrategy</exception>
+        public static CachePolicy<TResult> Cache<TResult>(ICacheProvider<TResult> cacheProvider, ITtlStrategy ttlStrategy)
+        {
+            return Cache<TResult>(cacheProvider, ttlStrategy, DefaultCacheKeyStrategy.Instance);
         }
 
         /// <summary>
@@ -40,15 +78,16 @@ namespace Polly
         /// </para>
         /// </summary>
         /// <param name="cacheProvider">The cache provider.</param>
+        /// <param name="ttl">Duration (ttl) for which to cache values.</param>
         /// <param name="cacheKeyStrategy">The cache key strategy.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        public static CachePolicy<TResult> Cache<TResult>(ICacheProvider cacheProvider, ICacheKeyStrategy cacheKeyStrategy)
+        public static CachePolicy<TResult> Cache<TResult>(ICacheProvider cacheProvider, TimeSpan ttl, ICacheKeyStrategy cacheKeyStrategy)
         {
             if (cacheProvider == null) throw new ArgumentNullException(nameof(cacheProvider));
 
-            return Cache<TResult>(cacheProvider.As<TResult>(), cacheKeyStrategy);
+            return Cache<TResult>(cacheProvider.As<TResult>(), new TimeSpanTtl(ttl), cacheKeyStrategy);
         }
 
         /// <summary>
@@ -58,16 +97,56 @@ namespace Polly
         /// </para>
         /// </summary>
         /// <param name="cacheProvider">The cache provider.</param>
+        /// <param name="ttlStrategy">A strategy for specifying ttl for values to be cached.</param>
+        /// <param name="cacheKeyStrategy">The cache key strategy.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="ArgumentNullException">cacheProvider</exception>
+        /// <exception cref="ArgumentNullException">ttlStrategy</exception>
+        /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+        public static CachePolicy<TResult> Cache<TResult>(ICacheProvider cacheProvider, ITtlStrategy ttlStrategy, ICacheKeyStrategy cacheKeyStrategy)
+        {
+            if (cacheProvider == null) throw new ArgumentNullException(nameof(cacheProvider));
+
+            return Cache<TResult>(cacheProvider.As<TResult>(), ttlStrategy, cacheKeyStrategy);
+        }
+
+        /// <summary>
+        /// <para>Builds a <see cref="Policy" /> that will function like a result cache for delegate executions returning a <typeparamref name="TResult"/>.</para>
+        /// <para>Before executing a delegate, checks whether the <paramref name="cacheProvider" /> holds a value for the cache key determined by applying the <paramref name="cacheKeyStrategy"/> to the execution <see cref="Context"/>.
+        /// If the <paramref name="cacheProvider" /> contains a value, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider" /> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider" />, then returns the value.
+        /// </para>
+        /// </summary>
+        /// <param name="cacheProvider">The cache provider.</param>
+        /// <param name="ttl">Duration (ttl) for which to cache values.</param>
         /// <param name="cacheKeyStrategy">The cache key strategy.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        public static CachePolicy<TResult> Cache<TResult>(ICacheProvider<TResult> cacheProvider, ICacheKeyStrategy cacheKeyStrategy)
+        public static CachePolicy<TResult> Cache<TResult>(ICacheProvider<TResult> cacheProvider, TimeSpan ttl, ICacheKeyStrategy cacheKeyStrategy)
+        {
+            return Cache<TResult>(cacheProvider, new TimeSpanTtl(ttl), cacheKeyStrategy);
+        }
+
+        /// <summary>
+        /// <para>Builds a <see cref="Policy" /> that will function like a result cache for delegate executions returning a <typeparamref name="TResult"/>.</para>
+        /// <para>Before executing a delegate, checks whether the <paramref name="cacheProvider" /> holds a value for the cache key determined by applying the <paramref name="cacheKeyStrategy"/> to the execution <see cref="Context"/>.
+        /// If the <paramref name="cacheProvider" /> contains a value, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider" /> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider" />, then returns the value.
+        /// </para>
+        /// </summary>
+        /// <param name="cacheProvider">The cache provider.</param>
+        /// <param name="ttlStrategy">A strategy for specifying ttl for values to be cached.</param>
+        /// <param name="cacheKeyStrategy">The cache key strategy.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="ArgumentNullException">cacheProvider</exception>
+        /// <exception cref="ArgumentNullException">ttlStrategy</exception>
+        /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+        public static CachePolicy<TResult> Cache<TResult>(ICacheProvider<TResult> cacheProvider, ITtlStrategy ttlStrategy, ICacheKeyStrategy cacheKeyStrategy)
         {
             if (cacheProvider == null) throw new ArgumentNullException(nameof(cacheProvider));
+            if (ttlStrategy == null) throw new ArgumentNullException(nameof(ttlStrategy));
             if (cacheKeyStrategy == null) throw new ArgumentNullException(nameof(cacheKeyStrategy));
 
-            return new CachePolicy<TResult>(cacheProvider, cacheKeyStrategy);
+            return new CachePolicy<TResult>(cacheProvider, ttlStrategy, cacheKeyStrategy);
         }
     }
 }

--- a/src/Polly.Shared/CacheTResultSyntaxAsync.cs
+++ b/src/Polly.Shared/CacheTResultSyntaxAsync.cs
@@ -11,13 +11,15 @@ namespace Polly
         /// If the <paramref name="cacheProvider"/> provides a value, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider"/> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider"/>, then returns the value.
         /// </para>
         /// </summary>
+        /// <param name="cacheProvider">The cache provider.</param>
+        /// <param name="ttl">Duration (ttl) for which to cache values.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
-        public static CachePolicy<TResult> CacheAsync<TResult>(ICacheProviderAsync cacheProvider)
+        public static CachePolicy<TResult> CacheAsync<TResult>(ICacheProviderAsync cacheProvider, TimeSpan ttl)
         {
             if (cacheProvider == null) throw new ArgumentNullException(nameof(cacheProvider));
 
-            return CacheAsync<TResult>(cacheProvider.AsAsync<TResult>(), DefaultCacheKeyStrategy.Instance);
+            return CacheAsync<TResult>(cacheProvider.AsAsync<TResult>(), new TimeSpanTtl(ttl), DefaultCacheKeyStrategy.Instance);
         }
 
         /// <summary>
@@ -26,11 +28,47 @@ namespace Polly
         /// If the <paramref name="cacheProvider"/> provides a value, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider"/> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider"/>, then returns the value.
         /// </para>
         /// </summary>
+        /// <param name="cacheProvider">The cache provider.</param>
+        /// <param name="ttlStrategy">A strategy for specifying ttl for values to be cached.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
-        public static CachePolicy<TResult> CacheAsync<TResult>(ICacheProviderAsync<TResult> cacheProvider)
+        /// <exception cref="ArgumentNullException">ttlStrategy</exception>
+        public static CachePolicy<TResult> CacheAsync<TResult>(ICacheProviderAsync cacheProvider, ITtlStrategy ttlStrategy)
         {
-            return CacheAsync<TResult>(cacheProvider, DefaultCacheKeyStrategy.Instance);
+            if (cacheProvider == null) throw new ArgumentNullException(nameof(cacheProvider));
+
+            return CacheAsync<TResult>(cacheProvider.AsAsync<TResult>(), ttlStrategy, DefaultCacheKeyStrategy.Instance);
+        }
+
+        /// <summary>
+        /// <para>Builds a <see cref="Policy"/> that will function like a result cache for delegate executions returning a <typeparamref name="TResult"/>.</para>
+        /// <para>Before executing a delegate, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="M:Context.ExecutionKey"/>.
+        /// If the <paramref name="cacheProvider"/> provides a value, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider"/> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider"/>, then returns the value.
+        /// </para>
+        /// </summary>
+        /// <param name="cacheProvider">The cache provider.</param>
+        /// <param name="ttl">Duration (ttl) for which to cache values.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="ArgumentNullException">cacheProvider</exception>
+        public static CachePolicy<TResult> CacheAsync<TResult>(ICacheProviderAsync<TResult> cacheProvider, TimeSpan ttl)
+        {
+            return CacheAsync<TResult>(cacheProvider, new TimeSpanTtl(ttl), DefaultCacheKeyStrategy.Instance);
+        }
+
+        /// <summary>
+        /// <para>Builds a <see cref="Policy"/> that will function like a result cache for delegate executions returning a <typeparamref name="TResult"/>.</para>
+        /// <para>Before executing a delegate, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="M:Context.ExecutionKey"/>.
+        /// If the <paramref name="cacheProvider"/> provides a value, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider"/> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider"/>, then returns the value.
+        /// </para>
+        /// </summary>
+        /// <param name="cacheProvider">The cache provider.</param>
+        /// <param name="ttlStrategy">A strategy for specifying ttl for values to be cached.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="ArgumentNullException">cacheProvider</exception>
+        /// <exception cref="ArgumentNullException">ttlStrategy</exception>
+        public static CachePolicy<TResult> CacheAsync<TResult>(ICacheProviderAsync<TResult> cacheProvider, ITtlStrategy ttlStrategy)
+        {
+            return CacheAsync<TResult>(cacheProvider, ttlStrategy, DefaultCacheKeyStrategy.Instance);
         }
 
         /// <summary>
@@ -40,15 +78,16 @@ namespace Polly
         /// </para>
         /// </summary>
         /// <param name="cacheProvider">The cache provider.</param>
+        /// <param name="ttl">Duration (ttl) for which to cache values.</param>
         /// <param name="cacheKeyStrategy">The cache key strategy.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
-        public static CachePolicy<TResult> CacheAsync<TResult>(ICacheProviderAsync cacheProvider, ICacheKeyStrategy cacheKeyStrategy)
+        public static CachePolicy<TResult> CacheAsync<TResult>(ICacheProviderAsync cacheProvider, TimeSpan ttl, ICacheKeyStrategy cacheKeyStrategy)
         {
             if (cacheProvider == null) throw new ArgumentNullException(nameof(cacheProvider));
 
-            return CacheAsync<TResult>(cacheProvider.AsAsync<TResult>(), cacheKeyStrategy);
+            return CacheAsync<TResult>(cacheProvider.AsAsync<TResult>(), new TimeSpanTtl(ttl), cacheKeyStrategy);
         }
 
         /// <summary>
@@ -58,16 +97,56 @@ namespace Polly
         /// </para>
         /// </summary>
         /// <param name="cacheProvider">The cache provider.</param>
+        /// <param name="ttlStrategy">A strategy for specifying ttl for values to be cached.</param>
+        /// <param name="cacheKeyStrategy">The cache key strategy.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+        /// <exception cref="ArgumentNullException">ttlStrategy</exception>
+        /// <exception cref="ArgumentNullException">cacheProvider</exception>
+        public static CachePolicy<TResult> CacheAsync<TResult>(ICacheProviderAsync cacheProvider, ITtlStrategy ttlStrategy, ICacheKeyStrategy cacheKeyStrategy)
+        {
+            if (cacheProvider == null) throw new ArgumentNullException(nameof(cacheProvider));
+
+            return CacheAsync<TResult>(cacheProvider.AsAsync<TResult>(), ttlStrategy, cacheKeyStrategy);
+        }
+
+        /// <summary>
+        /// <para>Builds a <see cref="Policy" /> that will function like a result cache for delegate executions returning a <typeparamref name="TResult"/>.</para>
+        /// <para>Before executing a delegate, checks whether the <paramref name="cacheProvider" /> holds a value for the cache key determined by applying the <paramref name="cacheKeyStrategy"/> to the execution <see cref="Context"/>.
+        /// If the <paramref name="cacheProvider" /> provides a value, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider" /> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider" />, then returns the value.
+        /// </para>
+        /// </summary>
+        /// <param name="cacheProvider">The cache provider.</param>
+        /// <param name="ttl">Duration (ttl) for which to cache values.</param>
         /// <param name="cacheKeyStrategy">The cache key strategy.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
-        public static CachePolicy<TResult> CacheAsync<TResult>(ICacheProviderAsync<TResult> cacheProvider, ICacheKeyStrategy cacheKeyStrategy)
+        public static CachePolicy<TResult> CacheAsync<TResult>(ICacheProviderAsync<TResult> cacheProvider, TimeSpan ttl, ICacheKeyStrategy cacheKeyStrategy)
+        {
+            return CacheAsync<TResult>(cacheProvider, new TimeSpanTtl(ttl), cacheKeyStrategy);
+        }
+
+        /// <summary>
+        /// <para>Builds a <see cref="Policy" /> that will function like a result cache for delegate executions returning a <typeparamref name="TResult"/>.</para>
+        /// <para>Before executing a delegate, checks whether the <paramref name="cacheProvider" /> holds a value for the cache key determined by applying the <paramref name="cacheKeyStrategy"/> to the execution <see cref="Context"/>.
+        /// If the <paramref name="cacheProvider" /> provides a value, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider" /> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider" />, then returns the value.
+        /// </para>
+        /// </summary>
+        /// <param name="cacheProvider">The cache provider.</param>
+        /// <param name="ttlStrategy">A strategy for specifying ttl for values to be cached.</param>
+        /// <param name="cacheKeyStrategy">The cache key strategy.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+        /// <exception cref="ArgumentNullException">ttlStrategy</exception>
+        /// <exception cref="ArgumentNullException">cacheProvider</exception>
+        public static CachePolicy<TResult> CacheAsync<TResult>(ICacheProviderAsync<TResult> cacheProvider, ITtlStrategy ttlStrategy, ICacheKeyStrategy cacheKeyStrategy)
         {
             if (cacheProvider == null) throw new ArgumentNullException(nameof(cacheProvider));
+            if (ttlStrategy == null) throw new ArgumentNullException(nameof(ttlStrategy));
             if (cacheKeyStrategy == null) throw new ArgumentNullException(nameof(cacheKeyStrategy));
 
-            return new CachePolicy<TResult>(cacheProvider, cacheKeyStrategy);
+            return new CachePolicy<TResult>(cacheProvider, ttlStrategy, cacheKeyStrategy);
         }
     }
 }

--- a/src/Polly.Shared/Caching/CacheEngine.cs
+++ b/src/Polly.Shared/Caching/CacheEngine.cs
@@ -7,6 +7,7 @@ namespace Polly.Caching
     {
         internal static TResult Implementation<TResult>(
             ICacheProvider<TResult> cacheProvider,
+            ITtlStrategy ttlStrategy,
             ICacheKeyStrategy cacheKeyStrategy,
             Func<CancellationToken, TResult> action,
             Context context,
@@ -27,7 +28,13 @@ namespace Polly.Caching
             }
 
             TResult result = action(cancellationToken);
-            cacheProvider.Put(cacheKey, result);
+
+            TimeSpan ttl = ttlStrategy.GetTtl(context);
+            if (ttl > TimeSpan.Zero)
+            {
+                cacheProvider.Put(cacheKey, ttl, result);
+            }
+
             return result;
         }
     }

--- a/src/Polly.Shared/Caching/CacheEngine.cs
+++ b/src/Polly.Shared/Caching/CacheEngine.cs
@@ -32,7 +32,7 @@ namespace Polly.Caching
             TimeSpan ttl = ttlStrategy.GetTtl(context);
             if (ttl > TimeSpan.Zero)
             {
-                cacheProvider.Put(cacheKey, ttl, result);
+                cacheProvider.Put(cacheKey, result, ttl);
             }
 
             return result;

--- a/src/Polly.Shared/Caching/CacheEngineAsync.cs
+++ b/src/Polly.Shared/Caching/CacheEngineAsync.cs
@@ -34,7 +34,7 @@ namespace Polly.Caching
             TimeSpan ttl = ttlStrategy.GetTtl(context);
             if (ttl > TimeSpan.Zero)
             {
-                await cacheProvider.PutAsync(cacheKey, ttl, result, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
+                await cacheProvider.PutAsync(cacheKey, result, ttl, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
             }
 
             return result;

--- a/src/Polly.Shared/Caching/ContextualTimeSpanTtl.cs
+++ b/src/Polly.Shared/Caching/ContextualTimeSpanTtl.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace Polly.Caching
+{
+    /// <summary>
+    /// Defines a ttl strategy which will cache items for a TimeSpan which may be influenced by data in the execution context.
+    /// </summary>
+    public class ContextualTimeSpanTtl : ITtlStrategy
+    {
+        /// <summary>
+        /// The key on the execution <see cref="Context"/> to use for storing the Ttl TimeSpan for which to cache.
+        /// </summary>
+        public static readonly string Key = "ContextualTimeSpanTtl";
+
+        /// <summary>
+        /// Gets the TimeSpan for which to keep an item about to be cached, which may be influenced by data in the execution context.
+        /// </summary>
+        /// <param name="context">The execution context.</param>
+        /// <returns>TimeSpan.</returns>
+        public TimeSpan GetTtl(Context context)
+        {
+            if (!context.ContainsKey(Key)) return TimeSpan.Zero;
+            return context[Key] as TimeSpan? ?? TimeSpan.Zero;
+        }
+
+    }
+}

--- a/src/Polly.Shared/Caching/ICacheProvider.cs
+++ b/src/Polly.Shared/Caching/ICacheProvider.cs
@@ -18,8 +18,9 @@ namespace Polly.Caching
         /// Puts the specified value in the cache.
         /// </summary>
         /// <param name="key">The cache key.</param>
+        /// <param name="ttl">The time-to-live for the cache entry.</param>
         /// <param name="value">The value to put into the cache.</param>
-        void Put(String key, object value);
+        void Put(String key, TimeSpan ttl, object value);
     }
 
     /// <summary>
@@ -38,7 +39,8 @@ namespace Polly.Caching
         /// Puts the specified value in the cache.
         /// </summary>
         /// <param name="key">The cache key.</param>
+        /// <param name="ttl">The time-to-live for the cache entry.</param>
         /// <param name="value">The value to put into the cache.</param>
-        void Put(String key, TResult value);
+        void Put(String key, TimeSpan ttl, TResult value);
     }
 }

--- a/src/Polly.Shared/Caching/ICacheProvider.cs
+++ b/src/Polly.Shared/Caching/ICacheProvider.cs
@@ -18,9 +18,9 @@ namespace Polly.Caching
         /// Puts the specified value in the cache.
         /// </summary>
         /// <param name="key">The cache key.</param>
-        /// <param name="ttl">The time-to-live for the cache entry.</param>
         /// <param name="value">The value to put into the cache.</param>
-        void Put(String key, TimeSpan ttl, object value);
+        /// <param name="ttl">The time-to-live for the cache entry.</param>
+        void Put(string key, object value, TimeSpan ttl);
     }
 
     /// <summary>
@@ -39,8 +39,8 @@ namespace Polly.Caching
         /// Puts the specified value in the cache.
         /// </summary>
         /// <param name="key">The cache key.</param>
-        /// <param name="ttl">The time-to-live for the cache entry.</param>
         /// <param name="value">The value to put into the cache.</param>
-        void Put(String key, TimeSpan ttl, TResult value);
+        /// <param name="ttl">The time-to-live for the cache entry.</param>
+        void Put(string key, TResult value, TimeSpan ttl);
     }
 }

--- a/src/Polly.Shared/Caching/ICacheProviderAsync.cs
+++ b/src/Polly.Shared/Caching/ICacheProviderAsync.cs
@@ -22,11 +22,12 @@ namespace Polly.Caching
         /// Puts the specified value in the cache asynchronously.
         /// </summary>
         /// <param name="key">The cache key.</param>
+        /// <param name="ttl">The time-to-live for the cache entry.</param>
         /// <param name="value">The value to put into the cache.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="continueOnCapturedContext">Whether async calls should continue on a captured synchronization context.<para><remarks>Note: if the underlying cache's async API does not support controlling whether to continue on a captured context, async Policy executions with continueOnCapturedContext == true cannot be guaranteed to remain on the captured context.</remarks></para></param>
         /// <returns>A <see cref="Task" /> which completes when the value has been cached.</returns>
-        Task PutAsync(string key, object value, CancellationToken cancellationToken, bool continueOnCapturedContext);
+        Task PutAsync(string key, TimeSpan ttl, object value, CancellationToken cancellationToken, bool continueOnCapturedContext);
     }
 
     /// <summary>
@@ -47,10 +48,11 @@ namespace Polly.Caching
         /// Puts the specified value in the cache asynchronously.
         /// </summary>
         /// <param name="key">The cache key.</param>
+        /// <param name="ttl">The time-to-live for the cache entry.</param>
         /// <param name="value">The value to put into the cache.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="continueOnCapturedContext">Whether async calls should continue on a captured synchronization context.<para><remarks>Note: if the underlying cache's async API does not support controlling whether to continue on a captured context, async Policy executions with continueOnCapturedContext == true cannot be guaranteed to remain on the captured context.</remarks></para></param>
         /// <returns>A <see cref="Task" /> which completes when the value has been cached.</returns>
-        Task PutAsync(string key, TResult value, CancellationToken cancellationToken, bool continueOnCapturedContext);
+        Task PutAsync(string key, TimeSpan ttl, TResult value, CancellationToken cancellationToken, bool continueOnCapturedContext);
     }
 }

--- a/src/Polly.Shared/Caching/ICacheProviderAsync.cs
+++ b/src/Polly.Shared/Caching/ICacheProviderAsync.cs
@@ -22,12 +22,12 @@ namespace Polly.Caching
         /// Puts the specified value in the cache asynchronously.
         /// </summary>
         /// <param name="key">The cache key.</param>
-        /// <param name="ttl">The time-to-live for the cache entry.</param>
         /// <param name="value">The value to put into the cache.</param>
+        /// <param name="ttl">The time-to-live for the cache entry.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="continueOnCapturedContext">Whether async calls should continue on a captured synchronization context.<para><remarks>Note: if the underlying cache's async API does not support controlling whether to continue on a captured context, async Policy executions with continueOnCapturedContext == true cannot be guaranteed to remain on the captured context.</remarks></para></param>
         /// <returns>A <see cref="Task" /> which completes when the value has been cached.</returns>
-        Task PutAsync(string key, TimeSpan ttl, object value, CancellationToken cancellationToken, bool continueOnCapturedContext);
+        Task PutAsync(string key, object value, TimeSpan ttl, CancellationToken cancellationToken, bool continueOnCapturedContext);
     }
 
     /// <summary>
@@ -48,11 +48,11 @@ namespace Polly.Caching
         /// Puts the specified value in the cache asynchronously.
         /// </summary>
         /// <param name="key">The cache key.</param>
-        /// <param name="ttl">The time-to-live for the cache entry.</param>
         /// <param name="value">The value to put into the cache.</param>
+        /// <param name="ttl">The time-to-live for the cache entry.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="continueOnCapturedContext">Whether async calls should continue on a captured synchronization context.<para><remarks>Note: if the underlying cache's async API does not support controlling whether to continue on a captured context, async Policy executions with continueOnCapturedContext == true cannot be guaranteed to remain on the captured context.</remarks></para></param>
         /// <returns>A <see cref="Task" /> which completes when the value has been cached.</returns>
-        Task PutAsync(string key, TimeSpan ttl, TResult value, CancellationToken cancellationToken, bool continueOnCapturedContext);
+        Task PutAsync(string key, TResult value, TimeSpan ttl, CancellationToken cancellationToken, bool continueOnCapturedContext);
     }
 }

--- a/src/Polly.Shared/Caching/ITtlStrategy.cs
+++ b/src/Polly.Shared/Caching/ITtlStrategy.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Polly.Caching
+{
+    /// <summary>
+    /// Defines a strategy for providing time-to-live durations for cacheable results.
+    /// </summary>
+    public interface ITtlStrategy
+    {
+        /// <summary>
+        /// Gets a TTL for a cacheable item, given the current execution context.
+        /// </summary>
+        /// <param name="context">The execution context.</param>
+        /// <returns>TimeSpan</returns>
+        TimeSpan GetTtl(Context context);
+    }
+}

--- a/src/Polly.Shared/Caching/MappingCacheProvider.cs
+++ b/src/Polly.Shared/Caching/MappingCacheProvider.cs
@@ -39,9 +39,9 @@ namespace Polly.Caching
             return GetMapper(_wrappedCacheProvider.Get(key));
         }
 
-        void ICacheProvider.Put(string key, TimeSpan ttl, object value)
+        void ICacheProvider.Put(string key, object value, TimeSpan ttl)
         {
-            _wrappedCacheProvider.Put(key, ttl, PutMapper(value));
+            _wrappedCacheProvider.Put(key, PutMapper(value), ttl);
         }
     }
     
@@ -82,9 +82,9 @@ namespace Polly.Caching
             return GetMapper(_wrappedCacheProvider.Get(key));
         }
 
-        void ICacheProvider<TNative>.Put(string key, TimeSpan ttl, TNative value)
+        void ICacheProvider<TNative>.Put(string key, TNative value, TimeSpan ttl)
         {
-            _wrappedCacheProvider.Put(key, ttl, PutMapper(value));
+            _wrappedCacheProvider.Put(key, PutMapper(value), ttl);
         }
     }
 }

--- a/src/Polly.Shared/Caching/MappingCacheProvider.cs
+++ b/src/Polly.Shared/Caching/MappingCacheProvider.cs
@@ -39,9 +39,9 @@ namespace Polly.Caching
             return GetMapper(_wrappedCacheProvider.Get(key));
         }
 
-        void ICacheProvider.Put(string key, object value)
+        void ICacheProvider.Put(string key, TimeSpan ttl, object value)
         {
-            _wrappedCacheProvider.Put(key, PutMapper(value));
+            _wrappedCacheProvider.Put(key, ttl, PutMapper(value));
         }
     }
     
@@ -82,9 +82,9 @@ namespace Polly.Caching
             return GetMapper(_wrappedCacheProvider.Get(key));
         }
 
-        void ICacheProvider<TNative>.Put(string key, TNative value)
+        void ICacheProvider<TNative>.Put(string key, TimeSpan ttl, TNative value)
         {
-            _wrappedCacheProvider.Put(key, PutMapper(value));
+            _wrappedCacheProvider.Put(key, ttl, PutMapper(value));
         }
     }
 }

--- a/src/Polly.Shared/Caching/MappingCacheProviderAsync.cs
+++ b/src/Polly.Shared/Caching/MappingCacheProviderAsync.cs
@@ -57,14 +57,16 @@ namespace Polly.Caching
         /// Puts the specified value in the cache asynchronously.
         /// </summary>
         /// <param name="key">The cache key.</param>
+        /// <param name="ttl">The time-to-live for the cache entry.</param>
         /// <param name="value">The value to put into the cache.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="continueOnCapturedContext">Whether async calls should continue on a captured synchronization context.</param>
         /// <returns>A <see cref="Task" /> which completes when the value has been cached.</returns>
-        public async Task PutAsync(string key, object value, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        public async Task PutAsync(string key, TimeSpan ttl, object value, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
             await _wrappedCacheProvider.PutAsync(
                     key, 
+                    ttl, 
                     await PutMapper(value, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext), 
                     cancellationToken,
                     continueOnCapturedContext
@@ -125,14 +127,16 @@ namespace Polly.Caching
         /// Puts the specified value in the cache asynchronously.
         /// </summary>
         /// <param name="key">The cache key.</param>
+        /// <param name="ttl">The time-to-live for the cache entry.</param>
         /// <param name="value">The value to put into the cache.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="continueOnCapturedContext">Whether async calls should continue on a captured synchronization context.</param>
         /// <returns>A <see cref="Task" /> which completes when the value has been cached.</returns>
-        public async Task PutAsync(string key, TNative value, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        public async Task PutAsync(string key, TimeSpan ttl, TNative value, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
             await _wrappedCacheProvider.PutAsync(
                     key,
+                    ttl,
                     await PutMapper(value, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext),
                     cancellationToken,
                     continueOnCapturedContext

--- a/src/Polly.Shared/Caching/MappingCacheProviderAsync.cs
+++ b/src/Polly.Shared/Caching/MappingCacheProviderAsync.cs
@@ -57,20 +57,18 @@ namespace Polly.Caching
         /// Puts the specified value in the cache asynchronously.
         /// </summary>
         /// <param name="key">The cache key.</param>
-        /// <param name="ttl">The time-to-live for the cache entry.</param>
         /// <param name="value">The value to put into the cache.</param>
+        /// <param name="ttl">The time-to-live for the cache entry.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="continueOnCapturedContext">Whether async calls should continue on a captured synchronization context.</param>
         /// <returns>A <see cref="Task" /> which completes when the value has been cached.</returns>
-        public async Task PutAsync(string key, TimeSpan ttl, object value, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        public async Task PutAsync(string key, object value, TimeSpan ttl, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
             await _wrappedCacheProvider.PutAsync(
                     key, 
-                    ttl, 
                     await PutMapper(value, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext), 
-                    cancellationToken,
-                    continueOnCapturedContext
-                ).ConfigureAwait(continueOnCapturedContext);
+                    ttl,
+                    cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
         }
     }
 
@@ -127,18 +125,18 @@ namespace Polly.Caching
         /// Puts the specified value in the cache asynchronously.
         /// </summary>
         /// <param name="key">The cache key.</param>
-        /// <param name="ttl">The time-to-live for the cache entry.</param>
         /// <param name="value">The value to put into the cache.</param>
+        /// <param name="ttl">The time-to-live for the cache entry.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="continueOnCapturedContext">Whether async calls should continue on a captured synchronization context.</param>
         /// <returns>A <see cref="Task" /> which completes when the value has been cached.</returns>
-        public async Task PutAsync(string key, TimeSpan ttl, TNative value, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        public async Task PutAsync(string key, TNative value, TimeSpan ttl, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
             await _wrappedCacheProvider.PutAsync(
                     key,
-                    ttl,
                     await PutMapper(value, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext),
-                    cancellationToken,
+                    ttl,
+                    cancellationToken, 
                     continueOnCapturedContext
                 ).ConfigureAwait(continueOnCapturedContext);
         }

--- a/src/Polly.Shared/Caching/PointInTimeTtl.cs
+++ b/src/Polly.Shared/Caching/PointInTimeTtl.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Polly.Utilities;
+
+namespace Polly.Caching
+{
+    /// <summary>
+    /// Defines a ttl strategy which will cache items until the specified point-in-time.
+    /// </summary>
+    public class PointInTimeTtl : ITtlStrategy
+    {
+        private readonly DateTimeOffset pointInTime;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PointInTimeTtl"/> class.
+        /// </summary>
+        /// <param name="pointInTime">The point in time until which to keep items cached.</param>
+        public PointInTimeTtl(DateTimeOffset pointInTime)
+        {
+            this.pointInTime = pointInTime;
+        }
+
+        /// <summary>
+        /// Gets the TimeSpan to keep items cached using this Ttl strategy, such that they are kept until the specified point-in-time.
+        /// </summary>
+        /// <param name="context">The execution context.</param>
+        /// <returns>TimeSpan.</returns>
+        public TimeSpan GetTtl(Context context)
+        {
+            TimeSpan untilPointInTime = pointInTime.Subtract(SystemClock.DateTimeOffsetUtcNow());
+            return untilPointInTime > TimeSpan.Zero ? untilPointInTime : TimeSpan.Zero;
+        }
+    }
+}

--- a/src/Polly.Shared/Caching/TimeSpanTtl.cs
+++ b/src/Polly.Shared/Caching/TimeSpanTtl.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace Polly.Caching
+{
+    /// <summary>
+    /// Defines a ttl strategy which will cache items for the specified TimeSpan.
+    /// </summary>
+    public class TimeSpanTtl : ITtlStrategy
+    {
+        private readonly TimeSpan ttl;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeSpanTtl" /> class.
+        /// </summary>
+        /// <param name="ttl">Duration (ttl) for which to cache values.</param>
+        /// <exception cref="System.ArgumentOutOfRangeException"></exception>
+        public TimeSpanTtl(TimeSpan ttl)
+        {
+            if (ttl < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(ttl), "The ttl for items to cache must be greater than zero.");
+
+            this.ttl = ttl;
+        }
+
+        /// <summary>
+        /// Gets the TimeSpan for which to keep items cached.
+        /// </summary>
+        /// <param name="context">The execution context.</param>
+        /// <returns>TimeSpan.</returns>
+        public TimeSpan GetTtl(Context context) => ttl;
+    }
+}

--- a/src/Polly.Shared/Caching/TypedCacheProvider.cs
+++ b/src/Polly.Shared/Caching/TypedCacheProvider.cs
@@ -22,9 +22,9 @@ namespace Polly.Caching
             return (TCacheFormat) _wrappedCacheProvider.Get(key);
         }
 
-        void ICacheProvider<TCacheFormat>.Put(string key, TimeSpan ttl, TCacheFormat value)
+        void ICacheProvider<TCacheFormat>.Put(string key, TCacheFormat value, TimeSpan ttl)
         {
-            _wrappedCacheProvider.Put(key, ttl, value);
+            _wrappedCacheProvider.Put(key, value, ttl);
         }
     }
 }

--- a/src/Polly.Shared/Caching/TypedCacheProvider.cs
+++ b/src/Polly.Shared/Caching/TypedCacheProvider.cs
@@ -22,9 +22,9 @@ namespace Polly.Caching
             return (TCacheFormat) _wrappedCacheProvider.Get(key);
         }
 
-        void ICacheProvider<TCacheFormat>.Put(string key, TCacheFormat value)
+        void ICacheProvider<TCacheFormat>.Put(string key, TimeSpan ttl, TCacheFormat value)
         {
-            _wrappedCacheProvider.Put(key, value);
+            _wrappedCacheProvider.Put(key, ttl, value);
         }
     }
 }

--- a/src/Polly.Shared/Caching/TypedCacheProviderAsync.cs
+++ b/src/Polly.Shared/Caching/TypedCacheProviderAsync.cs
@@ -25,9 +25,9 @@ namespace Polly.Caching
             return (TCacheFormat) await _wrappedCacheProvider.GetAsync(key, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
         }
 
-        Task ICacheProviderAsync<TCacheFormat>.PutAsync(string key, TCacheFormat value, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        Task ICacheProviderAsync<TCacheFormat>.PutAsync(string key, TimeSpan ttl, TCacheFormat value, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
-            return _wrappedCacheProvider.PutAsync(key, value, cancellationToken, continueOnCapturedContext);
+            return _wrappedCacheProvider.PutAsync(key, ttl, value, cancellationToken, continueOnCapturedContext);
         }
     }
 }

--- a/src/Polly.Shared/Caching/TypedCacheProviderAsync.cs
+++ b/src/Polly.Shared/Caching/TypedCacheProviderAsync.cs
@@ -25,9 +25,9 @@ namespace Polly.Caching
             return (TCacheFormat) await _wrappedCacheProvider.GetAsync(key, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
         }
 
-        Task ICacheProviderAsync<TCacheFormat>.PutAsync(string key, TimeSpan ttl, TCacheFormat value, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        Task ICacheProviderAsync<TCacheFormat>.PutAsync(string key, TCacheFormat value, TimeSpan ttl, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
-            return _wrappedCacheProvider.PutAsync(key, ttl, value, cancellationToken, continueOnCapturedContext);
+            return _wrappedCacheProvider.PutAsync(key, value, ttl, cancellationToken, continueOnCapturedContext);
         }
     }
 }

--- a/src/Polly.Shared/Polly.Shared.projitems
+++ b/src/Polly.Shared/Polly.Shared.projitems
@@ -29,12 +29,16 @@
     <Compile Include="$(MSBuildThisFileDirectory)Caching\CachePolicy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\CachePolicyAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\CacheProviderExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Caching\ContextualTimeSpanTtl.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\DefaultCacheKeyStrategy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\ICacheKeyStrategy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\ICacheProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\ICacheProviderAsync.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Caching\ITtlStrategy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\MappingCacheProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\MappingCacheProviderAsync.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Caching\PointInTimeTtl.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Caching\TimeSpanTtl.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\TypedCacheProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\TypedCacheProviderAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CircuitBreakerSyntax.cs" />

--- a/src/Polly.Shared/Utilities/SystemClock.cs
+++ b/src/Polly.Shared/Utilities/SystemClock.cs
@@ -39,6 +39,12 @@ namespace Polly.Utilities
         public static Func<DateTime> UtcNow = () => DateTime.UtcNow;
 
         /// <summary>
+        /// Allows the setting of a custom DateTimeOffset.UtcNow implementation for testing.
+        /// By default this will be a call to <see cref="DateTime.UtcNow"/>
+        /// </summary>
+        public static Func<DateTimeOffset> DateTimeOffsetUtcNow = () => DateTimeOffset.UtcNow;
+
+        /// <summary>
         /// Resets the custom implementations to their defaults. 
         /// Should be called during test teardowns.
         /// </summary>
@@ -52,12 +58,17 @@ namespace Polly.Utilities
 #endif
             .Delay(timeSpan, cancellationToken).Wait();
 
+            SleepAsync =
 #if NET40
-            SleepAsync = TaskEx.Delay;
+            TaskEx
 #else
-            SleepAsync = Task.Delay;
+            Task
 #endif
+            .Delay;
+
             UtcNow = () => DateTime.UtcNow;
+
+            DateTimeOffsetUtcNow = () => DateTimeOffset.UtcNow;
         }
     }
 }

--- a/src/Polly.SharedSpecs/CacheAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/CacheAsyncSpecs.cs
@@ -52,7 +52,7 @@ namespace Polly.Specs
 
             ICacheProviderAsync stubCacheProvider = new StubCacheProvider();
             CachePolicy cache = Policy.CacheAsync(stubCacheProvider, TimeSpan.MaxValue);
-            await stubCacheProvider.PutAsync(executionKey, TimeSpan.MaxValue, valueToReturnFromCache, CancellationToken.None, false).ConfigureAwait(false);
+            await stubCacheProvider.PutAsync(executionKey, valueToReturnFromCache, TimeSpan.MaxValue, CancellationToken.None, false).ConfigureAwait(false);
 
             bool delegateExecuted = false;
 
@@ -176,9 +176,9 @@ namespace Polly.Specs
             CachePolicy cache = Policy.CacheAsync(stubCacheProvider, TimeSpan.MaxValue, cacheKeyStrategy);
 
             object person1 = new object();
-            await stubCacheProvider.PutAsync("person1", TimeSpan.MaxValue, person1, CancellationToken.None, false).ConfigureAwait(false);
+            await stubCacheProvider.PutAsync("person1", person1, TimeSpan.MaxValue, CancellationToken.None, false).ConfigureAwait(false);
             object person2 = new object();
-            await stubCacheProvider.PutAsync("person2", TimeSpan.MaxValue, person2, CancellationToken.None, false).ConfigureAwait(false);
+            await stubCacheProvider.PutAsync("person2", person2, TimeSpan.MaxValue, CancellationToken.None, false).ConfigureAwait(false);
 
             bool funcExecuted = false;
             Func<Task<object>> func = async () => { funcExecuted = true; await TaskHelper.EmptyTask.ConfigureAwait(false); return new object(); };

--- a/src/Polly.SharedSpecs/CacheAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/CacheAsyncSpecs.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Polly.Specs
 {
-    public class CacheAsyncSpecs
+    public class CacheAsyncSpecs : IDisposable
     {
         #region Configuration
 
@@ -17,8 +17,17 @@ namespace Polly.Specs
         public void Should_throw_when_cache_provider_is_null()
         {
             ICacheProviderAsync cacheProvider = null;
-            Action action = () => Policy.CacheAsync(cacheProvider);
+            Action action = () => Policy.CacheAsync(cacheProvider, TimeSpan.MaxValue);
             action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("cacheProvider");
+        }
+
+        [Fact]
+        public void Should_throw_when_ttl_strategy_is_null()
+        {
+            ICacheProviderAsync cacheProvider = new StubCacheProvider();
+            ITtlStrategy ttlStrategy = null;
+            Action action = () => Policy.CacheAsync(cacheProvider, ttlStrategy);
+            action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("ttlStrategy");
         }
 
         [Fact]
@@ -26,7 +35,7 @@ namespace Polly.Specs
         {
             ICacheProviderAsync cacheProvider = new StubCacheProvider();
             ICacheKeyStrategy cacheKeyStrategy = null;
-            Action action = () => Policy.CacheAsync(cacheProvider, cacheKeyStrategy);
+            Action action = () => Policy.CacheAsync(cacheProvider, TimeSpan.MaxValue, cacheKeyStrategy);
             action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("cacheKeyStrategy");
         }
 
@@ -42,8 +51,8 @@ namespace Polly.Specs
             const string executionKey = "SomeExecutionKey";
 
             ICacheProviderAsync stubCacheProvider = new StubCacheProvider();
-            CachePolicy cache = Policy.CacheAsync(stubCacheProvider);
-            await stubCacheProvider.PutAsync(executionKey, valueToReturnFromCache, CancellationToken.None, false).ConfigureAwait(false);
+            CachePolicy cache = Policy.CacheAsync(stubCacheProvider, TimeSpan.MaxValue);
+            await stubCacheProvider.PutAsync(executionKey, TimeSpan.MaxValue, valueToReturnFromCache, CancellationToken.None, false).ConfigureAwait(false);
 
             bool delegateExecuted = false;
 
@@ -66,7 +75,7 @@ namespace Polly.Specs
             const string executionKey = "SomeExecutionKey";
 
             ICacheProviderAsync stubCacheProvider = new StubCacheProvider();
-            CachePolicy cache = Policy.CacheAsync(stubCacheProvider);
+            CachePolicy cache = Policy.CacheAsync(stubCacheProvider, TimeSpan.MaxValue);
 
             ((string) await stubCacheProvider.GetAsync(executionKey, CancellationToken.None, false).ConfigureAwait(false)).Should().BeNull();
 
@@ -76,12 +85,70 @@ namespace Polly.Specs
         }
 
         [Fact]
+        public async void Should_execute_delegate_and_put_value_in_cache_but_when_it_expires_execute_delegate_again()
+        {
+            const string valueToReturn = "valueToReturn";
+            const string executionKey = "SomeExecutionKey";
+
+            ICacheProviderAsync stubCacheProvider = new StubCacheProvider();
+            TimeSpan ttl = TimeSpan.FromMinutes(30);
+            CachePolicy cache = Policy.CacheAsync(stubCacheProvider, ttl);
+
+            ((string) await stubCacheProvider.GetAsync(executionKey, CancellationToken.None, false).ConfigureAwait(false)).Should().BeNull();
+
+            int delegateInvocations = 0;
+            Func<Task<string>> func = async () =>
+            {
+                delegateInvocations++;
+                await TaskHelper.EmptyTask.ConfigureAwait(false);
+                return valueToReturn;
+            };
+
+            DateTime fixedTime = SystemClock.UtcNow();
+            SystemClock.UtcNow = () => fixedTime;
+
+            // First execution should execute delegate and put result in the cache.
+            (await cache.ExecuteAsync(func, new Context(executionKey)).ConfigureAwait(false)).Should().Be(valueToReturn);
+            delegateInvocations.Should().Be(1);
+            ((string)await stubCacheProvider.GetAsync(executionKey, CancellationToken.None, false).ConfigureAwait(false)).Should().Be(valueToReturn);
+
+            // Second execution (before cache expires) should get it from the cache - no further delegate execution.
+            // (Manipulate time so just prior cache expiry).
+            SystemClock.UtcNow = () => fixedTime.Add(ttl).AddTicks(-1);
+            (await cache.ExecuteAsync(func, new Context(executionKey)).ConfigureAwait(false)).Should().Be(valueToReturn);
+            delegateInvocations.Should().Be(1);
+
+            // Manipulate time to force cache expiry.
+            SystemClock.UtcNow = () => fixedTime.Add(ttl).AddTicks(1);
+
+            // Third execution (cache expired) should not get it from the cache - should cause further delegate execution.
+            (await cache.ExecuteAsync(func, new Context(executionKey)).ConfigureAwait(false)).Should().Be(valueToReturn);
+            delegateInvocations.Should().Be(2);
+        }
+
+        [Fact]
+        public async void Should_execute_delegate_but_not_put_value_in_cache_if_cache_does_not_hold_value_but_ttl_indicates_not_worth_caching()
+        {
+            const string valueToReturn = "valueToReturn";
+            const string executionKey = "SomeExecutionKey";
+
+            ICacheProviderAsync stubCacheProvider = new StubCacheProvider();
+            CachePolicy cache = Policy.CacheAsync(stubCacheProvider, TimeSpan.Zero);
+
+            ((string)await stubCacheProvider.GetAsync(executionKey, CancellationToken.None, false).ConfigureAwait(false)).Should().Be(null);
+
+            (await cache.ExecuteAsync(async () => { await TaskHelper.EmptyTask.ConfigureAwait(false); return valueToReturn; }, new Context(executionKey)).ConfigureAwait(false)).Should().Be(valueToReturn);
+
+            ((string)await stubCacheProvider.GetAsync(executionKey, CancellationToken.None, false).ConfigureAwait(false)).Should().Be(null);
+        }
+
+        [Fact]
         public async void Should_return_value_from_cache_and_not_execute_delegate_if_prior_execution_has_cached()
         {
             const string valueToReturn = "valueToReturn";
             const string executionKey = "SomeExecutionKey";
 
-            CachePolicy cache = Policy.CacheAsync(new StubCacheProvider());
+            CachePolicy cache = Policy.CacheAsync(new StubCacheProvider(), TimeSpan.MaxValue);
 
             int delegateInvocations = 0;
             Func<Task<string>> func = async () =>
@@ -106,12 +173,12 @@ namespace Polly.Specs
         {
             ICacheProviderAsync stubCacheProvider = new StubCacheProvider();
             ICacheKeyStrategy cacheKeyStrategy = new MockCacheKeyStrategy(context => context.ExecutionKey + context["id"]);
-            CachePolicy cache = Policy.CacheAsync(stubCacheProvider, cacheKeyStrategy);
+            CachePolicy cache = Policy.CacheAsync(stubCacheProvider, TimeSpan.MaxValue, cacheKeyStrategy);
 
             object person1 = new object();
-            await stubCacheProvider.PutAsync("person1", person1, CancellationToken.None, false).ConfigureAwait(false);
+            await stubCacheProvider.PutAsync("person1", TimeSpan.MaxValue, person1, CancellationToken.None, false).ConfigureAwait(false);
             object person2 = new object();
-            await stubCacheProvider.PutAsync("person2", person2, CancellationToken.None, false).ConfigureAwait(false);
+            await stubCacheProvider.PutAsync("person2", TimeSpan.MaxValue, person2, CancellationToken.None, false).ConfigureAwait(false);
 
             bool funcExecuted = false;
             Func<Task<object>> func = async () => { funcExecuted = true; await TaskHelper.EmptyTask.ConfigureAwait(false); return new object(); };
@@ -131,8 +198,8 @@ namespace Polly.Specs
         public async void Should_always_execute_delegate_if_execution_key_not_set()
         {
             string valueToReturn = Guid.NewGuid().ToString();
-
-            CachePolicy cache = Policy.CacheAsync(new StubCacheProvider());
+            
+            CachePolicy cache = Policy.CacheAsync(new StubCacheProvider(), TimeSpan.MaxValue);
 
             int delegateInvocations = 0;
             Func<Task<string>> func = async () => {
@@ -153,7 +220,7 @@ namespace Polly.Specs
         {
             string executionKey = Guid.NewGuid().ToString();
 
-            CachePolicy cache = Policy.CacheAsync(new StubCacheProvider());
+            CachePolicy cache = Policy.CacheAsync(new StubCacheProvider(), TimeSpan.MaxValue);
 
             int delegateInvocations = 0;
             Func<Task> action = async () => { delegateInvocations++; await TaskHelper.EmptyTask.ConfigureAwait(false); };
@@ -175,7 +242,7 @@ namespace Polly.Specs
             const string valueToReturn = "valueToReturn";
             const string executionKey = "SomeExecutionKey";
 
-            CachePolicy cache = Policy.CacheAsync(new StubCacheProvider());
+            CachePolicy cache = Policy.CacheAsync(new StubCacheProvider(), TimeSpan.MaxValue);
 
             CancellationTokenSource tokenSource = new CancellationTokenSource();
 
@@ -205,7 +272,7 @@ namespace Polly.Specs
             const string executionKey = "SomeExecutionKey";
 
             ICacheProviderAsync stubCacheProvider = new StubCacheProvider();
-            CachePolicy cache = Policy.CacheAsync(stubCacheProvider);
+            CachePolicy cache = Policy.CacheAsync(stubCacheProvider, TimeSpan.MaxValue);
 
             CancellationTokenSource tokenSource = new CancellationTokenSource();
 
@@ -224,5 +291,10 @@ namespace Polly.Specs
         }
 
         #endregion
+
+        public void Dispose()
+        {
+            SystemClock.Reset();
+        }
     }
 }

--- a/src/Polly.SharedSpecs/CacheSpecs.cs
+++ b/src/Polly.SharedSpecs/CacheSpecs.cs
@@ -51,7 +51,7 @@ namespace Polly.Specs
 
             ICacheProvider stubCacheProvider = new StubCacheProvider();
             CachePolicy cache = Policy.Cache(stubCacheProvider, TimeSpan.MaxValue);
-            stubCacheProvider.Put(executionKey, TimeSpan.MaxValue, valueToReturnFromCache);
+            stubCacheProvider.Put(executionKey, valueToReturnFromCache, TimeSpan.MaxValue);
 
             bool delegateExecuted = false;
 
@@ -171,9 +171,9 @@ namespace Polly.Specs
             CachePolicy cache = Policy.Cache(stubCacheProvider, TimeSpan.MaxValue, cacheKeyStrategy);
 
             object person1 = new object();
-            stubCacheProvider.Put("person1", TimeSpan.MaxValue, person1);
+            stubCacheProvider.Put("person1", person1, TimeSpan.MaxValue);
             object person2 = new object();
-            stubCacheProvider.Put("person2", TimeSpan.MaxValue, person2);
+            stubCacheProvider.Put("person2", person2, TimeSpan.MaxValue);
 
             bool funcExecuted = false;
             Func<object> func = () => { funcExecuted = true; return new object(); };

--- a/src/Polly.SharedSpecs/CacheTResultAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/CacheTResultAsyncSpecs.cs
@@ -52,7 +52,7 @@ namespace Polly.Specs
 
             ICacheProviderAsync stubCacheProvider = new StubCacheProvider();
             CachePolicy<string> cache = Policy.CacheAsync<string>(stubCacheProvider, TimeSpan.MaxValue);
-            await stubCacheProvider.PutAsync(executionKey, TimeSpan.MaxValue, valueToReturnFromCache, CancellationToken.None, false).ConfigureAwait(false);
+            await stubCacheProvider.PutAsync(executionKey, valueToReturnFromCache, TimeSpan.MaxValue, CancellationToken.None, false).ConfigureAwait(false);
 
             bool delegateExecuted = false;
 
@@ -176,9 +176,9 @@ namespace Polly.Specs
             CachePolicy<ResultClass> cache = Policy.CacheAsync<ResultClass>(stubCacheProvider, TimeSpan.MaxValue, cacheKeyStrategy);
 
             object person1 = new ResultClass(ResultPrimitive.Good, "person1");
-            await stubCacheProvider.PutAsync("person1", TimeSpan.MaxValue, person1, CancellationToken.None, false).ConfigureAwait(false);
+            await stubCacheProvider.PutAsync("person1", person1, TimeSpan.MaxValue, CancellationToken.None, false).ConfigureAwait(false);
             object person2 = new ResultClass(ResultPrimitive.Good, "person2");
-            await stubCacheProvider.PutAsync("person2", TimeSpan.MaxValue, person2, CancellationToken.None, false).ConfigureAwait(false);
+            await stubCacheProvider.PutAsync("person2", person2, TimeSpan.MaxValue, CancellationToken.None, false).ConfigureAwait(false);
 
             bool funcExecuted = false;
             Func<Task<ResultClass>> func = async () => { funcExecuted = true; await TaskHelper.EmptyTask.ConfigureAwait(false); return new ResultClass(ResultPrimitive.Fault, "should never return this one"); };

--- a/src/Polly.SharedSpecs/CacheTResultAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/CacheTResultAsyncSpecs.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Polly.Specs
 {
-    public class CacheTResultAsyncSpecs
+    public class CacheTResultAsyncSpecs : IDisposable
     {
         #region Configuration
 
@@ -17,8 +17,17 @@ namespace Polly.Specs
         public void Should_throw_when_cache_provider_is_null()
         {
             ICacheProviderAsync cacheProvider = null;
-            Action action = () => Policy.CacheAsync<ResultPrimitive>(cacheProvider);
+            Action action = () => Policy.CacheAsync<ResultPrimitive>(cacheProvider, TimeSpan.MaxValue);
             action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("cacheProvider");
+        }
+
+        [Fact]
+        public void Should_throw_when_ttl_strategy_is_null()
+        {
+            ICacheProviderAsync cacheProvider = new StubCacheProvider();
+            ITtlStrategy ttlStrategy = null;
+            Action action = () => Policy.CacheAsync<ResultPrimitive>(cacheProvider, ttlStrategy);
+            action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("ttlStrategy");
         }
 
         [Fact]
@@ -26,7 +35,7 @@ namespace Polly.Specs
         {
             ICacheProviderAsync cacheProvider = new StubCacheProvider();
             ICacheKeyStrategy cacheKeyStrategy = null;
-            Action action = () => Policy.CacheAsync<ResultPrimitive>(cacheProvider, cacheKeyStrategy);
+            Action action = () => Policy.CacheAsync<ResultPrimitive>(cacheProvider, TimeSpan.MaxValue, cacheKeyStrategy);
             action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("cacheKeyStrategy");
         }
 
@@ -42,8 +51,8 @@ namespace Polly.Specs
             const string executionKey = "SomeExecutionKey";
 
             ICacheProviderAsync stubCacheProvider = new StubCacheProvider();
-            CachePolicy<string> cache = Policy.CacheAsync<string>(stubCacheProvider);
-            await stubCacheProvider.PutAsync(executionKey, valueToReturnFromCache, CancellationToken.None, false).ConfigureAwait(false);
+            CachePolicy<string> cache = Policy.CacheAsync<string>(stubCacheProvider, TimeSpan.MaxValue);
+            await stubCacheProvider.PutAsync(executionKey, TimeSpan.MaxValue, valueToReturnFromCache, CancellationToken.None, false).ConfigureAwait(false);
 
             bool delegateExecuted = false;
 
@@ -66,7 +75,7 @@ namespace Polly.Specs
             const string executionKey = "SomeExecutionKey";
 
             ICacheProviderAsync stubCacheProvider = new StubCacheProvider();
-            CachePolicy<string> cache = Policy.CacheAsync<string>(stubCacheProvider);
+            CachePolicy<string> cache = Policy.CacheAsync<string>(stubCacheProvider, TimeSpan.MaxValue);
 
             ((string)await stubCacheProvider.GetAsync(executionKey, CancellationToken.None, false).ConfigureAwait(false)).Should().BeNull();
 
@@ -76,12 +85,70 @@ namespace Polly.Specs
         }
 
         [Fact]
+        public async void Should_execute_delegate_and_put_value_in_cache_but_when_it_expires_execute_delegate_again()
+        {
+            const string valueToReturn = "valueToReturn";
+            const string executionKey = "SomeExecutionKey";
+
+            ICacheProviderAsync stubCacheProvider = new StubCacheProvider();
+            TimeSpan ttl = TimeSpan.FromMinutes(30);
+            CachePolicy<string> cache = Policy.CacheAsync<string>(stubCacheProvider, ttl);
+
+            ((string)await stubCacheProvider.GetAsync(executionKey, CancellationToken.None, false).ConfigureAwait(false)).Should().BeNull();
+
+            int delegateInvocations = 0;
+            Func<Task<string>> func = async () =>
+            {
+                delegateInvocations++;
+                await TaskHelper.EmptyTask.ConfigureAwait(false);
+                return valueToReturn;
+            };
+
+            DateTime fixedTime = SystemClock.UtcNow();
+            SystemClock.UtcNow = () => fixedTime;
+
+            // First execution should execute delegate and put result in the cache.
+            (await cache.ExecuteAsync(func, new Context(executionKey)).ConfigureAwait(false)).Should().Be(valueToReturn);
+            delegateInvocations.Should().Be(1);
+            ((string)await stubCacheProvider.GetAsync(executionKey, CancellationToken.None, false).ConfigureAwait(false)).Should().Be(valueToReturn);
+
+            // Second execution (before cache expires) should get it from the cache - no further delegate execution.
+            // (Manipulate time so just prior cache expiry).
+            SystemClock.UtcNow = () => fixedTime.Add(ttl).AddTicks(-1);
+            (await cache.ExecuteAsync(func, new Context(executionKey)).ConfigureAwait(false)).Should().Be(valueToReturn);
+            delegateInvocations.Should().Be(1);
+
+            // Manipulate time to force cache expiry.
+            SystemClock.UtcNow = () => fixedTime.Add(ttl).AddTicks(1);
+
+            // Third execution (cache expired) should not get it from the cache - should cause further delegate execution.
+            (await cache.ExecuteAsync(func, new Context(executionKey)).ConfigureAwait(false)).Should().Be(valueToReturn);
+            delegateInvocations.Should().Be(2);
+        }
+
+        [Fact]
+        public async void Should_execute_delegate_but_not_put_value_in_cache_if_cache_does_not_hold_value_but_ttl_indicates_not_worth_caching()
+        {
+            const string valueToReturn = "valueToReturn";
+            const string executionKey = "SomeExecutionKey";
+
+            ICacheProviderAsync stubCacheProvider = new StubCacheProvider();
+            CachePolicy<string> cache = Policy.CacheAsync<string>(stubCacheProvider, TimeSpan.Zero);
+
+            ((string)await stubCacheProvider.GetAsync(executionKey, CancellationToken.None, false).ConfigureAwait(false)).Should().Be(null);
+
+            (await cache.ExecuteAsync(async () => { await TaskHelper.EmptyTask.ConfigureAwait(false); return valueToReturn; }, new Context(executionKey)).ConfigureAwait(false)).Should().Be(valueToReturn);
+
+            ((string)await stubCacheProvider.GetAsync(executionKey, CancellationToken.None, false).ConfigureAwait(false)).Should().Be(null);
+        }
+
+        [Fact]
         public async void Should_return_value_from_cache_and_not_execute_delegate_if_prior_execution_has_cached()
         {
             const string valueToReturn = "valueToReturn";
             const string executionKey = "SomeExecutionKey";
 
-            CachePolicy<string> cache = Policy.CacheAsync<string>(new StubCacheProvider());
+            CachePolicy<string> cache = Policy.CacheAsync<string>(new StubCacheProvider(), TimeSpan.MaxValue);
 
             int delegateInvocations = 0;
             Func<Task<string>> func = async () =>
@@ -106,12 +173,12 @@ namespace Polly.Specs
         {
             ICacheProviderAsync stubCacheProvider = new StubCacheProvider();
             ICacheKeyStrategy cacheKeyStrategy = new MockCacheKeyStrategy(context => context.ExecutionKey + context["id"]);
-            CachePolicy<ResultClass> cache = Policy.CacheAsync<ResultClass>(stubCacheProvider, cacheKeyStrategy);
+            CachePolicy<ResultClass> cache = Policy.CacheAsync<ResultClass>(stubCacheProvider, TimeSpan.MaxValue, cacheKeyStrategy);
 
             object person1 = new ResultClass(ResultPrimitive.Good, "person1");
-            await stubCacheProvider.PutAsync("person1", person1, CancellationToken.None, false).ConfigureAwait(false);
+            await stubCacheProvider.PutAsync("person1", TimeSpan.MaxValue, person1, CancellationToken.None, false).ConfigureAwait(false);
             object person2 = new ResultClass(ResultPrimitive.Good, "person2");
-            await stubCacheProvider.PutAsync("person2", person2, CancellationToken.None, false).ConfigureAwait(false);
+            await stubCacheProvider.PutAsync("person2", TimeSpan.MaxValue, person2, CancellationToken.None, false).ConfigureAwait(false);
 
             bool funcExecuted = false;
             Func<Task<ResultClass>> func = async () => { funcExecuted = true; await TaskHelper.EmptyTask.ConfigureAwait(false); return new ResultClass(ResultPrimitive.Fault, "should never return this one"); };
@@ -132,7 +199,7 @@ namespace Polly.Specs
         {
             string valueToReturn = Guid.NewGuid().ToString();
 
-            CachePolicy<string> cache = Policy.CacheAsync<string>(new StubCacheProvider());
+            CachePolicy<string> cache = Policy.CacheAsync<string>(new StubCacheProvider(), TimeSpan.MaxValue);
 
             int delegateInvocations = 0;
             Func<Task<string>> func = async () => {
@@ -158,7 +225,7 @@ namespace Polly.Specs
             const string valueToReturn = "valueToReturn";
             const string executionKey = "SomeExecutionKey";
 
-            CachePolicy<string> cache = Policy.CacheAsync<string>(new StubCacheProvider());
+            CachePolicy<string> cache = Policy.CacheAsync<string>(new StubCacheProvider(), TimeSpan.MaxValue);
 
             CancellationTokenSource tokenSource = new CancellationTokenSource();
 
@@ -188,7 +255,7 @@ namespace Polly.Specs
             const string executionKey = "SomeExecutionKey";
 
             ICacheProviderAsync stubCacheProvider = new StubCacheProvider();
-            CachePolicy<string> cache = Policy.CacheAsync<string>(stubCacheProvider);
+            CachePolicy<string> cache = Policy.CacheAsync<string>(stubCacheProvider, TimeSpan.MaxValue);
 
             CancellationTokenSource tokenSource = new CancellationTokenSource();
 
@@ -207,5 +274,10 @@ namespace Polly.Specs
         }
 
         #endregion
+
+        public void Dispose()
+        {
+            SystemClock.Reset();
+        }
     }
 }

--- a/src/Polly.SharedSpecs/CacheTResultSpecs.cs
+++ b/src/Polly.SharedSpecs/CacheTResultSpecs.cs
@@ -50,7 +50,7 @@ namespace Polly.Specs
 
             ICacheProvider stubCacheProvider = new StubCacheProvider();
             CachePolicy<string> cache = Policy.Cache<string>(stubCacheProvider, TimeSpan.MaxValue);
-            stubCacheProvider.Put(executionKey, TimeSpan.MaxValue, valueToReturnFromCache);
+            stubCacheProvider.Put(executionKey, valueToReturnFromCache, TimeSpan.MaxValue);
 
             bool delegateExecuted = false;
 
@@ -170,9 +170,9 @@ namespace Polly.Specs
             CachePolicy<ResultClass> cache = Policy.Cache<ResultClass>(stubCacheProvider, TimeSpan.MaxValue, cacheKeyStrategy);
 
             object person1 = new ResultClass(ResultPrimitive.Good, "person1");
-            stubCacheProvider.Put("person1", TimeSpan.MaxValue, person1);
+            stubCacheProvider.Put("person1", person1, TimeSpan.MaxValue);
             object person2 = new ResultClass(ResultPrimitive.Good, "person2");
-            stubCacheProvider.Put("person2", TimeSpan.MaxValue, person2);
+            stubCacheProvider.Put("person2", person2, TimeSpan.MaxValue);
 
             bool funcExecuted = false;
             Func<ResultClass> func = () => { funcExecuted = true; return new ResultClass(ResultPrimitive.Fault, "should never return this one"); };

--- a/src/Polly.SharedSpecs/CacheTResultSpecs.cs
+++ b/src/Polly.SharedSpecs/CacheTResultSpecs.cs
@@ -3,11 +3,12 @@ using System.Threading;
 using FluentAssertions;
 using Polly.Caching;
 using Polly.Specs.Helpers;
+using Polly.Utilities;
 using Xunit;
 
 namespace Polly.Specs
 {
-    public class CacheTResultSpecs
+    public class CacheTResultSpecs : IDisposable
     {
         #region Configuration
 
@@ -15,16 +16,24 @@ namespace Polly.Specs
         public void Should_throw_when_cache_provider_is_null()
         {
             ICacheProvider cacheProvider = null;
-            Action action = () => Policy.Cache<ResultPrimitive>(cacheProvider);
+            Action action = () => Policy.Cache<ResultPrimitive>(cacheProvider, TimeSpan.MaxValue);
             action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("cacheProvider");
         }
 
+        [Fact]
+        public void Should_throw_when_ttl_strategy_is_null()
+        {
+            ICacheProvider cacheProvider = new StubCacheProvider();
+            ITtlStrategy ttlStrategy = null;
+            Action action = () => Policy.Cache<ResultPrimitive>(cacheProvider, ttlStrategy);
+            action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("ttlStrategy");
+        }
         [Fact]
         public void Should_throw_when_cache_key_strategy_is_null()
         {
             ICacheProvider cacheProvider = new StubCacheProvider();
             ICacheKeyStrategy cacheKeyStrategy = null;
-            Action action = () => Policy.Cache<ResultPrimitive>(cacheProvider, cacheKeyStrategy);
+            Action action = () => Policy.Cache<ResultPrimitive>(cacheProvider, TimeSpan.MaxValue, cacheKeyStrategy);
             action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("cacheKeyStrategy");
         }
 
@@ -40,8 +49,8 @@ namespace Polly.Specs
             const string executionKey = "SomeExecutionKey";
 
             ICacheProvider stubCacheProvider = new StubCacheProvider();
-            CachePolicy<string> cache = Policy.Cache<string>(stubCacheProvider);
-            stubCacheProvider.Put(executionKey, valueToReturnFromCache);
+            CachePolicy<string> cache = Policy.Cache<string>(stubCacheProvider, TimeSpan.MaxValue);
+            stubCacheProvider.Put(executionKey, TimeSpan.MaxValue, valueToReturnFromCache);
 
             bool delegateExecuted = false;
 
@@ -62,7 +71,7 @@ namespace Polly.Specs
             const string executionKey = "SomeExecutionKey";
 
             ICacheProvider stubCacheProvider = new StubCacheProvider();
-            CachePolicy<string> cache = Policy.Cache<string>(stubCacheProvider);
+            CachePolicy<string> cache = Policy.Cache<string>(stubCacheProvider, TimeSpan.MaxValue);
 
             stubCacheProvider.Get(executionKey).Should().BeNull();
 
@@ -72,12 +81,69 @@ namespace Polly.Specs
         }
 
         [Fact]
+        public void Should_execute_delegate_and_put_value_in_cache_but_when_it_expires_execute_delegate_again()
+        {
+            const string valueToReturn = "valueToReturn";
+            const string executionKey = "SomeExecutionKey";
+
+            ICacheProvider stubCacheProvider = new StubCacheProvider();
+            TimeSpan ttl = TimeSpan.FromMinutes(30);
+            CachePolicy<string> cache = Policy.Cache<string>(stubCacheProvider, ttl);
+
+            stubCacheProvider.Get(executionKey).Should().BeNull();
+
+            int delegateInvocations = 0;
+            Func<string> func = () =>
+            {
+                delegateInvocations++;
+                return valueToReturn;
+            };
+
+            DateTime fixedTime = SystemClock.UtcNow();
+            SystemClock.UtcNow = () => fixedTime;
+
+            // First execution should execute delegate and put result in the cache.
+            cache.Execute(func, new Context(executionKey)).Should().Be(valueToReturn);
+            delegateInvocations.Should().Be(1);
+            stubCacheProvider.Get(executionKey).Should().Be(valueToReturn);
+
+            // Second execution (before cache expires) should get it from the cache - no further delegate execution.
+            // (Manipulate time so just prior cache expiry).
+            SystemClock.UtcNow = () => fixedTime.Add(ttl).AddTicks(-1);
+            cache.Execute(func, new Context(executionKey)).Should().Be(valueToReturn);
+            delegateInvocations.Should().Be(1);
+
+            // Manipulate time to force cache expiry.
+            SystemClock.UtcNow = () => fixedTime.Add(ttl).AddTicks(1);
+
+            // Third execution (cache expired) should not get it from the cache - should cause further delegate execution.
+            cache.Execute(func, new Context(executionKey)).Should().Be(valueToReturn);
+            delegateInvocations.Should().Be(2);
+        }
+
+        [Fact]
+        public void Should_execute_delegate_but_not_put_value_in_cache_if_cache_does_not_hold_value_but_ttl_indicates_not_worth_caching()
+        {
+            const string valueToReturn = "valueToReturn";
+            const string executionKey = "SomeExecutionKey";
+
+            ICacheProvider stubCacheProvider = new StubCacheProvider();
+            CachePolicy<string> cache = Policy.Cache<string>(stubCacheProvider, TimeSpan.Zero);
+
+            stubCacheProvider.Get(executionKey).Should().BeNull();
+
+            cache.Execute(() => { return valueToReturn; }, new Context(executionKey)).Should().Be(valueToReturn);
+
+            stubCacheProvider.Get(executionKey).Should().Be(null);
+        }
+
+        [Fact]
         public void Should_return_value_from_cache_and_not_execute_delegate_if_prior_execution_has_cached()
         {
             const string valueToReturn = "valueToReturn";
             const string executionKey = "SomeExecutionKey";
 
-            CachePolicy<string> cache = Policy.Cache<string>(new StubCacheProvider());
+            CachePolicy<string> cache = Policy.Cache<string>(new StubCacheProvider(), TimeSpan.MaxValue);
 
             int delegateInvocations = 0;
             Func<string> func = () =>
@@ -101,12 +167,12 @@ namespace Polly.Specs
         {
             ICacheProvider stubCacheProvider = new StubCacheProvider();
             ICacheKeyStrategy cacheKeyStrategy = new MockCacheKeyStrategy(context => context.ExecutionKey + context["id"]);
-            CachePolicy<ResultClass> cache = Policy.Cache<ResultClass>(stubCacheProvider, cacheKeyStrategy);
+            CachePolicy<ResultClass> cache = Policy.Cache<ResultClass>(stubCacheProvider, TimeSpan.MaxValue, cacheKeyStrategy);
 
             object person1 = new ResultClass(ResultPrimitive.Good, "person1");
-            stubCacheProvider.Put("person1", person1);
+            stubCacheProvider.Put("person1", TimeSpan.MaxValue, person1);
             object person2 = new ResultClass(ResultPrimitive.Good, "person2");
-            stubCacheProvider.Put("person2", person2);
+            stubCacheProvider.Put("person2", TimeSpan.MaxValue, person2);
 
             bool funcExecuted = false;
             Func<ResultClass> func = () => { funcExecuted = true; return new ResultClass(ResultPrimitive.Fault, "should never return this one"); };
@@ -127,7 +193,7 @@ namespace Polly.Specs
         {
             string valueToReturn = Guid.NewGuid().ToString();
 
-            CachePolicy<string> cache = Policy.Cache<string>(new StubCacheProvider());
+            CachePolicy<string> cache = Policy.Cache<string>(new StubCacheProvider(), TimeSpan.MaxValue);
 
             int delegateInvocations = 0;
             Func<string> func = () =>
@@ -153,7 +219,7 @@ namespace Polly.Specs
             const string valueToReturn = "valueToReturn";
             const string executionKey = "SomeExecutionKey";
 
-            CachePolicy<string> cache = Policy.Cache<string>(new StubCacheProvider());
+            CachePolicy<string> cache = Policy.Cache<string>(new StubCacheProvider(), TimeSpan.MaxValue);
 
             CancellationTokenSource tokenSource = new CancellationTokenSource();
 
@@ -182,7 +248,7 @@ namespace Polly.Specs
             const string executionKey = "SomeExecutionKey";
 
             ICacheProvider stubCacheProvider = new StubCacheProvider();
-            CachePolicy<string> cache = Policy.Cache<string>(stubCacheProvider);
+            CachePolicy<string> cache = Policy.Cache<string>(stubCacheProvider, TimeSpan.MaxValue);
 
             CancellationTokenSource tokenSource = new CancellationTokenSource();
 
@@ -200,5 +266,10 @@ namespace Polly.Specs
         }
 
         #endregion
+
+        public void Dispose()
+        {
+            SystemClock.Reset();
+        }
     }
 }

--- a/src/Polly.SharedSpecs/ContextualTimeSpanTtlSpecs.cs
+++ b/src/Polly.SharedSpecs/ContextualTimeSpanTtlSpecs.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using FluentAssertions;
+using Polly.Caching;
+using Polly.Specs.Helpers;
+using Xunit;
+
+namespace Polly.Specs
+{
+    public class ContextualTimeSpanTtlSpecs
+    {
+        [Fact]
+        public void Should_return_zero_if_no_value_set_on_context()
+        {
+            new ContextualTimeSpanTtl().GetTtl(new Context("someExecutionKey")).Should().Be(TimeSpan.Zero);
+        }
+
+        [Fact]
+        public void Should_return_zero_if_invalid_value_set_on_context()
+        {
+            Dictionary<string, object> contextData = new Dictionary<string, object>();
+            contextData[ContextualTimeSpanTtl.Key] = new object();
+
+            Context context = new Context(String.Empty, contextData);
+            new ContextualTimeSpanTtl().GetTtl(context).Should().Be(TimeSpan.Zero);
+        }
+
+        [Fact]
+        public void Should_return_value_set_on_context()
+        {
+            TimeSpan ttl = TimeSpan.FromSeconds(30);
+            Dictionary<string, object> contextData = new Dictionary<string, object>();
+            contextData[ContextualTimeSpanTtl.Key] = ttl;
+
+            Context context = new Context(String.Empty, contextData);
+            new ContextualTimeSpanTtl().GetTtl(context).Should().Be(ttl);
+        }
+
+        [Fact]
+        public void Should_return_negative_value_set_on_context()
+        {
+            TimeSpan ttl = TimeSpan.FromTicks(-1);
+            Dictionary<string, object> contextData = new Dictionary<string, object>();
+            contextData[ContextualTimeSpanTtl.Key] = ttl;
+
+            Context context = new Context(String.Empty, contextData);
+            new ContextualTimeSpanTtl().GetTtl(context).Should().Be(ttl);
+        }
+    }
+}

--- a/src/Polly.SharedSpecs/Helpers/StubCacheProvider.cs
+++ b/src/Polly.SharedSpecs/Helpers/StubCacheProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Polly.Caching;
@@ -11,20 +12,39 @@ namespace Polly.Specs.Helpers
     /// </summary>
     internal class StubCacheProvider : ICacheProvider, ICacheProviderAsync
     {
-        private readonly Dictionary<string, object> cachedValues = new Dictionary<string, object>();
+        class CacheItem
+        {
+            public CacheItem(object value, TimeSpan ttl)
+            {
+                Expiry = DateTime.MaxValue - SystemClock.UtcNow() > ttl ? SystemClock.UtcNow().Add(ttl) : DateTime.MaxValue;
+                Value = value;
+            }
+
+            public readonly DateTime Expiry;
+            public readonly object Value;
+        }
+
+        private readonly Dictionary<string, CacheItem> cachedValues = new Dictionary<string, CacheItem>();
 
         public object Get(string key)
         {
             if (cachedValues.ContainsKey(key))
             {
-                return cachedValues[key];
+                if (SystemClock.UtcNow() < cachedValues[key].Expiry)
+                {
+                    return cachedValues[key].Value;
+                }
+                else
+                {
+                    cachedValues.Remove(key);
+                }
             }
             return null;
         }
 
-        public void Put(string key, object value)
+        public void Put(string key, TimeSpan ttl, object value)
         {
-            cachedValues[key] = value;
+            cachedValues[key] = new CacheItem(value, ttl);
         }
 
         #region Naive async-over-sync implementation
@@ -36,10 +56,10 @@ namespace Polly.Specs.Helpers
             return Task.FromResult(Get(key));
         }
 
-        public Task PutAsync(string key, object value, CancellationToken cancellationToken,
+        public Task PutAsync(string key, TimeSpan ttl, object value, CancellationToken cancellationToken,
             bool continueOnCapturedContext)
         {
-            Put(key, value);
+            Put(key, ttl, value);
             return TaskHelper.EmptyTask;
         }
 

--- a/src/Polly.SharedSpecs/Helpers/StubCacheProvider.cs
+++ b/src/Polly.SharedSpecs/Helpers/StubCacheProvider.cs
@@ -42,7 +42,7 @@ namespace Polly.Specs.Helpers
             return null;
         }
 
-        public void Put(string key, TimeSpan ttl, object value)
+        public void Put(string key, object value, TimeSpan ttl)
         {
             cachedValues[key] = new CacheItem(value, ttl);
         }
@@ -56,10 +56,9 @@ namespace Polly.Specs.Helpers
             return Task.FromResult(Get(key));
         }
 
-        public Task PutAsync(string key, TimeSpan ttl, object value, CancellationToken cancellationToken,
-            bool continueOnCapturedContext)
+        public Task PutAsync(string key, object value, TimeSpan ttl, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
-            Put(key, ttl, value);
+            Put(key, value, ttl);
             return TaskHelper.EmptyTask;
         }
 

--- a/src/Polly.SharedSpecs/MappingCacheProviderSpecs.cs
+++ b/src/Polly.SharedSpecs/MappingCacheProviderSpecs.cs
@@ -30,8 +30,8 @@ namespace Polly.Specs
             const string executionKey = "SomeExecutionKey";
 
             ICacheProvider mappedCacheProvider = new StubMappingCacheProvider_base64(new StubCacheProvider());
-            CachePolicy cache = Policy.Cache(mappedCacheProvider);
-            mappedCacheProvider.Put(executionKey, valueToReturnFromCache);
+            CachePolicy cache = Policy.Cache(mappedCacheProvider, TimeSpan.MaxValue);
+            mappedCacheProvider.Put(executionKey, TimeSpan.MaxValue, valueToReturnFromCache);
 
             bool delegateExecuted = false;
 
@@ -52,7 +52,7 @@ namespace Polly.Specs
             const string executionKey = "SomeExecutionKey";
 
             ICacheProvider mappedCacheProvider = new StubMappingCacheProvider_base64(new StubCacheProvider());
-            CachePolicy cache = Policy.Cache(mappedCacheProvider);
+            CachePolicy cache = Policy.Cache(mappedCacheProvider, TimeSpan.MaxValue);
 
             mappedCacheProvider.Get(executionKey).Should().BeNull();
 
@@ -67,7 +67,7 @@ namespace Polly.Specs
             const string valueToReturn = "valueToReturn";
             const string executionKey = "SomeExecutionKey";
 
-            CachePolicy cache = Policy.Cache(new StubMappingCacheProvider_base64(new StubCacheProvider()));
+            CachePolicy cache = Policy.Cache(new StubMappingCacheProvider_base64(new StubCacheProvider()), TimeSpan.MaxValue);
 
             int delegateExecutions = 0;
             Func<string> func = () =>
@@ -96,7 +96,7 @@ namespace Polly.Specs
             const string valueToReturn = "valueToReturn";
             const string executionKey = "SomeExecutionKey";
 
-            CachePolicy cache = Policy.Cache(new StubMappingCacheProvider_Reverse(new StubMappingCacheProvider_base64(new StubCacheProvider())));
+            CachePolicy cache = Policy.Cache(new StubMappingCacheProvider_Reverse(new StubMappingCacheProvider_base64(new StubCacheProvider())), TimeSpan.MaxValue);
 
             int delegateExecutions = 0;
             Func<string> func = () =>

--- a/src/Polly.SharedSpecs/MappingCacheProviderSpecs.cs
+++ b/src/Polly.SharedSpecs/MappingCacheProviderSpecs.cs
@@ -31,7 +31,7 @@ namespace Polly.Specs
 
             ICacheProvider mappedCacheProvider = new StubMappingCacheProvider_base64(new StubCacheProvider());
             CachePolicy cache = Policy.Cache(mappedCacheProvider, TimeSpan.MaxValue);
-            mappedCacheProvider.Put(executionKey, TimeSpan.MaxValue, valueToReturnFromCache);
+            mappedCacheProvider.Put(executionKey, valueToReturnFromCache, TimeSpan.MaxValue);
 
             bool delegateExecuted = false;
 

--- a/src/Polly.SharedSpecs/MappingCacheProviderTResultTMappedSpecs.cs
+++ b/src/Polly.SharedSpecs/MappingCacheProviderTResultTMappedSpecs.cs
@@ -31,7 +31,7 @@ namespace Polly.Specs
 
             ICacheProvider<string> mappedCacheProvider = new TypedStubMappingCacheProvider_base64(new StubCacheProvider().As<string>());
             CachePolicy<string> cache = Policy.Cache(mappedCacheProvider, TimeSpan.MaxValue);
-            mappedCacheProvider.Put(executionKey, TimeSpan.MaxValue, valueToReturnFromCache);
+            mappedCacheProvider.Put(executionKey, valueToReturnFromCache, TimeSpan.MaxValue);
 
             bool delegateExecuted = false;
 

--- a/src/Polly.SharedSpecs/MappingCacheProviderTResultTMappedSpecs.cs
+++ b/src/Polly.SharedSpecs/MappingCacheProviderTResultTMappedSpecs.cs
@@ -30,8 +30,8 @@ namespace Polly.Specs
             const string executionKey = "SomeExecutionKey";
 
             ICacheProvider<string> mappedCacheProvider = new TypedStubMappingCacheProvider_base64(new StubCacheProvider().As<string>());
-            CachePolicy<string> cache = Policy.Cache(mappedCacheProvider);
-            mappedCacheProvider.Put(executionKey, valueToReturnFromCache);
+            CachePolicy<string> cache = Policy.Cache(mappedCacheProvider, TimeSpan.MaxValue);
+            mappedCacheProvider.Put(executionKey, TimeSpan.MaxValue, valueToReturnFromCache);
 
             bool delegateExecuted = false;
 
@@ -52,7 +52,7 @@ namespace Polly.Specs
             const string executionKey = "SomeExecutionKey";
 
             ICacheProvider<string> mappedCacheProvider = new TypedStubMappingCacheProvider_base64(new StubCacheProvider().As<string>());
-            CachePolicy<string> cache = Policy.Cache(mappedCacheProvider);
+            CachePolicy<string> cache = Policy.Cache(mappedCacheProvider, TimeSpan.MaxValue);
 
             mappedCacheProvider.Get(executionKey).Should().BeNull();
 
@@ -67,7 +67,7 @@ namespace Polly.Specs
             const string valueToReturn = "valueToReturn";
             const string executionKey = "SomeExecutionKey";
 
-            CachePolicy<string> cache = Policy.Cache(new TypedStubMappingCacheProvider_base64(new StubCacheProvider().As<string>()));
+            CachePolicy<string> cache = Policy.Cache(new TypedStubMappingCacheProvider_base64(new StubCacheProvider().As<string>()), TimeSpan.MaxValue);
 
             int delegateExecutions = 0;
             Func<string> func = () =>
@@ -96,7 +96,7 @@ namespace Polly.Specs
             const string valueToReturn = "valueToReturn";
             const string executionKey = "SomeExecutionKey";
 
-            CachePolicy<string> cache = Policy.Cache(new TypedStubMappingCacheProvider_Reverse(new TypedStubMappingCacheProvider_base64(new StubCacheProvider().As<string>())));
+            CachePolicy<string> cache = Policy.Cache(new TypedStubMappingCacheProvider_Reverse(new TypedStubMappingCacheProvider_base64(new StubCacheProvider().As<string>())), TimeSpan.MaxValue);
 
             int delegateExecutions = 0;
             Func<string> func = () =>

--- a/src/Polly.SharedSpecs/PointInTimeTtlSpecs.cs
+++ b/src/Polly.SharedSpecs/PointInTimeTtlSpecs.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using FluentAssertions;
+using Polly.Caching;
+using Polly.Utilities;
+using Xunit;
+
+namespace Polly.Specs
+{
+    public class PointInTimeTtlSpecs : IDisposable
+    {
+        [Fact]
+        public void Should_be_able_to_configure_for_near_future_time()
+        {
+            Action configure = () => new PointInTimeTtl(DateTime.Today.AddDays(1));
+
+            configure.ShouldNotThrow();
+        }
+
+        [Fact]
+        public void Should_be_able_to_configure_for_far_future()
+        {
+            Action configure = () => new PointInTimeTtl(DateTimeOffset.MaxValue);
+
+            configure.ShouldNotThrow();
+        }
+
+        [Fact]
+        public void Should_be_able_to_configure_for_past()
+        {
+            Action configure = () => new PointInTimeTtl(DateTimeOffset.MinValue);
+
+            configure.ShouldNotThrow();
+        }
+
+        [Fact]
+        public void Should_return_zero_ttl_if_configured_to_expire_in_past()
+        {
+            PointInTimeTtl ttlStrategy = new PointInTimeTtl(DateTimeOffset.UtcNow.Subtract(TimeSpan.FromTicks(1)));
+
+            ttlStrategy.GetTtl(new Context("someExecutionKey")).Should().Be(TimeSpan.Zero);
+        }
+
+        [Fact]
+        public void Should_return_timespan_reflecting_time_until_expiry()
+        {
+            DateTime today = DateTime.Today;
+            DateTime tomorrow = today.AddDays(1);
+
+            PointInTimeTtl ttlStrategy = new PointInTimeTtl(tomorrow);
+
+            SystemClock.DateTimeOffsetUtcNow = () => today;
+            ttlStrategy.GetTtl(new Context("someExecutionKey")).Should().Be(TimeSpan.FromDays(1));
+        }
+
+        public void Dispose()
+        {
+            SystemClock.Reset();
+        }
+    }
+}

--- a/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
+++ b/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
@@ -28,6 +28,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ContextSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ContextualPolicyAsyncSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ContextualPolicySpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ContextualTimeSpanTtlSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DefaultCacheKeyStrategySpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FallbackAsyncSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FallbackSpecs.cs" />
@@ -51,6 +52,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ResultPrimitive.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MappingCacheProviderSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MappingCacheProviderTResultTMappedSpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)PointInTimeTtlSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PolicyAsyncSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PolicyContextAndKeyAsyncSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PolicyContextAndKeySpecs.cs" />
@@ -70,6 +72,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)TimeoutSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TimeoutTResultAsyncSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TimeoutTResultSpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TimeSpanTtlSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WaitAndRetryAsyncSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WaitAndRetryForeverAsyncSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WaitAndRetrySpecs.cs" />

--- a/src/Polly.SharedSpecs/TimeSpanTtlSpecs.cs
+++ b/src/Polly.SharedSpecs/TimeSpanTtlSpecs.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using FluentAssertions;
+using Polly.Caching;
+using Xunit;
+
+namespace Polly.Specs
+{
+    public class TimeSpanTtlSpecs
+    {
+        [Fact]
+        public void Should_throw_when_timespan_is_less_than_zero()
+        {
+            Action configure = () => new TimeSpanTtl(TimeSpan.FromMilliseconds(-1));
+
+            configure.ShouldThrow<ArgumentOutOfRangeException>().And.ParamName.Should().Be("ttl");
+        }
+
+        [Fact]
+        public void Should_not_throw_when_timespan_is_zero()
+        {
+            Action configure = () => new TimeSpanTtl(TimeSpan.Zero);
+
+            configure.ShouldNotThrow();
+        }
+
+        [Fact]
+        public void Should_allow_timespan_max_value()
+        {
+            Action configure = () => new TimeSpanTtl(TimeSpan.MaxValue);
+
+            configure.ShouldNotThrow();
+        }
+
+        [Fact]
+        public void Should_return_configured_timespan()
+        {
+            TimeSpan ttl = TimeSpan.FromSeconds(30);
+
+            TimeSpanTtl ttlStrategy = new TimeSpanTtl(ttl);
+
+            ttlStrategy.GetTtl(new Context("someExecutionKey")).Should().Be(ttl);
+        }
+    }
+}


### PR DESCRIPTION
Add to cache architecture spike : selection of caching ttl strategy by strategy pattern, when configuring a `CachePolicy`

(subject to review / change later, but gives cache contributors an improved baseline to continue spiking `ICacheProvider`s)

