### PR TITLE
[Third-party materials] Add ExceptionDispatchInfo for .NET4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -866,7 +866,7 @@ For details of changes by release see the [change log](https://github.com/App-vN
 * [Ian Griffith's TimedLock](http://www.interact-sw.co.uk/iangblog/2004/04/26/yetmoretimedlocking)
 * [Steven van Deursen's ReadOnlyDictionary](http://www.cuttingedge.it/blogs/steven/pivot/entry.php?id=29) (until v5.0.6)
 * [Stephen Cleary's AsyncEx library](https://github.com/StephenCleary/AsyncEx) for AsyncSemaphore (supports BulkheadAsync policy for .NET4.0 only) | [MIT license](https://github.com/StephenCleary/AsyncEx/blob/master/LICENSE)
-* [@theraot](https://github.com/theraot)'s [ExceptionDispatchInfo implementation for .NET4.0](https://stackoverflow.com/a/31226509/) (supports Timeout policy for .NET4.0 only) including also a contribution by [@migueldeicaza](https://github.com/migueldeicaza) | [Creative Commons Attribution Share Alike license](https://creativecommons.org/licenses/by-sa/3.0/)
+* [@theraot](https://github.com/theraot)'s [ExceptionDispatchInfo implementation for .NET4.0](https://stackoverflow.com/a/31226509/) (supports Timeout policy for .NET4.0 only) including also a contribution by [@migueldeicaza](https://github.com/migueldeicaza) | [Creative Commons Attribution Share Alike license](https://creativecommons.org/licenses/by-sa/3.0/) per [StackExchange Terms of Service](https://stackexchange.com/legal)
 * Build powered by [Cake](http://cakebuild.net/) and [GitVersionTask](https://github.com/GitTools/GitVersion).
 
 # Acknowledgements

--- a/README.md
+++ b/README.md
@@ -866,7 +866,7 @@ For details of changes by release see the [change log](https://github.com/App-vN
 * [Ian Griffith's TimedLock](http://www.interact-sw.co.uk/iangblog/2004/04/26/yetmoretimedlocking)
 * [Steven van Deursen's ReadOnlyDictionary](http://www.cuttingedge.it/blogs/steven/pivot/entry.php?id=29) (until v5.0.6)
 * [Stephen Cleary's AsyncEx library](https://github.com/StephenCleary/AsyncEx) for AsyncSemaphore (supports BulkheadAsync policy for .NET4.0 only) | [MIT license](https://github.com/StephenCleary/AsyncEx/blob/master/LICENSE)
-* [@theraot](https://github.com/theraot)'s [ExceptionDispatchInfo implementation for .NET4.0](https://stackoverflow.com/a/31226509/) (supports Timeout policy for .NET4.0 only) including also a contribution by [@migueldeicaza](https://github.com/migueldeicaza) | [Creative Commons Attribution Share Alike license](https://creativecommons.org/licenses/by-sa/3.0/) per [StackExchange Terms of Service](https://stackexchange.com/legal)
+* [@theraot](https://github.com/theraot)'s [ExceptionDispatchInfo implementation for .NET4.0](https://stackoverflow.com/a/31226509/) (supports Timeout policy for .NET4.0 only) including also a contribution by [@migueldeicaza](https://github.com/migueldeicaza) | Licensed under and distributed under [Creative Commons Attribution Share Alike license](https://creativecommons.org/licenses/by-sa/3.0/) per [StackExchange Terms of Service](https://stackexchange.com/legal)
 * Build powered by [Cake](http://cakebuild.net/) and [GitVersionTask](https://github.com/GitTools/GitVersion).
 
 # Acknowledgements

--- a/README.md
+++ b/README.md
@@ -859,13 +859,14 @@ The .NET4.0 package uses `Microsoft.Bcl.Async` to add async support.  To minimis
 
 For details of changes by release see the [change log](https://github.com/App-vNext/Polly/blob/master/CHANGELOG.md).  We also tag relevant Pull Requests and Issues with [milestones](https://github.com/App-vNext/Polly/milestones), which match to nuget package release numbers.
 
-# 3rd Party Libraries
+# 3rd Party Libraries and Contributions
 
 * [Fluent Assertions](https://github.com/fluentassertions/fluentassertions) - A set of .NET extension methods that allow you to more naturally specify the expected outcome of a TDD or BDD-style test | [Apache License 2.0 (Apache)](https://github.com/dennisdoomen/fluentassertions/blob/develop/LICENSE)
 * [xUnit.net](https://github.com/xunit/xunit) - Free, open source, community-focused unit testing tool for the .NET Framework | [Apache License 2.0 (Apache)](https://github.com/xunit/xunit/blob/master/license.txt)
 * [Ian Griffith's TimedLock](http://www.interact-sw.co.uk/iangblog/2004/04/26/yetmoretimedlocking)
 * [Steven van Deursen's ReadOnlyDictionary](http://www.cuttingedge.it/blogs/steven/pivot/entry.php?id=29) (until v5.0.6)
 * [Stephen Cleary's AsyncEx library](https://github.com/StephenCleary/AsyncEx) for AsyncSemaphore (supports BulkheadAsync policy for .NET4.0 only) | [MIT license](https://github.com/StephenCleary/AsyncEx/blob/master/LICENSE)
+* [@theraot](https://github.com/theraot)'s [ExceptionDispatchInfo implementation for .NET4.0](https://stackoverflow.com/a/31226509/) (supports Timeout policy for .NET4.0 only) including also a contribution by [@migueldeicaza](https://github.com/migueldeicaza) | [Creative Commons Attribution Share Alike license](https://creativecommons.org/licenses/by-sa/3.0/)
 * Build powered by [Cake](http://cakebuild.net/) and [GitVersionTask](https://github.com/GitTools/GitVersion).
 
 # Acknowledgements

--- a/src/Polly.Shared/Polly.Shared.projitems
+++ b/src/Polly.Shared/Polly.Shared.projitems
@@ -114,6 +114,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Timeout\TimeoutStrategy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\AsyncSemaphoreExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\EmptyStruct.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Utilities\ExceptionDispatchInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\KeyHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\PredicateHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\SemaphoreSlimFactory.cs" />

--- a/src/Polly.Shared/Utilities/ExceptionDispatchInfo.cs
+++ b/src/Polly.Shared/Utilities/ExceptionDispatchInfo.cs
@@ -1,8 +1,12 @@
-﻿#if NET40
-
+﻿// ==================================
 // This file only, code sourced from answer https://stackoverflow.com/a/31226509/ by https://stackoverflow.com/users/402022/theraot (Alfonso J. Ramos) to question https://stackoverflow.com/questions/20171877/ asked by https://stackoverflow.com/users/2674222/avo.  Also with contributions (as originally indicated by theraot within the code) by Miguel de Icaza (https://stackoverflow.com/users/16929/miguel-de-icaza).
 // Licensed as described in and following the conditions of the StackExchange Terms Of Service (https://stackexchange.com/legal) (retrieved 23 July 2017) under the Creative Commons Attribution Share Alike license (https://creativecommons.org/licenses/by-sa/3.0/) (retrieved 23 July 2017).
 // Minor amendment by @reisenberger (https://github.com/reisenberger/): removed unused private field _stackTraceOriginal.
+// Code in this file (only) distributed under and governed by the Creative Commons Attribution Share Alike license (https://creativecommons.org/licenses/by-sa/3.0/).
+// This notice must not be removed from this file.
+// ==================================
+
+#if NET40
 
 using System;
 using System.Text;

--- a/src/Polly.Shared/Utilities/ExceptionDispatchInfo.cs
+++ b/src/Polly.Shared/Utilities/ExceptionDispatchInfo.cs
@@ -1,7 +1,7 @@
 ﻿#if NET40
 
-// Code in this file sourced from answer https://stackoverflow.com/a/31226509/ by https://stackoverflow.com/users/402022/theraot (Alfonso J. Ramos) to question https://stackoverflow.com/questions/20171877/ asked by https://stackoverflow.com/users/2674222/avo.  Also with contributions (as originally indicated by theraot within the code) by Miguel de Icaza (https://stackoverflow.com/users/16929/miguel-de-icaza).
-// Licensed as described in the StackExchange Terms Of Service (https://stackexchange.com/legal) under the Creative Commons Attribution Share Alike license (https://creativecommons.org/licenses/by-sa/3.0/).
+// This file only, code sourced from answer https://stackoverflow.com/a/31226509/ by https://stackoverflow.com/users/402022/theraot (Alfonso J. Ramos) to question https://stackoverflow.com/questions/20171877/ asked by https://stackoverflow.com/users/2674222/avo.  Also with contributions (as originally indicated by theraot within the code) by Miguel de Icaza (https://stackoverflow.com/users/16929/miguel-de-icaza).
+// Licensed as described in and following the conditions of the StackExchange Terms Of Service (https://stackexchange.com/legal) (retrieved 23 July 2017) under the Creative Commons Attribution Share Alike license (https://creativecommons.org/licenses/by-sa/3.0/) (retrieved 23 July 2017).
 // Minor amendment by @reisenberger (https://github.com/reisenberger/): removed unused private field _stackTraceOriginal.
 
 using System;

--- a/src/Polly.Shared/Utilities/ExceptionDispatchInfo.cs
+++ b/src/Polly.Shared/Utilities/ExceptionDispatchInfo.cs
@@ -1,0 +1,140 @@
+﻿#if NET40
+
+// Code in this file sourced from answer https://stackoverflow.com/a/31226509/ by https://stackoverflow.com/users/402022/theraot (Alfonso J. Ramos) to question https://stackoverflow.com/questions/20171877/ asked by https://stackoverflow.com/users/2674222/avo.  Also with contributions (as originally indicated by theraot within the code) by Miguel de Icaza (https://stackoverflow.com/users/16929/miguel-de-icaza).
+// Licensed as described in the StackExchange Terms Of Service (https://stackexchange.com/legal) under the Creative Commons Attribution Share Alike license (https://creativecommons.org/licenses/by-sa/3.0/).
+// Minor amendment by @reisenberger (https://github.com/reisenberger/): removed unused private field _stackTraceOriginal.
+
+using System;
+using System.Text;
+using System.Reflection;
+
+namespace Polly.Shared.Utilities
+{
+    /// <summary>
+    /// The ExceptionDispatchInfo object stores the stack trace information and Watson information that the exception contains at the point where it is captured. The exception can be thrown at another time and possibly on another thread by calling the ExceptionDispatchInfo.Throw method. The exception is thrown as if it had flowed from the point where it was captured to the point where the Throw method is called.
+    /// </summary>
+    public sealed class ExceptionDispatchInfo
+    {
+        private static FieldInfo _remoteStackTraceString;
+
+        private readonly Exception _exception;
+        private readonly object _stackTrace;
+
+        private ExceptionDispatchInfo(Exception exception)
+        {
+            _exception = exception;
+            _stackTrace = _exception.StackTrace;
+            if (_stackTrace != null)
+            {
+                _stackTrace += Environment.NewLine + "---End of stack trace from previous location where exception was thrown ---" + Environment.NewLine;
+            }
+            else
+            {
+                _stackTrace = string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Creates an ExceptionDispatchInfo object that represents the specified exception at the current point in code.
+        /// </summary>
+        /// <param name="source">The exception whose state is captured, and which is represented by the returned object.</param>
+        /// <returns>An object that represents the specified exception at the current point in code. </returns>
+        public static ExceptionDispatchInfo Capture(Exception source)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+            return new ExceptionDispatchInfo(source);
+        }
+
+        /// <summary>
+        /// Gets the exception that is represented by the current instance.
+        /// </summary>
+        public Exception SourceException
+        {
+            get
+            {
+                return _exception;
+            }
+        }
+
+        private static FieldInfo GetFieldInfo()
+        {
+            if (_remoteStackTraceString == null)
+            {
+                // ---
+                // Code by Miguel de Icaza
+
+                FieldInfo remoteStackTraceString =
+                    typeof(Exception).GetField("_remoteStackTraceString",
+                    BindingFlags.Instance | BindingFlags.NonPublic); // MS.Net
+
+                if (remoteStackTraceString == null)
+                    remoteStackTraceString = typeof(Exception).GetField("remote_stack_trace",
+                        BindingFlags.Instance | BindingFlags.NonPublic); // Mono pre-2.6
+
+                // ---
+                _remoteStackTraceString = remoteStackTraceString;
+            }
+            return _remoteStackTraceString;
+        }
+
+        private static void SetStackTrace(Exception exception, object value)
+        {
+            FieldInfo remoteStackTraceString = GetFieldInfo();
+            remoteStackTraceString.SetValue(exception, value);
+        }
+
+        /// <summary>
+        /// Throws the exception that is represented by the current ExceptionDispatchInfo object, after restoring the state that was saved when the exception was captured.
+        /// </summary>
+        public void Throw()
+        {
+            try
+            {
+                throw _exception;
+            }
+            catch (Exception exception)
+            {
+                GC.KeepAlive(exception);
+                var newStackTrace = _stackTrace + BuildStackTrace(Environment.StackTrace);
+                SetStackTrace(_exception, newStackTrace);
+                throw;
+            }
+        }
+
+        private string BuildStackTrace(string trace)
+        {
+            var items = trace.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+            var newStackTrace = new StringBuilder();
+            var found = false;
+            foreach (var item in items)
+            {
+                // Only include lines that has files in the source code
+                if (item.Contains(":"))
+                {
+                    if (item.Contains("System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()"))
+                    {
+                        // Stacktrace from here on will be added by the CLR
+                        break;
+                    }
+                    if (found)
+                    {
+                        newStackTrace.Append(Environment.NewLine);
+                    }
+                    found = true;
+                    newStackTrace.Append(item);
+                }
+                else if (found)
+                {
+                    break;
+                }
+            }
+            var result = newStackTrace.ToString();
+            return result;
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
**Submission containing materials of a third party:** https://stackoverflow.com/users/402022/theraot and
https://stackoverflow.com/users/16929/miguel-de-icaza.  Licensed as described in the StackExchange Terms Of Service (https://stackexchange.com/legal) (retrieved 23 July 2017) under the Creative Commons Attribution Share Alike license (https://creativecommons.org/licenses/by-sa/3.0/) (retrieved 23 July 2017).

Appropriate license and credit information has been added in the appropriate section of our ReadMe.md and directly with the relevant code, in alignment with the StackExchange Terms of Service and Creative Commons Attribution Share Alike license.

//cc @theraot for info.

---

Adds third-party ExceptionDispatchInfo implementation for .NET4.0.