### PR TITLE
Change async void tests to async Task

### DIFF
--- a/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerTResultAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerTResultAsyncSpecs.cs
@@ -18,7 +18,7 @@ namespace Polly.Specs.CircuitBreaker
         #region Configuration tests
 
         [Fact]
-        public async void Should_be_able_to_handle_a_duration_of_timespan_maxvalue()
+        public async Task Should_be_able_to_handle_a_duration_of_timespan_maxvalue()
         {
             CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
                             .HandleResult(ResultPrimitive.Fault)
@@ -78,7 +78,7 @@ namespace Polly.Specs.CircuitBreaker
         #region Circuit-breaker threshold-to-break tests
 
         [Fact]
-        public async void Should_not_open_circuit_if_specified_number_of_specified_handled_result_are_not_raised_consecutively()
+        public async Task Should_not_open_circuit_if_specified_number_of_specified_handled_result_are_not_raised_consecutively()
         {
             CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
                             .HandleResult(ResultPrimitive.Fault)
@@ -98,7 +98,7 @@ namespace Polly.Specs.CircuitBreaker
         }
 
         [Fact]
-        public async void Should_open_circuit_with_the_last_handled_result_after_specified_number_of_specified_handled_result_have_been_returned()
+        public async Task Should_open_circuit_with_the_last_handled_result_after_specified_number_of_specified_handled_result_have_been_returned()
         {
             CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
                             .HandleResult(ResultPrimitive.Fault)
@@ -121,7 +121,7 @@ namespace Polly.Specs.CircuitBreaker
         }
 
         [Fact]
-        public async void Should_open_circuit_with_the_last_handled_result_after_specified_number_of_one_of_the_specified_handled_results_have_been_raised()
+        public async Task Should_open_circuit_with_the_last_handled_result_after_specified_number_of_one_of_the_specified_handled_results_have_been_raised()
         {
             CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
                             .HandleResult(ResultPrimitive.Fault)
@@ -145,7 +145,7 @@ namespace Polly.Specs.CircuitBreaker
         }
 
         [Fact]
-        public async void Should_open_circuit_with_the_last_handled_result_after_specified_number_of_specified_handled_result_with_predicate_have_been_returned()
+        public async Task Should_open_circuit_with_the_last_handled_result_after_specified_number_of_specified_handled_result_with_predicate_have_been_returned()
         {
             CircuitBreakerPolicy<ResultClass> breaker = Policy
                             .HandleResult<ResultClass>(r => r.ResultCode == ResultPrimitive.Fault)
@@ -168,7 +168,7 @@ namespace Polly.Specs.CircuitBreaker
         }
 
         [Fact]
-        public async void Should_not_open_circuit_if_result_returned_is_not_the_handled_result()
+        public async Task Should_not_open_circuit_if_result_returned_is_not_the_handled_result()
         {
             CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
                             .HandleResult(ResultPrimitive.Fault)
@@ -188,7 +188,7 @@ namespace Polly.Specs.CircuitBreaker
         }
 
         [Fact]
-        public async void Should_not_open_circuit_if_result_returned_is_not_one_of_the_handled_results()
+        public async Task Should_not_open_circuit_if_result_returned_is_not_one_of_the_handled_results()
         {
             CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
                             .HandleResult(ResultPrimitive.Fault)
@@ -209,7 +209,7 @@ namespace Polly.Specs.CircuitBreaker
         }
 
         [Fact]
-        public async void Should_not_open_circuit_if_result_returned_does_not_match_result_predicate()
+        public async Task Should_not_open_circuit_if_result_returned_does_not_match_result_predicate()
         {
             CircuitBreakerPolicy<ResultClass> breaker = Policy
                             .HandleResult<ResultClass>(r => r.ResultCode == ResultPrimitive.Fault)
@@ -229,7 +229,7 @@ namespace Polly.Specs.CircuitBreaker
         }
 
         [Fact]
-        public async void Should_not_open_circuit_if_result_returned_does_not_match_any_of_the_result_predicates()
+        public async Task Should_not_open_circuit_if_result_returned_does_not_match_any_of_the_result_predicates()
         {
             CircuitBreakerPolicy<ResultClass> breaker = Policy
                 .HandleResult<ResultClass>(r => r.ResultCode == ResultPrimitive.Fault)
@@ -254,7 +254,7 @@ namespace Polly.Specs.CircuitBreaker
         #region Circuit-breaker open->half-open->open/closed tests
 
         [Fact]
-        public async void Should_halfopen_circuit_after_the_specified_duration_has_passed()
+        public async Task Should_halfopen_circuit_after_the_specified_duration_has_passed()
         {
             var time = 1.January(2000);
             SystemClock.UtcNow = () => time;
@@ -287,7 +287,7 @@ namespace Polly.Specs.CircuitBreaker
         }
 
         [Fact]
-        public async void Should_open_circuit_again_after_the_specified_duration_has_passed_if_the_next_call_raises_a_fault()
+        public async Task Should_open_circuit_again_after_the_specified_duration_has_passed_if_the_next_call_raises_a_fault()
         {
             var time = 1.January(2000);
             SystemClock.UtcNow = () => time;
@@ -326,7 +326,7 @@ namespace Polly.Specs.CircuitBreaker
         }
 
         [Fact]
-        public async void Should_reset_circuit_after_the_specified_duration_has_passed_if_the_next_call_does_not_return_a_fault()
+        public async Task Should_reset_circuit_after_the_specified_duration_has_passed_if_the_next_call_does_not_return_a_fault()
         {
             var time = 1.January(2000);
             SystemClock.UtcNow = () => time;
@@ -729,7 +729,7 @@ namespace Polly.Specs.CircuitBreaker
         }
 
         [Fact]
-        public async void Should_be_able_to_reset_automatically_opened_circuit_without_specified_duration_passing()
+        public async Task Should_be_able_to_reset_automatically_opened_circuit_without_specified_duration_passing()
         {
             var time = 1.January(2000);
             SystemClock.UtcNow = () => time;
@@ -779,7 +779,7 @@ namespace Polly.Specs.CircuitBreaker
         }
 
         [Fact]
-        public async void Should_call_onbreak_when_breaking_circuit_automatically()
+        public async Task Should_call_onbreak_when_breaking_circuit_automatically()
         {
             bool onBreakCalled = false;
             Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, __) => { onBreakCalled = true; };
@@ -820,7 +820,7 @@ namespace Polly.Specs.CircuitBreaker
         }
 
         [Fact]
-        public async void Should_call_onbreak_when_breaking_circuit_first_time_but_not_for_subsequent_calls_placed_through_open_circuit()
+        public async Task Should_call_onbreak_when_breaking_circuit_first_time_but_not_for_subsequent_calls_placed_through_open_circuit()
         {
             int onBreakCalled = 0;
             Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, __) => { onBreakCalled++; };
@@ -910,7 +910,7 @@ namespace Polly.Specs.CircuitBreaker
         }
 
         [Fact]
