### PR TITLE
Extend PolicyWrap syntax for interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.6.1
+- Extend PolicyWrap syntax with interfaces
+
 ## 5.6.0
 - Add ability to handle inner exceptions natively: .HandleInner&lt;TEx&gt;()
 - Allow WaitAndRetry policies to calculate wait based on the handled fault

--- a/GitVersionConfig.yaml
+++ b/GitVersionConfig.yaml
@@ -1,1 +1,1 @@
-next-version: 5.6.0
+next-version: 5.6.1

--- a/src/Polly.Net40Async.nuspec
+++ b/src/Polly.Net40Async.nuspec
@@ -15,6 +15,10 @@
     <releaseNotes>
      v5.0 is a major release with significant new resilience policies: Timeout; Bulkhead Isolation; Fallback; Cache; and PolicyWrap.  See release notes back to v5.0.0 for full details.
 
+     5.6.1
+     ---------------------
+     - Extend PolicyWrap syntax with interfaces
+     
      5.6.0
      ---------------------
      - Add ability to handle inner exceptions natively: .HandleInner&lt;TEx&gt;()

--- a/src/Polly.NetStandard11/Properties/AssemblyInfo.cs
+++ b/src/Polly.NetStandard11/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Polly")]
-[assembly: AssemblyVersion("5.6.0.0")]
+[assembly: AssemblyVersion("5.6.1.0")]
 [assembly: CLSCompliant(true)]
 
 [assembly: InternalsVisibleTo("Polly.NetStandard11.Specs")]

--- a/src/Polly.Shared/Wrap/PolicyWrapSyntax.cs
+++ b/src/Polly.Shared/Wrap/PolicyWrapSyntax.cs
@@ -135,4 +135,58 @@ namespace Polly
             }
         }
     }
+
+    /// <summary>
+    /// Defines extensions for configuring <see cref="PolicyWrap"/> instances on an <see cref="ISyncPolicy"/> or <see cref="ISyncPolicy{TResult}"/>.
+    /// </summary>
+    public static class ISyncPolicyPolicyWrapExtensions
+    {
+        /// <summary>
+        /// Wraps the specified outer policy round the inner policy.
+        /// </summary>
+        /// <param name="outerPolicy">The outer policy.</param>
+        /// <param name="innerPolicy">The inner policy.</param>
+        /// <returns>A <see cref="PolicyWrap"/> instance representing the combined wrap.</returns>
+        public static PolicyWrap Wrap(this ISyncPolicy outerPolicy, ISyncPolicy innerPolicy)
+        {
+            if (outerPolicy == null) throw new ArgumentNullException(nameof(outerPolicy));
+            return ((Policy) outerPolicy).Wrap(innerPolicy);
+        }
+
+        /// <summary>
+        /// Wraps the specified outer policy round the inner policy.
+        /// </summary>
+        /// <param name="outerPolicy">The outer policy.</param>
+        /// <param name="innerPolicy">The inner policy.</param>
+        /// <returns>A <see cref="PolicyWrap"/> instance representing the combined wrap.</returns>
+        public static PolicyWrap<TResult> Wrap<TResult>(this ISyncPolicy outerPolicy, ISyncPolicy<TResult> innerPolicy)
+        {
+            if (outerPolicy == null) throw new ArgumentNullException(nameof(outerPolicy));
+            return ((Policy)outerPolicy).Wrap(innerPolicy);
+        }
+
+        /// <summary>
+        /// Wraps the specified outer policy round the inner policy.
+        /// </summary>
+        /// <param name="outerPolicy">The outer policy.</param>
+        /// <param name="innerPolicy">The inner policy.</param>
+        /// <returns>A <see cref="PolicyWrap"/> instance representing the combined wrap.</returns>
+        public static PolicyWrap<TResult> Wrap<TResult>(this ISyncPolicy<TResult> outerPolicy, ISyncPolicy innerPolicy)
+        {
+            if (outerPolicy == null) throw new ArgumentNullException(nameof(outerPolicy));
+            return ((Policy<TResult>)outerPolicy).Wrap(innerPolicy);
+        }
+
+        /// <summary>
+        /// Wraps the specified outer policy round the inner policy.
+        /// </summary>
+        /// <param name="outerPolicy">The outer policy.</param>
+        /// <param name="innerPolicy">The inner policy.</param>
+        /// <returns>A <see cref="PolicyWrap"/> instance representing the combined wrap.</returns>
+        public static PolicyWrap<TResult> Wrap<TResult>(this ISyncPolicy<TResult> outerPolicy, ISyncPolicy<TResult> innerPolicy)
+        {
+            if (outerPolicy == null) throw new ArgumentNullException(nameof(outerPolicy));
+            return ((Policy<TResult>)outerPolicy).Wrap(innerPolicy);
+        }
+    }
 }

