### PR TITLE
Revert Nito.AsyncEx dependency to latest stable

### DIFF
--- a/src/Polly.Net40Async/Polly.Net40Async.csproj
+++ b/src/Polly.Net40Async/Polly.Net40Async.csproj
@@ -48,16 +48,16 @@
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Nito.AsyncEx, Version=4.0.1.0, Culture=neutral, PublicKeyToken=09d695329ca273b7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nito.AsyncEx.4.0.1-pre\lib\net40\Nito.AsyncEx.dll</HintPath>
+    <Reference Include="Nito.AsyncEx, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nito.AsyncEx.3.0.1\lib\net40\Nito.AsyncEx.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Nito.AsyncEx.Concurrent, Version=4.0.1.0, Culture=neutral, PublicKeyToken=09d695329ca273b7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nito.AsyncEx.4.0.1-pre\lib\net40\Nito.AsyncEx.Concurrent.dll</HintPath>
+    <Reference Include="Nito.AsyncEx.Concurrent, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nito.AsyncEx.3.0.1\lib\net40\Nito.AsyncEx.Concurrent.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Nito.AsyncEx.Enlightenment, Version=4.0.1.0, Culture=neutral, PublicKeyToken=09d695329ca273b7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nito.AsyncEx.4.0.1-pre\lib\net40\Nito.AsyncEx.Enlightenment.dll</HintPath>
+    <Reference Include="Nito.AsyncEx.Enlightenment, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nito.AsyncEx.3.0.1\lib\net40\Nito.AsyncEx.Enlightenment.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Polly.Net40Async/packages.config
+++ b/src/Polly.Net40Async/packages.config
@@ -3,5 +3,5 @@
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />
-  <package id="Nito.AsyncEx" version="4.0.1-pre" targetFramework="net40" />
+  <package id="Nito.AsyncEx" version="3.0.1" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Stable v5.0.3RTM release of Polly must reference a stable (per semver syntax) version of the Nito.AsyncEx dependency.