### PR TITLE
determine wait duration from error response

### DIFF
--- a/src/Polly.Shared/Retry/RetryStateWaitAndRetryWithProvider.cs
+++ b/src/Polly.Shared/Retry/RetryStateWaitAndRetryWithProvider.cs
@@ -8,11 +8,11 @@ namespace Polly.Retry
     {
         private int _errorCount;
         private readonly int _retryCount;
-        private readonly Func<int, Context, TimeSpan> _sleepDurationProvider;
+        private readonly Func<int, DelegateResult<TResult>, Context, TimeSpan> _sleepDurationProvider;
         private readonly Action<DelegateResult<TResult>, TimeSpan, int, Context> _onRetry;
         private readonly Context _context;
 
-        public RetryStateWaitAndRetryWithProvider(int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry, Context context)
+        public RetryStateWaitAndRetryWithProvider(int retryCount, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry, Context context)
         {
             _retryCount = retryCount;
             _sleepDurationProvider = sleepDurationProvider;
@@ -27,7 +27,7 @@ namespace Polly.Retry
             bool shouldRetry = _errorCount <= _retryCount;
             if (shouldRetry)
             {
-                TimeSpan waitTimeSpan = _sleepDurationProvider(_errorCount, _context);
+                TimeSpan waitTimeSpan = _sleepDurationProvider(_errorCount, delegateResult, _context);
 
                 _onRetry(delegateResult, waitTimeSpan, _errorCount, _context);
 

--- a/src/Polly.Shared/Retry/RetryStateWaitAndRetryWithProviderAsync.cs
+++ b/src/Polly.Shared/Retry/RetryStateWaitAndRetryWithProviderAsync.cs
@@ -10,7 +10,7 @@ namespace Polly.Retry
     {
         private readonly Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> _onRetryAsync;
 
-        public RetryStateWaitAndRetryWithProvider(int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync, Context context)
+        public RetryStateWaitAndRetryWithProvider(int retryCount, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync, Context context)
         {
             _retryCount = retryCount;
             _sleepDurationProvider = sleepDurationProvider;
@@ -25,7 +25,7 @@ namespace Polly.Retry
             bool shouldRetry = _errorCount <= _retryCount;
             if (shouldRetry)
             {
-                TimeSpan waitTimeSpan = _sleepDurationProvider(_errorCount, _context);
+                TimeSpan waitTimeSpan = _sleepDurationProvider(_errorCount, delegateResult, _context);
 
                 await _onRetryAsync(delegateResult, waitTimeSpan, _errorCount, _context).ConfigureAwait(continueOnCapturedContext);
 

--- a/src/Polly.Shared/Retry/RetrySyntax.cs
+++ b/src/Polly.Shared/Retry/RetrySyntax.cs
@@ -336,9 +336,78 @@ namespace Polly
                 cancellationToken,
                 policyBuilder.ExceptionPredicates,
                 PredicateHelper<EmptyStruct>.EmptyResultPredicates,
-                () => new RetryStateWaitAndRetryWithProvider<EmptyStruct>(retryCount, sleepDurationProvider, (outcome, timespan, i, ctx) => onRetry(outcome.Exception, timespan, i, ctx), context)
+                () => new RetryStateWaitAndRetryWithProvider<EmptyStruct>(
+                    retryCount,
+                    sleepDurationProvider,
+                    (outcome, timespan, i, ctx) => onRetry(outcome.Exception, timespan, i, ctx),
+                    context)
             ), policyBuilder.ExceptionPredicates);
         }
+
+        // For v560waitDurationFromErrorResponse: delete the overload above, and replace with the two below
+
+        ///// <summary>
+        ///// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
+        ///// calling <paramref name="onRetry"/> on each retry with the raised exception, current sleep duration, retry count, and context data.
+        ///// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
+        ///// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///// </summary>
+        ///// <param name="policyBuilder">The policy builder.</param>
+        ///// <param name="retryCount">The retry count.</param>
+        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        ///// <param name="onRetry">The action to call on each retry.</param>
+        ///// <returns>The policy instance.</returns>
+        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        ///// <exception cref="System.ArgumentNullException">
+        ///// timeSpanProvider
+        ///// or
+        ///// onRetry
+        ///// </exception>
+        //public static RetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, int, Context> onRetry)
+        //{
+        //    return policyBuilder.WaitAndRetry(
+        //        retryCount,
+        //        (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+        //        onRetry);
+        //}
+
+        ///// <summary>
+        ///// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
+        ///// calling <paramref name="onRetry"/> on each retry with the raised exception, current sleep duration, retry count, and context data.
+        ///// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
+        ///// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///// </summary>
+        ///// <param name="policyBuilder">The policy builder.</param>
+        ///// <param name="retryCount">The retry count.</param>
+        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        ///// <param name="onRetry">The action to call on each retry.</param>
+        ///// <returns>The policy instance.</returns>
+        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        ///// <exception cref="System.ArgumentNullException">
+        ///// timeSpanProvider
+        ///// or
+        ///// onRetry
+        ///// </exception>
+        //public static RetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, Exception, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, int, Context> onRetry)
+        //{
+        //    if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
+        //    if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+        //    if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
+
+        //    return new RetryPolicy(
+        //        (action, context, cancellationToken) => RetryEngine.Implementation(
+        //        (ctx, ct) => { action(ctx, ct); return EmptyStruct.Instance; },
+        //        context,
+        //        cancellationToken,
+        //        policyBuilder.ExceptionPredicates,
+        //        PredicateHelper<EmptyStruct>.EmptyResultPredicates,
+        //        () => new RetryStateWaitAndRetryWithProvider<EmptyStruct>(
+        //            retryCount,
+        //            (i, outcome, ctx) => sleepDurationProvider(i, outcome.Exception, ctx),
+        //            (outcome, timespan, i, ctx) => onRetry(outcome.Exception, timespan, i, ctx), 
+        //            context)
+        //    ), policyBuilder.ExceptionPredicates);
+        //}
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry as many times as there are provided <paramref name="sleepDurations"/>

--- a/src/Polly.Shared/Retry/RetrySyntax.cs
+++ b/src/Polly.Shared/Retry/RetrySyntax.cs
@@ -306,46 +306,6 @@ namespace Polly
                 );
         }
 
-        /// <summary>
-        /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
-        /// calling <paramref name="onRetry"/> on each retry with the raised exception, current sleep duration, retry count, and context data.
-        /// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
-        /// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
-        /// </summary>
-        /// <param name="policyBuilder">The policy builder.</param>
-        /// <param name="retryCount">The retry count.</param>
-        /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
-        /// <param name="onRetry">The action to call on each retry.</param>
-        /// <returns>The policy instance.</returns>
-        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="System.ArgumentNullException">
-        /// timeSpanProvider
-        /// or
-        /// onRetry
-        /// </exception>
-        public static RetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, int, Context> onRetry)
-        {
-            if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
-            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
-            return new RetryPolicy(
-                (action, context, cancellationToken) => RetryEngine.Implementation(
-                (ctx, ct) => { action(ctx, ct); return EmptyStruct.Instance; },
-                context,
-                cancellationToken,
-                policyBuilder.ExceptionPredicates,
-                PredicateHelper<EmptyStruct>.EmptyResultPredicates,
-                () => new RetryStateWaitAndRetryWithProvider<EmptyStruct>(
-                    retryCount,
-                    sleepDurationProvider,
-                    (outcome, timespan, i, ctx) => onRetry(outcome.Exception, timespan, i, ctx),
-                    context)
-            ), policyBuilder.ExceptionPredicates);
-        }
-
-        // For v560waitDurationFromErrorResponse: delete the overload above, and replace with the two below
-
         ///// <summary>
         ///// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
         ///// calling <paramref name="onRetry"/> on each retry with the raised exception, current sleep duration, retry count, and context data.