--- a/src/Polly.Shared/Wrap/PolicyWrapSyntaxAsync.cs
+++ b/src/Polly.Shared/Wrap/PolicyWrapSyntaxAsync.cs
@@ -137,4 +137,58 @@ namespace Polly
             }
         }
     }
+
+    /// <summary>
+    /// Defines extensions for configuring <see cref="PolicyWrap"/> instances on an <see cref="IAsyncPolicy"/> or <see cref="IAsyncPolicy{TResult}"/>.
+    /// </summary>
+    public static class IAsyncPolicyPolicyWrapExtensions
+    {
+        /// <summary>
+        /// Wraps the specified outer policy round the inner policy.
+        /// </summary>
+        /// <param name="outerPolicy">The outer policy.</param>
+        /// <param name="innerPolicy">The inner policy.</param>
+        /// <returns>A <see cref="PolicyWrap"/> instance representing the combined wrap.</returns>
+        public static PolicyWrap WrapAsync(this IAsyncPolicy outerPolicy, IAsyncPolicy innerPolicy)
+        {
+            if (outerPolicy == null) throw new ArgumentNullException(nameof(outerPolicy));
+            return ((Policy)outerPolicy).WrapAsync(innerPolicy);
+        }
+
+        /// <summary>
+        /// Wraps the specified outer policy round the inner policy.
+        /// </summary>
+        /// <param name="outerPolicy">The outer policy.</param>
+        /// <param name="innerPolicy">The inner policy.</param>
+        /// <returns>A <see cref="PolicyWrap"/> instance representing the combined wrap.</returns>
+        public static PolicyWrap<TResult> WrapAsync<TResult>(this IAsyncPolicy outerPolicy, IAsyncPolicy<TResult> innerPolicy)
+        {
+            if (outerPolicy == null) throw new ArgumentNullException(nameof(outerPolicy));
+            return ((Policy)outerPolicy).WrapAsync(innerPolicy);
+        }
+
+        /// <summary>
+        /// Wraps the specified outer policy round the inner policy.
+        /// </summary>
+        /// <param name="outerPolicy">The outer policy.</param>
+        /// <param name="innerPolicy">The inner policy.</param>
+        /// <returns>A <see cref="PolicyWrap"/> instance representing the combined wrap.</returns>
+        public static PolicyWrap<TResult> WrapAsync<TResult>(this IAsyncPolicy<TResult> outerPolicy, IAsyncPolicy innerPolicy)
+        {
+            if (outerPolicy == null) throw new ArgumentNullException(nameof(outerPolicy));
+            return ((Policy<TResult>)outerPolicy).WrapAsync(innerPolicy);
+        }
+
+        /// <summary>
+        /// Wraps the specified outer policy round the inner policy.
+        /// </summary>
+        /// <param name="outerPolicy">The outer policy.</param>
+        /// <param name="innerPolicy">The inner policy.</param>
+        /// <returns>A <see cref="PolicyWrap"/> instance representing the combined wrap.</returns>
+        public static PolicyWrap<TResult> WrapAsync<TResult>(this IAsyncPolicy<TResult> outerPolicy, IAsyncPolicy<TResult> innerPolicy)
+        {
+            if (outerPolicy == null) throw new ArgumentNullException(nameof(outerPolicy));
+            return ((Policy<TResult>)outerPolicy).WrapAsync(innerPolicy);
+        }
+    }
 }

