### PR TITLE
Incorrect elements in policy documentation

### DIFF
--- a/src/Polly.Shared/Bulkhead/BulkheadPolicy.cs
+++ b/src/Polly.Shared/Bulkhead/BulkheadPolicy.cs
@@ -56,7 +56,7 @@ namespace Polly.Bulkhead
     }
 
     /// <summary>
-    /// A bulkhead-isolation policy which can be applied to delegates returning a value of type <typeparam name="TResult"/>.
+    /// A bulkhead-isolation policy which can be applied to delegates returning a value of type <typeparamref name="TResult"/>.
     /// </summary>
     public partial class BulkheadPolicy<TResult> : Policy<TResult>, IDisposable
     {

--- a/src/Polly.Shared/CircuitBreaker/CircuitBreakerPolicy.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitBreakerPolicy.cs
@@ -55,7 +55,7 @@ namespace Polly.CircuitBreaker
     }
 
     /// <summary>
-    /// A circuit-breaker policy that can be applied to delegates returning a value of type <typeparam name="TResult"/>.
+    /// A circuit-breaker policy that can be applied to delegates returning a value of type <typeparamref name="TResult"/>.
     /// </summary>
     public partial class CircuitBreakerPolicy<TResult> : Policy<TResult>
     {

--- a/src/Polly.Shared/Fallback/FallbackPolicy.cs
+++ b/src/Polly.Shared/Fallback/FallbackPolicy.cs
@@ -16,7 +16,7 @@ namespace Polly.Fallback
     }
 
     /// <summary>
-    /// A fallback policy that can be applied to delegates returning a value of type <typeparam name="TResult"/>.
+    /// A fallback policy that can be applied to delegates returning a value of type <typeparamref name="TResult"/>.
     /// </summary>
     public partial class FallbackPolicy<TResult> : Policy<TResult>
     {

--- a/src/Polly.Shared/Policy.cs
+++ b/src/Polly.Shared/Policy.cs
@@ -129,7 +129,7 @@ namespace Polly
     }
 
     /// <summary>
-    /// Transient fault handling policies that can be applied to delegates returning results of type <typeparam name="TResult"/>
+    /// Transient fault handling policies that can be applied to delegates returning results of type <typeparamref name="TResult"/>
     /// </summary>
     public partial class Policy<TResult> 
     {

--- a/src/Polly.Shared/Retry/RetryPolicy.cs
+++ b/src/Polly.Shared/Retry/RetryPolicy.cs
@@ -16,7 +16,7 @@ namespace Polly.Retry
     }
 
     /// <summary>
-    /// A retry policy that can be applied to delegates returning a value of type <typeparam name="TResult"/>.
+    /// A retry policy that can be applied to delegates returning a value of type <typeparamref name="TResult"/>.
     /// </summary>
     public partial class RetryPolicy<TResult> : Policy<TResult>
     {

--- a/src/Polly.Shared/Timeout/TimeoutPolicy.cs
+++ b/src/Polly.Shared/Timeout/TimeoutPolicy.cs
@@ -19,7 +19,7 @@ namespace Polly.Timeout
     }
 
     /// <summary>
-    /// A timeout policy which can be applied to delegates returning a value of type <typeparam name="TResult"/>.
+    /// A timeout policy which can be applied to delegates returning a value of type <typeparamref name="TResult"/>.
     /// </summary>
     public partial class TimeoutPolicy<TResult> : Policy<TResult>
     {


### PR DESCRIPTION
Updated incorrect usages of \<typeparam /\> element to \<typeparamref /\>