### PR TITLE
Make PolicyWrap configuration overloads take parameters as interfaces

### DIFF
--- a/src/Polly.Shared/Policy.TResult.cs
+++ b/src/Polly.Shared/Policy.TResult.cs
@@ -22,9 +22,7 @@ namespace Polly
             IEnumerable<ResultPredicate<TResult>> resultPredicates
             )
         {
-            if (executionPolicy == null) throw new ArgumentNullException(nameof(executionPolicy));
-
-            _executionPolicy = executionPolicy;
+            _executionPolicy = executionPolicy ?? throw new ArgumentNullException(nameof(executionPolicy));
             ExceptionPredicates = exceptionPredicates ?? PredicateHelper.EmptyExceptionPredicates;
             ResultPredicates = resultPredicates ?? PredicateHelper<TResult>.EmptyResultPredicates;
         }

--- a/src/Polly.Shared/Policy.cs
+++ b/src/Polly.Shared/Policy.cs
@@ -20,9 +20,7 @@ namespace Polly
             Action<Action<Context, CancellationToken>, Context, CancellationToken> exceptionPolicy,
             IEnumerable<ExceptionPredicate> exceptionPredicates)
         {
-            if (exceptionPolicy == null) throw new ArgumentNullException(nameof(exceptionPolicy));
-
-            _exceptionPolicy = exceptionPolicy;
+            _exceptionPolicy = exceptionPolicy ?? throw new ArgumentNullException(nameof(exceptionPolicy));
             ExceptionPredicates = exceptionPredicates ?? PredicateHelper.EmptyExceptionPredicates;
         }
 

--- a/src/Polly.Shared/PolicyAsync.TResult.cs
+++ b/src/Polly.Shared/PolicyAsync.TResult.cs
@@ -17,9 +17,7 @@ namespace Polly
             IEnumerable<ExceptionPredicate> exceptionPredicates,
             IEnumerable<ResultPredicate<TResult>> resultPredicates)
         {
-            if (asyncExecutionPolicy == null) throw new ArgumentNullException(nameof(asyncExecutionPolicy));
-
-            _asyncExecutionPolicy = asyncExecutionPolicy;
+            _asyncExecutionPolicy = asyncExecutionPolicy ?? throw new ArgumentNullException(nameof(asyncExecutionPolicy));
             ExceptionPredicates = exceptionPredicates ?? PredicateHelper.EmptyExceptionPredicates;
             ResultPredicates = resultPredicates ?? PredicateHelper<TResult>.EmptyResultPredicates;
         }

--- a/src/Polly.Shared/PolicyAsync.cs
+++ b/src/Polly.Shared/PolicyAsync.cs
@@ -15,9 +15,7 @@ namespace Polly
             Func<Func<Context, CancellationToken, Task>, Context, CancellationToken, bool, Task> asyncExceptionPolicy, 
             IEnumerable<ExceptionPredicate> exceptionPredicates)
         {
-            if (asyncExceptionPolicy == null) throw new ArgumentNullException(nameof(asyncExceptionPolicy));
-
-            _asyncExceptionPolicy = asyncExceptionPolicy;
+            _asyncExceptionPolicy = asyncExceptionPolicy ?? throw new ArgumentNullException(nameof(asyncExceptionPolicy));
             ExceptionPredicates = exceptionPredicates ?? PredicateHelper.EmptyExceptionPredicates;
         }
 

