### PR TITLE
Fix effects of overhanging executions on circuit-breaker half-open and open states 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 5.0.5 pre
 - Bug fix: Prevent request stampede during half-open state of CircuitBreaker and AdvancedCircuitBreaker.  Enforce only one new trial call per break duration, during half-open state.
 - Bug fix: Prevent duplicate raising of the onBreak delegate, if executions started when a circuit was closed, return faults when a circuit has already opened.
+- Optimisation: Optimise hotpaths for Circuit-Breaker, Retry and Fallback policies.
+- Minor behavioural change: For a circuit which has not handled any faults since initialisation or last reset, make `LastException` property return null rather than a fake exception.
 
 ## 5.0.4 pre
 - Fix Microsoft.Bcl and Nito.AsyncEx dependencies for Polly.Net40Async. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.0.5 pre
+- Bug fix: Prevent request stampede during half-open state of CircuitBreaker and AdvancedCircuitBreaker.  Enforce only one new trial call, after transition to half-open state.
+
 ## 5.0.4 pre
 - Fix Microsoft.Bcl and Nito.AsyncEx dependencies for Polly.Net40Async. 
      

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 5.0.5 pre
 - Bug fix: Prevent request stampede during half-open state of CircuitBreaker and AdvancedCircuitBreaker.  Enforce only one new trial call per break duration, during half-open state.
+- Bug fix: Prevent duplicate raising of the onBreak delegate, if executions started when a circuit was closed, return faults when a circuit has already opened.
 
 ## 5.0.4 pre
 - Fix Microsoft.Bcl and Nito.AsyncEx dependencies for Polly.Net40Async. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.0.5 pre
+## 5.0.5
 - Bug fix: Prevent request stampede during half-open state of CircuitBreaker and AdvancedCircuitBreaker.  Enforce only one new trial call per break duration, during half-open state.
 - Bug fix: Prevent duplicate raising of the onBreak delegate, if executions started when a circuit was closed, return faults when a circuit has already opened.
 - Optimisation: Optimise hotpaths for Circuit-Breaker, Retry and Fallback policies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 5.0.5 pre
-- Bug fix: Prevent request stampede during half-open state of CircuitBreaker and AdvancedCircuitBreaker.  Enforce only one new trial call, after transition to half-open state.
+- Bug fix: Prevent request stampede during half-open state of CircuitBreaker and AdvancedCircuitBreaker.  Enforce only one new trial call per break duration, during half-open state.
 
 ## 5.0.4 pre
 - Fix Microsoft.Bcl and Nito.AsyncEx dependencies for Polly.Net40Async. 

--- a/GitVersionConfig.yaml
+++ b/GitVersionConfig.yaml
@@ -1,1 +1,1 @@
-next-version: 5.0.4-pre
+next-version: 5.0.5-pre

--- a/GitVersionConfig.yaml
+++ b/GitVersionConfig.yaml
@@ -1,1 +1,1 @@
-next-version: 5.0.5-pre
+next-version: 5.0.5

--- a/README.md
+++ b/README.md
@@ -771,10 +771,10 @@ For `CircuitBreakerPolicy<TResult>` policies:
 
 # Acknowledgements
 
