### PR TITLE
Permit custom policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 
 ## 5.7.0
 - Minor cache fixes
+- Allow user-created custom policies 
 
 ## 5.6.1
 - Extend PolicyWrap syntax with interfaces

--- a/src/Polly.Net40Async.nuspec
+++ b/src/Polly.Net40Async.nuspec
@@ -18,6 +18,7 @@
      5.7.0
      ---------------------
      - Minor cache fixes
+     - Allow user-created custom policies
 
      5.6.1
      ---------------------

--- a/src/Polly.Shared/ExceptionPredicate.cs
+++ b/src/Polly.Shared/ExceptionPredicate.cs
@@ -2,5 +2,10 @@
 
 namespace Polly
 {
-    internal delegate Exception ExceptionPredicate(Exception ex); 
+    /// <summary>
+    /// A predicate that can be run against a passed <see cref="Exception"/> <paramref name="ex"/>.  
+    /// </summary>
+    /// <param name="ex">The passed exception, against which to evaluate the predicate.</param>
+    /// <returns>A matched <see cref="Exception"/>; or null, if an exception was not matched.  ExceptionPredicate implementations may return the passed Exception <paramref name="ex"/>, indicating that it matched the predicate. They may also return inner exceptions of the passed Exception <paramref name="ex"/>, to indicate that the returned inner exception matched the predicate.</returns>
+    public delegate Exception ExceptionPredicate(Exception ex); 
 }

--- a/src/Polly.Shared/Policy.TResult.cs
+++ b/src/Polly.Shared/Policy.TResult.cs
@@ -16,7 +16,13 @@ namespace Polly
         internal IEnumerable<ExceptionPredicate> ExceptionPredicates { get; }
         internal IEnumerable<ResultPredicate<TResult>> ResultPredicates { get; }
 
