### PR TITLE
CachePolicy and PolicyWrap fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.5.0
+- Bug fix: non-generic CachePolicy with PolicyWrap
+- Add Cache interfaces
+
 ## 5.4.0
 - Add CachePolicy: cache-aside pattern, with interfaces for pluggable cache providers and serializers.
 - Bug fix: Sync TimeoutPolicy in pessimistic mode no longer interposes AggregateException.

--- a/GitVersionConfig.yaml
+++ b/GitVersionConfig.yaml
@@ -1,1 +1,1 @@
-next-version: 5.4.0
+next-version: 5.5.0

--- a/src/Polly.Net40Async.nuspec
+++ b/src/Polly.Net40Async.nuspec
@@ -15,6 +15,11 @@
     <releaseNotes>
      v5.0 is a major release with significant new resilience policies: Timeout; Bulkhead Isolation; Fallback; Cache; and PolicyWrap.  See release notes back to v5.0.0 for full details.  v5.0.5 includes important circuit-breaker fixes.
 
+     5.5.0
+     ---------------------
+     - Bug fix: non-generic CachePolicy with PolicyWrap
+     - Add Cache interfaces
+
      5.4.0
      ---------------------
      - Add CachePolicy: cache-aside pattern, with interfaces for pluggable cache providers and serializers.

--- a/src/Polly.NetStandard11/Properties/AssemblyInfo.cs
+++ b/src/Polly.NetStandard11/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Polly")]
-[assembly: AssemblyVersion("5.4.0.0")]
+[assembly: AssemblyVersion("5.5.0.0")]
 [assembly: CLSCompliant(true)]
 
 [assembly: InternalsVisibleTo("Polly.NetStandard11.Specs")]

--- a/src/Polly.Shared/Caching/CachePolicy.cs
+++ b/src/Polly.Shared/Caching/CachePolicy.cs
@@ -8,7 +8,7 @@ namespace Polly.Caching
     /// <summary>
     /// A cache policy that can be applied to the results of delegate executions.
     /// </summary>