@@ -365,31 +325,6 @@ namespace Polly
         ///// </exception>
         //public static RetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, int, Context> onRetry)
         //{
-        //    return policyBuilder.WaitAndRetry(
-        //        retryCount,
-        //        (i, outcome, ctx) => sleepDurationProvider(i, ctx),
-        //        onRetry);
-        //}
-
-        ///// <summary>
-        ///// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
-        ///// calling <paramref name="onRetry"/> on each retry with the raised exception, current sleep duration, retry count, and context data.
-        ///// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
-        ///// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
-        ///// </summary>
-        ///// <param name="policyBuilder">The policy builder.</param>
-        ///// <param name="retryCount">The retry count.</param>
-        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
-        ///// <param name="onRetry">The action to call on each retry.</param>
-        ///// <returns>The policy instance.</returns>
-        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        ///// <exception cref="System.ArgumentNullException">
-        ///// timeSpanProvider
-        ///// or
-        ///// onRetry
-        ///// </exception>
-        //public static RetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, Exception, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, int, Context> onRetry)
-        //{
         //    if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
         //    if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
         //    if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
@@ -403,11 +338,78 @@ namespace Polly
         //        PredicateHelper<EmptyStruct>.EmptyResultPredicates,
         //        () => new RetryStateWaitAndRetryWithProvider<EmptyStruct>(
         //            retryCount,
