### PR TITLE
Prepare syntax for setting wait based on returned error

### DIFF
--- a/src/Polly.Shared/Retry/RetrySyntax.cs
+++ b/src/Polly.Shared/Retry/RetrySyntax.cs
@@ -336,9 +336,78 @@ namespace Polly
                 cancellationToken,
                 policyBuilder.ExceptionPredicates,
                 PredicateHelper<EmptyStruct>.EmptyResultPredicates,
-                () => new RetryStateWaitAndRetryWithProvider<EmptyStruct>(retryCount, sleepDurationProvider, (outcome, timespan, i, ctx) => onRetry(outcome.Exception, timespan, i, ctx), context)
+                () => new RetryStateWaitAndRetryWithProvider<EmptyStruct>(
+                    retryCount,
+                    sleepDurationProvider,
+                    (outcome, timespan, i, ctx) => onRetry(outcome.Exception, timespan, i, ctx),
+                    context)
             ), policyBuilder.ExceptionPredicates);
         }
+
+        // For v560waitDurationFromErrorResponse: delete the overload above, and replace with the two below
+
+        ///// <summary>
+        ///// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
+        ///// calling <paramref name="onRetry"/> on each retry with the raised exception, current sleep duration, retry count, and context data.
+        ///// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
+        ///// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///// </summary>
+        ///// <param name="policyBuilder">The policy builder.</param>
+        ///// <param name="retryCount">The retry count.</param>
+        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        ///// <param name="onRetry">The action to call on each retry.</param>
+        ///// <returns>The policy instance.</returns>
+        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        ///// <exception cref="System.ArgumentNullException">
+        ///// timeSpanProvider
+        ///// or
+        ///// onRetry
+        ///// </exception>
+        //public static RetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, int, Context> onRetry)
+        //{
+        //    return policyBuilder.WaitAndRetry(
+        //        retryCount,
+        //        (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+        //        onRetry);
+        //}
+
+        ///// <summary>
+        ///// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
+        ///// calling <paramref name="onRetry"/> on each retry with the raised exception, current sleep duration, retry count, and context data.
+        ///// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
+        ///// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///// </summary>
+        ///// <param name="policyBuilder">The policy builder.</param>
+        ///// <param name="retryCount">The retry count.</param>
+        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        ///// <param name="onRetry">The action to call on each retry.</param>
+        ///// <returns>The policy instance.</returns>
+        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        ///// <exception cref="System.ArgumentNullException">
+        ///// timeSpanProvider
+        ///// or
+        ///// onRetry
+        ///// </exception>
+        //public static RetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, Exception, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, int, Context> onRetry)
+        //{
+        //    if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
+        //    if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+        //    if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
+
+        //    return new RetryPolicy(
+        //        (action, context, cancellationToken) => RetryEngine.Implementation(
+        //        (ctx, ct) => { action(ctx, ct); return EmptyStruct.Instance; },
+        //        context,
+        //        cancellationToken,
+        //        policyBuilder.ExceptionPredicates,
+        //        PredicateHelper<EmptyStruct>.EmptyResultPredicates,
+        //        () => new RetryStateWaitAndRetryWithProvider<EmptyStruct>(
+        //            retryCount,
+        //            (i, outcome, ctx) => sleepDurationProvider(i, outcome.Exception, ctx),
+        //            (outcome, timespan, i, ctx) => onRetry(outcome.Exception, timespan, i, ctx), 
+        //            context)
+        //    ), policyBuilder.ExceptionPredicates);
+        //}
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry as many times as there are provided <paramref name="sleepDurations"/>

--- a/src/Polly.Shared/Retry/RetrySyntaxAsync.cs
+++ b/src/Polly.Shared/Retry/RetrySyntaxAsync.cs
@@ -602,6 +602,76 @@ namespace Polly
                 policyBuilder.ExceptionPredicates
             );
         }
