### PR TITLE
Adsk contrib/add circuit breaker policy interface

### DIFF
--- a/src/Polly.Shared/CircuitBreaker/CircuitBreakerPolicy.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitBreakerPolicy.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using Polly.Shared.CircuitBreaker;
 using Polly.Utilities;
 using System.Threading;
 

--- a/src/Polly.Shared/CircuitBreaker/CircuitBreakerPolicy.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitBreakerPolicy.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Polly.Shared.CircuitBreaker;
 using Polly.Utilities;
 using System.Threading;
 
@@ -8,7 +9,7 @@ namespace Polly.CircuitBreaker
     /// <summary>
     /// A circuit-breaker policy that can be applied to delegates.
     /// </summary>
-    public partial class CircuitBreakerPolicy : Policy
+    public partial class CircuitBreakerPolicy : Policy, ICircuitBreakerPolicy
     {
         private readonly ICircuitController<EmptyStruct> _breakerController;
 
@@ -57,7 +58,7 @@ namespace Polly.CircuitBreaker
     /// <summary>
     /// A circuit-breaker policy that can be applied to delegates returning a value of type <typeparam name="TResult"/>.
     /// </summary>
-    public partial class CircuitBreakerPolicy<TResult> : Policy<TResult>
+    public partial class CircuitBreakerPolicy<TResult> : Policy<TResult>, ICircuitBreakerPolicy
     {
         private readonly ICircuitController<TResult> _breakerController;
 

--- a/src/Polly.Shared/CircuitBreaker/ICircuitBreakerPolicy.cs
+++ b/src/Polly.Shared/CircuitBreaker/ICircuitBreakerPolicy.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using Polly.CircuitBreaker;
 
-namespace Polly.Shared.CircuitBreaker
+namespace Polly.CircuitBreaker
 {
     /// <summary>
     /// Common interface for CB policies allowing users of the library to 

--- a/src/Polly.Shared/CircuitBreaker/ICircuitBreakerPolicy.cs
+++ b/src/Polly.Shared/CircuitBreaker/ICircuitBreakerPolicy.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Polly.CircuitBreaker;
+
+namespace Polly.Shared.CircuitBreaker
+{
+    /// <summary>
+    /// Common interface for CB policies allowing users of the library to 
+    /// </summary>
+    public interface ICircuitBreakerPolicy
+    {
+        /// <summary>
+        /// Gets the state of the underlying circuit.
+        /// </summary>
+        CircuitState CircuitState { get; }
+
+        /// <summary>
+        /// Gets the last exception handled by the circuit-breaker.
+        /// </summary>
+        Exception LastException { get; }
+
+        /// <summary>
+        /// Isolates (opens) the circuit manually, and holds it in this state until a call to <see cref="Reset()"/> is made.
+        /// </summary>
+        void Isolate();
+
+        /// <summary>
+        /// Closes the circuit, and resets any statistics controlling automated circuit-breaking.
+        /// </summary>
+        void Reset();
+    }
+}

--- a/src/Polly.Shared/Polly.Shared.projitems
+++ b/src/Polly.Shared/Polly.Shared.projitems
@@ -35,6 +35,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CircuitBreaker\CircuitState.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CircuitBreaker\CircuitStateController.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CircuitBreaker\HealthCount.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CircuitBreaker\ICircuitBreakerPolicy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CircuitBreaker\ICircuitController.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CircuitBreaker\IHealthMetrics.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CircuitBreaker\IsolatedCircuitException.cs" />


### PR DESCRIPTION
We wanted to build something for our internal monitoring systems to track the current state of our active circuits but there isn't a nice way to hold a collection of `CircuitBreakerPolicy<T>` with different wrapped types. This adds an interface that allows for managing collections of policies.

We've done a workaround for the moment (just holding a collection of functions that return a CircuitState) but it would be a nice cleanup for us to have this. 