### PR TITLE
Fix dependencies for Polly.Net40Async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.0.4 pre
+- Fix Microsoft.Bcl and Nito.AsyncEx dependencies for Polly.Net40Async. 
+     
 ## 5.0.3 RTM
 - Refine implementation of cancellable synchronous WaitAndRetry
 - Minor breaking change: Where a user delegate does not observe cancellation, Polly will now honour the delegate's outcome rather than throw for the unobserved cancellation (issue 188).

--- a/GitVersionConfig.yaml
+++ b/GitVersionConfig.yaml
@@ -1,1 +1,1 @@
-next-version: 5.0.3
+next-version: 5.0.4-pre

--- a/src/Polly.Net40Async.nuspec
+++ b/src/Polly.Net40Async.nuspec
@@ -15,6 +15,10 @@
     <releaseNotes>
      v5.0 is a major release with significant new resilience policies: Timeout; Bulkhead Isolation; Fallback; and PolicyWrap.  See release notes back to v5.0.0 for full details.
 
+     5.0.4 pre
+     ---------------------
+     - Fix Microsoft.Bcl and Nito.AsyncEx dependencies for Polly.Net40Async. 
+
      5.0.3 RTM
      ---------------------
      - Refine implementation of cancellable synchronous WaitAndRetry
@@ -65,6 +69,8 @@
     <dependencies>
       <group targetFramework="net40">
         <dependency id="Microsoft.Bcl.Async" version="1.0.168" />
+        <dependency id="Microsoft.Bcl" version="1.1.10" />
+        <dependency id="Microsoft.Bcl.Build" version="1.0.21" />
         <dependency id="Nito.AsyncEx" version="3.0.1" />
       </group>
     </dependencies>

--- a/src/Polly.NetStandard10/Properties/AssemblyInfo.cs
+++ b/src/Polly.NetStandard10/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 using System;
 using System.Reflection;
 [assembly: AssemblyTitle("Polly")]
-[assembly: AssemblyVersion("5.0.3.0")]
+[assembly: AssemblyVersion("5.0.4.0")]
 [assembly: CLSCompliant(true)]

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -15,6 +15,10 @@
     <releaseNotes>
      v5.0 is a major release with significant new resilience policies: Timeout; Bulkhead Isolation; Fallback; and PolicyWrap.  See release notes back to v5.0.0 for full details. 
 
+     5.0.4 pre
+     ---------------------
+     - (.NET40Async package changes only)
+
      5.0.3 RTM
      ---------------------
      - Refine implementation of cancellable synchronous WaitAndRetry


### PR DESCRIPTION
Fixes #210, Microsoft.Bcl and Nito.AsyncEx dependencies for Polly.Net40Async.

+ Explicitly declares `Microsoft.Bcl` version 1.1.10 as a dependency of Polly.Net40Async, which dependency seems to be required by [Nito.AsyncEx v3.0.1](https://www.nuget.org/packages/Nito.AsyncEx/3.0.1).  
+ Explicitly state `Microsoft.Bcl.Build` dependency as latest stable, to match environment under which [Polly.Net40.Async nuget package](https://www.nuget.org/packages/Polly.Net40Async) is built.  (Not necessary for correct functioning of the package in trials, but consistency seems good.)
+ Update changelog etc, and bump to Polly v5.0.4-pre, for testing.





