### PR TITLE
Removed InvalidOperationException from initial _lastOutcome of CircuitStateController

### DIFF
--- a/src/Polly.Shared/CircuitBreaker/CircuitStateController.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitStateController.cs
@@ -114,7 +114,7 @@ namespace Polly.CircuitBreaker
         protected void ResetInternal_NeedsLock(Context context)
         {
             _blockedTill = DateTime.MinValue;
-            _lastOutcome = new DelegateResult<TResult>(new InvalidOperationException("This exception should never be thrown"));
+            _lastOutcome = new DelegateResult<TResult>(default(TResult));
 
             CircuitState priorState = _circuitState;
             _circuitState = CircuitState.Closed;

--- a/src/Polly.Shared/CircuitBreaker/CircuitStateController.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitStateController.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics.Contracts;
 using Polly.Utilities;
 
 namespace Polly.CircuitBreaker

--- a/src/Polly.Shared/CircuitBreaker/CircuitStateController.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitStateController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.Contracts;
 using Polly.Utilities;
 
 namespace Polly.CircuitBreaker
@@ -56,7 +57,7 @@ namespace Polly.CircuitBreaker
             {
                 using (TimedLock.Lock(_lock))
                 {
-                    return _lastOutcome.Exception;
+                    return _lastOutcome?.Exception;
                 }
             }
         }
@@ -67,7 +68,8 @@ namespace Polly.CircuitBreaker
             {
                 using (TimedLock.Lock(_lock))
                 {
-                    return _lastOutcome.Result;
+                    return _lastOutcome != null 
+                        ? _lastOutcome.Result : default(TResult);
                 }
             }
         }
@@ -114,7 +116,7 @@ namespace Polly.CircuitBreaker
         protected void ResetInternal_NeedsLock(Context context)
         {
             _blockedTill = DateTime.MinValue;
-            _lastOutcome = new DelegateResult<TResult>(default(TResult));
+            _lastOutcome = null;
 
             CircuitState priorState = _circuitState;
             _circuitState = CircuitState.Closed;


### PR DESCRIPTION
CircuitStateController.._lastOucome is now initialized with a default…(TResult), instead of an InvalidOperationException