### PR TITLE
Removed all non-netstandard monikers from nuspec

### DIFF
--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -147,14 +147,6 @@
      - Allow arbitrary data to be passed to policy execution
    </releaseNotes>
     <dependencies>
-      <group targetFramework="net" />
-      <group targetFramework="win" />
-      <group targetFramework="wp" />
-      <group targetFramework="wpa" />
-      <group targetFramework="MonoAndroid" />
-      <group targetFramework="MonoTouch" />
-      <group targetFramework="Xamarin.iOS" />
-      <group targetFramework="portable-net45+win8+wpa81+wp8" />
       <group targetFramework="netstandard1.0">
         <dependency id="NETStandard.Library" version="1.6.0" />
       </group>


### PR DESCRIPTION
It seems that according to https://docs.nuget.org/ndocs/schema/target-frameworks and https://docs.microsoft.com/en-us/dotnet/articles/standard/library all those frameworks in nuspec should be supported by netstandard1.0