### PR TITLE
Extend and rationalise RaiseException (and similar) test helpers

### DIFF
--- a/src/Polly.SharedSpecs/Fallback/FallbackAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Fallback/FallbackAsyncSpecs.cs
@@ -269,7 +269,7 @@ namespace Polly.Specs.Fallback
                 .FallbackAsync(fallbackActionAsync, onFallbackAsync);
 
             Exception instanceToThrow = new ArgumentNullException("myParam");
-            await fallbackPolicy.ExecuteAsync(() => { throw instanceToThrow; });
+            await fallbackPolicy.RaiseExceptionAsync(instanceToThrow);
 
             fallbackActionExecuted.Should().BeTrue();
             exceptionPassedToOnFallback.Should().BeOfType<ArgumentNullException>();
@@ -473,11 +473,11 @@ namespace Polly.Specs.Fallback
                 .Handle<ArgumentNullException>()
                 .FallbackAsync(fallbackFunc, onFallback);
 
-            fallbackPolicy.Awaiting(async p => await p.ExecuteAsync(() => { throw new ArgumentNullException(); }))
+            Exception instanceToThrow = new ArgumentNullException("myParam");
+            fallbackPolicy.Awaiting(p => p.RaiseExceptionAsync(instanceToThrow))
                 .ShouldNotThrow();
 
-            fallbackException.Should().NotBeNull()
-                .And.BeOfType(typeof(ArgumentNullException));
+            fallbackException.Should().Be(instanceToThrow);
         }
 
         [Fact]

--- a/src/Polly.SharedSpecs/Fallback/FallbackSpecs.cs
+++ b/src/Polly.SharedSpecs/Fallback/FallbackSpecs.cs
@@ -336,7 +336,7 @@ namespace Polly.Specs.Fallback
                 .Fallback(fallbackAction, onFallback);
 
             Exception instanceToThrow = new ArgumentNullException("myParam");
-            fallbackPolicy.Execute(() => { throw instanceToThrow; });
+            fallbackPolicy.RaiseException(instanceToThrow);
 
             fallbackActionExecuted.Should().BeTrue();
             exceptionPassedToOnFallback.Should().BeOfType<ArgumentNullException>();
@@ -539,11 +539,11 @@ namespace Polly.Specs.Fallback
                 .Handle<ArgumentNullException>()
                 .Fallback(fallbackAction, onFallback);
 
-            fallbackPolicy.Invoking(p => p.Execute(() => { throw new ArgumentNullException(); }))
+            Exception instanceToThrow = new ArgumentNullException("myParam");
+            fallbackPolicy.Invoking(p => p.RaiseException(instanceToThrow))
                 .ShouldNotThrow();
 
-            fallbackException.Should().NotBeNull()
-                .And.BeOfType(typeof(ArgumentNullException));
+            fallbackException.Should().Be(instanceToThrow);
         }
 
         [Fact]