-* [lokad-shared-libraries](https://github.com/Lokad/lokad-shared-libraries) - Helper assemblies for .NET 3.5 and Silverlight 2.0 that are being developed as part of the Open Source effort by Lokad.com (discontinued) | [New BSD License](https://raw.github.com/Lokad/lokad-shared-libraries/master/Lokad.Shared.License.txt)
+* [lokad-shared-libraries](https://github.com/Lokad/lokad-shared-libraries) - Helper assemblies originally for .NET 3.5 and Silverlight 2.0 which were developed as part of the Open Source effort by Lokad.com (discontinued) | [New BSD License](https://raw.github.com/Lokad/lokad-shared-libraries/master/Lokad.Shared.License.txt)
 * [@michael-wolfenden](https://github.com/michael-wolfenden) - The creator and mastermind of Polly!
 * [@ghuntley](https://github.com/ghuntley) - Portable Class Library implementation.
-* [@mauricedb](https://github.com/mauricedb) - Async implementation.
+* [@mauricedb](https://github.com/mauricedb) - Initial async implementation.
 * [@robgibbens](https://github.com/RobGibbens) - Added existing async files to PCL project
 * [Hacko](https://github.com/hacko-bede) - Added extra `NotOnCapturedContext` call to prevent potential deadlocks when blocking on asynchronous calls
 * [@ThomasMentzel](https://github.com/ThomasMentzel) - Added ability to capture the results of executing a policy via `ExecuteAndCapture`
@@ -799,6 +799,7 @@ For `CircuitBreakerPolicy<TResult>` policies:
 * [@reisenberger](https://github.com/reisenberger),  and contributions from [@brunolauze](https://github.com/brunolauze) -  Add Bulkhead Isolation policy.  
 * [@reisenberger](https://github.com/reisenberger) - Add Timeout policy.
 * [@reisenberger](https://github.com/reisenberger) - Fix .NETStandard 1.0 targeting.  Remove PCL259 target.  PCL259 support is provided via .NETStandard1.0 target, going forward.
+* [@reisenberger](https://github.com/reisenberger) - Fix CircuitBreaker HalfOpen state and cases when breakDuration is shorter than typical call timeout.  Thanks to [@vgouw](https://github.com/vgouw) and [@kharos](https://github.com/kharos) for the reports and insightful thinking.
 
 
 # Sample Projects

--- a/README.md
+++ b/README.md
@@ -800,6 +800,7 @@ For `CircuitBreakerPolicy<TResult>` policies:
 * [@reisenberger](https://github.com/reisenberger) - Add Timeout policy.
 * [@reisenberger](https://github.com/reisenberger) - Fix .NETStandard 1.0 targeting.  Remove PCL259 target.  PCL259 support is provided via .NETStandard1.0 target, going forward.
 * [@reisenberger](https://github.com/reisenberger) - Fix CircuitBreaker HalfOpen state and cases when breakDuration is shorter than typical call timeout.  Thanks to [@vgouw](https://github.com/vgouw) and [@kharos](https://github.com/kharos) for the reports and insightful thinking.
+* [@lakario](https://github.com/lakario) - Tidy CircuitBreaker LastException property.
 
 
 # Sample Projects

--- a/src/Polly.Net40Async.Specs/Polly.Net40Async.Specs.csproj
+++ b/src/Polly.Net40Async.Specs/Polly.Net40Async.Specs.csproj
@@ -86,7 +86,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Polly.Net40Async\Polly.Net40Async.csproj">
-      <Project>{29265540-f724-4324-9321-643a0fcb133f}</Project>
+      <Project>{D6A676C2-982D-42D1-AD21-FA53582A1C31}</Project>
       <Name>Polly.Net40Async</Name>
     </ProjectReference>
   </ItemGroup>

--- a/src/Polly.Net40Async.nuspec
+++ b/src/Polly.Net40Async.nuspec
@@ -15,12 +15,12 @@
     <releaseNotes>
      v5.0 is a major release with significant new resilience policies: Timeout; Bulkhead Isolation; Fallback; and PolicyWrap.  See release notes back to v5.0.0 for full details.
 
-     5.0.5 pre
+     5.0.5
      ---------------------
      - Bug fix: Prevent request stampede during half-open state of CircuitBreaker and AdvancedCircuitBreaker.  Enforce only one new trial call per break duration, during half-open state.
      - Bug fix: Prevent duplicate raising of the onBreak delegate, if executions started when a circuit was closed, return faults when a circuit has already opened.
      - Optimisation: Optimise hotpaths for Circuit-Breaker, Retry and Fallback policies.
-     
+
      5.0.4 pre
      ---------------------
      - Fix Microsoft.Bcl and Nito.AsyncEx dependencies for Polly.Net40Async. 

--- a/src/Polly.Net40Async.nuspec
+++ b/src/Polly.Net40Async.nuspec
@@ -19,7 +19,8 @@
      ---------------------
      - Bug fix: Prevent request stampede during half-open state of CircuitBreaker and AdvancedCircuitBreaker.  Enforce only one new trial call per break duration, during half-open state.
      - Bug fix: Prevent duplicate raising of the onBreak delegate, if executions started when a circuit was closed, return faults when a circuit has already opened.
-
+     - Optimisation: Optimise hotpaths for Circuit-Breaker, Retry and Fallback policies.
+     
      5.0.4 pre
      ---------------------
      - Fix Microsoft.Bcl and Nito.AsyncEx dependencies for Polly.Net40Async. 

--- a/src/Polly.Net40Async.nuspec
+++ b/src/Polly.Net40Async.nuspec
@@ -17,7 +17,7 @@
 
      5.0.5 pre
      ---------------------
-     - Bug fix: Prevent request stampede during half-open state of CircuitBreaker and AdvancedCircuitBreaker.  Enforce only one new trial call, after transition to half-open state.
+     - Bug fix: Prevent request stampede during half-open state of CircuitBreaker and AdvancedCircuitBreaker.  Enforce only one new trial call per break duration, during half-open state.
 
      5.0.4 pre
      ---------------------

--- a/src/Polly.Net40Async.nuspec
+++ b/src/Polly.Net40Async.nuspec
@@ -15,6 +15,10 @@
     <releaseNotes>
      v5.0 is a major release with significant new resilience policies: Timeout; Bulkhead Isolation; Fallback; and PolicyWrap.  See release notes back to v5.0.0 for full details.
 
+     5.0.5 pre
+     ---------------------
+     - Bug fix: Prevent request stampede during half-open state of CircuitBreaker and AdvancedCircuitBreaker.  Enforce only one new trial call, after transition to half-open state.
+
      5.0.4 pre
      ---------------------
      - Fix Microsoft.Bcl and Nito.AsyncEx dependencies for Polly.Net40Async. 

--- a/src/Polly.Net40Async.nuspec
+++ b/src/Polly.Net40Async.nuspec
@@ -18,6 +18,7 @@
      5.0.5 pre
      ---------------------
      - Bug fix: Prevent request stampede during half-open state of CircuitBreaker and AdvancedCircuitBreaker.  Enforce only one new trial call per break duration, during half-open state.
+     - Bug fix: Prevent duplicate raising of the onBreak delegate, if executions started when a circuit was closed, return faults when a circuit has already opened.
 
      5.0.4 pre
      ---------------------

--- a/src/Polly.Net40Async/Properties/AssemblyInfo.cs
+++ b/src/Polly.Net40Async/Properties/AssemblyInfo.cs
@@ -1,4 +1,8 @@
 ﻿using System;
 using System.Reflection;
+using System.Runtime.CompilerServices;
+
 [assembly: AssemblyTitle("Polly")]
 [assembly: CLSCompliant(false)] // Because Nito.AsycEx, on which Polly.Net40Async depends, is not CLSCompliant.
+
+[assembly: InternalsVisibleTo("Polly.Net40Async.Specs")]

--- a/src/Polly.Net45/Properties/AssemblyInfo.cs
+++ b/src/Polly.Net45/Properties/AssemblyInfo.cs
@@ -1,4 +1,8 @@
 ﻿using System;
 using System.Reflection;
+using System.Runtime.CompilerServices;
+
 [assembly: AssemblyTitle("Polly")]
 [assembly: CLSCompliant(true)]
+
+[assembly: InternalsVisibleTo("Polly.Net45.Specs")]

--- a/src/Polly.NetStandard10/Properties/AssemblyInfo.cs
+++ b/src/Polly.NetStandard10/Properties/AssemblyInfo.cs
@@ -1,5 +1,9 @@
 using System;
 using System.Reflection;
+using System.Runtime.CompilerServices;
+
 [assembly: AssemblyTitle("Polly")]
-[assembly: AssemblyVersion("5.0.4.0")]
+[assembly: AssemblyVersion("5.0.5.0")]
 [assembly: CLSCompliant(true)]
+
+[assembly: InternalsVisibleTo("Polly.Pcl.Specs")]

--- a/src/Polly.Shared/CircuitBreaker/CircuitBreakerPolicy.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitBreakerPolicy.cs
@@ -10,7 +10,7 @@ namespace Polly.CircuitBreaker
     /// </summary>
     public partial class CircuitBreakerPolicy : Policy
     {
-        private readonly ICircuitController<EmptyStruct> _breakerController;
+        internal readonly ICircuitController<EmptyStruct> _breakerController;
 
         internal CircuitBreakerPolicy(
             Action<Action<CancellationToken>, Context, CancellationToken> exceptionPolicy, 
@@ -59,7 +59,7 @@ namespace Polly.CircuitBreaker
     /// </summary>
     public partial class CircuitBreakerPolicy<TResult> : Policy<TResult>
     {
-        private readonly ICircuitController<TResult> _breakerController;
+        internal readonly ICircuitController<TResult> _breakerController;
 
         internal CircuitBreakerPolicy(
             Func<Func<CancellationToken, TResult>, Context, CancellationToken, TResult> executionPolicy, 

--- a/src/Polly.Shared/CircuitBreaker/CircuitStateController.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitStateController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using Polly.Utilities;
 
 namespace Polly.CircuitBreaker
@@ -6,12 +7,14 @@ namespace Polly.CircuitBreaker
     internal abstract class CircuitStateController<TResult> : ICircuitController<TResult>
     {
         protected readonly TimeSpan _durationOfBreak;
-        protected DateTime _blockedTill;
+        protected long _blockedTill;
         protected CircuitState _circuitState;
         protected DelegateResult<TResult> _lastOutcome;
+
         protected readonly Action<DelegateResult<TResult>, TimeSpan, Context> _onBreak;
         protected readonly Action<Context> _onReset;
         protected readonly Action _onHalfOpen;
+
         protected readonly object _lock = new object();
 
         protected CircuitStateController(
@@ -76,7 +79,7 @@ namespace Polly.CircuitBreaker
         {
             get
             {
-                return SystemClock.UtcNow() < _blockedTill;
+                return SystemClock.UtcNow().Ticks < _blockedTill;
             }
         }
 
@@ -99,8 +102,8 @@ namespace Polly.CircuitBreaker
         {
             bool willDurationTakeUsPastDateTimeMaxValue = durationOfBreak > DateTime.MaxValue - SystemClock.UtcNow();
             _blockedTill = willDurationTakeUsPastDateTimeMaxValue
-                ? DateTime.MaxValue
-                : SystemClock.UtcNow() + durationOfBreak;
+                ? DateTime.MaxValue.Ticks
+                : (SystemClock.UtcNow() + durationOfBreak).Ticks;
             _circuitState = CircuitState.Open;
 
             _onBreak(_lastOutcome, durationOfBreak, context);
@@ -113,7 +116,7 @@ namespace Polly.CircuitBreaker
 
         protected void ResetInternal_NeedsLock(Context context)
         {
-            _blockedTill = DateTime.MinValue;
+            _blockedTill = DateTime.MinValue.Ticks;
             _lastOutcome = new DelegateResult<TResult>(new InvalidOperationException("This exception should never be thrown"));
 
             CircuitState priorState = _circuitState;
@@ -124,17 +127,36 @@ namespace Polly.CircuitBreaker
             }
         }
 
+        protected bool PermitHalfOpenCircuitTest()
+        {
+            long currentlyBlockedUntil = _blockedTill;
+            if (SystemClock.UtcNow().Ticks >= currentlyBlockedUntil)
+            {
+                // It's time to permit a / another trial call in the half-open state ...
+                // ... but to prevent race conditions/multiple calls, we have to ensure only _one_ thread wins the race to own this next call.
+                return Interlocked.CompareExchange(ref _blockedTill, SystemClock.UtcNow().Ticks + _durationOfBreak.Ticks, currentlyBlockedUntil) == currentlyBlockedUntil;
+            }
+            return false;
+        }
+
+        private BrokenCircuitException GetBreakingException()
+        {
+            return _lastOutcome.Exception != null
+                ? new BrokenCircuitException("The circuit is now open and is not allowing calls.", _lastOutcome.Exception)
+                : new BrokenCircuitException<TResult>("The circuit is now open and is not allowing calls.", _lastOutcome.Result);
+        }
+
         public void OnActionPreExecute()
         {
             switch (CircuitState)
             {
                 case CircuitState.Closed:
+                    break;
                 case CircuitState.HalfOpen:
+                    if (!PermitHalfOpenCircuitTest()) { throw GetBreakingException(); }
                     break;
                 case CircuitState.Open:
-                    throw _lastOutcome.Exception != null
-                        ? new BrokenCircuitException("The circuit is now open and is not allowing calls.", _lastOutcome.Exception)
-                        : new BrokenCircuitException<TResult>("The circuit is now open and is not allowing calls.", _lastOutcome.Result);
+                    throw GetBreakingException();
                 case CircuitState.Isolated:
                     throw new IsolatedCircuitException("The circuit is manually held open and is not allowing calls.");
                 default:

--- a/src/Polly.SharedSpecs/CircuitBreaker/AdvancedCircuitBreakerAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/AdvancedCircuitBreakerAsyncSpecs.cs
@@ -1631,7 +1631,7 @@ namespace Polly.Specs.CircuitBreaker
                 permitFirstExecutionEnd.Set();
             });
 
-            // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. 
+            // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. This validates the test ran as expected (and background delegates are complete) before we assert on outcomes.
             permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
             permitFirstExecutionEnd.Set();
             Task.WaitAll(new[] { firstExecution, secondExecution }, testTimeoutToExposeDeadlocks).Should().BeTrue();
@@ -1739,7 +1739,7 @@ namespace Polly.Specs.CircuitBreaker
                 permitFirstExecutionEnd.Set();
             });
 
-            // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. 
+            // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. This validates the test ran as expected (and background delegates are complete) before we assert on outcomes.
             permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
             permitFirstExecutionEnd.Set();
             Task.WaitAll(new[] { firstExecution, secondExecution }, testTimeoutToExposeDeadlocks).Should().BeTrue();
@@ -1951,7 +1951,7 @@ namespace Polly.Specs.CircuitBreaker
         }
 
         [Fact]
-        public void Should_call_onbreak_when_breaking_circuit_first_time_but_not_for_subsequent_calls_through_open_circuit()
+        public void Should_call_onbreak_when_breaking_circuit_first_time_but_not_for_subsequent_calls_placed_through_open_circuit()
         {
             int onBreakCalled = 0;
             Action<Exception, TimeSpan> onBreak = (_, __) => { onBreakCalled++; };
@@ -1999,6 +1999,74 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
                 .ShouldThrow<BrokenCircuitException>();
 
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+            onBreakCalled.Should().Be(1);
+        }
+
+        [Fact]
+        public void Should_call_onbreak_when_breaking_circuit_first_time_but_not_for_subsequent_call_failure_which_arrives_on_open_state_though_started_on_closed_state()
+        {
+            int onBreakCalled = 0;
+            Action<Exception, TimeSpan> onBreak = (_, __) => { onBreakCalled++; };
+            Action onReset = () => { };
+
+            CircuitBreakerPolicy breaker = Policy
+                .Handle<DivideByZeroException>()
+                .AdvancedCircuitBreakerAsync(
+                    failureThreshold: 0.5,
+                    samplingDuration: TimeSpan.FromSeconds(10),
+                    minimumThroughput: 2,
+                    durationOfBreak: TimeSpan.FromSeconds(30),
+                    onBreak: onBreak,
+                    onReset: onReset
+                );
+
+            // Start an execution when the breaker is in the closed state, but hold it from returning (its failure) until the breaker has opened.  This call, a failure hitting an already open breaker, should indicate its fail, but should not cause onBreak() to be called a second time.
+            TimeSpan testTimeoutToExposeDeadlocks = TimeSpan.FromSeconds(5);
+            ManualResetEvent permitLongRunningExecutionToReturnItsFailure = new ManualResetEvent(false);
+            ManualResetEvent permitMainThreadToOpenCircuit = new ManualResetEvent(false);
+
+            Task longRunningExecution = Task.Run(() =>
+            {
+                breaker.CircuitState.Should().Be(CircuitState.Closed);
+
+                breaker.Awaiting(x => x.ExecuteAsync(async () =>
+                {
+                    await TaskHelper.EmptyTask;
+
+                    permitMainThreadToOpenCircuit.Set();
+
+                    // Hold this execution until rest of the test indicates it can proceed (or timeout, to expose deadlocks).
+                    permitLongRunningExecutionToReturnItsFailure.WaitOne(testTimeoutToExposeDeadlocks);
+
+                    // Throw a further failure when rest of test has already broken the circuit.
+                    breaker.CircuitState.Should().Be(CircuitState.Open);
+                    throw new DivideByZeroException();
+
+                })).ShouldThrow<DivideByZeroException>(); // However, since execution started when circuit was closed, BrokenCircuitException will not have been thrown on entry; the original exception will still be thrown.
+            });
+
+            permitMainThreadToOpenCircuit.WaitOne(testTimeoutToExposeDeadlocks).Should().BeTrue();
+
+            // Break circuit in the normal manner: onBreak() should be called once.
+            breaker.CircuitState.Should().Be(CircuitState.Closed);
+            onBreakCalled.Should().Be(0);
+            breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
+                  .ShouldThrow<DivideByZeroException>();
+            breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
+                  .ShouldThrow<DivideByZeroException>();
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+            onBreakCalled.Should().Be(1);
+
+            // Permit the second (long-running) execution to hit the open circuit with its failure.
+            permitLongRunningExecutionToReturnItsFailure.Set();
+
+            // Graceful cleanup: allow executions time to end naturally; timeout if any deadlocks; expose any execution faults.  This validates the test ran as expected (and background delegates are complete) before we assert on outcomes.
+            longRunningExecution.Wait(testTimeoutToExposeDeadlocks).Should().BeTrue();
+            if (longRunningExecution.IsFaulted) throw longRunningExecution.Exception;
+            longRunningExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+
+            // onBreak() should still only have been called once.
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
         }

--- a/src/Polly.SharedSpecs/CircuitBreaker/AdvancedCircuitBreakerAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/AdvancedCircuitBreakerAsyncSpecs.cs
@@ -1460,6 +1460,150 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
         }
 
+
+        [Fact]
+        public void Should_only_allow_single_execution_on_first_entering_halfopen_state__test_execution_permit_directly()
+        {
+            var time = 1.January(2000);
+            SystemClock.UtcNow = () => time;
+
+            var durationOfBreak = TimeSpan.FromMinutes(1);
+            CircuitBreakerPolicy breaker = Policy
+                .Handle<DivideByZeroException>()
+                .AdvancedCircuitBreakerAsync(
+                    failureThreshold: 0.5,
+                    samplingDuration: TimeSpan.FromSeconds(10),
+                    minimumThroughput: 2,
+                    durationOfBreak: durationOfBreak
+                );
+
+            breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
+                  .ShouldThrow<DivideByZeroException>();
+            breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
+                .ShouldThrow<DivideByZeroException>();
+
+            // exception raised, circuit is now open.  
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+
+            // break duration passes, circuit now half open
+            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+
+            // OnActionPreExecute() should permit first execution.
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // OnActionPreExecute() should reject a second execution. (tho still in half-open condition).
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldThrow<BrokenCircuitException>();
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        }
+
+        [Fact]
+        public void Should_only_allow_single_execution_on_first_entering_halfopen_state__integration_test()
+        {
+            var time = 1.January(2000);
+            SystemClock.UtcNow = () => time;
+
+            var durationOfBreak = TimeSpan.FromMinutes(1);
+            CircuitBreakerPolicy breaker = Policy
+                .Handle<DivideByZeroException>()
+                .AdvancedCircuitBreakerAsync(
+                    failureThreshold: 0.5,
+                    samplingDuration: TimeSpan.FromSeconds(10),
+                    minimumThroughput: 2,
+                    durationOfBreak: durationOfBreak
+                );
+
+            breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
+                  .ShouldThrow<DivideByZeroException>();
+            breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
+                .ShouldThrow<DivideByZeroException>();
+
+            // exceptions raised, circuit is now open.  
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+
+            // break duration passes, circuit now half open
+            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // Start one execution during the HalfOpen state, and request a second execution before the first has completed (ie still during the HalfOpen state).
+            // The second execution should be rejected due to the halfopen state.
+
+            TimeSpan testTimeoutToExposeDeadlocks = TimeSpan.FromSeconds(5);
+            ManualResetEvent permitSecondExecutionAttempt = new ManualResetEvent(false);
+            ManualResetEvent permitFirstExecutionEnd = new ManualResetEvent(false);
+
+            bool? firstDelegateExecutedInHalfOpenState = null;
+            bool? secondDelegateExecutedInHalfOpenState = null;
+            bool? secondDelegateRejectedInHalfOpenState = null;
+
+            bool firstExecutionActive = false;
+            // First execution in HalfOpen state: we should be able to verify state is HalfOpen as it executes.
+            Task firstExecution = Task.Run(() =>
+            {
+                breaker.Awaiting(x => x.ExecuteAsync(async () =>
+                {
+                    firstDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
+
+                    // Signal the second execution can start, overlapping with this (the first) execution.
+                    firstExecutionActive = true;
+                    permitSecondExecutionAttempt.Set();
+
+                    // Hold first execution open until second indicates it is no longer needed, or time out.
+                    permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
+                    await TaskHelper.EmptyTask;
+                    firstExecutionActive = false;
+
+                })).ShouldNotThrow();
+            });
+
+            // Attempt a second execution, signalled by the first execution to ensure they overlap: we should be able to verify it doesn't execute, and is rejected by a breaker in a HalfOpen state.
+            permitSecondExecutionAttempt.WaitOne(testTimeoutToExposeDeadlocks);
+
+            Task secondExecution = Task.Run(async () =>
+            {
+                // Validation of correct sequencing and overlapping of tasks in test (guard against erroneous test refactorings/operation).
+                firstExecutionActive.Should().BeTrue();
+                breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+                try
+                {
+                    await breaker.ExecuteAsync(async () =>
+                    {
+                        secondDelegateRejectedInHalfOpenState = false;
+                        secondDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
+                        await TaskHelper.EmptyTask;
+                    });
+                }
+                catch (BrokenCircuitException)
+                {
+                    secondDelegateExecutedInHalfOpenState = false;
+                    secondDelegateRejectedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested here.
+                }
+
+                // Release first execution soon as second overlapping execution is done gathering data.
+                permitFirstExecutionEnd.Set();
+            });
+
+            // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. 
+            permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
+            permitFirstExecutionEnd.Set();
+            Task.WaitAll(new[] { firstExecution, secondExecution }, testTimeoutToExposeDeadlocks).Should().BeTrue();
+            if (firstExecution.IsFaulted) throw firstExecution.Exception;
+            if (secondExecution.IsFaulted) throw secondExecution.Exception;
+            firstExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+            secondExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+
+            // Assert: 
+            // - First execution should have been permitted and executed under a HalfOpen state
+            // - Second overlapping execution in halfopen state should not have been permitted.
+            // - Second execution attempt should have been rejected with HalfOpen state as cause.
+            firstDelegateExecutedInHalfOpenState.Should().BeTrue();
+            secondDelegateExecutedInHalfOpenState.Should().BeFalse();
+            secondDelegateRejectedInHalfOpenState.Should().BeTrue();
+        }
+
         #endregion
 
         #region Isolate and reset tests

--- a/src/Polly.SharedSpecs/CircuitBreaker/AdvancedCircuitBreakerSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/AdvancedCircuitBreakerSpecs.cs
@@ -1632,7 +1632,7 @@ namespace Polly.Specs.CircuitBreaker
                 permitFirstExecutionEnd.Set();
             });
 
-            // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. 
+            // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. This validates the test ran as expected (and background delegates are complete) before we assert on outcomes.
             permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
             permitFirstExecutionEnd.Set();
             Task.WaitAll(new[] { firstExecution, secondExecution }, testTimeoutToExposeDeadlocks).Should().BeTrue();
@@ -1739,7 +1739,7 @@ namespace Polly.Specs.CircuitBreaker
                 permitFirstExecutionEnd.Set();
             });
 
-            // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. 
+            // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. This validates the test ran as expected (and background delegates are complete) before we assert on outcomes.
             permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
             permitFirstExecutionEnd.Set();
             Task.WaitAll(new[] { firstExecution, secondExecution }, testTimeoutToExposeDeadlocks).Should().BeTrue();
@@ -1949,7 +1949,7 @@ namespace Polly.Specs.CircuitBreaker
         }
 
         [Fact]
-        public void Should_call_onbreak_when_breaking_circuit_first_time_but_not_for_subsequent_calls_through_open_circuit()
+        public void Should_call_onbreak_when_breaking_circuit_first_time_but_not_for_subsequent_calls_placed_through_open_circuit()
         {
             int onBreakCalled = 0;
             Action<Exception, TimeSpan> onBreak = (_, __) => { onBreakCalled++; };
@@ -1997,6 +1997,72 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
                 .ShouldThrow<BrokenCircuitException>();
 
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+            onBreakCalled.Should().Be(1);
+        }
+
+        [Fact]
+        public void Should_call_onbreak_when_breaking_circuit_first_time_but_not_for_subsequent_call_failure_which_arrives_on_open_state_though_started_on_closed_state()
+        {
+            int onBreakCalled = 0;
+            Action<Exception, TimeSpan> onBreak = (_, __) => { onBreakCalled++; };
+            Action onReset = () => { };
+
+            CircuitBreakerPolicy breaker = Policy
+                .Handle<DivideByZeroException>()
+                .AdvancedCircuitBreaker(
+                    failureThreshold: 0.5,
+                    samplingDuration: TimeSpan.FromSeconds(10),
+                    minimumThroughput: 2,
+                    durationOfBreak: TimeSpan.FromSeconds(30),
+                    onBreak: onBreak,
+                    onReset: onReset
+                );
+
+            // Start an execution when the breaker is in the closed state, but hold it from returning (its failure) until the breaker has opened.  This call, a failure hitting an already open breaker, should indicate its fail, but should not cause onBreak() to be called a second time.
+            TimeSpan testTimeoutToExposeDeadlocks = TimeSpan.FromSeconds(5);
+            ManualResetEvent permitLongRunningExecutionToReturnItsFailure = new ManualResetEvent(false);
+            ManualResetEvent permitMainThreadToOpenCircuit = new ManualResetEvent(false);
+
+            Task longRunningExecution = Task.Run(() =>
+            {
+                breaker.CircuitState.Should().Be(CircuitState.Closed);
+
+                breaker.Invoking(x => x.Execute(() =>
+                {
+                    permitMainThreadToOpenCircuit.Set();
+
+                    // Hold this execution until rest of the test indicates it can proceed (or timeout, to expose deadlocks).
+                    permitLongRunningExecutionToReturnItsFailure.WaitOne(testTimeoutToExposeDeadlocks);
+
+                    // Throw a further failure when rest of test has already broken the circuit.
+                    breaker.CircuitState.Should().Be(CircuitState.Open);
+                    throw new DivideByZeroException();
+
+                })).ShouldThrow<DivideByZeroException>(); // However, since execution started when circuit was closed, BrokenCircuitException will not have been thrown on entry; the original exception will still be thrown.
+            });
+
+            permitMainThreadToOpenCircuit.WaitOne(testTimeoutToExposeDeadlocks).Should().BeTrue();
+
+            // Break circuit in the normal manner: onBreak() should be called once.
+            breaker.CircuitState.Should().Be(CircuitState.Closed);
+            onBreakCalled.Should().Be(0);
+            breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
+                .ShouldThrow<DivideByZeroException>();
+            breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
+                .ShouldThrow<DivideByZeroException>();
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+            onBreakCalled.Should().Be(1);
+
+            // Permit the second (long-running) execution to hit the open circuit with its failure.
+            permitLongRunningExecutionToReturnItsFailure.Set();
+
+            // Graceful cleanup: allow executions time to end naturally; timeout if any deadlocks; expose any execution faults.  This validates the test ran as expected (and background delegates are complete) before we assert on outcomes.
+            longRunningExecution.Wait(testTimeoutToExposeDeadlocks).Should().BeTrue();
+            if (longRunningExecution.IsFaulted) throw longRunningExecution.Exception;
+            longRunningExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+
+            // onBreak() should still only have been called once.
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
         }

--- a/src/Polly.SharedSpecs/CircuitBreaker/AdvancedCircuitBreakerSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/AdvancedCircuitBreakerSpecs.cs
@@ -1494,8 +1494,55 @@ namespace Polly.Specs.CircuitBreaker
             breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
-            // OnActionPreExecute() should reject a second execution..
+            // OnActionPreExecute() should reject a second execution.
             breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldThrow<BrokenCircuitException>();
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        }
+
+        [Fact]
+        public void Should_allow_single_execution_per_break_duration_in_halfopen_state__test_execution_permit_directly()
+        {
+            var time = 1.January(2000);
+            SystemClock.UtcNow = () => time;
+
+            var durationOfBreak = TimeSpan.FromSeconds(30);
+
+            CircuitBreakerPolicy breaker = Policy
+                .Handle<DivideByZeroException>()
+                .AdvancedCircuitBreaker(
+                    failureThreshold: 0.5,
+                    samplingDuration: TimeSpan.FromSeconds(10),
+                    minimumThroughput: 2,
+                    durationOfBreak: durationOfBreak
+                );
+
+            breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
+                .ShouldThrow<DivideByZeroException>();
+            breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
+                .ShouldThrow<DivideByZeroException>();
+
+            // exception raised, circuit is now open.  
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+
+            // break duration passes, circuit now half open
+            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+
+            // OnActionPreExecute() should permit first execution.
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // OnActionPreExecute() should reject a second execution.
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldThrow<BrokenCircuitException>();
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // Allow another time window to pass (breaker should still be HalfOpen).
+            SystemClock.UtcNow = () => time.Add(durationOfBreak).Add(durationOfBreak);
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // OnActionPreExecute() should now permit another trial execution.
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
         }
 
@@ -1601,6 +1648,112 @@ namespace Polly.Specs.CircuitBreaker
             firstDelegateExecutedInHalfOpenState.Should().BeTrue();
             secondDelegateExecutedInHalfOpenState.Should().BeFalse();
             secondDelegateRejectedInHalfOpenState.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Should_allow_single_execution_per_break_duration_in_halfopen_state__integration_test()
+        {
+            var time = 1.January(2000);
+            SystemClock.UtcNow = () => time;
+
+            var durationOfBreak = TimeSpan.FromSeconds(30);
+
+            CircuitBreakerPolicy breaker = Policy
+                .Handle<DivideByZeroException>()
+                .AdvancedCircuitBreaker(
+                    failureThreshold: 0.5,
+                    samplingDuration: TimeSpan.FromSeconds(10),
+                    minimumThroughput: 2,
+                    durationOfBreak: durationOfBreak
+                );
+
+            breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
+                .ShouldThrow<DivideByZeroException>();
+            breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
+                .ShouldThrow<DivideByZeroException>();
+
+            // exception raised, circuit is now open.  
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+
+            // break duration passes, circuit now half open
+            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // Start one execution during the HalfOpen state.
+            // Request a second execution while the first is still in flight (not completed), while still during the HalfOpen state, but after one breakDuration later.
+            // The second execution should be accepted in the halfopen state due to being requested after one breakDuration later.
+
+            TimeSpan testTimeoutToExposeDeadlocks = TimeSpan.FromSeconds(5);
+            ManualResetEvent permitSecondExecutionAttempt = new ManualResetEvent(false);
+            ManualResetEvent permitFirstExecutionEnd = new ManualResetEvent(false);
+
+            bool? firstDelegateExecutedInHalfOpenState = null;
+            bool? secondDelegateExecutedInHalfOpenState = null;
+            bool? secondDelegateRejectedInHalfOpenState = null;
+
+            bool firstExecutionActive = false;
+            // First execution in HalfOpen state: we should be able to verify state is HalfOpen as it executes.
+            Task firstExecution = Task.Run(() =>
+            {
+                breaker.Invoking(x => x.Execute(() =>
+                {
+                    firstDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
+
+                    // Signal the second execution can start, overlapping with this (the first) execution.
+                    firstExecutionActive = true;
+                    permitSecondExecutionAttempt.Set();
+
+                    // Hold first execution open until second indicates it is no longer needed, or time out.
+                    permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
+                    firstExecutionActive = false;
+
+                })).ShouldNotThrow();
+            });
+
+            // Attempt a second execution, signalled by the first execution to ensure they overlap; start it one breakDuration later.  We should be able to verify it does execute, though the breaker is still in a HalfOpen state.
+            permitSecondExecutionAttempt.WaitOne(testTimeoutToExposeDeadlocks);
+
+            Task secondExecution = Task.Run(() =>
+            {
+                // Validation of correct sequencing and overlapping of tasks in test (guard against erroneous test refactorings/operation).
+                firstExecutionActive.Should().BeTrue();
+                breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+                try
+                {
+                    SystemClock.UtcNow = () => time.Add(durationOfBreak).Add(durationOfBreak);
+
+                    breaker.Execute(() =>
+                    {
+                        secondDelegateRejectedInHalfOpenState = false;
+                        secondDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
+                    });
+                }
+                catch (BrokenCircuitException)
+                {
+                    secondDelegateExecutedInHalfOpenState = false;
+                    secondDelegateRejectedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested here.
+                }
+
+                // Release first execution soon as second overlapping execution is done gathering data.
+                permitFirstExecutionEnd.Set();
+            });
+
+            // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. 
+            permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
+            permitFirstExecutionEnd.Set();
+            Task.WaitAll(new[] { firstExecution, secondExecution }, testTimeoutToExposeDeadlocks).Should().BeTrue();
+            if (firstExecution.IsFaulted) throw firstExecution.Exception;
+            if (secondExecution.IsFaulted) throw secondExecution.Exception;
+            firstExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+            secondExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+
+            // Assert: 
+            // - First execution should have been permitted and executed under a HalfOpen state
+            // - Second overlapping execution in halfopen state should have been permitted, one breakDuration later.
+            firstDelegateExecutedInHalfOpenState.Should().BeTrue();
+            secondDelegateExecutedInHalfOpenState.Should().BeTrue();
+            secondDelegateRejectedInHalfOpenState.Should().BeFalse();
         }
 
         #endregion

--- a/src/Polly.SharedSpecs/CircuitBreaker/AdvancedCircuitBreakerSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/AdvancedCircuitBreakerSpecs.cs
@@ -1460,6 +1460,149 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
         }
 
+        [Fact]
+        public void Should_only_allow_single_execution_on_first_entering_halfopen_state__test_execution_permit_directly()
+        {
+            var time = 1.January(2000);
+            SystemClock.UtcNow = () => time;
+
+            var durationOfBreak = TimeSpan.FromSeconds(30);
+
+            CircuitBreakerPolicy breaker = Policy
+                .Handle<DivideByZeroException>()
+                .AdvancedCircuitBreaker(
+                    failureThreshold: 0.5,
+                    samplingDuration: TimeSpan.FromSeconds(10),
+                    minimumThroughput: 2,
+                    durationOfBreak: durationOfBreak
+                );
+
+            breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
+                .ShouldThrow<DivideByZeroException>();
+            breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
+                .ShouldThrow<DivideByZeroException>();
+
+            // exception raised, circuit is now open.  
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+
+            // break duration passes, circuit now half open
+            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+
+            // OnActionPreExecute() should permit first execution.
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // OnActionPreExecute() should reject a second execution..
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldThrow<BrokenCircuitException>();
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        }
+
+        [Fact]
+        public void Should_only_allow_single_execution_on_first_entering_halfopen_state__integration_test()
+        {
+            var time = 1.January(2000);
+            SystemClock.UtcNow = () => time;
+
+            var durationOfBreak = TimeSpan.FromSeconds(30);
+
+            CircuitBreakerPolicy breaker = Policy
+                .Handle<DivideByZeroException>()
+                .AdvancedCircuitBreaker(
+                    failureThreshold: 0.5,
+                    samplingDuration: TimeSpan.FromSeconds(10),
+                    minimumThroughput: 2,
+                    durationOfBreak: durationOfBreak
+                );
+
+            breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
+                .ShouldThrow<DivideByZeroException>();
+            breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
+                .ShouldThrow<DivideByZeroException>();
+
+            // exceptions raised, circuit is now open.  
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+
+            // break duration passes, circuit now half open
+            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // Start one execution during the HalfOpen state, and request a second execution before the first has completed (ie still during the HalfOpen state).
+            // The second execution should be rejected due to the halfopen state.
+
+            TimeSpan testTimeoutToExposeDeadlocks = TimeSpan.FromSeconds(5);
+            ManualResetEvent permitSecondExecutionAttempt = new ManualResetEvent(false);
+            ManualResetEvent permitFirstExecutionEnd = new ManualResetEvent(false);
+
+            bool? firstDelegateExecutedInHalfOpenState = null;
+            bool? secondDelegateExecutedInHalfOpenState = null;
+            bool? secondDelegateRejectedInHalfOpenState = null;
+
+            bool firstExecutionActive = false;
+            // First execution in HalfOpen state: we should be able to verify state is HalfOpen as it executes.
+            Task firstExecution = Task.Run(() =>
+            {
+                breaker.Invoking(x => x.Execute(() =>
+                {
+                    firstDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
+
+                    // Signal the second execution can start, overlapping with this (the first) execution.
+                    firstExecutionActive = true;
+                    permitSecondExecutionAttempt.Set();
+
+                    // Hold first execution open until second indicates it is no longer needed, or time out.
+                    permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
+                    firstExecutionActive = false;
+
+                })).ShouldNotThrow();
+            });
+
+            // Attempt a second execution, signalled by the first execution to ensure they overlap: we should be able to verify it doesn't execute, and is rejected by a breaker in a HalfOpen state.
+            permitSecondExecutionAttempt.WaitOne(testTimeoutToExposeDeadlocks);
+
+            Task secondExecution = Task.Run(() =>
+            {
+                // Validation of correct sequencing and overlapping of tasks in test (guard against erroneous test refactorings/operation).
+                firstExecutionActive.Should().BeTrue();
+                breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+                try
+                {
+                    breaker.Execute(() =>
+                    {
+                        secondDelegateRejectedInHalfOpenState = false;
+                        secondDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
+                    });
+                }
+                catch (BrokenCircuitException)
+                {
+                    secondDelegateExecutedInHalfOpenState = false;
+                    secondDelegateRejectedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested here.
+                }
+
+                // Release first execution soon as second overlapping execution is done gathering data.
+                permitFirstExecutionEnd.Set();
+            });
+
+            // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. 
+            permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
+            permitFirstExecutionEnd.Set();
+            Task.WaitAll(new[] { firstExecution, secondExecution }, testTimeoutToExposeDeadlocks).Should().BeTrue();
+            if (firstExecution.IsFaulted) throw firstExecution.Exception;
+            if (secondExecution.IsFaulted) throw secondExecution.Exception;
+            firstExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+            secondExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+
+            // Assert: 
+            // - First execution should have been permitted and executed under a HalfOpen state
+            // - Second overlapping execution in halfopen state should not have been permitted.
+            // - Second execution attempt should have been rejected with HalfOpen state as cause.
+            firstDelegateExecutedInHalfOpenState.Should().BeTrue();
+            secondDelegateExecutedInHalfOpenState.Should().BeFalse();
+            secondDelegateRejectedInHalfOpenState.Should().BeTrue();
+        }
+
         #endregion
 
         #region Isolate and reset tests

--- a/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerAsyncSpecs.cs
@@ -309,6 +309,135 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
         }
 
+        [Fact]
+        public void Should_only_allow_single_execution_on_first_entering_halfopen_state__test_execution_permit_directly()
+        {
+            var time = 1.January(2000);
+            SystemClock.UtcNow = () => time;
+
+            var durationOfBreak = TimeSpan.FromMinutes(1);
+            CircuitBreakerPolicy breaker = Policy
+                            .Handle<DivideByZeroException>()
+                            .CircuitBreakerAsync(1, durationOfBreak);
+
+            breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
+                  .ShouldThrow<DivideByZeroException>();
+
+            // exception raised, circuit is now open.  
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+
+            // break duration passes, circuit now half open
+            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+            
+
+            // OnActionPreExecute() should permit first execution.
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // OnActionPreExecute() should reject a second execution..
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldThrow<BrokenCircuitException>();
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        }
+
+        [Fact]
+        public void Should_only_allow_single_execution_on_first_entering_halfopen_state__integration_test()
+        {
+            var time = 1.January(2000);
+            SystemClock.UtcNow = () => time;
+
+            var durationOfBreak = TimeSpan.FromMinutes(1);
+            CircuitBreakerPolicy breaker = Policy
+                            .Handle<DivideByZeroException>()
+                            .CircuitBreakerAsync(1, durationOfBreak);
+
+            breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
+                  .ShouldThrow<DivideByZeroException>();
+
+            // exception raised, circuit is now open.  
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+
+            // break duration passes, circuit now half open
+            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // Start one execution during the HalfOpen state, and request a second execution before the first has completed (ie still during the HalfOpen state).
+            // The second execution should be rejected due to the halfopen state.
+
+            TimeSpan testTimeoutToExposeDeadlocks = TimeSpan.FromSeconds(5);
+            ManualResetEvent permitSecondExecutionAttempt = new ManualResetEvent(false);
+            ManualResetEvent permitFirstExecutionEnd = new ManualResetEvent(false);
+
+            bool? firstDelegateExecutedInHalfOpenState = null;
+            bool? secondDelegateExecutedInHalfOpenState = null;
+            bool? secondDelegateRejectedInHalfOpenState = null;
+
+            bool firstExecutionActive = false;
+            // First execution in HalfOpen state: we should be able to verify state is HalfOpen as it executes.
+            Task firstExecution = Task.Run(() =>
+            {
+                breaker.Awaiting(x => x.ExecuteAsync(async () =>
+                {
+                    firstDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
+
+                    // Signal the second execution can start, overlapping with this (the first) execution.
+                    firstExecutionActive = true;
+                    permitSecondExecutionAttempt.Set();
+
+                    // Hold first execution open until second indicates it is no longer needed, or time out.
+                    permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
+                    await TaskHelper.EmptyTask;
+                    firstExecutionActive = false;
+
+                })).ShouldNotThrow();
+            });
+
+            // Attempt a second execution, signalled by the first execution to ensure they overlap: we should be able to verify it doesn't execute, and is rejected by a breaker in a HalfOpen state.
+            permitSecondExecutionAttempt.WaitOne(testTimeoutToExposeDeadlocks);
+
+            Task secondExecution = Task.Run(async () =>
+            {
+                // Validation of correct sequencing and overlapping of tasks in test (guard against erroneous test refactorings/operation).
+                firstExecutionActive.Should().BeTrue();
+                breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+                try
+                {
+                    await breaker.ExecuteAsync(async () =>
+                    {
+                        secondDelegateRejectedInHalfOpenState = false;
+                        secondDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
+                        await TaskHelper.EmptyTask;
+                    });
+                }
+                catch (BrokenCircuitException)
+                {
+                    secondDelegateExecutedInHalfOpenState = false;
+                    secondDelegateRejectedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested here.
+                }
+
+                // Release first execution soon as second overlapping execution is done gathering data.
+                permitFirstExecutionEnd.Set();
+            });
+
+            // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. 
+            permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
+            permitFirstExecutionEnd.Set();
+            Task.WaitAll(new[] { firstExecution, secondExecution }, testTimeoutToExposeDeadlocks).Should().BeTrue();
+            if (firstExecution.IsFaulted) throw firstExecution.Exception;
+            if (secondExecution.IsFaulted) throw secondExecution.Exception;
+            firstExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+            secondExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+
+            // Assert: 
+            // - First execution should have been permitted and executed under a HalfOpen state
+            // - Second overlapping execution in halfopen state should not have been permitted.
+            // - Second execution attempt should have been rejected with HalfOpen state as cause.
+            firstDelegateExecutedInHalfOpenState.Should().BeTrue();
+            secondDelegateExecutedInHalfOpenState.Should().BeFalse();
+            secondDelegateRejectedInHalfOpenState.Should().BeTrue();
+        }
+
         #endregion
 
         #region Isolate and reset tests

--- a/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerAsyncSpecs.cs
@@ -329,14 +329,53 @@ namespace Polly.Specs.CircuitBreaker
             // break duration passes, circuit now half open
             SystemClock.UtcNow = () => time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+
+            // OnActionPreExecute() should permit first execution.
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // OnActionPreExecute() should reject a second execution.
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldThrow<BrokenCircuitException>();
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        }
+
+        [Fact]
+        public void Should_allow_single_execution_per_break_duration_in_halfopen_state__test_execution_permit_directly()
+        {
+            var time = 1.January(2000);
+            SystemClock.UtcNow = () => time;
+
+            var durationOfBreak = TimeSpan.FromMinutes(1);
+            CircuitBreakerPolicy breaker = Policy
+                            .Handle<DivideByZeroException>()
+                            .CircuitBreakerAsync(1, durationOfBreak);
+
+            breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
+                  .ShouldThrow<DivideByZeroException>();
+
+            // exception raised, circuit is now open.  
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+
+            // break duration passes, circuit now half open
+            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
             
 
             // OnActionPreExecute() should permit first execution.
             breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
-            // OnActionPreExecute() should reject a second execution..
+            // OnActionPreExecute() should reject a second execution.
             breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldThrow<BrokenCircuitException>();
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // Allow another time window to pass (breaker should still be HalfOpen).
+            SystemClock.UtcNow = () => time.Add(durationOfBreak).Add(durationOfBreak);
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // OnActionPreExecute() should now permit another trial execution.
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
         }
 
@@ -436,6 +475,106 @@ namespace Polly.Specs.CircuitBreaker
             firstDelegateExecutedInHalfOpenState.Should().BeTrue();
             secondDelegateExecutedInHalfOpenState.Should().BeFalse();
             secondDelegateRejectedInHalfOpenState.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Should_allow_single_execution_per_break_duration_in_halfopen_state__integration_test()
+        {
+            var time = 1.January(2000);
+            SystemClock.UtcNow = () => time;
+
+            var durationOfBreak = TimeSpan.FromMinutes(1);
+            CircuitBreakerPolicy breaker = Policy
+                            .Handle<DivideByZeroException>()
+                            .CircuitBreakerAsync(1, durationOfBreak);
+
+            breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
+                  .ShouldThrow<DivideByZeroException>();
+
+            // exception raised, circuit is now open.  
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+
+            // break duration passes, circuit now half open
+            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // Start one execution during the HalfOpen state.
+            // Request a second execution while the first is still in flight (not completed), while still during the HalfOpen state, but after one breakDuration later.
+            // The second execution should be accepted in the halfopen state due to being requested after one breakDuration later.
+
+            TimeSpan testTimeoutToExposeDeadlocks = TimeSpan.FromSeconds(5);
+            ManualResetEvent permitSecondExecutionAttempt = new ManualResetEvent(false);
+            ManualResetEvent permitFirstExecutionEnd = new ManualResetEvent(false);
+
+            bool? firstDelegateExecutedInHalfOpenState = null;
+            bool? secondDelegateExecutedInHalfOpenState = null;
+            bool? secondDelegateRejectedInHalfOpenState = null;
+
+            bool firstExecutionActive = false;
+            // First execution in HalfOpen state: we should be able to verify state is HalfOpen as it executes.
+            Task firstExecution = Task.Run(() =>
+            {
+                breaker.Awaiting(x => x.ExecuteAsync(async () =>
+                {
+                    firstDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
+
+                    // Signal the second execution can start, overlapping with this (the first) execution.
+                    firstExecutionActive = true;
+                    permitSecondExecutionAttempt.Set();
+
+                    // Hold first execution open until second indicates it is no longer needed, or time out.
+                    permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
+                    await TaskHelper.EmptyTask;
+                    firstExecutionActive = false;
+                })).ShouldNotThrow();
+            });
+
+            // Attempt a second execution, signalled by the first execution to ensure they overlap; start it one breakDuration later.  We should be able to verify it does execute, though the breaker is still in a HalfOpen state.
+            permitSecondExecutionAttempt.WaitOne(testTimeoutToExposeDeadlocks);
+
+            Task secondExecution = Task.Run(async () =>
+            {
+                // Validation of correct sequencing and overlapping of tasks in test (guard against erroneous test refactorings/operation).
+                firstExecutionActive.Should().BeTrue();
+                breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+                try
+                {
+                    SystemClock.UtcNow = () => time.Add(durationOfBreak).Add(durationOfBreak);
+
+                    await breaker.ExecuteAsync(async () =>
+                    {
+                        secondDelegateRejectedInHalfOpenState = false;
+                        secondDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
+
+                        await TaskHelper.EmptyTask;
+                    });
+                }
+                catch (BrokenCircuitException)
+                {
+                    secondDelegateExecutedInHalfOpenState = false;
+                    secondDelegateRejectedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested here.
+                }
+
+                // Release first execution soon as second overlapping execution is done gathering data.
+                permitFirstExecutionEnd.Set();
+            });
+
+            // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. 
+            permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
+            permitFirstExecutionEnd.Set();
+            Task.WaitAll(new[] { firstExecution, secondExecution }, testTimeoutToExposeDeadlocks).Should().BeTrue();
+            if (firstExecution.IsFaulted) throw firstExecution.Exception;
+            if (secondExecution.IsFaulted) throw secondExecution.Exception;
+            firstExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+            secondExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+
+            // Assert: 
+            // - First execution should have been permitted and executed under a HalfOpen state
+            // - Second overlapping execution in halfopen state should have been permitted, one breakDuration later.
+            firstDelegateExecutedInHalfOpenState.Should().BeTrue();
+            secondDelegateExecutedInHalfOpenState.Should().BeTrue();
+            secondDelegateRejectedInHalfOpenState.Should().BeFalse();
         }
 
         #endregion

--- a/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerSpecs.cs
@@ -332,8 +332,47 @@ namespace Polly.Specs.CircuitBreaker
             breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
-            // OnActionPreExecute() should reject a second execution..
+            // OnActionPreExecute() should reject a second execution.
             breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldThrow<BrokenCircuitException>();
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        }
+
+        [Fact]
+        public void Should_allow_single_execution_per_break_duration_in_halfopen_state__test_execution_permit_directly()
+        {
+            var time = 1.January(2000);
+            SystemClock.UtcNow = () => time;
+
+            var durationOfBreak = TimeSpan.FromMinutes(1);
+            CircuitBreakerPolicy breaker = Policy
+                            .Handle<DivideByZeroException>()
+                            .CircuitBreaker(1, durationOfBreak);
+
+            breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
+                  .ShouldThrow<DivideByZeroException>();
+
+            // exception raised, circuit is now open.  
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+
+            // break duration passes, circuit now half open
+            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+
+            // OnActionPreExecute() should permit first execution.
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // OnActionPreExecute() should reject a second execution in the same time window.
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldThrow<BrokenCircuitException>();
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // Allow another time window to pass (breaker should still be HalfOpen).
+            SystemClock.UtcNow = () => time.Add(durationOfBreak).Add(durationOfBreak);
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // OnActionPreExecute() should now permit another trial execution.
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
         }
 
@@ -418,7 +457,7 @@ namespace Polly.Specs.CircuitBreaker
             // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. 
             permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
             permitFirstExecutionEnd.Set();
-            Task.WaitAll(new[] {firstExecution, secondExecution}, testTimeoutToExposeDeadlocks).Should().BeTrue();
+            Task.WaitAll(new[] { firstExecution, secondExecution }, testTimeoutToExposeDeadlocks).Should().BeTrue();
             if (firstExecution.IsFaulted) throw firstExecution.Exception;
             if (secondExecution.IsFaulted) throw secondExecution.Exception;
             firstExecution.Status.Should().Be(TaskStatus.RanToCompletion);
@@ -430,7 +469,105 @@ namespace Polly.Specs.CircuitBreaker
             // - Second execution attempt should have been rejected with HalfOpen state as cause.
             firstDelegateExecutedInHalfOpenState.Should().BeTrue();
             secondDelegateExecutedInHalfOpenState.Should().BeFalse();
-            secondDelegateRejectedInHalfOpenState.Should().BeTrue(); 
+            secondDelegateRejectedInHalfOpenState.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Should_allow_single_execution_per_break_duration_in_halfopen_state__integration_test()
+        {
+            var time = 1.January(2000);
+            SystemClock.UtcNow = () => time;
+
+            var durationOfBreak = TimeSpan.FromMinutes(1);
+            CircuitBreakerPolicy breaker = Policy
+                            .Handle<DivideByZeroException>()
+                            .CircuitBreaker(1, durationOfBreak);
+
+            breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
+                  .ShouldThrow<DivideByZeroException>();
+
+            // exception raised, circuit is now open.  
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+
+            // break duration passes, circuit now half open
+            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // Start one execution during the HalfOpen state.
+            // Request a second execution while the first is still in flight (not completed), while still during the HalfOpen state, but after one breakDuration later.
+            // The second execution should be accepted in the halfopen state due to being requested after one breakDuration later.
+
+            TimeSpan testTimeoutToExposeDeadlocks = TimeSpan.FromSeconds(5);
+            ManualResetEvent permitSecondExecutionAttempt = new ManualResetEvent(false);
+            ManualResetEvent permitFirstExecutionEnd = new ManualResetEvent(false);
+
+            bool? firstDelegateExecutedInHalfOpenState = null;
+            bool? secondDelegateExecutedInHalfOpenState = null;
+            bool? secondDelegateRejectedInHalfOpenState = null;
+
+            bool firstExecutionActive = false;
+            // First execution in HalfOpen state: we should be able to verify state is HalfOpen as it executes.
+            Task firstExecution = Task.Run(() =>
+            {
+                breaker.Invoking(x => x.Execute(() =>
+                {
+                    firstDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
+
+                    // Signal the second execution can start, overlapping with this (the first) execution.
+                    firstExecutionActive = true;
+                    permitSecondExecutionAttempt.Set();
+
+                    // Hold first execution open until second indicates it is no longer needed, or time out.
+                    permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
+                    firstExecutionActive = false;
+
+                })).ShouldNotThrow();
+            });
+
+            // Attempt a second execution, signalled by the first execution to ensure they overlap; start it one breakDuration later.  We should be able to verify it does execute, though the breaker is still in a HalfOpen state.
+            permitSecondExecutionAttempt.WaitOne(testTimeoutToExposeDeadlocks);
+
+            Task secondExecution = Task.Run(() =>
+            {
+                // Validation of correct sequencing and overlapping of tasks in test (guard against erroneous test refactorings/operation).
+                firstExecutionActive.Should().BeTrue();
+                breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+                try
+                {
+                    SystemClock.UtcNow = () => time.Add(durationOfBreak).Add(durationOfBreak);
+
+                    breaker.Execute(() =>
+                    {
+                        secondDelegateRejectedInHalfOpenState = false;
+                        secondDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
+                    });
+                }
+                catch (BrokenCircuitException)
+                {
+                    secondDelegateExecutedInHalfOpenState = false;
+                    secondDelegateRejectedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested here.
+                }
+
+                // Release first execution soon as second overlapping execution is done gathering data.
+                permitFirstExecutionEnd.Set();
+            });
+
+            // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. 
+            permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
+            permitFirstExecutionEnd.Set();
+            Task.WaitAll(new[] {firstExecution, secondExecution}, testTimeoutToExposeDeadlocks).Should().BeTrue();
+            if (firstExecution.IsFaulted) throw firstExecution.Exception;
+            if (secondExecution.IsFaulted) throw secondExecution.Exception;
+            firstExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+            secondExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+
+            // Assert: 
+            // - First execution should have been permitted and executed under a HalfOpen state
+            // - Second overlapping execution in halfopen state should have been permitted, one breakDuration later.
+            firstDelegateExecutedInHalfOpenState.Should().BeTrue();
+            secondDelegateExecutedInHalfOpenState.Should().BeTrue();
+            secondDelegateRejectedInHalfOpenState.Should().BeFalse(); 
         }
 
         #endregion

--- a/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerSpecs.cs
@@ -454,7 +454,7 @@ namespace Polly.Specs.CircuitBreaker
                 permitFirstExecutionEnd.Set();
             });
 
-            // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. 
+            // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. This validates the test ran as expected (and background delegates are complete) before we assert on outcomes.
             permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
             permitFirstExecutionEnd.Set();
             Task.WaitAll(new[] { firstExecution, secondExecution }, testTimeoutToExposeDeadlocks).Should().BeTrue();
@@ -553,7 +553,7 @@ namespace Polly.Specs.CircuitBreaker
                 permitFirstExecutionEnd.Set();
             });
 
-            // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. 
+            // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. This validates the test ran as expected (and background delegates are complete) before we assert on outcomes.
             permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
             permitFirstExecutionEnd.Set();
             Task.WaitAll(new[] {firstExecution, secondExecution}, testTimeoutToExposeDeadlocks).Should().BeTrue();
@@ -739,7 +739,7 @@ namespace Polly.Specs.CircuitBreaker
         }
 
         [Fact]
-        public void Should_call_onbreak_when_breaking_circuit_first_time_but_not_for_subsequent_calls_through_open_circuit()
+        public void Should_call_onbreak_when_breaking_circuit_first_time_but_not_for_subsequent_calls_placed_through_open_circuit()
         {
             int onBreakCalled = 0;
             Action<Exception, TimeSpan> onBreak = (_, __) => { onBreakCalled++; };
@@ -765,6 +765,63 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
                   .ShouldThrow<BrokenCircuitException>();
 
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+            onBreakCalled.Should().Be(1);
+        }
+
+        [Fact]
+        public void Should_call_onbreak_when_breaking_circuit_first_time_but_not_for_subsequent_call_failure_which_arrives_on_open_state_though_started_on_closed_state()
+        {
+            int onBreakCalled = 0;
+            Action<Exception, TimeSpan> onBreak = (_, __) => { onBreakCalled++; };
+            Action onReset = () => { };
+
+            CircuitBreakerPolicy breaker = Policy
+                            .Handle<DivideByZeroException>()
+                            .CircuitBreaker(1, TimeSpan.FromMinutes(1), onBreak, onReset);
+
+            // Start an execution when the breaker is in the closed state, but hold it from returning (its failure) until the breaker has opened.  This call, a failure hitting an already open breaker, should indicate its fail, but should not cause onBreak() to be called a second time.
+            TimeSpan testTimeoutToExposeDeadlocks = TimeSpan.FromSeconds(5);
+            ManualResetEvent permitLongRunningExecutionToReturnItsFailure = new ManualResetEvent(false);
+            ManualResetEvent permitMainThreadToOpenCircuit = new ManualResetEvent(false);
+
+            Task longRunningExecution = Task.Run(() =>
+            {
+                breaker.CircuitState.Should().Be(CircuitState.Closed);
+
+                breaker.Invoking(x => x.Execute(() =>
+                {
+                    permitMainThreadToOpenCircuit.Set();
+
+                    // Hold this execution until rest of the test indicates it can proceed (or timeout, to expose deadlocks).
+                    permitLongRunningExecutionToReturnItsFailure.WaitOne(testTimeoutToExposeDeadlocks);
+
+                    // Throw a further failure when rest of test has already broken the circuit.
+                    breaker.CircuitState.Should().Be(CircuitState.Open);
+                    throw new DivideByZeroException();
+
+                })).ShouldThrow<DivideByZeroException>(); // However, since execution started when circuit was closed, BrokenCircuitException will not have been thrown on entry; the original exception will still be thrown.
+            });
+
+            permitMainThreadToOpenCircuit.WaitOne(testTimeoutToExposeDeadlocks).Should().BeTrue();
+
+            // Break circuit in the normal manner: onBreak() should be called once.
+            breaker.CircuitState.Should().Be(CircuitState.Closed);
+            onBreakCalled.Should().Be(0);
+            breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
+                  .ShouldThrow<DivideByZeroException>();
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+            onBreakCalled.Should().Be(1);
+
+            // Permit the second (long-running) execution to hit the open circuit with its failure.
+            permitLongRunningExecutionToReturnItsFailure.Set();
+
+            // Graceful cleanup: allow executions time to end naturally; timeout if any deadlocks; expose any execution faults.  This validates the test ran as expected (and background delegates are complete) before we assert on outcomes.
+            longRunningExecution.Wait(testTimeoutToExposeDeadlocks).Should().BeTrue();
+            if (longRunningExecution.IsFaulted) throw longRunningExecution.Exception;
+            longRunningExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+
+            // onBreak() should still only have been called once.
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
         }

--- a/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerTResultAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerTResultAsyncSpecs.cs
@@ -399,8 +399,47 @@ namespace Polly.Specs.CircuitBreaker
             breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
-            // OnActionPreExecute() should reject a second execution..
+            // OnActionPreExecute() should reject a second execution.
             breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldThrow<BrokenCircuitException>();
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        }
+
+        [Fact]
+        public async Task Should_allow_single_execution_per_break_duration_in_halfopen_state__test_execution_permit_directly()
+        {
+            var time = 1.January(2000);
+            SystemClock.UtcNow = () => time;
+
+            var durationOfBreak = TimeSpan.FromMinutes(1);
+            CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
+                .HandleResult(ResultPrimitive.Fault)
+                .CircuitBreakerAsync(1, durationOfBreak);
+
+            (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault).ConfigureAwait(false))
+                  .Should().Be(ResultPrimitive.Fault);
+
+            // exception raised, circuit is now open.  
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+
+            // break duration passes, circuit now half open
+            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+
+            // OnActionPreExecute() should permit first execution.
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // OnActionPreExecute() should reject a second execution.
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldThrow<BrokenCircuitException>();
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // Allow another time window to pass (breaker should still be HalfOpen).
+            SystemClock.UtcNow = () => time.Add(durationOfBreak).Add(durationOfBreak);
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // OnActionPreExecute() should now permit another trial execution.
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
         }
 
@@ -505,6 +544,111 @@ namespace Polly.Specs.CircuitBreaker
             secondDelegateExecutedInHalfOpenState.Should().BeFalse();
             secondDelegateRejectedInHalfOpenState.Should().BeTrue();
         }
+
+        [Fact]
+        public async Task Should_allow_single_execution_per_break_duration_in_halfopen_state__integration_test()
+        {
+            var time = 1.January(2000);
+            SystemClock.UtcNow = () => time;
+
+            var durationOfBreak = TimeSpan.FromMinutes(1);
+            CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
+                .HandleResult(ResultPrimitive.Fault)
+                .CircuitBreakerAsync(1, durationOfBreak);
+
+            (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault).ConfigureAwait(false))
+                  .Should().Be(ResultPrimitive.Fault);
+
+            // exception raised, circuit is now open.  
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+
+            // break duration passes, circuit now half open
+            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // Start one execution during the HalfOpen state.
+            // Request a second execution while the first is still in flight (not completed), while still during the HalfOpen state, but after one breakDuration later.
+            // The second execution should be accepted in the halfopen state due to being requested after one breakDuration later.
+
+            TimeSpan testTimeoutToExposeDeadlocks = TimeSpan.FromSeconds(5);
+            ManualResetEvent permitSecondExecutionAttempt = new ManualResetEvent(false);
+            ManualResetEvent permitFirstExecutionEnd = new ManualResetEvent(false);
+
+            bool? firstDelegateExecutedInHalfOpenState = null;
+            bool? secondDelegateExecutedInHalfOpenState = null;
+            bool? secondDelegateRejectedInHalfOpenState = null;
+
+            bool firstExecutionActive = false;
+            // First execution in HalfOpen state: we should be able to verify state is HalfOpen as it executes.
+            Task firstExecution = Task.Run(() =>
+            {
+                breaker.Awaiting(x => x.ExecuteAsync(async () =>
+                {
+                    firstDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
+
+                    // Signal the second execution can start, overlapping with this (the first) execution.
+                    firstExecutionActive = true;
+                    permitSecondExecutionAttempt.Set();
+
+                    // Hold first execution open until second indicates it is no longer needed, or time out.
+                    permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
+                    await TaskHelper.EmptyTask;
+                    firstExecutionActive = false;
+
+                    return ResultPrimitive.Good;
+                })).ShouldNotThrow();
+            });
+
+            // Attempt a second execution, signalled by the first execution to ensure they overlap; start it one breakDuration later.  We should be able to verify it does execute, though the breaker is still in a HalfOpen state.
+            permitSecondExecutionAttempt.WaitOne(testTimeoutToExposeDeadlocks);
+
+            Task secondExecution = Task.Run(async () =>
+            {
+                // Validation of correct sequencing and overlapping of tasks in test (guard against erroneous test refactorings/operation).
+                firstExecutionActive.Should().BeTrue();
+                breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+                try
+                {
+                    SystemClock.UtcNow = () => time.Add(durationOfBreak).Add(durationOfBreak);
+
+                    await breaker.ExecuteAsync(async () =>
+                    {
+                        secondDelegateRejectedInHalfOpenState = false;
+                        secondDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
+
+                        await TaskHelper.EmptyTask;
+
+                        return ResultPrimitive.Good;
+                    });
+                }
+                catch (BrokenCircuitException)
+                {
+                    secondDelegateExecutedInHalfOpenState = false;
+                    secondDelegateRejectedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested here.
+                }
+
+                // Release first execution soon as second overlapping execution is done gathering data.
+                permitFirstExecutionEnd.Set();
+            });
+
+            // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. 
+            permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
+            permitFirstExecutionEnd.Set();
+            Task.WaitAll(new[] { firstExecution, secondExecution }, testTimeoutToExposeDeadlocks).Should().BeTrue();
+            if (firstExecution.IsFaulted) throw firstExecution.Exception;
+            if (secondExecution.IsFaulted) throw secondExecution.Exception;
+            firstExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+            secondExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+
+            // Assert: 
+            // - First execution should have been permitted and executed under a HalfOpen state
+            // - Second overlapping execution in halfopen state should have been permitted, one breakDuration later.
+            firstDelegateExecutedInHalfOpenState.Should().BeTrue();
+            secondDelegateExecutedInHalfOpenState.Should().BeTrue();
+            secondDelegateRejectedInHalfOpenState.Should().BeFalse();
+        }
+
         #endregion
 
         #region Isolate and reset tests

