### PR TITLE
Reduce running time of Bulkhead specs

### DIFF
--- a/src/Polly.SharedSpecs/Bulkhead/BulkheadAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Bulkhead/BulkheadAsyncSpecs.cs
@@ -92,11 +92,11 @@ namespace Polly.Specs.Bulkhead
 
         [Theory, ClassData(typeof(BulkheadScenarios))]
         public void Should_control_executions_queuing_and_rejections_per_specification_with_cancellations(
-            int maxParallelization, int maxQueuingActions, int totalActions, string because, bool cancelQueuing,
-            bool cancelExecuting)
+            int maxParallelization, int maxQueuingActions, int totalActions, bool cancelQueuing,
+            bool cancelExecuting, string scenario)
         {
             if (totalActions < 0) throw new ArgumentOutOfRangeException(nameof(totalActions));
-            because = String.Format("MaxParallelization {0}; MaxQueuing {1}; TotalActions {2}; CancelQueuing {3}; CancelExecuting {4}: {5}", maxParallelization, maxQueuingActions, totalActions, cancelQueuing, cancelExecuting, because);
+            scenario = String.Format("MaxParallelization {0}; MaxQueuing {1}; TotalActions {2}; CancelQueuing {3}; CancelExecuting {4}: {5}", maxParallelization, maxQueuingActions, totalActions, cancelQueuing, cancelExecuting, scenario);
 
             BulkheadPolicy bulkhead = Policy.BulkheadAsync(maxParallelization, maxQueuingActions);
 
@@ -125,13 +125,13 @@ namespace Polly.Specs.Bulkhead
             try
             {
                 actions.Count(a => a.Status == TraceableActionStatus.Faulted).Should().Be(0);
-                Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Executing).Should().Be(expectedExecuting, because + ", when checking expectedExecuting"));
-                Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.QueueingForSemaphore).Should().Be(expectedQueuing, because + ", when checking expectedQueuing"));
-                Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Rejected).Should().Be(expectedRejects, because + ", when checking expectedRejects"));
-                actions.Count(a => a.Status == TraceableActionStatus.Completed).Should().Be(expectedCompleted, because + ", when checking expectedCompleted");
-                actions.Count(a => a.Status == TraceableActionStatus.Canceled).Should().Be(expectedCancelled, because + ", when checking expectedCancelled");
-                Within(shimTimeSpan, () => bulkhead.BulkheadAvailableCount.Should().Be(expectedBulkheadFree, because + ", when checking expectedBulkheadFree"));
-                Within(shimTimeSpan, () => bulkhead.QueueAvailableCount.Should().Be(expectedQueueFree, because + ", when checking expectedQueueFree"));
+                Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Executing).Should().Be(expectedExecuting, scenario + ", when checking expectedExecuting"));
+                Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.QueueingForSemaphore).Should().Be(expectedQueuing, scenario + ", when checking expectedQueuing"));
+                Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Rejected).Should().Be(expectedRejects, scenario + ", when checking expectedRejects"));
+                actions.Count(a => a.Status == TraceableActionStatus.Completed).Should().Be(expectedCompleted, scenario + ", when checking expectedCompleted");
+                actions.Count(a => a.Status == TraceableActionStatus.Canceled).Should().Be(expectedCancelled, scenario + ", when checking expectedCancelled");
+                Within(shimTimeSpan, () => bulkhead.BulkheadAvailableCount.Should().Be(expectedBulkheadFree, scenario + ", when checking expectedBulkheadFree"));
+                Within(shimTimeSpan, () => bulkhead.QueueAvailableCount.Should().Be(expectedQueueFree, scenario + ", when checking expectedQueueFree"));
             }
             finally
             {
@@ -200,13 +200,13 @@ namespace Polly.Specs.Bulkhead
                 try
                 {
                     actions.Count(a => a.Status == TraceableActionStatus.Faulted).Should().Be(0);
-                    Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Executing).Should().Be(expectedExecuting, because + ", when checking expectedExecuting"));
-                    actions.Count(a => a.Status == TraceableActionStatus.Rejected).Should().Be(expectedRejects, because + ", when checking expectedRejects");
-                    Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Completed).Should().Be(expectedCompleted, because + ", when checking expectedCompleted"));
-                    Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Canceled).Should().Be(expectedCancelled, because + ", when checking expectedCancelled"));
-                    Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.QueueingForSemaphore).Should().Be(expectedQueuing, because + ", when checking expectedQueuing"));
-                    Within(shimTimeSpan, () => bulkhead.BulkheadAvailableCount.Should().Be(expectedBulkheadFree, because + ", when checking expectedBulkheadFree"));
-                    Within(shimTimeSpan, () => bulkhead.QueueAvailableCount.Should().Be(expectedQueueFree, because + ", when checking expectedQueueFree"));
+                    Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Executing).Should().Be(expectedExecuting, scenario + ", when checking expectedExecuting"));
+                    actions.Count(a => a.Status == TraceableActionStatus.Rejected).Should().Be(expectedRejects, scenario + ", when checking expectedRejects");
+                    Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Completed).Should().Be(expectedCompleted, scenario + ", when checking expectedCompleted"));
+                    Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Canceled).Should().Be(expectedCancelled, scenario + ", when checking expectedCancelled"));
+                    Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.QueueingForSemaphore).Should().Be(expectedQueuing, scenario + ", when checking expectedQueuing"));
+                    Within(shimTimeSpan, () => bulkhead.BulkheadAvailableCount.Should().Be(expectedBulkheadFree, scenario + ", when checking expectedBulkheadFree"));
+                    Within(shimTimeSpan, () => bulkhead.QueueAvailableCount.Should().Be(expectedQueueFree, scenario + ", when checking expectedQueueFree"));
                 }
                 finally
                 {

--- a/src/Polly.SharedSpecs/Bulkhead/BulkheadScenario.cs
+++ b/src/Polly.SharedSpecs/Bulkhead/BulkheadScenario.cs
@@ -1,0 +1,27 @@
+﻿namespace Polly.Specs.Bulkhead
+{
+    internal struct BulkheadScenario
+    {
+        readonly int _maxParallelization;
+        readonly int _maxQueuingActions;
+        readonly int _totalTestLoad;
+        readonly string _scenario;
+        readonly bool _cancelQueuing;
+        readonly bool _cancelExecuting;
+
+        public BulkheadScenario(int maxParallelization, int maxQueuingActions, int totalTestLoad, bool cancelQueuing, bool cancelExecuting, string scenario)
+        {
+             _maxParallelization = maxParallelization;
+             _maxQueuingActions = maxQueuingActions;
+             _totalTestLoad = totalTestLoad;
+             _scenario = scenario;
+             _cancelQueuing = cancelQueuing;
+             _cancelExecuting = cancelExecuting;
+        }
+
+        public object[] ToTheoryData()
+        {
+            return new object[] {_maxParallelization, _maxQueuingActions, _totalTestLoad, _cancelQueuing, _cancelExecuting, _scenario };
+        }
+    }
+}

--- a/src/Polly.SharedSpecs/Bulkhead/BulkheadScenarios.cs
+++ b/src/Polly.SharedSpecs/Bulkhead/BulkheadScenarios.cs
@@ -8,22 +8,19 @@ namespace Polly.Specs.Bulkhead
     /// </summary>
     public class BulkheadScenarios : IEnumerable<object[]>
     {
-        private readonly List<object[]> _data = new List<object[]>
+        public IEnumerator<object[]> GetEnumerator()
         {
-            new object[] {5, 0, 3, "A light capacity bulkhead, with no queue, not even overloaded.", false, false},
-            new object[] {20, 0, 3, "A high capacity bulkhead, with no queue, not even overloaded; cancel some executing.", false, true},
-            new object[] {5, 0, 8, "A light capacity bulkhead, with no queue, overloaded.", false, false},
-            new object[] {20, 0, 30, "A high capacity bulkhead, with no queue, overloaded.", false, false},
-            new object[] {5, 1, 8, "A light capacity bulkhead, with not enough queue to avoid rejections, overloaded.", false, false},
-            new object[] {20, 10, 30, "A high capacity bulkhead, with not enough queue to avoid rejections, overloaded; cancel some queuing, and some executing.", true, true},
-            new object[] {5, 3, 8, "A light capacity bulkhead, with enough queue to avoid rejections, overloaded.", false, false},
-            new object[] {20, 10, 30, "A high capacity bulkhead, with enough queue to avoid rejections, overloaded; cancel some queuing, and some executing.", true, true},
-            new object[] {5, 30, 25, "A very tight capacity bulkhead, but which allows a huge queue; enough for all actions to be gradually processed; cancel some queuing, and some executing.", true, true},
-        };       
+            yield return new object[] {5, 0, 3, "A bulkhead, with no queue, not even oversubscribed.", false, false};
+            yield return new object[] {20, 0, 3, "A high capacity bulkhead, with no queue, not even oversubscribed; cancel some executing.", false, true};
+            yield return new object[] {3, 0, 4, "A bulkhead, with no queue, oversubscribed.", false, false};
+            yield return new object[] {3, 1, 5, "A bulkhead, with not enough queue to avoid rejections, oversubscribed.", false, false};
+            yield return new object[] {6, 3, 9, "A bulkhead, with not enough queue to avoid rejections, oversubscribed; cancel some queuing, and some executing.", true, true};
+            yield return new object[] {5, 3, 8, "A bulkhead, with enough queue to avoid rejections, oversubscribed.", false, false};
+            yield return new object[] {6, 3, 9, "A bulkhead, with enough queue to avoid rejections, oversubscribed; cancel some queuing, and some executing.", true, true};
+            yield return new object[] {1, 6, 5, "A very tight capacity bulkhead, but which allows a huge queue; enough for all actions to be gradually processed; cancel some queuing, and some executing.", true, true};
+        }       
 
-        public IEnumerator<object[]> GetEnumerator() { return _data.GetEnumerator(); }
-
-        IEnumerator IEnumerable.GetEnumerator() { return GetEnumerator(); }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     };
 
 }

