### PR TITLE
Refine cache handling of null-result-from-execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+
+## 5.7.0
+- Minor cache fixes
+
 ## 5.6.1
 - Extend PolicyWrap syntax with interfaces
 

--- a/GitVersionConfig.yaml
+++ b/GitVersionConfig.yaml
@@ -1,1 +1,1 @@
-next-version: 5.6.1
+next-version: 5.7.0

--- a/build.cake
+++ b/build.cake
@@ -1,4 +1,4 @@
-///////////////////////////////////////////////////////////////////////////////
+﻿///////////////////////////////////////////////////////////////////////////////
 // ARGUMENTS
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -92,12 +92,16 @@ Teardown(_ =>
 Task("__Clean")
     .Does(() =>
 {
-    CleanDirectories(new DirectoryPath[] {
+    DirectoryPath[] cleanDirectories = new DirectoryPath[] {
         buildDir,
-        artifactsDir,
         testResultsDir,
+        artifactsDir,
         nupkgDestDir
-  	});
+  	};
+
+    CleanDirectories(cleanDirectories);
+
+    foreach(var path in cleanDirectories) { EnsureDirectoryExists(path); }
 
     foreach(var path in solutionPaths)
     {

--- a/src/Polly.Net40Async.nuspec
+++ b/src/Polly.Net40Async.nuspec
@@ -15,6 +15,10 @@
     <releaseNotes>
      v5.0 is a major release with significant new resilience policies: Timeout; Bulkhead Isolation; Fallback; Cache; and PolicyWrap.  See release notes back to v5.0.0 for full details.
 
+     5.7.0
+     ---------------------
+     - Minor cache fixes
+
      5.6.1
      ---------------------
      - Extend PolicyWrap syntax with interfaces

--- a/src/Polly.NetStandard11/Properties/AssemblyInfo.cs
+++ b/src/Polly.NetStandard11/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Polly")]
-[assembly: AssemblyVersion("5.6.1.0")]
+[assembly: AssemblyVersion("5.7.0.0")]
 [assembly: CLSCompliant(true)]
 
 [assembly: InternalsVisibleTo("Polly.NetStandard11.Specs")]

--- a/src/Polly.Shared/Caching/CacheEngine.cs
+++ b/src/Polly.Shared/Caching/CacheEngine.cs
@@ -49,7 +49,7 @@ namespace Polly.Caching
             TResult result = action(context, cancellationToken);
 
             Ttl ttl = ttlStrategy.GetTtl(context, result);
-            if (ttl.Timespan > TimeSpan.Zero)
+            if (ttl.Timespan > TimeSpan.Zero && result != null && !result.Equals(default(TResult)))
             {
                 try
                 {

--- a/src/Polly.Shared/Caching/CacheEngineAsync.cs
+++ b/src/Polly.Shared/Caching/CacheEngineAsync.cs
@@ -51,7 +51,7 @@ namespace Polly.Caching
             TResult result = await action(context, cancellationToken).ConfigureAwait(continueOnCapturedContext);
 
             Ttl ttl = ttlStrategy.GetTtl(context, result);
-            if (ttl.Timespan > TimeSpan.Zero)
+            if (ttl.Timespan > TimeSpan.Zero && result != null && !result.Equals(default(TResult)))
             {
                 try
                 {

--- a/src/Polly.SharedSpecs/Caching/CacheAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Caching/CacheAsyncSpecs.cs
@@ -539,6 +539,34 @@ namespace Polly.Specs.Caching
         }
 
         [Fact]
+        public async Task Should_execute_oncachemiss_but_not_oncacheput_if_cache_does_not_hold_value_and_returned_value_not_worth_caching()
+        {
+            const string valueToReturn = null;
+
+            const string executionKey = "SomeExecutionKey";
+            string keyPassedToOnCacheMiss = null;
+            string keyPassedToOnCachePut = null;
+
+            Context contextToExecute = new Context(executionKey);
+            Context contextPassedToOnCacheMiss = null;
+            Context contextPassedToOnCachePut = null;
+
+            Action<Context, string, Exception> noErrorHandling = (_, __, ___) => { };
+            Action<Context, string> emptyDelegate = (_, __) => { };
+            Action<Context, string> onCacheMiss = (ctx, key) => { contextPassedToOnCacheMiss = ctx; keyPassedToOnCacheMiss = key; };
+            Action<Context, string> onCachePut = (ctx, key) => { contextPassedToOnCachePut = ctx; keyPassedToOnCachePut = key; };
+
+            IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+            CachePolicy cache = Policy.CacheAsync(stubCacheProvider, new RelativeTtl(TimeSpan.MaxValue), DefaultCacheKeyStrategy.Instance, emptyDelegate, onCacheMiss, onCachePut, noErrorHandling, noErrorHandling);
+
+            ((string)await stubCacheProvider.GetAsync(executionKey, CancellationToken.None, false).ConfigureAwait(false)).Should().BeNull();
+            (await cache.ExecuteAsync(async () => { await TaskHelper.EmptyTask.ConfigureAwait(false); return valueToReturn; }, contextToExecute).ConfigureAwait(false)).Should().Be(valueToReturn);
+
+            contextPassedToOnCachePut.Should().BeNull();
+            keyPassedToOnCachePut.Should().BeNull();
+        }
+
+        [Fact]
         public async Task Should_not_execute_oncachemiss_if_dont_query_cache_because_cache_key_not_set()
         {
             string valueToReturn = Guid.NewGuid().ToString();

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -15,6 +15,10 @@
     <releaseNotes>
      v5.0 is a major release with significant new resilience policies: Timeout; Bulkhead Isolation; Fallback; Cache; and PolicyWrap.  See release notes back to v5.0.0 for full details.
 
+     5.7.0
+     ---------------------
+     - Minor cache fixes
+
      5.6.1
      ---------------------
      - Extend PolicyWrap syntax with interfaces


### PR DESCRIPTION
Make `null` / `default(TResult)` handling symmetrical across cache get and put.  

`null` is not worth caching, as get (and some third-party caches) treat `null` as meaning 'cache did not hold a value'