### PR TITLE
Wrong Nito.Async dependency in Net40Async.nuspec

### DIFF
--- a/src/Polly.Net40Async.nuspec
+++ b/src/Polly.Net40Async.nuspec
@@ -65,7 +65,7 @@
     <dependencies>
       <group targetFramework="net40">
         <dependency id="Microsoft.Bcl.Async" version="1.0.168" />
-        <dependency id="Nito.Async" version="3.0.1" />
+        <dependency id="Nito.AsyncEx" version="3.0.1" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
Package [Nito.Async](https://www.nuget.org/packages/Nito.Async/) does not seem to exist, while package [Nito.AsyncEx](https://www.nuget.org/packages/Nito.AsyncEx/) exists and it is the one referenced in Polly for .NET 4.0 [packages.config](https://github.com/App-vNext/Polly/blob/master/src/Polly.Net40Async/packages.config).

Could you verify whether this change is correct and, if it is, release a new version of Polly for .NET 4.0? Thank you very much.