### PR TITLE
WaitAndRetry/Forever: calc wait from error response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 5.6.0
 - Bug fix: set context keys for generic execute method with PolicyWrap
 - Add GetPolicies extension method to IPolicyWrap
+- Allow WaitAndRetry policies to calculate wait based on the handled fault
 
 ## 5.5.0
 - Bug fix: non-generic CachePolicy with PolicyWrap

--- a/README.md
+++ b/README.md
@@ -939,6 +939,8 @@ For details of changes by release see the [change log](https://github.com/App-vN
 * [@Extremo75](https://github.com/ExtRemo75) - Allow fallback delegates to take handled fault as input parameter.
 * [@reisenberger](https://github.com/reisenberger) and [@seanfarrow](https://github.com/SeanFarrow) - Add CachePolicy, with interfaces for pluggable cache providers and serializers.
 * [@MartinSStewart](https://github.com/martinsstewart) - Add GetPolicies extension method to IPolicyWrap.
+* [@matst80](https://github.com/matst80) - Allow WaitAndRetry to take handled fault as an input to the sleepDurationProvider, allowing WaitAndRetry to take account of systems which specify a duration to wait as part of a fault response; eg Azure Cosmos DB may specify this in `x-ms-retry-after-ms` headers or in a property to an exception thrown by the Azure SDK.
+* [@reisenberger](https://github.com/reisenberger) - Allow WaitAndRetryForever to take handled fault as an input to the sleepDurationProvider.
 
 # Sample Projects
 

--- a/src/Polly.Net40Async.nuspec
+++ b/src/Polly.Net40Async.nuspec
@@ -19,6 +19,7 @@
      ---------------------
      - Bug fix: set context keys for generic execute method with PolicyWrap
      - Add GetPolicies extension method to IPolicyWrap
+     - Allow WaitAndRetry policies to calculate wait based on the handled fault
 
      5.5.0
      ---------------------

--- a/src/Polly.Shared/Retry/RetrySyntax.cs
+++ b/src/Polly.Shared/Retry/RetrySyntax.cs
@@ -306,46 +306,7 @@ namespace Polly
                 );
         }
 
-        ///// <summary>
-        ///// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
-        ///// calling <paramref name="onRetry"/> on each retry with the raised exception, current sleep duration, retry count, and context data.
-        ///// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
-        ///// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
-        ///// </summary>
-        ///// <param name="policyBuilder">The policy builder.</param>
-        ///// <param name="retryCount">The retry count.</param>
-        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
-        ///// <param name="onRetry">The action to call on each retry.</param>
-        ///// <returns>The policy instance.</returns>
-        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        ///// <exception cref="System.ArgumentNullException">
-        ///// timeSpanProvider
-        ///// or
-        ///// onRetry
-        ///// </exception>
-        //public static RetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, int, Context> onRetry)
-        //{
-        //    if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
-        //    if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-        //    if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
-        //    return new RetryPolicy(
-        //        (action, context, cancellationToken) => RetryEngine.Implementation(
-        //        (ctx, ct) => { action(ctx, ct); return EmptyStruct.Instance; },
-        //        context,
-        //        cancellationToken,
-        //        policyBuilder.ExceptionPredicates,
-        //        PredicateHelper<EmptyStruct>.EmptyResultPredicates,
-        //        () => new RetryStateWaitAndRetryWithProvider<EmptyStruct>(
-        //            retryCount,
-        //            sleepDurationProvider,
-        //            (outcome, timespan, i, ctx) => onRetry(outcome.Exception, timespan, i, ctx),
-        //            context)
-        //    ), policyBuilder.ExceptionPredicates);
-        //}
-
-        // For v560waitDurationFromErrorResponse: delete the overload above, and replace with the two below
-
+        
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
         /// calling <paramref name="onRetry"/> on each retry with the raised exception, current sleep duration, retry count, and context data.
@@ -365,6 +326,7 @@ namespace Polly
         /// </exception>
         public static RetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, int, Context> onRetry)
         {
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             return policyBuilder.WaitAndRetry(
                 retryCount,
                 (i, outcome, ctx) => sleepDurationProvider(i, ctx),
@@ -393,8 +355,6 @@ namespace Polly
             if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
-            //var wrappedEmptyStruct = new Action<DelegateResult<EmptyStruct>, TimeSpan, int, Context>() 
 
             return new RetryPolicy(
                 (action, context, cancellationToken) => RetryEngine.Implementation(
@@ -564,15 +524,37 @@ namespace Polly
         public static RetryPolicy WaitAndRetryForever(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, Context> onRetry)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+            return policyBuilder.WaitAndRetryForever(
+                (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+                onRetry
+            );
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
+        /// calling <paramref name="onRetry"/> on each retry with the raised exception and
+        /// execution context.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onRetry</exception>
+        public static RetryPolicy WaitAndRetryForever(this PolicyBuilder policyBuilder, Func<int, Exception, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, Context> onRetry)
+        {
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return new RetryPolicy((action, context, cancellationToken) => RetryEngine.Implementation(
                 (ctx, ct) => { action(ctx, ct); return EmptyStruct.Instance; },
-                context, 
+                context,
                 cancellationToken,
                 policyBuilder.ExceptionPredicates,
                 PredicateHelper<EmptyStruct>.EmptyResultPredicates,
-                () => new RetryStateWaitAndRetryForever<EmptyStruct>(sleepDurationProvider, (outcome, timespan, ctx) => onRetry(outcome.Exception, timespan, ctx), context)
+                () => new RetryStateWaitAndRetryForever<EmptyStruct>(
+                    (i, outcome, ctx) => sleepDurationProvider(i, outcome.Exception, ctx), 
+                    (outcome, timespan, ctx) => onRetry(outcome.Exception, timespan, ctx), context)
             ), policyBuilder.ExceptionPredicates);
         }
     }

--- a/src/Polly.Shared/Retry/RetrySyntaxAsync.cs
+++ b/src/Polly.Shared/Retry/RetrySyntaxAsync.cs
@@ -565,46 +565,6 @@ namespace Polly
             );
         }
 
-        ///// <summary>
-        /////     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
-        /////     calling <paramref name="onRetryAsync" /> on each retry with the raised exception, the current sleep duration, retry count, and context data.
-        /////     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        /////     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
-        ///// </summary>
-        ///// <param name="policyBuilder">The policy builder.</param>
-        ///// <param name="retryCount">The retry count.</param>
-        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
-        ///// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
-        ///// <returns>The policy instance.</returns>
-        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        ///// <exception cref="System.ArgumentNullException">
-        /////     sleepDurationProvider
-        /////     or
-        /////     onRetryAsync
-        ///// </exception>
-        //public static RetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
-        //    Func<int, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, int, Context, Task> onRetryAsync)
-        //{
-        //    if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
-        //    if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-        //    if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
-
-        //    return new RetryPolicy(
-        //        (action, context, cancellationToken, continueOnCapturedContext) =>
-        //          RetryEngine.ImplementationAsync(
-        //            async (ctx, ct) => { await action(ctx, ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
-        //            context,
-        //            cancellationToken,
-        //            policyBuilder.ExceptionPredicates,
-        //            PredicateHelper<EmptyStruct>.EmptyResultPredicates,
-        //            () => new RetryStateWaitAndRetryWithProvider<EmptyStruct>(retryCount, sleepDurationProvider, (outcome, timespan, i, ctx) => onRetryAsync(outcome.Exception, timespan, i, ctx), context), 
-        //            continueOnCapturedContext),
-        //        policyBuilder.ExceptionPredicates
-        //    );
-        //}
-
-        // For v560waitDurationFromErrorResponse: delete the overload above, and replace with the two below
-
         /// <summary>
         ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
         ///     calling <paramref name="onRetryAsync" /> on each retry with the raised exception, the current sleep duration, retry count, and context data.
@@ -625,6 +585,7 @@ namespace Polly
         public static RetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
             Func<int, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, int, Context, Task> onRetryAsync)
         {
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             return policyBuilder.WaitAndRetryAsync(
                 retryCount,
                 (i, outcome, ctx) => sleepDurationProvider(i, ctx),
@@ -966,6 +927,26 @@ namespace Polly
         public static RetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, Context, Task> onRetryAsync)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+            return policyBuilder.WaitAndRetryForeverAsync(
+                (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+                onRetryAsync
+            );
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait and retry indefinitely
+        /// calling <paramref name="onRetryAsync"/> on each retry with the raised exception and
+        /// execution context.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
+        /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onRetryAsync</exception>        
+        public static RetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, Exception, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, Context, Task> onRetryAsync)
+        {
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             return new RetryPolicy(
@@ -976,9 +957,12 @@ namespace Polly
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     PredicateHelper<EmptyStruct>.EmptyResultPredicates,
-                () => new RetryStateWaitAndRetryForever<EmptyStruct>(sleepDurationProvider, (outcome, timespan, ctx) => onRetryAsync(outcome.Exception, timespan, ctx), context),
-                continueOnCapturedContext
-            ), policyBuilder.ExceptionPredicates);
+                    () => new RetryStateWaitAndRetryForever<EmptyStruct>(
+                        (i, outcome, ctx) => sleepDurationProvider(i, outcome.Exception, ctx),
+                        (outcome, timespan, ctx) => onRetryAsync(outcome.Exception, timespan, ctx), 
+                        context),
+                    continueOnCapturedContext
+                  ), policyBuilder.ExceptionPredicates);
         }
     }
 }

