### PR TITLE
Make TimeoutPolicy tests use abstracted clock

### DIFF
--- a/src/Polly.Shared/Timeout/TimeoutEngine.cs
+++ b/src/Polly.Shared/Timeout/TimeoutEngine.cs
@@ -2,6 +2,7 @@
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Polly.Utilities;
 
 #if NET40
 using ExceptionDispatchInfo = Polly.Utilities.ExceptionDispatchInfo;
@@ -33,13 +34,13 @@ namespace Polly.Timeout
                     {
                         if (timeoutStrategy == TimeoutStrategy.Optimistic)
                         {
-                            timeoutCancellationTokenSource.CancelAfter(timeout);
+                            SystemClock.CancelTokenAfter(timeoutCancellationTokenSource, timeout);
                             return action(context, combinedToken);
                         }
 
                         // else: timeoutStrategy == TimeoutStrategy.Pessimistic
 
-                        timeoutCancellationTokenSource.CancelAfter(timeout);
+                        SystemClock.CancelTokenAfter(timeoutCancellationTokenSource, timeout);
 
                         actionTask = 
 

--- a/src/Polly.Shared/Timeout/TimeoutEngineAsync.cs
+++ b/src/Polly.Shared/Timeout/TimeoutEngineAsync.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Polly.Utilities;
 
 namespace Polly.Timeout
 {
@@ -29,7 +30,7 @@ namespace Polly.Timeout
                     {
                         if (timeoutStrategy == TimeoutStrategy.Optimistic)
                         {
-                            timeoutCancellationTokenSource.CancelAfter(timeout);
+                            SystemClock.CancelTokenAfter(timeoutCancellationTokenSource, timeout);
                             return await action(context, combinedToken).ConfigureAwait(continueOnCapturedContext);
                         }
 
@@ -37,7 +38,7 @@ namespace Polly.Timeout
 
                         Task<TResult> timeoutTask = timeoutCancellationTokenSource.Token.AsTask<TResult>();
 
-                        timeoutCancellationTokenSource.CancelAfter(timeout);
+                        SystemClock.CancelTokenAfter(timeoutCancellationTokenSource, timeout);
 
                         actionTask = action(context, combinedToken);
 

--- a/src/Polly.Shared/Utilities/SystemClock.cs
+++ b/src/Polly.Shared/Utilities/SystemClock.cs
@@ -40,6 +40,12 @@ namespace Polly.Utilities
         public static Func<DateTimeOffset> DateTimeOffsetUtcNow = () => DateTimeOffset.UtcNow;
 
         /// <summary>
+        /// Allows the setting of a custom method for cancelling tokens after a timespan, for use in testing.
+        /// By default this will be a call to CancellationTokenSource.CancelAfter(timespan)
+        /// </summary>
+        public static Action<CancellationTokenSource, TimeSpan> CancelTokenAfter = (tokenSource, timespan) => tokenSource.CancelAfter(timespan);
+
+        /// <summary>
         /// Resets the custom implementations to their defaults. 
         /// Should be called during test teardowns.
         /// </summary>
@@ -58,6 +64,9 @@ namespace Polly.Utilities
             UtcNow = () => DateTime.UtcNow;
 
             DateTimeOffsetUtcNow = () => DateTimeOffset.UtcNow;
+
+            CancelTokenAfter = (tokenSource, timespan) => tokenSource.CancelAfter(timespan);
+
         }
     }
 }

--- a/src/Polly.SharedSpecs/Timeout/TimeoutAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Timeout/TimeoutAsyncSpecs.cs
@@ -276,30 +276,22 @@ namespace Polly.Specs.Timeout
         #region Non-timeout cancellation - pessimistic (user-delegate does not observe cancellation)
 
         [Fact]
