### PR TITLE
Add a generic ITtlStrategy to base TTL on the result of the execution

### DIFF
--- a/src/Polly.Shared/Caching/CacheEngine.cs
+++ b/src/Polly.Shared/Caching/CacheEngine.cs
@@ -7,7 +7,7 @@ namespace Polly.Caching
     {
         internal static TResult Implementation<TResult>(
             ISyncCacheProvider<TResult> cacheProvider,
-            ITtlStrategy ttlStrategy,
+            ITtlStrategy<TResult> ttlStrategy,
             Func<Context, string> cacheKeyStrategy,
             Func<Context, CancellationToken, TResult> action,
             Context context,
@@ -48,7 +48,7 @@ namespace Polly.Caching
 
             TResult result = action(context, cancellationToken);
 
-            Ttl ttl = ttlStrategy.GetTtl(context);
+            Ttl ttl = ttlStrategy.GetTtl(context, result);
             if (ttl.Timespan > TimeSpan.Zero)
             {
                 try

--- a/src/Polly.Shared/Caching/CacheEngineAsync.cs
+++ b/src/Polly.Shared/Caching/CacheEngineAsync.cs
@@ -8,7 +8,7 @@ namespace Polly.Caching
     {
         internal static async Task<TResult> ImplementationAsync<TResult>(
             IAsyncCacheProvider<TResult> cacheProvider,
-            ITtlStrategy ttlStrategy,
+            ITtlStrategy<TResult> ttlStrategy,
             Func<Context, string> cacheKeyStrategy,
             Func<Context, CancellationToken, Task<TResult>> action,
             Context context,
@@ -50,7 +50,7 @@ namespace Polly.Caching
 
             TResult result = await action(context, cancellationToken).ConfigureAwait(continueOnCapturedContext);
 
-            Ttl ttl = ttlStrategy.GetTtl(context);
+            Ttl ttl = ttlStrategy.GetTtl(context, result);
             if (ttl.Timespan > TimeSpan.Zero)
             {
                 try

--- a/src/Polly.Shared/Caching/CachePolicy.cs
+++ b/src/Polly.Shared/Caching/CachePolicy.cs
@@ -55,7 +55,7 @@ namespace Polly.Caching
         {
             return CacheEngine.Implementation<TResult>(
                 _syncCacheProvider.For<TResult>(), 
-                _ttlStrategy, 
+                _ttlStrategy.For<TResult>(),
                 _cacheKeyStrategy, 
                 action, 
                 context, 
@@ -75,7 +75,7 @@ namespace Polly.Caching
     {
         internal CachePolicy(
             ISyncCacheProvider<TResult> syncCacheProvider, 
-            ITtlStrategy ttlStrategy,
+            ITtlStrategy<TResult> ttlStrategy,
             Func<Context, string> cacheKeyStrategy,
             Action<Context, string> onCacheGet,
             Action<Context, string> onCacheMiss,

--- a/src/Polly.Shared/Caching/CachePolicyAsync.cs
+++ b/src/Polly.Shared/Caching/CachePolicyAsync.cs
@@ -47,7 +47,7 @@ namespace Polly.Caching
         {
             return CacheEngine.ImplementationAsync<TResult>(
                 _asyncCacheProvider.AsyncFor<TResult>(), 
-                _ttlStrategy, 
+                _ttlStrategy.For<TResult>(), 
                 _cacheKeyStrategy, 
                 action, 
                 context, 
@@ -65,7 +65,7 @@ namespace Polly.Caching
     {
         internal CachePolicy(
             IAsyncCacheProvider<TResult> asyncCacheProvider, 
-            ITtlStrategy ttlStrategy,
+            ITtlStrategy<TResult> ttlStrategy,
             Func<Context, string> cacheKeyStrategy,
             Action<Context, string> onCacheGet,
             Action<Context, string> onCacheMiss,

--- a/src/Polly.Shared/Caching/CacheTResultSyntax.cs
+++ b/src/Polly.Shared/Caching/CacheTResultSyntax.cs
@@ -20,7 +20,7 @@ namespace Polly
         {
             if (cacheProvider == null) throw new ArgumentNullException(nameof(cacheProvider));
 
-            return Cache<TResult>(cacheProvider.For<TResult>(), new RelativeTtl(ttl), DefaultCacheKeyStrategy.Instance.GetCacheKey, onCacheError);
+            return Cache<TResult>(cacheProvider.For<TResult>(), new RelativeTtl(ttl).For<TResult>(), DefaultCacheKeyStrategy.Instance.GetCacheKey, onCacheError);
         }
 
         /// <summary>
@@ -39,7 +39,7 @@ namespace Polly
         {
             if (cacheProvider == null) throw new ArgumentNullException(nameof(cacheProvider));
 
-            return Cache<TResult>(cacheProvider.For<TResult>(), ttlStrategy, DefaultCacheKeyStrategy.Instance.GetCacheKey, onCacheError);
+            return Cache<TResult>(cacheProvider.For<TResult>(), ttlStrategy.For<TResult>(), DefaultCacheKeyStrategy.Instance.GetCacheKey, onCacheError);
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Polly
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         public static CachePolicy<TResult> Cache<TResult>(ISyncCacheProvider<TResult> cacheProvider, TimeSpan ttl, Action<Context, string, Exception> onCacheError = null)
         {
-            return Cache<TResult>(cacheProvider, new RelativeTtl(ttl), DefaultCacheKeyStrategy.Instance.GetCacheKey, onCacheError);
+            return Cache<TResult>(cacheProvider, new RelativeTtl(ttl).For<TResult>(), DefaultCacheKeyStrategy.Instance.GetCacheKey, onCacheError);
         }
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-        public static CachePolicy<TResult> Cache<TResult>(ISyncCacheProvider<TResult> cacheProvider, ITtlStrategy ttlStrategy, Action<Context, string, Exception> onCacheError = null)
+        public static CachePolicy<TResult> Cache<TResult>(ISyncCacheProvider<TResult> cacheProvider, ITtlStrategy<TResult> ttlStrategy, Action<Context, string, Exception> onCacheError = null)
         {
             return Cache<TResult>(cacheProvider, ttlStrategy, DefaultCacheKeyStrategy.Instance.GetCacheKey, onCacheError);
         }
@@ -92,7 +92,7 @@ namespace Polly
         {
             if (cacheProvider == null) throw new ArgumentNullException(nameof(cacheProvider));
 
-            return Cache<TResult>(cacheProvider.For<TResult>(), new RelativeTtl(ttl), cacheKeyStrategy, onCacheError);
+            return Cache<TResult>(cacheProvider.For<TResult>(), new RelativeTtl(ttl).For<TResult>(), cacheKeyStrategy, onCacheError);
         }
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace Polly
         {
             if (cacheProvider == null) throw new ArgumentNullException(nameof(cacheProvider));
 
-            return Cache<TResult>(cacheProvider.For<TResult>(), ttlStrategy, cacheKeyStrategy, onCacheError);
+            return Cache<TResult>(cacheProvider.For<TResult>(), ttlStrategy.For<TResult>(), cacheKeyStrategy, onCacheError);
         }
 
         /// <summary>
@@ -131,7 +131,7 @@ namespace Polly
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
         public static CachePolicy<TResult> Cache<TResult>(ISyncCacheProvider<TResult> cacheProvider, TimeSpan ttl, Func<Context, string> cacheKeyStrategy, Action<Context, string, Exception> onCacheError = null)
         {
-            return Cache<TResult>(cacheProvider, new RelativeTtl(ttl), cacheKeyStrategy, onCacheError);
+            return Cache<TResult>(cacheProvider, new RelativeTtl(ttl).For<TResult>(), cacheKeyStrategy, onCacheError);
         }
 
         /// <summary>
@@ -148,7 +148,7 @@ namespace Polly
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">ttlStrategy</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        public static CachePolicy<TResult> Cache<TResult>(ISyncCacheProvider<TResult> cacheProvider, ITtlStrategy ttlStrategy, Func<Context, string> cacheKeyStrategy, Action<Context, string, Exception> onCacheError = null)
+        public static CachePolicy<TResult> Cache<TResult>(ISyncCacheProvider<TResult> cacheProvider, ITtlStrategy<TResult> ttlStrategy, Func<Context, string> cacheKeyStrategy, Action<Context, string, Exception> onCacheError = null)
         {
             if (cacheProvider == null) throw new ArgumentNullException(nameof(cacheProvider));
             if (ttlStrategy == null) throw new ArgumentNullException(nameof(ttlStrategy));
@@ -186,7 +186,7 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static CachePolicy<TResult> Cache<TResult>(
             ISyncCacheProvider<TResult> cacheProvider, 
-            ITtlStrategy ttlStrategy, 
+            ITtlStrategy<TResult> ttlStrategy, 
             ICacheKeyStrategy cacheKeyStrategy,
             Action<Context, string> onCacheGet,
             Action<Context, string> onCacheMiss,
@@ -222,7 +222,7 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static CachePolicy<TResult> Cache<TResult>(
             ISyncCacheProvider<TResult> cacheProvider,
-            ITtlStrategy ttlStrategy,
+            ITtlStrategy<TResult> ttlStrategy,
             Func<Context, string> cacheKeyStrategy,
             Action<Context, string> onCacheGet,
             Action<Context, string> onCacheMiss,

--- a/src/Polly.Shared/Caching/CacheTResultSyntaxAsync.cs
+++ b/src/Polly.Shared/Caching/CacheTResultSyntaxAsync.cs
@@ -20,7 +20,7 @@ namespace Polly
         {
             if (cacheProvider == null) throw new ArgumentNullException(nameof(cacheProvider));
 
-            return CacheAsync<TResult>(cacheProvider.AsyncFor<TResult>(), new RelativeTtl(ttl), DefaultCacheKeyStrategy.Instance.GetCacheKey, onCacheError);
+            return CacheAsync<TResult>(cacheProvider.AsyncFor<TResult>(), new RelativeTtl(ttl).For<TResult>(), DefaultCacheKeyStrategy.Instance.GetCacheKey, onCacheError);
         }
 
         /// <summary>
@@ -39,7 +39,7 @@ namespace Polly
         {
             if (cacheProvider == null) throw new ArgumentNullException(nameof(cacheProvider));
 
-            return CacheAsync<TResult>(cacheProvider.AsyncFor<TResult>(), ttlStrategy, DefaultCacheKeyStrategy.Instance.GetCacheKey, onCacheError);
+            return CacheAsync<TResult>(cacheProvider.AsyncFor<TResult>(), ttlStrategy.For<TResult>(), DefaultCacheKeyStrategy.Instance.GetCacheKey, onCacheError);
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Polly
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         public static CachePolicy<TResult> CacheAsync<TResult>(IAsyncCacheProvider<TResult> cacheProvider, TimeSpan ttl, Action<Context, string, Exception> onCacheError = null)
         {
-            return CacheAsync<TResult>(cacheProvider, new RelativeTtl(ttl), DefaultCacheKeyStrategy.Instance.GetCacheKey, onCacheError);
+            return CacheAsync<TResult>(cacheProvider, new RelativeTtl(ttl).For<TResult>(), DefaultCacheKeyStrategy.Instance.GetCacheKey, onCacheError);
         }
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace Polly
         /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-        public static CachePolicy<TResult> CacheAsync<TResult>(IAsyncCacheProvider<TResult> cacheProvider, ITtlStrategy ttlStrategy, Action<Context, string, Exception> onCacheError = null)
+        public static CachePolicy<TResult> CacheAsync<TResult>(IAsyncCacheProvider<TResult> cacheProvider, ITtlStrategy<TResult> ttlStrategy, Action<Context, string, Exception> onCacheError = null)
         {
             return CacheAsync<TResult>(cacheProvider, ttlStrategy, DefaultCacheKeyStrategy.Instance.GetCacheKey, onCacheError);
         }
@@ -92,7 +92,7 @@ namespace Polly
         {
             if (cacheProvider == null) throw new ArgumentNullException(nameof(cacheProvider));
 
-            return CacheAsync<TResult>(cacheProvider.AsyncFor<TResult>(), new RelativeTtl(ttl), cacheKeyStrategy, onCacheError);
+            return CacheAsync<TResult>(cacheProvider.AsyncFor<TResult>(), new RelativeTtl(ttl).For<TResult>(), cacheKeyStrategy, onCacheError);
         }
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace Polly
         {
             if (cacheProvider == null) throw new ArgumentNullException(nameof(cacheProvider));
 
-            return CacheAsync<TResult>(cacheProvider.AsyncFor<TResult>(), ttlStrategy, cacheKeyStrategy, onCacheError);
+            return CacheAsync<TResult>(cacheProvider.AsyncFor<TResult>(), ttlStrategy.For<TResult>(), cacheKeyStrategy, onCacheError);
         }
 
         /// <summary>
@@ -131,7 +131,7 @@ namespace Polly
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         public static CachePolicy<TResult> CacheAsync<TResult>(IAsyncCacheProvider<TResult> cacheProvider, TimeSpan ttl, Func<Context, string> cacheKeyStrategy, Action<Context, string, Exception> onCacheError = null)
         {
-            return CacheAsync<TResult>(cacheProvider, new RelativeTtl(ttl), cacheKeyStrategy, onCacheError);
+            return CacheAsync<TResult>(cacheProvider, new RelativeTtl(ttl).For<TResult>(), cacheKeyStrategy, onCacheError);
         }
 
         /// <summary>
@@ -148,7 +148,7 @@ namespace Polly
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
         /// <exception cref="ArgumentNullException">ttlStrategy</exception>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
-        public static CachePolicy<TResult> CacheAsync<TResult>(IAsyncCacheProvider<TResult> cacheProvider, ITtlStrategy ttlStrategy, Func<Context, string> cacheKeyStrategy, Action<Context, string, Exception> onCacheError = null)
+        public static CachePolicy<TResult> CacheAsync<TResult>(IAsyncCacheProvider<TResult> cacheProvider, ITtlStrategy<TResult> ttlStrategy, Func<Context, string> cacheKeyStrategy, Action<Context, string, Exception> onCacheError = null)
         {
             if (cacheProvider == null) throw new ArgumentNullException(nameof(cacheProvider));
             if (ttlStrategy == null) throw new ArgumentNullException(nameof(ttlStrategy));
@@ -186,7 +186,7 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static CachePolicy<TResult> CacheAsync<TResult>(
             IAsyncCacheProvider<TResult> cacheProvider, 
-            ITtlStrategy ttlStrategy, 
+            ITtlStrategy<TResult> ttlStrategy, 
             ICacheKeyStrategy cacheKeyStrategy,
             Action<Context, string> onCacheGet,
             Action<Context, string> onCacheMiss,
@@ -222,7 +222,7 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static CachePolicy<TResult> CacheAsync<TResult>(
             IAsyncCacheProvider<TResult> cacheProvider,
-            ITtlStrategy ttlStrategy,
+            ITtlStrategy<TResult> ttlStrategy,
             Func<Context, string> cacheKeyStrategy,
             Action<Context, string> onCacheGet,
             Action<Context, string> onCacheMiss,

--- a/src/Polly.Shared/Caching/ContextualTtl.cs
+++ b/src/Polly.Shared/Caching/ContextualTtl.cs
@@ -24,8 +24,9 @@ namespace Polly.Caching
         /// Gets the TimeSpan for which to keep an item about to be cached, which may be influenced by data in the execution context.
         /// </summary>
         /// <param name="context">The execution context.</param>
+        /// <param name="result">The execution result.</param>
         /// <returns>TimeSpan.</returns>
-        public Ttl GetTtl(Context context)
+        public Ttl GetTtl(Context context, object result)
         {
             if (!context.ContainsKey(TimeSpanKey)) return _noTtl;
             bool sliding = context.ContainsKey(SlidingExpirationKey) ? context[SlidingExpirationKey] as bool? ?? false : false;

--- a/src/Polly.Shared/Caching/GenericTtlStrategy.cs
+++ b/src/Polly.Shared/Caching/GenericTtlStrategy.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Polly.Utilities;
+
+namespace Polly.Caching
+{
+    /// <summary>
+    /// Represents a <see cref="ITtlStrategy"/> expiring based on the execution result.
+    /// </summary>
+    internal class GenericTtlStrategy<TResult> : ITtlStrategy<TResult>
+    {
+        private readonly ITtlStrategy _wrappedTtlStrategy;
+
+        internal GenericTtlStrategy(ITtlStrategy ttlStrategy)
+        {
+            if (ttlStrategy == null) throw new ArgumentNullException(nameof(ttlStrategy));
+
+            _wrappedTtlStrategy = ttlStrategy;
+        }
+
+        /// <summary>
+        /// Gets a TTL for a cacheable item, given the current execution context and result.
+        /// </summary>
+        /// <param name="context">The execution context.</param>
+        /// <param name="result">The execution result.</param>
+        /// <returns>A <see cref="Ttl"/> representing the remaining Ttl of the cached item.</returns>
+        public Ttl GetTtl(Context context, TResult result)
+        {
+            return _wrappedTtlStrategy.GetTtl(context, (object)result);
+        }
+    }
+}

--- a/src/Polly.Shared/Caching/ITtlStrategy.cs
+++ b/src/Polly.Shared/Caching/ITtlStrategy.cs
@@ -5,13 +5,22 @@ namespace Polly.Caching
     /// <summary>
     /// Defines a strategy for providing time-to-live durations for cacheable results.
     /// </summary>
-    public interface ITtlStrategy
+    public interface ITtlStrategy : ITtlStrategy<object>
+    {
+        
+    }
+
+    /// <summary>
+    /// Defines a strategy for providing time-to-live durations for cacheable results.
+    /// </summary>
+    public interface ITtlStrategy<TResult>
     {
         /// <summary>
         /// Gets a TTL for a cacheable item, given the current execution context.
         /// </summary>
         /// <param name="context">The execution context.</param>
+        /// <param name="result">The execution result.</param>
         /// <returns>A <see cref="Ttl"/> representing the remaining Ttl of the cached item.</returns>
-        Ttl GetTtl(Context context);
+        Ttl GetTtl(Context context, TResult result);
     }
 }

--- a/src/Polly.Shared/Caching/NonSlidingTtl.cs
+++ b/src/Polly.Shared/Caching/NonSlidingTtl.cs
@@ -28,8 +28,9 @@ namespace Polly.Caching
         /// Gets a TTL for a cacheable item, given the current execution context.
         /// </summary>
         /// <param name="context">The execution context.</param>
+        /// <param name="result">The execution result.</param>
         /// <returns>A <see cref="Ttl"/> representing the remaining Ttl of the cached item.</returns>
-        public Ttl GetTtl(Context context)
+        public Ttl GetTtl(Context context, object result)
         {
             TimeSpan untilPointInTime = absoluteExpirationTime.Subtract(SystemClock.DateTimeOffsetUtcNow());
             TimeSpan remaining = untilPointInTime > TimeSpan.Zero ? untilPointInTime : TimeSpan.Zero;

--- a/src/Polly.Shared/Caching/ResultTtl.cs
+++ b/src/Polly.Shared/Caching/ResultTtl.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Polly.Caching
+{
+    /// <summary>
+    /// Defines a ttl strategy which will cache items with some calculation from the result of the execution.
+    /// </summary>
+
+    public class ResultTtl<TResult> : ITtlStrategy<TResult>
+    {
+        private readonly Func<TResult, Ttl> ttlFunc;
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="ResultTtl{TResult}"/> ttl strategy.
+        /// </summary>
+        /// <param name="ttlFunc">The function to calculate the TTL for which cache items should be considered valid.</param>
+        public ResultTtl(Func<TResult, Ttl> ttlFunc)
+        {
+            if (ttlFunc == null) throw new ArgumentNullException(nameof(ttlFunc));
+
+            this.ttlFunc = ttlFunc;
+        }
+
+        /// <summary>
+        /// Gets a TTL for the cacheable item.
+        /// </summary>
+        /// <param name="context">The execution context.</param>
+        /// <param name="result">The execution result.</param>
+        /// <returns>A <see cref="Ttl"/> representing the remaining Ttl of the cached item.</returns>
+
+        public Ttl GetTtl(Context context, TResult result)
+        {
+            return ttlFunc(result);
+        }
+    }
+}

--- a/src/Polly.Shared/Caching/SlidingTtl.cs
+++ b/src/Polly.Shared/Caching/SlidingTtl.cs
@@ -27,9 +27,10 @@ namespace Polly.Caching
         /// Gets a TTL for the cacheable item.
         /// </summary>
         /// <param name="context">The execution context.</param>
+        /// <param name="result">The execution result.</param>
         /// <returns>A <see cref="Ttl"/> representing the remaining Ttl of the cached item.</returns>
 
-        public Ttl GetTtl(Context context)
+        public Ttl GetTtl(Context context, object result)
         {
             return ttl;
         }

--- a/src/Polly.Shared/Caching/TtlStrategyExtensions.cs
+++ b/src/Polly.Shared/Caching/TtlStrategyExtensions.cs
@@ -1,0 +1,19 @@
+﻿namespace Polly.Caching
+{
+    /// <summary>
+    /// Class that provides helper methods for configuring TtlStrategies.
+    /// </summary>
+    public static class TtlStrategyExtensions
+    {
+        /// <summary>
+        /// Provides a strongly <typeparamref name="TResult"/>-typed version of the supplied <see cref="ITtlStrategy"/>
+        /// </summary>
+        /// <typeparam name="TResult">The type the returned <see cref="ITtlStrategy{TResult}"/> will handle.</typeparam>
+        /// <param name="ttlStrategy">The non-generic ttl strategy to wrap.</param>
+        /// <returns>ITtlStrategy{TCacheFormat}.</returns>
+        public static ITtlStrategy<TResult> For<TResult>(this ITtlStrategy ttlStrategy)
+        {
+            return new GenericTtlStrategy<TResult>(ttlStrategy);
+        }
+    }
+}

--- a/src/Polly.Shared/Polly.Shared.projitems
+++ b/src/Polly.Shared/Polly.Shared.projitems
@@ -31,6 +31,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Caching\CacheTResultSyntaxAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\ContextualTtl.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\DefaultCacheKeyStrategy.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Caching\GenericTtlStrategy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\ICacheItemSerializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\ICacheKeyStrategy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\ICachePolicy.cs" />
@@ -39,10 +40,12 @@
     <Compile Include="$(MSBuildThisFileDirectory)Caching\ITtlStrategy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\NonSlidingTtl.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\RelativeTtl.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Caching\ResultTtl.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\SerializingCacheProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\SerializingCacheProviderAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\SlidingTtl.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\Ttl.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Caching\TtlStrategyExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\GenericCacheProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\GenericCacheProviderAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CircuitBreaker\AdvancedCircuitBreakerSyntax.cs" />

--- a/src/Polly.SharedSpecs/Caching/AbsoluteTtlSpecs.cs
+++ b/src/Polly.SharedSpecs/Caching/AbsoluteTtlSpecs.cs
@@ -38,7 +38,7 @@ namespace Polly.Specs.Caching
         {
             AbsoluteTtl ttlStrategy = new AbsoluteTtl(SystemClock.DateTimeOffsetUtcNow().Subtract(TimeSpan.FromTicks(1)));
 
-            ttlStrategy.GetTtl(new Context("someExecutionKey")).Timespan.Should().Be(TimeSpan.Zero);
+            ttlStrategy.GetTtl(new Context("someExecutionKey"), null).Timespan.Should().Be(TimeSpan.Zero);
         }
 
         [Fact]
@@ -50,7 +50,7 @@ namespace Polly.Specs.Caching
             AbsoluteTtl ttlStrategy = new AbsoluteTtl(tomorrow);
 
             SystemClock.DateTimeOffsetUtcNow = () => today;
-            ttlStrategy.GetTtl(new Context("someExecutionKey")).Timespan.Should().Be(TimeSpan.FromDays(1));
+            ttlStrategy.GetTtl(new Context("someExecutionKey"), null).Timespan.Should().Be(TimeSpan.FromDays(1));
         }
 
         public void Dispose()

--- a/src/Polly.SharedSpecs/Caching/CacheTResultAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Caching/CacheTResultAsyncSpecs.cs
@@ -201,7 +201,7 @@ namespace Polly.Specs.Caching
             IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
             ICacheKeyStrategy cacheKeyStrategy = new StubCacheKeyStrategy(context => context.ExecutionKey + context["id"]);
             //CachePolicy<ResultClass> cache = Policy.CacheAsync<ResultClass>(stubCacheProvider, TimeSpan.MaxValue, cacheKeyStrategy);
-            CachePolicy<ResultClass> cache = Policy.CacheAsync<ResultClass>(stubCacheProvider.AsyncFor<ResultClass>(), new RelativeTtl(TimeSpan.MaxValue), cacheKeyStrategy, emptyDelegate, emptyDelegate, emptyDelegate, noErrorHandling, noErrorHandling);
+            CachePolicy<ResultClass> cache = Policy.CacheAsync<ResultClass>(stubCacheProvider.AsyncFor<ResultClass>(), new RelativeTtl(TimeSpan.MaxValue).For<ResultClass>(), cacheKeyStrategy, emptyDelegate, emptyDelegate, emptyDelegate, noErrorHandling, noErrorHandling);
 
             object person1 = new ResultClass(ResultPrimitive.Good, "person1");
             await stubCacheProvider.PutAsync("person1", person1, new Ttl(TimeSpan.MaxValue), CancellationToken.None, false).ConfigureAwait(false);

--- a/src/Polly.SharedSpecs/Caching/CacheTResultSpecs.cs
+++ b/src/Polly.SharedSpecs/Caching/CacheTResultSpecs.cs
@@ -195,7 +195,7 @@ namespace Polly.Specs.Caching
 
             ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
             ICacheKeyStrategy cacheKeyStrategy = new StubCacheKeyStrategy(context => context.ExecutionKey + context["id"]);
-            CachePolicy<ResultClass> cache = Policy.Cache<ResultClass>(stubCacheProvider.For<ResultClass>(), new RelativeTtl(TimeSpan.MaxValue), cacheKeyStrategy, emptyDelegate, emptyDelegate, emptyDelegate, noErrorHandling, noErrorHandling);
+            CachePolicy<ResultClass> cache = Policy.Cache<ResultClass>(stubCacheProvider.For<ResultClass>(), new RelativeTtl(TimeSpan.MaxValue).For<ResultClass>(), cacheKeyStrategy, emptyDelegate, emptyDelegate, emptyDelegate, noErrorHandling, noErrorHandling);
 
             object person1 = new ResultClass(ResultPrimitive.Good, "person1");
             stubCacheProvider.Put("person1", person1, new Ttl(TimeSpan.MaxValue));

--- a/src/Polly.SharedSpecs/Caching/ContextualTtlSpecs.cs
+++ b/src/Polly.SharedSpecs/Caching/ContextualTtlSpecs.cs
@@ -12,7 +12,7 @@ namespace Polly.Specs.Caching
         [Fact]
         public void Should_return_zero_if_no_value_set_on_context()
         {
-            new ContextualTtl().GetTtl(new Context("someExecutionKey")).Timespan.Should().Be(TimeSpan.Zero);
+            new ContextualTtl().GetTtl(new Context("someExecutionKey"), null).Timespan.Should().Be(TimeSpan.Zero);
         }
 
         [Fact]
@@ -22,7 +22,7 @@ namespace Polly.Specs.Caching
             contextData[ContextualTtl.TimeSpanKey] = new object();
 
             Context context = new Context(String.Empty, contextData);
-            new ContextualTtl().GetTtl(context).Timespan.Should().Be(TimeSpan.Zero);
+            new ContextualTtl().GetTtl(context, null).Timespan.Should().Be(TimeSpan.Zero);
         }
 
         [Fact]
@@ -33,7 +33,7 @@ namespace Polly.Specs.Caching
             contextData[ContextualTtl.TimeSpanKey] = ttl;
 
             Context context = new Context(String.Empty, contextData);
-            Ttl gotTtl = new ContextualTtl().GetTtl(context);
+            Ttl gotTtl = new ContextualTtl().GetTtl(context, null);
             gotTtl.Timespan.Should().Be(ttl);
             gotTtl.SlidingExpiration.Should().BeFalse();
         }
@@ -46,7 +46,7 @@ namespace Polly.Specs.Caching
             contextData[ContextualTtl.TimeSpanKey] = ttl;
 
             Context context = new Context(String.Empty, contextData);
-            Ttl gotTtl = new ContextualTtl().GetTtl(context);
+            Ttl gotTtl = new ContextualTtl().GetTtl(context, null);
             gotTtl.Timespan.Should().Be(ttl);
             gotTtl.SlidingExpiration.Should().BeFalse();
         }

--- a/src/Polly.SharedSpecs/Caching/RelativeTtlSpecs.cs
+++ b/src/Polly.SharedSpecs/Caching/RelativeTtlSpecs.cs
@@ -40,7 +40,7 @@ namespace Polly.Specs.Caching
 
             RelativeTtl ttlStrategy = new RelativeTtl(ttl);
 
-            Ttl retrieved = ttlStrategy.GetTtl(new Context("someExecutionKey"));
+            Ttl retrieved = ttlStrategy.GetTtl(new Context("someExecutionKey"), null);
             retrieved.Timespan.Should().BeCloseTo(ttl);
             retrieved.SlidingExpiration.Should().BeFalse();
         }

--- a/src/Polly.SharedSpecs/Caching/ResultTtlSpecs.cs
+++ b/src/Polly.SharedSpecs/Caching/ResultTtlSpecs.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using FluentAssertions;
+using Polly.Caching;
+using Xunit;
+
+namespace Polly.Specs.Caching
+{
+    public class ResultTtlSpecs
+    {
+        [Fact]
+        public void Should_throw_when_func_is_null()
+        {
+            Action configure = () => new ResultTtl<dynamic>(null);
+
+            configure.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("ttlFunc");
+        }
+
+        [Fact]
+        public void Should_not_throw_when_func_is_set()
+        {
+            Action configure = () => new ResultTtl<dynamic>((result) => new Ttl());
+
+            configure.ShouldNotThrow();
+        }
+
+        [Fact]
+        public void Should_return_func_result()
+        {
+            TimeSpan ttl = TimeSpan.FromMinutes(1);
+            Func<dynamic, Ttl> func = (result) => { return new Ttl(ttl); };
+
+            ResultTtl<dynamic> ttlStrategy = new ResultTtl<dynamic>(func);
+
+            Ttl retrieved = ttlStrategy.GetTtl(new Context("someExecutionKey"), new { Ttl = ttl });
+            retrieved.Timespan.Should().BeCloseTo(ttl);
+            retrieved.SlidingExpiration.Should().BeFalse();
+        }
+    }
+}

--- a/src/Polly.SharedSpecs/Caching/SlidingTtlSpecs.cs
+++ b/src/Polly.SharedSpecs/Caching/SlidingTtlSpecs.cs
@@ -40,7 +40,7 @@ namespace Polly.Specs.Caching
 
             SlidingTtl ttlStrategy = new SlidingTtl(ttl);
 
-            Ttl retrieved = ttlStrategy.GetTtl(new Context("someExecutionKey"));
+            Ttl retrieved = ttlStrategy.GetTtl(new Context("someExecutionKey"), null);
             retrieved.Timespan.Should().Be(ttl);
             retrieved.SlidingExpiration.Should().BeTrue();
         }

--- a/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
+++ b/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
@@ -25,6 +25,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Caching\ContextualTtlSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\DefaultCacheKeyStrategySpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\RelativeTtlSpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Caching\ResultTtlSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\SerializingCacheProviderAsyncSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\SerializingCacheProviderSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\SlidingTtlSpecs.cs" />


### PR DESCRIPTION
I would like to use this library to cache the result of an access token retrieval request. Since the expiration time of that token is known after the token is retrieved, I would like to dynamically assign the TTL to the expiration time of the token.

Hopefully these changes are abstract enough that it may be useful for the project at large. I also tried to follow the same pattern as the generic version of the Cache Provider, but please let me know if this can be cleaned up in any way.

My contributor agreement is still in progress, so I will get that completed ASAP.