--- a/src/Polly.Shared/Retry/RetryTResultSyntax.cs
+++ b/src/Polly.Shared/Retry/RetryTResultSyntax.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Polly.Retry;
 using System.Linq;
-using System.Runtime.InteropServices.ComTypes;
 
 namespace Polly
 {

--- a/src/Polly.Shared/Retry/RetryTResultSyntaxAsync.cs
+++ b/src/Polly.Shared/Retry/RetryTResultSyntaxAsync.cs
@@ -497,7 +497,7 @@ namespace Polly
         ///     onRetry
         /// </exception>
         public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
-            Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
+            Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
         {
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
@@ -527,7 +527,7 @@ namespace Polly
         ///     or
         ///     onRetryAsync
         /// </exception>
-        public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, Context, Task> onRetryAsync)
+        public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, Context, Task> onRetryAsync)
         {
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
@@ -555,7 +555,7 @@ namespace Polly
         ///     or
         ///     onRetry
         /// </exception>
-        public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
+        public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
         {
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
@@ -567,47 +567,6 @@ namespace Polly
 #pragma warning restore 1998
             );
         }
-
-        ///// <summary>
-        /////     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
-        /////     calling <paramref name="onRetryAsync" /> on each retry with the handled exception or result, the current sleep duration, retry count, and context data.
-        /////     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        /////     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
-        ///// </summary>
-        ///// <param name="policyBuilder">The policy builder.</param>
-        ///// <param name="retryCount">The retry count.</param>
-        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
-        ///// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
-        ///// <returns>The policy instance.</returns>
-        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        ///// <exception cref="System.ArgumentNullException">
-        /////     sleepDurationProvider
-        /////     or
-        /////     onRetryAsync
-        ///// </exception>
-        //public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
-        //    Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync)
-        //{
-        //    if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
-        //    if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-        //    if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
-
-        //    return new RetryPolicy<TResult>(
-        //        (action, context, cancellationToken, continueOnCapturedContext) =>
-        //          RetryEngine.ImplementationAsync(
-        //            action,
-        //            context,
-        //            cancellationToken,
-        //            policyBuilder.ExceptionPredicates,
-        //            policyBuilder.ResultPredicates,
-        //            () => new RetryStateWaitAndRetryWithProvider<TResult>(retryCount, sleepDurationProvider, onRetryAsync, context), 
-        //            continueOnCapturedContext),
-        //        policyBuilder.ExceptionPredicates,
-        //        policyBuilder.ResultPredicates
-        //    );
-        //}
-
-        // For v560waitDurationFromErrorResponse: delete the overload above, and replace with the two below
 
         /// <summary>
         ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