-        //            (i, outcome, ctx) => sleepDurationProvider(i, outcome.Exception, ctx),
-        //            (outcome, timespan, i, ctx) => onRetry(outcome.Exception, timespan, i, ctx), 
+        //            sleepDurationProvider,
+        //            (outcome, timespan, i, ctx) => onRetry(outcome.Exception, timespan, i, ctx),
         //            context)
         //    ), policyBuilder.ExceptionPredicates);
         //}
+
+        // For v560waitDurationFromErrorResponse: delete the overload above, and replace with the two below
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
+        /// calling <paramref name="onRetry"/> on each retry with the raised exception, current sleep duration, retry count, and context data.
+        /// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
+        /// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="retryCount">The retry count.</param>
+        /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        /// <exception cref="System.ArgumentNullException">
+        /// timeSpanProvider
+        /// or
+        /// onRetry
+        /// </exception>
+        public static RetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, int, Context> onRetry)
+        {
+            return policyBuilder.WaitAndRetry(
+                retryCount,
+                (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+                onRetry);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
+        /// calling <paramref name="onRetry"/> on each retry with the raised exception, current sleep duration, retry count, and context data.
+        /// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
+        /// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="retryCount">The retry count.</param>
+        /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        /// <exception cref="System.ArgumentNullException">
+        /// timeSpanProvider
+        /// or
+        /// onRetry
+        /// </exception>
+        public static RetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, Exception, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, int, Context> onRetry)
+        {
+            if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
+
+            //var wrappedEmptyStruct = new Action<DelegateResult<EmptyStruct>, TimeSpan, int, Context>() 
+
+            return new RetryPolicy(
+                (action, context, cancellationToken) => RetryEngine.Implementation(
+                (ctx, ct) => { action(ctx, ct); return EmptyStruct.Instance; },
+                context,
+                cancellationToken,
+                policyBuilder.ExceptionPredicates,
+                PredicateHelper<EmptyStruct>.EmptyResultPredicates,
+                () => new RetryStateWaitAndRetryWithProvider<EmptyStruct>(
+                    retryCount,
+                    (i, outcome, ctx) => sleepDurationProvider(i, outcome.Exception, ctx),
+                    (outcome, timespan, i, ctx) => onRetry(outcome.Exception, timespan, i, ctx),
+                    context)
+            ), policyBuilder.ExceptionPredicates);
+        }
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry as many times as there are provided <paramref name="sleepDurations"/>

--- a/src/Polly.Shared/Retry/RetrySyntaxAsync.cs
+++ b/src/Polly.Shared/Retry/RetrySyntaxAsync.cs
@@ -602,6 +602,76 @@ namespace Polly
                 policyBuilder.ExceptionPredicates
             );
         }