--- a/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerTResultAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerTResultAsyncSpecs.cs
@@ -373,6 +373,138 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
         }
 
+        [Fact]
+        public async Task Should_only_allow_single_execution_on_first_entering_halfopen_state__test_execution_permit_directly()
+        {
+            var time = 1.January(2000);
+            SystemClock.UtcNow = () => time;
+
+            var durationOfBreak = TimeSpan.FromMinutes(1);
+            CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
+                .HandleResult(ResultPrimitive.Fault)
+                .CircuitBreakerAsync(1, durationOfBreak);
+
+            (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault).ConfigureAwait(false))
+                  .Should().Be(ResultPrimitive.Fault);
+
+            // exception raised, circuit is now open.  
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+
+            // break duration passes, circuit now half open
+            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+
+            // OnActionPreExecute() should permit first execution.
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // OnActionPreExecute() should reject a second execution..
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldThrow<BrokenCircuitException>();
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        }
+
+        [Fact]
+        public async Task Should_only_allow_single_execution_on_first_entering_halfopen_state__integration_test()
+        {
+            var time = 1.January(2000);
+            SystemClock.UtcNow = () => time;
+
+            var durationOfBreak = TimeSpan.FromMinutes(1);
+            CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
+                .HandleResult(ResultPrimitive.Fault)
+                .CircuitBreakerAsync(1, durationOfBreak);
+
+            (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault).ConfigureAwait(false))
+                  .Should().Be(ResultPrimitive.Fault);
+
+            // exception raised, circuit is now open.  
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+
+            // break duration passes, circuit now half open
+            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // Start one execution during the HalfOpen state, and request a second execution before the first has completed (ie still during the HalfOpen state).
+            // The second execution should be rejected due to the halfopen state.
+
+            TimeSpan testTimeoutToExposeDeadlocks = TimeSpan.FromSeconds(5);
+            ManualResetEvent permitSecondExecutionAttempt = new ManualResetEvent(false);
+            ManualResetEvent permitFirstExecutionEnd = new ManualResetEvent(false);
+
+            bool? firstDelegateExecutedInHalfOpenState = null;
+            bool? secondDelegateExecutedInHalfOpenState = null;
+            bool? secondDelegateRejectedInHalfOpenState = null;
+
+            bool firstExecutionActive = false;
+            // First execution in HalfOpen state: we should be able to verify state is HalfOpen as it executes.
+            Task firstExecution = Task.Run(() =>
+            {
+                breaker.Awaiting(x => x.ExecuteAsync(async () =>
+                {
+                    firstDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
+
+                    // Signal the second execution can start, overlapping with this (the first) execution.
+                    firstExecutionActive = true;
+                    permitSecondExecutionAttempt.Set();
+
+                    // Hold first execution open until second indicates it is no longer needed, or time out.
+                    permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
+                    await TaskHelper.EmptyTask;
+                    firstExecutionActive = false;
+
+                    return ResultPrimitive.Good;
+                })).ShouldNotThrow();
+            });
+
+            // Attempt a second execution, signalled by the first execution to ensure they overlap: we should be able to verify it doesn't execute, and is rejected by a breaker in a HalfOpen state.
+            permitSecondExecutionAttempt.WaitOne(testTimeoutToExposeDeadlocks);
+
+            Task secondExecution = Task.Run(async () =>
+            {
+                // Validation of correct sequencing and overlapping of tasks in test (guard against erroneous test refactorings/operation).
+                firstExecutionActive.Should().BeTrue();
+                breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+                try
+                {
+                    await breaker.ExecuteAsync(async () =>
+                    {
+                        secondDelegateRejectedInHalfOpenState = false;
+                        secondDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
+
+                        await TaskHelper.EmptyTask;
+
+                        return ResultPrimitive.Good;
+                    });
+                }
+                catch (BrokenCircuitException)
+                {
+                    secondDelegateExecutedInHalfOpenState = false;
+                    secondDelegateRejectedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested here.
+                }
+
+                // Release first execution soon as second overlapping execution is done gathering data.
+                permitFirstExecutionEnd.Set();
+            });
+
+            // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. 
+            permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
+            permitFirstExecutionEnd.Set();
+            Task.WaitAll(new[] { firstExecution, secondExecution }, testTimeoutToExposeDeadlocks).Should().BeTrue();
+            if (firstExecution.IsFaulted) throw firstExecution.Exception;
+            if (secondExecution.IsFaulted) throw secondExecution.Exception;
+            firstExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+            secondExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+
+            // Assert: 
+            // - First execution should have been permitted and executed under a HalfOpen state
+            // - Second overlapping execution in halfopen state should not have been permitted.
+            // - Second execution attempt should have been rejected with HalfOpen state as cause.
+            firstDelegateExecutedInHalfOpenState.Should().BeTrue();
+            secondDelegateExecutedInHalfOpenState.Should().BeFalse();
+            secondDelegateRejectedInHalfOpenState.Should().BeTrue();
+        }
         #endregion
 
         #region Isolate and reset tests