-    public partial class CachePolicy : Policy
+    public partial class CachePolicy : Policy, ICachePolicy
     {
         private readonly ISyncCacheProvider _syncCacheProvider;
         private readonly ITtlStrategy _ttlStrategy;
@@ -71,7 +71,7 @@ namespace Polly.Caching
     /// <summary>
     /// A cache policy that can be applied to the results of delegate executions.
     /// </summary>
-    public partial class CachePolicy<TResult> : Policy<TResult>
+    public partial class CachePolicy<TResult> : Policy<TResult>, ICachePolicy<TResult>
     {
         internal CachePolicy(
             ISyncCacheProvider<TResult> syncCacheProvider, 

--- a/src/Polly.Shared/Caching/ICachePolicy.cs
+++ b/src/Polly.Shared/Caching/ICachePolicy.cs
@@ -1,0 +1,18 @@
+﻿namespace Polly.Caching
+{
+    /// <summary>
+    /// Defines properties and methods common to all Cache policies.
+    /// </summary>
+
+    public interface ICachePolicy : IsPolicy
+    {
+    }
+
+    /// <summary>
+    /// Defines properties and methods common to all Cache policies generic-typed for executions returning results of type <typeparamref name="TResult"/>.
+    /// </summary>
+    public interface ICachePolicy<TResult> : ICachePolicy
+    {
+
+    }
+}

--- a/src/Polly.Shared/Polly.Shared.projitems
+++ b/src/Polly.Shared/Polly.Shared.projitems
@@ -33,6 +33,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Caching\DefaultCacheKeyStrategy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\ICacheItemSerializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\ICacheKeyStrategy.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Caching\ICachePolicy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\ISyncCacheProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\IAsyncCacheProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\ITtlStrategy.cs" />

--- a/src/Polly.Shared/Wrap/IPolicyWrap.cs
+++ b/src/Polly.Shared/Wrap/IPolicyWrap.cs
@@ -6,6 +6,15 @@
 
     public interface IPolicyWrap : IsPolicy
     {
+        /// <summary>
+        /// Returns the outer <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>
+        /// </summary>
+        IsPolicy Outer { get; }
+
+        /// <summary>
+        /// Returns the next inner <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>
+        /// </summary>
+        IsPolicy Inner { get; }
     }
 
     /// <summary>

--- a/src/Polly.Shared/Wrap/PolicyWrap.cs
+++ b/src/Polly.Shared/Wrap/PolicyWrap.cs
@@ -56,12 +56,12 @@ namespace Polly.Wrap
     public partial class PolicyWrap<TResult> : Policy<TResult>, IPolicyWrap<TResult>
     {
         /// <summary>
-        /// Returns the outer <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>
+        /// Returns the outer <see cref="IsPolicy"/> in this <see cref="IPolicyWrap{TResult}"/>
         /// </summary>
         public IsPolicy Outer { get; private set; }
 
         /// <summary>
-        /// Returns the next inner <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>
+        /// Returns the next inner <see cref="IsPolicy"/> in this <see cref="IPolicyWrap{TResult}"/>
         /// </summary>
         public IsPolicy Inner { get; private set; }
 

--- a/src/Polly.Shared/Wrap/PolicyWrapAsync.cs
+++ b/src/Polly.Shared/Wrap/PolicyWrapAsync.cs
@@ -10,6 +10,28 @@ namespace Polly.Wrap
         internal PolicyWrap(Func<Func<Context, CancellationToken, Task>, Context, CancellationToken, bool, Task> policyAction, Policy outer, Policy inner)
             : base(policyAction, outer.ExceptionPredicates)
         {
+            _outer = outer;
+            _inner = inner;
+        }
+
+        /// <summary>
+        /// Executes the specified action asynchronously within the cache policy and returns the result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Execution context that is passed to the exception policy; defines the cache key to use in cache lookup.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <returns>The value returned by the action, or the cache.</returns>
+        public override Task<TResult> ExecuteAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        {
+            return PolicyWrapEngine.ImplementationAsync<TResult>(
+                action,
+                context,
+                cancellationToken,
+                continueOnCapturedContext,
+                _outer,
+                _inner);
         }
     }
 
@@ -18,11 +40,15 @@ namespace Polly.Wrap
         internal PolicyWrap(Func<Func<Context, CancellationToken, Task<TResult>>, Context, CancellationToken, bool, Task<TResult>> policyAction, Policy outer, IsPolicy inner)
             : base(policyAction, outer.ExceptionPredicates, PredicateHelper<TResult>.EmptyResultPredicates)
         {
+            Outer = outer;
+            Inner = inner;
         }
 
         internal PolicyWrap(Func<Func<Context, CancellationToken, Task<TResult>>, Context, CancellationToken, bool, Task<TResult>> policyAction, Policy<TResult> outer, IsPolicy inner)
             : base(policyAction, outer.ExceptionPredicates, outer.ResultPredicates)
         {
+            Outer = outer;
+            Inner = inner;
         }
     }
 }

--- a/src/Polly.Shared/Wrap/PolicyWrapEngine.cs
+++ b/src/Polly.Shared/Wrap/PolicyWrapEngine.cs
@@ -22,7 +22,7 @@ namespace Polly.Wrap
            Policy<TResult> outerPolicy,
            Policy innerPolicy)
         {
-            return outerPolicy.Execute((ctx, ct) => innerPolicy.Execute(func, ctx, ct), context, cancellationToken);
+            return outerPolicy.Execute((ctx, ct) => innerPolicy.Execute<TResult>(func, ctx, ct), context, cancellationToken);
         }
 
         internal static TResult Implementation<TResult>(
@@ -33,6 +33,16 @@ namespace Polly.Wrap
            Policy<TResult> innerPolicy)
         {
             return outerPolicy.Execute<TResult>((ctx, ct) => innerPolicy.Execute(func, ctx, ct), context, cancellationToken);
+        }
+
+        internal static TResult Implementation<TResult>(
+           Func<Context, CancellationToken, TResult> func,
+           Context context,
+           CancellationToken cancellationToken,
+           Policy outerPolicy,
+           Policy innerPolicy)
+        {
+            return outerPolicy.Execute<TResult>((ctx, ct) => innerPolicy.Execute<TResult>(func, ctx, ct), context, cancellationToken);
         }
 
         internal static void Implementation(

--- a/src/Polly.Shared/Wrap/PolicyWrapEngineAsync.cs
+++ b/src/Polly.Shared/Wrap/PolicyWrapEngineAsync.cs
@@ -36,7 +36,7 @@ namespace Polly.Wrap
             Policy innerPolicy)
         {
             return await outerPolicy.ExecuteAsync(
-                async (ctx, ct) => await innerPolicy.ExecuteAsync(
+                async (ctx, ct) => await innerPolicy.ExecuteAsync<TResult>(
                     func,
                     ctx,
                     ct,
@@ -56,7 +56,7 @@ namespace Polly.Wrap
             Policy outerPolicy,
             Policy<TResult> innerPolicy)
         {
-            return await outerPolicy.ExecuteAsync(
+            return await outerPolicy.ExecuteAsync<TResult>(
                 async (ctx, ct) => await innerPolicy.ExecuteAsync(
                     func,
                     ctx,
@@ -67,6 +67,27 @@ namespace Polly.Wrap
                 cancellationToken,
                 continueOnCapturedContext
                 ).ConfigureAwait(continueOnCapturedContext);
+        }
+
+        internal static async Task<TResult> ImplementationAsync<TResult>(
+           Func<Context, CancellationToken, Task<TResult>> func,
+           Context context,
+           CancellationToken cancellationToken,
+           bool continueOnCapturedContext,
+           Policy outerPolicy,
+           Policy innerPolicy)
+        {
+            return await outerPolicy.ExecuteAsync<TResult>(
+                async (ctx, ct) => await innerPolicy.ExecuteAsync<TResult>(
+                    func,
+                    ctx,
+                    ct,
+                    continueOnCapturedContext
+                ).ConfigureAwait(continueOnCapturedContext),
+                context,
+                cancellationToken,
+                continueOnCapturedContext
+            ).ConfigureAwait(continueOnCapturedContext);
         }
 
         internal static async Task ImplementationAsync(

--- a/src/Polly.SharedSpecs/Caching/CacheSpecs.cs
+++ b/src/Polly.SharedSpecs/Caching/CacheSpecs.cs
@@ -5,6 +5,7 @@ using Polly.Caching;
 using Polly.Specs.Helpers;
 using Polly.Specs.Helpers.Caching;
 using Polly.Utilities;
+using Polly.Wrap;
 using Xunit;
 
 namespace Polly.Specs.Caching
@@ -208,6 +209,88 @@ namespace Polly.Specs.Caching
 
             cache.Execute(func, new Context("person", new { id = "2" }.AsDictionary())).Should().BeSameAs(person2);
             funcExecuted.Should().BeFalse();
+        }
+
+        #endregion
+
+        #region Non-generic CachePolicy in non-generic PolicyWrap
+
+        [Fact]
+        public void Should_return_value_from_cache_and_not_execute_delegate_if_cache_holds_value_when_outermost_in_policywrap()
+        {
+            const string valueToReturnFromCache = "valueToReturnFromCache";
+            const string valueToReturnFromExecution = "valueToReturnFromExecution";
+            const string executionKey = "SomeExecutionKey";
+
+            ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+            CachePolicy cache = Policy.Cache(stubCacheProvider, TimeSpan.MaxValue);
+            Policy noop = Policy.NoOp();
+            PolicyWrap wrap = Policy.Wrap(cache, noop);
+
+            stubCacheProvider.Put(executionKey, valueToReturnFromCache, new Ttl(TimeSpan.MaxValue));
+
+            bool delegateExecuted = false;
+
+            wrap.Execute(() =>
+            {
+                delegateExecuted = true;
+                return valueToReturnFromExecution;
+            }, new Context(executionKey))
+                .Should().Be(valueToReturnFromCache);
+
+            delegateExecuted.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Should_return_value_from_cache_and_not_execute_delegate_if_cache_holds_value_when_innermost_in_policywrap()
+        {
+            const string valueToReturnFromCache = "valueToReturnFromCache";
+            const string valueToReturnFromExecution = "valueToReturnFromExecution";
+            const string executionKey = "SomeExecutionKey";
+
+            ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+            CachePolicy cache = Policy.Cache(stubCacheProvider, TimeSpan.MaxValue);
+            Policy noop = Policy.NoOp();
+            PolicyWrap wrap = Policy.Wrap(noop, cache);
+
+            stubCacheProvider.Put(executionKey, valueToReturnFromCache, new Ttl(TimeSpan.MaxValue));
+
+            bool delegateExecuted = false;
+
+            wrap.Execute(() =>
+            {
+                delegateExecuted = true;
+                return valueToReturnFromExecution;
+            }, new Context(executionKey))
+                .Should().Be(valueToReturnFromCache);
+
+            delegateExecuted.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Should_return_value_from_cache_and_not_execute_delegate_if_cache_holds_value_when_mid_policywrap()
+        {
+            const string valueToReturnFromCache = "valueToReturnFromCache";
+            const string valueToReturnFromExecution = "valueToReturnFromExecution";
+            const string executionKey = "SomeExecutionKey";
+
+            ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+            CachePolicy cache = Policy.Cache(stubCacheProvider, TimeSpan.MaxValue);
+            Policy noop = Policy.NoOp();
+            PolicyWrap wrap = Policy.Wrap(noop, cache, noop);
+
+            stubCacheProvider.Put(executionKey, valueToReturnFromCache, new Ttl(TimeSpan.MaxValue));
+
+            bool delegateExecuted = false;
+
+            wrap.Execute(() =>
+            {
+                delegateExecuted = true;
+                return valueToReturnFromExecution;
+            }, new Context(executionKey))
+                .Should().Be(valueToReturnFromCache);
+
+            delegateExecuted.Should().BeFalse();
         }
 
         #endregion

--- a/src/Polly.SharedSpecs/Caching/CacheTResultAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Caching/CacheTResultAsyncSpecs.cs
@@ -6,6 +6,7 @@ using Polly.Caching;
 using Polly.Specs.Helpers;
 using Polly.Specs.Helpers.Caching;
 using Polly.Utilities;
+using Polly.Wrap;
 using Xunit;
 
 namespace Polly.Specs.Caching
@@ -214,6 +215,94 @@ namespace Polly.Specs.Caching
 
             (await cache.ExecuteAsync(func, new Context("person", new { id = "2" }.AsDictionary())).ConfigureAwait(false)).Should().BeSameAs(person2);
             funcExecuted.Should().BeFalse();
+        }
+
+        #endregion
+
+        #region Generic CachePolicy in PolicyWrap
+
+        [Fact]
+        public async Task Should_return_value_from_cache_and_not_execute_delegate_if_cache_holds_value_when_outermost_in_policywrap()
+        {
+            const string valueToReturnFromCache = "valueToReturnFromCache";
+            const string valueToReturnFromExecution = "valueToReturnFromExecution";
+            const string executionKey = "SomeExecutionKey";
+
+            IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+            CachePolicy<string> cache = Policy.CacheAsync<string>(stubCacheProvider, TimeSpan.MaxValue);
+            Policy noop = Policy.NoOpAsync();
+            PolicyWrap<string> wrap = cache.WrapAsync(noop);
+
+            await stubCacheProvider.PutAsync(executionKey, valueToReturnFromCache, new Ttl(TimeSpan.MaxValue), CancellationToken.None, false).ConfigureAwait(false);
+
+            bool delegateExecuted = false;
+
+            (await wrap.ExecuteAsync(async () =>
+            {
+                delegateExecuted = true;
+                await TaskHelper.EmptyTask.ConfigureAwait(false);
+                return valueToReturnFromExecution;
+            }, new Context(executionKey))
+                .ConfigureAwait(false))
+                .Should().Be(valueToReturnFromCache);
+
+            delegateExecuted.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task Should_return_value_from_cache_and_not_execute_delegate_if_cache_holds_value_when_innermost_in_policywrap()
+        {
+            const string valueToReturnFromCache = "valueToReturnFromCache";
+            const string valueToReturnFromExecution = "valueToReturnFromExecution";
+            const string executionKey = "SomeExecutionKey";
+
+            IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+            CachePolicy<string> cache = Policy.CacheAsync<string>(stubCacheProvider, TimeSpan.MaxValue);
+            Policy noop = Policy.NoOpAsync();
+            PolicyWrap<string> wrap = noop.WrapAsync(cache);
+
+            await stubCacheProvider.PutAsync(executionKey, valueToReturnFromCache, new Ttl(TimeSpan.MaxValue), CancellationToken.None, false).ConfigureAwait(false);
+
+            bool delegateExecuted = false;
+
+            (await wrap.ExecuteAsync(async () =>
+            {
+                delegateExecuted = true;
+                await TaskHelper.EmptyTask.ConfigureAwait(false);
+                return valueToReturnFromExecution;
+            }, new Context(executionKey))
+                .ConfigureAwait(false))
+                .Should().Be(valueToReturnFromCache);
+
+            delegateExecuted.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task Should_return_value_from_cache_and_not_execute_delegate_if_cache_holds_value_when_mid_policywrap()
+        {
+            const string valueToReturnFromCache = "valueToReturnFromCache";
+            const string valueToReturnFromExecution = "valueToReturnFromExecution";
+            const string executionKey = "SomeExecutionKey";
+
+            IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+            CachePolicy<string> cache = Policy.CacheAsync<string>(stubCacheProvider, TimeSpan.MaxValue);
+            Policy<string> noop = Policy.NoOpAsync<string>();
+            PolicyWrap<string> wrap = Policy.WrapAsync(noop, cache, noop);
+
+            await stubCacheProvider.PutAsync(executionKey, valueToReturnFromCache, new Ttl(TimeSpan.MaxValue), CancellationToken.None, false).ConfigureAwait(false);
+
+            bool delegateExecuted = false;
+
+            (await wrap.ExecuteAsync(async () =>
+            {
+                delegateExecuted = true;
+                await TaskHelper.EmptyTask.ConfigureAwait(false);
+                return valueToReturnFromExecution;
+            }, new Context(executionKey))
+                .ConfigureAwait(false))
+                .Should().Be(valueToReturnFromCache);
+
+            delegateExecuted.Should().BeFalse();
         }
 
         #endregion

--- a/src/Polly.SharedSpecs/Wrap/PolicyWrapSpecs.cs
+++ b/src/Polly.SharedSpecs/Wrap/PolicyWrapSpecs.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using FluentAssertions;
 using Polly.CircuitBreaker;
+using Polly.NoOp;
 using Polly.Retry;
 using Polly.Specs.Helpers;
 using Polly.Wrap;
@@ -53,6 +54,54 @@ namespace Polly.Specs.Wrap
             config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
         }
 
+        [Fact]
+        public void Nongeneric_wraps_nongeneric_using_instance_wrap_syntax_should_set_outer_inner()
+        {
+            Policy policyA = Policy.NoOp();
+            Policy policyB = Policy.NoOp();
+
+            PolicyWrap wrap = policyA.Wrap(policyB);
+
+            wrap.Outer.Should().BeSameAs(policyA);
+            wrap.Inner.Should().BeSameAs(policyB);
+        }
+
+        [Fact]
+        public void Nongeneric_wraps_generic_using_instance_wrap_syntax_should_set_outer_inner()
+        {
+            Policy policyA = Policy.NoOp();
+            Policy<int> policyB = Policy.NoOp<int>();
+
+            PolicyWrap<int> wrap = policyA.Wrap(policyB);
+
+            wrap.Outer.Should().BeSameAs(policyA);
+            wrap.Inner.Should().BeSameAs(policyB);
+        }
+
+        [Fact]
+        public void Generic_wraps_nongeneric_using_instance_wrap_syntax_should_set_outer_inner()
+        {
+            Policy<int> policyA = Policy.NoOp<int>();
+            Policy policyB = Policy.NoOp();
+
+            PolicyWrap<int> wrap = policyA.Wrap(policyB);
+
+            wrap.Outer.Should().BeSameAs(policyA);
+            wrap.Inner.Should().BeSameAs(policyB);
+        }
+
+        [Fact]
+        public void Generic_wraps_generic_using_instance_wrap_syntax_should_set_outer_inner()
+        {
+            Policy<int> policyA = Policy.NoOp<int>();
+            Policy<int> policyB = Policy.NoOp<int>();
+
+            PolicyWrap<int> wrap = policyA.Wrap(policyB);
+
+            wrap.Outer.Should().BeSameAs(policyA);
+            wrap.Inner.Should().BeSameAs(policyB);
+        }
+
         #endregion
 
         #region Static configuration syntax tests, non-generic policies
@@ -96,6 +145,18 @@ namespace Polly.Specs.Wrap
             config.ShouldNotThrow();
         }
 
+        [Fact]
+        public void Wrapping_policies_using_static_wrap_syntax_should_set_outer_inner()
+        {
+            Policy policyA = Policy.NoOp();
+            Policy policyB = Policy.NoOp();
+
+            PolicyWrap wrap = Policy.Wrap(policyA, policyB);
+
+            wrap.Outer.Should().BeSameAs(policyA);
+            wrap.Inner.Should().BeSameAs(policyB);
+        }
+
         #endregion
 
         #region Static configuration syntax tests, strongly-typed policies
@@ -137,6 +198,18 @@ namespace Polly.Specs.Wrap
             Action config = () => Policy.Wrap<int>(new[] { divideByZeroRetry, retry, breaker });
 
             config.ShouldNotThrow();
+        }
+
+        [Fact]
+        public void Wrapping_policies_using_static_wrap_strongly_typed_syntax_should_set_outer_inner()
+        {
+            Policy<int> policyA = Policy.NoOp<int>();
+            Policy<int> policyB = Policy.NoOp<int>();
+
+            PolicyWrap<int> wrap = Policy.Wrap(policyA, policyB);
+
+            wrap.Outer.Should().BeSameAs(policyA);
+            wrap.Inner.Should().BeSameAs(policyB);
         }
 
         #endregion

--- a/src/Polly.SharedSpecs/Wrap/PolicyWrapSpecsAsync.cs
+++ b/src/Polly.SharedSpecs/Wrap/PolicyWrapSpecsAsync.cs
@@ -44,7 +44,6 @@ namespace Polly.Specs.Wrap
             config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
         }
 
-
         [Fact]
         public void Generic_wraps_generic_instance_syntax_wrapping_null_should_throw()
         {
@@ -53,6 +52,54 @@ namespace Polly.Specs.Wrap
             Action config = () => retry.WrapAsync((Policy<int>)null);
 
             config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+        }
+
+        [Fact]
+        public void Nongeneric_wraps_nongeneric_using_instance_wrap_syntax_should_set_outer_inner()
+        {
+            Policy policyA = Policy.NoOpAsync();
+            Policy policyB = Policy.NoOpAsync();
+
+            PolicyWrap wrap = policyA.WrapAsync(policyB);
+
+            wrap.Outer.Should().BeSameAs(policyA);
+            wrap.Inner.Should().BeSameAs(policyB);
+        }
+
+        [Fact]
+        public void Nongeneric_wraps_generic_using_instance_wrap_syntax_should_set_outer_inner()
+        {
+            Policy policyA = Policy.NoOpAsync();
+            Policy<int> policyB = Policy.NoOpAsync<int>();
+
+            PolicyWrap<int> wrap = policyA.WrapAsync(policyB);
+
+            wrap.Outer.Should().BeSameAs(policyA);
+            wrap.Inner.Should().BeSameAs(policyB);
+        }
+
+        [Fact]
+        public void Generic_wraps_nongeneric_using_instance_wrap_syntax_should_set_outer_inner()
+        {
+            Policy<int> policyA = Policy.NoOpAsync<int>();
+            Policy policyB = Policy.NoOpAsync();
+
+            PolicyWrap<int> wrap = policyA.WrapAsync(policyB);
+
+            wrap.Outer.Should().BeSameAs(policyA);
+            wrap.Inner.Should().BeSameAs(policyB);
+        }
+
+        [Fact]
+        public void Generic_wraps_generic_using_instance_wrap_syntax_should_set_outer_inner()
+        {
+            Policy<int> policyA = Policy.NoOpAsync<int>();
+            Policy<int> policyB = Policy.NoOpAsync<int>();
+
+            PolicyWrap<int> wrap = policyA.WrapAsync(policyB);
+
+            wrap.Outer.Should().BeSameAs(policyA);
+            wrap.Inner.Should().BeSameAs(policyB);
         }
 
         #endregion
@@ -98,6 +145,18 @@ namespace Polly.Specs.Wrap
             config.ShouldNotThrow();
         }
 
+        [Fact]
+        public void Wrapping_policies_using_static_wrap_syntax_should_set_outer_inner()
+        {
+            Policy policyA = Policy.NoOpAsync();
+            Policy policyB = Policy.NoOpAsync();
+
+            PolicyWrap wrap = Policy.WrapAsync(policyA, policyB);
+
+            wrap.Outer.Should().BeSameAs(policyA);
+            wrap.Inner.Should().BeSameAs(policyB);
+        }
+
         #endregion
 
         #region Static configuration syntax tests, strongly-typed policies
@@ -139,6 +198,18 @@ namespace Polly.Specs.Wrap
             Action config = () => Policy.WrapAsync<int>(new[] { divideByZeroRetry, retry, breaker });
 
             config.ShouldNotThrow();
+        }
+
+        [Fact]
+        public void Wrapping_policies_using_static_wrap_strongly_typed_syntax_should_set_outer_inner()
+        {
+            Policy<int> policyA = Policy.NoOpAsync<int>();
+            Policy<int> policyB = Policy.NoOpAsync<int>();
+
+            PolicyWrap<int> wrap = Policy.WrapAsync(policyA, policyB);
+
+            wrap.Outer.Should().BeSameAs(policyA);
+            wrap.Inner.Should().BeSameAs(policyB);
         }
 
         #endregion

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -15,6 +15,11 @@
     <releaseNotes>
      v5.0 is a major release with significant new resilience policies: Timeout; Bulkhead Isolation; Fallback; Cache; and PolicyWrap.  See release notes back to v5.0.0 for full details.  v5.0.5 includes important circuit-breaker fixes.
 
+     5.5.0
+     ---------------------
+     - Bug fix: non-generic CachePolicy with PolicyWrap
+     - Add Cache interfaces
+     
      5.4.0
      ---------------------
      - Add CachePolicy: cache-aside pattern, with interfaces for pluggable cache providers and serializers.


### PR DESCRIPTION
+ Fix #341  

+ Adds `Outer` and `Inner` properties to `IPolicyWrap`, representing the outer and inner policies in the particular `PolicyWrap` instance *

+ Add `ICachePolicy` interface *

+ Add v5.5.0 doco

SemVer: v5.5.0, because new backwards-compatible functionality *