+    
+        // For v560waitDurationFromErrorResponse: delete the overload above, and replace with the two below
+
+        ///// <summary>
+        /////     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
+        /////     calling <paramref name="onRetryAsync" /> on each retry with the raised exception, the current sleep duration, retry count, and context data.
+        /////     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
+        /////     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///// </summary>
+        ///// <param name="policyBuilder">The policy builder.</param>
+        ///// <param name="retryCount">The retry count.</param>
+        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        ///// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        ///// <returns>The policy instance.</returns>
+        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        ///// <exception cref="System.ArgumentNullException">
+        /////     sleepDurationProvider
+        /////     or
+        /////     onRetryAsync
+        ///// </exception>
+        //public static RetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
+        //    Func<int, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, int, Context, Task> onRetryAsync)
+        //{
+        //    return policyBuilder.WaitAndRetryAsync(
+        //        retryCount,
+        //        (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+        //        onRetryAsync);
+        //}
+
+        ///// <summary>
+        /////     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
+        /////     calling <paramref name="onRetryAsync" /> on each retry with the raised exception, the current sleep duration, retry count, and context data.
+        /////     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
+        /////     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///// </summary>
+        ///// <param name="policyBuilder">The policy builder.</param>
+        ///// <param name="retryCount">The retry count.</param>
+        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        ///// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        ///// <returns>The policy instance.</returns>
+        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        ///// <exception cref="System.ArgumentNullException">
+        /////     sleepDurationProvider
+        /////     or
+        /////     onRetryAsync
+        ///// </exception>
+        //public static RetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
+        //    Func<int, Exception, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, int, Context, Task> onRetryAsync)
+        //{
+        //    if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
+        //    if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+        //    if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
+
+        //    return new RetryPolicy(
+        //        (action, context, cancellationToken, continueOnCapturedContext) =>
+        //          RetryEngine.ImplementationAsync(
+        //            async (ctx, ct) => { await action(ctx, ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
+        //            context,
+        //            cancellationToken,
+        //            policyBuilder.ExceptionPredicates,
+        //            PredicateHelper<EmptyStruct>.EmptyResultPredicates,
+        //            () => new RetryStateWaitAndRetryWithProvider<EmptyStruct>(
+        //                retryCount, 
+        //                (i, outcome, ctx) => sleepDurationProvider(i, outcome.Exception, ctx), 
+        //                (outcome, timespan, i, ctx) => onRetryAsync(outcome.Exception, timespan, i, ctx), 
+        //                context), 
+        //            continueOnCapturedContext),
+        //        policyBuilder.ExceptionPredicates
+        //    );
+        //}
 
         /// <summary>
         ///     Builds a <see cref="Policy" /> that will wait and retry as many times as there are provided

--- a/src/Polly.Shared/Retry/RetrySyntaxAsync.cs
+++ b/src/Polly.Shared/Retry/RetrySyntaxAsync.cs
@@ -565,46 +565,6 @@ namespace Polly
             );
         }
 