--- a/src/Polly.Shared/Wrap/PolicyWrap.cs
+++ b/src/Polly.Shared/Wrap/PolicyWrap.cs
@@ -9,8 +9,8 @@ namespace Polly.Wrap
     /// </summary>
     public partial class PolicyWrap : Policy, IPolicyWrap
     {
-        private Policy _outer;
-        private Policy _inner;
+        private IsPolicy _outer;
+        private IsPolicy _inner;
 
         /// <summary>
         /// Returns the outer <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>
@@ -22,7 +22,7 @@ namespace Polly.Wrap
         /// </summary>
         public IsPolicy Inner => _inner;
 
-        internal PolicyWrap(Action<Action<Context, CancellationToken>, Context, CancellationToken> policyAction, Policy outer, Policy inner) 
+        internal PolicyWrap(Action<Action<Context, CancellationToken>, Context, CancellationToken> policyAction, Policy outer, ISyncPolicy inner) 
             : base(policyAction, outer.ExceptionPredicates)
         {
             _outer = outer;
@@ -43,8 +43,8 @@ namespace Polly.Wrap
                    action,
                    context,
                    cancellationToken,
-                   _outer, 
-                   _inner
+                   (ISyncPolicy)_outer,
+                   (ISyncPolicy)_inner
                    );
         }
     }

--- a/src/Polly.Shared/Wrap/PolicyWrapAsync.cs
+++ b/src/Polly.Shared/Wrap/PolicyWrapAsync.cs
@@ -7,7 +7,7 @@ namespace Polly.Wrap
 {
     public partial class PolicyWrap : IPolicyWrap
     {
-        internal PolicyWrap(Func<Func<Context, CancellationToken, Task>, Context, CancellationToken, bool, Task> policyAction, Policy outer, Policy inner)
+        internal PolicyWrap(Func<Func<Context, CancellationToken, Task>, Context, CancellationToken, bool, Task> policyAction, Policy outer, IAsyncPolicy inner)
             : base(policyAction, outer.ExceptionPredicates)
         {
             _outer = outer;
@@ -30,8 +30,8 @@ namespace Polly.Wrap
                 context,
                 cancellationToken,
                 continueOnCapturedContext,
-                _outer,
-                _inner);
+                (IAsyncPolicy)_outer,
+                (IAsyncPolicy)_inner);
         }
     }
 

--- a/src/Polly.Shared/Wrap/PolicyWrapEngine.cs
+++ b/src/Polly.Shared/Wrap/PolicyWrapEngine.cs
@@ -9,8 +9,8 @@ namespace Polly.Wrap
             Func<Context, CancellationToken, TResult> func,
             Context context,
             CancellationToken cancellationToken,
-            Policy<TResult> outerPolicy,
-            Policy<TResult> innerPolicy)
+            ISyncPolicy<TResult> outerPolicy,
+            ISyncPolicy<TResult> innerPolicy)
         {
             return outerPolicy.Execute((ctx, ct) => innerPolicy.Execute(func, ctx, ct), context, cancellationToken);
         }
@@ -19,8 +19,8 @@ namespace Polly.Wrap
            Func<Context, CancellationToken, TResult> func,
            Context context,
            CancellationToken cancellationToken,
-           Policy<TResult> outerPolicy,
-           Policy innerPolicy)
+           ISyncPolicy<TResult> outerPolicy,
+           ISyncPolicy innerPolicy)
         {
             return outerPolicy.Execute((ctx, ct) => innerPolicy.Execute<TResult>(func, ctx, ct), context, cancellationToken);
         }
@@ -29,8 +29,8 @@ namespace Polly.Wrap
            Func<Context, CancellationToken, TResult> func,
            Context context,
            CancellationToken cancellationToken,
-           Policy outerPolicy,
-           Policy<TResult> innerPolicy)
+           ISyncPolicy outerPolicy,
+           ISyncPolicy<TResult> innerPolicy)
         {
             return outerPolicy.Execute<TResult>((ctx, ct) => innerPolicy.Execute(func, ctx, ct), context, cancellationToken);
         }
@@ -39,8 +39,8 @@ namespace Polly.Wrap
            Func<Context, CancellationToken, TResult> func,
            Context context,
            CancellationToken cancellationToken,
-           Policy outerPolicy,
-           Policy innerPolicy)
+           ISyncPolicy outerPolicy,
+           ISyncPolicy innerPolicy)
         {
             return outerPolicy.Execute<TResult>((ctx, ct) => innerPolicy.Execute<TResult>(func, ctx, ct), context, cancellationToken);
         }