-        public async void Should_call_onreset_when_automatically_closing_circuit_but_not_when_halfopen()
+        public async Task Should_call_onreset_when_automatically_closing_circuit_but_not_when_halfopen()
         {
             int onBreakCalled = 0;
             int onResetCalled = 0;
@@ -978,7 +978,7 @@ namespace Polly.Specs.CircuitBreaker
         }
 
         [Fact]
-        public async void Should_call_onhalfopen_when_automatically_transitioning_to_halfopen_due_to_subsequent_execution()
+        public async Task Should_call_onhalfopen_when_automatically_transitioning_to_halfopen_due_to_subsequent_execution()
         {
             int onBreakCalled = 0;
             int onResetCalled = 0;
@@ -1025,7 +1025,7 @@ namespace Polly.Specs.CircuitBreaker
         }
 
         [Fact]
-        public async void Should_call_onhalfopen_when_automatically_transitioning_to_halfopen_due_to_state_read()
+        public async Task Should_call_onhalfopen_when_automatically_transitioning_to_halfopen_due_to_state_read()
         {
             int onBreakCalled = 0;
             int onResetCalled = 0;
@@ -1102,7 +1102,7 @@ namespace Polly.Specs.CircuitBreaker
         #region Tests of supplied parameters to onBreak delegate
 
         [Fact]
-        public async void Should_call_onbreak_with_the_last_handled_result()
+        public async Task Should_call_onbreak_with_the_last_handled_result()
         {
             ResultPrimitive? handledResult = null;
 
@@ -1127,7 +1127,7 @@ namespace Polly.Specs.CircuitBreaker
         }
 
         [Fact]
-        public async void Should_call_onbreak_with_the_correct_timespan()
+        public async Task Should_call_onbreak_with_the_correct_timespan()
         {
             TimeSpan? passedBreakTimespan = null;
 
@@ -1180,7 +1180,7 @@ namespace Polly.Specs.CircuitBreaker
         #region Tests that supplied context is passed to stage-change delegates
 
         [Fact]
-        public async void Should_call_onbreak_with_the_passed_context()
+        public async Task Should_call_onbreak_with_the_passed_context()
         {
             IDictionary<string, object> contextData = null;
 
@@ -1206,7 +1206,7 @@ namespace Polly.Specs.CircuitBreaker
         }
 
         [Fact]
-        public async void Should_call_onreset_with_the_passed_context()
+        public async Task Should_call_onreset_with_the_passed_context()
         {
             IDictionary<string, object> contextData = null;
 
@@ -1240,7 +1240,7 @@ namespace Polly.Specs.CircuitBreaker
         }
 
         [Fact]
-        public async void Context_should_be_empty_if_execute_not_called_with_any_context_data()
+        public async Task Context_should_be_empty_if_execute_not_called_with_any_context_data()
         {
             IDictionary<string, object> contextData = new { key1 = "value1", key2 = "value2" }.AsDictionary();
 
@@ -1263,7 +1263,7 @@ namespace Polly.Specs.CircuitBreaker
         }
 
         [Fact]
-        public async void Should_create_new_context_for_each_call_to_execute()
+        public async Task Should_create_new_context_for_each_call_to_execute()
         {
             string contextValue = null;
 
@@ -1382,7 +1382,7 @@ namespace Polly.Specs.CircuitBreaker
         #region Cancellation support
 
         [Fact]
-        public async void Should_execute_action_when_non_faulting_and_cancellationtoken_not_cancelled()
+        public async Task Should_execute_action_when_non_faulting_and_cancellationtoken_not_cancelled()
         {
             var durationOfBreak = TimeSpan.FromMinutes(1);
             CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
@@ -1497,7 +1497,7 @@ namespace Polly.Specs.CircuitBreaker
         }
 
         [Fact]
-        public async void Should_report_faulting_from_faulting_action_execution_when_user_delegate_does_not_observe_cancellation()
+        public async Task Should_report_faulting_from_faulting_action_execution_when_user_delegate_does_not_observe_cancellation()
         {
             var durationOfBreak = TimeSpan.FromMinutes(1);
             CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
@@ -1523,7 +1523,7 @@ namespace Polly.Specs.CircuitBreaker
         }
 
         [Fact]
-        public async void Should_report_cancellation_when_both_open_circuit_and_cancellation()
+        public async Task Should_report_cancellation_when_both_open_circuit_and_cancellation()
         {
             CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
                 .HandleResult(ResultPrimitive.Fault)

--- a/src/Polly.SharedSpecs/Fallback/FallbackAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Fallback/FallbackAsyncSpecs.cs
@@ -90,7 +90,7 @@ namespace Polly.Specs.Fallback
         #region Policy operation tests
 
         [Fact]
-        public async void Should_not_execute_fallback_when_execute_delegate_does_not_throw()
+        public async Task Should_not_execute_fallback_when_execute_delegate_does_not_throw()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task> fallbackActionAsync  = _ => { fallbackActionExecuted = true; return TaskHelper.EmptyTask; };
@@ -256,7 +256,7 @@ namespace Polly.Specs.Fallback
         #region onPolicyEvent delegate tests
 
         [Fact]
-        public async void Should_call_onFallback_passing_exception_triggering_fallback()
+        public async Task Should_call_onFallback_passing_exception_triggering_fallback()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task> fallbackActionAsync = _ => { fallbackActionExecuted = true; return TaskHelper.EmptyTask; };
@@ -277,7 +277,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public async void Should_not_call_onFallback_when_execute_delegate_does_not_throw()
+        public async Task Should_not_call_onFallback_when_execute_delegate_does_not_throw()
         {
             Func<CancellationToken, Task> fallbackActionAsync = _ => TaskHelper.EmptyTask;
 
@@ -372,7 +372,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public async void Context_should_be_empty_if_execute_not_called_with_any_context_data()
+        public async Task Context_should_be_empty_if_execute_not_called_with_any_context_data()
         {
             Context capturedContext = null;
             bool onFallbackExecuted = false;
@@ -436,7 +436,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public async void Context_should_be_empty_at_fallbackAction_if_execute_not_called_with_any_context_data()
+        public async Task Context_should_be_empty_at_fallbackAction_if_execute_not_called_with_any_context_data()
         {
             Context capturedContext = null;
             bool fallbackExecuted = false;

--- a/src/Polly.SharedSpecs/Fallback/FallbackTResultAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Fallback/FallbackTResultAsyncSpecs.cs
@@ -118,7 +118,7 @@ namespace Polly.Specs.Fallback
         #region Policy operation tests
 
         [Fact]
-        public async void Should_not_execute_fallback_when_execute_delegate_does_not_raise_fault()
+        public async Task Should_not_execute_fallback_when_execute_delegate_does_not_raise_fault()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = ct => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };
@@ -133,7 +133,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public async void Should_not_execute_fallback_when_execute_delegate_raises_fault_not_handled_by_policy()
+        public async Task Should_not_execute_fallback_when_execute_delegate_raises_fault_not_handled_by_policy()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = ct => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };
@@ -149,7 +149,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public async void Should_return_fallback_value_when_execute_delegate_raises_fault_handled_by_policy()
+        public async Task Should_return_fallback_value_when_execute_delegate_raises_fault_handled_by_policy()
         {
             FallbackPolicy<ResultPrimitive> fallbackPolicy = Policy
                                     .HandleResult(ResultPrimitive.Fault)
@@ -160,7 +160,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public async void Should_execute_fallback_when_execute_delegate_raises_fault_handled_by_policy()
+        public async Task Should_execute_fallback_when_execute_delegate_raises_fault_handled_by_policy()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = ct => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };
@@ -176,7 +176,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public async void Should_execute_fallback_when_execute_delegate_raises_one_of_results_handled_by_policy()
+        public async Task Should_execute_fallback_when_execute_delegate_raises_one_of_results_handled_by_policy()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = ct => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };
@@ -193,7 +193,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public async void Should_not_execute_fallback_when_execute_delegate_raises_fault_not_one_of_faults_handled_by_policy()
+        public async Task Should_not_execute_fallback_when_execute_delegate_raises_fault_not_one_of_faults_handled_by_policy()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = ct => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };
@@ -210,7 +210,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public async void Should_not_execute_fallback_when_result_raised_does_not_match_handling_predicates()
+        public async Task Should_not_execute_fallback_when_result_raised_does_not_match_handling_predicates()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = ct => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };
@@ -226,7 +226,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public async void Should_not_execute_fallback_when_execute_delegate_raises_fault_not_handled_by_any_of_predicates()
+        public async Task Should_not_execute_fallback_when_execute_delegate_raises_fault_not_handled_by_any_of_predicates()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = ct => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };
@@ -243,7 +243,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public async void Should_execute_fallback_when_result_raised_matches_handling_predicates()
+        public async Task Should_execute_fallback_when_result_raised_matches_handling_predicates()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = ct => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };
@@ -260,7 +260,7 @@ namespace Polly.Specs.Fallback
 
 
         [Fact]
