### PR TITLE
Ensure context keys are set when execute overridden

### DIFF
--- a/src/Polly.Shared/Caching/CachePolicy.cs
+++ b/src/Polly.Shared/Caching/CachePolicy.cs
@@ -51,7 +51,7 @@ namespace Polly.Caching
         /// <param name="context">Execution context that is passed to the exception policy; defines the cache key to use in cache lookup.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The value returned by the action, or the cache.</returns>
-        public override TResult Execute<TResult>(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken)
+        public override TResult ExecuteInternal<TResult>(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken)
         {
             return CacheEngine.Implementation<TResult>(
                 _syncCacheProvider.For<TResult>(), 

--- a/src/Polly.Shared/Caching/CachePolicyAsync.cs
+++ b/src/Polly.Shared/Caching/CachePolicyAsync.cs
@@ -43,7 +43,7 @@ namespace Polly.Caching
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
         /// <returns>The value returned by the action, or the cache.</returns>
-        public override Task<TResult> ExecuteAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        public override Task<TResult> ExecuteAsyncInternal<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
             return CacheEngine.ImplementationAsync<TResult>(
                 _asyncCacheProvider.AsyncFor<TResult>(), 

--- a/src/Polly.Shared/Policy.cs
+++ b/src/Polly.Shared/Policy.cs
@@ -296,18 +296,34 @@ namespace Polly
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The value returned by the action</returns>
         [DebuggerStepThrough]
-        public virtual TResult Execute<TResult>(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken)
+        public TResult Execute<TResult>(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken)
         {
-            if (_exceptionPolicy == null) throw new InvalidOperationException(
-                "Please use the synchronous-defined policies when calling the synchronous Execute (and similar) methods.");
             if (context == null) throw new ArgumentNullException(nameof(context));
 
             SetPolicyContext(context);
+
+            return ExecuteInternal(action, context, cancellationToken);
+        }
+
+        /// <summary>
+        /// Executes the specified action within the policy and returns the result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Context data that is passed to the exception policy.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The value returned by the action</returns>
+        [DebuggerStepThrough]
+        public virtual TResult ExecuteInternal<TResult>(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken)
+        {
+            if (_exceptionPolicy == null) throw new InvalidOperationException(
+                "Please use the synchronous-defined policies when calling the synchronous Execute (and similar) methods.");
 
             var result = default(TResult);
             _exceptionPolicy((ctx, ct) => { result = action(ctx, ct); }, context, cancellationToken);
             return result;
         }
+
         #endregion
 
         #endregion

--- a/src/Polly.Shared/PolicyAsync.cs
+++ b/src/Polly.Shared/PolicyAsync.cs
@@ -540,13 +540,29 @@ namespace Polly
         /// <returns>The value returned by the action</returns>
         /// <exception cref="System.InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
         [DebuggerStepThrough]
-        public virtual async Task<TResult> ExecuteAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        public Task<TResult> ExecuteAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        {
+            if (context == null) throw new ArgumentNullException(nameof(context));
+            SetPolicyContext(context);
+
+            return ExecuteAsyncInternal(action, context, cancellationToken, continueOnCapturedContext);
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Context data that is passed to the exception policy.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
+        /// <returns>The value returned by the action</returns>
+        /// <exception cref="System.InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
+        [DebuggerStepThrough]
+        public virtual async Task<TResult> ExecuteAsyncInternal<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
             if (_asyncExceptionPolicy == null) throw new InvalidOperationException(
                 "Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.");
-            if (context == null) throw new ArgumentNullException(nameof(context));
-
-            SetPolicyContext(context);
 
             var result = default(TResult);
             await _asyncExceptionPolicy(async (ctx, ct) =>
@@ -556,6 +572,7 @@ namespace Polly
                 .ConfigureAwait(continueOnCapturedContext);
             return result;
         }
+
         #endregion
 
         #endregion

--- a/src/Polly.Shared/Wrap/PolicyWrap.cs
+++ b/src/Polly.Shared/Wrap/PolicyWrap.cs
@@ -37,7 +37,7 @@ namespace Polly.Wrap
         /// <param name="context">Execution context that is passed to the exception policy; defines the cache key to use in cache lookup.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The value returned by the action, or the cache.</returns>
-        public override TResult Execute<TResult>(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken)
+        public override TResult ExecuteInternal<TResult>(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken)
         {
             return PolicyWrapEngine.Implementation<TResult>(
                    action,

--- a/src/Polly.Shared/Wrap/PolicyWrapAsync.cs
+++ b/src/Polly.Shared/Wrap/PolicyWrapAsync.cs
@@ -23,7 +23,7 @@ namespace Polly.Wrap
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
         /// <returns>The value returned by the action, or the cache.</returns>
-        public override Task<TResult> ExecuteAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        public override Task<TResult> ExecuteAsyncInternal<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
             return PolicyWrapEngine.ImplementationAsync<TResult>(
                 action,


### PR DESCRIPTION
Ensure `context.PolicyKey` and `context.PolicyWrapKey` are set when policies override the generic method `.Execute<TResult>` (and similar) on non-generic policies.

Fixes #352 