-        /// <summary>
-        ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
-        ///     calling <paramref name="onRetryAsync" /> on each retry with the raised exception, the current sleep duration, retry count, and context data.
-        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
-        /// </summary>
-        /// <param name="policyBuilder">The policy builder.</param>
-        /// <param name="retryCount">The retry count.</param>
-        /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
-        /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
-        /// <returns>The policy instance.</returns>
-        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="System.ArgumentNullException">
-        ///     sleepDurationProvider
-        ///     or
-        ///     onRetryAsync
-        /// </exception>
-        public static RetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
-            Func<int, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, int, Context, Task> onRetryAsync)
-        {
-            if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
-            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
-
-            return new RetryPolicy(
-                (action, context, cancellationToken, continueOnCapturedContext) =>
-                  RetryEngine.ImplementationAsync(
-                    async (ctx, ct) => { await action(ctx, ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
-                    context,
-                    cancellationToken,
-                    policyBuilder.ExceptionPredicates,
-                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
-                    () => new RetryStateWaitAndRetryWithProvider<EmptyStruct>(retryCount, sleepDurationProvider, (outcome, timespan, i, ctx) => onRetryAsync(outcome.Exception, timespan, i, ctx), context), 
-                    continueOnCapturedContext),
-                policyBuilder.ExceptionPredicates
-            );
-        }
-    
-        // For v560waitDurationFromErrorResponse: delete the overload above, and replace with the two below
-
         ///// <summary>
         /////     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
         /////     calling <paramref name="onRetryAsync" /> on each retry with the raised exception, the current sleep duration, retry count, and context data.
@@ -625,32 +585,6 @@ namespace Polly
         //public static RetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
         //    Func<int, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, int, Context, Task> onRetryAsync)
         //{
-        //    return policyBuilder.WaitAndRetryAsync(
-        //        retryCount,
-        //        (i, outcome, ctx) => sleepDurationProvider(i, ctx),
-        //        onRetryAsync);
-        //}
-
-        ///// <summary>
-        /////     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
-        /////     calling <paramref name="onRetryAsync" /> on each retry with the raised exception, the current sleep duration, retry count, and context data.
-        /////     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        /////     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
-        ///// </summary>
-        ///// <param name="policyBuilder">The policy builder.</param>
-        ///// <param name="retryCount">The retry count.</param>
-        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
-        ///// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
-        ///// <returns>The policy instance.</returns>
-        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        ///// <exception cref="System.ArgumentNullException">
-        /////     sleepDurationProvider
-        /////     or
-        /////     onRetryAsync
-        ///// </exception>
-        //public static RetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
-        //    Func<int, Exception, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, int, Context, Task> onRetryAsync)
-        //{
         //    if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
         //    if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
         //    if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
@@ -663,15 +597,81 @@ namespace Polly
         //            cancellationToken,
         //            policyBuilder.ExceptionPredicates,
         //            PredicateHelper<EmptyStruct>.EmptyResultPredicates,
-        //            () => new RetryStateWaitAndRetryWithProvider<EmptyStruct>(
-        //                retryCount, 
-        //                (i, outcome, ctx) => sleepDurationProvider(i, outcome.Exception, ctx), 
-        //                (outcome, timespan, i, ctx) => onRetryAsync(outcome.Exception, timespan, i, ctx), 
-        //                context), 
+        //            () => new RetryStateWaitAndRetryWithProvider<EmptyStruct>(retryCount, sleepDurationProvider, (outcome, timespan, i, ctx) => onRetryAsync(outcome.Exception, timespan, i, ctx), context), 
         //            continueOnCapturedContext),
         //        policyBuilder.ExceptionPredicates
         //    );
         //}
+
+        // For v560waitDurationFromErrorResponse: delete the overload above, and replace with the two below
+
+        /// <summary>
+        ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
+        ///     calling <paramref name="onRetryAsync" /> on each retry with the raised exception, the current sleep duration, retry count, and context data.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
+        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="retryCount">The retry count.</param>
+        /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        /// <exception cref="System.ArgumentNullException">
+        ///     sleepDurationProvider
+        ///     or
+        ///     onRetryAsync
+        /// </exception>
+        public static RetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
+            Func<int, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, int, Context, Task> onRetryAsync)
+        {
+            return policyBuilder.WaitAndRetryAsync(
+                retryCount,
+                (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+                onRetryAsync);
+        }
+
+        /// <summary>
+        ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
+        ///     calling <paramref name="onRetryAsync" /> on each retry with the raised exception, the current sleep duration, retry count, and context data.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
+        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="retryCount">The retry count.</param>
+        /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        /// <exception cref="System.ArgumentNullException">
+        ///     sleepDurationProvider
+        ///     or
+        ///     onRetryAsync
+        /// </exception>
+        public static RetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
+            Func<int, Exception, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, int, Context, Task> onRetryAsync)
+        {
+            if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
+
+            return new RetryPolicy(
+                (action, context, cancellationToken, continueOnCapturedContext) =>
+                  RetryEngine.ImplementationAsync(
+                    async (ctx, ct) => { await action(ctx, ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
+                    context,
+                    cancellationToken,
+                    policyBuilder.ExceptionPredicates,
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
+                    () => new RetryStateWaitAndRetryWithProvider<EmptyStruct>(
+                        retryCount,
+                        (i, outcome, ctx) => sleepDurationProvider(i, outcome.Exception, ctx),
+                        (outcome, timespan, i, ctx) => onRetryAsync(outcome.Exception, timespan, i, ctx),
+                        context),
+                    continueOnCapturedContext),
+                policyBuilder.ExceptionPredicates
+            );
+        }
 
         /// <summary>
         ///     Builds a <see cref="Policy" /> that will wait and retry as many times as there are provided

--- a/src/Polly.Shared/Retry/RetryTResultSyntax.cs
+++ b/src/Polly.Shared/Retry/RetryTResultSyntax.cs
@@ -277,7 +277,7 @@ namespace Polly
         /// <param name="retryCount">The retry count.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <returns>The policy instance.</returns>
-        public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider)
+        public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider)
         {
             Action<DelegateResult<TResult>, TimeSpan, int, Context> doNothing = (_, __, ___, ____) => { };
 
@@ -301,7 +301,7 @@ namespace Polly
         /// or
         /// onRetry
         /// </exception>
-        public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
+        public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
         {
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
@@ -329,7 +329,7 @@ namespace Polly
         /// or
         /// onRetry
         /// </exception>
-        public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
+        public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
         {
             if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));

--- a/src/Polly.Shared/Retry/RetryTResultSyntax.cs
+++ b/src/Polly.Shared/Retry/RetryTResultSyntax.cs
@@ -344,9 +344,72 @@ namespace Polly
                     policyBuilder.ResultPredicates,
                     () => new RetryStateWaitAndRetryWithProvider<TResult>(retryCount, sleepDurationProvider, onRetry, context)
                 ),
-            policyBuilder.ExceptionPredicates,
-            policyBuilder.ResultPredicates);
+                policyBuilder.ExceptionPredicates,
+                policyBuilder.ResultPredicates);
         }