--- a/src/Polly.SharedSpecs/Caching/AbsoluteTtlSpecs.cs
+++ b/src/Polly.SharedSpecs/Caching/AbsoluteTtlSpecs.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Polly.Specs.Caching
 {
-    [Collection("SystemClockDependantCollection")]
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
     public class AbsoluteTtlSpecs : IDisposable
     {
         [Fact]

--- a/src/Polly.SharedSpecs/Caching/CacheAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Caching/CacheAsyncSpecs.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Polly.Specs.Caching
 {
-    [Collection("SystemClockDependantCollection")]
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
     public class CacheAsyncSpecs : IDisposable
     {
         #region Configuration

--- a/src/Polly.SharedSpecs/Caching/CacheSpecs.cs
+++ b/src/Polly.SharedSpecs/Caching/CacheSpecs.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Polly.Specs.Caching
 {
-    [Collection("SystemClockDependantCollection")]
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
     public class CacheSpecs : IDisposable
     {
         #region Configuration

--- a/src/Polly.SharedSpecs/Caching/CacheTResultAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Caching/CacheTResultAsyncSpecs.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Polly.Specs.Caching
 {
-    [Collection("SystemClockDependantCollection")]
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
     public class CacheTResultAsyncSpecs : IDisposable
     {
         #region Configuration

--- a/src/Polly.SharedSpecs/Caching/CacheTResultSpecs.cs
+++ b/src/Polly.SharedSpecs/Caching/CacheTResultSpecs.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Polly.Specs.Caching
 {
-    [Collection("SystemClockDependantCollection")]
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
     public class CacheTResultSpecs : IDisposable
     {
         #region Configuration

--- a/src/Polly.SharedSpecs/CircuitBreaker/AdvancedCircuitBreakerAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/AdvancedCircuitBreakerAsyncSpecs.cs
@@ -12,7 +12,7 @@ using Scenario = Polly.Specs.Helpers.PolicyExtensionsAsync.ExceptionAndOrCancell
 
 namespace Polly.Specs.CircuitBreaker
 {
-    [Collection("SystemClockDependantCollection")]
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
     public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
     {
         #region Configuration tests

--- a/src/Polly.SharedSpecs/CircuitBreaker/AdvancedCircuitBreakerSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/AdvancedCircuitBreakerSpecs.cs
@@ -13,7 +13,7 @@ using Scenario = Polly.Specs.Helpers.PolicyExtensions.ExceptionAndOrCancellation
 namespace Polly.Specs.CircuitBreaker
 {
 
-    [Collection("SystemClockDependantCollection")]
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
     public class AdvancedCircuitBreakerSpecs : IDisposable
     {
         #region Configuration tests

--- a/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerAsyncSpecs.cs
@@ -12,7 +12,7 @@ using Scenario = Polly.Specs.Helpers.PolicyExtensionsAsync.ExceptionAndOrCancell
 
 namespace Polly.Specs.CircuitBreaker
 {
-    [Collection("SystemClockDependantCollection")]
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
     public class CircuitBreakerAsyncSpecs : IDisposable
     {
         #region Configuration tests

--- a/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerSpecs.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Polly.Specs.CircuitBreaker
 {
-    [Collection("SystemClockDependantCollection")]
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
     public class CircuitBreakerSpecs : IDisposable
     {
         #region Configuration tests

--- a/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerTResultAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerTResultAsyncSpecs.cs
@@ -13,7 +13,7 @@ using Scenario = Polly.Specs.Helpers.PolicyTResultExtensionsAsync.ResultAndOrCan
 
 namespace Polly.Specs.CircuitBreaker
 {
-    [Collection("SystemClockDependantCollection")]
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
     public class CircuitBreakerTResultAsyncSpecs : IDisposable
     {
         #region Configuration tests

--- a/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerTResultMixedResultExceptionSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerTResultMixedResultExceptionSpecs.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Polly.Specs.CircuitBreaker
 {
-    [Collection("SystemClockDependantCollection")]
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
     public class CircuitBreakerTResultMixedResultExceptionSpecs : IDisposable
     {
         #region Circuit-breaker threshold-to-break tests

--- a/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerTResultSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerTResultSpecs.cs
@@ -12,7 +12,7 @@ using Scenario = Polly.Specs.Helpers.PolicyTResultExtensions.ResultAndOrCancella
 
 namespace Polly.Specs.CircuitBreaker
 {
-    [Collection("SystemClockDependantCollection")]
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
     public class CircuitBreakerTResultSpecs : IDisposable
     {
         #region Configuration tests

--- a/src/Polly.SharedSpecs/Helpers/Constants.cs
+++ b/src/Polly.SharedSpecs/Helpers/Constants.cs
@@ -1,0 +1,13 @@
+﻿namespace Polly.Specs.Helpers
+{
+    /// <summary>
+    /// Constants supporting tests.
+    /// </summary>
+    public class Constants
+    {
+        /// <summary>
+        /// Denotes a test collection dependent on manipulating the abstracted <see cref="Polly.Utilities.SystemClock"/>.  <remarks>These tests are not parallelized.</remarks>
+        /// </summary>
+        public const string SystemClockDependentTestCollection = "SystemClockDependentTestCollection";
+    }
+}

--- a/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
+++ b/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
@@ -48,6 +48,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\Caching\StubErroringCacheProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\Caching\StubSerialized.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\Caching\StubSerializer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\Constants.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ContextualPolicyExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ContextualPolicyExtensionsAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ContextualPolicyTResultExtensions.cs" />

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetryAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetryAsyncSpecs.cs
@@ -13,7 +13,7 @@ using Scenario = Polly.Specs.Helpers.PolicyExtensionsAsync.ExceptionAndOrCancell
 
 namespace Polly.Specs.Retry
 {
-    [Collection("SystemClockDependantCollection")]
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
     public class WaitAndRetryAsyncSpecs : IDisposable
     {
         public WaitAndRetryAsyncSpecs()

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverAsyncSpecs.cs
@@ -12,7 +12,7 @@ using Scenario = Polly.Specs.Helpers.PolicyExtensionsAsync.ExceptionAndOrCancell
 
 namespace Polly.Specs.Retry
 {
-    [Collection("SystemClockDependantCollection")]
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
     public class WaitAndRetryForeverAsyncSpecs : IDisposable
     {
         public WaitAndRetryForeverAsyncSpecs()

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverSpecs.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Polly.Specs.Retry
 {
-    [Collection("SystemClockDependantCollection")]
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
     public class WaitAndRetryForeverSpecs : IDisposable
     {
         public WaitAndRetryForeverSpecs()

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverTResultAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverTResultAsyncSpecs.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Polly.Specs.Retry
 {
-    [Collection("SystemClockDependantCollection")]
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
     public class WaitAndRetryForeverTResultAsyncSpecs : IDisposable
     {
         public WaitAndRetryForeverTResultAsyncSpecs()

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverTResultSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverTResultSpecs.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Polly.Specs.Retry
 {
-    [Collection("SystemClockDependantCollection")]
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
     public class WaitAndRetryForeverTResultSpecs : IDisposable
     {
         public WaitAndRetryForeverTResultSpecs()

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetrySpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetrySpecs.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Polly.Specs.Retry
 {
-    [Collection("SystemClockDependantCollection")]
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
     public class WaitAndRetrySpecs : IDisposable
     {
         public WaitAndRetrySpecs()

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetryTResultAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetryTResultAsyncSpecs.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Polly.Specs.Retry
 {
-    [Collection("SystemClockDependantCollection")]
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
     public class WaitAndRetryTResultAsyncSpecs : IDisposable
     {
         public WaitAndRetryTResultAsyncSpecs()

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetryTResultSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetryTResultSpecs.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Polly.Specs.Retry
 {
-    [Collection("SystemClockDependantCollection")]
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
     public class WaitAndRetryTResultSpecs : IDisposable
     {
         public WaitAndRetryTResultSpecs()

--- a/src/Polly.SharedSpecs/Timeout/TimeoutAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Timeout/TimeoutAsyncSpecs.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Polly.Specs.Timeout
 {
-    [Collection("SystemClockDependantCollection")]
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
     public class TimeoutAsyncSpecs : TimeoutSpecsBase
     {
         #region Configuration

--- a/src/Polly.SharedSpecs/Timeout/TimeoutSpecs.cs
+++ b/src/Polly.SharedSpecs/Timeout/TimeoutSpecs.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Polly.Specs.Timeout
 {
-    [Collection("SystemClockDependantCollection")]
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
     public class TimeoutSpecs : TimeoutSpecsBase
     {
         #region Configuration

--- a/src/Polly.SharedSpecs/Timeout/TimeoutTResultAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Timeout/TimeoutTResultAsyncSpecs.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Polly.Specs.Timeout
 {
-    [Collection("SystemClockDependantCollection")]
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
     public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
     {
         #region Configuration

--- a/src/Polly.SharedSpecs/Timeout/TimeoutTResultSpecs.cs
+++ b/src/Polly.SharedSpecs/Timeout/TimeoutTResultSpecs.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Polly.Specs.Timeout
 {
-    [Collection("SystemClockDependantCollection")]
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
     public class TimeoutTResultSpecs : TimeoutSpecsBase
     {
         #region Configuration

--- a/src/Polly.SharedSpecs/Wrap/PolicyWrapContextAndKeySpecs.cs
+++ b/src/Polly.SharedSpecs/Wrap/PolicyWrapContextAndKeySpecs.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Polly.Specs.Wrap
 {
-    [Collection("SystemClockDependantCollection")]
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
     public class PolicyWrapContextAndKeySpecs
     {
         #region PolicyKey and execution Context tests

--- a/src/Polly.SharedSpecs/Wrap/PolicyWrapContextAndKeySpecsAsync.cs
+++ b/src/Polly.SharedSpecs/Wrap/PolicyWrapContextAndKeySpecsAsync.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Polly.Specs.Wrap
 {
-    [Collection("SystemClockDependantCollection")]
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
     public class PolicyWrapContextAndKeySpecsAsync
     {
         #region PolicyKey and execution Context tests

--- a/src/Polly.SharedSpecs/Wrap/PolicyWrapSpecs.cs
+++ b/src/Polly.SharedSpecs/Wrap/PolicyWrapSpecs.cs
@@ -60,7 +60,7 @@ namespace Polly.Specs.Wrap
 
         #endregion
 
-        #region   Instance configuration syntax tests, generic outer
+        #region Instance configuration syntax tests, generic outer
 
         [Fact]
         public void Generic_wraps_nongeneric_instance_syntax_wrapping_null_should_throw()
@@ -102,6 +102,146 @@ namespace Polly.Specs.Wrap
             Policy<int> policyB = Policy.NoOp<int>();
 
             PolicyWrap<int> wrap = policyA.Wrap(policyB);
+
+            wrap.Outer.Should().BeSameAs(policyA);
+            wrap.Inner.Should().BeSameAs(policyB);
+        }
+
+        #endregion
+
+        #region Interface extension configuration syntax tests, non-generic outer
+
+        [Fact]
+        public void Nongeneric_interface_wraps_nongeneric_instance_syntax_null_wrapping_should_throw()
+        {
+            ISyncPolicy outerNull = null;
+            ISyncPolicy retry = Policy.Handle<Exception>().Retry(1);
+
+            Action config = () => outerNull.Wrap(retry);
+
+            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
+        }
+
+        [Fact]
+        public void Nongeneric_interface_wraps_generic_instance_syntax_null_wrapping_should_throw()
+        {
+            ISyncPolicy outerNull = null;
+            ISyncPolicy<int> retry = Policy.HandleResult<int>(0).Retry(1);
+
+            Action config = () => outerNull.Wrap<int>(retry);
+
+            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
+        }
+
+        [Fact]
+        public void Nongeneric_interface_wraps_nongeneric_instance_syntax_wrapping_null_should_throw()
+        {
+            ISyncPolicy retry = Policy.Handle<Exception>().Retry(1);
+
+            Action config = () => retry.Wrap((Policy)null);
+
+            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+        }
+
+        [Fact]
+        public void Nongeneric_interface_wraps_generic_instance_syntax_wrapping_null_should_throw()
+        {
+            ISyncPolicy retry = Policy.Handle<Exception>().Retry(1);
+
+            Action config = () => retry.Wrap<int>((Policy<int>)null);
+
+            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+        }
+
+        [Fact]
+        public void Nongeneric_interface_wraps_nongeneric_using_instance_wrap_syntax_should_set_outer_inner()
+        {
+            ISyncPolicy policyA = Policy.NoOp();
+            ISyncPolicy policyB = Policy.NoOp();
+
+            IPolicyWrap wrap = policyA.Wrap(policyB);
+
+            wrap.Outer.Should().BeSameAs(policyA);
+            wrap.Inner.Should().BeSameAs(policyB);
+        }
+
+        [Fact]
+        public void Nongeneric_interface_wraps_generic_using_instance_wrap_syntax_should_set_outer_inner()
+        {
+            ISyncPolicy policyA = Policy.NoOp();
+            ISyncPolicy<int> policyB = Policy.NoOp<int>();
+
+            IPolicyWrap<int> wrap = policyA.Wrap(policyB);
+
+            wrap.Outer.Should().BeSameAs(policyA);
+            wrap.Inner.Should().BeSameAs(policyB);
+        }
+
+        #endregion
+
+        #region Interface extension configuration syntax tests, generic outer
+
+        [Fact]
+        public void Generic_interface_wraps_nongeneric_instance_syntax_null_wrapping_should_throw()
+        {
+            ISyncPolicy<int> outerNull = null;
+            ISyncPolicy retry = Policy.Handle<Exception>().Retry(1);
+
+            Action config = () => outerNull.Wrap(retry);
+
+            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
+        }
+
+        [Fact]
+        public void Generic_interface_wraps_generic_instance_syntax_null_wrapping_should_throw()
+        {
+            ISyncPolicy<int> outerNull = null;
+            ISyncPolicy<int> retry = Policy.HandleResult<int>(0).Retry(1);
+
+            Action config = () => outerNull.Wrap<int>(retry);
+
+            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
+        }
+
+        [Fact]
+        public void Generic_interface_wraps_nongeneric_instance_syntax_wrapping_null_should_throw()
+        {
+            ISyncPolicy<int> retry = Policy.HandleResult<int>(0).Retry(1);
+
+            Action config = () => retry.Wrap((Policy)null);
+
+            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+        }
+
+        [Fact]
+        public void Generic_interface_wraps_generic_instance_syntax_wrapping_null_should_throw()
+        {
+            ISyncPolicy<int> retry = Policy.HandleResult<int>(0).Retry(1);
+
+            Action config = () => retry.Wrap((Policy<int>)null);
+
+            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+        }
+
+        [Fact]
+        public void Generic_interface_wraps_nongeneric_using_instance_wrap_syntax_should_set_outer_inner()
+        {
+            ISyncPolicy<int> policyA = Policy.NoOp<int>();
+            ISyncPolicy policyB = Policy.NoOp();
+
+            IPolicyWrap<int> wrap = policyA.Wrap(policyB);
+
+            wrap.Outer.Should().BeSameAs(policyA);
+            wrap.Inner.Should().BeSameAs(policyB);
+        }
+
+        [Fact]
+        public void Generic_interface_wraps_generic_using_instance_wrap_syntax_should_set_outer_inner()
+        {
+            ISyncPolicy<int> policyA = Policy.NoOp<int>();
+            ISyncPolicy<int> policyB = Policy.NoOp<int>();
+
+            IPolicyWrap<int> wrap = policyA.Wrap(policyB);
 
             wrap.Outer.Should().BeSameAs(policyA);
             wrap.Inner.Should().BeSameAs(policyB);

--- a/src/Polly.SharedSpecs/Wrap/PolicyWrapSpecs.cs
+++ b/src/Polly.SharedSpecs/Wrap/PolicyWrapSpecs.cs
@@ -12,7 +12,7 @@ namespace Polly.Specs.Wrap
     [Collection("SystemClockDependantCollection")]
     public class PolicyWrapSpecs
     {
-        #region Instance configuration syntax tests, non-generic policies
+        #region Instance configuration syntax tests, non-generic outer
 
         [Fact]
         public void Nongeneric_wraps_nongeneric_instance_syntax_wrapping_null_should_throw()
@@ -30,27 +30,6 @@ namespace Polly.Specs.Wrap
             RetryPolicy retry = Policy.Handle<Exception>().Retry(1);
 
             Action config = () => retry.Wrap<int>((Policy<int>)null);
-
-            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
-        }
-
-        [Fact]
-        public void Generic_wraps_nongeneric_instance_syntax_wrapping_null_should_throw()
-        {
-            RetryPolicy<int> retry = Policy.HandleResult<int>(0).Retry(1);
-
-            Action config = () => retry.Wrap((Policy)null);
-
-            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
-        }
-
-
-        [Fact]
-        public void Generic_wraps_generic_instance_syntax_wrapping_null_should_throw()
-        {
-            RetryPolicy<int> retry = Policy.HandleResult<int>(0).Retry(1);
-
-            Action config = () => retry.Wrap((Policy<int>)null);
 
             config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
         }
@@ -77,6 +56,31 @@ namespace Polly.Specs.Wrap
 
             wrap.Outer.Should().BeSameAs(policyA);
             wrap.Inner.Should().BeSameAs(policyB);
+        }
+
+        #endregion
+
+        #region   Instance configuration syntax tests, generic outer
+
+        [Fact]
+        public void Generic_wraps_nongeneric_instance_syntax_wrapping_null_should_throw()
+        {
+            RetryPolicy<int> retry = Policy.HandleResult<int>(0).Retry(1);
+
+            Action config = () => retry.Wrap((Policy)null);
+
+            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+        }
+
+
+        [Fact]
+        public void Generic_wraps_generic_instance_syntax_wrapping_null_should_throw()
+        {
+            RetryPolicy<int> retry = Policy.HandleResult<int>(0).Retry(1);
+
+            Action config = () => retry.Wrap((Policy<int>)null);
+
+            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
         }
 
         [Fact]

--- a/src/Polly.SharedSpecs/Wrap/PolicyWrapSpecs.cs
+++ b/src/Polly.SharedSpecs/Wrap/PolicyWrapSpecs.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Polly.Specs.Wrap
 {
-    [Collection("SystemClockDependantCollection")]
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
     public class PolicyWrapSpecs
     {
         #region Instance configuration syntax tests, non-generic outer

--- a/src/Polly.SharedSpecs/Wrap/PolicyWrapSpecsAsync.cs
+++ b/src/Polly.SharedSpecs/Wrap/PolicyWrapSpecsAsync.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Polly.Specs.Wrap
 {
-    [Collection("SystemClockDependantCollection")]
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
     public class PolicyWrapSpecsAsync
     {
         #region Instance configuration syntax tests, non-generic outer

--- a/src/Polly.SharedSpecs/Wrap/PolicyWrapSpecsAsync.cs
+++ b/src/Polly.SharedSpecs/Wrap/PolicyWrapSpecsAsync.cs
@@ -109,6 +109,146 @@ namespace Polly.Specs.Wrap
 
         #endregion
 
+        #region Interface extension configuration syntax tests, non-generic outer
+
+        [Fact]
+        public void Nongeneric_interface_wraps_nongeneric_instance_syntax_null_wrapping_should_throw()
+        {
+            IAsyncPolicy outerNull = null;
+            IAsyncPolicy retry = Policy.Handle<Exception>().RetryAsync(1);
+
+            Action config = () => outerNull.WrapAsync(retry);
+
+            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
+        }
+
+        [Fact]
+        public void Nongeneric_interface_wraps_generic_instance_syntax_null_wrapping_should_throw()
+        {
+            IAsyncPolicy outerNull = null;
+            IAsyncPolicy<int> retry = Policy.HandleResult<int>(0).RetryAsync(1);
+
+            Action config = () => outerNull.WrapAsync<int>(retry);
+
+            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
+        }
+
+        [Fact]
+        public void Nongeneric_interface_wraps_nongeneric_instance_syntax_wrapping_null_should_throw()
+        {
+            IAsyncPolicy retry = Policy.Handle<Exception>().RetryAsync(1);
+
+            Action config = () => retry.WrapAsync((Policy)null);
+
+            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+        }
+
+        [Fact]
+        public void Nongeneric_interface_wraps_generic_instance_syntax_wrapping_null_should_throw()
+        {
+            IAsyncPolicy retry = Policy.Handle<Exception>().RetryAsync(1);
+
+            Action config = () => retry.WrapAsync<int>((Policy<int>)null);
+
+            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+        }
+
+        [Fact]
+        public void Nongeneric_interface_wraps_nongeneric_using_instance_wrap_syntax_should_set_outer_inner()
+        {
+            IAsyncPolicy policyA = Policy.NoOpAsync();
+            IAsyncPolicy policyB = Policy.NoOpAsync();
+
+            IPolicyWrap wrap = policyA.WrapAsync(policyB);
+
+            wrap.Outer.Should().BeSameAs(policyA);
+            wrap.Inner.Should().BeSameAs(policyB);
+        }
+
+        [Fact]
+        public void Nongeneric_interface_wraps_generic_using_instance_wrap_syntax_should_set_outer_inner()
+        {
+            IAsyncPolicy policyA = Policy.NoOpAsync();
+            IAsyncPolicy<int> policyB = Policy.NoOpAsync<int>();
+
+            IPolicyWrap<int> wrap = policyA.WrapAsync(policyB);
+
+            wrap.Outer.Should().BeSameAs(policyA);
+            wrap.Inner.Should().BeSameAs(policyB);
+        }
+
+        #endregion
+
+        #region Interface extension configuration syntax tests, generic outer
+
+        [Fact]
+        public void Generic_interface_wraps_nongeneric_instance_syntax_null_wrapping_should_throw()
+        {
+            IAsyncPolicy<int> outerNull = null;
+            IAsyncPolicy retry = Policy.Handle<Exception>().RetryAsync(1);
+
+            Action config = () => outerNull.WrapAsync(retry);
+
+            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
+        }
+
+        [Fact]
+        public void Generic_interface_wraps_generic_instance_syntax_null_wrapping_should_throw()
+        {
+            IAsyncPolicy<int> outerNull = null;
+            IAsyncPolicy<int> retry = Policy.HandleResult<int>(0).RetryAsync(1);
+
+            Action config = () => outerNull.WrapAsync<int>(retry);
+
+            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
+        }
+
+        [Fact]
+        public void Generic_interface_wraps_nongeneric_instance_syntax_wrapping_null_should_throw()
+        {
+            IAsyncPolicy<int> retry = Policy.HandleResult<int>(0).RetryAsync(1);
+
+            Action config = () => retry.WrapAsync((Policy)null);
+
+            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+        }
+
+        [Fact]
+        public void Generic_interface_wraps_generic_instance_syntax_wrapping_null_should_throw()
+        {
+            IAsyncPolicy<int> retry = Policy.HandleResult<int>(0).RetryAsync(1);
+
+            Action config = () => retry.WrapAsync((Policy<int>)null);
+
+            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+        }
+
+        [Fact]
+        public void Generic_interface_wraps_nongeneric_using_instance_wrap_syntax_should_set_outer_inner()
+        {
+            IAsyncPolicy<int> policyA = Policy.NoOpAsync<int>();
+            IAsyncPolicy policyB = Policy.NoOpAsync();
+
+            IPolicyWrap<int> wrap = policyA.WrapAsync(policyB);
+
+            wrap.Outer.Should().BeSameAs(policyA);
+            wrap.Inner.Should().BeSameAs(policyB);
+        }
+
+        [Fact]
+        public void Generic_interface_wraps_generic_using_instance_wrap_syntax_should_set_outer_inner()
+        {
+            IAsyncPolicy<int> policyA = Policy.NoOpAsync<int>();
+            IAsyncPolicy<int> policyB = Policy.NoOpAsync<int>();
+
+            IPolicyWrap<int> wrap = policyA.WrapAsync(policyB);
+
+            wrap.Outer.Should().BeSameAs(policyA);
+            wrap.Inner.Should().BeSameAs(policyB);
+        }
+
+        #endregion
+
         #region Static configuration syntax tests, non-generic policies
 
         [Fact]

--- a/src/Polly.SharedSpecs/Wrap/PolicyWrapSpecsAsync.cs
+++ b/src/Polly.SharedSpecs/Wrap/PolicyWrapSpecsAsync.cs
@@ -13,7 +13,7 @@ namespace Polly.Specs.Wrap
     [Collection("SystemClockDependantCollection")]
     public class PolicyWrapSpecsAsync
     {
-        #region Instance configuration syntax tests, non-generic policies
+        #region Instance configuration syntax tests, non-generic outer
 
         [Fact]
         public void Nongeneric_wraps_nongeneric_instance_syntax_wrapping_null_should_throw()
@@ -31,26 +31,6 @@ namespace Polly.Specs.Wrap
             RetryPolicy retry = Policy.Handle<Exception>().RetryAsync(1);
 
             Action config = () => retry.WrapAsync<int>((Policy<int>)null);
-
-            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
-        }
-
-        [Fact]
-        public void Generic_wraps_nongeneric_instance_syntax_wrapping_null_should_throw()
-        {
-            RetryPolicy<int> retry = Policy.HandleResult<int>(0).RetryAsync(1);
-
-            Action config = () => retry.WrapAsync((Policy)null);
-
-            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
-        }
-
-        [Fact]
-        public void Generic_wraps_generic_instance_syntax_wrapping_null_should_throw()
-        {
-            RetryPolicy<int> retry = Policy.HandleResult<int>(0).RetryAsync(1);
-
-            Action config = () => retry.WrapAsync((Policy<int>)null);
 
             config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
         }
@@ -77,6 +57,30 @@ namespace Polly.Specs.Wrap
 
             wrap.Outer.Should().BeSameAs(policyA);
             wrap.Inner.Should().BeSameAs(policyB);
+        }
+
+        #endregion
+
+        #region   Instance configuration syntax tests, generic outer
+
+        [Fact]
+        public void Generic_wraps_nongeneric_instance_syntax_wrapping_null_should_throw()
+        {
+            RetryPolicy<int> retry = Policy.HandleResult<int>(0).RetryAsync(1);
+
+            Action config = () => retry.WrapAsync((Policy)null);
+
+            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+        }
+
+        [Fact]
+        public void Generic_wraps_generic_instance_syntax_wrapping_null_should_throw()
+        {
+            RetryPolicy<int> retry = Policy.HandleResult<int>(0).RetryAsync(1);
+
+            Action config = () => retry.WrapAsync((Policy<int>)null);
+
+            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
         }
 
         [Fact]

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -15,6 +15,10 @@
     <releaseNotes>
      v5.0 is a major release with significant new resilience policies: Timeout; Bulkhead Isolation; Fallback; Cache; and PolicyWrap.  See release notes back to v5.0.0 for full details.
 
+     5.6.1
+     ---------------------
+     - Extend PolicyWrap syntax with interfaces
+
      5.6.0
      ---------------------
      - Add ability to handle inner exceptions natively: .HandleInner&lt;TEx&gt;()


### PR DESCRIPTION
Given:

    ISyncPolicy policyA = ...
    ISyncPolicy policyB = ...

(and similarly for `ISyncPolicy<TResult>`, `IAsyncPolicy`, `IAsyncPolicy<TResult>`)

allows:

    policyA.Wrap(policyB)

as a configuration syntax.