### PR TITLE
Update NetStandard.Library dependency to NETStandard.Library 1.6.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.0.6
+- Update NETStandard.Library dependency to latest 1.6.1.  Resolves compatibility for some Xamarin targets.
+
 ## 5.0.5
 - Bug fix: Prevent request stampede during half-open state of CircuitBreaker and AdvancedCircuitBreaker.  Enforce only one new trial call per break duration, during half-open state.
 - Bug fix: Prevent duplicate raising of the onBreak delegate, if executions started when a circuit was closed, return faults when a circuit has already opened.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 5.0.6
-- Update NETStandard.Library dependency to latest 1.6.1.  Resolves compatibility for some Xamarin targets.
+- Update NETStandard.Library dependency to latest 1.6.1 for .NetStandard1.0 target.  Resolves compatibility for some Xamarin targets.
 
 ## 5.0.5
 - Bug fix: Prevent request stampede during half-open state of CircuitBreaker and AdvancedCircuitBreaker.  Enforce only one new trial call per break duration, during half-open state.

--- a/GitVersionConfig.yaml
+++ b/GitVersionConfig.yaml
@@ -1,1 +1,1 @@
-next-version: 5.0.5
+next-version: 5.0.6

--- a/src/Polly.Net40Async.nuspec
+++ b/src/Polly.Net40Async.nuspec
@@ -15,6 +15,10 @@
     <releaseNotes>
      v5.0 is a major release with significant new resilience policies: Timeout; Bulkhead Isolation; Fallback; and PolicyWrap.  See release notes back to v5.0.0 for full details.
 
+     5.0.6
+     ---------------------
+     - (.NETStandard1.0 changes only.)
+
      5.0.5
      ---------------------
      - Bug fix: Prevent request stampede during half-open state of CircuitBreaker and AdvancedCircuitBreaker.  Enforce only one new trial call per break duration, during half-open state.

--- a/src/Polly.NetStandard10/Properties/AssemblyInfo.cs
+++ b/src/Polly.NetStandard10/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Polly")]
-[assembly: AssemblyVersion("5.0.5.0")]
+[assembly: AssemblyVersion("5.0.6.0")]
 [assembly: CLSCompliant(true)]
 
 [assembly: InternalsVisibleTo("Polly.Pcl.Specs")]

--- a/src/Polly.NetStandard10/project.json
+++ b/src/Polly.NetStandard10/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "supports": {},
   "dependencies": {
-    "NETStandard.Library": "1.6.0"
+    "NETStandard.Library": "1.6.1"
   },
   "frameworks": {
     "netstandard1.0": {}

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -15,6 +15,10 @@
     <releaseNotes>
      v5.0 is a major release with significant new resilience policies: Timeout; Bulkhead Isolation; Fallback; and PolicyWrap.  See release notes back to v5.0.0 for full details. 
 
+     5.0.6
+     ---------------------
+     - Update NETStandard.Library dependency to latest 1.6.1.  Resolves compatibility for some Xamarin targets.
+
      5.0.5
      ---------------------
      - Bug fix: Prevent request stampede during half-open state of CircuitBreaker and AdvancedCircuitBreaker.  Enforce only one new trial call per break duration, during half-open state.
@@ -160,7 +164,7 @@
     <dependencies>
       <group targetFramework="net45"/>
       <group targetFramework="netstandard1.0">
-        <dependency id="NETStandard.Library" version="1.6.0" />
+        <dependency id="NETStandard.Library" version="1.6.1" />
       </group>
     </dependencies>
   </metadata>

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -17,7 +17,7 @@
 
      5.0.6
      ---------------------
-     - Update NETStandard.Library dependency to latest 1.6.1.  Resolves compatibility for some Xamarin targets.
+     - Update NETStandard.Library dependency to latest 1.6.1 for .NetStandard1.0 target.  Resolves compatibility for some Xamarin targets.
 
      5.0.5
      ---------------------


### PR DESCRIPTION
Update NetStandard.Library dependency to NETStandard.Library 1.6.1, to
resolve compatibility for some Xamarin targets.