-        public void Should_not_be_able_to_cancel_with_user_cancellation_token_before_timeout__pessimistic()
+        public void Should_not_be_able_to_cancel_with_unobserved_user_cancellation_token_before_timeout__pessimistic()
         {
-            Stopwatch watch = new Stopwatch();
-
             int timeout = 5;
             var policy = Policy.TimeoutAsync(timeout, TimeoutStrategy.Pessimistic);
 
-            TimeSpan tolerance = TimeSpan.FromSeconds(3); // Consider increasing tolerance, if test fails transiently in different test/build environments.
-
-            TimeSpan userTokenExpiry = TimeSpan.FromSeconds(1); // Use of time-based token irrelevant to timeout policy; we just need some user token that cancels independently of policy's internal token.
-            using (CancellationTokenSource userTokenSource = new CancellationTokenSource(userTokenExpiry))
+            using (CancellationTokenSource userTokenSource = new CancellationTokenSource())
             {
-                watch.Start();
                 policy.Awaiting(async p => await p.ExecuteAsync(async
                     _ => {
-                        await SystemClock.SleepAsync(TimeSpan.FromSeconds(timeout * 2), CancellationToken.None).ConfigureAwait(false); // Do not observe any cancellation in the middle of execution
-
-                    }, userTokenSource.Token) // ... with user token.
-                   ).ShouldThrow<TimeoutRejectedException>();
-                watch.Stop();
+                        userTokenSource.Cancel(); // User token cancels in the middle of execution ...
+                        await SystemClock.SleepAsync(TimeSpan.FromSeconds(timeout * 2), 
+                            CancellationToken.None // ... but if the executed delegate does not observe it
+                            ).ConfigureAwait(false); 
+                    }, userTokenSource.Token)
+                   ).ShouldThrow<TimeoutRejectedException>(); // ... it's still the timeout we expect.
             }
-
-            watch.Elapsed.Should().BeCloseTo(TimeSpan.FromSeconds(timeout), ((int)tolerance.TotalMilliseconds));
-
         }
 
         [Fact]
