### PR TITLE
Refine cancellation in Retry, CircuitBreaker, Timeout and Fallback policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 5.0.3
+## 5.0.3 RTM
 - Refine implementation of cancellable synchronous WaitAndRetry
+- Minor breaking change: Where a user delegate does not observe cancellation, Polly will now honour the delegate's outcome rather than throw for the unobserved cancellation (issue 188).
 
-## 5.0.2
+## 5.0.2 alpha
 
 - .NETStandard1.0 target: Correctly state dependencies. 
 - .NETStandard1.0 target: Fix SemVer stamping of Polly.dll.
@@ -12,11 +13,11 @@
 - Added Polly.Net40Async specs project.
 - Fix issue 179: Make Net4.0 async implementation for Bulkhead truly async. 
 
-## 5.0.1
+## 5.0.1 alpha
 
 - Add .NET Standard 1.0 project and target.
 
-## 5.0.0
+## 5.0.0 alpha
 
 A major release, adding significant new resilience policies:
 - Timeout policy: allows timing out any execution. Thanks to [@reisenberger](https://github.com/reisenberger).

--- a/src/Polly.Net40Async.nuspec
+++ b/src/Polly.Net40Async.nuspec
@@ -13,25 +13,23 @@
     <tags>Exception Handling Resilience Transient Fault Policy Circuit Breaker CircuitBreaker Retry Wait Bulkhead Fallback Timeout Throttle Parallelization</tags>
     <copyright>Copyright © 2016, App vNext</copyright>
     <releaseNotes>
-     5.0.3
+     v5.0 is a major release with significant new resilience policies: Timeout; Bulkhead Isolation; Fallback; and PolicyWrap.  See release notes back to v5.0.0 for full details.
+
+     5.0.3 RTM
      ---------------------
      - Refine implementation of cancellable synchronous WaitAndRetry
+     - Minor breaking change: Where a user delegate does not observe cancellation, Polly will now honour the delegate's outcome rather than throw for the unobserved cancellation (issue 188).
 
-     5.0.2
+     5.0.2 alpha
      ---------------------
-     - (.NETStandard1.0 target: Correctly state dependencies). 
-     - (.NETStandard1.0 target: Fix SemVer stamping of Polly.dll).
-     - (PCL259 project and target: Remove, in favour of .NETStandard1.0 target.  PCL259 is still supported, via .NETStandard1.0 target).
-     - Tidy build around GitVersionTask and ReferenceGenerator.
-     - Update FluentAssertions dependency.
      - Add full specs support for .NET40. 
      - Fix issue 179: Make Net4.0 async implementation for Bulkhead truly async.
 
-     5.0.1
+     5.0.1 alpha
      ---------------------
-     - (Add a .NETStandard1.0 project and target to main Nuget package).
+     - (Add a .NETStandard1.0 target.)
 
-     5.0.0
+     5.0.0 alpha
      ---------------------
      A major release, adding significant new resilience policies:
      - Timeout policy: allows timing out any execution

--- a/src/Polly.Shared/CircuitBreaker/CircuitBreakerEngine.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitBreakerEngine.cs
@@ -23,8 +23,6 @@ namespace Polly.CircuitBreaker
             {
                 DelegateResult<TResult> delegateOutcome = new DelegateResult<TResult>(action(cancellationToken));
 
-                cancellationToken.ThrowIfCancellationRequested();
-
                 if (shouldHandleResultPredicates.Any(predicate => predicate(delegateOutcome.Result)))
                 {
                     breakerController.OnActionFailure(delegateOutcome, context);
@@ -38,15 +36,6 @@ namespace Polly.CircuitBreaker
             }
             catch (Exception ex)
             {
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    if (ex is OperationCanceledException && ((OperationCanceledException)ex).CancellationToken == cancellationToken)
-                    {
-                        throw;
-                    }
-                    cancellationToken.ThrowIfCancellationRequested();
-                }
-
                 if (!shouldHandleExceptionPredicates.Any(predicate => predicate(ex)))
                 {
                     throw;

--- a/src/Polly.Shared/CircuitBreaker/CircuitBreakerEngineAsync.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitBreakerEngineAsync.cs
@@ -27,8 +27,6 @@ namespace Polly.CircuitBreaker
             {
                 DelegateResult<TResult> delegateOutcome = new DelegateResult<TResult>(await action(cancellationToken).ConfigureAwait(continueOnCapturedContext));
 
-                cancellationToken.ThrowIfCancellationRequested();
-
                 if (shouldHandleResultPredicates.Any(predicate => predicate(delegateOutcome.Result)))
                 {
                     breakerController.OnActionFailure(delegateOutcome, context);
@@ -42,15 +40,6 @@ namespace Polly.CircuitBreaker
             }
             catch (Exception ex)
             {
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    if (ex is OperationCanceledException && ((OperationCanceledException) ex).CancellationToken == cancellationToken)
-                    {
-                        throw;
-                    }
-                    cancellationToken.ThrowIfCancellationRequested();
-                }
-
                 if (!shouldHandleExceptionPredicates.Any(predicate => predicate(ex)))
                 {
                     throw;

--- a/src/Polly.Shared/Fallback/FallbackEngine.cs
+++ b/src/Polly.Shared/Fallback/FallbackEngine.cs
@@ -18,13 +18,11 @@ namespace Polly.Fallback
         {
             DelegateResult<TResult> delegateOutcome;
 
-            cancellationToken.ThrowIfCancellationRequested();
-
             try
             {
-                delegateOutcome = new DelegateResult<TResult>(action(cancellationToken));
-
                 cancellationToken.ThrowIfCancellationRequested();
+
+                delegateOutcome = new DelegateResult<TResult>(action(cancellationToken));
 
                 if (!shouldHandleResultPredicates.Any(predicate => predicate(delegateOutcome.Result)))
                 {
@@ -33,15 +31,6 @@ namespace Polly.Fallback
             }
             catch (Exception ex)
             {
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    if (ex is OperationCanceledException && ((OperationCanceledException)ex).CancellationToken == cancellationToken)
-                    {
-                        throw;
-                    }
-                    cancellationToken.ThrowIfCancellationRequested();
-                }
-
                 if (!shouldHandleExceptionPredicates.Any(predicate => predicate(ex)))
                 {
                     throw;
@@ -51,8 +40,6 @@ namespace Polly.Fallback
             }
 
             onFallback(delegateOutcome, context);
-
-            cancellationToken.ThrowIfCancellationRequested();
 
             return fallbackAction(cancellationToken);
         }

--- a/src/Polly.Shared/Retry/RetryEngine.cs
+++ b/src/Polly.Shared/Retry/RetryEngine.cs
@@ -24,8 +24,6 @@ namespace Polly.Retry
                 {
                     DelegateResult<TResult> delegateOutcome = new DelegateResult<TResult>(action(cancellationToken));
 
-                    cancellationToken.ThrowIfCancellationRequested();
-
                     if (!shouldRetryResultPredicates.Any(predicate => predicate(delegateOutcome.Result)))
                     {
                         return delegateOutcome.Result;
@@ -38,15 +36,6 @@ namespace Polly.Retry
                 }
                 catch (Exception ex)
                 {
-                    if (cancellationToken.IsCancellationRequested)
-                    {
-                        if (ex is OperationCanceledException && ((OperationCanceledException)ex).CancellationToken == cancellationToken)
-                        {
-                            throw;
-                        }
-                        cancellationToken.ThrowIfCancellationRequested();
-                    }
-
                     if (!shouldRetryExceptionPredicates.Any(predicate => predicate(ex)))
                     {
                         throw;

--- a/src/Polly.Shared/Retry/RetryEngineAsync.cs
+++ b/src/Polly.Shared/Retry/RetryEngineAsync.cs
@@ -29,12 +29,14 @@ namespace Polly.Retry
                 {
                     DelegateResult<TResult> delegateOutcome = new DelegateResult<TResult>(await action(cancellationToken).ConfigureAwait(continueOnCapturedContext));
 
-                    cancellationToken.ThrowIfCancellationRequested();
+                    //cancellationToken.ThrowIfCancellationRequested();
 
                     if (!shouldRetryResultPredicates.Any(predicate => predicate(delegateOutcome.Result)))
                     {
                         return delegateOutcome.Result;
                     }
+
+                    //cancellationToken.ThrowIfCancellationRequested();
 
                     if (!await policyState
                         .CanRetryAsync(delegateOutcome, cancellationToken, continueOnCapturedContext)
@@ -45,14 +47,14 @@ namespace Polly.Retry
                 }
                 catch (Exception ex)
                 {
-                    if (cancellationToken.IsCancellationRequested)
-                    {
-                        if (ex is OperationCanceledException && ((OperationCanceledException)ex).CancellationToken == cancellationToken)
-                        {
-                            throw;
-                        }
-                        cancellationToken.ThrowIfCancellationRequested();
-                    }
+                    //if (cancellationToken.IsCancellationRequested)
+                    //{
+                    //    if (ex is OperationCanceledException && ((OperationCanceledException)ex).CancellationToken == cancellationToken)
+                    //    {
+                    //        throw;
+                    //    }
+                    //    cancellationToken.ThrowIfCancellationRequested();
+                    //}
 
                     if (!shouldRetryExceptionPredicates.Any(predicate => predicate(ex)))
                     {

--- a/src/Polly.Shared/Timeout/TimeoutEngine.cs
+++ b/src/Polly.Shared/Timeout/TimeoutEngine.cs
@@ -48,7 +48,7 @@ namespace Polly.Timeout
                             action(combinedToken)       // cancellation token here allows the user delegate to react to cancellation: possibly clear up; then throw an OperationCanceledException.
                             , combinedToken);           // cancellation token here only allows Task.Run() to not begin the passed delegate at all, if cancellation occurs prior to invoking the delegate.  
 
-                        actionTask.Wait(combinedToken); // cancellation token here cancels the Wait() and causes it to throw, but does not cancel actionTask.
+                        actionTask.Wait(timeoutCancellationTokenSource.Token); // cancellation token here cancels the Wait() and causes it to throw, but does not cancel actionTask.  We use only timeoutCancellationTokenSource.Token here, not combinedToken.  If we allowed the user's cancellation token to cancel the Wait(), in this pessimistic scenario where the user delegate may not observe that cancellation, that would create a no-longer-observed task.  That task could in turn later fault before completing, risking an UnobservedTaskException.
 
                         return actionTask.Result;
                     }

--- a/src/Polly.SharedSpecs/AdvancedCircuitBreakerAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/AdvancedCircuitBreakerAsyncSpecs.cs
@@ -2377,7 +2377,7 @@ namespace Polly.Specs
         }
 
         [Fact]
-        public void Should_report_cancellation_during_faulting_action_execution_when_user_delegate_does_not_observe_cancellationtoken()
+        public void Should_report_faulting_from_faulting_action_execution_when_user_delegate_does_not_observe_cancellation()
         {
             var durationOfBreak = TimeSpan.FromMinutes(1);
             CircuitBreakerPolicy breaker = Policy
@@ -2398,8 +2398,7 @@ namespace Polly.Specs
             };
 
             breaker.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
-                .And.CancellationToken.Should().Be(cancellationToken);
+                .ShouldThrow<DivideByZeroException>();
 
             attemptsInvoked.Should().Be(1);
         }

--- a/src/Polly.SharedSpecs/CircuitBreakerAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreakerAsyncSpecs.cs
@@ -1011,7 +1011,7 @@ namespace Polly.Specs
         }
 
         [Fact]
-        public void Should_report_cancellation_during_faulting_action_execution_when_user_delegate_does_not_observe_cancellationtoken()
+        public void Should_report_faulting_from_faulting_action_execution_when_user_delegate_does_not_observe_cancellation()
         {
             var durationOfBreak = TimeSpan.FromMinutes(1);
             CircuitBreakerPolicy breaker = Policy
@@ -1032,8 +1032,7 @@ namespace Polly.Specs
             };
 
             breaker.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
-                .And.CancellationToken.Should().Be(cancellationToken);
+                .ShouldThrow<DivideByZeroException>();
 
             attemptsInvoked.Should().Be(1);
         }

--- a/src/Polly.SharedSpecs/CircuitBreakerSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreakerSpecs.cs
@@ -1012,7 +1012,7 @@ namespace Polly.Specs
         }
 
         [Fact]
-        public void Should_report_cancellation_during_faulting_action_execution_when_user_delegate_does_not_observe_cancellationtoken()
+        public void Should_report_faulting_from_faulting_action_execution_when_user_delegate_does_not_observe_cancellation()
         {
             var durationOfBreak = TimeSpan.FromMinutes(1);
             CircuitBreakerPolicy breaker = Policy
@@ -1033,8 +1033,7 @@ namespace Polly.Specs
             };
 
             breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
-                .And.CancellationToken.Should().Be(cancellationToken);
+                .ShouldThrow<DivideByZeroException>();
 
             attemptsInvoked.Should().Be(1);
         }

--- a/src/Polly.SharedSpecs/CircuitBreakerTResultAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreakerTResultAsyncSpecs.cs
@@ -11,7 +11,6 @@ using Xunit;
 
 using Scenario = Polly.Specs.Helpers.PolicyTResultExtensionsAsync.ResultAndOrCancellationScenario;
 
-
 namespace Polly.Specs
 {
     public class CircuitBreakerTResultAsyncSpecs : IDisposable
@@ -1087,7 +1086,7 @@ namespace Polly.Specs
         }
 
         [Fact]
-        public void Should_report_cancellation_during_faulting_action_execution_when_user_delegate_does_not_observe_cancellationtoken()
+        public async void Should_report_faulting_from_faulting_action_execution_when_user_delegate_does_not_observe_cancellation()
         {
             var durationOfBreak = TimeSpan.FromMinutes(1);
             CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
@@ -1106,11 +1105,8 @@ namespace Polly.Specs
                 ActionObservesCancellation = false
             };
 
-            breaker.Awaiting(async x => await x.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute,
-                   ResultPrimitive.Fault,
-                   ResultPrimitive.Good))
-                .ShouldThrow<TaskCanceledException>()
-                .And.CancellationToken.Should().Be(cancellationToken);
+            (await breaker.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute, ResultPrimitive.Fault).ConfigureAwait(false))
+                            .Should().Be(ResultPrimitive.Fault);
 
             attemptsInvoked.Should().Be(1);
         }

--- a/src/Polly.SharedSpecs/FallbackAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/FallbackAsyncSpecs.cs
@@ -488,7 +488,7 @@ namespace Polly.Specs
         }
 
         [Fact]