-        public async void Should_execute_fallback_when_result_raised_matches_one_of_handling_predicates()
+        public async Task Should_execute_fallback_when_result_raised_matches_one_of_handling_predicates()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = ct => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };
@@ -277,7 +277,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public async void Should_not_handle_result_raised_by_fallback_delegate_even_if_is_result_handled_by_policy()
+        public async Task Should_not_handle_result_raised_by_fallback_delegate_even_if_is_result_handled_by_policy()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task<ResultClass>> fallbackAction = ct =>
@@ -301,7 +301,7 @@ namespace Polly.Specs.Fallback
         #region onPolicyEvent delegate tests
 
         [Fact]
-        public async void Should_call_onFallback_passing_result_triggering_fallback()
+        public async Task Should_call_onFallback_passing_result_triggering_fallback()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task<ResultClass>> fallbackAction = ct => { fallbackActionExecuted = true; return Task.FromResult(new ResultClass(ResultPrimitive.Substitute)); };
@@ -322,7 +322,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public async void Should_not_call_onFallback_when_execute_delegate_does_not_raise_fault()
+        public async Task Should_not_call_onFallback_when_execute_delegate_does_not_raise_fault()
         {
                         Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = ct => Task.FromResult(ResultPrimitive.Substitute);
 
@@ -366,7 +366,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public async void Should_call_onFallback_with_the_passed_context_when_execute_and_capture()
+        public async Task Should_call_onFallback_with_the_passed_context_when_execute_and_capture()
         {
             Func<Context, CancellationToken, Task<ResultPrimitive>> fallbackAction = (_, __) => Task.FromResult(ResultPrimitive.Substitute);
 
@@ -417,7 +417,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public async void Context_should_be_empty_if_execute_not_called_with_any_context_data()
+        public async Task Context_should_be_empty_if_execute_not_called_with_any_context_data()
         {
             Context capturedContext = null;
             bool onFallbackExecuted = false;
@@ -483,7 +483,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public async void Context_should_be_empty_at_fallbackAction_if_execute_not_called_with_any_context_data()
+        public async Task Context_should_be_empty_at_fallbackAction_if_execute_not_called_with_any_context_data()
         {
             Context capturedContext = null;
             bool fallbackExecuted = false;
@@ -509,7 +509,7 @@ namespace Polly.Specs.Fallback
         #region Cancellation tests
 
         [Fact]
-        public async void Should_execute_action_when_non_faulting_and_cancellationtoken_not_cancelled()
+        public async Task Should_execute_action_when_non_faulting_and_cancellationtoken_not_cancelled()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = ct => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };
@@ -538,7 +538,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public async void Should_execute_fallback_when_faulting_and_cancellationtoken_not_cancelled()
+        public async Task Should_execute_fallback_when_faulting_and_cancellationtoken_not_cancelled()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = ct => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };
@@ -631,7 +631,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public async void Should_handle_cancellation_and_execute_fallback_during_otherwise_non_faulting_action_execution_when_user_delegate_observes_cancellationtoken_and_fallback_handles_cancellations()
+        public async Task Should_handle_cancellation_and_execute_fallback_during_otherwise_non_faulting_action_execution_when_user_delegate_observes_cancellationtoken_and_fallback_handles_cancellations()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = ct => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };
@@ -662,7 +662,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public async void Should_not_report_cancellation_and_not_execute_fallback_if_non_faulting_action_execution_completes_and_user_delegate_does_not_observe_the_set_cancellationtoken()
+        public async Task Should_not_report_cancellation_and_not_execute_fallback_if_non_faulting_action_execution_completes_and_user_delegate_does_not_observe_the_set_cancellationtoken()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = ct => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };
@@ -692,7 +692,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public async void Should_report_unhandled_fault_and_not_execute_fallback_if_action_execution_raises_unhandled_fault_and_user_delegate_does_not_observe_the_set_cancellationtoken()
+        public async Task Should_report_unhandled_fault_and_not_execute_fallback_if_action_execution_raises_unhandled_fault_and_user_delegate_does_not_observe_the_set_cancellationtoken()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = ct => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };
@@ -722,7 +722,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public async void Should_handle_handled_fault_and_execute_fallback_following_faulting_action_execution_when_user_delegate_does_not_observe_cancellationtoken()
+        public async Task Should_handle_handled_fault_and_execute_fallback_following_faulting_action_execution_when_user_delegate_does_not_observe_cancellationtoken()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = ct => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };

