### PR TITLE
Merge development branch for v5.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ TestResults
 *.user
 *.sln.docstates
 .vs/
+.vscode/
 
 # Build results
 [Dd]ebug/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 5.6.0
 - Bug fix: set context keys for generic execute method with PolicyWrap
+- Add ability to handle inner exceptions natively: .HandleInner&lt;TEx&gt;()
 - Add GetPolicies extension method to IPolicyWrap
 - Allow WaitAndRetry policies to calculate wait based on the handled fault
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.6.0
+- Bug fix: set context keys for generic execute method with PolicyWrap
+
 ## 5.5.0
 - Bug fix: non-generic CachePolicy with PolicyWrap
 - Add Cache interfaces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## 5.6.0
-- Bug fix: set context keys for generic execute method with PolicyWrap
 - Add ability to handle inner exceptions natively: .HandleInner&lt;TEx&gt;()
-- Add GetPolicies extension method to IPolicyWrap
 - Allow WaitAndRetry policies to calculate wait based on the handled fault
+- Add GetPolicies() extension methods to IPolicyWrap
+- Allow PolicyWrap to take interfaces as parameters
+- Bug fix: set context keys for generic execute method with PolicyWrap
+- Performance improvements
+- Multiple build speed improvements
 
 ## 5.5.0
 - Bug fix: non-generic CachePolicy with PolicyWrap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## 5.6.0
 - Add ability to handle inner exceptions natively: .HandleInner&lt;TEx&gt;()
 - Allow WaitAndRetry policies to calculate wait based on the handled fault
-- Add GetPolicies() extension methods to IPolicyWrap
-- Allow PolicyWrap to take interfaces as parameters
-- Bug fix: set context keys for generic execute method with PolicyWrap
+- Add the ability to access the policies within an IPolicyWrap
+- Allow PolicyWrap to configure policies expressed as interfaces
+- Bug fix: set context keys for generic execute methods with PolicyWrap
+- Bug fix: generic TResult method with non-generic fallback policy
 - Performance improvements
 - Multiple build speed improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 5.6.0
 - Bug fix: set context keys for generic execute method with PolicyWrap
+- Add GetPolicies extension method to IPolicyWrap
 
 ## 5.5.0
 - Bug fix: non-generic CachePolicy with PolicyWrap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 5.6.0
 - Bug fix: set context keys for generic execute method with PolicyWrap
 - Add GetPolicies extension method to IPolicyWrap
+- Allow WaitAndRetry policies to calculate wait based on the handled fault
 
 ## 5.5.0
 - Bug fix: non-generic CachePolicy with PolicyWrap

--- a/GitVersionConfig.yaml
+++ b/GitVersionConfig.yaml
@@ -1,1 +1,1 @@
-next-version: 5.5.0
+next-version: 5.6.0

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Polly
+﻿# Polly
 
 Polly is a .NET resilience and transient-fault-handling library that allows developers to express policies such as Retry, Circuit Breaker, Timeout, Bulkhead Isolation, and Fallback in a fluent and thread-safe manner.  
 
@@ -27,7 +27,6 @@ You can install the Strongly Named version via:
     Install-Package Polly.Net40Async-Signed
 
 
-
 # Resilience policies
 
 Polly offers multiple resilience policies:
@@ -52,8 +51,6 @@ Fault-handling policies handle specific exceptions thrown by, or results returne
 
 ### (for fault-handling policies:  Retry family, CircuitBreaker family and Fallback)
 
-
-
 ```csharp
 // Single exception type
 Policy
@@ -72,6 +69,11 @@ Policy
 Policy
   .Handle<SqlException>(ex => ex.Number == 1205)
   .Or<ArgumentException>(ex => ex.ParamName == "example")
+
+// Inner exceptions of ordinary exceptions or AggregateException, with or without conditions
+Policy
+  .HandleInner<HttpResponseException>()
+  .OrInner<OperationCanceledException>(ex => ex.CancellationToken == myToken)
 ```
 
 ## Step 1b: (optionally) Specify return results you want to handle