@@ -629,6 +588,7 @@ namespace Polly
         public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
             Func<int, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync)
         {
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             return policyBuilder.WaitAndRetryAsync(
                 retryCount,
                 (i, outcome, ctx) => sleepDurationProvider(i, ctx),
@@ -967,19 +927,39 @@ namespace Polly
         public static RetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, Context, Task> onRetryAsync)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+            return policyBuilder.WaitAndRetryForeverAsync(
+                (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+                onRetryAsync
+            );
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
+        /// calling <paramref name="onRetryAsync"/> on each retry with the handled exception or result and
+        /// execution context.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
+        /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onRetryAsync</exception>        
+        public static RetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, Context, Task> onRetryAsync)
+        {
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             return new RetryPolicy<TResult>(
                 (action, context, cancellationToken, continueOnCapturedContext) =>
-                  RetryEngine.ImplementationAsync(
-                    action,
-                    context,
-                    cancellationToken,
-                    policyBuilder.ExceptionPredicates,
-                    policyBuilder.ResultPredicates,
-                    () => new RetryStateWaitAndRetryForever<TResult>(sleepDurationProvider, onRetryAsync, context),
-                    continueOnCapturedContext
-                ), 
+                    RetryEngine.ImplementationAsync(
+                        action,
+                        context,
+                        cancellationToken,
+                        policyBuilder.ExceptionPredicates,
+                        policyBuilder.ResultPredicates,
+                        () => new RetryStateWaitAndRetryForever<TResult>(sleepDurationProvider, onRetryAsync, context),
+                        continueOnCapturedContext
+                    ),
                 policyBuilder.ExceptionPredicates,
                 policyBuilder.ResultPredicates);
         }

--- a/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
+++ b/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
@@ -80,8 +80,12 @@
     <Compile Include="$(MSBuildThisFileDirectory)Retry\RetryTResultSpecsAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Retry\WaitAndRetryAsyncSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Retry\WaitAndRetryForeverAsyncSpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Retry\WaitAndRetryForeverTResultAsyncSpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Retry\WaitAndRetryForeverTResultSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Retry\WaitAndRetrySpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Retry\WaitAndRetryForeverSpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Retry\WaitAndRetryTResultAsyncSpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Retry\WaitAndRetryTResultSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Timeout\TimeoutAsyncSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Timeout\TimeoutSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Timeout\TimeoutSpecsBase.cs" />

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverAsyncSpecs.cs
@@ -288,6 +288,42 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
+        public async Task Should_be_able_to_calculate_retry_timespans_based_on_the_handled_fault()
+        {
+            Dictionary<Exception, TimeSpan> expectedRetryWaits = new Dictionary<Exception, TimeSpan>(){
+
+                {new DivideByZeroException(), 2.Seconds()},
+                {new ArgumentNullException(), 4.Seconds()},
+            };
+
+            var actualRetryWaits = new List<TimeSpan>();
+
+            var policy = Policy
+                .Handle<Exception>()
+                .WaitAndRetryForeverAsync(
+                    sleepDurationProvider: (retryAttempt, exc, ctx) =>
+                    {
+                        return expectedRetryWaits[exc];
+                    },
+                    onRetryAsync: (_, timeSpan, __) =>
+                    {
+                        actualRetryWaits.Add(timeSpan);
+                        return TaskHelper.EmptyTask;
+                    });
+
+            using (var enumerator = expectedRetryWaits.GetEnumerator())
+            {
+                await policy.ExecuteAsync(() => {
+                    if (enumerator.MoveNext()) throw enumerator.Current.Key;
+                    return TaskHelper.EmptyTask;
+                });
+            }
+
+            actualRetryWaits.Should().ContainInOrder(expectedRetryWaits.Values);
+        }
+
+
+        [Fact]
         public async Task Should_be_able_to_pass_retry_duration_from_execution_to_sleepDurationProvider_via_context()
         {
             var expectedRetryDuration = 1.Seconds();

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverSpecs.cs
@@ -35,9 +35,11 @@ namespace Polly.Specs.Retry
         {
             Action<Exception, TimeSpan, Context> onRetry = (_, __, ___) => { };
 
+            Func<int, Context, TimeSpan> sleepDurationProvider = null;
+
             Action policy = () => Policy
                                       .Handle<DivideByZeroException>()
-                                      .WaitAndRetryForever(null, onRetry);
+                                      .WaitAndRetryForever(sleepDurationProvider, onRetry);
 
             policy.ShouldThrow<ArgumentNullException>().And
                   .ParamName.Should().Be("sleepDurationProvider");
@@ -281,6 +283,32 @@ namespace Polly.Specs.Retry
 
             actualRetryWaits.Should()
                        .ContainInOrder(expectedRetryWaits);
+        }
+
+        [Fact]
+        public void Should_be_able_to_calculate_retry_timespans_based_on_the_handled_fault()
+        {
+            Dictionary<Exception, TimeSpan> expectedRetryWaits = new Dictionary<Exception, TimeSpan>(){
+
+                {new DivideByZeroException(), 2.Seconds()},
+                {new ArgumentNullException(), 4.Seconds()},
+            };
+
+            var actualRetryWaits = new List<TimeSpan>();
+
+            var policy = Policy
+                .Handle<Exception>()
+                .WaitAndRetryForever(
+                    (retryAttempt, exc, ctx) => expectedRetryWaits[exc],
+                    (_, timeSpan, __) => actualRetryWaits.Add(timeSpan)
+                );
+
+            using (var enumerator = expectedRetryWaits.GetEnumerator())
+            {
+                policy.Execute(() => { if (enumerator.MoveNext()) throw enumerator.Current.Key; });
+            }
+
+            actualRetryWaits.Should().ContainInOrder(expectedRetryWaits.Values);
         }
 
         [Fact]

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverTResultAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverTResultAsyncSpecs.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using FluentAssertions;
+using Polly.Specs.Helpers;
+using Polly.Utilities;
+using Xunit;
+
+namespace Polly.Specs.Retry
+{
+    [Collection("SystemClockDependantCollection")]
+    public class WaitAndRetryForeverTResultAsyncSpecs : IDisposable
+    {
+        public WaitAndRetryForeverTResultAsyncSpecs()
+        {
+            // do nothing on call to sleep
+            SystemClock.SleepAsync = (_, __) => TaskHelper.EmptyTask;
+        }
+
+        [Fact]
+        public async Task Should_be_able_to_calculate_retry_timespans_based_on_the_handled_fault()
+        {
+            Dictionary<ResultPrimitive, TimeSpan> expectedRetryWaits = new Dictionary<ResultPrimitive, TimeSpan>(){
+
+                {ResultPrimitive.Fault, 2.Seconds()},
+                {ResultPrimitive.FaultAgain, 4.Seconds()},
+            };
+
+            var actualRetryWaits = new List<TimeSpan>();
+
+            var policy = Policy
+                .HandleResult(ResultPrimitive.Fault)
+                .OrResult(ResultPrimitive.FaultAgain)
+                .WaitAndRetryForeverAsync(
+                    (retryAttempt, outcome, ctx) => expectedRetryWaits[outcome.Result],
+                    (_, timeSpan, __) =>
+                    {
+                        actualRetryWaits.Add(timeSpan);
+                        return TaskHelper.EmptyTask;
+                    });
+
+            using (var enumerator = expectedRetryWaits.GetEnumerator())
+            {
+                await policy.ExecuteAsync(async () =>
+                {
+                    await TaskHelper.EmptyTask;
+                    if (enumerator.MoveNext()) return enumerator.Current.Key;
+                    else return ResultPrimitive.Undefined;
+                });
+            }
+
+            actualRetryWaits.Should().ContainInOrder(expectedRetryWaits.Values);
+        }
+
+        public void Dispose()
+        {
+            SystemClock.Reset();
+        }
+
+    }
+}

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverTResultSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverTResultSpecs.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Polly.Specs.Helpers;
+using Polly.Utilities;
+using Xunit;
+
+namespace Polly.Specs.Retry
+{
+    [Collection("SystemClockDependantCollection")]
+    public class WaitAndRetryForeverTResultSpecs : IDisposable
+    {
+        public WaitAndRetryForeverTResultSpecs()
+        {
+            // do nothing on call to sleep
+            SystemClock.Sleep = (_, __) => { };
+        }
+
+        [Fact]
+        public void Should_be_able_to_calculate_retry_timespans_based_on_the_handled_fault()
+        {
+            Dictionary<ResultPrimitive, TimeSpan> expectedRetryWaits = new Dictionary<ResultPrimitive, TimeSpan>(){
+
+                {ResultPrimitive.Fault, 2.Seconds()},
+                {ResultPrimitive.FaultAgain, 4.Seconds()},
+            };
+
+            var actualRetryWaits = new List<TimeSpan>();
+
+            var policy = Policy
+                .HandleResult(ResultPrimitive.Fault)
+                .OrResult(ResultPrimitive.FaultAgain)
+                .WaitAndRetryForever(
+                    (retryAttempt, outcome, ctx) => expectedRetryWaits[outcome.Result],
+                    (_, timeSpan, __) => actualRetryWaits.Add(timeSpan)
+                );
+
+            using (var enumerator = expectedRetryWaits.GetEnumerator())
+            {
+                policy.Execute(() =>
+                {
+                    if (enumerator.MoveNext()) return enumerator.Current.Key;
+                    else return ResultPrimitive.Undefined;
+                });
+            }
+
+            actualRetryWaits.Should().ContainInOrder(expectedRetryWaits.Values);
+        }
+
+        public void Dispose()
+        {
+            SystemClock.Reset();
+        }
+
+    }
+}

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetrySpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetrySpecs.cs
@@ -707,6 +707,57 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
+        public void Should_be_able_to_pass_handled_exception_to_sleepdurationprovider()
+        {
+            object capturedExceptionInstance = null;
+
+            DivideByZeroException exceptionInstance = new DivideByZeroException();
+
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .WaitAndRetry(5,
+                    sleepDurationProvider: (retries, ex, ctx) =>
+                    {
+                        capturedExceptionInstance = ex;
+                        return TimeSpan.FromMilliseconds(0);
+                    },
+                    onRetry: (ex, ts, i, ctx) =>
+                    {
+                    }
+                );
+
+            policy.RaiseException(exceptionInstance);
+
+            capturedExceptionInstance.Should().Be(exceptionInstance);
+        }
+
+        [Fact]
+        public void Should_be_able_to_calculate_retry_timespans_based_on_the_handled_fault()
+        {
+            Dictionary<Exception, TimeSpan> expectedRetryWaits = new Dictionary<Exception, TimeSpan>(){
+
+                {new DivideByZeroException(), 2.Seconds()},
+                {new ArgumentNullException(), 4.Seconds()},
+            };
+
+            var actualRetryWaits = new List<TimeSpan>();
+
+            var policy = Policy
+                .Handle<Exception>()
+                .WaitAndRetry(2,
+                    (retryAttempt, exc, ctx) => expectedRetryWaits[exc],
+                    (_, timeSpan, __, ___) => actualRetryWaits.Add(timeSpan)
+                );
+
+            using (var enumerator = expectedRetryWaits.GetEnumerator())
+            {
+                policy.Execute(() => { if (enumerator.MoveNext()) throw enumerator.Current.Key; });
+            }
+
+            actualRetryWaits.Should().ContainInOrder(expectedRetryWaits.Values);
+        }
+
+        [Fact]
         public void Should_be_able_to_pass_retry_duration_from_execution_to_sleepDurationProvider_via_context()
         {
             var expectedRetryDuration = 1.Seconds();
@@ -1138,12 +1189,12 @@ namespace Polly.Specs.Retry
             attemptsInvoked.Should().Be(1);
         }
 
+        #endregion
+
         public void Dispose()
         {
             SystemClock.Reset();
         }
-
-        #endregion
 
     }
 }

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetryTResultAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetryTResultAsyncSpecs.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using FluentAssertions;
+using Polly.Specs.Helpers;
+using Polly.Utilities;
+using Xunit;
+
+namespace Polly.Specs.Retry
+{
+    [Collection("SystemClockDependantCollection")]
+    public class WaitAndRetryTResultAsyncSpecs : IDisposable
+    {
+        public WaitAndRetryTResultAsyncSpecs()
+        {
+            // do nothing on call to sleep
+            SystemClock.SleepAsync = (_, __) => TaskHelper.EmptyTask;
+        }
+
+        [Fact]
+        public async Task Should_be_able_to_calculate_retry_timespans_based_on_the_handled_fault()
+        {
+            Dictionary<ResultPrimitive, TimeSpan> expectedRetryWaits = new Dictionary<ResultPrimitive, TimeSpan>(){
+
+                {ResultPrimitive.Fault, 2.Seconds()},
+                {ResultPrimitive.FaultAgain, 4.Seconds()},
+            };
+
+            var actualRetryWaits = new List<TimeSpan>();
+
+            var policy = Policy
+                .HandleResult(ResultPrimitive.Fault)
+                .OrResult(ResultPrimitive.FaultAgain)
+                .WaitAndRetryAsync(2,
+                    (retryAttempt, outcome, ctx) => expectedRetryWaits[outcome.Result],
+                    (_, timeSpan, __, ___) =>
+                    {
+                        actualRetryWaits.Add(timeSpan);
+                        return TaskHelper.EmptyTask;
+                    });
+
+            using (var enumerator = expectedRetryWaits.GetEnumerator())
+            {
+                await policy.ExecuteAsync(async () =>
+                {
+                    await TaskHelper.EmptyTask;
+                    if (enumerator.MoveNext()) return enumerator.Current.Key;
+                    else return ResultPrimitive.Undefined;
+                });
+            }
+
+            actualRetryWaits.Should().ContainInOrder(expectedRetryWaits.Values);
+        }
+
+        public void Dispose()
+        {
+            SystemClock.Reset();
+        }
+
+    }
+}

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetryTResultSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetryTResultSpecs.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Polly.Specs.Helpers;
+using Polly.Utilities;
+using Xunit;
+
+namespace Polly.Specs.Retry
+{
+    [Collection("SystemClockDependantCollection")]
+    public class WaitAndRetryTResultSpecs : IDisposable
+    {
+        public WaitAndRetryTResultSpecs()
+        {
+            // do nothing on call to sleep
+            SystemClock.Sleep = (_, __) => { };
+        }
+
+        [Fact]
+        public void Should_be_able_to_calculate_retry_timespans_based_on_the_handled_fault()
+        {
+            Dictionary<ResultPrimitive, TimeSpan> expectedRetryWaits = new Dictionary<ResultPrimitive, TimeSpan>(){
+
+                {ResultPrimitive.Fault, 2.Seconds()},
+                {ResultPrimitive.FaultAgain, 4.Seconds()},
+            };
+
+            var actualRetryWaits = new List<TimeSpan>();
+
+            var policy = Policy
+                .HandleResult(ResultPrimitive.Fault)
+                .OrResult(ResultPrimitive.FaultAgain)
+                .WaitAndRetry(2,
+                    (retryAttempt, outcome, ctx) => expectedRetryWaits[outcome.Result],
+                    (_, timeSpan, __, ___) => actualRetryWaits.Add(timeSpan)
+                );
+
+            using (var enumerator = expectedRetryWaits.GetEnumerator())
+            {
+                policy.Execute(() =>
+                {
+                    if (enumerator.MoveNext()) return enumerator.Current.Key;
+                    else return ResultPrimitive.Undefined;
+                });
+            }
+
+            actualRetryWaits.Should().ContainInOrder(expectedRetryWaits.Values);
+        }
+
+        public void Dispose()
+        {
+            SystemClock.Reset();
+        }
+
+    }
+}

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -18,7 +18,8 @@
      5.6.0
      ---------------------
      - Bug fix: set context keys for generic execute method with PolicyWrap
-     - Add GetPolicies extension method to IPolicyWrap 
+     - Add GetPolicies extension method to IPolicyWrap
+     - Allow WaitAndRetry policies to calculate wait based on the handled fault
 
      5.5.0
      ---------------------


### PR DESCRIPTION
* Allow WaitAndRetryForever to take error as input to sleepDurationProvider.
* Tidy up overloads where WaitAndRetry takes error as input to sleepDurationProvider.
* Tests on both.