### PR TITLE
Add interface providing read-only access to a policy registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 5.3.0
 - Fix ExecuteAndCapture() usage with PolicyWrap   
 - Allow Fallback delegates to take execution Context
+- Provide IReadOnlyPolicyRegistry interface
 
 ## 5.2.0
 - Add PolicyRegistry for storing and retrieving policies.

--- a/README.md
+++ b/README.md
@@ -734,7 +734,7 @@ registry["StandardHttpResilience"] = myStandardHttpResiliencePolicy;
 // Pass the registry instance to usage sites by DI, perhaps
 public class MyServiceGateway 
 {
-    public void MyServiceGateway(..., IPolicyRegistry<string> registry, ...)
+    public void MyServiceGateway(..., IReadOnlyPolicyRegistry<string> registry, ...)
     {
        ...
     } 
@@ -905,6 +905,7 @@ For details of changes by release see the [change log](https://github.com/App-vN
 * [@reisenberger](https://github.com/reisenberger) - Add mutable Context and extra overloads taking Context.  Allows different parts of a policy execution to exchange data via the mutable Context travelling with each execution.
 * [@ankitbko](https://github.com/ankitbko) - Add PolicyRegistry for storing and retrieving policies.
 * [@reisenberger](https://github.com/reisenberger) - Add interfaces by policy type and execution type.
+* [@seanfarrow](https://github.com/SeanFarrow) - Add IReadOnlyPolicyRegistry interface.
 
 # Sample Projects
 

--- a/src/Polly.Net40Async.nuspec
+++ b/src/Polly.Net40Async.nuspec
@@ -19,6 +19,7 @@
      ---------------------
      - Fix ExecuteAndCapture() usage with PolicyWrap   
      - Allow Fallback delegates to take execution Context
+     - Provide IReadOnlyPolicyRegistry interface
 
      5.2.0
      ---------------------

--- a/src/Polly.Shared/Polly.Shared.projitems
+++ b/src/Polly.Shared/Polly.Shared.projitems
@@ -77,6 +77,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)PolicyBuilder.OrSyntax.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PolicyResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Policy.TResult.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Registry\IReadOnlyPolicyRegistry.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Registry\PolicyRegistry.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Registry\IPolicyRegistry.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ResultPredicate.cs" />

--- a/src/Polly.Shared/Registry/IPolicyRegistry.cs
+++ b/src/Polly.Shared/Registry/IPolicyRegistry.cs
@@ -8,7 +8,7 @@ namespace Polly.Registry
     /// Represents a collection of policies keyed by <typeparamref name="TKey"/>.
     /// </summary>
     /// <typeparam name="TKey">The type of keys in the policy registry.</typeparam>
-    public interface IPolicyRegistry<in TKey> 
+    public interface IPolicyRegistry<in TKey> : IReadOnlyPolicyRegistry<TKey>
     {
         /// <summary>
         /// Adds an element with the provided key and policy to the registry.
@@ -21,49 +21,15 @@ namespace Polly.Registry
         void Add<TPolicy>(TKey key, TPolicy policy) where TPolicy : IsPolicy;
 
         /// <summary>
-        /// Gets of sets the <see cref="IsPolicy"/> with the specified key.
-        /// <remarks>To retrieve a policy directly as a particular Policy type or Policy interface (avoiding a cast), use the <see cref="Get{TPolicy}"/> method.</remarks>
+        /// Gets or sets the <see cref="IsPolicy"/> with the specified key.
+        /// <remarks>To retrieve a policy directly as a particular Policy type or Policy interface (avoiding a cast), use the <see cref="IReadOnlyPolicyRegistry{TKey}.Get{TPolicy}"/> method.</remarks>
         /// </summary>
         /// <param name="key">The key of the value to get or set.</param>
         /// <exception cref="T:System.ArgumentNullException"><paramref name="key" /> is null.</exception>
         /// <exception cref="KeyNotFoundException">The given key was not present in the dictionary.</exception>
         /// <returns>The value associated with the specified key.</returns>
-        IsPolicy this[TKey key] { get; set; }
-
-        /// <summary>
-        /// Gets the policy stored under the provided key, casting to <typeparamref name="TPolicy"/>.
-        /// </summary>
-        /// <typeparam name="TPolicy">The type of Policy.</typeparam>
-        /// <returns>The policy stored in the registry under the given key.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="key"/> is null.</exception>
-        TPolicy Get<TPolicy>(TKey key) where TPolicy : IsPolicy;
-
-        /// <summary>
-        /// Gets the policy stored under the provided key, casting to <typeparamref name="TPolicy"/>.
-        /// </summary>
-        /// <param name="key">The key of the policy to get.</param>
-        /// <param name="policy">
-        /// This method returns the policy associated with the specified <paramref name="key"/>, if the
-        /// key is found; otherwise null.
-        /// This parameter is passed uninitialized.
-        /// </param>
-        /// <typeparam name="TPolicy">The type of Policy.</typeparam>
-        /// <returns>True if Policy exists for the provided Key. False otherwise.</returns>
-        bool TryGet<TPolicy>(TKey key, out TPolicy policy) where TPolicy : IsPolicy;
-
-        /// <summary>
-        /// Total number of policies in the registry.
-        /// </summary>
-        int Count { get; }
-
-        /// <summary>
-        /// Determines whether the specified <paramref name="key"/> exists.
-        /// </summary>
-        /// <param name="key">The Key to locate in the registry</param>
-        /// <returns>True if <paramref name="key"/> exists otherwise false</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="key"/> is null</exception>
-        bool ContainsKey(TKey key);
-
+        new IsPolicy this[TKey key] { get; set; }
+        
         /// <summary>
         /// Removes the specified <see cref="Polly.Policy"/> from the registry.
         /// </summary>

--- a/src/Polly.Shared/Registry/IReadOnlyPolicyRegistry.cs
+++ b/src/Polly.Shared/Registry/IReadOnlyPolicyRegistry.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using Polly;
+
+namespace Polly.Registry
+{
+    /// <summary>
+    /// Represents a read-only collection of policies keyed by <typeparamref name="TKey"/>.
+    /// </summary>
+    /// <typeparam name="TKey">The type of keys in the policy registry.</typeparam>
+    public interface IReadOnlyPolicyRegistry<in TKey>
+    {
+        /// <summary>
+        /// Gets the <see cref="IsPolicy"/> with the specified key.
+        /// <remarks>To retrieve a policy directly as a particular Policy type or Policy interface (avoiding a cast), use the <see cref="Get{TPolicy}"/> method.</remarks>
+        /// </summary>
+        /// <param name="key">The key of the value to get or set.</param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="key" /> is null.</exception>
+        /// <exception cref="KeyNotFoundException">The given key was not present in the dictionary.</exception>
+        /// <returns>The value associated with the specified key.</returns>
+        IsPolicy this[TKey key] { get; }
+
+        /// <summary>
+        /// Gets the policy stored under the provided key, casting to <typeparamref name="TPolicy"/>.
+        /// </summary>
+        /// <typeparam name="TPolicy">The type of Policy.</typeparam>
+        /// <returns>The policy stored in the registry under the given key.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key"/> is null.</exception>
+        TPolicy Get<TPolicy>(TKey key) where TPolicy : IsPolicy;
+
+        /// <summary>
+        /// Gets the policy stored under the provided key, casting to <typeparamref name="TPolicy"/>.
+        /// </summary>
+        /// <param name="key">The key of the policy to get.</param>
+        /// <param name="policy">
+        /// This method returns the policy associated with the specified <paramref name="key"/>, if the
+        /// key is found; otherwise null.
+        /// This parameter is passed uninitialized.
+        /// </param>
+        /// <typeparam name="TPolicy">The type of Policy.</typeparam>
+        /// <returns>True if Policy exists for the provided Key. False otherwise.</returns>
+        bool TryGet<TPolicy>(TKey key, out TPolicy policy) where TPolicy : IsPolicy;
+
+        /// <summary>
+        /// Total number of policies in the registry.
+        /// </summary>
+        int Count { get; }
+
+        /// <summary>
+        /// Determines whether the specified <paramref name="key"/> exists.
+        /// </summary>
+        /// <param name="key">The Key to locate in the registry</param>
+        /// <returns>True if <paramref name="key"/> exists otherwise false</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key"/> is null</exception>
+        bool ContainsKey(TKey key);
+    }
+}

--- a/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
+++ b/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
@@ -53,6 +53,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)PolicyTResultAsyncSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PolicyTResultSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Registry\PolicyRegistrySpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Registry\IReadOnlyPolicyRegistrySpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Retry\RetryAsyncSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Retry\RetryForeverAsyncSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Retry\RetryForeverSpecs.cs" />

--- a/src/Polly.SharedSpecs/Registry/IReadOnlyPolicyRegistrySpecs.cs
+++ b/src/Polly.SharedSpecs/Registry/IReadOnlyPolicyRegistrySpecs.cs
@@ -1,0 +1,258 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using FluentAssertions;
+using Polly.Registry;
+using Polly.Specs.Helpers;
+using Xunit;
+
+namespace Polly.Specs.Registry
+{
+    public class IReadOnlyPolicyRegistrySpecs
+    {
+        IPolicyRegistry<string> _registry;
+
+        IReadOnlyPolicyRegistry<string> ReadOnlyRegistry { get{ return _registry; } }
+
+        public IReadOnlyPolicyRegistrySpecs()
+        {
+            _registry = new PolicyRegistry();
+        }
+
+        #region Tests for retrieving policy
+
+        [Fact]
+        public void Should_be_able_to_retrieve_stored_Policy_using_TryGet()
+        {
+            Policy policy = Policy.NoOp();
+            string key = Guid.NewGuid().ToString();
+            Policy outPolicy = null;
+
+            _registry.Add(key, policy);
+            ReadOnlyRegistry.TryGet(key, out outPolicy).Should().BeTrue();
+            outPolicy.Should().BeSameAs(policy);
+        }
+
+        [Fact]
+        public void Should_be_able_to_retrieve_stored_PolicyTResult_using_TryGet()
+        {
+            Policy<ResultPrimitive> policy = Policy<ResultPrimitive>.HandleResult(ResultPrimitive.Fault).Retry();
+            string key = Guid.NewGuid().ToString();
+            Policy<ResultPrimitive> outPolicy = null;
+
+            _registry.Add(key, policy);
+            ReadOnlyRegistry.TryGet(key, out outPolicy).Should().BeTrue();
+            outPolicy.Should().BeSameAs(policy);
+        }
+
+        [Fact]
+        public void Should_be_able_to_retrieve_stored_Policy_by_interface_using_TryGet()
+        {
+            ISyncPolicy<ResultPrimitive> policy = Policy<ResultPrimitive>.HandleResult(ResultPrimitive.Fault).Retry();
+            string key = Guid.NewGuid().ToString();
+            ISyncPolicy<ResultPrimitive> outPolicy = null;
+
+            _registry.Add(key, policy);
+            ReadOnlyRegistry.TryGet(key, out outPolicy).Should().BeTrue();
+            outPolicy.Should().BeSameAs(policy);
+        }
+
+        [Fact]
+        public void Should_be_able_to_retrieve_stored_Policy_using_Get()
+        {
+            Policy policy = Policy.NoOp();
+            string key = Guid.NewGuid().ToString();
+
+            _registry.Add(key, policy);
+            ReadOnlyRegistry.Get<Policy>(key).Should().BeSameAs(policy);
+        }
+
+        [Fact]
+        public void Should_be_able_to_retrieve_stored_PolicyTResult_using_Get()
+        {
+            Policy<ResultPrimitive> policy = Policy<ResultPrimitive>.HandleResult(ResultPrimitive.Fault).Retry();
+            string key = Guid.NewGuid().ToString();
+
+            _registry.Add(key, policy);
+            ReadOnlyRegistry.Get<Policy<ResultPrimitive>>(key).Should().BeSameAs(policy);
+        }
+
+        [Fact]
+        public void Should_be_able_to_retrieve_stored_Policy_by_interface_using_Get()
+        {
+            ISyncPolicy<ResultPrimitive> policy = Policy<ResultPrimitive>.HandleResult(ResultPrimitive.Fault).Retry();
+            string key = Guid.NewGuid().ToString();
+
+            _registry.Add(key, policy);
+            ReadOnlyRegistry.Get<ISyncPolicy<ResultPrimitive>>(key).Should().BeSameAs(policy);
+        }
+
+        [Fact]
+        public void Should_be_able_to_retrieve_stored_Policy_using_Indexer()
+        {
+            Policy policy = Policy.NoOp();
+            string key = Guid.NewGuid().ToString();
+
+            _registry.Add(key, policy);
+            ReadOnlyRegistry[key].Should().BeSameAs(policy);
+        }
+
+        [Fact]
+        public void Should_be_able_to_retrieve_stored_PolicyTResult_using_Indexer()
+        {
+            Policy<ResultPrimitive> policy = Policy<ResultPrimitive>.HandleResult(ResultPrimitive.Fault).Retry();
+            string key = Guid.NewGuid().ToString();
+
+            _registry.Add(key, policy);
+            ReadOnlyRegistry[key].Should().BeSameAs(policy);
+        }
+
+        [Fact]
+        public void Should_be_able_to_retrieve_stored_Policy_by_interface_using_Indexer()
+        {
+            ISyncPolicy<ResultPrimitive> policy = Policy<ResultPrimitive>.HandleResult(ResultPrimitive.Fault).Retry();
+            string key = Guid.NewGuid().ToString();
+
+            _registry.Add(key, policy);
+            ReadOnlyRegistry[key].Should().BeSameAs(policy);
+        }
+
+        [Fact]
+        public void Should_not_throw_while_retrieving_when_key_does_not_exist_using_TryGet()
+        {
+            string key = Guid.NewGuid().ToString();
+            Policy outPolicy = null;
+            bool result = false;
+
+            ReadOnlyRegistry.Invoking(r => result = r.TryGet(key, out outPolicy))
+                .ShouldNotThrow();
+
+            result.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Should_not_throw_while_retrieving_when_key_does_not_exist_using_TryGetPolicyTResult()
+        {
+            string key = Guid.NewGuid().ToString();
+            Policy<ResultPrimitive> outPolicy = null;
+            bool result = false;
+
+            ReadOnlyRegistry.Invoking(r => result = r.TryGet(key, out outPolicy))
+                .ShouldNotThrow();
+
+            result.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Should_not_throw_while_retrieving_when_key_does_not_exist_using_TryGetPolicy_by_interface()
+        {
+            string key = Guid.NewGuid().ToString();
+            ISyncPolicy<ResultPrimitive> outPolicy = null;
+            bool result = false;
+
+            ReadOnlyRegistry.Invoking(r => result = r.TryGet<ISyncPolicy<ResultPrimitive>>(key, out outPolicy))
+                .ShouldNotThrow();
+
+            result.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Should_throw_while_retrieving_using_Get_when_key_does_not_exist()
+        {
+            string key = Guid.NewGuid().ToString();
+            Policy policy = null;
+            ReadOnlyRegistry.Invoking(r => policy = r.Get<Policy>(key))
+                .ShouldThrow<KeyNotFoundException>();
+        }
+
+        [Fact]
+        public void Should_throw_while_retrieving_using_GetTResult_when_key_does_not_exist()
+        {
+            string key = Guid.NewGuid().ToString();
+            Policy<ResultPrimitive> policy = null;
+            ReadOnlyRegistry.Invoking(r => policy = r.Get<Policy<ResultPrimitive>>(key))
+                .ShouldThrow<KeyNotFoundException>();
+        }
+
+        [Fact]
+        public void Should_throw_while_retrieving_using_Get_by_interface_when_key_does_not_exist()
+        {
+            string key = Guid.NewGuid().ToString();
+            ISyncPolicy<ResultPrimitive> policy = null;
+            ReadOnlyRegistry.Invoking(r => policy = r.Get<ISyncPolicy<ResultPrimitive>>(key))
+                .ShouldThrow<KeyNotFoundException>();
+        }
+
+        [Fact]
+        public void Should_throw_while_retrieving_when_key_does_not_exist_using_Indexer()
+        {
+            string key = Guid.NewGuid().ToString();
+            IsPolicy outPolicy = null;
+            ReadOnlyRegistry.Invoking(r => outPolicy = r[key])
+                .ShouldThrow<KeyNotFoundException>();
+        }
+
+
+        [Fact]
+        public void Should_throw_when_retrieving_using_Get_when_key_is_null()
+        {
+            string key = null;
+            Policy policy = null;
+            ReadOnlyRegistry.Invoking(r => policy = r.Get<Policy>(key))
+                .ShouldThrow<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Should_throw_when_retrieving_using_GetTResult_when_key_is_null()
+        {
+            string key = null;
+            Policy<ResultPrimitive> policy = null;
+            ReadOnlyRegistry.Invoking(r => policy = r.Get<Policy<ResultPrimitive>>(key))
+                .ShouldThrow<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Should_throw_when_retrieving_using_Get_by_interface_when_key_is_null()
+        {
+            string key = null;
+            ISyncPolicy<ResultPrimitive> policy = null;
+            ReadOnlyRegistry.Invoking(r => policy = r.Get<ISyncPolicy<ResultPrimitive>>(key))
+                .ShouldThrow<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Should_throw_when_retrieving_using_Indexer_when_key_is_null()
+        {
+            string key = null;
+            IsPolicy policy = null;
+            ReadOnlyRegistry.Invoking(r => policy = r[key])
+                .ShouldThrow<ArgumentNullException>();
+        }
+        #endregion
+
+        #region Tests for checking if key exists
+
+        [Fact]
+        public void Should_be_able_to_check_if_key_exists()
+        {
+            Policy policy = Policy.NoOp();
+            string key = Guid.NewGuid().ToString();
+
+            _registry.Add(key, policy);
+            ReadOnlyRegistry.ContainsKey(key).Should().BeTrue();
+
+            string key2 = Guid.NewGuid().ToString();
+            ReadOnlyRegistry.ContainsKey(key2).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Should_throw_when_checking_if_key_exists_when_key_is_null()
+        {
+            string key = null;
+            ReadOnlyRegistry.Invoking(r => r.ContainsKey(key))
+                .ShouldThrow<ArgumentNullException>();
+        }
+        #endregion
+
+    }
+}

--- a/src/Polly.SharedSpecs/Registry/PolicyRegistrySpecs.cs
+++ b/src/Polly.SharedSpecs/Registry/PolicyRegistrySpecs.cs
@@ -419,6 +419,7 @@ namespace Polly.Specs.Registry
         #endregion
 
         #region Tests for checking if key exists
+
         [Fact]
         public void Should_be_able_to_check_if_key_exists()
         {

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -15,6 +15,12 @@
     <releaseNotes>
      v5.0 is a major release with significant new resilience policies: Timeout; Bulkhead Isolation; Fallback; and PolicyWrap.  See release notes back to v5.0.0 for full details.  v5.0.5 includes important circuit-breaker fixes.
 
+     5.3.0
+     ---------------------
+     - Fix ExecuteAndCapture() usage with PolicyWrap   
+     - Allow Fallback delegates to take execution Context
+     - Provide IReadOnlyPolicyRegistry interface
+
      5.2.0
      ---------------------
      - Add PolicyRegistry for storing and retrieving policies.


### PR DESCRIPTION
Adds an interface providing read-only access to a policy registry.  Useful to prevent consumers changing policies in registry; for example to enforce separation of population of policy registry from usage.

( Minor revise of #282 as requested offline by @seanfarrow )