@@ -49,8 +49,8 @@ namespace Polly.Wrap
            Action<Context, CancellationToken> action,
            Context context,
            CancellationToken cancellationToken, 
-           Policy outerPolicy,
-           Policy innerPolicy)
+           ISyncPolicy outerPolicy,
+           ISyncPolicy innerPolicy)
         {
             outerPolicy.Execute((ctx, ct) => innerPolicy.Execute(action, ctx, ct), context, cancellationToken);
         }

--- a/src/Polly.Shared/Wrap/PolicyWrapEngineAsync.cs
+++ b/src/Polly.Shared/Wrap/PolicyWrapEngineAsync.cs
@@ -11,8 +11,8 @@ namespace Polly.Wrap
             Context context,
             CancellationToken cancellationToken,
             bool continueOnCapturedContext,
-            Policy<TResult> outerPolicy,
-            Policy<TResult> innerPolicy)
+            IAsyncPolicy<TResult> outerPolicy,
+            IAsyncPolicy<TResult> innerPolicy)
         {
             return await outerPolicy.ExecuteAsync(
                 async (ctx, ct) => await innerPolicy.ExecuteAsync(
@@ -32,8 +32,8 @@ namespace Polly.Wrap
             Context context,
             CancellationToken cancellationToken,
             bool continueOnCapturedContext,
-            Policy<TResult> outerPolicy,
-            Policy innerPolicy)
+            IAsyncPolicy<TResult> outerPolicy,
+            IAsyncPolicy innerPolicy)
         {
             return await outerPolicy.ExecuteAsync(
                 async (ctx, ct) => await innerPolicy.ExecuteAsync<TResult>(
@@ -53,8 +53,8 @@ namespace Polly.Wrap
             Context context,
             CancellationToken cancellationToken,
             bool continueOnCapturedContext,
-            Policy outerPolicy,
-            Policy<TResult> innerPolicy)
+            IAsyncPolicy outerPolicy,
+            IAsyncPolicy<TResult> innerPolicy)
         {
             return await outerPolicy.ExecuteAsync<TResult>(
                 async (ctx, ct) => await innerPolicy.ExecuteAsync(
@@ -74,8 +74,8 @@ namespace Polly.Wrap
            Context context,
            CancellationToken cancellationToken,
            bool continueOnCapturedContext,
-           Policy outerPolicy,
-           Policy innerPolicy)
+           IAsyncPolicy outerPolicy,
+           IAsyncPolicy innerPolicy)
         {
             return await outerPolicy.ExecuteAsync<TResult>(
                 async (ctx, ct) => await innerPolicy.ExecuteAsync<TResult>(
@@ -95,8 +95,8 @@ namespace Polly.Wrap
             Context context,
             CancellationToken cancellationToken,
             bool continueOnCapturedContext,
-            Policy outerPolicy,
-            Policy innerPolicy)
+            IAsyncPolicy outerPolicy,
+            IAsyncPolicy innerPolicy)
         {
             await outerPolicy.ExecuteAsync(
                 async (ctx, ct) => await innerPolicy.ExecuteAsync(

--- a/src/Polly.Shared/Wrap/PolicyWrapSyntax.cs
+++ b/src/Polly.Shared/Wrap/PolicyWrapSyntax.cs
@@ -12,7 +12,7 @@ namespace Polly
         /// </summary>
         /// <param name="innerPolicy">The inner policy.</param>
         /// <returns>PolicyWrap.PolicyWrap.</returns>
-        public PolicyWrap Wrap(Policy innerPolicy)
+        public PolicyWrap Wrap(ISyncPolicy innerPolicy)
         {
             if (innerPolicy == null) throw new ArgumentNullException(nameof(innerPolicy));
 
@@ -29,7 +29,7 @@ namespace Polly
         /// <param name="innerPolicy">The inner policy.</param>
         /// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
         /// <returns>PolicyWrap.PolicyWrap.</returns>
-        public PolicyWrap<TResult> Wrap<TResult>(Policy<TResult> innerPolicy)
+        public PolicyWrap<TResult> Wrap<TResult>(ISyncPolicy<TResult> innerPolicy)
         {
             if (innerPolicy == null) throw new ArgumentNullException(nameof(innerPolicy));
 
@@ -48,7 +48,7 @@ namespace Polly
         /// </summary>
         /// <param name="innerPolicy">The inner policy.</param>
         /// <returns>PolicyWrap.PolicyWrap.</returns>
-        public PolicyWrap<TResult> Wrap(Policy innerPolicy)
+        public PolicyWrap<TResult> Wrap(ISyncPolicy innerPolicy)
         {
             if (innerPolicy == null) throw new ArgumentNullException(nameof(innerPolicy));
 
@@ -64,7 +64,7 @@ namespace Polly
         /// </summary>
         /// <param name="innerPolicy">The inner policy.</param>
         /// <returns>PolicyWrap.PolicyWrap.</returns>
-        public PolicyWrap<TResult> Wrap(Policy<TResult> innerPolicy)
+        public PolicyWrap<TResult> Wrap(ISyncPolicy<TResult> innerPolicy)
         {
             if (innerPolicy == null) throw new ArgumentNullException(nameof(innerPolicy));
 
@@ -84,16 +84,25 @@ namespace Polly
         /// <param name="policies">The policies to place in the wrap, outermost (at left) to innermost (at right).</param>
         /// <returns>The PolicyWrap.</returns>
         /// <exception cref="System.ArgumentException">The enumerable of policies to form the wrap must contain at least two policies.</exception>
-        public static PolicyWrap Wrap(params Policy[] policies)
+        public static PolicyWrap Wrap(params ISyncPolicy[] policies)
         {
             switch (policies.Length)
             {
                 case 0:
                 case 1:
                     throw new ArgumentException("The enumerable of policies to form the wrap must contain at least two policies.", nameof(policies));
+                case 2:
+                    return new PolicyWrap(
+                        (func, context, cancellationtoken) => PolicyWrapEngine.Implementation(
+                            func, 
+                            context, 
+                            cancellationtoken, 
+                            policies[0], 
+                            policies[1]), 
+                        (Policy)policies[0], policies[1]);
+
                 default:
-                    IEnumerable<Policy> remainder = policies.Skip(1);
-                    return policies.First().Wrap(remainder.Count() == 1 ? remainder.Single() : Wrap(remainder.ToArray()));
+                    return Wrap(policies[0], Wrap(policies.Skip(1).ToArray()));
             }
         }
 
@@ -104,16 +113,25 @@ namespace Polly
         /// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
         /// <returns>The PolicyWrap.</returns>
         /// <exception cref="System.ArgumentException">The enumerable of policies to form the wrap must contain at least two policies.</exception>
-        public static PolicyWrap<TResult> Wrap<TResult>(params Policy<TResult>[] policies)
+        public static PolicyWrap<TResult> Wrap<TResult>(params ISyncPolicy<TResult>[] policies)
         {
-            switch (policies.Count())
+            switch (policies.Length)
             {
                 case 0:
                 case 1:
                     throw new ArgumentException("The enumerable of policies to form the wrap must contain at least two policies.", nameof(policies));
+                case 2:
+                    return new PolicyWrap<TResult>(
+                        (func, context, cancellationtoken) => PolicyWrapEngine.Implementation(
+                            func,
+                            context,
+                            cancellationtoken,
+                            policies[0],
+                            policies[1]),
+                        (Policy<TResult>)policies[0], policies[1]);
+
                 default:
-                    IEnumerable<Policy<TResult>> remainder = policies.Skip(1);
-                    return policies.First().Wrap(remainder.Count() == 1 ? remainder.Single() : Wrap(remainder.ToArray()));
+                    return Wrap(policies[0], Wrap(policies.Skip(1).ToArray()));
             }
         }
     }


### PR DESCRIPTION
Makes `PolicyWrap` configuration overloads take parameters as interfaces.  Closes #297 . 

Similar to #302 , but not including the parts of #302 which also brought in #299 (still under discussion).  