@@ -331,29 +323,18 @@ namespace Polly.Specs.Timeout
         [Fact]
         public void Should_be_able_to_cancel_with_user_cancellation_token_before_timeout__optimistic()
         {
-            Stopwatch watch = new Stopwatch();
-
             int timeout = 10;
             var policy = Policy.TimeoutAsync(timeout, TimeoutStrategy.Optimistic);
 
-            TimeSpan tolerance = TimeSpan.FromSeconds(3); // Consider increasing tolerance, if test fails transiently in different test/build environments.
-
-            TimeSpan userTokenExpiry = TimeSpan.FromSeconds(1); // Use of time-based token irrelevant to timeout policy; we just need some user token that cancels independently of policy's internal token.
-            using (CancellationTokenSource userTokenSource = new CancellationTokenSource(userTokenExpiry))
+            using (CancellationTokenSource userTokenSource = new CancellationTokenSource())
             {
-                watch.Start();
-                policy.Awaiting(async p => await p.ExecuteAsync(async
+                policy.Awaiting(async p => await p.ExecuteAsync(
                     ct => {
-                        await SystemClock.SleepAsync(TimeSpan.FromSeconds(timeout), ct).ConfigureAwait(false);  // Simulate cancel in the middle of execution
-                        
+                        userTokenSource.Cancel(); ct.ThrowIfCancellationRequested();   // Simulate cancel in the middle of execution
+                        return TaskHelper.EmptyTask;
                     }, userTokenSource.Token) // ... with user token.
                    ).ShouldThrow<OperationCanceledException>();
-                watch.Stop();
             }
-
-            watch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(timeout * 0.8));
-            watch.Elapsed.Should().BeCloseTo(userTokenExpiry, ((int)tolerance.TotalMilliseconds));
-
         }
 
         [Fact]
@@ -515,6 +496,10 @@ namespace Polly.Specs.Timeout
         [Fact]
         public async Task Should_call_ontimeout_with_task_wrapping_abandoned_action_allowing_capture_of_otherwise_unobserved_exception__pessimistic()
         {
+            SystemClock.Reset(); // This is the only test which cannot work with the artificial SystemClock of TimeoutSpecsBase.  We want the invoked delegate to continue as far as: throw exceptionToThrow, to genuinely check that the walked-away-from task throws that, and that we pass it to onTimeoutAsync.  
+            // That means we can't use the SystemClock.SleepAsync(...) within the executed delegate to artificially trigger the timeout cancellation (as for example the test above does).
+            // In real execution, it is the .WhenAny() in the timeout implementation which throws for the timeout.  We don't want to go as far as abstracting Task.WhenAny() out into SystemClock, so we let this test run at real-world speed, not abstracted-clock speed.
+
             Exception exceptionToThrow = new DivideByZeroException();
 
             Exception exceptionObservedFromTaskPassedToOnTimeout = null;

--- a/src/Polly.SharedSpecs/Timeout/TimeoutSpecs.cs
+++ b/src/Polly.SharedSpecs/Timeout/TimeoutSpecs.cs
@@ -310,28 +310,23 @@ namespace Polly.Specs.Timeout
         #region Non-timeout cancellation - pessimistic (user-delegate does not observe cancellation)
 
         [Fact]
-        public void Should_not_be_able_to_cancel_with_user_cancellation_token_before_timeout__pessimistic()
+        public void Should_not_be_able_to_cancel_with_unobserved_user_cancellation_token_before_timeout__pessimistic()
         {
-            Stopwatch watch = new Stopwatch();
-
             int timeout = 5;
             var policy = Policy.Timeout(timeout, TimeoutStrategy.Pessimistic);
 
-            TimeSpan tolerance = TimeSpan.FromSeconds(3); // Consider increasing tolerance, if test fails transiently in different test/build environments.
-
-            TimeSpan userTokenExpiry = TimeSpan.FromSeconds(1); // Use of time-based token irrelevant to timeout policy; we just need some user token that cancels independently of policy's internal token.
-            using (CancellationTokenSource userTokenSource = new CancellationTokenSource(userTokenExpiry))
+            using (CancellationTokenSource userTokenSource = new CancellationTokenSource())
             {
-                watch.Start();
                 policy.Invoking(p => p.Execute(
-                    _ => SystemClock.Sleep(TimeSpan.FromSeconds(timeout * 2), CancellationToken.None) // Do not observe any cancellation in the middle of execution
-                    , userTokenSource.Token) // ... with user token.
-                   ).ShouldThrow<TimeoutRejectedException>();
-                watch.Stop();
+                    _ => {
+                        userTokenSource.Cancel(); // User token cancels in the middle of execution ...
+                        SystemClock.Sleep(TimeSpan.FromSeconds(timeout * 2), 
+                            CancellationToken.None // ... but if the executed delegate does not observe it
+                            );
+                    } 
+                    , userTokenSource.Token) 
+                   ).ShouldThrow<TimeoutRejectedException>(); // ... it's still the timeout we expect.
             }
-
-            watch.Elapsed.Should().BeCloseTo(TimeSpan.FromSeconds(timeout), ((int)tolerance.TotalMilliseconds));
-
         }
 
         [Fact]
@@ -359,27 +354,16 @@ namespace Polly.Specs.Timeout
         [Fact]
         public void Should_be_able_to_cancel_with_user_cancellation_token_before_timeout__optimistic()
         {
-            Stopwatch watch = new Stopwatch();
-
             int timeout = 10;
             var policy = Policy.Timeout(timeout, TimeoutStrategy.Optimistic);
 
-            TimeSpan tolerance = TimeSpan.FromSeconds(3); // Consider increasing tolerance, if test fails transiently in different test/build environments.
-
-            TimeSpan userTokenExpiry = TimeSpan.FromSeconds(1); // Use of time-based token irrelevant to timeout policy; we just need some user token that cancels independently of policy's internal token.
-            using (CancellationTokenSource userTokenSource = new CancellationTokenSource(userTokenExpiry))
+            using (CancellationTokenSource userTokenSource = new CancellationTokenSource())
             {
-                watch.Start();
                 policy.Invoking(p => p.Execute(
-                    ct => SystemClock.Sleep(TimeSpan.FromSeconds(timeout), ct) // Simulate cancel in the middle of execution
+                    ct => { userTokenSource.Cancel(); ct.ThrowIfCancellationRequested(); } // Simulate cancel in the middle of execution
                     , userTokenSource.Token) // ... with user token.
-                   ).ShouldThrow<OperationCanceledException>();
-                watch.Stop();
+                   ).ShouldThrow<OperationCanceledException>(); // Not a TimeoutRejectedException; i.e. policy can distinguish user cancellation from timeout cancellation.
             }