+
+        // For v560waitDurationFromErrorResponse: delete the overload above, and replace with the two below
+
+        ///// <summary>
+        ///// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
+        ///// calling <paramref name="onRetry"/> on each retry with the handled exception or result, current sleep duration, retry count, and context data.
+        ///// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
+        ///// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///// </summary>
+        ///// <param name="policyBuilder">The policy builder.</param>
+        ///// <param name="retryCount">The retry count.</param>
+        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        ///// <param name="onRetry">The action to call on each retry.</param>
+        ///// <returns>The policy instance.</returns>
+        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        ///// <exception cref="System.ArgumentNullException">
+        ///// timeSpanProvider
+        ///// or
+        ///// onRetry
+        ///// </exception>
+        //public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
+        //{
+        //    return policyBuilder.WaitAndRetry(
+        //        retryCount,
+        //        (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+        //        onRetry);
+        //}
+
+        ///// <summary>
+        ///// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
+        ///// calling <paramref name="onRetry"/> on each retry with the handled exception or result, current sleep duration, retry count, and context data.
+        ///// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
+        ///// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///// </summary>
+        ///// <param name="policyBuilder">The policy builder.</param>
+        ///// <param name="retryCount">The retry count.</param>
+        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        ///// <param name="onRetry">The action to call on each retry.</param>
+        ///// <returns>The policy instance.</returns>
+        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        ///// <exception cref="System.ArgumentNullException">
+        ///// timeSpanProvider
+        ///// or
+        ///// onRetry
+        ///// </exception>
+        //public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
+        //{
+        //    if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
+        //    if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+        //    if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
+
+        //    return new RetryPolicy<TResult>(
+        //        (action, context, cancellationToken) => RetryEngine.Implementation(
+        //            action,
+        //            context,
+        //            cancellationToken,
+        //            policyBuilder.ExceptionPredicates,
+        //            policyBuilder.ResultPredicates,
+        //            () => new RetryStateWaitAndRetryWithProvider<TResult>(retryCount, sleepDurationProvider, onRetry, context)
+        //        ),
+        //    policyBuilder.ExceptionPredicates,
+        //    policyBuilder.ResultPredicates);
+        //}
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry as many times as there are provided <paramref name="sleepDurations"/>

--- a/src/Polly.Shared/Retry/RetryTResultSyntaxAsync.cs
+++ b/src/Polly.Shared/Retry/RetryTResultSyntaxAsync.cs
@@ -607,6 +607,73 @@ namespace Polly
             );
         }
 