--- a/src/Polly.SharedSpecs/Retry/RetryTResultSpecsAsync.cs
+++ b/src/Polly.SharedSpecs/Retry/RetryTResultSpecsAsync.cs
@@ -68,7 +68,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public async void Should_not_return_handled_result_when_handled_result_raised_same_number_of_times_as_retry_count()
+        public async Task Should_not_return_handled_result_when_handled_result_raised_same_number_of_times_as_retry_count()
         {
             RetryPolicy<ResultPrimitive> policy = Policy
                 .HandleResult(ResultPrimitive.Fault)
@@ -79,7 +79,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public async void Should_not_return_handled_result_when_one_of_the_handled_results_raised_same_number_of_times_as_retry_count()
+        public async Task Should_not_return_handled_result_when_one_of_the_handled_results_raised_same_number_of_times_as_retry_count()
         {
             RetryPolicy<ResultPrimitive> policy = Policy
                 .HandleResult(ResultPrimitive.Fault)
@@ -91,7 +91,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public async void Should_not_return_handled_result_when_handled_result_raised_less_number_of_times_than_retry_count()
+        public async Task Should_not_return_handled_result_when_handled_result_raised_less_number_of_times_than_retry_count()
         {
             RetryPolicy<ResultPrimitive> policy = Policy
                 .HandleResult(ResultPrimitive.Fault)
@@ -102,7 +102,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public async void Should_not_return_handled_result_when_all_of_the_handled_results_raised_less_number_of_times_than_retry_count()
+        public async Task Should_not_return_handled_result_when_all_of_the_handled_results_raised_less_number_of_times_than_retry_count()
         {
             RetryPolicy<ResultPrimitive> policy = Policy
                 .HandleResult(ResultPrimitive.Fault)
@@ -114,7 +114,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public async void Should_return_handled_result_when_handled_result_raised_more_times_then_retry_count()
+        public async Task Should_return_handled_result_when_handled_result_raised_more_times_then_retry_count()
         {
             RetryPolicy<ResultPrimitive> policy = Policy
                 .HandleResult(ResultPrimitive.Fault)
@@ -125,7 +125,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public async void Should_return_handled_result_when_one_of_the_handled_results_is_raised_more_times_then_retry_count()
+        public async Task Should_return_handled_result_when_one_of_the_handled_results_is_raised_more_times_then_retry_count()
         {
             RetryPolicy<ResultPrimitive> policy = Policy
                 .HandleResult(ResultPrimitive.Fault)
@@ -137,7 +137,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public async void Should_return_result_when_result_is_not_the_specified_handled_result()
+        public async Task Should_return_result_when_result_is_not_the_specified_handled_result()
         {
             RetryPolicy<ResultPrimitive> policy = Policy
                 .HandleResult(ResultPrimitive.Fault)
@@ -148,7 +148,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public async void Should_return_result_when_result_is_not_one_of_the_specified_handled_results()
+        public async Task Should_return_result_when_result_is_not_one_of_the_specified_handled_results()
         {
             RetryPolicy<ResultPrimitive> policy = Policy
                 .HandleResult(ResultPrimitive.Fault)
@@ -160,7 +160,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public async void Should_return_result_when_specified_result_predicate_is_not_satisfied()
+        public async Task Should_return_result_when_specified_result_predicate_is_not_satisfied()
         {
             Policy<ResultClass> policy = Policy
                 .HandleResult<ResultClass>(r => r.ResultCode == ResultPrimitive.Fault)
@@ -171,7 +171,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public async void Should_return_result_when_none_of_the_specified_result_predicates_are_satisfied()
+        public async Task Should_return_result_when_none_of_the_specified_result_predicates_are_satisfied()
         {
             Policy<ResultClass> policy = Policy
                 .HandleResult<ResultClass>(r => r.ResultCode == ResultPrimitive.Fault)
@@ -183,7 +183,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public async void Should_not_return_handled_result_when_specified_result_predicate_is_satisfied()
+        public async Task Should_not_return_handled_result_when_specified_result_predicate_is_satisfied()
         {
             Policy<ResultClass> policy = Policy
                 .HandleResult<ResultClass>(r => r.ResultCode == ResultPrimitive.Fault)
@@ -194,7 +194,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public async void Should_not_return_handled_result_when_one_of_the_specified_result_predicates_is_satisfied()
+        public async Task Should_not_return_handled_result_when_one_of_the_specified_result_predicates_is_satisfied()
         {
             Policy<ResultClass> policy = Policy
                 .HandleResult<ResultClass>(r => r.ResultCode == ResultPrimitive.Fault)
@@ -206,7 +206,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public async void Should_call_onretry_on_each_retry_with_the_current_retry_count()
+        public async Task Should_call_onretry_on_each_retry_with_the_current_retry_count()
         {
             var expectedRetryCounts = new[] { 1, 2, 3 };
             var retryCounts = new List<int>();
@@ -223,7 +223,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public async void Should_call_onretry_on_each_retry_with_the_current_handled_result()
+        public async Task Should_call_onretry_on_each_retry_with_the_current_handled_result()
         {
             var expectedFaults = new[] { "Fault #1", "Fault #2", "Fault #3" };
             var retryFaults = new List<string>();
@@ -244,7 +244,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public async void Should_not_call_onretry_when_no_retries_are_performed()
+        public async Task Should_not_call_onretry_when_no_retries_are_performed()
         {
             var retryCounts = new List<int>();
 
@@ -260,7 +260,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public async void Should_call_onretry_with_the_passed_context()
+        public async Task Should_call_onretry_with_the_passed_context()
         {
             IDictionary<string, object> contextData = null;
 
@@ -280,7 +280,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public async void Should_call_onretry_with_the_passed_context_when_execute_and_capture()
+        public async Task Should_call_onretry_with_the_passed_context_when_execute_and_capture()
         {
             IDictionary<string, object> contextData = null;
 
@@ -309,7 +309,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public async void Context_should_be_empty_if_execute_not_called_with_any_context_data()
+        public async Task Context_should_be_empty_if_execute_not_called_with_any_context_data()
         {
             Context capturedContext = null;
 
@@ -324,7 +324,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public async void Should_create_new_context_for_each_call_to_execute()
+        public async Task Should_create_new_context_for_each_call_to_execute()
         {
             string contextValue = null;
 
@@ -348,7 +348,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public async void Should_create_new_context_for_each_call_to_execute_and_capture()
+        public async Task Should_create_new_context_for_each_call_to_execute_and_capture()
         {
             string contextValue = null;
 
@@ -372,7 +372,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public async void Should_create_new_state_for_each_call_to_policy()
+        public async Task Should_create_new_state_for_each_call_to_policy()
         {
             RetryPolicy<ResultPrimitive> policy = Policy
                 .HandleResult(ResultPrimitive.Fault)
@@ -385,7 +385,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public async void Should_not_call_onretry_when_retry_count_is_zero_without_context()
+        public async Task Should_not_call_onretry_when_retry_count_is_zero_without_context()
         {
             bool retryInvoked = false;
 
@@ -401,7 +401,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public async void Should_not_call_onretry_when_retry_count_is_zero_with_context()
+        public async Task Should_not_call_onretry_when_retry_count_is_zero_with_context()
         {
             bool retryInvoked = false;
 
@@ -421,7 +421,7 @@ namespace Polly.Specs.Retry
         #region Async and cancellation tests
 
         [Fact]
-        public async void Should_wait_asynchronously_for_async_onretry_delegate()
+        public async Task Should_wait_asynchronously_for_async_onretry_delegate()
         {
             // This test relates to https://github.com/App-vNext/Polly/issues/107.  
             // An async (...) => { ... } anonymous delegate with no return type may compile to either an async void or an async Task method; which assign to an Action<...> or Func<..., Task> respectively.  However, if it compiles to async void (assigning tp Action<...>), then the delegate, when run, will return at the first await, and execution continues without waiting for the Action to complete, as described by Stephen Toub: http://blogs.msdn.com/b/pfxteam/archive/2012/02/08/10265476.aspx
@@ -455,7 +455,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public async void Should_execute_all_tries_when_faulting_and_cancellationtoken_not_cancelled()
+        public async Task Should_execute_all_tries_when_faulting_and_cancellationtoken_not_cancelled()
         {
             RetryPolicy<ResultPrimitive> policy = Policy
                 .HandleResult(ResultPrimitive.Fault)
@@ -695,7 +695,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public async void Should_report_faulting_from_faulting_last_retry_execution_when_user_delegate_does_not_observe_cancellation_raised_during_last_retry()
+        public async Task Should_report_faulting_from_faulting_last_retry_execution_when_user_delegate_does_not_observe_cancellation_raised_during_last_retry()
         {
             RetryPolicy<ResultPrimitive> policy = Policy
                        .HandleResult(ResultPrimitive.Fault)

--- a/src/Polly.SharedSpecs/Timeout/TimeoutAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Timeout/TimeoutAsyncSpecs.cs
@@ -145,7 +145,7 @@ namespace Polly.Specs.Timeout
         }
 
         [Fact]
-        public async void Should_not_throw_when_timeout_is_greater_than_execution_duration__pessimistic()
+        public async Task Should_not_throw_when_timeout_is_greater_than_execution_duration__pessimistic()
         {
             var policy = Policy.TimeoutAsync(TimeSpan.FromSeconds(1), TimeoutStrategy.Pessimistic);
 
@@ -210,7 +210,7 @@ namespace Polly.Specs.Timeout
         }
 
         [Fact]
-        public async void Should_not_throw_when_timeout_is_greater_than_execution_duration__optimistic()
+        public async Task Should_not_throw_when_timeout_is_greater_than_execution_duration__optimistic()
         {
             var policy = Policy.TimeoutAsync(TimeSpan.FromSeconds(1), TimeoutStrategy.Optimistic);
 
@@ -497,7 +497,7 @@ namespace Polly.Specs.Timeout
         }
 
         [Fact]
-        public async void Should_call_ontimeout_with_task_wrapping_abandoned_action_allowing_capture_of_otherwise_unobserved_exception__pessimistic()
+        public async Task Should_call_ontimeout_with_task_wrapping_abandoned_action_allowing_capture_of_otherwise_unobserved_exception__pessimistic()
         {
             Exception exceptionToThrow = new DivideByZeroException();
 

--- a/src/Polly.SharedSpecs/Timeout/TimeoutTResultAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Timeout/TimeoutTResultAsyncSpecs.cs
@@ -145,7 +145,7 @@ namespace Polly.Specs.Timeout
         }
 
         [Fact]
-        public async void Should_not_throw_when_timeout_is_greater_than_execution_duration__pessimistic()
+        public async Task Should_not_throw_when_timeout_is_greater_than_execution_duration__pessimistic()
         {
             var policy = Policy.TimeoutAsync<ResultPrimitive>(TimeSpan.FromSeconds(1), TimeoutStrategy.Pessimistic);
 
@@ -206,7 +206,7 @@ namespace Polly.Specs.Timeout
         }
 
         [Fact]
-        public async void Should_not_throw_when_timeout_is_greater_than_execution_duration__optimistic()
+        public async Task Should_not_throw_when_timeout_is_greater_than_execution_duration__optimistic()
         {
             var policy = Policy.TimeoutAsync<ResultPrimitive>(TimeSpan.FromSeconds(1), TimeoutStrategy.Optimistic);
 
@@ -497,7 +497,7 @@ namespace Polly.Specs.Timeout
         }
 
         [Fact]
-        public async void Should_call_ontimeout_with_task_wrapping_abandoned_action_allowing_capture_of_otherwise_unobserved_exception__pessimistic()
+        public async Task Should_call_ontimeout_with_task_wrapping_abandoned_action_allowing_capture_of_otherwise_unobserved_exception__pessimistic()
         {
             Exception exceptionToThrow = new DivideByZeroException();
 

--- a/src/Polly.SharedSpecs/Wrap/PolicyWrapSpecsAsync.cs
+++ b/src/Polly.SharedSpecs/Wrap/PolicyWrapSpecsAsync.cs
@@ -167,7 +167,7 @@ namespace Polly.Specs.Wrap
         }
 
         [Fact]
-        public async void Wrapping_two_generic_policies_by_instance_syntax_and_executing_should_wrap_outer_then_inner_around_delegate()
+        public async Task Wrapping_two_generic_policies_by_instance_syntax_and_executing_should_wrap_outer_then_inner_around_delegate()
         {
             RetryPolicy<ResultPrimitive> retry = Policy.HandleResult(ResultPrimitive.Fault).RetryAsync(1); // Two tries in total: first try, plus one retry.
             CircuitBreakerPolicy<ResultPrimitive> breaker = Policy.HandleResult(ResultPrimitive.Fault).CircuitBreakerAsync(2, TimeSpan.MaxValue);
@@ -215,7 +215,7 @@ namespace Polly.Specs.Wrap
         }
 
         [Fact]
-        public async void Wrapping_two_generic_policies_by_static_syntax_and_executing_should_wrap_outer_then_inner_around_delegate()
+        public async Task Wrapping_two_generic_policies_by_static_syntax_and_executing_should_wrap_outer_then_inner_around_delegate()
         {
             RetryPolicy<ResultPrimitive> retry = Policy.HandleResult(ResultPrimitive.Fault).RetryAsync(1); // Two tries in total: first try, plus one retry.
             CircuitBreakerPolicy<ResultPrimitive> breaker = Policy.HandleResult(ResultPrimitive.Fault).CircuitBreakerAsync(2, TimeSpan.MaxValue);
@@ -241,7 +241,7 @@ namespace Polly.Specs.Wrap
         #region ExecuteAndCaptureAsyncSpecs
 
         [Fact]
-        public async void Outermost_policy_handling_exception_should_report_as_PolicyWrap_handled_exception()
+        public async Task Outermost_policy_handling_exception_should_report_as_PolicyWrap_handled_exception()
         {
             CircuitBreakerPolicy innerHandlingDBZE = Policy
                 .Handle<DivideByZeroException>()
@@ -260,7 +260,7 @@ namespace Polly.Specs.Wrap
         }
 
         [Fact]
-        public async void Outermost_policy_not_handling_exception_even_if_inner_policies_do_should_report_as_unhandled_exception()
+        public async Task Outermost_policy_not_handling_exception_even_if_inner_policies_do_should_report_as_unhandled_exception()
         {
             CircuitBreakerPolicy innerHandlingDBZE = Policy
                 .Handle<DivideByZeroException>()
@@ -279,7 +279,7 @@ namespace Polly.Specs.Wrap
         }
 
         [Fact]
-        public async void Outermost_generic_policy_handling_exception_should_report_as_PolicyWrap_handled_exception()
+        public async Task Outermost_generic_policy_handling_exception_should_report_as_PolicyWrap_handled_exception()
         {
             CircuitBreakerPolicy<ResultPrimitive> innerHandlingDBZE = Policy<ResultPrimitive>
                 .Handle<DivideByZeroException>()
@@ -298,7 +298,7 @@ namespace Polly.Specs.Wrap
         }
 
         [Fact]
-        public async void Outermost_generic_policy_not_handling_exception_even_if_inner_policies_do_should_report_as_unhandled_exception()
+        public async Task Outermost_generic_policy_not_handling_exception_even_if_inner_policies_do_should_report_as_unhandled_exception()
         {
             CircuitBreakerPolicy<ResultPrimitive> innerHandlingDBZE = Policy<ResultPrimitive>
                 .Handle<DivideByZeroException>()
@@ -317,7 +317,7 @@ namespace Polly.Specs.Wrap
         }
 
         [Fact]
-        public async void Outermost_generic_policy_handling_result_should_report_as_PolicyWrap_handled_result()
+        public async Task Outermost_generic_policy_handling_result_should_report_as_PolicyWrap_handled_result()
         {
             CircuitBreakerPolicy<ResultPrimitive> innerHandlingFaultAgain = Policy
                 .HandleResult(ResultPrimitive.FaultAgain)
@@ -337,7 +337,7 @@ namespace Polly.Specs.Wrap
         }
 
         [Fact]
-        public async void Outermost_generic_policy_not_handling_result_even_if_inner_policies_do_should_not_report_as_handled()
+        public async Task Outermost_generic_policy_not_handling_result_even_if_inner_policies_do_should_not_report_as_handled()
         {
             CircuitBreakerPolicy<ResultPrimitive> innerHandlingFaultAgain = Policy
                 .HandleResult(ResultPrimitive.FaultAgain)

--- a/src/Polly.SharedSpecs/Wrap/PolicyWrapSpecsAsync.cs
+++ b/src/Polly.SharedSpecs/Wrap/PolicyWrapSpecsAsync.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Polly.CircuitBreaker;
 using Polly.Retry;


### PR DESCRIPTION
xunit 2.0 correctly handles the `async void` tests, but `async Task` is (obviously) cleaner practice, and avoids any ambiguity/false-positives in how the tests might perform in future if, eg, we switched to a different test runner.