--- a/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerTResultSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerTResultSpecs.cs
@@ -397,8 +397,47 @@ namespace Polly.Specs.CircuitBreaker
             breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
-            // OnActionPreExecute() should reject a second execution..
+            // OnActionPreExecute() should reject a second execution.
             breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldThrow<BrokenCircuitException>();
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        }
+
+        [Fact]
+        public void Should_allow_single_execution_per_break_duration_in_halfopen_state__test_execution_permit_directly()
+        {
+            var time = 1.January(2000);
+            SystemClock.UtcNow = () => time;
+
+            var durationOfBreak = TimeSpan.FromMinutes(1);
+            CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
+                .HandleResult(ResultPrimitive.Fault)
+                .CircuitBreaker(1, durationOfBreak);
+
+            breaker.RaiseResultSequence(ResultPrimitive.Fault)
+                .Should().Be(ResultPrimitive.Fault);
+
+            // exception raised, circuit is now open.  
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+
+            // break duration passes, circuit now half open
+            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+
+            // OnActionPreExecute() should permit first execution.
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // OnActionPreExecute() should reject a second execution.
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldThrow<BrokenCircuitException>();
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // Allow another time window to pass (breaker should still be HalfOpen).
+            SystemClock.UtcNow = () => time.Add(durationOfBreak).Add(durationOfBreak);
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // OnActionPreExecute() should now permit another trial execution.
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
         }
 