+    
+        // For v560waitDurationFromErrorResponse: delete the overload above, and replace with the two below
+
+        ///// <summary>
+        /////     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
+        /////     calling <paramref name="onRetryAsync" /> on each retry with the raised exception, the current sleep duration, retry count, and context data.
+        /////     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
+        /////     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///// </summary>
+        ///// <param name="policyBuilder">The policy builder.</param>
+        ///// <param name="retryCount">The retry count.</param>
+        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        ///// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        ///// <returns>The policy instance.</returns>
+        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        ///// <exception cref="System.ArgumentNullException">
+        /////     sleepDurationProvider
+        /////     or
+        /////     onRetryAsync
+        ///// </exception>
+        //public static RetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
+        //    Func<int, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, int, Context, Task> onRetryAsync)
+        //{
+        //    return policyBuilder.WaitAndRetryAsync(
+        //        retryCount,
+        //        (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+        //        onRetryAsync);
+        //}
+
+        ///// <summary>
+        /////     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
+        /////     calling <paramref name="onRetryAsync" /> on each retry with the raised exception, the current sleep duration, retry count, and context data.
+        /////     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
+        /////     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///// </summary>
+        ///// <param name="policyBuilder">The policy builder.</param>
+        ///// <param name="retryCount">The retry count.</param>
+        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        ///// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        ///// <returns>The policy instance.</returns>
+        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        ///// <exception cref="System.ArgumentNullException">
+        /////     sleepDurationProvider
+        /////     or
+        /////     onRetryAsync
+        ///// </exception>
+        //public static RetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
+        //    Func<int, Exception, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, int, Context, Task> onRetryAsync)
+        //{
+        //    if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
+        //    if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+        //    if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
+
+        //    return new RetryPolicy(
+        //        (action, context, cancellationToken, continueOnCapturedContext) =>
+        //          RetryEngine.ImplementationAsync(
+        //            async (ctx, ct) => { await action(ctx, ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
+        //            context,
+        //            cancellationToken,
+        //            policyBuilder.ExceptionPredicates,
+        //            PredicateHelper<EmptyStruct>.EmptyResultPredicates,
+        //            () => new RetryStateWaitAndRetryWithProvider<EmptyStruct>(
+        //                retryCount, 
+        //                (i, outcome, ctx) => sleepDurationProvider(i, outcome.Exception, ctx), 
+        //                (outcome, timespan, i, ctx) => onRetryAsync(outcome.Exception, timespan, i, ctx), 
+        //                context), 
+        //            continueOnCapturedContext),
+        //        policyBuilder.ExceptionPredicates
+        //    );
+        //}
 
         /// <summary>
         ///     Builds a <see cref="Policy" /> that will wait and retry as many times as there are provided

--- a/src/Polly.Shared/Retry/RetryTResultSyntax.cs
+++ b/src/Polly.Shared/Retry/RetryTResultSyntax.cs
@@ -344,9 +344,72 @@ namespace Polly
                     policyBuilder.ResultPredicates,
                     () => new RetryStateWaitAndRetryWithProvider<TResult>(retryCount, sleepDurationProvider, onRetry, context)
                 ),
-            policyBuilder.ExceptionPredicates,
-            policyBuilder.ResultPredicates);
+                policyBuilder.ExceptionPredicates,
+                policyBuilder.ResultPredicates);
         }