--- a/src/Polly.SharedSpecs/Helpers/PolicyExtensionsAsync.cs
+++ b/src/Polly.SharedSpecs/Helpers/PolicyExtensionsAsync.cs
@@ -7,34 +7,6 @@ namespace Polly.Specs.Helpers
 {
     public static class PolicyExtensionsAsync
     {
-        public static Task RaiseExceptionAsync<TException>(this Policy policy, int numberOfTimesToRaiseException, Action<TException, int> configureException = null, CancellationToken cancellationToken = default(CancellationToken)) where TException : Exception, new()
-        {
-            int counter = 0;
-
-            return policy.ExecuteAsync(ct =>
-            {
-                if (counter < numberOfTimesToRaiseException)
-                {
-                    counter++;
-
-                    var exception = new TException();
-
-                    if (configureException != null)
-                    {
-                        configureException(exception, counter);
-                    }
-
-                    throw exception;
-                }
-                return TaskHelper.EmptyTask;
-            }, cancellationToken);
-        }
-
-        public static Task RaiseExceptionAsync<TException>(this Policy policy, Action<TException, int> configureException = null) where TException : Exception, new()
-        {
-            return policy.RaiseExceptionAsync(1, configureException);
-        }
-
         public class ExceptionAndOrCancellationScenario
         {
             public int NumberOfTimesToRaiseException = 0;
@@ -44,12 +16,54 @@ namespace Polly.Specs.Helpers
             public bool ActionObservesCancellation = true;
         }
 
+        public static Task RaiseExceptionAsync<TException>(this Policy policy, TException instance) where TException : Exception
+        {
+            ExceptionAndOrCancellationScenario scenario = new ExceptionAndOrCancellationScenario
+            {
+                ActionObservesCancellation = false,
+                AttemptDuringWhichToCancel = null,
+                NumberOfTimesToRaiseException = 1
+            };
+
+            return policy.RaiseExceptionAndOrCancellationAsync(scenario, new CancellationTokenSource(), () => { }, _ => instance, 0);
+        }
+
+        public static Task RaiseExceptionAsync<TException>(this Policy policy, Action<TException, int> configureException = null) where TException : Exception, new()
+        {
+            return policy.RaiseExceptionAsync(1, configureException);
+        }
+
+        public static Task RaiseExceptionAsync<TException>(this Policy policy, int numberOfTimesToRaiseException, Action<TException, int> configureException = null, CancellationToken cancellationToken = default(CancellationToken)) where TException : Exception, new()
+        {
+            ExceptionAndOrCancellationScenario scenario = new ExceptionAndOrCancellationScenario
+            {
+                ActionObservesCancellation = false,
+                AttemptDuringWhichToCancel = null,
+                NumberOfTimesToRaiseException = numberOfTimesToRaiseException
+            };
+
+            Func<int, TException> exceptionFactory = i =>
+            {
+                var exception = new TException();
+                configureException?.Invoke(exception, i);
+                return exception;
+            };
+
+            return policy.RaiseExceptionAndOrCancellationAsync(scenario, new CancellationTokenSource(), () => { }, exceptionFactory, 0);
+        }
+
         public static Task RaiseExceptionAndOrCancellationAsync<TException>(this Policy policy, ExceptionAndOrCancellationScenario scenario, CancellationTokenSource cancellationTokenSource, Action onExecute) where TException : Exception, new()
         {
             return policy.RaiseExceptionAndOrCancellationAsync<TException, int>(scenario, cancellationTokenSource, onExecute, 0);
         }
 
         public static Task<TResult> RaiseExceptionAndOrCancellationAsync<TException, TResult>(this Policy policy, ExceptionAndOrCancellationScenario scenario, CancellationTokenSource cancellationTokenSource, Action onExecute, TResult successResult) where TException : Exception, new()
+        {
+            return policy.RaiseExceptionAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute,
+                _ => new TException(), successResult);
+        }
+
+        public static Task<TResult> RaiseExceptionAndOrCancellationAsync<TException, TResult>(this Policy policy, ExceptionAndOrCancellationScenario scenario, CancellationTokenSource cancellationTokenSource, Action onExecute, Func<int, TException> exceptionFactory, TResult successResult) where TException : Exception
         {
             int counter = 0;
 
@@ -73,7 +87,7 @@ namespace Polly.Specs.Helpers
 
                 if (counter <= scenario.NumberOfTimesToRaiseException)
                 {
-                    throw new TException();
+                    throw exceptionFactory(counter);
                 }
 
                 return Task.FromResult(successResult);

--- a/src/Polly.SharedSpecs/PolicyContextAndKeyAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/PolicyContextAndKeyAsyncSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Polly.Retry;
 using Polly.Specs.Helpers;
@@ -103,7 +104,7 @@ namespace Polly.Specs
         #region PolicyKey and execution Context tests
 
         [Fact]
-        public void Should_pass_PolicyKey_to_execution_context()
+        public async Task Should_pass_PolicyKey_to_execution_context()
         {
             string policyKey = Guid.NewGuid().ToString();
 
@@ -111,13 +112,13 @@ namespace Polly.Specs
             Action<Exception, int, Context> onRetry = (e, i, context) => { policyKeySetOnExecutionContext = context.PolicyKey; };
             var retry = Policy.Handle<Exception>().RetryAsync(1, onRetry).WithPolicyKey(policyKey);
 
-            retry.RaiseExceptionAsync<Exception>(1);
+            await retry.RaiseExceptionAsync<Exception>(1);
 
             policyKeySetOnExecutionContext.Should().Be(policyKey);
         }
 
         [Fact]
-        public void Should_pass_ExecutionKey_to_execution_context()
+        public async Task Should_pass_ExecutionKey_to_execution_context()
         {
             string executionKey = Guid.NewGuid().ToString();
 
@@ -126,7 +127,7 @@ namespace Polly.Specs
             var retry = Policy.Handle<Exception>().RetryAsync(1, onRetry);
 
             bool firstExecution = true;
-            retry.ExecuteAsync(async () =>
+            await retry.ExecuteAsync(async () =>
             {
                 await TaskHelper.EmptyTask.ConfigureAwait(false);
                 if (firstExecution)
@@ -140,7 +141,7 @@ namespace Polly.Specs
         }
 
         [Fact]
-        public void Should_pass_PolicyKey_to_execution_context_in_generic_execution_on_non_generic_policy()
+        public async Task Should_pass_PolicyKey_to_execution_context_in_generic_execution_on_non_generic_policy()
         {
             string policyKey = Guid.NewGuid().ToString();
 
@@ -149,7 +150,7 @@ namespace Polly.Specs
             var retry = Policy.Handle<Exception>().RetryAsync(1, onRetry).WithPolicyKey(policyKey);
 
             bool firstExecution = true;
-            retry.ExecuteAsync<int>(async () =>
+            await retry.ExecuteAsync<int>(async () =>
             {
                 await TaskHelper.EmptyTask.ConfigureAwait(false);
                 if (firstExecution)
@@ -164,7 +165,7 @@ namespace Polly.Specs
         }
 
         [Fact]
-        public void Should_pass_ExecutionKey_to_execution_context_in_generic_execution_on_non_generic_policy()
+        public async Task Should_pass_ExecutionKey_to_execution_context_in_generic_execution_on_non_generic_policy()
         {
             string executionKey = Guid.NewGuid().ToString();
 
@@ -173,7 +174,7 @@ namespace Polly.Specs
             var retry = Policy.Handle<Exception>().RetryAsync(1, onRetry);
 
             bool firstExecution = true;
-            retry.ExecuteAsync<int>(async () =>
+            await retry.ExecuteAsync<int>(async () =>
             {
                 await TaskHelper.EmptyTask.ConfigureAwait(false);
                 if (firstExecution)
@@ -286,7 +287,7 @@ namespace Polly.Specs
         #region PolicyKey and execution Context tests
 
         [Fact]
-        public void Should_pass_PolicyKey_to_execution_context()
+        public async Task Should_pass_PolicyKey_to_execution_context()
         {
             string policyKey = Guid.NewGuid().ToString();
 
@@ -294,13 +295,13 @@ namespace Polly.Specs
             Action<DelegateResult<ResultPrimitive>, int, Context> onRetry = (outcome, i, context) => { policyKeySetOnExecutionContext = context.PolicyKey; };
             var retry = Policy.HandleResult(ResultPrimitive.Fault).RetryAsync(1, onRetry).WithPolicyKey(policyKey);
 
-            retry.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Good);
+            await retry.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Good);
 
             policyKeySetOnExecutionContext.Should().Be(policyKey);
         }
 
         [Fact]
-        public void Should_pass_ExecutionKey_to_execution_context()
+        public async Task Should_pass_ExecutionKey_to_execution_context()
         {
             string executionKey = Guid.NewGuid().ToString();
 
@@ -309,7 +310,7 @@ namespace Polly.Specs
             var retry = Policy.HandleResult(ResultPrimitive.Fault).RetryAsync(1, onRetry);
 
             bool firstExecution = true;
-            retry.ExecuteAsync(async () =>
+            await retry.ExecuteAsync(async () =>
             {
                 await TaskHelper.EmptyTask.ConfigureAwait(false);
                 if (firstExecution)

--- a/src/Polly.SharedSpecs/Retry/RetryAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/RetryAsyncSpecs.cs
@@ -166,7 +166,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public void Should_call_onretry_on_each_retry_with_the_current_retry_count()
+        public async Task Should_call_onretry_on_each_retry_with_the_current_retry_count()
         {
             var expectedRetryCounts = new[] { 1, 2, 3 };
             var retryCounts = new List<int>();
@@ -175,14 +175,14 @@ namespace Polly.Specs.Retry
                 .Handle<DivideByZeroException>()
                 .RetryAsync(3, (_, retryCount) => retryCounts.Add(retryCount));
 
-            policy.RaiseExceptionAsync<DivideByZeroException>(3);
+            await policy.RaiseExceptionAsync<DivideByZeroException>(3);
 
             retryCounts.Should()
                        .ContainInOrder(expectedRetryCounts);
         }
 
         [Fact]
-        public void Should_call_onretry_on_each_retry_with_the_current_exception()
+        public async Task Should_call_onretry_on_each_retry_with_the_current_exception()
         {
             var expectedExceptions = new object[] { "Exception #1", "Exception #2", "Exception #3" };
             var retryExceptions = new List<Exception>();
@@ -191,7 +191,7 @@ namespace Polly.Specs.Retry
                 .Handle<DivideByZeroException>()
                 .RetryAsync(3, (exception, _) => retryExceptions.Add(exception));
 
-            policy.RaiseExceptionAsync<DivideByZeroException>(3, (e, i) => e.HelpLink = "Exception #" + i);
+            await policy.RaiseExceptionAsync<DivideByZeroException>(3, (e, i) => e.HelpLink = "Exception #" + i);
 
             retryExceptions
                 .Select(x => x.HelpLink)
@@ -274,7 +274,7 @@ namespace Polly.Specs.Retry
                 .Handle<DivideByZeroException>()
                 .RetryAsync((_, __, context) => capturedContext = context);
 
-            policy.RaiseExceptionAsync<DivideByZeroException>();
+            policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>()).ShouldNotThrow();
 
             capturedContext.Should()
                            .BeEmpty();

--- a/src/Polly.SharedSpecs/Retry/RetryForeverAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/RetryForeverAsyncSpecs.cs
@@ -108,7 +108,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public void Should_call_onretry_on_each_retry_with_the_current_exception()
+        public async Task Should_call_onretry_on_each_retry_with_the_current_exception()
         {
             var expectedExceptions = new object[] {"Exception #1", "Exception #2", "Exception #3"};
             var retryExceptions = new List<Exception>();
@@ -117,7 +117,7 @@ namespace Polly.Specs.Retry
                 .Handle<DivideByZeroException>()
                 .RetryForeverAsync(exception => retryExceptions.Add(exception));
 
-            policy.RaiseExceptionAsync<DivideByZeroException>(3, (e, i) => e.HelpLink = "Exception #" + i);
+            await policy.RaiseExceptionAsync<DivideByZeroException>(3, (e, i) => e.HelpLink = "Exception #" + i);
 
             retryExceptions
                 .Select(x => x.HelpLink)
@@ -152,7 +152,7 @@ namespace Polly.Specs.Retry
                 .Handle<DivideByZeroException>()
                 .RetryForeverAsync((_, context) => capturedContext = context);
 
-            policy.RaiseExceptionAsync<DivideByZeroException>();
+            policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>()).ShouldNotThrow();
 
             capturedContext.Should()
                            .BeEmpty();

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetryAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetryAsyncSpecs.cs
@@ -275,7 +275,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public void Should_sleep_for_the_specified_duration_each_retry_when_specified_exception_thrown_less_number_of_times_than_there_are_sleep_durations()
+        public async Task Should_sleep_for_the_specified_duration_each_retry_when_specified_exception_thrown_less_number_of_times_than_there_are_sleep_durations()
         {
             var totalTimeSlept = 0;
 
@@ -294,7 +294,7 @@ namespace Polly.Specs.Retry
                 return TaskHelper.EmptyTask;
             };
 
-            policy.RaiseExceptionAsync<DivideByZeroException>(2);
+            await policy.RaiseExceptionAsync<DivideByZeroException>(2);
 
             totalTimeSlept.Should()
                           .Be(1 + 2);
@@ -323,7 +323,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public void Should_call_onretry_on_each_retry_with_the_current_timespan()
+        public async Task Should_call_onretry_on_each_retry_with_the_current_timespan()
         {
             var expectedRetryWaits = new []
                 {
@@ -343,14 +343,14 @@ namespace Polly.Specs.Retry
                    3.Seconds()
                 }, (_, timeSpan) => actualRetryWaits.Add(timeSpan));
 
-            policy.RaiseExceptionAsync<DivideByZeroException>(3);
+            await policy.RaiseExceptionAsync<DivideByZeroException>(3);
 
             actualRetryWaits.Should()
                        .ContainInOrder(expectedRetryWaits);
         }
 
         [Fact]
-        public void Should_call_onretry_on_each_retry_with_the_current_exception()
+        public async Task Should_call_onretry_on_each_retry_with_the_current_exception()
         {
             var expectedExceptions = new object[] { "Exception #1", "Exception #2", "Exception #3" };
             var retryExceptions = new List<Exception>();
@@ -364,7 +364,7 @@ namespace Polly.Specs.Retry
                    3.Seconds()
                 }, (exception, _) => retryExceptions.Add(exception));
 
-            policy.RaiseExceptionAsync<DivideByZeroException>(3, (e, i) => e.HelpLink = "Exception #" + i);
+            await policy.RaiseExceptionAsync<DivideByZeroException>(3, (e, i) => e.HelpLink = "Exception #" + i);
 
             retryExceptions
                 .Select(x => x.HelpLink)
@@ -373,7 +373,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public void Should_call_onretry_on_each_retry_with_the_current_retry_count()
+        public async Task Should_call_onretry_on_each_retry_with_the_current_retry_count()
         {
             var expectedRetryCounts = new[] { 1, 2, 3 };
             var retryCounts = new List<int>();
@@ -387,7 +387,7 @@ namespace Polly.Specs.Retry
                    3.Seconds()
                 }, (_, __, retryCount, ___) => retryCounts.Add(retryCount));
 
-            policy.RaiseExceptionAsync<DivideByZeroException>(3);
+            await policy.RaiseExceptionAsync<DivideByZeroException>(3);
 
             retryCounts.Should()
                        .ContainInOrder(expectedRetryCounts);
@@ -426,7 +426,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public void Should_call_onretry_with_the_passed_context()
+        public async Task Should_call_onretry_with_the_passed_context()
         {
             IDictionary<string, object> contextData = null;
 
@@ -439,7 +439,7 @@ namespace Polly.Specs.Retry
                     3.Seconds()
                 }, (_, __, context) => contextData = context);
 
-            policy.RaiseExceptionAsync<DivideByZeroException>(
+            await policy.RaiseExceptionAsync<DivideByZeroException>(
                 new { key1 = "value1", key2 = "value2" }.AsDictionary()
                 );
 
@@ -461,14 +461,14 @@ namespace Polly.Specs.Retry
                     2.Seconds(),
                     3.Seconds()
                 }, (_, __, context) => capturedContext = context);
-            policy.RaiseExceptionAsync<DivideByZeroException>();
+            policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>()).ShouldNotThrow();
 
             capturedContext.Should()
                            .BeEmpty();
         }
 
         [Fact]
-        public void Should_create_new_context_for_each_call_to_execute()
+        public async Task Should_create_new_context_for_each_call_to_execute()
         {
             string contextValue = null;
 
@@ -480,13 +480,13 @@ namespace Polly.Specs.Retry
                 },
                 (_, __, context) => contextValue = context["key"].ToString());
 
-            policy.RaiseExceptionAsync<DivideByZeroException>(
+            await policy.RaiseExceptionAsync<DivideByZeroException>(
                 new { key = "original_value" }.AsDictionary()
             );
 
             contextValue.Should().Be("original_value");
 
-            policy.RaiseExceptionAsync<DivideByZeroException>(
+            await policy.RaiseExceptionAsync<DivideByZeroException>(
                 new { key = "new_value" }.AsDictionary()
             );
 
@@ -533,7 +533,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public void Should_calculate_retry_timespans_from_current_retry_attempt_and_timespan_provider()
+        public async Task Should_calculate_retry_timespans_from_current_retry_attempt_and_timespan_provider()
         {
             var expectedRetryWaits = new[]
                 {
@@ -553,7 +553,7 @@ namespace Polly.Specs.Retry
                     (_, timeSpan) => actualRetryWaits.Add(timeSpan)
                 );
 
-            policy.RaiseExceptionAsync<DivideByZeroException>(5);
+            await policy.RaiseExceptionAsync<DivideByZeroException>(5);
 
             actualRetryWaits.Should()
                        .ContainInOrder(expectedRetryWaits);

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverAsyncSpecs.cs
@@ -199,7 +199,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public void Should_call_onretry_on_each_retry_with_the_current_exception()
+        public async Task Should_call_onretry_on_each_retry_with_the_current_exception()
         {
             var expectedExceptions = new object[] { "Exception #1", "Exception #2", "Exception #3" };
             var retryExceptions = new List<Exception>();
@@ -209,7 +209,7 @@ namespace Polly.Specs.Retry
                 .Handle<DivideByZeroException>()
                 .WaitAndRetryForeverAsync(provider, (exception, _) => retryExceptions.Add(exception));
 
-            policy.RaiseExceptionAsync<DivideByZeroException>(3, (e, i) => e.HelpLink = "Exception #" + i);
+            await policy.RaiseExceptionAsync<DivideByZeroException>(3, (e, i) => e.HelpLink = "Exception #" + i);
 
             retryExceptions
                 .Select(x => x.HelpLink)
@@ -260,7 +260,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public void Should_calculate_retry_timespans_from_current_retry_attempt_and_timespan_provider()
+        public async Task Should_calculate_retry_timespans_from_current_retry_attempt_and_timespan_provider()
         {
             var expectedRetryWaits = new[]
                 {
@@ -280,7 +280,7 @@ namespace Polly.Specs.Retry
                     (_, timeSpan) => actualRetryWaits.Add(timeSpan)
                 );
 
-            policy.RaiseExceptionAsync<DivideByZeroException>(5);
+            await policy.RaiseExceptionAsync<DivideByZeroException>(5);
 
             actualRetryWaits.Should()
                        .ContainInOrder(expectedRetryWaits);

--- a/src/Polly.SharedSpecs/Wrap/PolicyWrapContextAndKeySpecsAsync.cs
+++ b/src/Polly.SharedSpecs/Wrap/PolicyWrapContextAndKeySpecsAsync.cs
@@ -12,7 +12,7 @@ namespace Polly.Specs.Wrap
         #region PolicyKey and execution Context tests
 
         [Fact]
-        public void Should_pass_PolicyKey_to_execution_context_of_outer_policy_as_PolicyWrapKey()
+        public async Task Should_pass_PolicyKey_to_execution_context_of_outer_policy_as_PolicyWrapKey()
         {
             string retryKey = Guid.NewGuid().ToString();
             string breakerKey = Guid.NewGuid().ToString();
@@ -28,7 +28,7 @@ namespace Polly.Specs.Wrap
             var breaker = Policy.Handle<Exception>().CircuitBreakerAsync(1, TimeSpan.Zero).WithPolicyKey(breakerKey);
             var wrap = retry.WrapAsync(breaker).WithPolicyKey(wrapKey);
 
-            wrap.RaiseExceptionAsync<Exception>(1);
+            await wrap.RaiseExceptionAsync<Exception>(1);
 
             policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
             policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
@@ -36,7 +36,7 @@ namespace Polly.Specs.Wrap
         }
 
         [Fact]
-        public void Should_pass_PolicyKey_to_execution_context_of_inner_policy_as_PolicyWrapKey()
+        public async Task Should_pass_PolicyKey_to_execution_context_of_inner_policy_as_PolicyWrapKey()
         {
             string retryKey = Guid.NewGuid().ToString();
             string breakerKey = Guid.NewGuid().ToString();
@@ -53,7 +53,7 @@ namespace Polly.Specs.Wrap
             var breaker = Policy.Handle<Exception>().CircuitBreakerAsync(1, TimeSpan.Zero, onBreak, onReset).WithPolicyKey(breakerKey);
             var wrap = retry.WrapAsync(breaker).WithPolicyKey(wrapKey);
 
-            wrap.RaiseExceptionAsync<Exception>(1);
+            await wrap.RaiseExceptionAsync<Exception>(1);
 
             policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
             policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
@@ -61,7 +61,7 @@ namespace Polly.Specs.Wrap
         }
 
         [Fact]
-        public void Should_pass_outmost_PolicyWrap_Key_as_PolicyWrapKey_ignoring_inner_PolicyWrap_keys_even_when_executing_policies_in_inner_WrapAsync()
+        public async Task Should_pass_outmost_PolicyWrap_Key_as_PolicyWrapKey_ignoring_inner_PolicyWrap_keys_even_when_executing_policies_in_inner_WrapAsync()
         {
             string retryKey = Guid.NewGuid().ToString();
             string breakerKey = Guid.NewGuid().ToString();
@@ -83,7 +83,7 @@ namespace Polly.Specs.Wrap
             var innerWrap = retry.WrapAsync(breaker).WithPolicyKey(innerWrapKey);
             var outerWrap = fallback.WrapAsync(innerWrap).WithPolicyKey(outerWrapKey);
 
-            outerWrap.RaiseExceptionAsync<Exception>(1);
+            await outerWrap.RaiseExceptionAsync<Exception>(1);
 
             policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
             policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
@@ -132,6 +132,7 @@ namespace Polly.Specs.Wrap
             policyWrapKeySetOnExecutionContext.Should().NotBe(innerWrapKey);
             policyWrapKeySetOnExecutionContext.Should().Be(outerWrapKey);
         }
+
         #endregion
 
     }
@@ -141,7 +142,7 @@ namespace Polly.Specs.Wrap
         #region PolicyKey and execution Context tests
 
         [Fact]
-        public void Should_pass_PolicyKey_to_execution_context_of_outer_policy_as_PolicyWrapKey()
+        public async Task Should_pass_PolicyKey_to_execution_context_of_outer_policy_as_PolicyWrapKey()
         {
             string retryKey = Guid.NewGuid().ToString();
             string breakerKey = Guid.NewGuid().ToString();
@@ -157,7 +158,7 @@ namespace Polly.Specs.Wrap
             var breaker = Policy.HandleResult(ResultPrimitive.Fault).CircuitBreakerAsync(1, TimeSpan.Zero).WithPolicyKey(breakerKey);
             var wrap = retry.WrapAsync(breaker).WithPolicyKey(wrapKey);
 
-            wrap.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Good);
+            await wrap.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Good);
 
             policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
             policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
@@ -165,7 +166,7 @@ namespace Polly.Specs.Wrap
         }
 
         [Fact]
-        public void Should_pass_PolicyKey_to_execution_context_of_inner_policy_as_PolicyWrapKey()
+        public async Task Should_pass_PolicyKey_to_execution_context_of_inner_policy_as_PolicyWrapKey()
         {
             string retryKey = Guid.NewGuid().ToString();
             string breakerKey = Guid.NewGuid().ToString();
@@ -182,7 +183,7 @@ namespace Polly.Specs.Wrap
             var breaker = Policy.HandleResult(ResultPrimitive.Fault).CircuitBreakerAsync(1, TimeSpan.Zero, onBreak, onReset).WithPolicyKey(breakerKey);
             var wrap = retry.WrapAsync(breaker).WithPolicyKey(wrapKey);
 
-            wrap.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Good);
+            await wrap.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Good);
 
             policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
             policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
@@ -190,7 +191,7 @@ namespace Polly.Specs.Wrap
         }
 
         [Fact]
-        public void Should_pass_outmost_PolicyWrap_Key_as_PolicyWrapKey_ignoring_inner_PolicyWrap_keys_even_when_executing_policies_in_inner_WrapAsync()
+        public async Task Should_pass_outmost_PolicyWrap_Key_as_PolicyWrapKey_ignoring_inner_PolicyWrap_keys_even_when_executing_policies_in_inner_WrapAsync()
         {
             string retryKey = Guid.NewGuid().ToString();
             string breakerKey = Guid.NewGuid().ToString();
@@ -212,7 +213,7 @@ namespace Polly.Specs.Wrap
             var innerWrap = retry.WrapAsync(breaker).WithPolicyKey(innerWrapKey);
             var outerWrap = fallback.WrapAsync(innerWrap).WithPolicyKey(outerWrapKey);
 
-            outerWrap.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Good);
+            await outerWrap.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Good);
 
             policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
             policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);

--- a/src/Polly.SharedSpecs/Wrap/PolicyWrapSpecsAsync.cs
+++ b/src/Polly.SharedSpecs/Wrap/PolicyWrapSpecsAsync.cs
@@ -326,7 +326,7 @@ namespace Polly.Specs.Wrap
             PolicyResult executeAndCaptureResultOnPolicyWrap =
                 await wrap.ExecuteAndCaptureAsync(() => { throw new ArgumentNullException(); });
 
-        executeAndCaptureResultOnPolicyWrap.Outcome.Should().Be(OutcomeType.Failure);
+            executeAndCaptureResultOnPolicyWrap.Outcome.Should().Be(OutcomeType.Failure);
             executeAndCaptureResultOnPolicyWrap.FinalException.Should().BeOfType<ArgumentNullException>();
             executeAndCaptureResultOnPolicyWrap.ExceptionType.Should().Be(ExceptionType.HandledByThisPolicy);
         }


### PR DESCRIPTION
* Rationalise RaiseException helpers.  
* Add new `RaiseException(/*specific exception instance*/)` helper.
* Demonstrate use of new helper in fallback tests