-        public void Should_report_cancellation_and_not_execute_fallback_during_otherwise_non_faulting_action_execution_when_user_delegate_observes_cancellationtoken()
+        public void Should_report_cancellation_and_not_execute_fallback_during_otherwise_non_faulting_action_execution_when_user_delegate_observes_cancellationtoken_and_fallback_does_not_handle_cancellations()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task> fallbackActionAsync = _ => { fallbackActionExecuted = true; return TaskHelper.EmptyTask; };
@@ -519,7 +519,38 @@ namespace Polly.Specs
         }
 
         [Fact]
-        public void Should_report_cancellation_and_not_execute_fallback_during_otherwise_non_faulting_action_execution_when_user_delegate_does_not_observe_cancellationtoken()
+        public void Should_handle_cancellation_and_execute_fallback_during_otherwise_non_faulting_action_execution_when_user_delegate_observes_cancellationtoken_and_fallback_handles_cancellations()
+        {
+            bool fallbackActionExecuted = false;
+            Func<CancellationToken, Task> fallbackActionAsync = _ => { fallbackActionExecuted = true; return TaskHelper.EmptyTask; };
+
+            FallbackPolicy policy = Policy
+                                    .Handle<DivideByZeroException>()
+                                    .Or<OperationCanceledException>()
+                                    .FallbackAsync(fallbackActionAsync);
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+
+            int attemptsInvoked = 0;
+            Action onExecute = () => attemptsInvoked++;
+
+            Scenario scenario = new Scenario
+            {
+                NumberOfTimesToRaiseException = 0,
+                AttemptDuringWhichToCancel = 1,
+                ActionObservesCancellation = true
+            };
+
+            policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .ShouldNotThrow();
+            attemptsInvoked.Should().Be(1);
+
+            fallbackActionExecuted.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Should_not_report_cancellation_and_not_execute_fallback_if_non_faulting_action_execution_completes_and_user_delegate_does_not_observe_the_set_cancellationtoken()
         {
 
             bool fallbackActionExecuted = false;
@@ -543,15 +574,14 @@ namespace Polly.Specs
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
-                .And.CancellationToken.Should().Be(cancellationToken);
+                .ShouldNotThrow();
             attemptsInvoked.Should().Be(1);
 
             fallbackActionExecuted.Should().BeFalse();
         }
 
         [Fact]
-        public void Should_report_cancellation_after_faulting_action_execution_and_not_call_fallback_function_if_onFallback_invokes_cancellation()
+        public void Should_report_unhandled_fault_and_not_execute_fallback_if_action_execution_raises_unhandled_fault_and_user_delegate_does_not_observe_the_set_cancellationtoken()
         {
 
             bool fallbackActionExecuted = false;
@@ -561,11 +591,9 @@ namespace Polly.Specs
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            Func<Exception, Context, Task> onFallbackAsync = (_, __) => { cancellationTokenSource.Cancel(); return TaskHelper.EmptyTask; };
-
             FallbackPolicy policy = Policy
                                     .Handle<DivideByZeroException>()
-                                    .FallbackAsync(fallbackActionAsync, onFallbackAsync);
+                                    .FallbackAsync(fallbackActionAsync);
 
             int attemptsInvoked = 0;
             Action onExecute = () => attemptsInvoked++;
@@ -573,16 +601,47 @@ namespace Polly.Specs
             Scenario scenario = new Scenario
             {
                 NumberOfTimesToRaiseException = 1,
-                AttemptDuringWhichToCancel = null, // Cancellation during onFallback instead - see above.
+                AttemptDuringWhichToCancel = 1,
+                ActionObservesCancellation = false
+            };
+
+            policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<NullReferenceException>(scenario, cancellationTokenSource, onExecute))
+                .ShouldThrow<NullReferenceException>();
+            attemptsInvoked.Should().Be(1);
+
+            fallbackActionExecuted.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Should_handle_handled_fault_and_execute_fallback_following_faulting_action_execution_when_user_delegate_does_not_observe_cancellationtoken()
+        {
+
+            bool fallbackActionExecuted = false;
+            Func<CancellationToken, Task> fallbackActionAsync = _ => { fallbackActionExecuted = true; return TaskHelper.EmptyTask; };
+
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+
+            FallbackPolicy policy = Policy
+                                    .Handle<DivideByZeroException>()
+                                    .FallbackAsync(fallbackActionAsync);
+
+            int attemptsInvoked = 0;
+            Action onExecute = () => attemptsInvoked++;
+
+            Scenario scenario = new Scenario
+            {
+                NumberOfTimesToRaiseException = 1,
+                AttemptDuringWhichToCancel = 1,
                 ActionObservesCancellation = false
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
-                .And.CancellationToken.Should().Be(cancellationToken);
+                .ShouldNotThrow();
             attemptsInvoked.Should().Be(1);
 
-            fallbackActionExecuted.Should().BeFalse();
+            fallbackActionExecuted.Should().BeTrue();
         }
 
         #endregion

--- a/src/Polly.SharedSpecs/Helpers/PolicyTResultExtensionsAsync.cs
+++ b/src/Polly.SharedSpecs/Helpers/PolicyTResultExtensionsAsync.cs
@@ -28,7 +28,7 @@ namespace Polly.Specs.Helpers
             {
                 if (!enumerator.MoveNext())
                 {
-                    throw new ArgumentOutOfRangeException("resultsToRaise", "Not enough TResult values in resultsToRaise.");
+                    throw new ArgumentOutOfRangeException(nameof(resultsToRaise), "Not enough TResult values in resultsToRaise.");
                 }
 
                 return Task.FromResult(enumerator.Current);
@@ -104,7 +104,7 @@ namespace Polly.Specs.Helpers
 
                 if (!enumerator.MoveNext())
                 {
-                    throw new ArgumentOutOfRangeException("resultsToRaise", "Not enough TResult values in resultsToRaise.");
+                    throw new ArgumentOutOfRangeException(nameof(resultsToRaise), "Not enough TResult values in resultsToRaise.");
                 }
 
                 if (scenario.AttemptDuringWhichToCancel.HasValue && counter >= scenario.AttemptDuringWhichToCancel.Value)

--- a/src/Polly.SharedSpecs/RetrySpecs.cs
+++ b/src/Polly.SharedSpecs/RetrySpecs.cs
@@ -610,7 +610,34 @@ namespace Polly.Specs
         }
 
         [Fact]
-        public void Should_report_cancellation_during_faulting_last_retry_execution_when_user_delegate_does_not_observe_cancellationtoken()
+        public void Should_report_cancellation_during_faulting_last_retry_execution_when_user_delegate_does_observe_cancellationtoken()
+        {
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .Retry(3);
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+
+            int attemptsInvoked = 0;
+            Action onExecute = () => attemptsInvoked++;
+
+            PolicyExtensions.ExceptionAndOrCancellationScenario scenario = new PolicyExtensions.ExceptionAndOrCancellationScenario
+            {
+                NumberOfTimesToRaiseException = 1 + 3,
+                AttemptDuringWhichToCancel = 1 + 3,
+                ActionObservesCancellation = true
+            };
+
+            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .ShouldThrow<OperationCanceledException>()
+                .And.CancellationToken.Should().Be(cancellationToken);
+
+            attemptsInvoked.Should().Be(1 + 3);
+        }
+
+        [Fact]
+        public void Should_report_faulting_from_faulting_last_retry_execution_when_user_delegate_does_not_observe_cancellation_raised_during_last_retry()
         {
             var policy = Policy
                 .Handle<DivideByZeroException>()
@@ -630,8 +657,7 @@ namespace Polly.Specs
             };
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
-                .And.CancellationToken.Should().Be(cancellationToken);
+                .ShouldThrow<DivideByZeroException>();
 
             attemptsInvoked.Should().Be(1 + 3);
         }

--- a/src/Polly.SharedSpecs/TimeoutAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/TimeoutAsyncSpecs.cs
@@ -257,15 +257,68 @@ namespace Polly.Specs
 
         #endregion
 
-        #region Non-timeout cancellation
+        #region Non-timeout cancellation - pessimistic (user-delegate does not observe cancellation)
 
         [Fact]
-        public void Should_be_able_to_cancel_with_user_cancellation_token_before_timeout()
+        public void Should_not_be_able_to_cancel_with_user_cancellation_token_before_timeout__pessimistic()
+        {
+            Stopwatch watch = new Stopwatch();
+
+            int timeout = 5;
+            var policy = Policy.TimeoutAsync(timeout, TimeoutStrategy.Pessimistic);
+
+            TimeSpan tolerance = TimeSpan.FromSeconds(1); // Consider increasing tolerance, if test fails transiently in different test/build environments.
+
+            TimeSpan userTokenExpiry = TimeSpan.FromSeconds(1); // Use of time-based token irrelevant to timeout policy; we just need some user token that cancels independently of policy's internal token.
+            using (CancellationTokenSource userTokenSource = new CancellationTokenSource(userTokenExpiry))
+            {
+                watch.Start();
+                policy.Awaiting(async p => await p.ExecuteAsync(async
+                    _ => {
+                        await SystemClock.SleepAsync(TimeSpan.FromSeconds(timeout + 2), CancellationToken.None).ConfigureAwait(false); // Do not observe any cancellation in the middle of execution
+
+                    }, userTokenSource.Token) // ... with user token.
+                   ).ShouldThrow<TimeoutRejectedException>();
+                watch.Stop();
+            }
+
+            watch.Elapsed.Should().BeCloseTo(TimeSpan.FromSeconds(timeout), ((int)tolerance.TotalMilliseconds));
+
+        }
+
+        [Fact]
+        public void Should_not_execute_user_delegate_if_user_cancellationtoken_cancelled_before_delegate_reached__pressimistic()
+        {
+            var policy = Policy.TimeoutAsync(10, TimeoutStrategy.Pessimistic);
+
+            bool executed = false;
+
+            using (CancellationTokenSource cts = new CancellationTokenSource())
+            {
+                cts.Cancel();
+
+                policy.Awaiting(async p => await p.ExecuteAsync(ct =>
+                {
+                    executed = true;
+                    return TaskHelper.EmptyTask;
+                }, cts.Token))
+                .ShouldThrow<OperationCanceledException>();
+            }
+
+            executed.Should().BeFalse();
+        }
+
+        #endregion
+
+        #region Non-timeout cancellation - optimistic (user-delegate observes cancellation)
+
+        [Fact]
+        public void Should_be_able_to_cancel_with_user_cancellation_token_before_timeout__optimistic()
         {
             Stopwatch watch = new Stopwatch();
 
             int timeout = 10;
-            var policy = Policy.TimeoutAsync(timeout);
+            var policy = Policy.TimeoutAsync(timeout, TimeoutStrategy.Optimistic);
 
             TimeSpan tolerance = TimeSpan.FromSeconds(1); // Consider increasing tolerance, if test fails transiently in different test/build environments.
 
@@ -288,9 +341,9 @@ namespace Polly.Specs
         }
 
         [Fact]
-        public void Should_not_execute_user_delegate_if_user_cancellationtoken_cancelled_before_delegate_reached()
+        public void Should_not_execute_user_delegate_if_user_cancellationtoken_cancelled_before_delegate_reached__optimistic()
         {
-            var policy = Policy.TimeoutAsync(10);
+            var policy = Policy.TimeoutAsync(10, TimeoutStrategy.Optimistic);
 
             bool executed = false;
 

--- a/src/Polly.SharedSpecs/TimeoutSpecs.cs
+++ b/src/Polly.SharedSpecs/TimeoutSpecs.cs
@@ -210,15 +210,62 @@ namespace Polly.Specs
 
         #endregion
 
-        #region Non-timeout cancellation
+        #region Non-timeout cancellation - pessimistic (user-delegate does not observe cancellation)
 
         [Fact]
-        public void Should_be_able_to_cancel_with_user_cancellation_token_before_timeout()
+        public void Should_not_be_able_to_cancel_with_user_cancellation_token_before_timeout__pessimistic()
+        {
+            Stopwatch watch = new Stopwatch();
+
+            int timeout = 5;
+            var policy = Policy.Timeout(timeout, TimeoutStrategy.Pessimistic);
+
+            TimeSpan tolerance = TimeSpan.FromSeconds(1); // Consider increasing tolerance, if test fails transiently in different test/build environments.
+
+            TimeSpan userTokenExpiry = TimeSpan.FromSeconds(1); // Use of time-based token irrelevant to timeout policy; we just need some user token that cancels independently of policy's internal token.
+            using (CancellationTokenSource userTokenSource = new CancellationTokenSource(userTokenExpiry))
+            {
+                watch.Start();
+                policy.Invoking(p => p.Execute(
+                    _ => SystemClock.Sleep(TimeSpan.FromSeconds(timeout + 2), CancellationToken.None) // Do not observe any cancellation in the middle of execution
+                    , userTokenSource.Token) // ... with user token.
+                   ).ShouldThrow<TimeoutRejectedException>();
+                watch.Stop();
+            }
+
+            watch.Elapsed.Should().BeCloseTo(TimeSpan.FromSeconds(timeout), ((int)tolerance.TotalMilliseconds));
+
+        }
+
+        [Fact]
+        public void Should_not_execute_user_delegate_if_user_cancellationtoken_cancelled_before_delegate_reached__pessimistic()
+        {
+            var policy = Policy.Timeout(10, TimeoutStrategy.Pessimistic);
+
+            bool executed = false;
+
+            using (CancellationTokenSource cts = new CancellationTokenSource())
+            {
+                cts.Cancel();
+
+                policy.Invoking(p => p.Execute(ct => { executed = true; }, cts.Token))
+                    .ShouldThrow<OperationCanceledException>();
+            }
+
+            executed.Should().BeFalse();
+        }
+
+        #endregion
+
+        #region Non-timeout cancellation - optimistic (user-delegate observes cancellation)
+
+        [Fact]
+        public void Should_be_able_to_cancel_with_user_cancellation_token_before_timeout__optimistic()
         {
             Stopwatch watch = new Stopwatch();
 
             int timeout = 10;
-            var policy = Policy.Timeout(timeout);
+            var policy = Policy.Timeout(timeout, TimeoutStrategy.Optimistic);
 
             TimeSpan tolerance = TimeSpan.FromSeconds(1); // Consider increasing tolerance, if test fails transiently in different test/build environments.
 
@@ -239,9 +286,9 @@ namespace Polly.Specs
         }
 
         [Fact]
-        public void Should_not_execute_user_delegate_if_user_cancellationtoken_cancelled_before_delegate_reached()
+        public void Should_not_execute_user_delegate_if_user_cancellationtoken_cancelled_before_delegate_reached__optimistic()
         {
-            var policy = Policy.Timeout(10);
+            var policy = Policy.Timeout(10, TimeoutStrategy.Optimistic);
 
             bool executed = false;
 

--- a/src/Polly.SharedSpecs/TimeoutTResultSpecs.cs
+++ b/src/Polly.SharedSpecs/TimeoutTResultSpecs.cs
@@ -238,15 +238,67 @@ namespace Polly.Specs
 
         #endregion
 
-        #region Non-timeout cancellation
+        #region Non-timeout cancellation - pessimistic (user-delegate does not observe cancellation)
 
         [Fact]
-        public void Should_be_able_to_cancel_with_user_cancellation_token_before_timeout()
+        public void Should_not_be_able_to_cancel_with_user_cancellation_token_before_timeout__pessimistic()
+        {
+            Stopwatch watch = new Stopwatch();
+
+            int timeout = 5;
+            var policy = Policy.Timeout<ResultPrimitive>(timeout, TimeoutStrategy.Pessimistic);
+
+            TimeSpan tolerance = TimeSpan.FromSeconds(1); // Consider increasing tolerance, if test fails transiently in different test/build environments.
+
+            TimeSpan userTokenExpiry = TimeSpan.FromSeconds(1); // Use of time-based token irrelevant to timeout policy; we just need some user token that cancels independently of policy's internal token.
+            using (CancellationTokenSource userTokenSource = new CancellationTokenSource(userTokenExpiry))
+            {
+                watch.Start();
+                policy.Invoking(p => p.Execute(
+                    _ => { SystemClock.Sleep(TimeSpan.FromSeconds(timeout + 2), CancellationToken.None); // Do not observe any cancellation in the middle of execution
+                        return ResultPrimitive.WhateverButTooLate;
+                    }, userTokenSource.Token) // ... with user token.
+                   ).ShouldThrow<TimeoutRejectedException>();
+                watch.Stop();
+            }
+
+            watch.Elapsed.Should().BeCloseTo(TimeSpan.FromSeconds(timeout), ((int)tolerance.TotalMilliseconds));
+
+        }
+
+        [Fact]
+        public void Should_not_execute_user_delegate_if_user_cancellationtoken_cancelled_before_delegate_reached__pessimistic()
+        {
+            var policy = Policy.Timeout<ResultPrimitive>(10, TimeoutStrategy.Pessimistic);
+
+            bool executed = false;
+
+            using (CancellationTokenSource cts = new CancellationTokenSource())
+            {
+                cts.Cancel();
+
+                policy.Invoking(p => p.Execute(ct =>
+                {
+                    executed = true;
+                    return ResultPrimitive.WhateverButTooLate;
+                }, cts.Token))
+                .ShouldThrow<OperationCanceledException>();
+            }
+
+            executed.Should().BeFalse();
+        }
+
+        #endregion
+
+        #region Non-timeout cancellation - optimistic (user-delegate observes cancellation)
+
+        [Fact]
+        public void Should_be_able_to_cancel_with_user_cancellation_token_before_timeout__optimistic()
         {
             Stopwatch watch = new Stopwatch();
 
             int timeout = 10;
-            var policy = Policy.Timeout<ResultPrimitive>(timeout);
+            var policy = Policy.Timeout<ResultPrimitive>(timeout, TimeoutStrategy.Optimistic);
 
             TimeSpan tolerance = TimeSpan.FromSeconds(1); // Consider increasing tolerance, if test fails transiently in different test/build environments.
 
@@ -269,9 +321,9 @@ namespace Polly.Specs
         }
 
         [Fact]
-        public void Should_not_execute_user_delegate_if_user_cancellationtoken_cancelled_before_delegate_reached()
+        public void Should_not_execute_user_delegate_if_user_cancellationtoken_cancelled_before_delegate_reached__optimistic()
         {
-            var policy = Policy.Timeout<ResultPrimitive>(10);
+            var policy = Policy.Timeout<ResultPrimitive>(10, TimeoutStrategy.Optimistic);
 
             bool executed = false;
 

--- a/src/Polly.SharedSpecs/WaitAndRetryAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/WaitAndRetryAsyncSpecs.cs
@@ -826,7 +826,34 @@ namespace Polly.Specs
         }
 
         [Fact]
-        public void Should_report_cancellation_during_faulting_last_retry_execution_when_user_delegate_does_not_observe_cancellationtoken()
+        public void Should_report_cancellation_during_faulting_last_retry_execution_when_user_delegate_does_observe_cancellationtoken()
+        {
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .WaitAndRetryAsync(new[] { 1.Seconds(), 2.Seconds(), 3.Seconds() });
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+
+            int attemptsInvoked = 0;
+            Action onExecute = () => attemptsInvoked++;
+
+            Scenario scenario = new Scenario
+            {
+                NumberOfTimesToRaiseException = 1 + 3,
+                AttemptDuringWhichToCancel = 1 + 3,
+                ActionObservesCancellation = true
+            };
+
+            policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .ShouldThrow<TaskCanceledException>()
+                .And.CancellationToken.Should().Be(cancellationToken);
+
+            attemptsInvoked.Should().Be(1 + 3);
+        }
+
+        [Fact]
+        public void Should_report_faulting_from_faulting_last_retry_execution_when_user_delegate_does_not_observe_cancellation_raised_during_last_retry()
         {
             var policy = Policy
                 .Handle<DivideByZeroException>()
@@ -846,8 +873,7 @@ namespace Polly.Specs
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
-                .And.CancellationToken.Should().Be(cancellationToken);
+                .ShouldThrow<DivideByZeroException>();
 
             attemptsInvoked.Should().Be(1 + 3);
         }

--- a/src/Polly.SharedSpecs/WaitAndRetrySpecs.cs
+++ b/src/Polly.SharedSpecs/WaitAndRetrySpecs.cs
@@ -922,7 +922,34 @@ namespace Polly.Specs
         }
 
         [Fact]
-        public void Should_report_cancellation_during_faulting_last_retry_execution_when_user_delegate_does_not_observe_cancellationtoken()
+        public void Should_report_cancellation_during_faulting_last_retry_execution_when_user_delegate_does_observe_cancellationtoken()
+        {
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .WaitAndRetry(new[] { 1.Seconds(), 2.Seconds(), 3.Seconds() });
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+
+            int attemptsInvoked = 0;
+            Action onExecute = () => attemptsInvoked++;
+
+            PolicyExtensions.ExceptionAndOrCancellationScenario scenario = new PolicyExtensions.ExceptionAndOrCancellationScenario
+            {
+                NumberOfTimesToRaiseException = 1 + 3,
+                AttemptDuringWhichToCancel = 1 + 3,
+                ActionObservesCancellation = true
+            };
+
+            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .ShouldThrow<OperationCanceledException>()
+                .And.CancellationToken.Should().Be(cancellationToken);
+
+            attemptsInvoked.Should().Be(1 + 3);
+        }
+
+        [Fact]
+        public void Should_report_faulting_from_faulting_last_retry_execution_when_user_delegate_does_not_observe_cancellation_raised_during_last_retry()
         {
             var policy = Policy
                 .Handle<DivideByZeroException>()
@@ -942,8 +969,7 @@ namespace Polly.Specs
             };
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
-                .And.CancellationToken.Should().Be(cancellationToken);
+                .ShouldThrow<DivideByZeroException>();
 
             attemptsInvoked.Should().Be(1 + 3);
         }

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -13,25 +13,25 @@
     <tags>Exception Handling Resilience Transient Fault Policy Circuit Breaker CircuitBreaker Retry Wait Bulkhead Fallback Timeout Throttle Parallelization</tags>
     <copyright>Copyright © 2016, App vNext</copyright>
     <releaseNotes>
-     5.0.3
+     v5.0 is a major release with significant new resilience policies: Timeout; Bulkhead Isolation; Fallback; and PolicyWrap.  See release notes back to v5.0.0 for full details. 
+
+     5.0.3 RTM
      ---------------------
      - Refine implementation of cancellable synchronous WaitAndRetry
+     - Minor breaking change: Where a user delegate does not observe cancellation, Polly will now honour the delegate's outcome rather than throw for the unobserved cancellation (issue 188).
 
-     5.0.2
+     5.0.2 alpha
      ---------------------
      - .NETStandard1.0 target: Correctly state dependencies. 
      - .NETStandard1.0 target: Fix SemVer stamping of Polly.dll.
-     - PCL259 project and target: Remove, in favour of .NETStandard1.0 target.  PCL259 is still supported, via .NETStandard1.0 target.
+     - PCL259 project and target: Remove, in favour of .NETStandard1.0 target.  PCL259 targets are still supported, via .NETStandard1.0 target.
      - Mark Polly.dll as CLSCompliant.
-     - Tidy build around GitVersionTask and ReferenceGenerator.
-     - Update FluentAssertions dependency.
-     - Fix issue 179: Make Net4.0 async implementation for Bulkhead truly async.
      
-     5.0.1
+     5.0.1 alpha
      ---------------------
-     - Add a .NETStandard1.0 project and target to Nuget package.
+     - Add a .NETStandard1.0 target.
 
-     5.0.0
+     5.0.0 alpha
      ---------------------
      A major release, adding significant new resilience policies:
      - Timeout policy: allows timing out any execution


### PR DESCRIPTION
+ Refine cancellation in Retry, CircuitBreaker, Timeout and Fallback policies, according to #188 .  Polly policies will no longer aggressively throw-for-cancellation-after-success/-failure/-other exception, where the user delegate has not observed cancellation.

+ Update doco for v5.0.3 RTM