@@ -499,6 +538,107 @@ namespace Polly.Specs.CircuitBreaker
             firstDelegateExecutedInHalfOpenState.Should().BeTrue();
             secondDelegateExecutedInHalfOpenState.Should().BeFalse();
             secondDelegateRejectedInHalfOpenState.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Should_allow_single_execution_per_break_duration_in_halfopen_state__integration_test()
+        {
+            var time = 1.January(2000);
+            SystemClock.UtcNow = () => time;
+
+            var durationOfBreak = TimeSpan.FromMinutes(1);
+            CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
+                .HandleResult(ResultPrimitive.Fault)
+                .CircuitBreaker(1, durationOfBreak);
+
+            breaker.RaiseResultSequence(ResultPrimitive.Fault)
+                  .Should().Be(ResultPrimitive.Fault);
+
+            // exception raised, circuit is now open.  
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+
+            // break duration passes, circuit now half open
+            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // Start one execution during the HalfOpen state.
+            // Request a second execution while the first is still in flight (not completed), while still during the HalfOpen state, but after one breakDuration later.
+            // The second execution should be accepted in the halfopen state due to being requested after one breakDuration later.
+
+            TimeSpan testTimeoutToExposeDeadlocks = TimeSpan.FromSeconds(5);
+            ManualResetEvent permitSecondExecutionAttempt = new ManualResetEvent(false);
+            ManualResetEvent permitFirstExecutionEnd = new ManualResetEvent(false);
+
+            bool? firstDelegateExecutedInHalfOpenState = null;
+            bool? secondDelegateExecutedInHalfOpenState = null;
+            bool? secondDelegateRejectedInHalfOpenState = null;
+
+            bool firstExecutionActive = false;
+            // First execution in HalfOpen state: we should be able to verify state is HalfOpen as it executes.
+            Task firstExecution = Task.Run(() =>
+            {
+                breaker.Invoking(x => x.Execute(() =>
+                {
+                    firstDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
+
+                    // Signal the second execution can start, overlapping with this (the first) execution.
+                    firstExecutionActive = true;
+                    permitSecondExecutionAttempt.Set();
+
+                    // Hold first execution open until second indicates it is no longer needed, or time out.
+                    permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
+                    firstExecutionActive = false;
+
+                    return ResultPrimitive.Good;
+                })).ShouldNotThrow();
+            });
+
+            // Attempt a second execution, signalled by the first execution to ensure they overlap; start it one breakDuration later.  We should be able to verify it does execute, though the breaker is still in a HalfOpen state.
+            permitSecondExecutionAttempt.WaitOne(testTimeoutToExposeDeadlocks);
+
+            Task secondExecution = Task.Run(() =>
+            {
+                // Validation of correct sequencing and overlapping of tasks in test (guard against erroneous test refactorings/operation).
+                firstExecutionActive.Should().BeTrue();
+                breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+                try
+                {
+                    SystemClock.UtcNow = () => time.Add(durationOfBreak).Add(durationOfBreak);
+
+                    breaker.Execute(() =>
+                    {
+                        secondDelegateRejectedInHalfOpenState = false;
+                        secondDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
+
+                        return ResultPrimitive.Good;
+                    });
+                }
+                catch (BrokenCircuitException)
+                {
+                    secondDelegateExecutedInHalfOpenState = false;
+                    secondDelegateRejectedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested here.
+                }
+
+                // Release first execution soon as second overlapping execution is done gathering data.
+                permitFirstExecutionEnd.Set();
+            });
+
+            // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. 
+            permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
+            permitFirstExecutionEnd.Set();
+            Task.WaitAll(new[] { firstExecution, secondExecution }, testTimeoutToExposeDeadlocks).Should().BeTrue();
+            if (firstExecution.IsFaulted) throw firstExecution.Exception;
+            if (secondExecution.IsFaulted) throw secondExecution.Exception;
+            firstExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+            secondExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+
+            // Assert: 
+            // - First execution should have been permitted and executed under a HalfOpen state
+            // - Second overlapping execution in halfopen state should have been permitted, one breakDuration later.
+            firstDelegateExecutedInHalfOpenState.Should().BeTrue();
+            secondDelegateExecutedInHalfOpenState.Should().BeTrue();
+            secondDelegateRejectedInHalfOpenState.Should().BeFalse();
         }
 
         #endregion