+        // For v560waitDurationFromErrorResponse: delete the overload above, and replace with the two below
+
+        ///// <summary>
+        /////     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
+        /////     calling <paramref name="onRetryAsync" /> on each retry with the handled exception or result, the current sleep duration, retry count, and context data.
+        /////     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
+        /////     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///// </summary>
+        ///// <param name="policyBuilder">The policy builder.</param>
+        ///// <param name="retryCount">The retry count.</param>
+        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        ///// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        ///// <returns>The policy instance.</returns>
+        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        ///// <exception cref="System.ArgumentNullException">
+        /////     sleepDurationProvider
+        /////     or
+        /////     onRetryAsync
+        ///// </exception>
+        //public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
+        //    Func<int, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync)
+        //{
+        //    return policyBuilder.WaitAndRetryAsync(
+        //        retryCount,
+        //        (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+        //        onRetryAsync);
+        //}
+
+        ///// <summary>
+        /////     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
+        /////     calling <paramref name="onRetryAsync" /> on each retry with the handled exception or result, the current sleep duration, retry count, and context data.
+        /////     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
+        /////     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///// </summary>
+        ///// <param name="policyBuilder">The policy builder.</param>
+        ///// <param name="retryCount">The retry count.</param>
+        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        ///// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        ///// <returns>The policy instance.</returns>
+        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        ///// <exception cref="System.ArgumentNullException">
+        /////     sleepDurationProvider
+        /////     or
+        /////     onRetryAsync
+        ///// </exception>
+        //public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
+        //    Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync)
+        //{
+        //    if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
+        //    if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+        //    if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
+
+        //    return new RetryPolicy<TResult>(
+        //        (action, context, cancellationToken, continueOnCapturedContext) =>
+        //          RetryEngine.ImplementationAsync(
+        //            action,
+        //            context,
+        //            cancellationToken,
+        //            policyBuilder.ExceptionPredicates,
+        //            policyBuilder.ResultPredicates,
+        //            () => new RetryStateWaitAndRetryWithProvider<TResult>(retryCount, sleepDurationProvider, onRetryAsync, context), 
+        //            continueOnCapturedContext),
+        //        policyBuilder.ExceptionPredicates,
+        //        policyBuilder.ResultPredicates
+        //    );
+        //}
+
         /// <summary>
         ///     Builds a <see cref="Policy" /> that will wait and retry as many times as there are provided
         ///     <paramref name="sleepDurations" />

--- a/src/Polly.Shared/Retry/RetryTResultSyntaxAsync.cs
+++ b/src/Polly.Shared/Retry/RetryTResultSyntaxAsync.cs
@@ -497,7 +497,7 @@ namespace Polly
         ///     onRetry
         /// </exception>
         public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
-            Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
+            Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
         {
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
@@ -527,7 +527,7 @@ namespace Polly
         ///     or
         ///     onRetryAsync
         /// </exception>
-        public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, Context, Task> onRetryAsync)
+        public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, Context, Task> onRetryAsync)
         {
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
@@ -555,7 +555,7 @@ namespace Polly
         ///     or
         ///     onRetry
         /// </exception>
-        public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
+        public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
         {
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
@@ -567,73 +567,6 @@ namespace Polly
 #pragma warning restore 1998
             );
         }
-
-        /// <summary>
-        ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
-        ///     calling <paramref name="onRetryAsync" /> on each retry with the handled exception or result, the current sleep duration, retry count, and context data.
-        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
-        /// </summary>
-        /// <param name="policyBuilder">The policy builder.</param>
-        /// <param name="retryCount">The retry count.</param>
-        /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
-        /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
-        /// <returns>The policy instance.</returns>
-        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="System.ArgumentNullException">
-        ///     sleepDurationProvider
-        ///     or
-        ///     onRetryAsync
-        /// </exception>
-        public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
-            Func<int, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync)
-        {
-            if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
-            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
-
-            return new RetryPolicy<TResult>(
-                (action, context, cancellationToken, continueOnCapturedContext) =>
-                  RetryEngine.ImplementationAsync(
-                    action,
-                    context,
-                    cancellationToken,
-                    policyBuilder.ExceptionPredicates,
-                    policyBuilder.ResultPredicates,
-                    () => new RetryStateWaitAndRetryWithProvider<TResult>(retryCount, sleepDurationProvider, onRetryAsync, context), 
-                    continueOnCapturedContext),
-                policyBuilder.ExceptionPredicates,
-                policyBuilder.ResultPredicates
-            );
-        }
-
-        // For v560waitDurationFromErrorResponse: delete the overload above, and replace with the two below
-
-        ///// <summary>
-        /////     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
-        /////     calling <paramref name="onRetryAsync" /> on each retry with the handled exception or result, the current sleep duration, retry count, and context data.
-        /////     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        /////     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
-        ///// </summary>
-        ///// <param name="policyBuilder">The policy builder.</param>
-        ///// <param name="retryCount">The retry count.</param>
-        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
-        ///// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
-        ///// <returns>The policy instance.</returns>
-        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        ///// <exception cref="System.ArgumentNullException">
-        /////     sleepDurationProvider
-        /////     or
-        /////     onRetryAsync
-        ///// </exception>
-        //public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
-        //    Func<int, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync)
-        //{
-        //    return policyBuilder.WaitAndRetryAsync(
-        //        retryCount,
-        //        (i, outcome, ctx) => sleepDurationProvider(i, ctx),
-        //        onRetryAsync);
-        //}
 
         ///// <summary>
         /////     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