@@ -938,6 +940,7 @@ For details of changes by release see the [change log](https://github.com/App-vN
 * [@jiimaho](https://github.com/jiimaho) and [@Extremo75](https://github.com/ExtRemo75) - Provide public factory methods for PolicyResult, to support testing.
 * [@Extremo75](https://github.com/ExtRemo75) - Allow fallback delegates to take handled fault as input parameter.
 * [@reisenberger](https://github.com/reisenberger) and [@seanfarrow](https://github.com/SeanFarrow) - Add CachePolicy, with interfaces for pluggable cache providers and serializers.
+* [@reisenberger](https://github.com/reisenberger) - Add new .HandleInner<TException>(...) syntax for handling inner exceptions natively.
 * [@MartinSStewart](https://github.com/martinsstewart) - Add GetPolicies extension method to IPolicyWrap.
 * [@matst80](https://github.com/matst80) - Allow WaitAndRetry to take handled fault as an input to the sleepDurationProvider, allowing WaitAndRetry to take account of systems which specify a duration to wait as part of a fault response; eg Azure Cosmos DB may specify this in `x-ms-retry-after-ms` headers or in a property to an exception thrown by the Azure SDK.
 * [@reisenberger](https://github.com/reisenberger) - Allow WaitAndRetryForever to take handled fault as an input to the sleepDurationProvider.

--- a/README.md
+++ b/README.md
@@ -938,6 +938,7 @@ For details of changes by release see the [change log](https://github.com/App-vN
 * [@jiimaho](https://github.com/jiimaho) and [@Extremo75](https://github.com/ExtRemo75) - Provide public factory methods for PolicyResult, to support testing.
 * [@Extremo75](https://github.com/ExtRemo75) - Allow fallback delegates to take handled fault as input parameter.
 * [@reisenberger](https://github.com/reisenberger) and [@seanfarrow](https://github.com/SeanFarrow) - Add CachePolicy, with interfaces for pluggable cache providers and serializers.
+* [@MartinSStewart](https://github.com/martinsstewart) - Add GetPolicies extension method to IPolicyWrap.
 
 # Sample Projects
 

--- a/README.md
+++ b/README.md
@@ -939,6 +939,8 @@ For details of changes by release see the [change log](https://github.com/App-vN
 * [@Extremo75](https://github.com/ExtRemo75) - Allow fallback delegates to take handled fault as input parameter.
 * [@reisenberger](https://github.com/reisenberger) and [@seanfarrow](https://github.com/SeanFarrow) - Add CachePolicy, with interfaces for pluggable cache providers and serializers.
 * [@MartinSStewart](https://github.com/martinsstewart) - Add GetPolicies extension method to IPolicyWrap.
+* [@matst80](https://github.com/matst80) - Allow WaitAndRetry to take handled fault as an input to the sleepDurationProvider, allowing WaitAndRetry to take account of systems which specify a duration to wait as part of a fault response; eg Azure Cosmos DB may specify this in `x-ms-retry-after-ms` headers or in a property to an exception thrown by the Azure SDK.
+* [@reisenberger](https://github.com/reisenberger) - Allow WaitAndRetryForever to take handled fault as an input to the sleepDurationProvider.
 
 # Sample Projects
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# Polly
+# Polly
 
 Polly is a .NET resilience and transient-fault-handling library that allows developers to express policies such as Retry, Circuit Breaker, Timeout, Bulkhead Isolation, and Fallback in a fluent and thread-safe manner.  
 
@@ -940,10 +940,13 @@ For details of changes by release see the [change log](https://github.com/App-vN
 * [@jiimaho](https://github.com/jiimaho) and [@Extremo75](https://github.com/ExtRemo75) - Provide public factory methods for PolicyResult, to support testing.
 * [@Extremo75](https://github.com/ExtRemo75) - Allow fallback delegates to take handled fault as input parameter.
 * [@reisenberger](https://github.com/reisenberger) and [@seanfarrow](https://github.com/SeanFarrow) - Add CachePolicy, with interfaces for pluggable cache providers and serializers.
+* Thanks to the awesome devs at [@tretton37](https://github.com/tretton37) who delivered the following as part of a one-day in-company hackathon led by [@reisenberger](https://github.com/reisenberger), sponsored by [@tretton37](https://github.com/tretton37) and convened by [@thecodejunkie](https://github.com/thecodejunkie) 
+  * [@matst80](https://github.com/matst80) - Allow WaitAndRetry to take handled fault as an input to the sleepDurationProvider, allowing WaitAndRetry to take account of systems which specify a duration to wait as part of a fault response; eg Azure CosmosDB may specify this in `x-ms-retry-after-ms` headers or in a property to an exception thrown by the Azure CosmosDB SDK.
+  * [@MartinSStewart](https://github.com/martinsstewart) - Add GetPolicies() extension methods to IPolicyWrap.
+  * [@jbergens37](https://github.com/jbergens37) - Parallelize test running where possible, to improve overall build speed.
 * [@reisenberger](https://github.com/reisenberger) - Add new .HandleInner<TException>(...) syntax for handling inner exceptions natively.
-* [@MartinSStewart](https://github.com/martinsstewart) - Add GetPolicies extension method to IPolicyWrap.
-* [@matst80](https://github.com/matst80) - Allow WaitAndRetry to take handled fault as an input to the sleepDurationProvider, allowing WaitAndRetry to take account of systems which specify a duration to wait as part of a fault response; eg Azure Cosmos DB may specify this in `x-ms-retry-after-ms` headers or in a property to an exception thrown by the Azure SDK.
-* [@reisenberger](https://github.com/reisenberger) - Allow WaitAndRetryForever to take handled fault as an input to the sleepDurationProvider.
+* [@rjongeneelen](https://github.com/rjongeneelen) and [@reisenberger](https://github.com/reisenberger) - Allow PolicyWrap configuration to configure policies via interfaces. 
+* [@reisenberger](https://github.com/reisenberger) - Performance improvements.
 
 # Sample Projects
 

--- a/src/Polly.Net40Async.Specs/Properties/AssemblyInfo.cs
+++ b/src/Polly.Net40Async.Specs/Properties/AssemblyInfo.cs
@@ -2,4 +2,4 @@
 using Xunit;
 
 [assembly: AssemblyTitle("Polly.Net40Async.Specs")]
-[assembly: CollectionBehavior(DisableTestParallelization = true)]
+[assembly: CollectionBehavior(DisableTestParallelization = false)]

--- a/src/Polly.Net40Async.nuspec
+++ b/src/Polly.Net40Async.nuspec
@@ -17,10 +17,12 @@
 
      5.6.0
      ---------------------
-     - Bug fix: set context keys for generic execute method with PolicyWrap
      - Add ability to handle inner exceptions natively: .HandleInner&lt;TEx&gt;()
-     - Add GetPolicies extension method to IPolicyWrap
      - Allow WaitAndRetry policies to calculate wait based on the handled fault
+     - Add GetPolicies() extension methods to IPolicyWrap
+     - Allow PolicyWrap to take interfaces as parameters
+     - Bug fix: set context keys for generic execute method with PolicyWrap
+     - Performance improvements
 
      5.5.0
      ---------------------

--- a/src/Polly.Net40Async.nuspec
+++ b/src/Polly.Net40Async.nuspec
@@ -18,6 +18,7 @@
      5.6.0
      ---------------------
      - Bug fix: set context keys for generic execute method with PolicyWrap
+     - Add GetPolicies extension method to IPolicyWrap
 
      5.5.0
      ---------------------

--- a/src/Polly.Net40Async.nuspec
+++ b/src/Polly.Net40Async.nuspec
@@ -18,6 +18,7 @@
      5.6.0
      ---------------------
      - Bug fix: set context keys for generic execute method with PolicyWrap
+     - Add ability to handle inner exceptions natively: .HandleInner&lt;TEx&gt;()
      - Add GetPolicies extension method to IPolicyWrap
      - Allow WaitAndRetry policies to calculate wait based on the handled fault
 

--- a/src/Polly.Net40Async.nuspec
+++ b/src/Polly.Net40Async.nuspec
@@ -13,7 +13,11 @@
     <tags>Exception Handling Resilience Transient Fault Policy Circuit Breaker CircuitBreaker Retry Wait Cache Cache-aside Bulkhead Fallback Timeout Throttle Parallelization</tags>
     <copyright>Copyright © 2017, App vNext</copyright>
     <releaseNotes>
-     v5.0 is a major release with significant new resilience policies: Timeout; Bulkhead Isolation; Fallback; Cache; and PolicyWrap.  See release notes back to v5.0.0 for full details.  v5.0.5 includes important circuit-breaker fixes.
+     v5.0 is a major release with significant new resilience policies: Timeout; Bulkhead Isolation; Fallback; Cache; and PolicyWrap.  See release notes back to v5.0.0 for full details.
+
+     5.6.0
+     ---------------------
+     - Bug fix: set context keys for generic execute method with PolicyWrap
 
      5.5.0
      ---------------------

--- a/src/Polly.Net40Async.nuspec
+++ b/src/Polly.Net40Async.nuspec
@@ -19,9 +19,10 @@
      ---------------------
      - Add ability to handle inner exceptions natively: .HandleInner&lt;TEx&gt;()
      - Allow WaitAndRetry policies to calculate wait based on the handled fault
-     - Add GetPolicies() extension methods to IPolicyWrap
+     - Add the ability to access the policies within an IPolicyWrap
      - Allow PolicyWrap to take interfaces as parameters
      - Bug fix: set context keys for generic execute method with PolicyWrap
+     - Bug fix: generic TResult method with non-generic fallback policy
      - Performance improvements
 
      5.5.0

--- a/src/Polly.Net40Async.nuspec
+++ b/src/Polly.Net40Async.nuspec
@@ -19,6 +19,7 @@
      ---------------------
      - Bug fix: set context keys for generic execute method with PolicyWrap
      - Add GetPolicies extension method to IPolicyWrap
+     - Allow WaitAndRetry policies to calculate wait based on the handled fault
 
      5.5.0
      ---------------------

--- a/src/Polly.Net45.Specs/Properties/AssemblyInfo.cs
+++ b/src/Polly.Net45.Specs/Properties/AssemblyInfo.cs
@@ -2,4 +2,4 @@
 using Xunit;
 
 [assembly: AssemblyTitle("Polly.Net45.Specs")]
-[assembly: CollectionBehavior(DisableTestParallelization = true)]
+[assembly: CollectionBehavior(DisableTestParallelization = false)]

--- a/src/Polly.NetStandard11.Specs/Properties/AssemblyInfo.cs
+++ b/src/Polly.NetStandard11.Specs/Properties/AssemblyInfo.cs
@@ -1,1 +1,1 @@
-﻿[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]
+﻿[assembly: Xunit.CollectionBehavior(DisableTestParallelization = false)]

--- a/src/Polly.NetStandard11/Properties/AssemblyInfo.cs
+++ b/src/Polly.NetStandard11/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Polly")]
-[assembly: AssemblyVersion("5.5.1.0")]
+[assembly: AssemblyVersion("5.6.0.0")]
 [assembly: CLSCompliant(true)]
 
 [assembly: InternalsVisibleTo("Polly.NetStandard11.Specs")]

--- a/src/Polly.NetStandard11/Properties/AssemblyInfo.cs
+++ b/src/Polly.NetStandard11/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Polly")]
-[assembly: AssemblyVersion("5.5.0.0")]
+[assembly: AssemblyVersion("5.5.1.0")]
 [assembly: CLSCompliant(true)]
 
 [assembly: InternalsVisibleTo("Polly.NetStandard11.Specs")]

--- a/src/Polly.Shared/CircuitBreaker/CircuitBreakerEngineAsync.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitBreakerEngineAsync.cs
@@ -1,10 +1,13 @@
-﻿
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
+
+#if NET40
+using ExceptionDispatchInfo = Polly.Utilities.ExceptionDispatchInfo;
+#endif
 
 namespace Polly.CircuitBreaker
 {
@@ -40,13 +43,20 @@ namespace Polly.CircuitBreaker
             }
             catch (Exception ex)
             {
-                if (!shouldHandleExceptionPredicates.Any(predicate => predicate(ex)))
+                Exception handledException = shouldHandleExceptionPredicates
+                    .Select(predicate => predicate(ex))
+                    .FirstOrDefault(e => e != null);
+                if (handledException == null)
                 {
                     throw;
                 }
 
-                breakerController.OnActionFailure(new DelegateResult<TResult>(ex), context);
+                breakerController.OnActionFailure(new DelegateResult<TResult>(handledException), context);
 
+                if (handledException != ex)
+                {
+                    ExceptionDispatchInfo.Capture(handledException).Throw();
+                }
                 throw;
             }
 

--- a/src/Polly.Shared/Context.Dictionary.cs
+++ b/src/Polly.Shared/Context.Dictionary.cs
@@ -1,0 +1,159 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Polly
+{
+    /// <summary>
+    /// Context that carries with a single execution through a Policy.   Commonly-used properties are directly on the class.  Backed by a dictionary of string key / object value pairs, to which user-defined values may be added.
+    /// <remarks>Do not re-use an instance of <see cref="Context"/> across more than one execution.</remarks>
+    /// </summary>
+    public partial class Context : IDictionary<string, object>, IDictionary
+#if !NET40
+        , IReadOnlyDictionary<string, object>
+#endif
+    {
+        // For an individual execution through a policy or policywrap, it is expected that all execution steps (for example executing the user delegate, invoking policy-activity delegates such as onRetry, onBreak, onTimeout etc) execute sequentially.  
+        // Therefore, this class is intentionally not constructed to be safe for concurrent access from multiple threads.
+
+        private Dictionary<string, object> wrappedDictionary = null;
+
+        private Dictionary<string, object> WrappedDictionary => wrappedDictionary ?? (wrappedDictionary = new Dictionary<string, object>());
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Context"/> class, with the specified <paramref name="executionKey" /> and the supplied <paramref name="contextData"/>.
+        /// </summary>
+        /// <param name="executionKey">The execution key.</param>
+        /// <param name="contextData">The context data.</param>
+        public Context(String executionKey, IDictionary<string, object> contextData) : this(contextData)
+        {
+            ExecutionKey = executionKey;
+        }
+
+        internal Context(IDictionary<string, object> contextData) : this()
+        {
+            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
+            wrappedDictionary = new Dictionary<string, object>(contextData);
+        }
+
+#region IDictionary<string,object> implementation
+
+        /// <inheritdoc cref="IDictionary{TKey,Value}"/>
+        public ICollection<string> Keys => WrappedDictionary.Keys;
+
+        /// <inheritdoc cref="IDictionary{TKey,Value}"/>
+        public ICollection<object> Values => WrappedDictionary.Values;
+
+        /// <inheritdoc cref="IDictionary{TKey,Value}"/>
+        public int Count => WrappedDictionary.Count;
+
+        /// <inheritdoc cref="IDictionary{TKey,Value}"/>
+        bool ICollection<KeyValuePair<string, object>>.IsReadOnly => ((IDictionary<string, object>)WrappedDictionary).IsReadOnly;
+
+        /// <inheritdoc cref="IDictionary{TKey,Value}"/>
+        public object this[string key]
+        {
+            get => WrappedDictionary[key];
+            set => WrappedDictionary[key] = value;
+        }
+
+        /// <inheritdoc cref="IDictionary{TKey,Value}"/>
+        public void Add(string key, object value)
+        {
+            WrappedDictionary.Add(key, value);
+        }
+
+        /// <inheritdoc cref="IDictionary{TKey,Value}"/>
+        public bool ContainsKey(string key) => WrappedDictionary.ContainsKey(key);
+
+        /// <inheritdoc cref="IDictionary{TKey,Value}"/>
+        public bool Remove(string key) => WrappedDictionary.Remove(key);
+
+        /// <inheritdoc cref="IDictionary{TKey,Value}"/>
+        public bool TryGetValue(string key, out object value) => WrappedDictionary.TryGetValue(key, out value);
+
+        /// <inheritdoc cref="IDictionary{TKey,Value}"/>
+        void ICollection<KeyValuePair<string, object>>.Add(KeyValuePair<string, object> item) => ((IDictionary<string, object>)WrappedDictionary).Add(item);
+
+        /// <inheritdoc cref="IDictionary{TKey,Value}"/>
+        public void Clear() => WrappedDictionary.Clear();
+
+        /// <inheritdoc cref="IDictionary{TKey,Value}"/>
+        bool ICollection<KeyValuePair<string, object>>.Contains(KeyValuePair<string, object> item) => ((IDictionary<string, object>)WrappedDictionary).Contains(item);
+
+        /// <inheritdoc cref="IDictionary{TKey,Value}"/>
+        void ICollection<KeyValuePair<string, object>>.CopyTo(KeyValuePair<string, object>[] array, int arrayIndex) => ((IDictionary<string, object>) WrappedDictionary).CopyTo(array, arrayIndex);
+
+        /// <inheritdoc cref="IDictionary{TKey,Value}"/>
+        bool ICollection<KeyValuePair<string, object>>.Remove(KeyValuePair<string, object> item) => ((IDictionary<string, object>)WrappedDictionary).Remove(item);
+
+        /// <inheritdoc cref="IDictionary{TKey,Value}"/>
+        public IEnumerator<KeyValuePair<string, object>> GetEnumerator() => WrappedDictionary.GetEnumerator();
+
+        /// <inheritdoc cref="IDictionary{TKey,Value}"/> 
+        IEnumerator IEnumerable.GetEnumerator() => WrappedDictionary.GetEnumerator();
+
+        /// <inheritdoc cref="IDictionary"/> 
+        public void Add(object key, object value)
+        {
+            ((IDictionary)WrappedDictionary).Add(key, value);
+        }
+
+        /// <inheritdoc cref="IDictionary"/> 
+        public bool Contains(object key)
+        {
+            return ((IDictionary)WrappedDictionary).Contains(key);
+        }
+
+        /// <inheritdoc cref="IDictionary"/> 
+        IDictionaryEnumerator IDictionary.GetEnumerator()
+        {
+            return ((IDictionary)WrappedDictionary).GetEnumerator();
+        }
+
+        /// <inheritdoc cref="IDictionary"/> 
+        public void Remove(object key)
+        {
+            ((IDictionary)WrappedDictionary).Remove(key);
+        }
+
+        /// <inheritdoc cref="IDictionary"/> 
+        public void CopyTo(Array array, int index)
+        {
+            ((IDictionary)WrappedDictionary).CopyTo(array, index);
+        }
+
+        #endregion
+
+#if !NET40
+        #region IReadOnlyDictionary<string, object> implementation
+        IEnumerable<string> IReadOnlyDictionary<string, object>.Keys => ((IReadOnlyDictionary<string, object>)WrappedDictionary).Keys;
+
+        IEnumerable<object> IReadOnlyDictionary<string, object>.Values => ((IReadOnlyDictionary<string, object>)WrappedDictionary).Values;
+        #endregion
+#endif
+
+        #region IDictionary implementation
+
+        /// <inheritdoc cref="IDictionary"/> 
+        bool IDictionary.IsFixedSize => ((IDictionary)WrappedDictionary).IsFixedSize;
+
+        /// <inheritdoc cref="IDictionary"/> 
+        bool IDictionary.IsReadOnly => ((IDictionary)WrappedDictionary).IsReadOnly;
+
+        ICollection IDictionary.Keys => ((IDictionary)WrappedDictionary).Keys;
+
+        ICollection IDictionary.Values => ((IDictionary)WrappedDictionary).Values;
+
+        /// <inheritdoc cref="IDictionary"/> 
+        bool ICollection.IsSynchronized => ((IDictionary)WrappedDictionary).IsSynchronized;
+
+        /// <inheritdoc cref="IDictionary"/> 
+        object ICollection.SyncRoot => ((IDictionary)WrappedDictionary).SyncRoot;
+
+        /// <inheritdoc cref="IDictionary"/> 
+        object IDictionary.this[object key] { get => ((IDictionary)WrappedDictionary)[key]; set => ((IDictionary)WrappedDictionary)[key] = value; }
+
+#endregion
+    }
+}

--- a/src/Polly.Shared/Context.cs
+++ b/src/Polly.Shared/Context.cs
@@ -7,13 +7,9 @@ namespace Polly
     /// Context that carries with a single execution through a Policy.   Commonly-used properties are directly on the class.  Backed by a dictionary of string key / object value pairs, to which user-defined values may be added.
     /// <remarks>Do not re-use an instance of <see cref="Context"/> across more than one execution.</remarks>
     /// </summary>
-    public class Context : Dictionary<string, object>
+    public partial class Context
     {
-        // For an individual execution through a policy or policywrap, it is expected that all execution steps (for example executing the user delegate, invoking policy-activity delegates such as onRetry, onBreak, onTimeout etc) execute sequentially.  
-        // Therefore, this class is intentionally not constructed to be safe for concurrent access from multiple threads.
-
-        private static readonly IDictionary<string, object> emptyDictionary = new Dictionary<string, object>();
-        internal static readonly Context None = new Context(emptyDictionary);
+        internal static readonly Context None = new Context();
 
         private Guid? _executionGuid;
 
@@ -21,27 +17,13 @@ namespace Polly
         /// Initializes a new instance of the <see cref="Context"/> class, with the specified <paramref name="executionKey"/>.
         /// </summary>
         /// <param name="executionKey">The execution key.</param>
-        public Context(String executionKey) : this(executionKey, emptyDictionary)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Context"/> class, with the specified <paramref name="executionKey" /> and the supplied <paramref name="contextData"/>.
-        /// </summary>
-        /// <param name="executionKey">The execution key.</param>
-        /// <param name="contextData">The context data.</param>
-        public Context(String executionKey, IDictionary<string, object> contextData) : this(contextData)
+        public Context(String executionKey)
         {
             ExecutionKey = executionKey;
         }
 
-        internal Context() : this(emptyDictionary)
+        internal Context()
         {
-        }
-
-        internal Context(IDictionary<string, object> contextData) : base(contextData)
-        {
-            if (contextData == null) throw new ArgumentNullException(nameof(contextData));
         }
 
         /// <summary>

--- a/src/Polly.Shared/ExceptionPredicate.cs
+++ b/src/Polly.Shared/ExceptionPredicate.cs
@@ -2,5 +2,5 @@
 
 namespace Polly
 {
-    internal delegate bool ExceptionPredicate(Exception ex); 
+    internal delegate Exception ExceptionPredicate(Exception ex); 
 }

--- a/src/Polly.Shared/Fallback/FallbackEngine.cs
+++ b/src/Polly.Shared/Fallback/FallbackEngine.cs
@@ -1,7 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Threading;
+
+#if NET40
+using ExceptionDispatchInfo = Polly.Utilities.ExceptionDispatchInfo;
+#endif
 
 namespace Polly.Fallback
 {
@@ -33,12 +38,15 @@ namespace Polly.Fallback
             }
             catch (Exception ex)
             {
-                if (!shouldHandleExceptionPredicates.Any(predicate => predicate(ex)))
+                Exception handledException = shouldHandleExceptionPredicates
+                    .Select(predicate => predicate(ex))
+                    .FirstOrDefault(e => e != null);
+                if (handledException == null)
                 {
                     throw;
                 }
 
-                delegateOutcome = new DelegateResult<TResult>(ex);
+                delegateOutcome = new DelegateResult<TResult>(handledException);
             }
 
             onFallback(delegateOutcome, context);

--- a/src/Polly.Shared/Fallback/FallbackEngineAsync.cs
+++ b/src/Polly.Shared/Fallback/FallbackEngineAsync.cs
@@ -1,8 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
+
+#if NET40
+using ExceptionDispatchInfo = Polly.Utilities.ExceptionDispatchInfo;
+#endif
 
 namespace Polly.Fallback
 {
@@ -35,12 +40,15 @@ namespace Polly.Fallback
             }
             catch (Exception ex)
             {
-                if (!shouldHandleExceptionPredicates.Any(predicate => predicate(ex)))
+                Exception handledException = shouldHandleExceptionPredicates
+                    .Select(predicate => predicate(ex))
+                    .FirstOrDefault(e => e != null);
+                if (handledException == null)
                 {
                     throw;
                 }
 
-                delegateOutcome = new DelegateResult<TResult>(ex);
+                delegateOutcome = new DelegateResult<TResult>(handledException);
             }
 
             await onFallbackAsync(delegateOutcome, context).ConfigureAwait(continueOnCapturedContext);

--- a/src/Polly.Shared/Fallback/FallbackPolicy.cs
+++ b/src/Polly.Shared/Fallback/FallbackPolicy.cs
@@ -13,6 +13,19 @@ namespace Polly.Fallback
             : base(exceptionPolicy, exceptionPredicates)
         {
         }
+
+        /// <summary>
+        /// Executes the specified action within the cache policy and returns the result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Execution context that is passed to the exception policy; defines the cache key to use in cache lookup.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The value returned by the action, or the cache.</returns>
+        public override TResult ExecuteInternal<TResult>(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken)
+        {
+          throw new InvalidOperationException($"You have executed the generic .Execute<{nameof(TResult)}> method on a non-generic {nameof(FallbackPolicy)}.  A non-generic {nameof(FallbackPolicy)} only defines a fallback action which returns void; it can never return a substitute {nameof(TResult)} value.  To use {nameof(FallbackPolicy)} to provide fallback {nameof(TResult)} values you must define a generic fallback policy {nameof(FallbackPolicy)}<{nameof(TResult)}>.  For example, define the policy as Policy<{nameof(TResult)}>.Handle<Whatever>.Fallback<{nameof(TResult)}>(/* some {nameof(TResult)} value or Func<..., {nameof(TResult)}> */);");
+        }
     }
 
     /// <summary>

--- a/src/Polly.Shared/Fallback/FallbackPolicyAsync.cs
+++ b/src/Polly.Shared/Fallback/FallbackPolicyAsync.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,6 +11,22 @@ namespace Polly.Fallback
         internal FallbackPolicy(Func<Func<Context, CancellationToken, Task>, Context, CancellationToken, bool, Task> asyncExceptionPolicy, IEnumerable<ExceptionPredicate> exceptionPredicates)
            : base(asyncExceptionPolicy, exceptionPredicates)
         {
+        }
+
+        /// <summary>
+        ///     Executes the specified asynchronous action within the policy and returns the result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="context">Context data that is passed to the exception policy.</param>
+        /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
+        /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
+        /// <returns>The value returned by the action</returns>
+        /// <exception cref="System.InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
+        [DebuggerStepThrough]
+        public override Task<TResult> ExecuteAsyncInternal<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        {
+            throw new InvalidOperationException($"You have executed the generic .Execute<{nameof(TResult)}> method on a non-generic {nameof(FallbackPolicy)}.  A non-generic {nameof(FallbackPolicy)} only defines a fallback action which returns void; it can never return a substitute {nameof(TResult)} value.  To use {nameof(FallbackPolicy)} to provide fallback {nameof(TResult)} values you must define a generic fallback policy {nameof(FallbackPolicy)}<{nameof(TResult)}>.  For example, define the policy as Policy<{nameof(TResult)}>.Handle<Whatever>.Fallback<{nameof(TResult)}>(/* some {nameof(TResult)} value or Func<..., {nameof(TResult)}> */);");
         }
     }
 

--- a/src/Polly.Shared/Policy.HandleSyntax.cs
+++ b/src/Polly.Shared/Policy.HandleSyntax.cs
@@ -9,12 +9,10 @@ namespace Polly
         /// Specifies the type of exception that this policy can handle.
         /// </summary>
         /// <typeparam name="TException">The type of the exception to handle.</typeparam>
-        /// <returns>The PolicyBuilder instance.</returns>
+        /// <returns>The PolicyBuilder instance, for fluent chaining.</returns>
         public static PolicyBuilder Handle<TException>() where TException : Exception
         {
-            ExceptionPredicate predicate = exception => exception is TException;
-
-            return new PolicyBuilder(predicate);
+            return new PolicyBuilder(exception => exception is TException ? exception : null);
         }
 
         /// <summary>
@@ -22,13 +20,30 @@ namespace Polly
         /// </summary>
         /// <typeparam name="TException">The type of the exception.</typeparam>
         /// <param name="exceptionPredicate">The exception predicate to filter the type of exception this policy can handle.</param>
-        /// <returns>The PolicyBuilder instance.</returns>
+        /// <returns>The PolicyBuilder instance, for fluent chaining.</returns>
         public static PolicyBuilder Handle<TException>(Func<TException, bool> exceptionPredicate) where TException : Exception
         {
-            ExceptionPredicate predicate = exception => exception is TException &&
-                                                        exceptionPredicate((TException)exception);
+            return new PolicyBuilder(exception => exception is TException texception && exceptionPredicate(texception) ? exception : null);
+        }
 
-            return new PolicyBuilder(predicate);
+        /// <summary>
+        /// Specifies the type of exception that this policy can handle if found as an InnerException of a regular <see cref="Exception"/>, or at any level of nesting within an <see cref="AggregateException"/>.
+        /// </summary>
+        /// <typeparam name="TException">The type of the exception to handle.</typeparam>
+        /// <returns>The PolicyBuilder instance, for fluent chaining.</returns>
+        public static PolicyBuilder HandleInner<TException>() where TException : Exception
+        {
+            return new PolicyBuilder(PolicyBuilder.HandleInner(ex => ex is TException));
+        }
+
+        /// <summary>
+        /// Specifies the type of exception that this policy can handle, with additional filters on this exception type, if found as an InnerException of a regular <see cref="Exception"/>, or at any level of nesting within an <see cref="AggregateException"/>.
+        /// </summary>
+        /// <typeparam name="TException">The type of the exception to handle.</typeparam>
+        /// <returns>The PolicyBuilder instance, for fluent chaining.</returns>
+        public static PolicyBuilder HandleInner<TException>(Func<TException, bool> exceptionPredicate) where TException : Exception
+        {
+            return new PolicyBuilder(PolicyBuilder.HandleInner(ex => ex is TException texception && exceptionPredicate(texception)));
         }
 
         /// <summary>
@@ -64,9 +79,7 @@ namespace Polly
         /// <returns>The PolicyBuilder instance.</returns>
         public static PolicyBuilder<TResult> Handle<TException>() where TException : Exception
         {
-            ExceptionPredicate predicate = exception => exception is TException;
-
-            return new PolicyBuilder<TResult>(predicate);
+            return new PolicyBuilder<TResult>(exception => exception is TException ? exception : null);
         }
 
         /// <summary>
@@ -77,10 +90,27 @@ namespace Polly
         /// <returns>The PolicyBuilder instance.</returns>
         public static PolicyBuilder<TResult> Handle<TException>(Func<TException, bool> exceptionPredicate) where TException : Exception
         {
-            ExceptionPredicate predicate = exception => exception is TException &&
-                                                        exceptionPredicate((TException)exception);
+            return new PolicyBuilder<TResult>(exception => exception is TException texception && exceptionPredicate(texception) ? exception : null);
+        }
 
-            return new PolicyBuilder<TResult>(predicate);
+        /// <summary>
+        /// Specifies the type of exception that this policy can handle if found as an InnerException of a regular <see cref="Exception"/>, or at any level of nesting within an <see cref="AggregateException"/>.
+        /// </summary>
+        /// <typeparam name="TException">The type of the exception to handle.</typeparam>
+        /// <returns>The PolicyBuilder instance, for fluent chaining.</returns>
+        public static PolicyBuilder<TResult> HandleInner<TException>() where TException : Exception
+        {
+            return new PolicyBuilder<TResult>(PolicyBuilder.HandleInner(ex => ex is TException));
+        }
+
+        /// <summary>
+        /// Specifies the type of exception that this policy can handle, with additional filters on this exception type, if found as an InnerException of a regular <see cref="Exception"/>, or at any level of nesting within an <see cref="AggregateException"/>.
+        /// </summary>
+        /// <typeparam name="TException">The type of the exception to handle.</typeparam>
+        /// <returns>The PolicyBuilder instance, for fluent chaining.</returns>
+        public static PolicyBuilder<TResult> HandleInner<TException>(Func<TException, bool> exceptionPredicate) where TException : Exception
+        {
+            return new PolicyBuilder<TResult>(PolicyBuilder.HandleInner(ex => ex is TException texception && exceptionPredicate(texception)));
         }
 
         /// <summary>

--- a/src/Polly.Shared/Policy.TResult.cs
+++ b/src/Polly.Shared/Policy.TResult.cs
@@ -22,9 +22,7 @@ namespace Polly
             IEnumerable<ResultPredicate<TResult>> resultPredicates
             )
         {
-            if (executionPolicy == null) throw new ArgumentNullException(nameof(executionPolicy));
-
-            _executionPolicy = executionPolicy;
+            _executionPolicy = executionPolicy ?? throw new ArgumentNullException(nameof(executionPolicy));
             ExceptionPredicates = exceptionPredicates ?? PredicateHelper.EmptyExceptionPredicates;
             ResultPredicates = resultPredicates ?? PredicateHelper<TResult>.EmptyResultPredicates;
         }

--- a/src/Polly.Shared/Policy.cs
+++ b/src/Polly.Shared/Policy.cs
@@ -20,9 +20,7 @@ namespace Polly
             Action<Action<Context, CancellationToken>, Context, CancellationToken> exceptionPolicy,
             IEnumerable<ExceptionPredicate> exceptionPredicates)
         {
-            if (exceptionPolicy == null) throw new ArgumentNullException(nameof(exceptionPolicy));
-
-            _exceptionPolicy = exceptionPolicy;
+            _exceptionPolicy = exceptionPolicy ?? throw new ArgumentNullException(nameof(exceptionPolicy));
             ExceptionPredicates = exceptionPredicates ?? PredicateHelper.EmptyExceptionPredicates;
         }
 

--- a/src/Polly.Shared/Policy.cs
+++ b/src/Polly.Shared/Policy.cs
@@ -619,7 +619,7 @@ namespace Polly
 
         internal static ExceptionType GetExceptionType(IEnumerable<ExceptionPredicate> exceptionPredicates, Exception exception)
         {
-            var isExceptionTypeHandledByThisPolicy = exceptionPredicates.Any(predicate => predicate(exception));
+            var isExceptionTypeHandledByThisPolicy = exceptionPredicates.Any(predicate => predicate(exception) != null);
 
             return isExceptionTypeHandledByThisPolicy
                 ? ExceptionType.HandledByThisPolicy

--- a/src/Polly.Shared/PolicyAsync.TResult.cs
+++ b/src/Polly.Shared/PolicyAsync.TResult.cs
@@ -17,9 +17,7 @@ namespace Polly
             IEnumerable<ExceptionPredicate> exceptionPredicates,
             IEnumerable<ResultPredicate<TResult>> resultPredicates)
         {
-            if (asyncExecutionPolicy == null) throw new ArgumentNullException(nameof(asyncExecutionPolicy));
-
-            _asyncExecutionPolicy = asyncExecutionPolicy;
+            _asyncExecutionPolicy = asyncExecutionPolicy ?? throw new ArgumentNullException(nameof(asyncExecutionPolicy));
             ExceptionPredicates = exceptionPredicates ?? PredicateHelper.EmptyExceptionPredicates;
             ResultPredicates = resultPredicates ?? PredicateHelper<TResult>.EmptyResultPredicates;
         }

--- a/src/Polly.Shared/PolicyAsync.cs
+++ b/src/Polly.Shared/PolicyAsync.cs
@@ -15,9 +15,7 @@ namespace Polly
             Func<Func<Context, CancellationToken, Task>, Context, CancellationToken, bool, Task> asyncExceptionPolicy, 
             IEnumerable<ExceptionPredicate> exceptionPredicates)
         {
-            if (asyncExceptionPolicy == null) throw new ArgumentNullException(nameof(asyncExceptionPolicy));
-
-            _asyncExceptionPolicy = asyncExceptionPolicy;
+            _asyncExceptionPolicy = asyncExceptionPolicy ?? throw new ArgumentNullException(nameof(asyncExceptionPolicy));
             ExceptionPredicates = exceptionPredicates ?? PredicateHelper.EmptyExceptionPredicates;
         }
 

--- a/src/Polly.Shared/Polly.Shared.projitems
+++ b/src/Polly.Shared/Polly.Shared.projitems
@@ -149,6 +149,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\TaskHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\TimedLock.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Wrap\IPolicyWrap.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Wrap\IPolicyWrapExtension.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Wrap\PolicyWrapSyntax.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Wrap\PolicyWrapSyntaxAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Wrap\PolicyWrap.ContextAndKeys.cs" />

--- a/src/Polly.Shared/Polly.Shared.projitems
+++ b/src/Polly.Shared/Polly.Shared.projitems
@@ -70,6 +70,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CircuitBreaker\SingleHealthMetrics.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CircuitBreaker\AdvancedCircuitController.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Context.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Context.Dictionary.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExceptionPredicate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DelegateResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExecutionRejectedException.cs" />

--- a/src/Polly.Shared/Retry/RetryStateWaitAndRetryWithProvider.cs
+++ b/src/Polly.Shared/Retry/RetryStateWaitAndRetryWithProvider.cs
@@ -8,11 +8,11 @@ namespace Polly.Retry
     {
         private int _errorCount;
         private readonly int _retryCount;
-        private readonly Func<int, Context, TimeSpan> _sleepDurationProvider;
+        private readonly Func<int, DelegateResult<TResult>, Context, TimeSpan> _sleepDurationProvider;
         private readonly Action<DelegateResult<TResult>, TimeSpan, int, Context> _onRetry;
         private readonly Context _context;
 
-        public RetryStateWaitAndRetryWithProvider(int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry, Context context)
+        public RetryStateWaitAndRetryWithProvider(int retryCount, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry, Context context)
         {
             _retryCount = retryCount;
             _sleepDurationProvider = sleepDurationProvider;
@@ -27,7 +27,7 @@ namespace Polly.Retry
             bool shouldRetry = _errorCount <= _retryCount;
             if (shouldRetry)
             {
-                TimeSpan waitTimeSpan = _sleepDurationProvider(_errorCount, _context);
+                TimeSpan waitTimeSpan = _sleepDurationProvider(_errorCount, delegateResult, _context);
 
                 _onRetry(delegateResult, waitTimeSpan, _errorCount, _context);
 

--- a/src/Polly.Shared/Retry/RetryStateWaitAndRetryWithProviderAsync.cs
+++ b/src/Polly.Shared/Retry/RetryStateWaitAndRetryWithProviderAsync.cs
@@ -10,7 +10,7 @@ namespace Polly.Retry
     {
         private readonly Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> _onRetryAsync;
 
-        public RetryStateWaitAndRetryWithProvider(int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync, Context context)
+        public RetryStateWaitAndRetryWithProvider(int retryCount, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync, Context context)
         {
             _retryCount = retryCount;
             _sleepDurationProvider = sleepDurationProvider;
@@ -25,7 +25,7 @@ namespace Polly.Retry
             bool shouldRetry = _errorCount <= _retryCount;
             if (shouldRetry)
             {
-                TimeSpan waitTimeSpan = _sleepDurationProvider(_errorCount, _context);
+                TimeSpan waitTimeSpan = _sleepDurationProvider(_errorCount, delegateResult, _context);
 
                 await _onRetryAsync(delegateResult, waitTimeSpan, _errorCount, _context).ConfigureAwait(continueOnCapturedContext);
 

--- a/src/Polly.Shared/Retry/RetrySyntax.cs
+++ b/src/Polly.Shared/Retry/RetrySyntax.cs
@@ -306,46 +306,7 @@ namespace Polly
                 );
         }
 
-        ///// <summary>
-        ///// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
-        ///// calling <paramref name="onRetry"/> on each retry with the raised exception, current sleep duration, retry count, and context data.
-        ///// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
-        ///// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
-        ///// </summary>
-        ///// <param name="policyBuilder">The policy builder.</param>
-        ///// <param name="retryCount">The retry count.</param>
-        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
-        ///// <param name="onRetry">The action to call on each retry.</param>
-        ///// <returns>The policy instance.</returns>
-        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        ///// <exception cref="System.ArgumentNullException">
-        ///// timeSpanProvider
-        ///// or
-        ///// onRetry
-        ///// </exception>
-        //public static RetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, int, Context> onRetry)
-        //{
-        //    if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
-        //    if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-        //    if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
-        //    return new RetryPolicy(
-        //        (action, context, cancellationToken) => RetryEngine.Implementation(
-        //        (ctx, ct) => { action(ctx, ct); return EmptyStruct.Instance; },
-        //        context,
-        //        cancellationToken,
-        //        policyBuilder.ExceptionPredicates,
-        //        PredicateHelper<EmptyStruct>.EmptyResultPredicates,
-        //        () => new RetryStateWaitAndRetryWithProvider<EmptyStruct>(
-        //            retryCount,
-        //            sleepDurationProvider,
-        //            (outcome, timespan, i, ctx) => onRetry(outcome.Exception, timespan, i, ctx),
-        //            context)
-        //    ), policyBuilder.ExceptionPredicates);
-        //}
-
-        // For v560waitDurationFromErrorResponse: delete the overload above, and replace with the two below
-
+        
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
         /// calling <paramref name="onRetry"/> on each retry with the raised exception, current sleep duration, retry count, and context data.
@@ -365,6 +326,7 @@ namespace Polly
         /// </exception>
         public static RetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, int, Context> onRetry)
         {
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             return policyBuilder.WaitAndRetry(
                 retryCount,
                 (i, outcome, ctx) => sleepDurationProvider(i, ctx),
@@ -393,8 +355,6 @@ namespace Polly
             if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
-            //var wrappedEmptyStruct = new Action<DelegateResult<EmptyStruct>, TimeSpan, int, Context>() 
 
             return new RetryPolicy(
                 (action, context, cancellationToken) => RetryEngine.Implementation(
@@ -564,15 +524,37 @@ namespace Polly
         public static RetryPolicy WaitAndRetryForever(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, Context> onRetry)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+            return policyBuilder.WaitAndRetryForever(
+                (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+                onRetry
+            );
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
+        /// calling <paramref name="onRetry"/> on each retry with the raised exception and
+        /// execution context.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onRetry</exception>
+        public static RetryPolicy WaitAndRetryForever(this PolicyBuilder policyBuilder, Func<int, Exception, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, Context> onRetry)
+        {
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return new RetryPolicy((action, context, cancellationToken) => RetryEngine.Implementation(
                 (ctx, ct) => { action(ctx, ct); return EmptyStruct.Instance; },
-                context, 
+                context,
                 cancellationToken,
                 policyBuilder.ExceptionPredicates,
                 PredicateHelper<EmptyStruct>.EmptyResultPredicates,
-                () => new RetryStateWaitAndRetryForever<EmptyStruct>(sleepDurationProvider, (outcome, timespan, ctx) => onRetry(outcome.Exception, timespan, ctx), context)
+                () => new RetryStateWaitAndRetryForever<EmptyStruct>(
+                    (i, outcome, ctx) => sleepDurationProvider(i, outcome.Exception, ctx), 
+                    (outcome, timespan, ctx) => onRetry(outcome.Exception, timespan, ctx), context)
             ), policyBuilder.ExceptionPredicates);
         }
     }

--- a/src/Polly.Shared/Retry/RetrySyntax.cs
+++ b/src/Polly.Shared/Retry/RetrySyntax.cs
@@ -306,6 +306,46 @@ namespace Polly
                 );
         }
 
+        ///// <summary>
+        ///// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
+        ///// calling <paramref name="onRetry"/> on each retry with the raised exception, current sleep duration, retry count, and context data.
+        ///// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
+        ///// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///// </summary>
+        ///// <param name="policyBuilder">The policy builder.</param>
+        ///// <param name="retryCount">The retry count.</param>
+        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        ///// <param name="onRetry">The action to call on each retry.</param>
+        ///// <returns>The policy instance.</returns>
+        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        ///// <exception cref="System.ArgumentNullException">
+        ///// timeSpanProvider
+        ///// or
+        ///// onRetry
+        ///// </exception>
+        //public static RetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, int, Context> onRetry)
+        //{
+        //    if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
+        //    if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+        //    if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
+
+        //    return new RetryPolicy(
+        //        (action, context, cancellationToken) => RetryEngine.Implementation(
+        //        (ctx, ct) => { action(ctx, ct); return EmptyStruct.Instance; },
+        //        context,
+        //        cancellationToken,
+        //        policyBuilder.ExceptionPredicates,
+        //        PredicateHelper<EmptyStruct>.EmptyResultPredicates,
+        //        () => new RetryStateWaitAndRetryWithProvider<EmptyStruct>(
+        //            retryCount,
+        //            sleepDurationProvider,
+        //            (outcome, timespan, i, ctx) => onRetry(outcome.Exception, timespan, i, ctx),
+        //            context)
+        //    ), policyBuilder.ExceptionPredicates);
+        //}
+
+        // For v560waitDurationFromErrorResponse: delete the overload above, and replace with the two below
+
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
         /// calling <paramref name="onRetry"/> on each retry with the raised exception, current sleep duration, retry count, and context data.
@@ -325,9 +365,36 @@ namespace Polly
         /// </exception>
         public static RetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, int, Context> onRetry)
         {
+            return policyBuilder.WaitAndRetry(
+                retryCount,
+                (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+                onRetry);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
+        /// calling <paramref name="onRetry"/> on each retry with the raised exception, current sleep duration, retry count, and context data.
+        /// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
+        /// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="retryCount">The retry count.</param>
+        /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        /// <exception cref="System.ArgumentNullException">
+        /// timeSpanProvider
+        /// or
+        /// onRetry
+        /// </exception>
+        public static RetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, Exception, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, int, Context> onRetry)
+        {
             if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
+
+            //var wrappedEmptyStruct = new Action<DelegateResult<EmptyStruct>, TimeSpan, int, Context>() 
 
             return new RetryPolicy(
                 (action, context, cancellationToken) => RetryEngine.Implementation(
@@ -336,7 +403,11 @@ namespace Polly
                 cancellationToken,
                 policyBuilder.ExceptionPredicates,
                 PredicateHelper<EmptyStruct>.EmptyResultPredicates,
-                () => new RetryStateWaitAndRetryWithProvider<EmptyStruct>(retryCount, sleepDurationProvider, (outcome, timespan, i, ctx) => onRetry(outcome.Exception, timespan, i, ctx), context)
+                () => new RetryStateWaitAndRetryWithProvider<EmptyStruct>(
+                    retryCount,
+                    (i, outcome, ctx) => sleepDurationProvider(i, outcome.Exception, ctx),
+                    (outcome, timespan, i, ctx) => onRetry(outcome.Exception, timespan, i, ctx),
+                    context)
             ), policyBuilder.ExceptionPredicates);
         }
 

--- a/src/Polly.Shared/Retry/RetrySyntaxAsync.cs
+++ b/src/Polly.Shared/Retry/RetrySyntaxAsync.cs
@@ -565,46 +565,6 @@ namespace Polly
             );
         }
 
-        ///// <summary>
-        /////     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
-        /////     calling <paramref name="onRetryAsync" /> on each retry with the raised exception, the current sleep duration, retry count, and context data.
-        /////     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        /////     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
-        ///// </summary>
-        ///// <param name="policyBuilder">The policy builder.</param>
-        ///// <param name="retryCount">The retry count.</param>
-        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
-        ///// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
-        ///// <returns>The policy instance.</returns>
-        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        ///// <exception cref="System.ArgumentNullException">
-        /////     sleepDurationProvider
-        /////     or
-        /////     onRetryAsync
-        ///// </exception>
-        //public static RetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
-        //    Func<int, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, int, Context, Task> onRetryAsync)
-        //{
-        //    if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
-        //    if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-        //    if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
-
-        //    return new RetryPolicy(
-        //        (action, context, cancellationToken, continueOnCapturedContext) =>
-        //          RetryEngine.ImplementationAsync(
-        //            async (ctx, ct) => { await action(ctx, ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
-        //            context,
-        //            cancellationToken,
-        //            policyBuilder.ExceptionPredicates,
-        //            PredicateHelper<EmptyStruct>.EmptyResultPredicates,
-        //            () => new RetryStateWaitAndRetryWithProvider<EmptyStruct>(retryCount, sleepDurationProvider, (outcome, timespan, i, ctx) => onRetryAsync(outcome.Exception, timespan, i, ctx), context), 
-        //            continueOnCapturedContext),
-        //        policyBuilder.ExceptionPredicates
-        //    );
-        //}
-
-        // For v560waitDurationFromErrorResponse: delete the overload above, and replace with the two below
-
         /// <summary>
         ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
         ///     calling <paramref name="onRetryAsync" /> on each retry with the raised exception, the current sleep duration, retry count, and context data.
@@ -625,6 +585,7 @@ namespace Polly
         public static RetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
             Func<int, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, int, Context, Task> onRetryAsync)
         {
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             return policyBuilder.WaitAndRetryAsync(
                 retryCount,
                 (i, outcome, ctx) => sleepDurationProvider(i, ctx),
@@ -966,6 +927,26 @@ namespace Polly
         public static RetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, Context, Task> onRetryAsync)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+            return policyBuilder.WaitAndRetryForeverAsync(
+                (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+                onRetryAsync
+            );
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait and retry indefinitely
+        /// calling <paramref name="onRetryAsync"/> on each retry with the raised exception and
+        /// execution context.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
+        /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onRetryAsync</exception>        
+        public static RetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, Exception, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, Context, Task> onRetryAsync)
+        {
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             return new RetryPolicy(
@@ -976,9 +957,12 @@ namespace Polly
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     PredicateHelper<EmptyStruct>.EmptyResultPredicates,
-                () => new RetryStateWaitAndRetryForever<EmptyStruct>(sleepDurationProvider, (outcome, timespan, ctx) => onRetryAsync(outcome.Exception, timespan, ctx), context),
-                continueOnCapturedContext
-            ), policyBuilder.ExceptionPredicates);
+                    () => new RetryStateWaitAndRetryForever<EmptyStruct>(
+                        (i, outcome, ctx) => sleepDurationProvider(i, outcome.Exception, ctx),
+                        (outcome, timespan, ctx) => onRetryAsync(outcome.Exception, timespan, ctx), 
+                        context),
+                    continueOnCapturedContext
+                  ), policyBuilder.ExceptionPredicates);
         }
     }
 }

--- a/src/Polly.Shared/Retry/RetrySyntaxAsync.cs
+++ b/src/Polly.Shared/Retry/RetrySyntaxAsync.cs
@@ -565,6 +565,46 @@ namespace Polly
             );
         }
 
+        ///// <summary>
+        /////     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
+        /////     calling <paramref name="onRetryAsync" /> on each retry with the raised exception, the current sleep duration, retry count, and context data.
+        /////     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
+        /////     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///// </summary>
+        ///// <param name="policyBuilder">The policy builder.</param>
+        ///// <param name="retryCount">The retry count.</param>
+        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        ///// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        ///// <returns>The policy instance.</returns>
+        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        ///// <exception cref="System.ArgumentNullException">
+        /////     sleepDurationProvider
+        /////     or
+        /////     onRetryAsync
+        ///// </exception>
+        //public static RetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
+        //    Func<int, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, int, Context, Task> onRetryAsync)
+        //{
+        //    if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
+        //    if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+        //    if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
+
+        //    return new RetryPolicy(
+        //        (action, context, cancellationToken, continueOnCapturedContext) =>
+        //          RetryEngine.ImplementationAsync(
+        //            async (ctx, ct) => { await action(ctx, ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
+        //            context,
+        //            cancellationToken,
+        //            policyBuilder.ExceptionPredicates,
+        //            PredicateHelper<EmptyStruct>.EmptyResultPredicates,
+        //            () => new RetryStateWaitAndRetryWithProvider<EmptyStruct>(retryCount, sleepDurationProvider, (outcome, timespan, i, ctx) => onRetryAsync(outcome.Exception, timespan, i, ctx), context), 
+        //            continueOnCapturedContext),
+        //        policyBuilder.ExceptionPredicates
+        //    );
+        //}
+
+        // For v560waitDurationFromErrorResponse: delete the overload above, and replace with the two below
+
         /// <summary>
         ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
         ///     calling <paramref name="onRetryAsync" /> on each retry with the raised exception, the current sleep duration, retry count, and context data.
@@ -585,6 +625,32 @@ namespace Polly
         public static RetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
             Func<int, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, int, Context, Task> onRetryAsync)
         {
+            return policyBuilder.WaitAndRetryAsync(
+                retryCount,
+                (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+                onRetryAsync);
+        }
+
+        /// <summary>
+        ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
+        ///     calling <paramref name="onRetryAsync" /> on each retry with the raised exception, the current sleep duration, retry count, and context data.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
+        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="retryCount">The retry count.</param>
+        /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        /// <exception cref="System.ArgumentNullException">
+        ///     sleepDurationProvider
+        ///     or
+        ///     onRetryAsync
+        /// </exception>
+        public static RetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
+            Func<int, Exception, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, int, Context, Task> onRetryAsync)
+        {
             if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
@@ -597,7 +663,11 @@ namespace Polly
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     PredicateHelper<EmptyStruct>.EmptyResultPredicates,
-                    () => new RetryStateWaitAndRetryWithProvider<EmptyStruct>(retryCount, sleepDurationProvider, (outcome, timespan, i, ctx) => onRetryAsync(outcome.Exception, timespan, i, ctx), context), 
+                    () => new RetryStateWaitAndRetryWithProvider<EmptyStruct>(
+                        retryCount,
+                        (i, outcome, ctx) => sleepDurationProvider(i, outcome.Exception, ctx),
+                        (outcome, timespan, i, ctx) => onRetryAsync(outcome.Exception, timespan, i, ctx),
+                        context),
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates
             );

--- a/src/Polly.Shared/Retry/RetryTResultSyntax.cs
+++ b/src/Polly.Shared/Retry/RetryTResultSyntax.cs
@@ -277,7 +277,7 @@ namespace Polly
         /// <param name="retryCount">The retry count.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <returns>The policy instance.</returns>
-        public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider)
+        public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider)
         {
             Action<DelegateResult<TResult>, TimeSpan, int, Context> doNothing = (_, __, ___, ____) => { };
 
@@ -301,7 +301,7 @@ namespace Polly
         /// or
         /// onRetry
         /// </exception>
-        public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
+        public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
         {
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
@@ -329,7 +329,7 @@ namespace Polly
         /// or
         /// onRetry
         /// </exception>
-        public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
+        public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
         {
             if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
@@ -344,9 +344,72 @@ namespace Polly
                     policyBuilder.ResultPredicates,
                     () => new RetryStateWaitAndRetryWithProvider<TResult>(retryCount, sleepDurationProvider, onRetry, context)
                 ),
-            policyBuilder.ExceptionPredicates,
-            policyBuilder.ResultPredicates);
+                policyBuilder.ExceptionPredicates,
+                policyBuilder.ResultPredicates);
         }
+
+        // For v560waitDurationFromErrorResponse: delete the overload above, and replace with the two below
+
+        ///// <summary>
+        ///// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
+        ///// calling <paramref name="onRetry"/> on each retry with the handled exception or result, current sleep duration, retry count, and context data.
+        ///// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
+        ///// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///// </summary>
+        ///// <param name="policyBuilder">The policy builder.</param>
+        ///// <param name="retryCount">The retry count.</param>
+        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        ///// <param name="onRetry">The action to call on each retry.</param>
+        ///// <returns>The policy instance.</returns>
+        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        ///// <exception cref="System.ArgumentNullException">
+        ///// timeSpanProvider
+        ///// or
+        ///// onRetry
+        ///// </exception>
+        //public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
+        //{
+        //    return policyBuilder.WaitAndRetry(
+        //        retryCount,
+        //        (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+        //        onRetry);
+        //}
+
+        ///// <summary>
+        ///// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
+        ///// calling <paramref name="onRetry"/> on each retry with the handled exception or result, current sleep duration, retry count, and context data.
+        ///// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
+        ///// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///// </summary>
+        ///// <param name="policyBuilder">The policy builder.</param>
+        ///// <param name="retryCount">The retry count.</param>
+        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        ///// <param name="onRetry">The action to call on each retry.</param>
+        ///// <returns>The policy instance.</returns>
+        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        ///// <exception cref="System.ArgumentNullException">
+        ///// timeSpanProvider
+        ///// or
+        ///// onRetry
+        ///// </exception>
+        //public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
+        //{
+        //    if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
+        //    if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+        //    if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
+
+        //    return new RetryPolicy<TResult>(
+        //        (action, context, cancellationToken) => RetryEngine.Implementation(
+        //            action,
+        //            context,
+        //            cancellationToken,
+        //            policyBuilder.ExceptionPredicates,
+        //            policyBuilder.ResultPredicates,
+        //            () => new RetryStateWaitAndRetryWithProvider<TResult>(retryCount, sleepDurationProvider, onRetry, context)
+        //        ),
+        //    policyBuilder.ExceptionPredicates,
+        //    policyBuilder.ResultPredicates);
+        //}
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry as many times as there are provided <paramref name="sleepDurations"/>

--- a/src/Polly.Shared/Retry/RetryTResultSyntax.cs
+++ b/src/Polly.Shared/Retry/RetryTResultSyntax.cs
@@ -277,6 +277,76 @@ namespace Polly
         /// <param name="retryCount">The retry count.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <returns>The policy instance.</returns>
+        public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider)
+        {
+            Action<DelegateResult<TResult>, TimeSpan, int, Context> doNothing = (_, __, ___, ____) => { };
+
+            return policyBuilder.WaitAndRetry(retryCount, sleepDurationProvider, doNothing);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
+        /// calling <paramref name="onRetry"/> on each retry with the handled exception or result, current sleep duration and context data.
+        /// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
+        /// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="retryCount">The retry count.</param>
+        /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        /// <exception cref="System.ArgumentNullException">
+        /// sleepDurationProvider
+        /// or
+        /// onRetry
+        /// </exception>
+        public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
+        {
+            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
+
+            return policyBuilder.WaitAndRetry(
+                retryCount,
+                sleepDurationProvider,
+                (outcome, span, i, ctx) => onRetry(outcome, span, ctx)
+                );
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
+        /// calling <paramref name="onRetry"/> on each retry with the handled exception or result, current sleep duration, retry count, and context data.
+        /// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
+        /// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="retryCount">The retry count.</param>
+        /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        /// <exception cref="System.ArgumentNullException">
+        /// timeSpanProvider
+        /// or
+        /// onRetry
+        /// </exception>
+        public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
+        {
+            return policyBuilder.WaitAndRetry(
+                retryCount,
+                (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+                onRetry
+            );
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times.
+        /// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
+        /// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="retryCount">The retry count.</param>
+        /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        /// <returns>The policy instance.</returns>
         public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider)
         {
             Action<DelegateResult<TResult>, TimeSpan, int, Context> doNothing = (_, __, ___, ____) => { };
@@ -347,69 +417,6 @@ namespace Polly
                 policyBuilder.ExceptionPredicates,
                 policyBuilder.ResultPredicates);
         }
-
-        // For v560waitDurationFromErrorResponse: delete the overload above, and replace with the two below
-
-        ///// <summary>
-        ///// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
-        ///// calling <paramref name="onRetry"/> on each retry with the handled exception or result, current sleep duration, retry count, and context data.
-        ///// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
-        ///// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
-        ///// </summary>
-        ///// <param name="policyBuilder">The policy builder.</param>
-        ///// <param name="retryCount">The retry count.</param>
-        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
-        ///// <param name="onRetry">The action to call on each retry.</param>
-        ///// <returns>The policy instance.</returns>
-        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        ///// <exception cref="System.ArgumentNullException">
-        ///// timeSpanProvider
-        ///// or
-        ///// onRetry
-        ///// </exception>
-        //public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
-        //{
-        //    return policyBuilder.WaitAndRetry(
-        //        retryCount,
-        //        (i, outcome, ctx) => sleepDurationProvider(i, ctx),
-        //        onRetry);
-        //}
-
-        ///// <summary>
-        ///// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
-        ///// calling <paramref name="onRetry"/> on each retry with the handled exception or result, current sleep duration, retry count, and context data.
-        ///// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
-        ///// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
-        ///// </summary>
-        ///// <param name="policyBuilder">The policy builder.</param>
-        ///// <param name="retryCount">The retry count.</param>
-        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
-        ///// <param name="onRetry">The action to call on each retry.</param>
-        ///// <returns>The policy instance.</returns>
-        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        ///// <exception cref="System.ArgumentNullException">
-        ///// timeSpanProvider
-        ///// or
-        ///// onRetry
-        ///// </exception>
-        //public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
-        //{
-        //    if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
-        //    if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-        //    if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
-        //    return new RetryPolicy<TResult>(
-        //        (action, context, cancellationToken) => RetryEngine.Implementation(
-        //            action,
-        //            context,
-        //            cancellationToken,
-        //            policyBuilder.ExceptionPredicates,
-        //            policyBuilder.ResultPredicates,
-        //            () => new RetryStateWaitAndRetryWithProvider<TResult>(retryCount, sleepDurationProvider, onRetry, context)
-        //        ),
-        //    policyBuilder.ExceptionPredicates,
-        //    policyBuilder.ResultPredicates);
-        //}
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry as many times as there are provided <paramref name="sleepDurations"/>
@@ -567,6 +574,26 @@ namespace Polly
         public static RetryPolicy<TResult> WaitAndRetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+            return policyBuilder.WaitAndRetryForever(
+                (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+                onRetry
+            );
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
+        /// calling <paramref name="onRetry"/> on each retry with the handled exception or result and
+        /// execution context.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onRetry</exception>
+        public static RetryPolicy<TResult> WaitAndRetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
+        {
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return new RetryPolicy<TResult>(
@@ -577,7 +604,7 @@ namespace Polly
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
                     () => new RetryStateWaitAndRetryForever<TResult>(sleepDurationProvider, onRetry, context)
-                ), 
+                ),
                 policyBuilder.ExceptionPredicates,
                 policyBuilder.ResultPredicates
             );

--- a/src/Polly.Shared/Retry/RetryTResultSyntaxAsync.cs
+++ b/src/Polly.Shared/Retry/RetryTResultSyntaxAsync.cs
@@ -497,7 +497,7 @@ namespace Polly
         ///     onRetry
         /// </exception>
         public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
-            Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
+            Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
         {
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
@@ -527,7 +527,7 @@ namespace Polly
         ///     or
         ///     onRetryAsync
         /// </exception>
-        public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, Context, Task> onRetryAsync)
+        public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, Context, Task> onRetryAsync)
         {
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
@@ -555,7 +555,7 @@ namespace Polly
         ///     or
         ///     onRetry
         /// </exception>
-        public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
+        public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
         {
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
@@ -567,6 +567,47 @@ namespace Polly
 #pragma warning restore 1998
             );
         }
+
+        ///// <summary>
+        /////     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
+        /////     calling <paramref name="onRetryAsync" /> on each retry with the handled exception or result, the current sleep duration, retry count, and context data.
+        /////     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
+        /////     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///// </summary>
+        ///// <param name="policyBuilder">The policy builder.</param>
+        ///// <param name="retryCount">The retry count.</param>
+        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        ///// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        ///// <returns>The policy instance.</returns>
+        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        ///// <exception cref="System.ArgumentNullException">
+        /////     sleepDurationProvider
+        /////     or
+        /////     onRetryAsync
+        ///// </exception>
+        //public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
+        //    Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync)
+        //{
+        //    if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
+        //    if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+        //    if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
+
+        //    return new RetryPolicy<TResult>(
+        //        (action, context, cancellationToken, continueOnCapturedContext) =>
+        //          RetryEngine.ImplementationAsync(
+        //            action,
+        //            context,
+        //            cancellationToken,
+        //            policyBuilder.ExceptionPredicates,
+        //            policyBuilder.ResultPredicates,
+        //            () => new RetryStateWaitAndRetryWithProvider<TResult>(retryCount, sleepDurationProvider, onRetryAsync, context), 
+        //            continueOnCapturedContext),
+        //        policyBuilder.ExceptionPredicates,
+        //        policyBuilder.ResultPredicates
+        //    );
+        //}
+
+        // For v560waitDurationFromErrorResponse: delete the overload above, and replace with the two below
 
         /// <summary>
         ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
@@ -588,6 +629,32 @@ namespace Polly
         public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
             Func<int, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync)
         {
+            return policyBuilder.WaitAndRetryAsync(
+                retryCount,
+                (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+                onRetryAsync);
+        }
+
+        /// <summary>
+        ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
+        ///     calling <paramref name="onRetryAsync" /> on each retry with the handled exception or result, the current sleep duration, retry count, and context data.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
+        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="retryCount">The retry count.</param>
+        /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
+        /// <exception cref="System.ArgumentNullException">
+        ///     sleepDurationProvider
+        ///     or
+        ///     onRetryAsync
+        /// </exception>
+        public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
+            Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync)
+        {
             if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
@@ -600,7 +667,7 @@ namespace Polly
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
-                    () => new RetryStateWaitAndRetryWithProvider<TResult>(retryCount, sleepDurationProvider, onRetryAsync, context), 
+                    () => new RetryStateWaitAndRetryWithProvider<TResult>(retryCount, sleepDurationProvider, onRetryAsync, context),
                     continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates,
                 policyBuilder.ResultPredicates

--- a/src/Polly.Shared/Retry/RetryTResultSyntaxAsync.cs
+++ b/src/Polly.Shared/Retry/RetryTResultSyntaxAsync.cs
@@ -497,7 +497,7 @@ namespace Polly
         ///     onRetry
         /// </exception>
         public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
-            Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
+            Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
         {
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
@@ -527,7 +527,7 @@ namespace Polly
         ///     or
         ///     onRetryAsync
         /// </exception>
-        public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, Context, Task> onRetryAsync)
+        public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, Context, Task> onRetryAsync)
         {
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
@@ -555,7 +555,7 @@ namespace Polly
         ///     or
         ///     onRetry
         /// </exception>
-        public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
+        public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
         {
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
@@ -567,47 +567,6 @@ namespace Polly
 #pragma warning restore 1998
             );
         }
-
-        ///// <summary>
-        /////     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
-        /////     calling <paramref name="onRetryAsync" /> on each retry with the handled exception or result, the current sleep duration, retry count, and context data.
-        /////     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        /////     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
-        ///// </summary>
-        ///// <param name="policyBuilder">The policy builder.</param>
-        ///// <param name="retryCount">The retry count.</param>
-        ///// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
-        ///// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
-        ///// <returns>The policy instance.</returns>
-        ///// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        ///// <exception cref="System.ArgumentNullException">
-        /////     sleepDurationProvider
-        /////     or
-        /////     onRetryAsync
-        ///// </exception>
-        //public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
-        //    Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync)
-        //{
-        //    if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
-        //    if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-        //    if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
-
-        //    return new RetryPolicy<TResult>(
-        //        (action, context, cancellationToken, continueOnCapturedContext) =>
-        //          RetryEngine.ImplementationAsync(
-        //            action,
-        //            context,
-        //            cancellationToken,
-        //            policyBuilder.ExceptionPredicates,
-        //            policyBuilder.ResultPredicates,
-        //            () => new RetryStateWaitAndRetryWithProvider<TResult>(retryCount, sleepDurationProvider, onRetryAsync, context), 
-        //            continueOnCapturedContext),
-        //        policyBuilder.ExceptionPredicates,
-        //        policyBuilder.ResultPredicates
-        //    );
-        //}
-
-        // For v560waitDurationFromErrorResponse: delete the overload above, and replace with the two below
 
         /// <summary>
         ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
@@ -629,6 +588,7 @@ namespace Polly
         public static RetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
             Func<int, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync)
         {
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             return policyBuilder.WaitAndRetryAsync(
                 retryCount,
                 (i, outcome, ctx) => sleepDurationProvider(i, ctx),
@@ -967,19 +927,39 @@ namespace Polly
         public static RetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, Context, Task> onRetryAsync)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+            return policyBuilder.WaitAndRetryForeverAsync(
+                (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+                onRetryAsync
+            );
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
+        /// calling <paramref name="onRetryAsync"/> on each retry with the handled exception or result and
+        /// execution context.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
+        /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onRetryAsync</exception>        
+        public static RetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, Context, Task> onRetryAsync)
+        {
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             return new RetryPolicy<TResult>(
                 (action, context, cancellationToken, continueOnCapturedContext) =>
-                  RetryEngine.ImplementationAsync(
-                    action,
-                    context,
-                    cancellationToken,
-                    policyBuilder.ExceptionPredicates,
-                    policyBuilder.ResultPredicates,
-                    () => new RetryStateWaitAndRetryForever<TResult>(sleepDurationProvider, onRetryAsync, context),
-                    continueOnCapturedContext
-                ), 
+                    RetryEngine.ImplementationAsync(
+                        action,
+                        context,
+                        cancellationToken,
+                        policyBuilder.ExceptionPredicates,
+                        policyBuilder.ResultPredicates,
+                        () => new RetryStateWaitAndRetryForever<TResult>(sleepDurationProvider, onRetryAsync, context),
+                        continueOnCapturedContext
+                    ),
                 policyBuilder.ExceptionPredicates,
                 policyBuilder.ResultPredicates);
         }

--- a/src/Polly.Shared/Wrap/IPolicyWrapExtension.cs
+++ b/src/Polly.Shared/Wrap/IPolicyWrapExtension.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Polly.Wrap
+{
+    /// <summary>
+    /// Extension methods for IPolicyWrap.
+    /// </summary>
+    public static class IPolicyWrapExtension
+    {
+        /// <summary>
+        /// Recursively iterates through <see cref="PolicyWrap"/> nodes returning <see cref="IsPolicy"/> in Outer-Inner order.
+        /// </summary>
+        /// <param name="policyWrap"></param>
+        /// <returns></returns>
+        public static IEnumerable<IsPolicy> GetPolicies(this IPolicyWrap policyWrap)
+        {
+            var subPolicies = new[] { policyWrap.Outer, policyWrap.Inner };
+            foreach (var subPolicy in subPolicies)
+            {
+                if (subPolicy is IPolicyWrap outerWrap)
+                {
+                    foreach (var policy in outerWrap.GetPolicies())
+                    {
+                        yield return policy;
+                    }
+                }
+                else if (subPolicy != null)
+                {
+                    yield return subPolicy;
+                }
+            }
+        }
+    }
+}

--- a/src/Polly.Shared/Wrap/IPolicyWrapExtension.cs
+++ b/src/Polly.Shared/Wrap/IPolicyWrapExtension.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Linq;
 
 namespace Polly.Wrap
 {
@@ -10,27 +10,77 @@ namespace Polly.Wrap
     public static class IPolicyWrapExtension
     {
         /// <summary>
-        /// Recursively iterates through <see cref="PolicyWrap"/> nodes returning <see cref="IsPolicy"/> in Outer-Inner order.
+        /// Returns all the policies in this <see cref="IPolicyWrap"/>, in Outer-to-Inner order.
         /// </summary>
-        /// <param name="policyWrap"></param>
-        /// <returns></returns>
+        /// <param name="policyWrap">The <see cref="IPolicyWrap"/> for which to return policies.</param>
+        /// <returns>An <see cref="IEnumerable{IsPolicy}"/> of all the policies in the wrap.</returns>
         public static IEnumerable<IsPolicy> GetPolicies(this IPolicyWrap policyWrap)
         {
-            var subPolicies = new[] { policyWrap.Outer, policyWrap.Inner };
-            foreach (var subPolicy in subPolicies)
+            var childPolicies = new[] { policyWrap.Outer, policyWrap.Inner };
+            foreach (var childPolicy in childPolicies)
             {
-                if (subPolicy is IPolicyWrap outerWrap)
+                if (childPolicy is IPolicyWrap anotherWrap)
                 {
-                    foreach (var policy in outerWrap.GetPolicies())
+                    foreach (var policy in anotherWrap.GetPolicies())
                     {
                         yield return policy;
                     }
                 }
-                else if (subPolicy != null)
+                else if (childPolicy != null)
                 {
-                    yield return subPolicy;
+                    yield return childPolicy;
                 }
             }
+        }
+
+        /// <summary>
+        /// Returns all the policies in this <see cref="IPolicyWrap"/> of type <typeparamref name="TPolicy"/>, in Outer-to-Inner order.
+        /// </summary>
+        /// <param name="policyWrap">The <see cref="IPolicyWrap"/> for which to return policies.</param>
+        /// <typeparam name="TPolicy">The type of policies to return.</typeparam>
+        /// <returns>An <see cref="IEnumerable{TPolicy}"/> of all the policies of the given type.</returns>
+        public static IEnumerable<TPolicy> GetPolicies<TPolicy>(this IPolicyWrap policyWrap)
+        {
+            return policyWrap.GetPolicies().OfType<TPolicy>();
+        }
+
+        /// <summary>
+        /// Returns all the policies in this <see cref="IPolicyWrap"/> of type <typeparamref name="TPolicy"/> matching the filter, in Outer-to-Inner order.
+        /// </summary>
+        /// <param name="policyWrap">The <see cref="IPolicyWrap"/> for which to return policies.</param>
+        /// <param name="filter">A filter to apply to any policies of type <typeparamref name="TPolicy"/> found.</param>
+        /// <typeparam name="TPolicy">The type of policies to return.</typeparam>
+        /// <returns>An <see cref="IEnumerable{TPolicy}"/> of all the policies of the given type, matching the filter.</returns>
+        public static IEnumerable<TPolicy> GetPolicies<TPolicy>(this IPolicyWrap policyWrap, Func<TPolicy, bool> filter)
+        {
+            if (filter == null) throw new ArgumentNullException(nameof(filter));
+            return policyWrap.GetPolicies().OfType<TPolicy>().Where(filter);
+        }
+
+        /// <summary>
+        /// Returns the single policy in this <see cref="IPolicyWrap"/> of type <typeparamref name="TPolicy"/>.
+        /// </summary>
+        /// <param name="policyWrap">The <see cref="IPolicyWrap"/> for which to search for the policy.</param>
+        /// <typeparam name="TPolicy">The type of policy to return.</typeparam>
+        /// <returns>A <typeparamref name="TPolicy"/> if one is found; else null.</returns>
+        /// <throws>InvalidOperationException, if more than one policy of the type is found in the wrap.</throws>
+        public static TPolicy GetPolicy<TPolicy>(this IPolicyWrap policyWrap)
+        {
+            return policyWrap.GetPolicies().OfType<TPolicy>().SingleOrDefault();
+        }
+
+        /// <summary>
+        /// Returns the single policy in this <see cref="IPolicyWrap"/> of type <typeparamref name="TPolicy"/> matching the filter.
+        /// </summary>
+        /// <param name="policyWrap">The <see cref="IPolicyWrap"/> for which to search for the policy.</param>
+        /// <param name="filter">A filter to apply to any policies of type <typeparamref name="TPolicy"/> found.</param>
+        /// <typeparam name="TPolicy">The type of policy to return.</typeparam>
+        /// <returns>A matching <typeparamref name="TPolicy"/> if one is found; else null.</returns>
+        /// <throws>InvalidOperationException, if more than one policy of the type is found in the wrap.</throws>
+        public static TPolicy GetPolicy<TPolicy>(this IPolicyWrap policyWrap, Func<TPolicy, bool> filter)
+        {
+            if (filter == null) throw new ArgumentNullException(nameof(filter));
+            return policyWrap.GetPolicies().OfType<TPolicy>().SingleOrDefault(filter);
         }
     }
 }

--- a/src/Polly.Shared/Wrap/PolicyWrap.cs
+++ b/src/Polly.Shared/Wrap/PolicyWrap.cs
@@ -9,8 +9,8 @@ namespace Polly.Wrap
     /// </summary>
     public partial class PolicyWrap : Policy, IPolicyWrap
     {
-        private Policy _outer;
-        private Policy _inner;
+        private IsPolicy _outer;
+        private IsPolicy _inner;
 
         /// <summary>
         /// Returns the outer <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>
@@ -22,7 +22,7 @@ namespace Polly.Wrap
         /// </summary>
         public IsPolicy Inner => _inner;
 
-        internal PolicyWrap(Action<Action<Context, CancellationToken>, Context, CancellationToken> policyAction, Policy outer, Policy inner) 
+        internal PolicyWrap(Action<Action<Context, CancellationToken>, Context, CancellationToken> policyAction, Policy outer, ISyncPolicy inner) 
             : base(policyAction, outer.ExceptionPredicates)
         {
             _outer = outer;
@@ -43,8 +43,8 @@ namespace Polly.Wrap
                    action,
                    context,
                    cancellationToken,
-                   _outer, 
-                   _inner
+                   (ISyncPolicy)_outer,
+                   (ISyncPolicy)_inner
                    );
         }
     }

--- a/src/Polly.Shared/Wrap/PolicyWrapAsync.cs
+++ b/src/Polly.Shared/Wrap/PolicyWrapAsync.cs
@@ -7,7 +7,7 @@ namespace Polly.Wrap
 {
     public partial class PolicyWrap : IPolicyWrap
     {
-        internal PolicyWrap(Func<Func<Context, CancellationToken, Task>, Context, CancellationToken, bool, Task> policyAction, Policy outer, Policy inner)
+        internal PolicyWrap(Func<Func<Context, CancellationToken, Task>, Context, CancellationToken, bool, Task> policyAction, Policy outer, IAsyncPolicy inner)
             : base(policyAction, outer.ExceptionPredicates)
         {
             _outer = outer;
@@ -30,8 +30,8 @@ namespace Polly.Wrap
                 context,
                 cancellationToken,
                 continueOnCapturedContext,
-                _outer,
-                _inner);
+                (IAsyncPolicy)_outer,
+                (IAsyncPolicy)_inner);
         }
     }
 

--- a/src/Polly.Shared/Wrap/PolicyWrapEngine.cs
+++ b/src/Polly.Shared/Wrap/PolicyWrapEngine.cs
@@ -9,8 +9,8 @@ namespace Polly.Wrap
             Func<Context, CancellationToken, TResult> func,
             Context context,
             CancellationToken cancellationToken,
-            Policy<TResult> outerPolicy,
-            Policy<TResult> innerPolicy)
+            ISyncPolicy<TResult> outerPolicy,
+            ISyncPolicy<TResult> innerPolicy)
         {
             return outerPolicy.Execute((ctx, ct) => innerPolicy.Execute(func, ctx, ct), context, cancellationToken);
         }
@@ -19,8 +19,8 @@ namespace Polly.Wrap
            Func<Context, CancellationToken, TResult> func,
            Context context,
            CancellationToken cancellationToken,
-           Policy<TResult> outerPolicy,
-           Policy innerPolicy)
+           ISyncPolicy<TResult> outerPolicy,
+           ISyncPolicy innerPolicy)
         {
             return outerPolicy.Execute((ctx, ct) => innerPolicy.Execute<TResult>(func, ctx, ct), context, cancellationToken);
         }
@@ -29,8 +29,8 @@ namespace Polly.Wrap
            Func<Context, CancellationToken, TResult> func,
            Context context,
            CancellationToken cancellationToken,
-           Policy outerPolicy,
-           Policy<TResult> innerPolicy)
+           ISyncPolicy outerPolicy,
+           ISyncPolicy<TResult> innerPolicy)
         {
             return outerPolicy.Execute<TResult>((ctx, ct) => innerPolicy.Execute(func, ctx, ct), context, cancellationToken);
         }
@@ -39,8 +39,8 @@ namespace Polly.Wrap
            Func<Context, CancellationToken, TResult> func,
            Context context,
            CancellationToken cancellationToken,
-           Policy outerPolicy,
-           Policy innerPolicy)
+           ISyncPolicy outerPolicy,
+           ISyncPolicy innerPolicy)
         {
             return outerPolicy.Execute<TResult>((ctx, ct) => innerPolicy.Execute<TResult>(func, ctx, ct), context, cancellationToken);
         }
@@ -49,8 +49,8 @@ namespace Polly.Wrap
            Action<Context, CancellationToken> action,
            Context context,
            CancellationToken cancellationToken, 
-           Policy outerPolicy,
-           Policy innerPolicy)
+           ISyncPolicy outerPolicy,
+           ISyncPolicy innerPolicy)
         {
             outerPolicy.Execute((ctx, ct) => innerPolicy.Execute(action, ctx, ct), context, cancellationToken);
         }

--- a/src/Polly.Shared/Wrap/PolicyWrapEngineAsync.cs
+++ b/src/Polly.Shared/Wrap/PolicyWrapEngineAsync.cs
@@ -11,8 +11,8 @@ namespace Polly.Wrap
             Context context,
             CancellationToken cancellationToken,
             bool continueOnCapturedContext,
-            Policy<TResult> outerPolicy,
-            Policy<TResult> innerPolicy)
+            IAsyncPolicy<TResult> outerPolicy,
+            IAsyncPolicy<TResult> innerPolicy)
         {
             return await outerPolicy.ExecuteAsync(
                 async (ctx, ct) => await innerPolicy.ExecuteAsync(
@@ -32,8 +32,8 @@ namespace Polly.Wrap
             Context context,
             CancellationToken cancellationToken,
             bool continueOnCapturedContext,
-            Policy<TResult> outerPolicy,
-            Policy innerPolicy)
+            IAsyncPolicy<TResult> outerPolicy,
+            IAsyncPolicy innerPolicy)
         {
             return await outerPolicy.ExecuteAsync(
                 async (ctx, ct) => await innerPolicy.ExecuteAsync<TResult>(
@@ -53,8 +53,8 @@ namespace Polly.Wrap
             Context context,
             CancellationToken cancellationToken,
             bool continueOnCapturedContext,
-            Policy outerPolicy,
-            Policy<TResult> innerPolicy)
+            IAsyncPolicy outerPolicy,
+            IAsyncPolicy<TResult> innerPolicy)
         {
             return await outerPolicy.ExecuteAsync<TResult>(
                 async (ctx, ct) => await innerPolicy.ExecuteAsync(
@@ -74,8 +74,8 @@ namespace Polly.Wrap
            Context context,
            CancellationToken cancellationToken,
            bool continueOnCapturedContext,
-           Policy outerPolicy,
-           Policy innerPolicy)
+           IAsyncPolicy outerPolicy,
+           IAsyncPolicy innerPolicy)
         {
             return await outerPolicy.ExecuteAsync<TResult>(
                 async (ctx, ct) => await innerPolicy.ExecuteAsync<TResult>(
@@ -95,8 +95,8 @@ namespace Polly.Wrap
             Context context,
             CancellationToken cancellationToken,
             bool continueOnCapturedContext,
-            Policy outerPolicy,
-            Policy innerPolicy)
+            IAsyncPolicy outerPolicy,
+            IAsyncPolicy innerPolicy)
         {
             await outerPolicy.ExecuteAsync(
                 async (ctx, ct) => await innerPolicy.ExecuteAsync(

--- a/src/Polly.Shared/Wrap/PolicyWrapSyntax.cs
+++ b/src/Polly.Shared/Wrap/PolicyWrapSyntax.cs
@@ -86,7 +86,7 @@ namespace Polly
         /// <exception cref="System.ArgumentException">The enumerable of policies to form the wrap must contain at least two policies.</exception>
         public static PolicyWrap Wrap(params Policy[] policies)
         {
-            switch (policies.Count())
+            switch (policies.Length)
             {
                 case 0:
                 case 1:

--- a/src/Polly.Shared/Wrap/PolicyWrapSyntax.cs
+++ b/src/Polly.Shared/Wrap/PolicyWrapSyntax.cs
@@ -12,7 +12,7 @@ namespace Polly
         /// </summary>
         /// <param name="innerPolicy">The inner policy.</param>
         /// <returns>PolicyWrap.PolicyWrap.</returns>
-        public PolicyWrap Wrap(Policy innerPolicy)
+        public PolicyWrap Wrap(ISyncPolicy innerPolicy)
         {
             if (innerPolicy == null) throw new ArgumentNullException(nameof(innerPolicy));
 
@@ -29,7 +29,7 @@ namespace Polly
         /// <param name="innerPolicy">The inner policy.</param>
         /// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
         /// <returns>PolicyWrap.PolicyWrap.</returns>
-        public PolicyWrap<TResult> Wrap<TResult>(Policy<TResult> innerPolicy)
+        public PolicyWrap<TResult> Wrap<TResult>(ISyncPolicy<TResult> innerPolicy)
         {
             if (innerPolicy == null) throw new ArgumentNullException(nameof(innerPolicy));
 
@@ -48,7 +48,7 @@ namespace Polly
         /// </summary>
         /// <param name="innerPolicy">The inner policy.</param>
         /// <returns>PolicyWrap.PolicyWrap.</returns>
-        public PolicyWrap<TResult> Wrap(Policy innerPolicy)
+        public PolicyWrap<TResult> Wrap(ISyncPolicy innerPolicy)
         {
             if (innerPolicy == null) throw new ArgumentNullException(nameof(innerPolicy));
 
@@ -64,7 +64,7 @@ namespace Polly
         /// </summary>
         /// <param name="innerPolicy">The inner policy.</param>
         /// <returns>PolicyWrap.PolicyWrap.</returns>
-        public PolicyWrap<TResult> Wrap(Policy<TResult> innerPolicy)
+        public PolicyWrap<TResult> Wrap(ISyncPolicy<TResult> innerPolicy)
         {
             if (innerPolicy == null) throw new ArgumentNullException(nameof(innerPolicy));
 
@@ -84,16 +84,25 @@ namespace Polly
         /// <param name="policies">The policies to place in the wrap, outermost (at left) to innermost (at right).</param>
         /// <returns>The PolicyWrap.</returns>
         /// <exception cref="System.ArgumentException">The enumerable of policies to form the wrap must contain at least two policies.</exception>
-        public static PolicyWrap Wrap(params Policy[] policies)
+        public static PolicyWrap Wrap(params ISyncPolicy[] policies)
         {
             switch (policies.Length)
             {
                 case 0:
                 case 1:
                     throw new ArgumentException("The enumerable of policies to form the wrap must contain at least two policies.", nameof(policies));
+                case 2:
+                    return new PolicyWrap(
+                        (func, context, cancellationtoken) => PolicyWrapEngine.Implementation(
+                            func, 
+                            context, 
+                            cancellationtoken, 
+                            policies[0], 
+                            policies[1]), 
+                        (Policy)policies[0], policies[1]);
+
                 default:
-                    IEnumerable<Policy> remainder = policies.Skip(1);
-                    return policies.First().Wrap(remainder.Count() == 1 ? remainder.Single() : Wrap(remainder.ToArray()));
+                    return Wrap(policies[0], Wrap(policies.Skip(1).ToArray()));
             }
         }
 
@@ -104,16 +113,25 @@ namespace Polly
         /// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
         /// <returns>The PolicyWrap.</returns>
         /// <exception cref="System.ArgumentException">The enumerable of policies to form the wrap must contain at least two policies.</exception>
-        public static PolicyWrap<TResult> Wrap<TResult>(params Policy<TResult>[] policies)
+        public static PolicyWrap<TResult> Wrap<TResult>(params ISyncPolicy<TResult>[] policies)
         {
-            switch (policies.Count())
+            switch (policies.Length)
             {
                 case 0:
                 case 1:
                     throw new ArgumentException("The enumerable of policies to form the wrap must contain at least two policies.", nameof(policies));
+                case 2:
+                    return new PolicyWrap<TResult>(
+                        (func, context, cancellationtoken) => PolicyWrapEngine.Implementation(
+                            func,
+                            context,
+                            cancellationtoken,
+                            policies[0],
+                            policies[1]),
+                        (Policy<TResult>)policies[0], policies[1]);
+
                 default:
-                    IEnumerable<Policy<TResult>> remainder = policies.Skip(1);
-                    return policies.First().Wrap(remainder.Count() == 1 ? remainder.Single() : Wrap(remainder.ToArray()));
+                    return Wrap(policies[0], Wrap(policies.Skip(1).ToArray()));
             }
         }
     }

--- a/src/Polly.SharedSpecs/Caching/AbsoluteTtlSpecs.cs
+++ b/src/Polly.SharedSpecs/Caching/AbsoluteTtlSpecs.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace Polly.Specs.Caching
 {
+    [Collection("SystemClockDependantCollection")]
     public class AbsoluteTtlSpecs : IDisposable
     {
         [Fact]

--- a/src/Polly.SharedSpecs/Caching/CacheAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Caching/CacheAsyncSpecs.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace Polly.Specs.Caching
 {
+    [Collection("SystemClockDependantCollection")]
     public class CacheAsyncSpecs : IDisposable
     {
         #region Configuration

--- a/src/Polly.SharedSpecs/Caching/CacheSpecs.cs
+++ b/src/Polly.SharedSpecs/Caching/CacheSpecs.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Polly.Specs.Caching
 {
+    [Collection("SystemClockDependantCollection")]
     public class CacheSpecs : IDisposable
     {
         #region Configuration

--- a/src/Polly.SharedSpecs/Caching/CacheTResultAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Caching/CacheTResultAsyncSpecs.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace Polly.Specs.Caching
 {
+    [Collection("SystemClockDependantCollection")]
     public class CacheTResultAsyncSpecs : IDisposable
     {
         #region Configuration

--- a/src/Polly.SharedSpecs/Caching/CacheTResultSpecs.cs
+++ b/src/Polly.SharedSpecs/Caching/CacheTResultSpecs.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Polly.Specs.Caching
 {
+    [Collection("SystemClockDependantCollection")]
     public class CacheTResultSpecs : IDisposable
     {
         #region Configuration

--- a/src/Polly.SharedSpecs/CircuitBreaker/AdvancedCircuitBreakerAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/AdvancedCircuitBreakerAsyncSpecs.cs
@@ -12,6 +12,7 @@ using Scenario = Polly.Specs.Helpers.PolicyExtensionsAsync.ExceptionAndOrCancell
 
 namespace Polly.Specs.CircuitBreaker
 {
+    [Collection("SystemClockDependantCollection")]
     public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
     {
         #region Configuration tests

--- a/src/Polly.SharedSpecs/CircuitBreaker/AdvancedCircuitBreakerSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/AdvancedCircuitBreakerSpecs.cs
@@ -12,6 +12,8 @@ using Scenario = Polly.Specs.Helpers.PolicyExtensions.ExceptionAndOrCancellation
 
 namespace Polly.Specs.CircuitBreaker
 {
+
+    [Collection("SystemClockDependantCollection")]
     public class AdvancedCircuitBreakerSpecs : IDisposable
     {
         #region Configuration tests

--- a/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerAsyncSpecs.cs
@@ -12,6 +12,7 @@ using Scenario = Polly.Specs.Helpers.PolicyExtensionsAsync.ExceptionAndOrCancell
 
 namespace Polly.Specs.CircuitBreaker
 {
+    [Collection("SystemClockDependantCollection")]
     public class CircuitBreakerAsyncSpecs : IDisposable
     {
         #region Configuration tests

--- a/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerAsyncSpecs.cs
@@ -1051,6 +1051,35 @@ namespace Polly.Specs.CircuitBreaker
         }
 
         [Fact]
+        public void Should_rethrow_and_call_onbreak_with_the_last_raised_exception_unwrapped_if_matched_as_inner()
+        {
+            Exception passedException = null;
+
+            Action<Exception, TimeSpan, Context> onBreak = (exception, _, __) => { passedException = exception; };
+            Action<Context> onReset = _ => { };
+
+            TimeSpan durationOfBreak = TimeSpan.FromMinutes(1);
+
+            CircuitBreakerPolicy breaker = Policy
+                .HandleInner<DivideByZeroException>()
+                .Or<DivideByZeroException>()
+                .CircuitBreakerAsync(2, durationOfBreak, onBreak, onReset);
+
+            Exception toRaiseAsInner = new DivideByZeroException();
+            Exception withInner = new AggregateException(toRaiseAsInner);
+
+            breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
+                .ShouldThrow<DivideByZeroException>();
+
+            breaker.Awaiting(x => x.RaiseExceptionAsync(withInner))
+                .ShouldThrow<DivideByZeroException>().Which.Should().BeSameAs(toRaiseAsInner);
+
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+
+            passedException?.Should().BeSameAs(toRaiseAsInner);
+        }
+
+        [Fact]
         public void Should_call_onbreak_with_the_correct_timespan()
         {
             TimeSpan? passedBreakTimespan = null;
@@ -1251,6 +1280,24 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.LastException.Should().BeOfType<DivideByZeroException>();
+        }
+
+        [Fact]
+        public void Should_set_LastException_on_handling_inner_exception_even_when_not_breaking()
+        {
+            CircuitBreakerPolicy breaker = Policy
+                .HandleInner<DivideByZeroException>()
+                .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
+
+            Exception toRaiseAsInner = new DivideByZeroException();
+            Exception withInner = new AggregateException(toRaiseAsInner);
+
+            breaker.Awaiting(x => x.RaiseExceptionAsync(withInner))
+                .ShouldThrow<DivideByZeroException>().Which.Should().BeSameAs(toRaiseAsInner);
+
+            breaker.CircuitState.Should().Be(CircuitState.Closed);
+
+            breaker.LastException.Should().BeSameAs(toRaiseAsInner);
         }
 
         [Fact]

--- a/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerSpecs.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Polly.Specs.CircuitBreaker
 {
+    [Collection("SystemClockDependantCollection")]
     public class CircuitBreakerSpecs : IDisposable
     {
         #region Configuration tests

--- a/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerSpecs.cs
@@ -1043,6 +1043,35 @@ namespace Polly.Specs.CircuitBreaker
         }
 
         [Fact]
+        public void Should_rethrow_and_call_onbreak_with_the_last_raised_exception_unwrapped_if_matched_as_inner()
+        {
+            Exception passedException = null;
+
+            Action<Exception, TimeSpan, Context> onBreak = (exception, _, __) => { passedException = exception; };
+            Action<Context> onReset = _ => { };
+
+            TimeSpan durationOfBreak = TimeSpan.FromMinutes(1);
+
+            CircuitBreakerPolicy breaker = Policy
+                .HandleInner<DivideByZeroException>()
+                .Or<DivideByZeroException>()
+                .CircuitBreaker(2, durationOfBreak, onBreak, onReset);
+
+            Exception toRaiseAsInner = new DivideByZeroException();
+            Exception withInner = new AggregateException(toRaiseAsInner);
+
+            breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
+                .ShouldThrow<DivideByZeroException>();
+
+            breaker.Invoking(x => x.RaiseException(withInner))
+                .ShouldThrow<DivideByZeroException>().Which.Should().BeSameAs(toRaiseAsInner);
+
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+
+            passedException?.Should().BeSameAs(toRaiseAsInner);
+        }
+
+        [Fact]
         public void Should_call_onbreak_with_the_correct_timespan()
         {
             TimeSpan? passedBreakTimespan = null;
@@ -1248,6 +1277,25 @@ namespace Polly.Specs.CircuitBreaker
         }
 
         [Fact]
+        public void Should_set_LastException_on_handling_inner_exception_even_when_not_breaking()
+        {
+            CircuitBreakerPolicy breaker = Policy
+                .HandleInner<DivideByZeroException>()
+                .CircuitBreaker(2, TimeSpan.FromMinutes(1));
+
+
+            Exception toRaiseAsInner = new DivideByZeroException();
+            Exception withInner = new AggregateException(toRaiseAsInner);
+
+            breaker.Invoking(x => x.RaiseException(withInner))
+                .ShouldThrow<DivideByZeroException>().Which.Should().BeSameAs(toRaiseAsInner);
+
+            breaker.CircuitState.Should().Be(CircuitState.Closed);
+
+            breaker.LastException.Should().BeSameAs(toRaiseAsInner);
+        }
+
+        [Fact]
         public void Should_set_LastException_to_last_raised_exception_when_breaking()
         {
             CircuitBreakerPolicy breaker = Policy
@@ -1285,6 +1333,27 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Reset();
 
             breaker.LastException.Should().BeNull();
+        }
+
+        #endregion
+
+        #region ExecuteAndCapture with HandleInner
+
+        [Fact]
+        public void Should_set_PolicyResult_on_handling_inner_exception()
+        {
+            CircuitBreakerPolicy breaker = Policy
+                .HandleInner<DivideByZeroException>()
+                .CircuitBreaker(2, TimeSpan.FromMinutes(1));
+
+
+            Exception toRaiseAsInner = new DivideByZeroException();
+            Exception withInner = new AggregateException(toRaiseAsInner);
+
+            PolicyResult policyResult = breaker.ExecuteAndCapture(() => throw withInner);
+
+            policyResult.ExceptionType.Should().Be(ExceptionType.HandledByThisPolicy);
+            policyResult.FinalException.Should().BeSameAs(toRaiseAsInner);
         }
 
         #endregion

--- a/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerTResultAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerTResultAsyncSpecs.cs
@@ -13,6 +13,7 @@ using Scenario = Polly.Specs.Helpers.PolicyTResultExtensionsAsync.ResultAndOrCan
 
 namespace Polly.Specs.CircuitBreaker
 {
+    [Collection("SystemClockDependantCollection")]
     public class CircuitBreakerTResultAsyncSpecs : IDisposable
     {
         #region Configuration tests

--- a/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerTResultMixedResultExceptionSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerTResultMixedResultExceptionSpecs.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace Polly.Specs.CircuitBreaker
 {
+    [Collection("SystemClockDependantCollection")]
     public class CircuitBreakerTResultMixedResultExceptionSpecs : IDisposable
     {
         #region Circuit-breaker threshold-to-break tests

--- a/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerTResultSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerTResultSpecs.cs
@@ -12,6 +12,7 @@ using Scenario = Polly.Specs.Helpers.PolicyTResultExtensions.ResultAndOrCancella
 
 namespace Polly.Specs.CircuitBreaker
 {
+    [Collection("SystemClockDependantCollection")]
     public class CircuitBreakerTResultSpecs : IDisposable
     {
         #region Configuration tests

--- a/src/Polly.SharedSpecs/Fallback/FallbackAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Fallback/FallbackAsyncSpecs.cs
@@ -90,7 +90,7 @@ namespace Polly.Specs.Fallback
         #region Policy operation tests
 
         [Fact]
-        public async Task Should_not_execute_fallback_when_execute_delegate_does_not_throw()
+        public async Task Should_not_execute_fallback_when_executed_delegate_does_not_throw()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task> fallbackActionAsync  = _ => { fallbackActionExecuted = true; return TaskHelper.EmptyTask; };
@@ -105,7 +105,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public void Should_not_execute_fallback_when_execute_delegate_throws_exception_not_handled_by_policy()
+        public void Should_not_execute_fallback_when_executed_delegate_throws_exception_not_handled_by_policy()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task> fallbackActionAsync  = _ => { fallbackActionExecuted = true; return TaskHelper.EmptyTask; };
@@ -120,7 +120,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public void Should_execute_fallback_when_execute_delegate_throws_exception_handled_by_policy()
+        public void Should_execute_fallback_when_executed_delegate_throws_exception_handled_by_policy()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task> fallbackActionAsync  = _ => { fallbackActionExecuted = true; return TaskHelper.EmptyTask; };
@@ -136,7 +136,7 @@ namespace Polly.Specs.Fallback
 
 
         [Fact]
-        public void Should_execute_fallback_when_execute_delegate_throws_one_of_exceptions_handled_by_policy()
+        public void Should_execute_fallback_when_executed_delegate_throws_one_of_exceptions_handled_by_policy()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task> fallbackActionAsync  = _ => { fallbackActionExecuted = true; return TaskHelper.EmptyTask; };
@@ -153,7 +153,7 @@ namespace Polly.Specs.Fallback
 
 
         [Fact]
-        public void Should_not_execute_fallback_when_execute_delegate_throws_exception_not_one_of_exceptions_handled_by_policy()
+        public void Should_not_execute_fallback_when_executed_delegate_throws_exception_not_one_of_exceptions_handled_by_policy()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task> fallbackActionAsync  = _ => { fallbackActionExecuted = true; return TaskHelper.EmptyTask; };
@@ -277,7 +277,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public async Task Should_not_call_onFallback_when_execute_delegate_does_not_throw()
+        public async Task Should_not_call_onFallback_when_executed_delegate_does_not_throw()
         {
             Func<CancellationToken, Task> fallbackActionAsync = _ => TaskHelper.EmptyTask;
 
@@ -498,6 +498,47 @@ namespace Polly.Specs.Fallback
 
             fallbackException.Should().NotBeNull()
                 .And.BeOfType(typeof(ArgumentNullException));
+        }
+
+        public void Should_call_fallbackAction_with_the_matched_inner_exception_unwrapped()
+        {
+            Exception fallbackException = null;
+
+            Func<Exception, Context, CancellationToken, Task> fallbackFunc = (ex, ctx, ct) => { fallbackException = ex; return TaskHelper.EmptyTask; };
+
+            Func<Exception, Context, Task> onFallback = (ex, ctx) => { return TaskHelper.EmptyTask; };
+
+            FallbackPolicy fallbackPolicy = Policy
+                .HandleInner<ArgumentNullException>()
+                .FallbackAsync(fallbackFunc, onFallback);
+
+            Exception instanceToCapture = new ArgumentNullException("myParam");
+            Exception instanceToThrow = new Exception(String.Empty, instanceToCapture);
+            fallbackPolicy.Awaiting(p => p.RaiseExceptionAsync(instanceToThrow))
+                .ShouldNotThrow();
+
+            fallbackException.Should().Be(instanceToCapture);
+        }
+
+        [Fact]
+        public void Should_call_fallbackAction_with_the_matched_inner_of_aggregate_exception_unwrapped()
+        {
+            Exception fallbackException = null;
+
+            Func<Exception, Context, CancellationToken, Task> fallbackFunc = (ex, ctx, ct) => { fallbackException = ex; return TaskHelper.EmptyTask; };
+
+            Func<Exception, Context, Task> onFallback = (ex, ctx) => { return TaskHelper.EmptyTask; };
+
+            FallbackPolicy fallbackPolicy = Policy
+                .HandleInner<ArgumentNullException>()
+                .FallbackAsync(fallbackFunc, onFallback);
+
+            Exception instanceToCapture = new ArgumentNullException("myParam");
+            Exception instanceToThrow = new AggregateException(instanceToCapture);
+            fallbackPolicy.Awaiting(p => p.RaiseExceptionAsync(instanceToThrow))
+                .ShouldNotThrow();
+
+            fallbackException.Should().Be(instanceToCapture);
         }
 
         [Fact]

--- a/src/Polly.SharedSpecs/Fallback/FallbackAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Fallback/FallbackAsyncSpecs.cs
@@ -251,6 +251,16 @@ namespace Polly.Specs.Fallback
             fallbackActionExecuted.Should().BeTrue();
         }
 
+        [Fact]
+        public void Should_throw_for_generic_method_execution_on_non_generic_policy()
+        {
+            FallbackPolicy fallbackPolicy = Policy
+                .Handle<DivideByZeroException>()
+                .FallbackAsync(_ => TaskHelper.EmptyTask);
+
+            fallbackPolicy.Awaiting(p => p.ExecuteAsync<int>(() => TaskHelper.FromResult(0))).ShouldThrow<InvalidOperationException>();
+        }
+
         #endregion
 
         #region onPolicyEvent delegate tests

--- a/src/Polly.SharedSpecs/Fallback/FallbackSpecs.cs
+++ b/src/Polly.SharedSpecs/Fallback/FallbackSpecs.cs
@@ -157,7 +157,7 @@ namespace Polly.Specs.Fallback
         #region Policy operation tests
 
         [Fact]
-        public void Should_not_execute_fallback_when_execute_delegate_does_not_throw()
+        public void Should_not_execute_fallback_when_executed_delegate_does_not_throw()
         {
             bool fallbackActionExecuted = false;
             Action fallbackAction = () => { fallbackActionExecuted = true; };
@@ -172,7 +172,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public void Should_not_execute_fallback_when_execute_delegate_throws_exception_not_handled_by_policy()
+        public void Should_not_execute_fallback_when_executed_delegate_throws_exception_not_handled_by_policy()
         {
             bool fallbackActionExecuted = false;
             Action fallbackAction = () => { fallbackActionExecuted = true; };
@@ -186,41 +186,40 @@ namespace Polly.Specs.Fallback
             fallbackActionExecuted.Should().BeFalse();
         }
 
+
         [Fact]
-        public void Should_execute_fallback_when_execute_delegate_throws_exception_handled_by_policy()
+        public void Should_execute_fallback_when_executed_delegate_throws_exception_handled_by_policy()
         {
             bool fallbackActionExecuted = false;
             Action fallbackAction = () => { fallbackActionExecuted = true; };
 
             FallbackPolicy fallbackPolicy = Policy
-                                    .Handle<DivideByZeroException>()
-                                    .Fallback(fallbackAction);
+                .Handle<DivideByZeroException>()
+                .Fallback(fallbackAction);
 
             fallbackPolicy.Invoking(x => x.RaiseException<DivideByZeroException>()).ShouldNotThrow();
 
             fallbackActionExecuted.Should().BeTrue();
         }
 
-
         [Fact]
-        public void Should_execute_fallback_when_execute_delegate_throws_one_of_exceptions_handled_by_policy()
+        public void Should_execute_fallback_when_executed_delegate_throws_one_of_exceptions_handled_by_policy()
         {
             bool fallbackActionExecuted = false;
             Action fallbackAction = () => { fallbackActionExecuted = true; };
 
             FallbackPolicy fallbackPolicy = Policy
-                                    .Handle<DivideByZeroException>()
-                                    .Or<ArgumentException>()
-                                    .Fallback(fallbackAction);
+                .Handle<DivideByZeroException>()
+                .Or<ArgumentException>()
+                .Fallback(fallbackAction);
 
             fallbackPolicy.Invoking(x => x.RaiseException<ArgumentException>()).ShouldNotThrow();
 
             fallbackActionExecuted.Should().BeTrue();
         }
 
-
         [Fact]
-        public void Should_not_execute_fallback_when_execute_delegate_throws_exception_not_one_of_exceptions_handled_by_policy()
+        public void Should_not_execute_fallback_when_executed_delegate_throws_exception_not_one_of_exceptions_handled_by_policy()
         {
             bool fallbackActionExecuted = false;
             Action fallbackAction = () => { fallbackActionExecuted = true; };
@@ -273,14 +272,13 @@ namespace Polly.Specs.Fallback
             Action fallbackAction = () => { fallbackActionExecuted = true; };
 
             FallbackPolicy fallbackPolicy = Policy
-                                    .Handle<DivideByZeroException>(e => true)
-                                    .Fallback(fallbackAction);
+                .Handle<DivideByZeroException>(e => true)
+                .Fallback(fallbackAction);
 
             fallbackPolicy.Invoking(x => x.RaiseException<DivideByZeroException>()).ShouldNotThrow();
 
             fallbackActionExecuted.Should().BeTrue();
         }
-
 
         [Fact]
         public void Should_execute_fallback_when_exception_thrown_matches_one_of_handling_predicates()
@@ -289,9 +287,9 @@ namespace Polly.Specs.Fallback
             Action fallbackAction = () => { fallbackActionExecuted = true; };
 
             FallbackPolicy fallbackPolicy = Policy
-                                    .Handle<DivideByZeroException>(e => true)
-                                    .Or<ArgumentNullException>()
-                                    .Fallback(fallbackAction);
+                .Handle<DivideByZeroException>(e => true)
+                .Or<ArgumentNullException>()
+                .Fallback(fallbackAction);
 
             fallbackPolicy.Invoking(x => x.RaiseException<DivideByZeroException>()).ShouldNotThrow();
 
@@ -320,6 +318,398 @@ namespace Polly.Specs.Fallback
 
         #endregion
 
+        #region HandleInner tests, inner of normal exceptions
+
+        [Fact]
+        public void Should_not_execute_fallback_when_executed_delegate_throws_inner_exception_where_policy_doesnt_handle_inner()
+        {
+            bool fallbackActionExecuted = false;
+            Action fallbackAction = () => { fallbackActionExecuted = true; };
+
+            FallbackPolicy fallbackPolicy = Policy
+                .Handle<DivideByZeroException>()
+                .Fallback(fallbackAction);
+
+            Exception withInner = new Exception(String.Empty, new DivideByZeroException());
+
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldThrow<Exception>().And.InnerException.Should().BeOfType<DivideByZeroException>();
+
+            fallbackActionExecuted.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Should_execute_fallback_when_policy_handles_inner_and_executed_delegate_throws_as_non_inner()
+        {
+            bool fallbackActionExecuted = false;
+            Action fallbackAction = () => { fallbackActionExecuted = true; };
+
+            FallbackPolicy fallbackPolicy = Policy
+                .HandleInner<DivideByZeroException>()
+                .Fallback(fallbackAction);
+
+            Exception nonInner = new DivideByZeroException();
+
+            fallbackPolicy.Invoking(x => x.RaiseException(nonInner)).ShouldNotThrow();
+
+            fallbackActionExecuted.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Should_execute_fallback_when_executed_delegate_throws_inner_exception_handled_by_policy()
+        {
+            bool fallbackActionExecuted = false;
+            Action fallbackAction = () => { fallbackActionExecuted = true; };
+
+            FallbackPolicy fallbackPolicy = Policy
+                .HandleInner<DivideByZeroException>()
+                .Fallback(fallbackAction);
+
+            Exception withInner = new Exception(String.Empty, new DivideByZeroException());
+
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldNotThrow();
+
+            fallbackActionExecuted.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Should_execute_fallback_when_executed_delegate_throws_one_of_inner_exceptions_handled_by_policy()
+        {
+            bool fallbackActionExecuted = false;
+            Action fallbackAction = () => { fallbackActionExecuted = true; };
+
+            FallbackPolicy fallbackPolicy = Policy
+                .Handle<DivideByZeroException>()
+                .OrInner<ArgumentException>()
+                .Fallback(fallbackAction);
+
+            Exception withInner = new Exception(String.Empty, new ArgumentException());
+
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldNotThrow();
+
+            fallbackActionExecuted.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Should_execute_fallback_when_executed_delegate_throws_nested_inner_exception_handled_by_policy()
+        {
+            bool fallbackActionExecuted = false;
+            Action fallbackAction = () => { fallbackActionExecuted = true; };
+
+            FallbackPolicy fallbackPolicy = Policy
+                .HandleInner<DivideByZeroException>()
+                .Fallback(fallbackAction);
+
+            Exception withInner = new Exception(String.Empty, new Exception(String.Empty, new Exception(String.Empty, new DivideByZeroException())));
+
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldNotThrow();
+
+            fallbackActionExecuted.Should().BeTrue();
+        }
+
+
+        [Fact]
+        public void Should_not_execute_fallback_when_executed_delegate_throws_inner_exception_not_handled_by_policy()
+        {
+            bool fallbackActionExecuted = false;
+            Action fallbackAction = () => { fallbackActionExecuted = true; };
+
+            FallbackPolicy fallbackPolicy = Policy
+                                    .HandleInner<DivideByZeroException>()
+                                    .Fallback(fallbackAction);
+
+            Exception withInner = new Exception(String.Empty, new ArgumentException());
+
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldThrow<Exception>().And.InnerException.Should().BeOfType<ArgumentException>();
+
+            fallbackActionExecuted.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Should_execute_fallback_when_inner_exception_thrown_matches_handling_predicates()
+        {
+            bool fallbackActionExecuted = false;
+            Action fallbackAction = () => { fallbackActionExecuted = true; };
+
+            FallbackPolicy fallbackPolicy = Policy
+                .HandleInner<DivideByZeroException>(e => true)
+                .Fallback(fallbackAction);
+
+            Exception withInner = new Exception(String.Empty, new DivideByZeroException());
+
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldNotThrow();
+
+            fallbackActionExecuted.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Should_execute_fallback_when_inner_nested_exception_thrown_matches_handling_predicates()
+        {
+            bool fallbackActionExecuted = false;
+            Action fallbackAction = () => { fallbackActionExecuted = true; };
+
+            FallbackPolicy fallbackPolicy = Policy
+                .HandleInner<DivideByZeroException>(e => true)
+                .Fallback(fallbackAction);
+
+            Exception withInner = new Exception(String.Empty, new Exception(String.Empty, new Exception(String.Empty, new DivideByZeroException())));
+
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldNotThrow();
+
+            fallbackActionExecuted.Should().BeTrue();
+        }
+
+
+        [Fact]
+        public void Should_execute_fallback_when_inner_exception_thrown_matches_one_of_handling_predicates()
+        {
+            bool fallbackActionExecuted = false;
+            Action fallbackAction = () => { fallbackActionExecuted = true; };
+
+            FallbackPolicy fallbackPolicy = Policy
+                .HandleInner<DivideByZeroException>(e => true)
+                .OrInner<ArgumentNullException>(e => true)
+                .Fallback(fallbackAction);
+
+            Exception withInner = new Exception(String.Empty, new ArgumentNullException());
+
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldNotThrow();
+
+            fallbackActionExecuted.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Should_not_execute_fallback_when_inner_exception_thrown_does_not_match_handling_predicates()
+        {
+            bool fallbackActionExecuted = false;
+            Action fallbackAction = () => { fallbackActionExecuted = true; };
+
+            FallbackPolicy fallbackPolicy = Policy
+                                    .HandleInner<DivideByZeroException>(e => false)
+                                    .Fallback(fallbackAction);
+
+            Exception withInner = new Exception(String.Empty, new DivideByZeroException());
+
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldThrow<Exception>().And.InnerException.Should().BeOfType<DivideByZeroException>();
+
+            fallbackActionExecuted.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Should_not_execute_fallback_when_inner_exception_thrown_does_not_match_any_of_handling_predicates()
+        {
+            bool fallbackActionExecuted = false;
+            Action fallbackAction = () => { fallbackActionExecuted = true; };
+
+            FallbackPolicy fallbackPolicy = Policy
+                                    .HandleInner<DivideByZeroException>(e => false)
+                                    .OrInner<ArgumentNullException>(e => false)
+                                    .Fallback(fallbackAction);
+
+            Exception withInner = new Exception(String.Empty, new ArgumentNullException());
+
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldThrow<Exception>().And.InnerException.Should().BeOfType<ArgumentNullException>();
+
+            fallbackActionExecuted.Should().BeFalse();
+        }
+
+        #endregion
+
+
+        #region HandleInner tests, inner of aggregate exceptions
+
+        [Fact]
+        public void Should_not_execute_fallback_when_executed_delegate_throws_inner_of_aggregate_exception_where_policy_doesnt_handle_inner()
+        {
+            bool fallbackActionExecuted = false;
+            Action fallbackAction = () => { fallbackActionExecuted = true; };
+
+            FallbackPolicy fallbackPolicy = Policy
+                .Handle<DivideByZeroException>()
+                .Fallback(fallbackAction);
+
+            Exception withInner = new AggregateException(new DivideByZeroException());
+
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldThrow<AggregateException>().And.InnerExceptions.Should().ContainSingle(e => e is DivideByZeroException);
+
+            fallbackActionExecuted.Should().BeFalse();
+        }
+        
+        [Fact]
+        public void Should_execute_fallback_when_executed_delegate_throws_inner_of_aggregate_exception_handled_by_policy()
+        {
+            bool fallbackActionExecuted = false;
+            Action fallbackAction = () => { fallbackActionExecuted = true; };
+
+            FallbackPolicy fallbackPolicy = Policy
+                .HandleInner<DivideByZeroException>()
+                .Fallback(fallbackAction);
+
+            Exception withInner = new AggregateException(new DivideByZeroException());
+
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldNotThrow();
+
+            fallbackActionExecuted.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Should_execute_fallback_when_executed_delegate_throws_one_of_inner_of_aggregate_exceptions_handled_by_policy()
+        {
+            bool fallbackActionExecuted = false;
+            Action fallbackAction = () => { fallbackActionExecuted = true; };
+
+            FallbackPolicy fallbackPolicy = Policy
+                .Handle<DivideByZeroException>()
+                .OrInner<ArgumentException>()
+                .Fallback(fallbackAction);
+
+            Exception withInner = new AggregateException(new ArgumentException());
+
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldNotThrow();
+
+            fallbackActionExecuted.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Should_execute_fallback_when_executed_delegate_throws_aggregate_exception_with_inner_handled_by_policy_amongst_other_inners()
+        {
+            bool fallbackActionExecuted = false;
+            Action fallbackAction = () => { fallbackActionExecuted = true; };
+
+            FallbackPolicy fallbackPolicy = Policy
+                .HandleInner<DivideByZeroException>()
+                .Fallback(fallbackAction);
+
+            Exception withInner = new AggregateException(new ArgumentException(), new DivideByZeroException(), new ArgumentNullException());
+
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldNotThrow();
+
+            fallbackActionExecuted.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Should_execute_fallback_when_executed_delegate_throws_nested_inner_of_aggregate_exception_handled_by_policy()
+        {
+            bool fallbackActionExecuted = false;
+            Action fallbackAction = () => { fallbackActionExecuted = true; };
+
+            FallbackPolicy fallbackPolicy = Policy
+                .HandleInner<DivideByZeroException>()
+                .Fallback(fallbackAction);
+
+            Exception withInner = new AggregateException(new AggregateException(new DivideByZeroException()));
+
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldNotThrow();
+
+            fallbackActionExecuted.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Should_not_execute_fallback_when_executed_delegate_throws_inner_of_aggregate_exception_not_handled_by_policy()
+        {
+            bool fallbackActionExecuted = false;
+            Action fallbackAction = () => { fallbackActionExecuted = true; };
+
+            FallbackPolicy fallbackPolicy = Policy
+                                    .HandleInner<DivideByZeroException>()
+                                    .Fallback(fallbackAction);
+
+            Exception withInner = new AggregateException(new ArgumentException());
+
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldThrow<AggregateException>().And.InnerExceptions.Should().ContainSingle(e => e is ArgumentException);
+
+             fallbackActionExecuted.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Should_execute_fallback_when_inner_of_aggregate_exception_thrown_matches_handling_predicates()
+        {
+            bool fallbackActionExecuted = false;
+            Action fallbackAction = () => { fallbackActionExecuted = true; };
+
+            FallbackPolicy fallbackPolicy = Policy
+                .HandleInner<DivideByZeroException>(e => true)
+                .Fallback(fallbackAction);
+
+            Exception withInner = new AggregateException(new DivideByZeroException());
+
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldNotThrow();
+
+            fallbackActionExecuted.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Should_execute_fallback_when_inner_of_aggregate_nested_exception_thrown_matches_handling_predicates()
+        {
+            bool fallbackActionExecuted = false;
+            Action fallbackAction = () => { fallbackActionExecuted = true; };
+
+            FallbackPolicy fallbackPolicy = Policy
+                .HandleInner<DivideByZeroException>(e => true)
+                .Fallback(fallbackAction);
+
+            Exception withInner = new AggregateException(new AggregateException(new DivideByZeroException()));
+
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldNotThrow();
+
+            fallbackActionExecuted.Should().BeTrue();
+        }
+
+
+        [Fact]
+        public void Should_execute_fallback_when_inner_of_aggregate_exception_thrown_matches_one_of_handling_predicates()
+        {
+            bool fallbackActionExecuted = false;
+            Action fallbackAction = () => { fallbackActionExecuted = true; };
+
+            FallbackPolicy fallbackPolicy = Policy
+                .HandleInner<DivideByZeroException>(e => true)
+                .OrInner<ArgumentNullException>(e => true)
+                .Fallback(fallbackAction);
+
+            Exception withInner = new AggregateException(new ArgumentNullException());
+
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldNotThrow();
+
+            fallbackActionExecuted.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Should_not_execute_fallback_when_inner_of_aggregate_exception_thrown_does_not_match_handling_predicates()
+        {
+            bool fallbackActionExecuted = false;
+            Action fallbackAction = () => { fallbackActionExecuted = true; };
+
+            FallbackPolicy fallbackPolicy = Policy
+                                    .HandleInner<DivideByZeroException>(e => false)
+                                    .Fallback(fallbackAction);
+
+            Exception withInner = new AggregateException(new DivideByZeroException());
+
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldThrow<AggregateException>().And.InnerExceptions.Should().ContainSingle(e => e is DivideByZeroException);
+
+            fallbackActionExecuted.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Should_not_execute_fallback_when_inner_of_aggregate_exception_thrown_does_not_match_any_of_handling_predicates()
+        {
+            bool fallbackActionExecuted = false;
+            Action fallbackAction = () => { fallbackActionExecuted = true; };
+
+            FallbackPolicy fallbackPolicy = Policy
+                                    .HandleInner<DivideByZeroException>(e => false)
+                                    .OrInner<ArgumentNullException>(e => false)
+                                    .Fallback(fallbackAction);
+
+            Exception withInner = new AggregateException(new ArgumentNullException());
+
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldThrow<AggregateException>().And.InnerExceptions.Should().ContainSingle(e => e is ArgumentNullException);
+
+            fallbackActionExecuted.Should().BeFalse();
+        }
+
+        #endregion
+
         #region onPolicyEvent delegate tests
 
         [Fact]
@@ -344,7 +734,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public void Should_not_call_onFallback_when_execute_delegate_does_not_throw()
+        public void Should_not_call_onFallback_when_executed_delegate_does_not_throw()
         {
             Action fallbackAction = () => { };
 
@@ -564,6 +954,48 @@ namespace Polly.Specs.Fallback
 
             fallbackException.Should().NotBeNull()
                 .And.BeOfType(typeof(ArgumentNullException));
+        }
+
+        [Fact]
+        public void Should_call_fallbackAction_with_the_matched_inner_exception_unwrapped()
+        {
+            Exception fallbackException = null;
+
+            Action<Exception, Context, CancellationToken> fallbackAction = (ex, ctx, ct) => { fallbackException = ex; };
+
+            Action<Exception, Context> onFallback = (ex, ctx) => { };
+
+            FallbackPolicy fallbackPolicy = Policy
+                .HandleInner<ArgumentNullException>()
+                .Fallback(fallbackAction, onFallback);
+
+            Exception instanceToCapture = new ArgumentNullException("myParam");
+            Exception instanceToThrow = new Exception(String.Empty, instanceToCapture);
+            fallbackPolicy.Invoking(p => p.RaiseException(instanceToThrow))
+                .ShouldNotThrow();
+
+            fallbackException.Should().Be(instanceToCapture);
+        }
+
+        [Fact]
+        public void Should_call_fallbackAction_with_the_matched_inner_of_aggregate_exception_unwrapped()
+        {
+            Exception fallbackException = null;
+
+            Action<Exception, Context, CancellationToken> fallbackAction = (ex, ctx, ct) => { fallbackException = ex; };
+
+            Action<Exception, Context> onFallback = (ex, ctx) => { };
+
+            FallbackPolicy fallbackPolicy = Policy
+                .HandleInner<ArgumentNullException>()
+                .Fallback(fallbackAction, onFallback);
+
+            Exception instanceToCapture = new ArgumentNullException("myParam");
+            Exception instanceToThrow = new AggregateException(instanceToCapture);
+            fallbackPolicy.Invoking(p => p.RaiseException(instanceToThrow))
+                .ShouldNotThrow();
+
+            fallbackException.Should().Be(instanceToCapture);
         }
 
         [Fact]

--- a/src/Polly.SharedSpecs/Fallback/FallbackSpecs.cs
+++ b/src/Polly.SharedSpecs/Fallback/FallbackSpecs.cs
@@ -316,6 +316,16 @@ namespace Polly.Specs.Fallback
             fallbackActionExecuted.Should().BeTrue();
         }
 
+        [Fact]
+        public void Should_throw_for_generic_method_execution_on_non_generic_policy()
+        {
+            FallbackPolicy fallbackPolicy = Policy
+                .Handle<DivideByZeroException>()
+                .Fallback(() => {});
+
+            fallbackPolicy.Invoking(p => p.Execute<int>(() => 0)).ShouldThrow<InvalidOperationException>();
+        }
+
         #endregion
 
         #region HandleInner tests, inner of normal exceptions

--- a/src/Polly.SharedSpecs/Fallback/FallbackTResultAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Fallback/FallbackTResultAsyncSpecs.cs
@@ -118,7 +118,7 @@ namespace Polly.Specs.Fallback
         #region Policy operation tests
 
         [Fact]
-        public async Task Should_not_execute_fallback_when_execute_delegate_does_not_raise_fault()
+        public async Task Should_not_execute_fallback_when_executed_delegate_does_not_raise_fault()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = ct => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };
@@ -133,7 +133,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public async Task Should_not_execute_fallback_when_execute_delegate_raises_fault_not_handled_by_policy()
+        public async Task Should_not_execute_fallback_when_executed_delegate_raises_fault_not_handled_by_policy()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = ct => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };
@@ -149,7 +149,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public async Task Should_return_fallback_value_when_execute_delegate_raises_fault_handled_by_policy()
+        public async Task Should_return_fallback_value_when_executed_delegate_raises_fault_handled_by_policy()
         {
             FallbackPolicy<ResultPrimitive> fallbackPolicy = Policy
                                     .HandleResult(ResultPrimitive.Fault)
@@ -160,7 +160,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public async Task Should_execute_fallback_when_execute_delegate_raises_fault_handled_by_policy()
+        public async Task Should_execute_fallback_when_executed_delegate_raises_fault_handled_by_policy()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = ct => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };
@@ -176,7 +176,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public async Task Should_execute_fallback_when_execute_delegate_raises_one_of_results_handled_by_policy()
+        public async Task Should_execute_fallback_when_executed_delegate_raises_one_of_results_handled_by_policy()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = ct => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };
@@ -193,7 +193,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public async Task Should_not_execute_fallback_when_execute_delegate_raises_fault_not_one_of_faults_handled_by_policy()
+        public async Task Should_not_execute_fallback_when_executed_delegate_raises_fault_not_one_of_faults_handled_by_policy()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = ct => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };
@@ -226,7 +226,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public async Task Should_not_execute_fallback_when_execute_delegate_raises_fault_not_handled_by_any_of_predicates()
+        public async Task Should_not_execute_fallback_when_executed_delegate_raises_fault_not_handled_by_any_of_predicates()
         {
             bool fallbackActionExecuted = false;
             Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = ct => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };
@@ -322,7 +322,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public async Task Should_not_call_onFallback_when_execute_delegate_does_not_raise_fault()
+        public async Task Should_not_call_onFallback_when_executed_delegate_does_not_raise_fault()
         {
                         Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = ct => Task.FromResult(ResultPrimitive.Substitute);
 

--- a/src/Polly.SharedSpecs/Fallback/FallbackTResultSpecs.cs
+++ b/src/Polly.SharedSpecs/Fallback/FallbackTResultSpecs.cs
@@ -157,7 +157,7 @@ namespace Polly.Specs.Fallback
         #region Policy operation tests
 
         [Fact]
-        public void Should_not_execute_fallback_when_execute_delegate_does_not_raise_fault()
+        public void Should_not_execute_fallback_when_executed_delegate_does_not_raise_fault()
         {
             bool fallbackActionExecuted = false;
             Func<ResultPrimitive> fallbackAction = () => { fallbackActionExecuted = true; return ResultPrimitive.Substitute; };
@@ -172,7 +172,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public void Should_not_execute_fallback_when_execute_delegate_raises_fault_not_handled_by_policy()
+        public void Should_not_execute_fallback_when_executed_delegate_raises_fault_not_handled_by_policy()
         {
             bool fallbackActionExecuted = false;
             Func<ResultPrimitive> fallbackAction = () => { fallbackActionExecuted = true; return ResultPrimitive.Substitute; };
@@ -187,7 +187,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public void Should_return_fallback_value_when_execute_delegate_raises_fault_handled_by_policy()
+        public void Should_return_fallback_value_when_executed_delegate_raises_fault_handled_by_policy()
         {
             FallbackPolicy<ResultPrimitive> fallbackPolicy = Policy
                                     .HandleResult(ResultPrimitive.Fault)
@@ -197,7 +197,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public void Should_execute_fallback_when_execute_delegate_raises_fault_handled_by_policy()
+        public void Should_execute_fallback_when_executed_delegate_raises_fault_handled_by_policy()
         {
             bool fallbackActionExecuted = false;
             Func<ResultPrimitive> fallbackAction = () => { fallbackActionExecuted = true; return ResultPrimitive.Substitute; };
@@ -212,7 +212,7 @@ namespace Polly.Specs.Fallback
         }
         
         [Fact]
-        public void Should_execute_fallback_when_execute_delegate_raises_one_of_results_handled_by_policy()
+        public void Should_execute_fallback_when_executed_delegate_raises_one_of_results_handled_by_policy()
         {
             bool fallbackActionExecuted = false;
             Func<ResultPrimitive> fallbackAction = () => { fallbackActionExecuted = true; return ResultPrimitive.Substitute; };
@@ -228,7 +228,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public void Should_not_execute_fallback_when_execute_delegate_raises_fault_not_one_of_faults_handled_by_policy()
+        public void Should_not_execute_fallback_when_executed_delegate_raises_fault_not_one_of_faults_handled_by_policy()
         {
             bool fallbackActionExecuted = false;
             Func<ResultPrimitive> fallbackAction = () => { fallbackActionExecuted = true; return ResultPrimitive.Substitute; };
@@ -259,7 +259,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public void Should_not_execute_fallback_when_execute_delegate_raises_fault_not_handled_by_any_of_predicates()
+        public void Should_not_execute_fallback_when_executed_delegate_raises_fault_not_handled_by_any_of_predicates()
         {
             bool fallbackActionExecuted = false;
             Func<ResultPrimitive> fallbackAction = () => { fallbackActionExecuted = true; return ResultPrimitive.Substitute; };
@@ -352,7 +352,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public void Should_not_call_onFallback_when_execute_delegate_does_not_raise_fault()
+        public void Should_not_call_onFallback_when_executed_delegate_does_not_raise_fault()
         {
             Func<ResultPrimitive> fallbackAction = () => ResultPrimitive.Substitute;
 

--- a/src/Polly.SharedSpecs/Helpers/PolicyExtensions.cs
+++ b/src/Polly.SharedSpecs/Helpers/PolicyExtensions.cs
@@ -22,7 +22,7 @@ namespace Polly.Specs.Helpers
                 NumberOfTimesToRaiseException = 1
             };
 
-            policy.RaiseExceptionAndOrCancellation(scenario, new CancellationTokenSource(), () => { }, _ => instance, 0);
+            policy.RaiseExceptionAndOrCancellation(scenario, new CancellationTokenSource(), () => { }, _ => instance);
         }
 
         public static void RaiseException<TException>(this Policy policy, Action<TException, int> configureException = null) where TException : Exception, new()
@@ -46,18 +46,48 @@ namespace Polly.Specs.Helpers
                 return exception;
             };
 
-            policy.RaiseExceptionAndOrCancellation(scenario, new CancellationTokenSource(), () => { }, exceptionFactory, 0);
+            policy.RaiseExceptionAndOrCancellation(scenario, new CancellationTokenSource(), () => { }, exceptionFactory);
         }
 
         public static void RaiseExceptionAndOrCancellation<TException>(this Policy policy, ExceptionAndOrCancellationScenario scenario, CancellationTokenSource cancellationTokenSource, Action onExecute) where TException : Exception, new()
         {
-            policy.RaiseExceptionAndOrCancellation<TException, int>(scenario, cancellationTokenSource, onExecute, 0);
+            policy.RaiseExceptionAndOrCancellation<TException>(scenario, cancellationTokenSource, onExecute, _ => new TException());
         }
 
         public static TResult RaiseExceptionAndOrCancellation<TException, TResult>(this Policy policy, ExceptionAndOrCancellationScenario scenario, CancellationTokenSource cancellationTokenSource, Action onExecute, TResult successResult) where TException : Exception, new()
         {
             return policy.RaiseExceptionAndOrCancellation(scenario, cancellationTokenSource, onExecute,
                 _ => new TException(), successResult);
+        }
+
+        public static void RaiseExceptionAndOrCancellation<TException>(this Policy policy, ExceptionAndOrCancellationScenario scenario, CancellationTokenSource cancellationTokenSource, Action onExecute, Func<int, TException> exceptionFactory) where TException : Exception
+        {
+            int counter = 0;
+
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+
+            policy.Execute(ct =>
+            {
+                onExecute();
+
+                counter++;
+
+                if (scenario.AttemptDuringWhichToCancel.HasValue && counter >= scenario.AttemptDuringWhichToCancel.Value)
+                {
+                    cancellationTokenSource.Cancel();
+                }
+
+                if (scenario.ActionObservesCancellation)
+                {
+                    ct.ThrowIfCancellationRequested();
+                }
+
+                if (counter <= scenario.NumberOfTimesToRaiseException)
+                {
+                    throw exceptionFactory(counter);
+                }
+
+            }, cancellationToken);
         }
 
         public static TResult RaiseExceptionAndOrCancellation<TException, TResult>(this Policy policy, ExceptionAndOrCancellationScenario scenario, CancellationTokenSource cancellationTokenSource, Action onExecute, Func<int, TException> exceptionFactory, TResult successResult) where TException : Exception

--- a/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
+++ b/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
@@ -87,7 +87,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Timeout\TimeoutSpecsBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Timeout\TimeoutTResultAsyncSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Timeout\TimeoutTResultSpecs.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Wrap\IPolicyWrapExSpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Wrap\IPolicyWrapExtensionSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Wrap\PolicyWrapSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Wrap\PolicyWrapContextAndKeySpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Wrap\PolicyWrapContextAndKeySpecsAsync.cs" />

--- a/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
+++ b/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
@@ -87,6 +87,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Timeout\TimeoutSpecsBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Timeout\TimeoutTResultAsyncSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Timeout\TimeoutTResultSpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Wrap\IPolicyWrapExSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Wrap\PolicyWrapSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Wrap\PolicyWrapContextAndKeySpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Wrap\PolicyWrapContextAndKeySpecsAsync.cs" />

--- a/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
+++ b/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
@@ -80,8 +80,12 @@
     <Compile Include="$(MSBuildThisFileDirectory)Retry\RetryTResultSpecsAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Retry\WaitAndRetryAsyncSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Retry\WaitAndRetryForeverAsyncSpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Retry\WaitAndRetryForeverTResultAsyncSpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Retry\WaitAndRetryForeverTResultSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Retry\WaitAndRetrySpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Retry\WaitAndRetryForeverSpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Retry\WaitAndRetryTResultAsyncSpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Retry\WaitAndRetryTResultSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Timeout\TimeoutAsyncSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Timeout\TimeoutSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Timeout\TimeoutSpecsBase.cs" />

--- a/src/Polly.SharedSpecs/Retry/RetryAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/RetryAsyncSpecs.cs
@@ -200,6 +200,23 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
+        public async Task Should_call_onretry_with_a_handled_innerexception()
+        {
+            Exception passedToOnRetry = null;
+
+            var policy = Policy
+                .HandleInner<DivideByZeroException>()
+                .RetryAsync(3, (exception, _) => passedToOnRetry = exception);
+
+            Exception toRaiseAsInner = new DivideByZeroException();
+            Exception withInner = new AggregateException(toRaiseAsInner);
+
+            await policy.RaiseExceptionAsync(withInner);
+
+            passedToOnRetry.Should().BeSameAs(toRaiseAsInner);
+        }
+
+        [Fact]
         public void Should_not_call_onretry_when_no_retries_are_performed()
         {
             var retryCounts = new List<int>();

--- a/src/Polly.SharedSpecs/Retry/RetrySpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/RetrySpecs.cs
@@ -235,6 +235,23 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
+        public void Should_call_onretry_with_a_handled_innerexception()
+        {
+            Exception passedToOnRetry = null;
+
+            var policy = Policy
+                .HandleInner<DivideByZeroException>()
+                .Retry(3, (exception, _) => passedToOnRetry = exception);
+
+            Exception toRaiseAsInner = new DivideByZeroException();
+            Exception withInner = new AggregateException(toRaiseAsInner);
+
+            policy.RaiseException(withInner);
+
+            passedToOnRetry.Should().BeSameAs(toRaiseAsInner);
+        }
+
+        [Fact]
         public void Should_not_call_onretry_when_no_retries_are_performed()
         {
             var retryCounts = new List<int>();

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetryAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetryAsyncSpecs.cs
@@ -13,6 +13,7 @@ using Scenario = Polly.Specs.Helpers.PolicyExtensionsAsync.ExceptionAndOrCancell
 
 namespace Polly.Specs.Retry
 {
+    [Collection("SystemClockDependantCollection")]
     public class WaitAndRetryAsyncSpecs : IDisposable
     {
         public WaitAndRetryAsyncSpecs()

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetryAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetryAsyncSpecs.cs
@@ -561,6 +561,45 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
+        public async Task Should_calculate_retry_timespans_from_current_retry_attempt_and_timespan_provider_with_exception_handling()
+        {
+            var expectedRetryWaits = new[]
+                {
+                    2.Seconds(),
+                    4.Seconds(),
+                    8.Seconds(),
+                    16.Seconds(),
+                    32.Seconds()
+                };
+
+            object capturedExceptionInstance = null;
+
+            DivideByZeroException exceptionInstance = new DivideByZeroException() {
+                
+            };
+
+            var actualRetryWaits = new List<TimeSpan>();
+
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .WaitAndRetryAsync(5,
+                    sleepDurationProvider:( retries,  ex,  ctx) =>
+                    {
+                        capturedExceptionInstance = ex;
+                        return TimeSpan.FromMilliseconds(10);
+                    },
+                    onRetryAsync: ( ts,  i,  ctx,  task) =>
+                    {
+                        return TaskHelper.EmptyTask;
+                    }
+                );
+
+            await policy.RaiseExceptionAsync(exceptionInstance);
+            capturedExceptionInstance.Should().Be(exceptionInstance);
+            
+        }
+
+        [Fact]
         public async Task Should_be_able_to_pass_retry_duration_from_execution_to_sleepDurationProvider_via_context()
         {
             var expectedRetryDuration = 1.Seconds();

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverAsyncSpecs.cs
@@ -12,6 +12,7 @@ using Scenario = Polly.Specs.Helpers.PolicyExtensionsAsync.ExceptionAndOrCancell
 
 namespace Polly.Specs.Retry
 {
+    [Collection("SystemClockDependantCollection")]
     public class WaitAndRetryForeverAsyncSpecs : IDisposable
     {
         public WaitAndRetryForeverAsyncSpecs()

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverAsyncSpecs.cs
@@ -288,6 +288,42 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
+        public async Task Should_be_able_to_calculate_retry_timespans_based_on_the_handled_fault()
+        {
+            Dictionary<Exception, TimeSpan> expectedRetryWaits = new Dictionary<Exception, TimeSpan>(){
+
+                {new DivideByZeroException(), 2.Seconds()},
+                {new ArgumentNullException(), 4.Seconds()},
+            };
+
+            var actualRetryWaits = new List<TimeSpan>();
+
+            var policy = Policy
+                .Handle<Exception>()
+                .WaitAndRetryForeverAsync(
+                    sleepDurationProvider: (retryAttempt, exc, ctx) =>
+                    {
+                        return expectedRetryWaits[exc];
+                    },
+                    onRetryAsync: (_, timeSpan, __) =>
+                    {
+                        actualRetryWaits.Add(timeSpan);
+                        return TaskHelper.EmptyTask;
+                    });
+
+            using (var enumerator = expectedRetryWaits.GetEnumerator())
+            {
+                await policy.ExecuteAsync(() => {
+                    if (enumerator.MoveNext()) throw enumerator.Current.Key;
+                    return TaskHelper.EmptyTask;
+                });
+            }
+
+            actualRetryWaits.Should().ContainInOrder(expectedRetryWaits.Values);
+        }
+
+
+        [Fact]
         public async Task Should_be_able_to_pass_retry_duration_from_execution_to_sleepDurationProvider_via_context()
         {
             var expectedRetryDuration = 1.Seconds();

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverSpecs.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace Polly.Specs.Retry
 {
+    [Collection("SystemClockDependantCollection")]
     public class WaitAndRetryForeverSpecs : IDisposable
     {
         public WaitAndRetryForeverSpecs()

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverSpecs.cs
@@ -35,9 +35,11 @@ namespace Polly.Specs.Retry
         {
             Action<Exception, TimeSpan, Context> onRetry = (_, __, ___) => { };
 
+            Func<int, Context, TimeSpan> sleepDurationProvider = null;
+
             Action policy = () => Policy
                                       .Handle<DivideByZeroException>()
-                                      .WaitAndRetryForever(null, onRetry);
+                                      .WaitAndRetryForever(sleepDurationProvider, onRetry);
 
             policy.ShouldThrow<ArgumentNullException>().And
                   .ParamName.Should().Be("sleepDurationProvider");
@@ -281,6 +283,32 @@ namespace Polly.Specs.Retry
 
             actualRetryWaits.Should()
                        .ContainInOrder(expectedRetryWaits);
+        }
+
+        [Fact]
+        public void Should_be_able_to_calculate_retry_timespans_based_on_the_handled_fault()
+        {
+            Dictionary<Exception, TimeSpan> expectedRetryWaits = new Dictionary<Exception, TimeSpan>(){
+
+                {new DivideByZeroException(), 2.Seconds()},
+                {new ArgumentNullException(), 4.Seconds()},
+            };
+
+            var actualRetryWaits = new List<TimeSpan>();
+
+            var policy = Policy
+                .Handle<Exception>()
+                .WaitAndRetryForever(
+                    (retryAttempt, exc, ctx) => expectedRetryWaits[exc],
+                    (_, timeSpan, __) => actualRetryWaits.Add(timeSpan)
+                );
+
+            using (var enumerator = expectedRetryWaits.GetEnumerator())
+            {
+                policy.Execute(() => { if (enumerator.MoveNext()) throw enumerator.Current.Key; });
+            }
+
+            actualRetryWaits.Should().ContainInOrder(expectedRetryWaits.Values);
         }
 
         [Fact]

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverTResultAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverTResultAsyncSpecs.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using FluentAssertions;
+using Polly.Specs.Helpers;
+using Polly.Utilities;
+using Xunit;
+
+namespace Polly.Specs.Retry
+{
+    [Collection("SystemClockDependantCollection")]
+    public class WaitAndRetryForeverTResultAsyncSpecs : IDisposable
+    {
+        public WaitAndRetryForeverTResultAsyncSpecs()
+        {
+            // do nothing on call to sleep
+            SystemClock.SleepAsync = (_, __) => TaskHelper.EmptyTask;
+        }
+
+        [Fact]
+        public async Task Should_be_able_to_calculate_retry_timespans_based_on_the_handled_fault()
+        {
+            Dictionary<ResultPrimitive, TimeSpan> expectedRetryWaits = new Dictionary<ResultPrimitive, TimeSpan>(){
+
+                {ResultPrimitive.Fault, 2.Seconds()},
+                {ResultPrimitive.FaultAgain, 4.Seconds()},
+            };
+
+            var actualRetryWaits = new List<TimeSpan>();
+
+            var policy = Policy
+                .HandleResult(ResultPrimitive.Fault)
+                .OrResult(ResultPrimitive.FaultAgain)
+                .WaitAndRetryForeverAsync(
+                    (retryAttempt, outcome, ctx) => expectedRetryWaits[outcome.Result],
+                    (_, timeSpan, __) =>
+                    {
+                        actualRetryWaits.Add(timeSpan);
+                        return TaskHelper.EmptyTask;
+                    });
+
+            using (var enumerator = expectedRetryWaits.GetEnumerator())
+            {
+                await policy.ExecuteAsync(async () =>
+                {
+                    await TaskHelper.EmptyTask;
+                    if (enumerator.MoveNext()) return enumerator.Current.Key;
+                    else return ResultPrimitive.Undefined;
+                });
+            }
+
+            actualRetryWaits.Should().ContainInOrder(expectedRetryWaits.Values);
+        }
+
+        public void Dispose()
+        {
+            SystemClock.Reset();
+        }
+
+    }
+}

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverTResultSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverTResultSpecs.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Polly.Specs.Helpers;
+using Polly.Utilities;
+using Xunit;
+
+namespace Polly.Specs.Retry
+{
+    [Collection("SystemClockDependantCollection")]
+    public class WaitAndRetryForeverTResultSpecs : IDisposable
+    {
+        public WaitAndRetryForeverTResultSpecs()
+        {
+            // do nothing on call to sleep
+            SystemClock.Sleep = (_, __) => { };
+        }
+
+        [Fact]
+        public void Should_be_able_to_calculate_retry_timespans_based_on_the_handled_fault()
+        {
+            Dictionary<ResultPrimitive, TimeSpan> expectedRetryWaits = new Dictionary<ResultPrimitive, TimeSpan>(){
+
+                {ResultPrimitive.Fault, 2.Seconds()},
+                {ResultPrimitive.FaultAgain, 4.Seconds()},
+            };
+
+            var actualRetryWaits = new List<TimeSpan>();
+
+            var policy = Policy
+                .HandleResult(ResultPrimitive.Fault)
+                .OrResult(ResultPrimitive.FaultAgain)
+                .WaitAndRetryForever(
+                    (retryAttempt, outcome, ctx) => expectedRetryWaits[outcome.Result],
+                    (_, timeSpan, __) => actualRetryWaits.Add(timeSpan)
+                );
+
+            using (var enumerator = expectedRetryWaits.GetEnumerator())
+            {
+                policy.Execute(() =>
+                {
+                    if (enumerator.MoveNext()) return enumerator.Current.Key;
+                    else return ResultPrimitive.Undefined;
+                });
+            }
+
+            actualRetryWaits.Should().ContainInOrder(expectedRetryWaits.Values);
+        }
+
+        public void Dispose()
+        {
+            SystemClock.Reset();
+        }
+
+    }
+}

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetrySpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetrySpecs.cs
@@ -707,6 +707,57 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
+        public void Should_be_able_to_pass_handled_exception_to_sleepdurationprovider()
+        {
+            object capturedExceptionInstance = null;
+
+            DivideByZeroException exceptionInstance = new DivideByZeroException();
+
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .WaitAndRetry(5,
+                    sleepDurationProvider: (retries, ex, ctx) =>
+                    {
+                        capturedExceptionInstance = ex;
+                        return TimeSpan.FromMilliseconds(0);
+                    },
+                    onRetry: (ex, ts, i, ctx) =>
+                    {
+                    }
+                );
+
+            policy.RaiseException(exceptionInstance);
+
+            capturedExceptionInstance.Should().Be(exceptionInstance);
+        }
+
+        [Fact]
+        public void Should_be_able_to_calculate_retry_timespans_based_on_the_handled_fault()
+        {
+            Dictionary<Exception, TimeSpan> expectedRetryWaits = new Dictionary<Exception, TimeSpan>(){
+
+                {new DivideByZeroException(), 2.Seconds()},
+                {new ArgumentNullException(), 4.Seconds()},
+            };
+
+            var actualRetryWaits = new List<TimeSpan>();
+
+            var policy = Policy
+                .Handle<Exception>()
+                .WaitAndRetry(2,
+                    (retryAttempt, exc, ctx) => expectedRetryWaits[exc],
+                    (_, timeSpan, __, ___) => actualRetryWaits.Add(timeSpan)
+                );
+
+            using (var enumerator = expectedRetryWaits.GetEnumerator())
+            {
+                policy.Execute(() => { if (enumerator.MoveNext()) throw enumerator.Current.Key; });
+            }
+
+            actualRetryWaits.Should().ContainInOrder(expectedRetryWaits.Values);
+        }
+
+        [Fact]
         public void Should_be_able_to_pass_retry_duration_from_execution_to_sleepDurationProvider_via_context()
         {
             var expectedRetryDuration = 1.Seconds();
@@ -1138,12 +1189,12 @@ namespace Polly.Specs.Retry
             attemptsInvoked.Should().Be(1);
         }
 
+        #endregion
+
         public void Dispose()
         {
             SystemClock.Reset();
         }
-
-        #endregion
 
     }
 }

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetrySpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetrySpecs.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace Polly.Specs.Retry
 {
+    [Collection("SystemClockDependantCollection")]
     public class WaitAndRetrySpecs : IDisposable
     {
         public WaitAndRetrySpecs()

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetryTResultAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetryTResultAsyncSpecs.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using FluentAssertions;
+using Polly.Specs.Helpers;
+using Polly.Utilities;
+using Xunit;
+
+namespace Polly.Specs.Retry
+{
+    [Collection("SystemClockDependantCollection")]
+    public class WaitAndRetryTResultAsyncSpecs : IDisposable
+    {
+        public WaitAndRetryTResultAsyncSpecs()
+        {
+            // do nothing on call to sleep
+            SystemClock.SleepAsync = (_, __) => TaskHelper.EmptyTask;
+        }
+
+        [Fact]
+        public async Task Should_be_able_to_calculate_retry_timespans_based_on_the_handled_fault()
+        {
+            Dictionary<ResultPrimitive, TimeSpan> expectedRetryWaits = new Dictionary<ResultPrimitive, TimeSpan>(){
+
+                {ResultPrimitive.Fault, 2.Seconds()},
+                {ResultPrimitive.FaultAgain, 4.Seconds()},
+            };
+
+            var actualRetryWaits = new List<TimeSpan>();
+
+            var policy = Policy
+                .HandleResult(ResultPrimitive.Fault)
+                .OrResult(ResultPrimitive.FaultAgain)
+                .WaitAndRetryAsync(2,
+                    (retryAttempt, outcome, ctx) => expectedRetryWaits[outcome.Result],
+                    (_, timeSpan, __, ___) =>
+                    {
+                        actualRetryWaits.Add(timeSpan);
+                        return TaskHelper.EmptyTask;
+                    });
+
+            using (var enumerator = expectedRetryWaits.GetEnumerator())
+            {
+                await policy.ExecuteAsync(async () =>
+                {
+                    await TaskHelper.EmptyTask;
+                    if (enumerator.MoveNext()) return enumerator.Current.Key;
+                    else return ResultPrimitive.Undefined;
+                });
+            }
+
+            actualRetryWaits.Should().ContainInOrder(expectedRetryWaits.Values);
+        }
+
+        public void Dispose()
+        {
+            SystemClock.Reset();
+        }
+
+    }
+}

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetryTResultSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetryTResultSpecs.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Polly.Specs.Helpers;
+using Polly.Utilities;
+using Xunit;
+
+namespace Polly.Specs.Retry
+{
+    [Collection("SystemClockDependantCollection")]
+    public class WaitAndRetryTResultSpecs : IDisposable
+    {
+        public WaitAndRetryTResultSpecs()
+        {
+            // do nothing on call to sleep
+            SystemClock.Sleep = (_, __) => { };
+        }
+
+        [Fact]
+        public void Should_be_able_to_calculate_retry_timespans_based_on_the_handled_fault()
+        {
+            Dictionary<ResultPrimitive, TimeSpan> expectedRetryWaits = new Dictionary<ResultPrimitive, TimeSpan>(){
+
+                {ResultPrimitive.Fault, 2.Seconds()},
+                {ResultPrimitive.FaultAgain, 4.Seconds()},
+            };
+
+            var actualRetryWaits = new List<TimeSpan>();
+
+            var policy = Policy
+                .HandleResult(ResultPrimitive.Fault)
+                .OrResult(ResultPrimitive.FaultAgain)
+                .WaitAndRetry(2,
+                    (retryAttempt, outcome, ctx) => expectedRetryWaits[outcome.Result],
+                    (_, timeSpan, __, ___) => actualRetryWaits.Add(timeSpan)
+                );
+
+            using (var enumerator = expectedRetryWaits.GetEnumerator())
+            {
+                policy.Execute(() =>
+                {
+                    if (enumerator.MoveNext()) return enumerator.Current.Key;
+                    else return ResultPrimitive.Undefined;
+                });
+            }
+
+            actualRetryWaits.Should().ContainInOrder(expectedRetryWaits.Values);
+        }
+
+        public void Dispose()
+        {
+            SystemClock.Reset();
+        }
+
+    }
+}

--- a/src/Polly.SharedSpecs/Timeout/TimeoutAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Timeout/TimeoutAsyncSpecs.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Polly.Specs.Timeout
 {
+    [Collection("SystemClockDependantCollection")]
     public class TimeoutAsyncSpecs : TimeoutSpecsBase
     {
         #region Configuration

--- a/src/Polly.SharedSpecs/Timeout/TimeoutSpecs.cs
+++ b/src/Polly.SharedSpecs/Timeout/TimeoutSpecs.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace Polly.Specs.Timeout
 {
+    [Collection("SystemClockDependantCollection")]
     public class TimeoutSpecs : TimeoutSpecsBase
     {
         #region Configuration

--- a/src/Polly.SharedSpecs/Timeout/TimeoutTResultAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Timeout/TimeoutTResultAsyncSpecs.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Polly.Specs.Timeout
 {
+    [Collection("SystemClockDependantCollection")]
     public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
     {
         #region Configuration

--- a/src/Polly.SharedSpecs/Timeout/TimeoutTResultSpecs.cs
+++ b/src/Polly.SharedSpecs/Timeout/TimeoutTResultSpecs.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Polly.Specs.Timeout
 {
+    [Collection("SystemClockDependantCollection")]
     public class TimeoutTResultSpecs : TimeoutSpecsBase
     {
         #region Configuration

--- a/src/Polly.SharedSpecs/Wrap/IPolicyWrapExtensionSpecs.cs
+++ b/src/Polly.SharedSpecs/Wrap/IPolicyWrapExtensionSpecs.cs
@@ -1,67 +1,28 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using Xunit;
 using Polly.Wrap;
 using System.Linq;
 using FluentAssertions;
+using Polly.CircuitBreaker;
+using Polly.NoOp;
+using Polly.Retry;
 
 namespace Polly.Specs.Wrap
 {
     public class IPolicyWrapExtensionSpecs
     {
-        [Fact]
-        public void Should_pass_outer_policy_and_then_inner_policy_from_PolicyWrap()
-        {
-            var outerPolicy = Policy.NoOp();
-            var innerPolicy = Policy.NoOp();
-            var policyWrap = Policy.Wrap(outerPolicy, innerPolicy);
-
-            var policies = policyWrap.GetPolicies().ToList();
-            policies[0].Should().Be(outerPolicy);
-            policies[1].Should().Be(innerPolicy);
-        }
-
-        [Fact]
-        public void Should_pass_no_policy_if_PolicyWrap_has_no_inner_or_outer_policy()
-        {
-            var policyWrap = new CustomWrap();
-
-            var policies = policyWrap.GetPolicies().ToList();
-            policies.Count.Should().Be(0);
-        }
-
-        [Fact]
-        public void Should_pass_only_inner_policy_if_PolicyWrap_has_no_outer_policy()
-        {
-            var innerPolicy = Policy.NoOp();
-            var policyWrap = new CustomWrap(null, innerPolicy);
-
-            var policies = policyWrap.GetPolicies().ToList();
-            policies.Count.Should().Be(1);
-            policies[0].Should().Be(innerPolicy);
-        }
-
-        [Fact]
-        public void Should_pass_only_outer_policy_if_PolicyWrap_has_no_inner_policy()
-        {
-            var outerPolicy = Policy.NoOp();
-            var policyWrap = new CustomWrap(outerPolicy, null);
-
-            var policies = policyWrap.GetPolicies().ToList();
-            policies.Count.Should().Be(1);
-            policies[0].Should().Be(outerPolicy);
-        }
 
         [Fact]
         public void Should_pass_all_nested_policies_from_PolicyWrap_in_same_order_they_were_added()
         {
-            var policy0 = Policy.NoOp();
-            var policy1 = Policy.NoOp();
-            var policy2 = Policy.NoOp();
-            var policyWrap = Policy.Wrap(policy0, policy1, policy2);
+            NoOpPolicy policy0 = Policy.NoOp();
+            NoOpPolicy policy1 = Policy.NoOp();
+            NoOpPolicy policy2 = Policy.NoOp();
 
-            var policies = policyWrap.GetPolicies().ToList();
+            PolicyWrap policyWrap = Policy.Wrap(policy0, policy1, policy2);
+
+            List<IsPolicy> policies = policyWrap.GetPolicies().ToList();
             policies.Count.Should().Be(3);
             policies[0].Should().Be(policy0);
             policies[1].Should().Be(policy1);
@@ -69,43 +30,210 @@ namespace Polly.Specs.Wrap
         }
 
         [Fact]
-        public void Should_pass_nested_policies_in_outer_inner_order()
+        public void Should_return_sequence_from_GetPolicies()
         {
-            var policy0 = Policy.NoOp();
-            var policy1 = Policy.NoOp();
-            var policy2 = Policy.NoOp();
-            var policy3 = Policy.NoOp();
-            var policyWrap = 
-                new CustomWrap(
-                    new CustomWrap(policy0, policy1),
-                    new CustomWrap(
-                        policy2,
-                        new CustomWrap(null, policy3)));
+            Policy policyA = Policy.NoOp();
+            Policy policyB = Policy.NoOp();
+            PolicyWrap wrap = Policy.Wrap(policyA, policyB);
 
-            var policies = policyWrap.GetPolicies().ToList();
-            policies.Count.Should().Be(4);
-            policies[0].Should().Be(policy0);
-            policies[1].Should().Be(policy1);
-            policies[2].Should().Be(policy2);
-            policies[3].Should().Be(policy3);
+            wrap.GetPolicies().ShouldBeEquivalentTo(new[] { policyA, policyB }, options => options.WithStrictOrdering());
         }
 
-        public class CustomWrap : IPolicyWrap
+        [Fact]
+        public void Threepolicies_by_static_sequence_should_return_correct_sequence_from_GetPolicies()
         {
-            public IsPolicy Outer { get; }
-            public IsPolicy Inner { get; }
+            Policy policyA = Policy.NoOp();
+            Policy policyB = Policy.NoOp();
+            Policy policyC = Policy.NoOp();
+            PolicyWrap wrap = Policy.Wrap(policyA, policyB, policyC);
 
-            public string PolicyKey => throw new NotImplementedException();
+            wrap.GetPolicies().ShouldBeEquivalentTo(new[] { policyA, policyB, policyC }, options => options.WithStrictOrdering());
+        }
 
-            public CustomWrap()
-            {
-            }
+        [Fact]
+        public void Threepolicies_lefttree_should_return_correct_sequence_from_GetPolicies()
+        {
+            Policy policyA = Policy.NoOp();
+            Policy policyB = Policy.NoOp();
+            Policy policyC = Policy.NoOp();
+            PolicyWrap wrap = policyA.Wrap(policyB).Wrap(policyC);
 
-            public CustomWrap(IsPolicy outer, IsPolicy inner)
-            {
-                Outer = outer;
-                Inner = inner;
-            }
+            wrap.GetPolicies().ShouldBeEquivalentTo(new[] { policyA, policyB, policyC }, options => options.WithStrictOrdering());
+        }
+
+        [Fact]
+        public void Threepolicies_righttree_should_return_correct_sequence_from_GetPolicies()
+        {
+            Policy policyA = Policy.NoOp();
+            Policy policyB = Policy.NoOp();
+            Policy policyC = Policy.NoOp();
+            PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
+
+            wrap.GetPolicies().ShouldBeEquivalentTo(new[] { policyA, policyB, policyC }, options => options.WithStrictOrdering());
+        }
+
+        [Fact]
+        public void GetPoliciesTPolicy_should_return_single_policy_of_type_TPolicy()
+        {
+            Policy policyA = Policy.NoOp();
+            Policy policyB = Policy.Handle<Exception>().Retry();
+            Policy policyC = Policy.NoOp();
+            PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
+
+            wrap.GetPolicies<RetryPolicy>().ShouldBeEquivalentTo(new[] { policyB }, options => options.WithStrictOrdering());
+        }
+
+        [Fact]
+        public void GetPoliciesTPolicy_should_return_empty_enumerable_if_no_policy_of_type_TPolicy()
+        {
+            Policy policyA = Policy.NoOp();
+            Policy policyB = Policy.Handle<Exception>().Retry();
+            Policy policyC = Policy.NoOp();
+            PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
+
+            wrap.GetPolicies<CircuitBreakerPolicy>().Should().BeEmpty();
+        }
+
+        [Fact]
+        public void GetPoliciesTPolicy_should_return_multiple_policies_of_type_TPolicy()
+        {
+            Policy policyA = Policy.NoOp();
+            Policy policyB = Policy.Handle<Exception>().Retry();
+            Policy policyC = Policy.NoOp();
+            PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
+
+            wrap.GetPolicies<NoOpPolicy>().ShouldBeEquivalentTo(new[] { policyA, policyC }, options => options.WithStrictOrdering());
+        }
+
+        [Fact]
+        public void GetPoliciesTPolicy_should_return_policies_of_type_TPolicy_matching_predicate()
+        {
+            CircuitBreakerPolicy policyA = Policy.Handle<Exception>().CircuitBreaker(1, TimeSpan.Zero);
+            Policy policyB = Policy.Handle<Exception>().Retry();
+            CircuitBreakerPolicy policyC = Policy.Handle<Exception>().CircuitBreaker(1, TimeSpan.Zero);
+
+            policyA.Isolate();
+
+            PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
+
+            wrap.GetPolicies<CircuitBreakerPolicy>(p => p.CircuitState == CircuitState.Closed).ShouldBeEquivalentTo(new[] { policyC }, options => options.WithStrictOrdering());
+        }
+
+        [Fact]
+        public void GetPoliciesTPolicy_should_return_empty_enumerable_if_none_match_predicate()
+        {
+            CircuitBreakerPolicy policyA = Policy.Handle<Exception>().CircuitBreaker(1, TimeSpan.Zero);
+            Policy policyB = Policy.Handle<Exception>().Retry();
+            CircuitBreakerPolicy policyC = Policy.Handle<Exception>().CircuitBreaker(1, TimeSpan.Zero);
+
+            PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
+
+            wrap.GetPolicies<CircuitBreakerPolicy>(p => p.CircuitState == CircuitState.Open).Should().BeEmpty();
+        }
+
+        [Fact]
+        public void GetPoliciesTPolicy_with_predicate_should_return_multiple_policies_of_type_TPolicy_if_multiple_match_predicate()
+        {
+            Policy policyA = Policy.NoOp();
+            Policy policyB = Policy.Handle<Exception>().Retry();
+            Policy policyC = Policy.NoOp();
+            PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
+
+            wrap.GetPolicies<NoOpPolicy>(_ => true).ShouldBeEquivalentTo(new[] { policyA, policyC }, options => options.WithStrictOrdering());
+        }
+
+        [Fact]
+        public void GetPoliciesTPolicy_with_predicate_should_throw_if_predicate_is_null()
+        {
+            Policy policyA = Policy.NoOp();
+            Policy policyB = Policy.NoOp();
+            PolicyWrap wrap = policyA.Wrap(policyB);
+
+            Action configure = () => wrap.GetPolicies<NoOpPolicy>(null);
+            
+            configure.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("filter");
+        }
+
+        [Fact]
+        public void GetPolicyTPolicy_should_return_single_policy_of_type_TPolicy()
+        {
+            Policy policyA = Policy.NoOp();
+            Policy policyB = Policy.Handle<Exception>().Retry();
+            Policy policyC = Policy.NoOp();
+            PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
+
+            wrap.GetPolicy<RetryPolicy>().Should().BeSameAs(policyB);
+        }
+
+        [Fact]
+        public void GetPolicyTPolicy_should_return_null_if_no_TPolicy()
+        {
+            Policy policyA = Policy.NoOp();
+            Policy policyB = Policy.Handle<Exception>().Retry();
+            Policy policyC = Policy.NoOp();
+            PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
+
+            wrap.GetPolicy<CircuitBreakerPolicy>().Should().BeNull();
+        }
+
+        [Fact]
+        public void GetPolicyTPolicy_should_throw_if_multiple_TPolicy()
+        {
+            Policy policyA = Policy.NoOp();
+            Policy policyB = Policy.Handle<Exception>().Retry();
+            Policy policyC = Policy.NoOp();
+            PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
+
+            wrap.Invoking(p => p.GetPolicy<NoOpPolicy>()).ShouldThrow<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void GetPolicyTPolicy_should_return_single_policy_of_type_TPolicy_matching_predicate()
+        {
+            CircuitBreakerPolicy policyA = Policy.Handle<Exception>().CircuitBreaker(1, TimeSpan.Zero);
+            Policy policyB = Policy.Handle<Exception>().Retry();
+            CircuitBreakerPolicy policyC = Policy.Handle<Exception>().CircuitBreaker(1, TimeSpan.Zero);
+
+            policyA.Isolate();
+
+            PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
+
+            wrap.GetPolicy<CircuitBreakerPolicy>(p => p.CircuitState == CircuitState.Closed).Should().BeSameAs(policyC);
+        }
+
+        [Fact]
+        public void GetPolicyTPolicy_should_return_null_if_none_match_predicate()
+        {
+            CircuitBreakerPolicy policyA = Policy.Handle<Exception>().CircuitBreaker(1, TimeSpan.Zero);
+            Policy policyB = Policy.Handle<Exception>().Retry();
+            CircuitBreakerPolicy policyC = Policy.Handle<Exception>().CircuitBreaker(1, TimeSpan.Zero);
+
+            PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
+
+            wrap.GetPolicy<CircuitBreakerPolicy>(p => p.CircuitState == CircuitState.Open).Should().BeNull();
+        }
+
+        [Fact]
+        public void GetPolicyTPolicy_with_predicate_should_throw_if_multiple_TPolicy_if_multiple_match_predicate()
+        {
+            Policy policyA = Policy.NoOp();
+            Policy policyB = Policy.Handle<Exception>().Retry();
+            Policy policyC = Policy.NoOp();
+            PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
+
+            wrap.Invoking(p => p.GetPolicy<NoOpPolicy>(_ => true)).ShouldThrow<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void GetPolicyTPolicy_with_predicate_should_throw_if_predicate_is_null()
+        {
+            Policy policyA = Policy.NoOp();
+            Policy policyB = Policy.NoOp();
+            PolicyWrap wrap = policyA.Wrap(policyB);
+
+            Action configure = () => wrap.GetPolicy<NoOpPolicy>(null);
+
+            configure.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("filter");
         }
     }
 }

--- a/src/Polly.SharedSpecs/Wrap/IPolicyWrapExtensionSpecs.cs
+++ b/src/Polly.SharedSpecs/Wrap/IPolicyWrapExtensionSpecs.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+using Polly.Wrap;
+using System.Linq;
+using FluentAssertions;
+
+namespace Polly.Specs.Wrap
+{
+    public class IPolicyWrapExtensionSpecs
+    {
+        [Fact]
+        public void Should_pass_outer_policy_and_then_inner_policy_from_PolicyWrap()
+        {
+            var outerPolicy = Policy.NoOp();
+            var innerPolicy = Policy.NoOp();
+            var policyWrap = Policy.Wrap(outerPolicy, innerPolicy);
+
+            var policies = policyWrap.GetPolicies().ToList();
+            policies[0].Should().Be(outerPolicy);
+            policies[1].Should().Be(innerPolicy);
+        }
+
+        [Fact]
+        public void Should_pass_no_policy_if_PolicyWrap_has_no_inner_or_outer_policy()
+        {
+            var policyWrap = new CustomWrap();
+
+            var policies = policyWrap.GetPolicies().ToList();
+            policies.Count.Should().Be(0);
+        }
+
+        [Fact]
+        public void Should_pass_only_inner_policy_if_PolicyWrap_has_no_outer_policy()
+        {
+            var innerPolicy = Policy.NoOp();
+            var policyWrap = new CustomWrap(null, innerPolicy);
+
+            var policies = policyWrap.GetPolicies().ToList();
+            policies.Count.Should().Be(1);
+            policies[0].Should().Be(innerPolicy);
+        }
+
+        [Fact]
+        public void Should_pass_only_outer_policy_if_PolicyWrap_has_no_inner_policy()
+        {
+            var outerPolicy = Policy.NoOp();
+            var policyWrap = new CustomWrap(outerPolicy, null);
+
+            var policies = policyWrap.GetPolicies().ToList();
+            policies.Count.Should().Be(1);
+            policies[0].Should().Be(outerPolicy);
+        }
+
+        [Fact]
+        public void Should_pass_all_nested_policies_from_PolicyWrap_in_same_order_they_were_added()
+        {
+            var policy0 = Policy.NoOp();
+            var policy1 = Policy.NoOp();
+            var policy2 = Policy.NoOp();
+            var policyWrap = Policy.Wrap(policy0, policy1, policy2);
+
+            var policies = policyWrap.GetPolicies().ToList();
+            policies.Count.Should().Be(3);
+            policies[0].Should().Be(policy0);
+            policies[1].Should().Be(policy1);
+            policies[2].Should().Be(policy2);
+        }
+
+        [Fact]
+        public void Should_pass_nested_policies_in_outer_inner_order()
+        {
+            var policy0 = Policy.NoOp();
+            var policy1 = Policy.NoOp();
+            var policy2 = Policy.NoOp();
+            var policy3 = Policy.NoOp();
+            var policyWrap = 
+                new CustomWrap(
+                    new CustomWrap(policy0, policy1),
+                    new CustomWrap(
+                        policy2,
+                        new CustomWrap(null, policy3)));
+
+            var policies = policyWrap.GetPolicies().ToList();
+            policies.Count.Should().Be(4);
+            policies[0].Should().Be(policy0);
+            policies[1].Should().Be(policy1);
+            policies[2].Should().Be(policy2);
+            policies[3].Should().Be(policy3);
+        }
+
+        public class CustomWrap : IPolicyWrap
+        {
+            public IsPolicy Outer { get; }
+            public IsPolicy Inner { get; }
+
+            public string PolicyKey => throw new NotImplementedException();
+
+            public CustomWrap()
+            {
+            }
+
+            public CustomWrap(IsPolicy outer, IsPolicy inner)
+            {
+                Outer = outer;
+                Inner = inner;
+            }
+        }
+    }
+}

--- a/src/Polly.SharedSpecs/Wrap/PolicyWrapContextAndKeySpecs.cs
+++ b/src/Polly.SharedSpecs/Wrap/PolicyWrapContextAndKeySpecs.cs
@@ -115,14 +115,13 @@ namespace Polly.Specs.Wrap
             var outerWrap = fallback.Wrap(innerWrap).WithPolicyKey(outerWrapKey);
 
             bool doneOnceOny = false;
-            outerWrap.Execute<int>(() =>
+            outerWrap.Execute(() =>
             {
                 if (!doneOnceOny)
                 {
                     doneOnceOny = true;
                     throw new Exception();
                 }
-                return 0;
             });
 
             policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);

--- a/src/Polly.SharedSpecs/Wrap/PolicyWrapContextAndKeySpecs.cs
+++ b/src/Polly.SharedSpecs/Wrap/PolicyWrapContextAndKeySpecs.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace Polly.Specs.Wrap
 {
+    [Collection("SystemClockDependantCollection")]
     public class PolicyWrapContextAndKeySpecs
     {
         #region PolicyKey and execution Context tests

--- a/src/Polly.SharedSpecs/Wrap/PolicyWrapContextAndKeySpecsAsync.cs
+++ b/src/Polly.SharedSpecs/Wrap/PolicyWrapContextAndKeySpecsAsync.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace Polly.Specs.Wrap
 {
+    [Collection("SystemClockDependantCollection")]
     public class PolicyWrapContextAndKeySpecsAsync
     {
         #region PolicyKey and execution Context tests

--- a/src/Polly.SharedSpecs/Wrap/PolicyWrapContextAndKeySpecsAsync.cs
+++ b/src/Polly.SharedSpecs/Wrap/PolicyWrapContextAndKeySpecsAsync.cs
@@ -117,14 +117,14 @@ namespace Polly.Specs.Wrap
             var outerWrap = fallback.WrapAsync(innerWrap).WithPolicyKey(outerWrapKey);
 
             bool doneOnceOny = false;
-            await outerWrap.ExecuteAsync<int>(() =>
+            await outerWrap.ExecuteAsync(() =>
             {
                 if (!doneOnceOny)
                 {
                     doneOnceOny = true;
                     throw new Exception();
                 }
-                return TaskHelper.FromResult(0);
+                return TaskHelper.EmptyTask;
             });
 
             policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);

--- a/src/Polly.SharedSpecs/Wrap/PolicyWrapSpecs.cs
+++ b/src/Polly.SharedSpecs/Wrap/PolicyWrapSpecs.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace Polly.Specs.Wrap
 {
+    [Collection("SystemClockDependantCollection")]
     public class PolicyWrapSpecs
     {
         #region Instance configuration syntax tests, non-generic policies

--- a/src/Polly.SharedSpecs/Wrap/PolicyWrapSpecsAsync.cs
+++ b/src/Polly.SharedSpecs/Wrap/PolicyWrapSpecsAsync.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Polly.Specs.Wrap
 {
+    [Collection("SystemClockDependantCollection")]
     public class PolicyWrapSpecsAsync
     {
         #region Instance configuration syntax tests, non-generic policies

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -18,7 +18,8 @@
      5.6.0
      ---------------------
      - Bug fix: set context keys for generic execute method with PolicyWrap
-     - Add GetPolicies extension method to IPolicyWrap 
+     - Add GetPolicies extension method to IPolicyWrap
+     - Allow WaitAndRetry policies to calculate wait based on the handled fault
 
      5.5.0
      ---------------------

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -17,10 +17,12 @@
 
      5.6.0
      ---------------------
-     - Bug fix: set context keys for generic execute method with PolicyWrap
      - Add ability to handle inner exceptions natively: .HandleInner&lt;TEx&gt;()
-     - Add GetPolicies extension method to IPolicyWrap
      - Allow WaitAndRetry policies to calculate wait based on the handled fault
+     - Add GetPolicies() extension methods to IPolicyWrap
+     - Allow PolicyWrap to take interfaces as parameters
+     - Bug fix: set context keys for generic execute method with PolicyWrap
+     - Performance improvements
 
      5.5.0
      ---------------------

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -18,6 +18,7 @@
      5.6.0
      ---------------------
      - Bug fix: set context keys for generic execute method with PolicyWrap
+     - Add GetPolicies extension method to IPolicyWrap 
 
      5.5.0
      ---------------------

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -18,6 +18,7 @@
      5.6.0
      ---------------------
      - Bug fix: set context keys for generic execute method with PolicyWrap
+     - Add ability to handle inner exceptions natively: .HandleInner&lt;TEx&gt;()
      - Add GetPolicies extension method to IPolicyWrap
      - Allow WaitAndRetry policies to calculate wait based on the handled fault
 

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -13,7 +13,11 @@
     <tags>Exception Handling Resilience Transient Fault Policy Circuit Breaker CircuitBreaker Retry Wait Cache Cache-aside Bulkhead Fallback Timeout Throttle Parallelization</tags>
     <copyright>Copyright © 2017, App vNext</copyright>
     <releaseNotes>
-     v5.0 is a major release with significant new resilience policies: Timeout; Bulkhead Isolation; Fallback; Cache; and PolicyWrap.  See release notes back to v5.0.0 for full details.  v5.0.5 includes important circuit-breaker fixes.
+     v5.0 is a major release with significant new resilience policies: Timeout; Bulkhead Isolation; Fallback; Cache; and PolicyWrap.  See release notes back to v5.0.0 for full details.
+
+     5.6.0
+     ---------------------
+     - Bug fix: set context keys for generic execute method with PolicyWrap
 
      5.5.0
      ---------------------

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -19,9 +19,10 @@
      ---------------------
      - Add ability to handle inner exceptions natively: .HandleInner&lt;TEx&gt;()
      - Allow WaitAndRetry policies to calculate wait based on the handled fault
-     - Add GetPolicies() extension methods to IPolicyWrap
+     - Add the ability to access the policies within an IPolicyWrap
      - Allow PolicyWrap to take interfaces as parameters
      - Bug fix: set context keys for generic execute method with PolicyWrap
+     - Bug fix: generic TResult method with non-generic fallback policy
      - Performance improvements
 
      5.5.0


### PR DESCRIPTION
Delivers:

+ Refine PolicyWrap to take parameters as interfaces #297 / #370 
+ Tooling for InnerExceptions of AggregateException #256 / #368 
+ Performance improvement, make `Context` use dictionary only lazily #369 
+ Allow WaitAndRetry to calculate wait from error response #177 / #247 / #301 / #361 /  #366 / #367 
+ Add ability to access the policies within a wrap #312 / #360 / #365 
+ Bug fix: ensure execution context keys are set when using non-generic `CachePolicy` and non-generic `PolicyWrap` with generic _methods_ `.Execute<TResult>(...)` #352 / #353 
+ Bug fix: non-generic `FallbackPolicy` with generic _methods_ `.Execute<TResult>(...)`  #294 / #372