--- a/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerTResultSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerTResultSpecs.cs
@@ -371,6 +371,136 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
         }
 
+        [Fact]
+        public void Should_only_allow_single_execution_on_first_entering_halfopen_state__test_execution_permit_directly()
+        {
+            var time = 1.January(2000);
+            SystemClock.UtcNow = () => time;
+
+            var durationOfBreak = TimeSpan.FromMinutes(1);
+            CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
+                .HandleResult(ResultPrimitive.Fault)
+                .CircuitBreaker(1, durationOfBreak);
+
+            breaker.RaiseResultSequence(ResultPrimitive.Fault)
+                .Should().Be(ResultPrimitive.Fault);
+
+            // exception raised, circuit is now open.  
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+
+            // break duration passes, circuit now half open
+            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+
+            // OnActionPreExecute() should permit first execution.
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // OnActionPreExecute() should reject a second execution..
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldThrow<BrokenCircuitException>();
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        }
+
+        [Fact]
+        public void Should_only_allow_single_execution_on_first_entering_halfopen_state__integration_test()
+        {
+            var time = 1.January(2000);
+            SystemClock.UtcNow = () => time;
+
+            var durationOfBreak = TimeSpan.FromMinutes(1);
+            CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
+                .HandleResult(ResultPrimitive.Fault)
+                .CircuitBreaker(1, durationOfBreak);
+
+            breaker.RaiseResultSequence(ResultPrimitive.Fault)
+                  .Should().Be(ResultPrimitive.Fault);
+
+            // exception raised, circuit is now open.  
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+
+            // break duration passes, circuit now half open
+            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+            // Start one execution during the HalfOpen state, and request a second execution before the first has completed (ie still during the HalfOpen state).
+            // The second execution should be rejected due to the halfopen state.
+
+            TimeSpan testTimeoutToExposeDeadlocks = TimeSpan.FromSeconds(5);
+            ManualResetEvent permitSecondExecutionAttempt = new ManualResetEvent(false);
+            ManualResetEvent permitFirstExecutionEnd = new ManualResetEvent(false);
+
+            bool? firstDelegateExecutedInHalfOpenState = null;
+            bool? secondDelegateExecutedInHalfOpenState = null;
+            bool? secondDelegateRejectedInHalfOpenState = null;
+
+            bool firstExecutionActive = false;
+            // First execution in HalfOpen state: we should be able to verify state is HalfOpen as it executes.
+            Task firstExecution = Task.Run(() =>
+            {
+                breaker.Invoking(x => x.Execute(() =>
+                {
+                    firstDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
+
+                    // Signal the second execution can start, overlapping with this (the first) execution.
+                    firstExecutionActive = true;
+                    permitSecondExecutionAttempt.Set();
+
+                    // Hold first execution open until second indicates it is no longer needed, or time out.
+                    permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
+                    firstExecutionActive = false;
+
+                    return ResultPrimitive.Good;
+                })).ShouldNotThrow();
+            });
+
+            // Attempt a second execution, signalled by the first execution to ensure they overlap: we should be able to verify it doesn't execute, and is rejected by a breaker in a HalfOpen state.
+            permitSecondExecutionAttempt.WaitOne(testTimeoutToExposeDeadlocks);
+
+            Task secondExecution = Task.Run(() =>
+            {
+                // Validation of correct sequencing and overlapping of tasks in test (guard against erroneous test refactorings/operation).
+                firstExecutionActive.Should().BeTrue();
+                breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+                try
+                {
+                    breaker.Execute(() =>
+                    {
+                        secondDelegateRejectedInHalfOpenState = false;
+                        secondDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
+
+                        return ResultPrimitive.Good;
+                    });
+                }
+                catch (BrokenCircuitException)
+                {
+                    secondDelegateExecutedInHalfOpenState = false;
+                    secondDelegateRejectedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested here.
+                }
+
+                // Release first execution soon as second overlapping execution is done gathering data.
+                permitFirstExecutionEnd.Set();
+            });
+
+            // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. 
+            permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
+            permitFirstExecutionEnd.Set();
+            Task.WaitAll(new[] { firstExecution, secondExecution }, testTimeoutToExposeDeadlocks).Should().BeTrue();
+            if (firstExecution.IsFaulted) throw firstExecution.Exception;
+            if (secondExecution.IsFaulted) throw secondExecution.Exception;
+            firstExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+            secondExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+
+            // Assert: 
+            // - First execution should have been permitted and executed under a HalfOpen state
+            // - Second overlapping execution in halfopen state should not have been permitted.
+            // - Second execution attempt should have been rejected with HalfOpen state as cause.
+            firstDelegateExecutedInHalfOpenState.Should().BeTrue();
+            secondDelegateExecutedInHalfOpenState.Should().BeFalse();
+            secondDelegateRejectedInHalfOpenState.Should().BeTrue();
+        }
+
         #endregion
 
         #region Isolate and reset tests

