### PR TITLE
Tidy v5.0.3 nuspec dependencies

### DIFF
--- a/src/Polly.Net40Async.nuspec
+++ b/src/Polly.Net40Async.nuspec
@@ -65,6 +65,7 @@
     <dependencies>
       <group targetFramework="net40">
         <dependency id="Microsoft.Bcl.Async" version="1.0.168" />
+        <dependency id="Nito.Async" version="4.0.1-pre" />
       </group>
     </dependencies>
   </metadata>

--- a/src/Polly.NetStandard10/Polly.NetStandard10.csproj
+++ b/src/Polly.NetStandard10/Polly.NetStandard10.csproj
@@ -22,7 +22,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;PORTABLE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;PORTABLE;SUPPORTS_READONLY_COLLECTION</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Polly.XML</DocumentationFile>
@@ -31,7 +31,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;PORTABLE</DefineConstants>
+    <DefineConstants>TRACE;PORTABLE;SUPPORTS_READONLY_COLLECTION</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Polly.XML</DocumentationFile>

--- a/src/Polly.Pcl.Specs/Polly.Pcl.Specs.csproj
+++ b/src/Polly.Pcl.Specs/Polly.Pcl.Specs.csproj
@@ -24,7 +24,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;PORTABLE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;PORTABLE;SUPPORTS_READONLY_COLLECTION</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -32,7 +32,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;PORTABLE</DefineConstants>
+    <DefineConstants>TRACE;PORTABLE;SUPPORTS_READONLY_COLLECTION</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -147,6 +147,7 @@
      - Allow arbitrary data to be passed to policy execution
    </releaseNotes>
     <dependencies>
+      <group targetFramework="net45"/>
       <group targetFramework="netstandard1.0">
         <dependency id="NETStandard.Library" version="1.6.0" />
       </group>


### PR DESCRIPTION
+ Correctly label .NET45-targeting Polly.dll as `net45` TFM.  Ref discussion in #195 
+ Correctly state `Nito.Async` dependency
+ Use native ReadOnlyDictionary for .NET Standard 1.0