### PR TITLE
Update README Dot Net Foundation CLA links

### DIFF
--- a/README.md
+++ b/README.md
@@ -956,7 +956,7 @@ For details of changes by release see the [change log](https://github.com/App-vN
 
 Please check out our [Wiki](https://github.com/App-vNext/Polly/wiki/Git-Workflow) for contributing guidelines. We are following the excellent GitHub Flow process, and would like to make sure you have all of the information needed to be a world-class contributor!
 
-Since Polly is part of the .NET Foundation, we ask our contributors to abide by their [Code of Conduct](https://www.dotnetfoundation.org/code-of-conduct).  To contribute (beyond trivial typo corrections), review and sign the .Net Foundation Contributor License Agreement ([info](https://cla.dotnetfoundation.org/); [sign](https://cla2.dotnetfoundation.org/)). This ensures the community is free to use your contributions.  The registration process can be completed entirely online.
+Since Polly is part of the .NET Foundation, we ask our contributors to abide by their [Code of Conduct](https://www.dotnetfoundation.org/code-of-conduct).  To contribute (beyond trivial typo corrections), review and sign the [.Net Foundation Contributor License Agreement](https://cla.dotnetfoundation.org/). This ensures the community is free to use your contributions.  The registration process can be completed entirely online.
 
 Also, we've stood up a [Slack](http://www.pollytalk.org) channel for easier real-time discussion of ideas and the general direction of Polly as a whole. Be sure to [join the conversation](http://www.pollytalk.org) today!
 


### PR DESCRIPTION
Update README links to Dot Net Foundation CLA.  Only the one link will apply, with the project migrated to the new Dot Net Foundation CLA bot.