--- a/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerTResultSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerTResultSpecs.cs
@@ -522,7 +522,7 @@ namespace Polly.Specs.CircuitBreaker
                 permitFirstExecutionEnd.Set();
             });
 
-            // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. 
+            // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. This validates the test ran as expected (and background delegates are complete) before we assert on outcomes.
             permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
             permitFirstExecutionEnd.Set();
             Task.WaitAll(new[] { firstExecution, secondExecution }, testTimeoutToExposeDeadlocks).Should().BeTrue();
@@ -624,7 +624,7 @@ namespace Polly.Specs.CircuitBreaker
                 permitFirstExecutionEnd.Set();
             });
 
-            // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. 
+            // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. This validates the test ran as expected (and background delegates are complete) before we assert on outcomes.
             permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
             permitFirstExecutionEnd.Set();
             Task.WaitAll(new[] { firstExecution, secondExecution }, testTimeoutToExposeDeadlocks).Should().BeTrue();
@@ -811,7 +811,7 @@ namespace Polly.Specs.CircuitBreaker
         }
 
         [Fact]
-        public void Should_call_onbreak_when_breaking_circuit_first_time_but_not_for_subsequent_calls_through_open_circuit()
+        public void Should_call_onbreak_when_breaking_circuit_first_time_but_not_for_subsequent_calls_placed_through_open_circuit()
         {
             int onBreakCalled = 0;
             Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, __) => { onBreakCalled++; };