-
-            watch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(timeout*0.8));
-            watch.Elapsed.Should().BeCloseTo(userTokenExpiry, ((int)tolerance.TotalMilliseconds));
-
         }
 
         [Fact]
@@ -498,6 +482,10 @@ namespace Polly.Specs.Timeout
         [Fact]
         public void Should_call_ontimeout_with_task_wrapping_abandoned_action_allowing_capture_of_otherwise_unobserved_exception__pessimistic()
         {
+            SystemClock.Reset(); // This is the only test which cannot work with the artificial SystemClock of TimeoutSpecsBase.  We want the invoked delegate to continue as far as: throw exceptionToThrow, to genuinely check that the walked-away-from task throws that, and that we pass it to onTimeout.  
+            // That means we can't use the SystemClock.Sleep(...) within the executed delegate to artificially trigger the timeout cancellation (as for example the test above does).
+            // In real execution, it is the .Wait(timeoutCancellationTokenSource.Token) in the timeout implementation which throws for the timeout.  We don't want to go as far as abstracting Task.Wait() out into SystemClock, so we let this test run at real-world speed, not abstracted-clock speed.
+
             Exception exceptionToThrow = new DivideByZeroException();
 
             Exception exceptionObservedFromTaskPassedToOnTimeout = null;

--- a/src/Polly.SharedSpecs/Timeout/TimeoutSpecsBase.cs
+++ b/src/Polly.SharedSpecs/Timeout/TimeoutSpecsBase.cs
@@ -1,11 +1,95 @@
 ﻿using System;
+using Polly.Utilities;
+using System.Threading;
 
 namespace Polly.Specs.Timeout
 {
-    public class TimeoutSpecsBase
+    /// <summary>
+    /// Provides common functionality for timeout specs, which abstracts out both SystemClock.Sleep, and SystemClock.CancelTokenAfter.
+    /// <remarks>Polly's TimeoutPolicy uses timing-out CancellationTokens to drive timeouts.
+    /// For tests, rather than letting .NET's timers drive the timing out of CancellationTokens, we override SystemClock.CancelTokenAfter and SystemClock.Sleep to make the tests run fast.
+    /// </remarks>
+    /// </summary>
+    public abstract class TimeoutSpecsBase : IDisposable
     {
+        // xUnit creates a new class instance per test, so these variables are isolated per test.
+
+        // Track a CancellationTokenSource, and when it might be cancelled at.
+        private CancellationTokenSource _trackedTokenSource = null;
+        private DateTimeOffset _cancelAt = DateTimeOffset.MaxValue;
+
+        private DateTimeOffset _offsetUtcNow = DateTimeOffset.UtcNow;
+        private DateTime _utcNow = DateTime.UtcNow;
+        
+        protected TimeoutSpecsBase()
+        {
+            // Override the SystemClock, to return time stored in variables we manipulate.
+            SystemClock.DateTimeOffsetUtcNow = () => _offsetUtcNow;
+            SystemClock.UtcNow = () => _utcNow;
+
+            // Override SystemClock.CancelTokenAfter to record when the policy wants the token to cancel.
+            SystemClock.CancelTokenAfter = (tokenSource, timespan) =>
+            {
+                if (_trackedTokenSource != null && tokenSource != _trackedTokenSource) throw new InvalidOperationException("Timeout tests cannot track more than one timing out token at a time.");
+
+                _trackedTokenSource = tokenSource;
+
+                DateTimeOffset newCancelAt = _offsetUtcNow.Add(timespan);
+                _cancelAt = newCancelAt < _cancelAt ? newCancelAt : _cancelAt;
+
+                SystemClock.Sleep(TimeSpan.Zero, CancellationToken.None); // Invoke our custom definition of sleep, to check for immediate cancellation.
+            };
+
+            // Override SysteClock.Sleep, to manipulate our artificial clock.  And - if it means sleeping beyond the time when a tracked token should cancel - cancel it!
+            SystemClock.Sleep = (sleepTimespan, sleepCancellationtoken) =>
+            {
+                if (sleepCancellationtoken.IsCancellationRequested) return;
+
+                if (_trackedTokenSource == null || _trackedTokenSource.IsCancellationRequested)
+                {
+                    // Not tracking any CancellationToken (or already cancelled) - just advance time.
+                    _utcNow += sleepTimespan;
+                    _offsetUtcNow += sleepTimespan;
+                }
+                else
+                {
+                    // Tracking something to cancel - does this sleep hit time to cancel?
+                    TimeSpan timeToCancellation = _cancelAt - _offsetUtcNow;
+                    if (sleepTimespan >= timeToCancellation)
+                    {
+                        // Cancel!  (And advance time only to the instant of cancellation)
+                        _offsetUtcNow += timeToCancellation;
+                        _utcNow += timeToCancellation;
+
+                        // (and stop tracking it after cancelling; it can't be cancelled twice, so there is no need, and the owner may dispose it)
+                        CancellationTokenSource copySource = _trackedTokenSource;
+                        _trackedTokenSource = null;
+                        copySource.Cancel();
+                        copySource.Token.ThrowIfCancellationRequested();
+                    }
+                    else
+                    {
+                        // (not yet time to cancel - just advance time)
+                        _utcNow += sleepTimespan;
+                        _offsetUtcNow += sleepTimespan;
+                    }
+                }
+            };
+
+            SystemClock.SleepAsync = (sleepTimespan, cancellationtoken) =>
+            {
+                SystemClock.Sleep(sleepTimespan, cancellationtoken);
+                return TaskHelper.FromResult(true);
+            };
+        }
+
+        public void Dispose()
+        {
+            SystemClock.Reset();
+        }
+
         /// <summary>
-        /// A helper method which simply throws the passed exception.  Supports tests verifying the stack trace of where an exception was thrown.
+        /// A helper method which simply throws the passed exception.  Supports tests verifying the stack trace of where an exception was thrown, by throwing that exception from a specific (other) location.
         /// </summary>
         /// <param name="ex">The exception to throw.</param>
         protected void Helper_ThrowException(Exception ex)

--- a/src/Polly.SharedSpecs/Timeout/TimeoutTResultSpecs.cs
+++ b/src/Polly.SharedSpecs/Timeout/TimeoutTResultSpecs.cs
@@ -343,29 +343,23 @@ namespace Polly.Specs.Timeout
         #region Non-timeout cancellation - pessimistic (user-delegate does not observe cancellation)
 
         [Fact]
-        public void Should_not_be_able_to_cancel_with_user_cancellation_token_before_timeout__pessimistic()
+        public void Should_not_be_able_to_cancel_with_unobserved_user_cancellation_token_before_timeout__pessimistic()
         {
-            Stopwatch watch = new Stopwatch();
-
             int timeout = 5;
             var policy = Policy.Timeout<ResultPrimitive>(timeout, TimeoutStrategy.Pessimistic);
 
-            TimeSpan tolerance = TimeSpan.FromSeconds(3); // Consider increasing tolerance, if test fails transiently in different test/build environments.
-
-            TimeSpan userTokenExpiry = TimeSpan.FromSeconds(1); // Use of time-based token irrelevant to timeout policy; we just need some user token that cancels independently of policy's internal token.
-            using (CancellationTokenSource userTokenSource = new CancellationTokenSource(userTokenExpiry))
+            using (CancellationTokenSource userTokenSource = new CancellationTokenSource())
             {
-                watch.Start();
                 policy.Invoking(p => p.Execute(
-                    _ => { SystemClock.Sleep(TimeSpan.FromSeconds(timeout * 2), CancellationToken.None); // Do not observe any cancellation in the middle of execution
+                    _ => {
+                        userTokenSource.Cancel(); // User token cancels in the middle of execution ...
+                        SystemClock.Sleep(TimeSpan.FromSeconds(timeout * 2),
+                            CancellationToken.None // ... but if the executed delegate does not observe it
+                           );
                         return ResultPrimitive.WhateverButTooLate;
-                    }, userTokenSource.Token) // ... with user token.
-                   ).ShouldThrow<TimeoutRejectedException>();
-                watch.Stop();
+                    }, userTokenSource.Token) 
+                   ).ShouldThrow<TimeoutRejectedException>(); // ... it's still the timeout we expect.
             }
-
-            watch.Elapsed.Should().BeCloseTo(TimeSpan.FromSeconds(timeout), ((int)tolerance.TotalMilliseconds));
-
         }
 
         [Fact]
@@ -397,29 +391,17 @@ namespace Polly.Specs.Timeout
         [Fact]
         public void Should_be_able_to_cancel_with_user_cancellation_token_before_timeout__optimistic()
         {
-            Stopwatch watch = new Stopwatch();
-
             int timeout = 10;
             var policy = Policy.Timeout<ResultPrimitive>(timeout, TimeoutStrategy.Optimistic);
-
-            TimeSpan tolerance = TimeSpan.FromSeconds(3); // Consider increasing tolerance, if test fails transiently in different test/build environments.
-
-            TimeSpan userTokenExpiry = TimeSpan.FromSeconds(1); // Use of time-based token irrelevant to timeout policy; we just need some user token that cancels independently of policy's internal token.
-            using (CancellationTokenSource userTokenSource = new CancellationTokenSource(userTokenExpiry))
+            using (CancellationTokenSource userTokenSource = new CancellationTokenSource())
             {
-                watch.Start();
                 policy.Invoking(p => p.Execute(
                     ct => {
-                        SystemClock.Sleep(TimeSpan.FromSeconds(timeout), ct);  // Simulate cancel in the middle of execution
+                        userTokenSource.Cancel(); ct.ThrowIfCancellationRequested(); // Simulate cancel in the middle of execution
                         return ResultPrimitive.WhateverButTooLate;
                     }, userTokenSource.Token) // ... with user token.
-                   ).ShouldThrow<OperationCanceledException>();
-                watch.Stop();
+                   ).ShouldThrow<OperationCanceledException>(); // Not a TimeoutRejectedException; i.e. policy can distinguish user cancellation from timeout cancellation.
             }
-
-            watch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(timeout * 0.8));
-            watch.Elapsed.Should().BeCloseTo(userTokenExpiry, ((int)tolerance.TotalMilliseconds));
-
         }
 
         [Fact]