--- a/src/Polly.SharedSpecs/Bulkhead/BulkheadScenarios.cs
+++ b/src/Polly.SharedSpecs/Bulkhead/BulkheadScenarios.cs
@@ -6,21 +6,20 @@ namespace Polly.Specs.Bulkhead
     /// <summary>
     /// A set of test scenarios used in all BulkheadPolicy tests.
     /// </summary>
-    public class BulkheadScenarios : IEnumerable<object[]>
+    internal class BulkheadScenarios : IEnumerable<object[]>
     {
         public IEnumerator<object[]> GetEnumerator()
         {
-            yield return new object[] {5, 0, 3, "A bulkhead, with no queue, not even oversubscribed.", false, false};
-            yield return new object[] {20, 0, 3, "A high capacity bulkhead, with no queue, not even oversubscribed; cancel some executing.", false, true};
-            yield return new object[] {3, 0, 4, "A bulkhead, with no queue, oversubscribed.", false, false};
-            yield return new object[] {3, 1, 5, "A bulkhead, with not enough queue to avoid rejections, oversubscribed.", false, false};
-            yield return new object[] {6, 3, 9, "A bulkhead, with not enough queue to avoid rejections, oversubscribed; cancel some queuing, and some executing.", true, true};
-            yield return new object[] {5, 3, 8, "A bulkhead, with enough queue to avoid rejections, oversubscribed.", false, false};
-            yield return new object[] {6, 3, 9, "A bulkhead, with enough queue to avoid rejections, oversubscribed; cancel some queuing, and some executing.", true, true};
-            yield return new object[] {1, 6, 5, "A very tight capacity bulkhead, but which allows a huge queue; enough for all actions to be gradually processed; cancel some queuing, and some executing.", true, true};
-        }       
+            yield return new BulkheadScenario(maxParallelization: 5, maxQueuingActions: 0, totalTestLoad: 3, cancelQueuing: false, cancelExecuting: false, scenario: "A bulkhead, with no queue, not even oversubscribed.").ToTheoryData();
+            yield return new BulkheadScenario(maxParallelization: 20, maxQueuingActions: 0, totalTestLoad: 3, cancelQueuing: false, cancelExecuting: true, scenario: "A high capacity bulkhead, with no queue, not even oversubscribed; cancel some executing.").ToTheoryData();
+            yield return new BulkheadScenario(maxParallelization: 3, maxQueuingActions: 0, totalTestLoad: 4, cancelQueuing: false, cancelExecuting: false, scenario: "A bulkhead, with no queue, oversubscribed.").ToTheoryData();
+            yield return new BulkheadScenario(maxParallelization: 3, maxQueuingActions: 1, totalTestLoad: 5, cancelQueuing: false, cancelExecuting: false, scenario: "A bulkhead, with not enough queue to avoid rejections, oversubscribed.").ToTheoryData();
+            yield return new BulkheadScenario(maxParallelization: 6, maxQueuingActions: 3, totalTestLoad: 9, cancelQueuing: true, cancelExecuting: true, scenario: "A bulkhead, with not enough queue to avoid rejections, oversubscribed; cancel some queuing, and some executing.").ToTheoryData();
+            yield return new BulkheadScenario(5, 3, 8, cancelQueuing: false, cancelExecuting: false, scenario: "A bulkhead, with enough queue to avoid rejections, oversubscribed.").ToTheoryData();
+            yield return new BulkheadScenario(maxParallelization: 6, maxQueuingActions: 3, totalTestLoad: 9, cancelQueuing: true, cancelExecuting: true, scenario: "A bulkhead, with enough queue to avoid rejections, oversubscribed; cancel some queuing, and some executing.").ToTheoryData();
+            yield return new BulkheadScenario(maxParallelization: 1, maxQueuingActions: 6, totalTestLoad: 5, cancelQueuing: true, cancelExecuting: true, scenario: "A very tight capacity bulkhead, but which allows a huge queue; enough for all actions to be gradually processed; cancel some queuing, and some executing.").ToTheoryData();
+        }
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-    };
-
+    }
 }