@@ -837,6 +837,63 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Invoking(x => x.Execute(() => ResultPrimitive.Good))
                   .ShouldThrow<BrokenCircuitException>();
 
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+            onBreakCalled.Should().Be(1);
+        }
+
+        [Fact]
+        public void Should_call_onbreak_when_breaking_circuit_first_time_but_not_for_subsequent_call_failure_which_arrives_on_open_state_though_started_on_closed_state()
+        {
+            int onBreakCalled = 0;
+            Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, __) => { onBreakCalled++; };
+            Action onReset = () => { };
+
+            CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
+                            .HandleResult(ResultPrimitive.Fault)
+                            .CircuitBreaker(1, TimeSpan.FromMinutes(1), onBreak, onReset);
+
+            // Start an execution when the breaker is in the closed state, but hold it from returning (its failure) until the breaker has opened.  This call, a failure hitting an already open breaker, should indicate its fail, but should not cause onBreak() to be called a second time.
+            TimeSpan testTimeoutToExposeDeadlocks = TimeSpan.FromSeconds(5);
+            ManualResetEvent permitLongRunningExecutionToReturnItsFailure = new ManualResetEvent(false);
+            ManualResetEvent permitMainThreadToOpenCircuit = new ManualResetEvent(false);
+
+            Task longRunningExecution = Task.Run(() =>
+            {
+                breaker.CircuitState.Should().Be(CircuitState.Closed);
+
+                breaker.Execute(() =>
+                {
+                    permitMainThreadToOpenCircuit.Set();
+
+                    // Hold this execution until rest of the test indicates it can proceed (or timeout, to expose deadlocks).
+                    permitLongRunningExecutionToReturnItsFailure.WaitOne(testTimeoutToExposeDeadlocks);
+
+                    // Throw a further failure when rest of test has already broken the circuit.
+                    breaker.CircuitState.Should().Be(CircuitState.Open);
+                    return ResultPrimitive.Fault;
+
+                }).Should().Be(ResultPrimitive.Fault); // However, since execution started when circuit was closed, BrokenCircuitException will not have been thrown on entry; the original fault should still be returned.
+            });
+
+            permitMainThreadToOpenCircuit.WaitOne(testTimeoutToExposeDeadlocks).Should().BeTrue();
+
+            // Break circuit in the normal manner: onBreak() should be called once.
+            breaker.CircuitState.Should().Be(CircuitState.Closed);
+            onBreakCalled.Should().Be(0);
+            breaker.RaiseResultSequence(ResultPrimitive.Fault)
+                  .Should().Be(ResultPrimitive.Fault);
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+            onBreakCalled.Should().Be(1);
+
+            // Permit the second (long-running) execution to hit the open circuit with its failure.
+            permitLongRunningExecutionToReturnItsFailure.Set();
+
+            // Graceful cleanup: allow executions time to end naturally; timeout if any deadlocks; expose any execution faults.  This validates the test ran as expected (and background delegates are complete) before we assert on outcomes.
+            longRunningExecution.Wait(testTimeoutToExposeDeadlocks).Should().BeTrue();
+            if (longRunningExecution.IsFaulted) throw longRunningExecution.Exception;
+            longRunningExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+
+            // onBreak() should still only have been called once.
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
         }

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -15,6 +15,10 @@
     <releaseNotes>
      v5.0 is a major release with significant new resilience policies: Timeout; Bulkhead Isolation; Fallback; and PolicyWrap.  See release notes back to v5.0.0 for full details. 
 
+     5.0.5 pre
+     ---------------------
+     - Bug fix: Prevent request stampede during half-open state of CircuitBreaker and AdvancedCircuitBreaker.  Enforce only one new trial call, after transition to half-open state.
+
      5.0.4 pre
      ---------------------
      - (.NET40Async package changes only)

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -19,6 +19,7 @@
      ---------------------
      - Bug fix: Prevent request stampede during half-open state of CircuitBreaker and AdvancedCircuitBreaker.  Enforce only one new trial call per break duration, during half-open state.
      - Bug fix: Prevent duplicate raising of the onBreak delegate, if executions started when a circuit was closed, return faults when a circuit has already opened.
+     - Optimisation: Optimise hotpaths for Circuit-Breaker, Retry and Fallback policies.
 
      5.0.4 pre
      ---------------------

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -17,7 +17,7 @@
 
      5.0.5 pre
      ---------------------
-     - Bug fix: Prevent request stampede during half-open state of CircuitBreaker and AdvancedCircuitBreaker.  Enforce only one new trial call, after transition to half-open state.
+     - Bug fix: Prevent request stampede during half-open state of CircuitBreaker and AdvancedCircuitBreaker.  Enforce only one new trial call per break duration, during half-open state.
 
      5.0.4 pre
      ---------------------

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -15,7 +15,7 @@
     <releaseNotes>
      v5.0 is a major release with significant new resilience policies: Timeout; Bulkhead Isolation; Fallback; and PolicyWrap.  See release notes back to v5.0.0 for full details. 
 
-     5.0.5 pre
+     5.0.5
      ---------------------
      - Bug fix: Prevent request stampede during half-open state of CircuitBreaker and AdvancedCircuitBreaker.  Enforce only one new trial call per break duration, during half-open state.
      - Bug fix: Prevent duplicate raising of the onBreak delegate, if executions started when a circuit was closed, return faults when a circuit has already opened.

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -18,6 +18,7 @@
      5.0.5 pre
      ---------------------
      - Bug fix: Prevent request stampede during half-open state of CircuitBreaker and AdvancedCircuitBreaker.  Enforce only one new trial call per break duration, during half-open state.
+     - Bug fix: Prevent duplicate raising of the onBreak delegate, if executions started when a circuit was closed, return faults when a circuit has already opened.
 
      5.0.4 pre
      ---------------------


### PR DESCRIPTION
Fixes the effects of long-running executions on the circuit-breaker half-open and open states.  Executions started when the circuit was closed may conceivably return their results when the breaker is half-open or open.

**Half-open state:** Fix to prevent request stampede.  Breaker will now only allow one trial execution per configured `durationOfBreak`

**Open state:** Prevent failures arriving during the open state causing duplicate invocations of the `onBreak()` delegate

Closes #216, #219, #217, #218 