@@ -673,6 +606,73 @@ namespace Polly
         //        policyBuilder.ResultPredicates
         //    );
         //}
+
+        // For v560waitDurationFromErrorResponse: delete the overload above, and replace with the two below
+
+        /// <summary>
+        ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
+        ///     calling <paramref name="onRetryAsync" /> on each retry with the handled exception or result, the current sleep duration, retry count, and context data.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
+        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="retryCount">The retry count.</param>
+        /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        /// <exception cref="System.ArgumentNullException">
+        ///     sleepDurationProvider
+        ///     or
+        ///     onRetryAsync
+        /// </exception>
+        public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
+            Func<int, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync)
+        {
+            return policyBuilder.WaitAndRetryAsync(
+                retryCount,
+                (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+                onRetryAsync);
+        }
+
+        /// <summary>
+        ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
+        ///     calling <paramref name="onRetryAsync" /> on each retry with the handled exception or result, the current sleep duration, retry count, and context data.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
+        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="retryCount">The retry count.</param>
+        /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        /// <exception cref="System.ArgumentNullException">
+        ///     sleepDurationProvider
+        ///     or
+        ///     onRetryAsync
+        /// </exception>
+        public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
+            Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync)
+        {
+            if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
+
+            return new RetryPolicy<TResult>(
+                (action, context, cancellationToken, continueOnCapturedContext) =>
+                  RetryEngine.ImplementationAsync(
+                    action,
+                    context,
+                    cancellationToken,
+                    policyBuilder.ExceptionPredicates,
+                    policyBuilder.ResultPredicates,
+                    () => new RetryStateWaitAndRetryWithProvider<TResult>(retryCount, sleepDurationProvider, onRetryAsync, context),
+                    continueOnCapturedContext),
+                policyBuilder.ExceptionPredicates,
+                policyBuilder.ResultPredicates
+            );
+        }
 
         /// <summary>
         ///     Builds a <see cref="Policy" /> that will wait and retry as many times as there are provided

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetryAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetryAsyncSpecs.cs
@@ -560,6 +560,45 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
+        public async Task Should_calculate_retry_timespans_from_current_retry_attempt_and_timespan_provider_with_exception_handling()
+        {
+            var expectedRetryWaits = new[]
+                {
+                    2.Seconds(),
+                    4.Seconds(),
+                    8.Seconds(),
+                    16.Seconds(),
+                    32.Seconds()
+                };
+
+            object capturedExceptionInstance = null;
+
+            DivideByZeroException exceptionInstance = new DivideByZeroException() {
+                
+            };
+
+            var actualRetryWaits = new List<TimeSpan>();
+
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .WaitAndRetryAsync(5,
+                    sleepDurationProvider:( retries,  ex,  ctx) =>
+                    {
+                        capturedExceptionInstance = ex;
+                        return TimeSpan.FromMilliseconds(10);
+                    },
+                    onRetryAsync: ( ts,  i,  ctx,  task) =>
+                    {
+                        return TaskHelper.EmptyTask;
+                    }
+                );
+
+            await policy.RaiseExceptionAsync(exceptionInstance);
+            capturedExceptionInstance.Should().Be(exceptionInstance);
+            
+        }
+
+        [Fact]
         public async Task Should_be_able_to_pass_retry_duration_from_execution_to_sleepDurationProvider_via_context()
         {
             var expectedRetryDuration = 1.Seconds();


### PR DESCRIPTION
Merge down to v560dev branch, of @matst80 implementation of determining WaitAndRetry wait duration from error response