--- a/src/Polly.SharedSpecs/Bulkhead/BulkheadSpecs.cs
+++ b/src/Polly.SharedSpecs/Bulkhead/BulkheadSpecs.cs
@@ -91,10 +91,10 @@ namespace Polly.Specs.Bulkhead
 
         [Theory, ClassData(typeof (BulkheadScenarios))]
         public void Should_control_executions_queuing_and_rejections_per_specification_with_cancellations(
-            int maxParallelization, int maxQueuingActions, int totalActions, string because, bool cancelQueuing, bool cancelExecuting)
+            int maxParallelization, int maxQueuingActions, int totalActions, bool cancelQueuing, bool cancelExecuting, string scenario)
         {
             if (totalActions < 0) throw new ArgumentOutOfRangeException(nameof(totalActions));
-            because = String.Format("MaxParallelization {0}; MaxQueuing {1}; TotalActions {2}; CancelQueuing {3}; CancelExecuting {4}: {5}", maxParallelization, maxQueuingActions, totalActions, cancelQueuing, cancelExecuting, because);
+            scenario = String.Format("MaxParallelization {0}; MaxQueuing {1}; TotalActions {2}; CancelQueuing {3}; CancelExecuting {4}: {5}", maxParallelization, maxQueuingActions, totalActions, cancelQueuing, cancelExecuting, scenario);
 
             BulkheadPolicy bulkhead = Policy.Bulkhead(maxParallelization, maxQueuingActions);
 
@@ -123,13 +123,13 @@ namespace Polly.Specs.Bulkhead
             try
             {
                 actions.Count(a => a.Status == TraceableActionStatus.Faulted).Should().Be(0);
-                Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Executing).Should().Be(expectedExecuting, because + ", when checking expectedExecuting"));
-                Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.QueueingForSemaphore).Should().Be(expectedQueuing, because + ", when checking expectedQueuing"));
-                Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Rejected).Should().Be(expectedRejects, because + ", when checking expectedRejects"));
-                actions.Count(a => a.Status == TraceableActionStatus.Completed).Should().Be(expectedCompleted, because + ", when checking expectedCompleted");
-                actions.Count(a => a.Status == TraceableActionStatus.Canceled).Should().Be(expectedCancelled, because + ", when checking expectedCancelled");
-                Within(shimTimeSpan, () => bulkhead.BulkheadAvailableCount.Should().Be(expectedBulkheadFree, because + ", when checking expectedBulkheadFree"));
-                Within(shimTimeSpan, () => bulkhead.QueueAvailableCount.Should().Be(expectedQueueFree, because + ", when checking expectedQueueFree"));
+                Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Executing).Should().Be(expectedExecuting, scenario + ", when checking expectedExecuting"));
+                Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.QueueingForSemaphore).Should().Be(expectedQueuing, scenario + ", when checking expectedQueuing"));
+                Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Rejected).Should().Be(expectedRejects, scenario + ", when checking expectedRejects"));
+                actions.Count(a => a.Status == TraceableActionStatus.Completed).Should().Be(expectedCompleted, scenario + ", when checking expectedCompleted");
+                actions.Count(a => a.Status == TraceableActionStatus.Canceled).Should().Be(expectedCancelled, scenario + ", when checking expectedCancelled");
+                Within(shimTimeSpan, () => bulkhead.BulkheadAvailableCount.Should().Be(expectedBulkheadFree, scenario + ", when checking expectedBulkheadFree"));
+                Within(shimTimeSpan, () => bulkhead.QueueAvailableCount.Should().Be(expectedQueueFree, scenario + ", when checking expectedQueueFree"));
             }
             finally
             {
@@ -198,13 +198,13 @@ namespace Polly.Specs.Bulkhead
                 try
                 {
                     actions.Count(a => a.Status == TraceableActionStatus.Faulted).Should().Be(0);
-                    Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Executing).Should().Be(expectedExecuting, because + ", when checking expectedExecuting"));
-                    Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.QueueingForSemaphore).Should().Be(expectedQueuing, because + ", when checking expectedQueuing"));
-                    Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Completed).Should().Be(expectedCompleted, because + ", when checking expectedCompleted"));
-                    Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Canceled).Should().Be(expectedCancelled, because + ", when checking expectedCancelled"));
-                    actions.Count(a => a.Status == TraceableActionStatus.Rejected).Should().Be(expectedRejects, because + ", when checking expectedRejects");
-                    Within(shimTimeSpan, () => bulkhead.BulkheadAvailableCount.Should().Be(expectedBulkheadFree, because + ", when checking expectedBulkheadFree"));
-                    Within(shimTimeSpan, () => bulkhead.QueueAvailableCount.Should().Be(expectedQueueFree, because + ", when checking expectedQueueFree"));
+                    Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Executing).Should().Be(expectedExecuting, scenario + ", when checking expectedExecuting"));
+                    Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.QueueingForSemaphore).Should().Be(expectedQueuing, scenario + ", when checking expectedQueuing"));
+                    Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Completed).Should().Be(expectedCompleted, scenario + ", when checking expectedCompleted"));
+                    Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Canceled).Should().Be(expectedCancelled, scenario + ", when checking expectedCancelled"));
+                    actions.Count(a => a.Status == TraceableActionStatus.Rejected).Should().Be(expectedRejects, scenario + ", when checking expectedRejects");
+                    Within(shimTimeSpan, () => bulkhead.BulkheadAvailableCount.Should().Be(expectedBulkheadFree, scenario + ", when checking expectedBulkheadFree"));
+                    Within(shimTimeSpan, () => bulkhead.QueueAvailableCount.Should().Be(expectedQueueFree, scenario + ", when checking expectedQueueFree"));
                 }
                 finally
                 {

--- a/src/Polly.SharedSpecs/Bulkhead/BulkheadTResultAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Bulkhead/BulkheadTResultAsyncSpecs.cs
@@ -94,11 +94,11 @@ namespace Polly.Specs.Bulkhead
 
         [Theory, ClassData(typeof(BulkheadScenarios))]
         public void Should_control_executions_queuing_and_rejections_per_specification_with_cancellations(
-            int maxParallelization, int maxQueuingActions, int totalActions, string because, bool cancelQueuing,
-            bool cancelExecuting)
+            int maxParallelization, int maxQueuingActions, int totalActions, bool cancelQueuing,
+            bool cancelExecuting, string scenario)
         {
             if (totalActions < 0) throw new ArgumentOutOfRangeException(nameof(totalActions));
-            because = String.Format("MaxParallelization {0}; MaxQueuing {1}; TotalActions {2}; CancelQueuing {3}; CancelExecuting {4}: {5}", maxParallelization, maxQueuingActions, totalActions, cancelQueuing, cancelExecuting, because);
+            scenario = String.Format("MaxParallelization {0}; MaxQueuing {1}; TotalActions {2}; CancelQueuing {3}; CancelExecuting {4}: {5}", maxParallelization, maxQueuingActions, totalActions, cancelQueuing, cancelExecuting, scenario);
 
             BulkheadPolicy<ResultPrimitive> bulkhead = Policy.BulkheadAsync<ResultPrimitive>(maxParallelization, maxQueuingActions);
 
@@ -127,13 +127,13 @@ namespace Polly.Specs.Bulkhead
             try
             {
                 actions.Count(a => a.Status == TraceableActionStatus.Faulted).Should().Be(0);
-                Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Executing).Should().Be(expectedExecuting, because + ", when checking expectedExecuting"));
-                Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.QueueingForSemaphore).Should().Be(expectedQueuing, because + ", when checking expectedQueuing"));
-                Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Rejected).Should().Be(expectedRejects, because + ", when checking expectedRejects"));
-                actions.Count(a => a.Status == TraceableActionStatus.Completed).Should().Be(expectedCompleted, because + ", when checking expectedCompleted");
-                actions.Count(a => a.Status == TraceableActionStatus.Canceled).Should().Be(expectedCancelled, because + ", when checking expectedCancelled");
-                Within(shimTimeSpan, () => bulkhead.BulkheadAvailableCount.Should().Be(expectedBulkheadFree, because + ", when checking expectedBulkheadFree"));
-                Within(shimTimeSpan, () => bulkhead.QueueAvailableCount.Should().Be(expectedQueueFree, because + ", when checking expectedQueueFree"));
+                Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Executing).Should().Be(expectedExecuting, scenario + ", when checking expectedExecuting"));
+                Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.QueueingForSemaphore).Should().Be(expectedQueuing, scenario + ", when checking expectedQueuing"));
+                Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Rejected).Should().Be(expectedRejects, scenario + ", when checking expectedRejects"));
+                actions.Count(a => a.Status == TraceableActionStatus.Completed).Should().Be(expectedCompleted, scenario + ", when checking expectedCompleted");
+                actions.Count(a => a.Status == TraceableActionStatus.Canceled).Should().Be(expectedCancelled, scenario + ", when checking expectedCancelled");
+                Within(shimTimeSpan, () => bulkhead.BulkheadAvailableCount.Should().Be(expectedBulkheadFree, scenario + ", when checking expectedBulkheadFree"));
+                Within(shimTimeSpan, () => bulkhead.QueueAvailableCount.Should().Be(expectedQueueFree, scenario + ", when checking expectedQueueFree"));
             }
             finally
             {
@@ -202,13 +202,13 @@ namespace Polly.Specs.Bulkhead
                 try
                 {
                     actions.Count(a => a.Status == TraceableActionStatus.Faulted).Should().Be(0);
-                    Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Executing).Should().Be(expectedExecuting, because + ", when checking expectedExecuting"));
-                    Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.QueueingForSemaphore).Should().Be(expectedQueuing, because + ", when checking expectedQueuing"));
-                    Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Completed).Should().Be(expectedCompleted, because + ", when checking expectedCompleted"));
-                    Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Canceled).Should().Be(expectedCancelled, because + ", when checking expectedCancelled"));
-                    actions.Count(a => a.Status == TraceableActionStatus.Rejected).Should().Be(expectedRejects, because + ", when checking expectedRejects");
-                    Within(shimTimeSpan, () => bulkhead.BulkheadAvailableCount.Should().Be(expectedBulkheadFree, because + ", when checking expectedBulkheadFree"));
-                    Within(shimTimeSpan, () => bulkhead.QueueAvailableCount.Should().Be(expectedQueueFree, because + ", when checking expectedQueueFree"));
+                    Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Executing).Should().Be(expectedExecuting, scenario + ", when checking expectedExecuting"));
+                    Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.QueueingForSemaphore).Should().Be(expectedQueuing, scenario + ", when checking expectedQueuing"));
+                    Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Completed).Should().Be(expectedCompleted, scenario + ", when checking expectedCompleted"));
+                    Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Canceled).Should().Be(expectedCancelled, scenario + ", when checking expectedCancelled"));
+                    actions.Count(a => a.Status == TraceableActionStatus.Rejected).Should().Be(expectedRejects, scenario + ", when checking expectedRejects");
+                    Within(shimTimeSpan, () => bulkhead.BulkheadAvailableCount.Should().Be(expectedBulkheadFree, scenario + ", when checking expectedBulkheadFree"));
+                    Within(shimTimeSpan, () => bulkhead.QueueAvailableCount.Should().Be(expectedQueueFree, scenario + ", when checking expectedQueueFree"));
                 }
                 finally
                 {

--- a/src/Polly.SharedSpecs/Bulkhead/BulkheadTResultSpecs.cs
+++ b/src/Polly.SharedSpecs/Bulkhead/BulkheadTResultSpecs.cs
@@ -93,11 +93,11 @@ namespace Polly.Specs.Bulkhead
 
         [Theory, ClassData(typeof(BulkheadScenarios))]
         public void Should_control_executions_queuing_and_rejections_per_specification_with_cancellations(
-            int maxParallelization, int maxQueuingActions, int totalActions, string because, bool cancelQueuing,
-            bool cancelExecuting)
+            int maxParallelization, int maxQueuingActions, int totalActions, bool cancelQueuing,
+            bool cancelExecuting, string scenario)
         {
             if (totalActions < 0) throw new ArgumentOutOfRangeException(nameof(totalActions));
-            because = String.Format("MaxParallelization {0}; MaxQueuing {1}; TotalActions {2}; CancelQueuing {3}; CancelExecuting {4}: {5}", maxParallelization, maxQueuingActions, totalActions, cancelQueuing, cancelExecuting, because);
+            scenario = String.Format("MaxParallelization {0}; MaxQueuing {1}; TotalActions {2}; CancelQueuing {3}; CancelExecuting {4}: {5}", maxParallelization, maxQueuingActions, totalActions, cancelQueuing, cancelExecuting, scenario);
 
             BulkheadPolicy<ResultPrimitive> bulkhead = Policy.Bulkhead<ResultPrimitive>(maxParallelization, maxQueuingActions);
 
@@ -126,13 +126,13 @@ namespace Polly.Specs.Bulkhead
             try
             {
                 actions.Count(a => a.Status == TraceableActionStatus.Faulted).Should().Be(0);
-                Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Executing).Should().Be(expectedExecuting, because + ", when checking expectedExecuting"));
-                Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.QueueingForSemaphore).Should().Be(expectedQueuing, because + ", when checking expectedQueuing"));
-                Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Rejected).Should().Be(expectedRejects, because + ", when checking expectedRejects"));
-                actions.Count(a => a.Status == TraceableActionStatus.Completed).Should().Be(expectedCompleted, because + ", when checking expectedCompleted");
-                actions.Count(a => a.Status == TraceableActionStatus.Canceled).Should().Be(expectedCancelled, because + ", when checking expectedCancelled");
-                Within(shimTimeSpan, () => bulkhead.BulkheadAvailableCount.Should().Be(expectedBulkheadFree, because + ", when checking expectedBulkheadFree"));
-                Within(shimTimeSpan, () => bulkhead.QueueAvailableCount.Should().Be(expectedQueueFree, because + ", when checking expectedQueueFree"));
+                Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Executing).Should().Be(expectedExecuting, scenario + ", when checking expectedExecuting"));
+                Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.QueueingForSemaphore).Should().Be(expectedQueuing, scenario + ", when checking expectedQueuing"));
+                Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Rejected).Should().Be(expectedRejects, scenario + ", when checking expectedRejects"));
+                actions.Count(a => a.Status == TraceableActionStatus.Completed).Should().Be(expectedCompleted, scenario + ", when checking expectedCompleted");
+                actions.Count(a => a.Status == TraceableActionStatus.Canceled).Should().Be(expectedCancelled, scenario + ", when checking expectedCancelled");
+                Within(shimTimeSpan, () => bulkhead.BulkheadAvailableCount.Should().Be(expectedBulkheadFree, scenario + ", when checking expectedBulkheadFree"));
+                Within(shimTimeSpan, () => bulkhead.QueueAvailableCount.Should().Be(expectedQueueFree, scenario + ", when checking expectedQueueFree"));
             }
             finally
             {
@@ -199,13 +199,13 @@ namespace Polly.Specs.Bulkhead
                 try
                     {
                         actions.Count(a => a.Status == TraceableActionStatus.Faulted).Should().Be(0);
-                        Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Executing).Should().Be(expectedExecuting, because + ", when checking expectedExecuting"));
-                        Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.QueueingForSemaphore).Should().Be(expectedQueuing, because + ", when checking expectedQueuing"));
-                        Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Completed).Should().Be(expectedCompleted, because + ", when checking expectedCompleted"));
-                        Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Canceled).Should().Be(expectedCancelled, because + ", when checking expectedCancelled"));
-                        actions.Count(a => a.Status == TraceableActionStatus.Rejected).Should().Be(expectedRejects, because + ", when checking expectedRejects");
-                        Within(shimTimeSpan, () => bulkhead.BulkheadAvailableCount.Should().Be(expectedBulkheadFree, because + ", when checking expectedBulkheadFree"));
-                        Within(shimTimeSpan, () => bulkhead.QueueAvailableCount.Should().Be(expectedQueueFree, because + ", when checking expectedQueueFree"));
+                        Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Executing).Should().Be(expectedExecuting, scenario + ", when checking expectedExecuting"));
+                        Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.QueueingForSemaphore).Should().Be(expectedQueuing, scenario + ", when checking expectedQueuing"));
+                        Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Completed).Should().Be(expectedCompleted, scenario + ", when checking expectedCompleted"));
+                        Within(shimTimeSpan, () => actions.Count(a => a.Status == TraceableActionStatus.Canceled).Should().Be(expectedCancelled, scenario + ", when checking expectedCancelled"));
+                        actions.Count(a => a.Status == TraceableActionStatus.Rejected).Should().Be(expectedRejects, scenario + ", when checking expectedRejects");
+                        Within(shimTimeSpan, () => bulkhead.BulkheadAvailableCount.Should().Be(expectedBulkheadFree, scenario + ", when checking expectedBulkheadFree"));
+                        Within(shimTimeSpan, () => bulkhead.QueueAvailableCount.Should().Be(expectedQueueFree, scenario + ", when checking expectedQueueFree"));
                     }
                     finally
                     {

--- a/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
+++ b/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Bulkhead\BulkheadAsyncSpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Bulkhead\BulkheadScenario.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bulkhead\BulkheadSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bulkhead\BulkheadScenarios.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bulkhead\BulkheadSpecsHelper.cs" />


### PR DESCRIPTION
* Reduce running time of Bulkhead specs (takes around 60 seconds off build time **EDIT** in Visual Studio).
* Make meaning of bulkhead test scenarios clearer by constructing struct with strongly-typed and named parameters  (work round xUnit object[] syntax for `Theory` tests).