-        internal Policy(
+        /// <summary>
+        /// Constructs a new instance of a derived <see cref="Policy"/> type with the passed <paramref name="executionPolicy"/>, <paramref name="exceptionPredicates"/> and <paramref name="resultPredicates"/> 
+        /// </summary>
+        /// <param name="executionPolicy">The policy that will be applied to delegates executed through the policy.</param>
+        /// <param name="exceptionPredicates">Predicates indicating which exceptions the policy should handle. </param>
+        /// <param name="resultPredicates">Predicates indicating which results the policy should handle. </param>
+        protected Policy(
             Func<Func<Context, CancellationToken, TResult>, Context, CancellationToken, TResult> executionPolicy,
             IEnumerable<ExceptionPredicate> exceptionPredicates,
             IEnumerable<ResultPredicate<TResult>> resultPredicates

--- a/src/Polly.Shared/Policy.TResult.cs
+++ b/src/Polly.Shared/Policy.TResult.cs
@@ -19,7 +19,7 @@ namespace Polly
         /// <summary>
         /// Constructs a new instance of a derived <see cref="Policy"/> type with the passed <paramref name="executionPolicy"/>, <paramref name="exceptionPredicates"/> and <paramref name="resultPredicates"/> 
         /// </summary>
-        /// <param name="executionPolicy">The policy that will be applied to delegates executed through the policy.</param>
+        /// <param name="executionPolicy">The execution policy that will be applied to delegates executed synchronously through the policy.</param>
         /// <param name="exceptionPredicates">Predicates indicating which exceptions the policy should handle. </param>
         /// <param name="resultPredicates">Predicates indicating which results the policy should handle. </param>
         protected Policy(

--- a/src/Polly.Shared/Policy.cs
+++ b/src/Polly.Shared/Policy.cs
@@ -16,7 +16,12 @@ namespace Polly
         private readonly Action<Action<Context, CancellationToken>, Context, CancellationToken> _exceptionPolicy;
         internal IEnumerable<ExceptionPredicate> ExceptionPredicates { get; }
 
-        internal Policy(
+        /// <summary>
+        /// Constructs a new instance of a derived <see cref="Policy"/> type with the passed <paramref name="exceptionPolicy"/> and <paramref name="exceptionPredicates"/> 
+        /// </summary>
+        /// <param name="exceptionPolicy">The policy that will be applied to delegates executed through the policy.</param>
+        /// <param name="exceptionPredicates">Predicates indicating which exceptions the policy should handle. </param>
+        protected Policy(
             Action<Action<Context, CancellationToken>, Context, CancellationToken> exceptionPolicy,
             IEnumerable<ExceptionPredicate> exceptionPredicates)
         {

--- a/src/Polly.Shared/Policy.cs
+++ b/src/Polly.Shared/Policy.cs
@@ -19,7 +19,7 @@ namespace Polly
         /// <summary>
         /// Constructs a new instance of a derived <see cref="Policy"/> type with the passed <paramref name="exceptionPolicy"/> and <paramref name="exceptionPredicates"/> 
         /// </summary>
-        /// <param name="exceptionPolicy">The policy that will be applied to delegates executed through the policy.</param>
+        /// <param name="exceptionPolicy">The execution policy that will be applied to delegates executed synchronously through the policy.</param>
         /// <param name="exceptionPredicates">Predicates indicating which exceptions the policy should handle. </param>
         protected Policy(
             Action<Action<Context, CancellationToken>, Context, CancellationToken> exceptionPolicy,

--- a/src/Polly.Shared/PolicyAsync.TResult.cs
+++ b/src/Polly.Shared/PolicyAsync.TResult.cs
@@ -12,7 +12,13 @@ namespace Polly
     {
         private readonly Func<Func<Context, CancellationToken, Task<TResult>>, Context, CancellationToken, bool, Task<TResult>> _asyncExecutionPolicy;
 
-        internal Policy(
+        /// <summary>
+        /// Constructs a new instance of a derived <see cref="Policy"/> type with the passed <paramref name="asyncExecutionPolicy"/>, <paramref name="exceptionPredicates"/> and <paramref name="resultPredicates"/> 
+        /// </summary>
+        /// <param name="asyncExecutionPolicy">The execution policy that will be applied to delegates executed asychronously through the asynchronous policy.</param>
+        /// <param name="exceptionPredicates">Predicates indicating which exceptions the policy should handle. </param>
+        /// <param name="resultPredicates">Predicates indicating which results the policy should handle. </param>
+        protected Policy(
             Func<Func<Context, CancellationToken, Task<TResult>>, Context, CancellationToken, bool, Task<TResult>> asyncExecutionPolicy,
             IEnumerable<ExceptionPredicate> exceptionPredicates,
             IEnumerable<ResultPredicate<TResult>> resultPredicates)

--- a/src/Polly.Shared/PolicyAsync.cs
+++ b/src/Polly.Shared/PolicyAsync.cs
@@ -11,7 +11,12 @@ namespace Polly
     {
         private readonly Func<Func<Context, CancellationToken, Task>, Context, CancellationToken, bool, Task> _asyncExceptionPolicy;
 
-        internal Policy(
+        /// <summary>
+        /// Constructs a new instance of a derived <see cref="Policy"/> type with the passed <paramref name="asyncExceptionPolicy"/> and <paramref name="exceptionPredicates"/>.
+        /// </summary>
+        /// <param name="asyncExceptionPolicy">The execution policy that will be applied to delegates executed asychronously through the asynchronous policy.</param>
+        /// <param name="exceptionPredicates">Predicates indicating which exceptions the policy should handle. </param>
+        protected Policy(
             Func<Func<Context, CancellationToken, Task>, Context, CancellationToken, bool, Task> asyncExceptionPolicy, 
             IEnumerable<ExceptionPredicate> exceptionPredicates)
         {

--- a/src/Polly.Shared/ResultPredicate.cs
+++ b/src/Polly.Shared/ResultPredicate.cs
@@ -1,4 +1,11 @@
 ﻿namespace Polly
 {
-    internal delegate bool ResultPredicate<TResult>(TResult result);
+    /// <summary>
+    /// A predicate that can be run against a passed result value of type <typeparamref name="TResult"/>.
+    /// </summary>
+    /// <param name="result">The passed result, against which to evaluate the predicate.</param>
+    /// <typeparam name="TResult">The type of results which this predicate can evaluate.</typeparam>
+    /// <returns>True if the passed <paramref name="result"/> matched the predicate; otherwise, false.</returns>
+
+    public delegate bool ResultPredicate<in TResult>(TResult result);
 }

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -18,6 +18,7 @@
      5.7.0
      ---------------------
      - Minor cache fixes
+     - Allow user-created custom policies
 
      5.6.1
      ---------------------


### PR DESCRIPTION
+ Change constructors of `Policy` and `Policy<TResult>` base classes from `internal` to `protected`.
+ Make `ExceptionPredicate` and `ResultPredicate` classes `public` (necessary to allow users to create custom policies responding to faults declared in handle clauses)