+
+        // For v560waitDurationFromErrorResponse: delete the overload above, and replace with the two below
+
+        ///// <summary>
+        ///// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
+        ///// calling <paramref name="onRetry"/> on each retry with the handled exception or result, current sleep duration, retry count, and context data.
+        ///// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
+        ///// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///// </summary>
+        ///// <param name="policyBuilder">The policy builder.</param>
+        ///// <param name="retryCount">The retry count.</param>
+        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        ///// <param name="onRetry">The action to call on each retry.</param>
+        ///// <returns>The policy instance.</returns>
+        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        ///// <exception cref="System.ArgumentNullException">
+        ///// timeSpanProvider
+        ///// or
+        ///// onRetry
+        ///// </exception>
+        //public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
+        //{
+        //    return policyBuilder.WaitAndRetry(
+        //        retryCount,
+        //        (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+        //        onRetry);
+        //}
+
+        ///// <summary>
+        ///// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
+        ///// calling <paramref name="onRetry"/> on each retry with the handled exception or result, current sleep duration, retry count, and context data.
+        ///// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
+        ///// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///// </summary>
+        ///// <param name="policyBuilder">The policy builder.</param>
+        ///// <param name="retryCount">The retry count.</param>
+        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        ///// <param name="onRetry">The action to call on each retry.</param>
+        ///// <returns>The policy instance.</returns>
+        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        ///// <exception cref="System.ArgumentNullException">
+        ///// timeSpanProvider
+        ///// or
+        ///// onRetry
+        ///// </exception>
+        //public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
+        //{
+        //    if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
+        //    if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+        //    if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
+
+        //    return new RetryPolicy<TResult>(
+        //        (action, context, cancellationToken) => RetryEngine.Implementation(
+        //            action,
+        //            context,
+        //            cancellationToken,
+        //            policyBuilder.ExceptionPredicates,
+        //            policyBuilder.ResultPredicates,
+        //            () => new RetryStateWaitAndRetryWithProvider<TResult>(retryCount, sleepDurationProvider, onRetry, context)
+        //        ),
+        //    policyBuilder.ExceptionPredicates,
+        //    policyBuilder.ResultPredicates);
+        //}
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry as many times as there are provided <paramref name="sleepDurations"/>

--- a/src/Polly.Shared/Retry/RetryTResultSyntaxAsync.cs
+++ b/src/Polly.Shared/Retry/RetryTResultSyntaxAsync.cs
@@ -607,6 +607,73 @@ namespace Polly
             );
         }
 
+        // For v560waitDurationFromErrorResponse: delete the overload above, and replace with the two below
+
+        ///// <summary>
+        /////     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
+        /////     calling <paramref name="onRetryAsync" /> on each retry with the handled exception or result, the current sleep duration, retry count, and context data.
+        /////     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
+        /////     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///// </summary>
+        ///// <param name="policyBuilder">The policy builder.</param>
+        ///// <param name="retryCount">The retry count.</param>
+        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        ///// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        ///// <returns>The policy instance.</returns>
+        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        ///// <exception cref="System.ArgumentNullException">
+        /////     sleepDurationProvider
+        /////     or
+        /////     onRetryAsync
+        ///// </exception>
+        //public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
+        //    Func<int, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync)
+        //{
+        //    return policyBuilder.WaitAndRetryAsync(
+        //        retryCount,
+        //        (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+        //        onRetryAsync);
+        //}
+
+        ///// <summary>
+        /////     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
+        /////     calling <paramref name="onRetryAsync" /> on each retry with the handled exception or result, the current sleep duration, retry count, and context data.
+        /////     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
+        /////     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///// </summary>
+        ///// <param name="policyBuilder">The policy builder.</param>
+        ///// <param name="retryCount">The retry count.</param>
+        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        ///// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        ///// <returns>The policy instance.</returns>
+        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        ///// <exception cref="System.ArgumentNullException">
+        /////     sleepDurationProvider
+        /////     or
+        /////     onRetryAsync
+        ///// </exception>
+        //public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
+        //    Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync)
+        //{
+        //    if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
+        //    if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+        //    if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
+
+        //    return new RetryPolicy<TResult>(
+        //        (action, context, cancellationToken, continueOnCapturedContext) =>
+        //          RetryEngine.ImplementationAsync(
+        //            action,
+        //            context,
+        //            cancellationToken,
+        //            policyBuilder.ExceptionPredicates,
+        //            policyBuilder.ResultPredicates,
+        //            () => new RetryStateWaitAndRetryWithProvider<TResult>(retryCount, sleepDurationProvider, onRetryAsync, context), 
+        //            continueOnCapturedContext),
+        //        policyBuilder.ExceptionPredicates,
+        //        policyBuilder.ResultPredicates
+        //    );
+        //}
+
         /// <summary>
         ///     Builds a <see cref="Policy" /> that will wait and retry as many times as there are provided
         ///     <paramref name="sleepDurations" />


### PR DESCRIPTION
Prepare syntax for easier strategy for setting wait based on returned error, for example 429 headers from Cosmos DB.

For Hackathon