@@ -564,6 +546,10 @@ namespace Polly.Specs.Timeout
         [Fact]
         public void Should_call_ontimeout_with_task_wrapping_abandoned_action_allowing_capture_of_otherwise_unobserved_exception__pessimistic()
         {
+            SystemClock.Reset(); // This is the only test which cannot work with the artificial SystemClock of TimeoutSpecsBase.  We want the invoked delegate to continue as far as: throw exceptionToThrow, to genuinely check that the walked-away-from task throws that, and that we pass it to onTimeout.  
+            // That means we can't use the SystemClock.Sleep(...) within the executed delegate to artificially trigger the timeout cancellation (as for example the test above does).
+            // In real execution, it is the .Wait(timeoutCancellationTokenSource.Token) in the timeout implementation which throws for the timeout.  We don't want to go as far as abstracting Task.Wait() out into SystemClock, so we let this test run at real-world speed, not abstracted-clock speed.
+
             Exception exceptionToThrow = new DivideByZeroException();
 
             Exception exceptionObservedFromTaskPassedToOnTimeout = null;


### PR DESCRIPTION
* Abstract out `CancellationTokenSource.CancelAfter(timeout)` into `SystemClock`, in order that timeout tests can run with an abstracted system clock.
* Takes 45 (or more) seconds off test execution time in build.