### PR TITLE
V571on break delegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 5.7.1
+- Add a new onBreak overload that provides the prior state on a transition to an open state
 
 ## 5.7.0
 - Minor cache fixes

--- a/README.md
+++ b/README.md
@@ -952,6 +952,7 @@ For details of changes by release see the [change log](https://github.com/App-vN
 * [@rjongeneelen](https://github.com/rjongeneelen) and [@reisenberger](https://github.com/reisenberger) - Allow PolicyWrap configuration to configure policies via interfaces. 
 * [@reisenberger](https://github.com/reisenberger) - Performance improvements.
 * [@awarrenlove](https://github.com/awarrenlove) - Add ability to calculate cache Ttl based on item to cache.
+* [@awarrenlove](https://github.com/awarrenlove) - Add a new onBreak overload that provides the prior state on a transition to an open state.
 
 # Sample Projects
 

--- a/README.md
+++ b/README.md
@@ -952,7 +952,7 @@ For details of changes by release see the [change log](https://github.com/App-vN
 * [@rjongeneelen](https://github.com/rjongeneelen) and [@reisenberger](https://github.com/reisenberger) - Allow PolicyWrap configuration to configure policies via interfaces. 
 * [@reisenberger](https://github.com/reisenberger) - Performance improvements.
 * [@awarrenlove](https://github.com/awarrenlove) - Add ability to calculate cache Ttl based on item to cache.
-* [@awarrenlove](https://github.com/erickhouse) - Add a new onBreak overload that provides the prior state on a transition to an open state.
+* [@erickhouse](https://github.com/erickhouse) - Add a new onBreak overload that provides the prior state on a transition to an open state.
 
 # Sample Projects
 

--- a/README.md
+++ b/README.md
@@ -952,7 +952,7 @@ For details of changes by release see the [change log](https://github.com/App-vN
 * [@rjongeneelen](https://github.com/rjongeneelen) and [@reisenberger](https://github.com/reisenberger) - Allow PolicyWrap configuration to configure policies via interfaces. 
 * [@reisenberger](https://github.com/reisenberger) - Performance improvements.
 * [@awarrenlove](https://github.com/awarrenlove) - Add ability to calculate cache Ttl based on item to cache.
-* [@awarrenlove](https://github.com/awarrenlove) - Add a new onBreak overload that provides the prior state on a transition to an open state.
+* [@awarrenlove](https://github.com/erickhouse) - Add a new onBreak overload that provides the prior state on a transition to an open state.
 
 # Sample Projects
 

--- a/src/Polly.Net40Async.nuspec
+++ b/src/Polly.Net40Async.nuspec
@@ -13,21 +13,25 @@
     <tags>Exception Handling Resilience Transient Fault Policy Circuit Breaker CircuitBreaker Retry Wait Cache Cache-aside Bulkhead Fallback Timeout Throttle Parallelization</tags>
     <copyright>Copyright © 2017, App vNext</copyright>
     <releaseNotes>
-     v5.0 is a major release with significant new resilience policies: Timeout; Bulkhead Isolation; Fallback; Cache; and PolicyWrap.  See release notes back to v5.0.0 for full details.
+      v5.0 is a major release with significant new resilience policies: Timeout; Bulkhead Isolation; Fallback; Cache; and PolicyWrap.  See release notes back to v5.0.0 for full details.
 
-     5.7.0
-     ---------------------
-     - Minor cache fixes
-     - Add ability to calculate cache Ttl based on item to cache
-     - Allow user-created custom policies
+      5.7.1
+      ---------------------
+      - Add a new onBreak overload that provides the prior state on a transition to an open state
+      
+      5.7.0
+      ---------------------
+      - Minor cache fixes
+      - Add ability to calculate cache Ttl based on item to cache
+      - Allow user-created custom policies
 
-     5.6.1
-     ---------------------
-     - Extend PolicyWrap syntax with interfaces
-     
-     5.6.0
-     ---------------------
-     - Add ability to handle inner exceptions natively: .HandleInner&lt;TEx&gt;()
+      5.6.1
+      ---------------------
+      - Extend PolicyWrap syntax with interfaces
+
+      5.6.0
+      ---------------------
+      - Add ability to handle inner exceptions natively: .HandleInner&lt;TEx&gt;()
      - Allow WaitAndRetry policies to calculate wait based on the handled fault
      - Add the ability to access the policies within an IPolicyWrap
      - Allow PolicyWrap to take interfaces as parameters

--- a/src/Polly.Shared/CircuitBreaker/AdvancedCircuitBreakerSyntax.cs
+++ b/src/Polly.Shared/CircuitBreaker/AdvancedCircuitBreakerSyntax.cs
@@ -189,6 +189,46 @@ namespace Polly
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         public static CircuitBreakerPolicy AdvancedCircuitBreaker(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
         {
+            return policyBuilder.AdvancedCircuitBreaker(
+                failureThreshold, samplingDuration, minimumThroughput,
+                durationOfBreak,
+                (exception, state, timespan, context) => onBreak(exception, timespan, context),
+                onReset,
+                onHalfOpen
+            );
+        }
+
+        /// <summary>
+        /// <para> Builds a <see cref="Policy" /> that will function like a Circuit Breaker.</para>
+        /// <para>The circuit will break if, within any timeslice of duration <paramref name="samplingDuration"/>, the proportion of actions resulting in a handled exception exceeds <paramref name="failureThreshold"/>, provided also that the number of actions through the circuit in the timeslice is at least <paramref name="minimumThroughput" />. </para>
+        /// <para>The circuit will stay broken for the <paramref name="durationOfBreak" />. Any attempt to execute this policy
+        /// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException" /> containing the exception
+        /// that broke the circuit.
+        /// </para>
+        /// <para>If the first action after the break duration period results in a handled exception, the circuit will break
+        /// again for another <paramref name="durationOfBreak" />; if no exception is thrown, the circuit will reset.
+        /// </para>
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="failureThreshold">The failure threshold at which the circuit will break (a number between 0 and 1; eg 0.5 represents breaking if 50% or more of actions result in a handled failure.</param>
+        /// <param name="samplingDuration">The duration of the timeslice over which failure ratios are assessed.</param>
+        /// <param name="minimumThroughput">The minimum throughput: this many actions or more must pass through the circuit in the timeslice, for statistics to be considered significant and the circuit-breaker to come into action.</param>
+        /// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
+        /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open" /> state.</param>
+        /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed" /> state.</param>
+        /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen" /> state, ready to try action executions again.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
+        /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
+        /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
+        /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
+        /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+        /// <exception cref="ArgumentNullException">onBreak</exception>
+        /// <exception cref="ArgumentNullException">onReset</exception>
+        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+        /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+        public static CircuitBreakerPolicy AdvancedCircuitBreaker(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
+        {
             var resolutionOfCircuit = TimeSpan.FromTicks(AdvancedCircuitController<EmptyStruct>.ResolutionOfCircuitTimer);
 
             if (failureThreshold <= 0) throw new ArgumentOutOfRangeException("failureThreshold", "Value must be greater than zero.");
@@ -202,131 +242,25 @@ namespace Polly
             if (onHalfOpen == null) throw new ArgumentNullException("onHalfOpen");
 
             var breakerController = new AdvancedCircuitController<EmptyStruct>(
-                failureThreshold, 
-                samplingDuration, 
-                minimumThroughput, 
-                durationOfBreak, 
-                (outcome, timespan, context) => onBreak(outcome.Exception, timespan, context), 
-                onReset, 
+                failureThreshold,
+                samplingDuration,
+                minimumThroughput,
+                durationOfBreak,
+                (outcome, state, timespan, context) => onBreak(outcome.Exception, state, timespan, context),
+                onReset,
                 onHalfOpen);
             return new CircuitBreakerPolicy(
                 (action, context, cancellationToken) => CircuitBreakerEngine.Implementation<EmptyStruct>(
                     (ctx, ct) => { action(ctx, ct); return EmptyStruct.Instance; },
                     context,
                     cancellationToken,
-                    policyBuilder.ExceptionPredicates, 
-                    PredicateHelper<EmptyStruct>.EmptyResultPredicates, 
-                    breakerController), 
-                policyBuilder.ExceptionPredicates, 
+                    policyBuilder.ExceptionPredicates,
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
+                    breakerController),
+                policyBuilder.ExceptionPredicates,
                 breakerController
                 );
         }
-
-        // For v571onBreakDelegate : delete the overload above, and replace with the two below
-
-        ///// <summary>
-        ///// <para> Builds a <see cref="Policy" /> that will function like a Circuit Breaker.</para>
-        ///// <para>The circuit will break if, within any timeslice of duration <paramref name="samplingDuration"/>, the proportion of actions resulting in a handled exception exceeds <paramref name="failureThreshold"/>, provided also that the number of actions through the circuit in the timeslice is at least <paramref name="minimumThroughput" />. </para>
-        ///// <para>The circuit will stay broken for the <paramref name="durationOfBreak" />. Any attempt to execute this policy
-        ///// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException" /> containing the exception
-        ///// that broke the circuit.
-        ///// </para>
-        ///// <para>If the first action after the break duration period results in a handled exception, the circuit will break
-        ///// again for another <paramref name="durationOfBreak" />; if no exception is thrown, the circuit will reset.
-        ///// </para>
-        ///// </summary>
-        ///// <param name="policyBuilder">The policy builder.</param>
-        ///// <param name="failureThreshold">The failure threshold at which the circuit will break (a number between 0 and 1; eg 0.5 represents breaking if 50% or more of actions result in a handled failure.</param>
-        ///// <param name="samplingDuration">The duration of the timeslice over which failure ratios are assessed.</param>
-        ///// <param name="minimumThroughput">The minimum throughput: this many actions or more must pass through the circuit in the timeslice, for statistics to be considered significant and the circuit-breaker to come into action.</param>
-        ///// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
-        ///// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open" /> state.</param>
-        ///// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed" /> state.</param>
-        ///// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen" /> state, ready to try action executions again.</param>
-        ///// <returns>The policy instance.</returns>
-        ///// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-        ///// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-        ///// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-        ///// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-        ///// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-        ///// <exception cref="ArgumentNullException">onBreak</exception>
-        ///// <exception cref="ArgumentNullException">onReset</exception>
-        ///// <exception cref="ArgumentNullException">onHalfOpen</exception>
-        ///// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
-        //public static CircuitBreakerPolicy AdvancedCircuitBreaker(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
-        //{
-        //    return policyBuilder.AdvancedCircuitBreaker(
-        //        failureThreshold, samplingDuration, minimumThroughput,
-        //        durationOfBreak,
-        //        (exception, state, timespan, context) => onBreak(exception, timespan, context),
-        //        onReset,
-        //        onHalfOpen
-        //    );
-        //}
-
-        ///// <summary>
-        ///// <para> Builds a <see cref="Policy" /> that will function like a Circuit Breaker.</para>
-        ///// <para>The circuit will break if, within any timeslice of duration <paramref name="samplingDuration"/>, the proportion of actions resulting in a handled exception exceeds <paramref name="failureThreshold"/>, provided also that the number of actions through the circuit in the timeslice is at least <paramref name="minimumThroughput" />. </para>
-        ///// <para>The circuit will stay broken for the <paramref name="durationOfBreak" />. Any attempt to execute this policy
-        ///// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException" /> containing the exception
-        ///// that broke the circuit.
-        ///// </para>
-        ///// <para>If the first action after the break duration period results in a handled exception, the circuit will break
-        ///// again for another <paramref name="durationOfBreak" />; if no exception is thrown, the circuit will reset.
-        ///// </para>
-        ///// </summary>
-        ///// <param name="policyBuilder">The policy builder.</param>
-        ///// <param name="failureThreshold">The failure threshold at which the circuit will break (a number between 0 and 1; eg 0.5 represents breaking if 50% or more of actions result in a handled failure.</param>
-        ///// <param name="samplingDuration">The duration of the timeslice over which failure ratios are assessed.</param>
-        ///// <param name="minimumThroughput">The minimum throughput: this many actions or more must pass through the circuit in the timeslice, for statistics to be considered significant and the circuit-breaker to come into action.</param>
-        ///// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
-        ///// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open" /> state.</param>
-        ///// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed" /> state.</param>
-        ///// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen" /> state, ready to try action executions again.</param>
-        ///// <returns>The policy instance.</returns>
-        ///// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-        ///// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-        ///// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-        ///// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-        ///// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-        ///// <exception cref="ArgumentNullException">onBreak</exception>
-        ///// <exception cref="ArgumentNullException">onReset</exception>
-        ///// <exception cref="ArgumentNullException">onHalfOpen</exception>
-        ///// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
-        //public static CircuitBreakerPolicy AdvancedCircuitBreaker(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
-        //{
-        //    var resolutionOfCircuit = TimeSpan.FromTicks(AdvancedCircuitController<EmptyStruct>.ResolutionOfCircuitTimer);
-
-        //    if (failureThreshold <= 0) throw new ArgumentOutOfRangeException("failureThreshold", "Value must be greater than zero.");
-        //    if (failureThreshold > 1) throw new ArgumentOutOfRangeException("failureThreshold", "Value must be less than or equal to one.");
-        //    if (samplingDuration < resolutionOfCircuit) throw new ArgumentOutOfRangeException("samplingDuration", String.Format("Value must be equal to or greater than {0} milliseconds. This is the minimum resolution of the CircuitBreaker timer.", resolutionOfCircuit.TotalMilliseconds));
-        //    if (minimumThroughput <= 1) throw new ArgumentOutOfRangeException("minimumThroughput", "Value must be greater than one.");
-        //    if (durationOfBreak < TimeSpan.Zero) throw new ArgumentOutOfRangeException("durationOfBreak", "Value must be greater than zero.");
-
-        //    if (onBreak == null) throw new ArgumentNullException("onBreak");
-        //    if (onReset == null) throw new ArgumentNullException("onReset");
-        //    if (onHalfOpen == null) throw new ArgumentNullException("onHalfOpen");
-
-        //    var breakerController = new AdvancedCircuitController<EmptyStruct>(
-        //        failureThreshold, 
-        //        samplingDuration, 
-        //        minimumThroughput, 
-        //        durationOfBreak, 
-        //        (outcome, state, timespan, context) => onBreak(outcome.Exception, state, timespan, context), 
-        //        onReset, 
-        //        onHalfOpen);
-        //    return new CircuitBreakerPolicy(
-        //        (action, context, cancellationToken) => CircuitBreakerEngine.Implementation<EmptyStruct>(
-        //            (ctx, ct) => { action(ctx, ct); return EmptyStruct.Instance; },
-        //            context,
-        //            cancellationToken,
-        //            policyBuilder.ExceptionPredicates, 
-        //            PredicateHelper<EmptyStruct>.EmptyResultPredicates, 
-        //            breakerController), 
-        //        policyBuilder.ExceptionPredicates, 
-        //        breakerController
-        //        );
-        //}
 
     }
 }

--- a/src/Polly.Shared/CircuitBreaker/AdvancedCircuitBreakerSyntaxAsync.cs
+++ b/src/Polly.Shared/CircuitBreaker/AdvancedCircuitBreakerSyntaxAsync.cs
@@ -195,6 +195,46 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static CircuitBreakerPolicy AdvancedCircuitBreakerAsync(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
         {
+            return policyBuilder.AdvancedCircuitBreakerAsync(
+                failureThreshold, samplingDuration, minimumThroughput,
+                durationOfBreak,
+                (exception, state, timespan, context) => onBreak(exception, timespan, context),
+                onReset,
+                onHalfOpen
+            );
+        }
+
+        /// <summary>
+        /// <para> Builds a <see cref="Policy"/> that will function like a Circuit Breaker.</para>
+        /// <para>The circuit will break if, within any timeslice of duration <paramref name="samplingDuration"/>, the proportion of actions resulting in a handled exception exceeds <paramref name="failureThreshold"/>, provided also that the number of actions through the circuit in the timeslice is at least <paramref name="minimumThroughput" />. </para>
+        /// <para>The circuit will stay broken for the <paramref name="durationOfBreak" />. Any attempt to execute this policy
+        /// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException" /> containing the exception
+        /// that broke the circuit.
+        /// </para>
+        /// <para>If the first action after the break duration period results in a handled exception, the circuit will break
+        /// again for another <paramref name="durationOfBreak" />; if no exception is thrown, the circuit will reset.
+        /// </para>
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="failureThreshold">The failure threshold at which the circuit will break (a number between 0 and 1; eg 0.5 represents breaking if 50% or more of actions result in a handled failure.</param>
+        /// <param name="samplingDuration">The duration of the timeslice over which failure ratios are assessed.</param>
+        /// <param name="minimumThroughput">The minimum throughput: this many actions or more must pass through the circuit in the timeslice, for statistics to be considered significant and the circuit-breaker to come into action.</param>
+        /// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
+        /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
+        /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
+        /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
+        /// <returns>The policy instance.</returns>
+        /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
+        /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
+        /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
+        /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
+        /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+        /// <exception cref="ArgumentNullException">onBreak</exception>
+        /// <exception cref="ArgumentNullException">onReset</exception>
+        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+        public static CircuitBreakerPolicy AdvancedCircuitBreakerAsync(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
+        {
             var resolutionOfCircuit = TimeSpan.FromTicks(AdvancedCircuitController<EmptyStruct>.ResolutionOfCircuitTimer);
 
             if (failureThreshold <= 0) throw new ArgumentOutOfRangeException("failureThreshold", "Value must be greater than zero.");
@@ -212,7 +252,7 @@ namespace Polly
                 samplingDuration,
                 minimumThroughput,
                 durationOfBreak,
-                (outcome, timespan, context) => onBreak(outcome.Exception, timespan, context),
+                (outcome, state, timespan, context) => onBreak(outcome.Exception, state, timespan, context),
                 onReset,
                 onHalfOpen);
             return new CircuitBreakerPolicy(
@@ -220,7 +260,7 @@ namespace Polly
                     async (ctx, ct) => { await action(ctx, ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                     context,
                     policyBuilder.ExceptionPredicates,
-                    PredicateHelper<EmptyStruct>.EmptyResultPredicates, 
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
                     breakerController,
                     cancellationToken,
                     continueOnCapturedContext),
@@ -228,112 +268,5 @@ namespace Polly
                 breakerController
             );
         }
- 
-        // For v571onBreakDelegate : delete the overload above, and replace with the two below
-
-        ///// <summary>
-        ///// <para> Builds a <see cref="Policy"/> that will function like a Circuit Breaker.</para>
-        ///// <para>The circuit will break if, within any timeslice of duration <paramref name="samplingDuration"/>, the proportion of actions resulting in a handled exception exceeds <paramref name="failureThreshold"/>, provided also that the number of actions through the circuit in the timeslice is at least <paramref name="minimumThroughput" />. </para>
-        ///// <para>The circuit will stay broken for the <paramref name="durationOfBreak" />. Any attempt to execute this policy
-        ///// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException" /> containing the exception
-        ///// that broke the circuit.
-        ///// </para>
-        ///// <para>If the first action after the break duration period results in a handled exception, the circuit will break
-        ///// again for another <paramref name="durationOfBreak" />; if no exception is thrown, the circuit will reset.
-        ///// </para>
-        ///// </summary>
-        ///// <param name="policyBuilder">The policy builder.</param>
-        ///// <param name="failureThreshold">The failure threshold at which the circuit will break (a number between 0 and 1; eg 0.5 represents breaking if 50% or more of actions result in a handled failure.</param>
-        ///// <param name="samplingDuration">The duration of the timeslice over which failure ratios are assessed.</param>
-        ///// <param name="minimumThroughput">The minimum throughput: this many actions or more must pass through the circuit in the timeslice, for statistics to be considered significant and the circuit-breaker to come into action.</param>
-        ///// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
-        ///// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
-        ///// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
-        ///// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
-        ///// <returns>The policy instance.</returns>
-        ///// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
-        ///// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-        ///// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-        ///// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-        ///// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-        ///// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-        ///// <exception cref="ArgumentNullException">onBreak</exception>
-        ///// <exception cref="ArgumentNullException">onReset</exception>
-        ///// <exception cref="ArgumentNullException">onHalfOpen</exception>
-        //public static CircuitBreakerPolicy AdvancedCircuitBreakerAsync(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
-        //{
-        //    return policyBuilder.AdvancedCircuitBreakerAsync(
-        //        failureThreshold, samplingDuration, minimumThroughput,
-        //        durationOfBreak,
-        //        (exception, state, timespan, context) => onBreak(exception, timespan, context),
-        //        onReset,
-        //        onHalfOpen
-        //    );
-        //}
-
-        ///// <summary>
-        ///// <para> Builds a <see cref="Policy"/> that will function like a Circuit Breaker.</para>
-        ///// <para>The circuit will break if, within any timeslice of duration <paramref name="samplingDuration"/>, the proportion of actions resulting in a handled exception exceeds <paramref name="failureThreshold"/>, provided also that the number of actions through the circuit in the timeslice is at least <paramref name="minimumThroughput" />. </para>
-        ///// <para>The circuit will stay broken for the <paramref name="durationOfBreak" />. Any attempt to execute this policy
-        ///// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException" /> containing the exception
-        ///// that broke the circuit.
-        ///// </para>
-        ///// <para>If the first action after the break duration period results in a handled exception, the circuit will break
-        ///// again for another <paramref name="durationOfBreak" />; if no exception is thrown, the circuit will reset.
-        ///// </para>
-        ///// </summary>
-        ///// <param name="policyBuilder">The policy builder.</param>
-        ///// <param name="failureThreshold">The failure threshold at which the circuit will break (a number between 0 and 1; eg 0.5 represents breaking if 50% or more of actions result in a handled failure.</param>
-        ///// <param name="samplingDuration">The duration of the timeslice over which failure ratios are assessed.</param>
-        ///// <param name="minimumThroughput">The minimum throughput: this many actions or more must pass through the circuit in the timeslice, for statistics to be considered significant and the circuit-breaker to come into action.</param>
-        ///// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
-        ///// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
-        ///// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
-        ///// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
-        ///// <returns>The policy instance.</returns>
-        ///// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
-        ///// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-        ///// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-        ///// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-        ///// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-        ///// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-        ///// <exception cref="ArgumentNullException">onBreak</exception>
-        ///// <exception cref="ArgumentNullException">onReset</exception>
-        ///// <exception cref="ArgumentNullException">onHalfOpen</exception>
-        //public static CircuitBreakerPolicy AdvancedCircuitBreakerAsync(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
-        //{
-        //    var resolutionOfCircuit = TimeSpan.FromTicks(AdvancedCircuitController<EmptyStruct>.ResolutionOfCircuitTimer);
-
-        //    if (failureThreshold <= 0) throw new ArgumentOutOfRangeException("failureThreshold", "Value must be greater than zero.");
-        //    if (failureThreshold > 1) throw new ArgumentOutOfRangeException("failureThreshold", "Value must be less than or equal to one.");
-        //    if (samplingDuration < resolutionOfCircuit) throw new ArgumentOutOfRangeException("samplingDuration", String.Format("Value must be equal to or greater than {0} milliseconds. This is the minimum resolution of the CircuitBreaker timer.", resolutionOfCircuit.TotalMilliseconds));
-        //    if (minimumThroughput <= 1) throw new ArgumentOutOfRangeException("minimumThroughput", "Value must be greater than one.");
-        //    if (durationOfBreak < TimeSpan.Zero) throw new ArgumentOutOfRangeException("durationOfBreak", "Value must be greater than zero.");
-
-        //    if (onBreak == null) throw new ArgumentNullException("onBreak");
-        //    if (onReset == null) throw new ArgumentNullException("onReset");
-        //    if (onHalfOpen == null) throw new ArgumentNullException("onHalfOpen");
-
-        //    var breakerController = new AdvancedCircuitController<EmptyStruct>(
-        //        failureThreshold,
-        //        samplingDuration,
-        //        minimumThroughput,
-        //        durationOfBreak,
-        //        (outcome, state, timespan, context) => onBreak(outcome.Exception, state, timespan, context),
-        //        onReset,
-        //        onHalfOpen);
-        //    return new CircuitBreakerPolicy(
-        //        (action, context, cancellationToken, continueOnCapturedContext) => CircuitBreakerEngine.ImplementationAsync<EmptyStruct>(
-        //            async (ctx, ct) => { await action(ctx, ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
-        //            context,
-        //            policyBuilder.ExceptionPredicates,
-        //            PredicateHelper<EmptyStruct>.EmptyResultPredicates, 
-        //            breakerController,
-        //            cancellationToken,
-        //            continueOnCapturedContext),
-        //        policyBuilder.ExceptionPredicates,
-        //        breakerController
-        //    );
-        //}
     }
 }

--- a/src/Polly.Shared/CircuitBreaker/AdvancedCircuitBreakerTResultSyntax.cs
+++ b/src/Polly.Shared/CircuitBreaker/AdvancedCircuitBreakerTResultSyntax.cs
@@ -190,6 +190,47 @@ namespace Polly
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         public static CircuitBreakerPolicy<TResult> AdvancedCircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
         {
+            return policyBuilder.AdvancedCircuitBreaker(
+                failureThreshold, samplingDuration, minimumThroughput,
+                durationOfBreak,
+                (outcome, state, timespan, context) => onBreak(outcome, timespan, context),
+                onReset,
+                onHalfOpen
+            );
+        }
+
+        /// <summary>
+        /// <para> Builds a <see cref="Policy" /> that will function like a Circuit Breaker.</para>
+        /// <para>The circuit will break if, within any timeslice of duration <paramref name="samplingDuration" />, the proportion of actions resulting in a handled exception or result exceeds <paramref name="failureThreshold" />, provided also that the number of actions through the circuit in the timeslice is at least <paramref name="minimumThroughput" />. </para>
+        /// <para>The circuit will stay broken for the <paramref name="durationOfBreak" />. Any attempt to execute this policy
+        /// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException" /> containing the exception or result
+        /// that broke the circuit.
+        /// </para>
+        /// <para>If the first action after the break duration period results in a handled exception or result, the circuit will break
+        /// again for another <paramref name="durationOfBreak" />; if no exception or handled result is encountered, the circuit will reset.
+        /// </para>
+        /// </summary>
+        /// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="failureThreshold">The failure threshold at which the circuit will break (a number between 0 and 1; eg 0.5 represents breaking if 50% or more of actions result in a handled failure.</param>
+        /// <param name="samplingDuration">The duration of the timeslice over which failure ratios are assessed.</param>
+        /// <param name="minimumThroughput">The minimum throughput: this many actions or more must pass through the circuit in the timeslice, for statistics to be considered significant and the circuit-breaker to come into action.</param>
+        /// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
+        /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open" /> state.</param>
+        /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed" /> state.</param>
+        /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen" /> state, ready to try action executions again.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
+        /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
+        /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
+        /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
+        /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+        /// <exception cref="ArgumentNullException">onBreak</exception>
+        /// <exception cref="ArgumentNullException">onReset</exception>
+        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+        /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+        public static CircuitBreakerPolicy<TResult> AdvancedCircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
+        {
             var resolutionOfCircuit = TimeSpan.FromTicks(AdvancedCircuitController<EmptyStruct>.ResolutionOfCircuitTimer);
 
             if (failureThreshold <= 0) throw new ArgumentOutOfRangeException("failureThreshold", "Value must be greater than zero.");
@@ -223,114 +264,5 @@ namespace Polly
                 breakerController
                 );
         }
-
-        // For v571onBreakDelegate : delete the overload above, and replace with the two below
-
-            ///// <summary>
-            ///// <para> Builds a <see cref="Policy" /> that will function like a Circuit Breaker.</para>
-            ///// <para>The circuit will break if, within any timeslice of duration <paramref name="samplingDuration" />, the proportion of actions resulting in a handled exception or result exceeds <paramref name="failureThreshold" />, provided also that the number of actions through the circuit in the timeslice is at least <paramref name="minimumThroughput" />. </para>
-            ///// <para>The circuit will stay broken for the <paramref name="durationOfBreak" />. Any attempt to execute this policy
-            ///// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException" /> containing the exception or result
-            ///// that broke the circuit.
-            ///// </para>
-            ///// <para>If the first action after the break duration period results in a handled exception or result, the circuit will break
-            ///// again for another <paramref name="durationOfBreak" />; if no exception or handled result is encountered, the circuit will reset.
-            ///// </para>
-            ///// </summary>
-            ///// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
-            ///// <param name="policyBuilder">The policy builder.</param>
-            ///// <param name="failureThreshold">The failure threshold at which the circuit will break (a number between 0 and 1; eg 0.5 represents breaking if 50% or more of actions result in a handled failure.</param>
-            ///// <param name="samplingDuration">The duration of the timeslice over which failure ratios are assessed.</param>
-            ///// <param name="minimumThroughput">The minimum throughput: this many actions or more must pass through the circuit in the timeslice, for statistics to be considered significant and the circuit-breaker to come into action.</param>
-            ///// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
-            ///// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open" /> state.</param>
-            ///// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed" /> state.</param>
-            ///// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen" /> state, ready to try action executions again.</param>
-            ///// <returns>The policy instance.</returns>
-            ///// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-            ///// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-            ///// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-            ///// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-            ///// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-            ///// <exception cref="ArgumentNullException">onBreak</exception>
-            ///// <exception cref="ArgumentNullException">onReset</exception>
-            ///// <exception cref="ArgumentNullException">onHalfOpen</exception>
-            ///// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
-            //public static CircuitBreakerPolicy<TResult> AdvancedCircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
-            //{
-            //    return policyBuilder.AdvancedCircuitBreaker(
-            //        failureThreshold, samplingDuration, minimumThroughput,
-            //        durationOfBreak,
-            //        (outcome, state, timespan, context) => onBreak(outcome, timespan, context),
-            //        onReset,
-            //        onHalfOpen
-            //    );
-            //}
-
-            ///// <summary>
-            ///// <para> Builds a <see cref="Policy" /> that will function like a Circuit Breaker.</para>
-            ///// <para>The circuit will break if, within any timeslice of duration <paramref name="samplingDuration" />, the proportion of actions resulting in a handled exception or result exceeds <paramref name="failureThreshold" />, provided also that the number of actions through the circuit in the timeslice is at least <paramref name="minimumThroughput" />. </para>
-            ///// <para>The circuit will stay broken for the <paramref name="durationOfBreak" />. Any attempt to execute this policy
-            ///// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException" /> containing the exception or result
-            ///// that broke the circuit.
-            ///// </para>
-            ///// <para>If the first action after the break duration period results in a handled exception or result, the circuit will break
-            ///// again for another <paramref name="durationOfBreak" />; if no exception or handled result is encountered, the circuit will reset.
-            ///// </para>
-            ///// </summary>
-            ///// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
-            ///// <param name="policyBuilder">The policy builder.</param>
-            ///// <param name="failureThreshold">The failure threshold at which the circuit will break (a number between 0 and 1; eg 0.5 represents breaking if 50% or more of actions result in a handled failure.</param>
-            ///// <param name="samplingDuration">The duration of the timeslice over which failure ratios are assessed.</param>
-            ///// <param name="minimumThroughput">The minimum throughput: this many actions or more must pass through the circuit in the timeslice, for statistics to be considered significant and the circuit-breaker to come into action.</param>
-            ///// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
-            ///// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open" /> state.</param>
-            ///// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed" /> state.</param>
-            ///// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen" /> state, ready to try action executions again.</param>
-            ///// <returns>The policy instance.</returns>
-            ///// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-            ///// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-            ///// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-            ///// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-            ///// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-            ///// <exception cref="ArgumentNullException">onBreak</exception>
-            ///// <exception cref="ArgumentNullException">onReset</exception>
-            ///// <exception cref="ArgumentNullException">onHalfOpen</exception>
-            ///// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
-            //public static CircuitBreakerPolicy<TResult> AdvancedCircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
-            //{
-            //    var resolutionOfCircuit = TimeSpan.FromTicks(AdvancedCircuitController<EmptyStruct>.ResolutionOfCircuitTimer);
-
-            //    if (failureThreshold <= 0) throw new ArgumentOutOfRangeException("failureThreshold", "Value must be greater than zero.");
-            //    if (failureThreshold > 1) throw new ArgumentOutOfRangeException("failureThreshold", "Value must be less than or equal to one.");
-            //    if (samplingDuration < resolutionOfCircuit) throw new ArgumentOutOfRangeException("samplingDuration", String.Format("Value must be equal to or greater than {0} milliseconds. This is the minimum resolution of the CircuitBreaker timer.", resolutionOfCircuit.TotalMilliseconds));
-            //    if (minimumThroughput <= 1) throw new ArgumentOutOfRangeException("minimumThroughput", "Value must be greater than one.");
-            //    if (durationOfBreak < TimeSpan.Zero) throw new ArgumentOutOfRangeException("durationOfBreak", "Value must be greater than zero.");
-
-            //    if (onBreak == null) throw new ArgumentNullException("onBreak");
-            //    if (onReset == null) throw new ArgumentNullException("onReset");
-            //    if (onHalfOpen == null) throw new ArgumentNullException("onHalfOpen");
-
-            //    var breakerController = new AdvancedCircuitController<TResult>(
-            //        failureThreshold,
-            //        samplingDuration,
-            //        minimumThroughput,
-            //        durationOfBreak,
-            //        onBreak,
-            //        onReset,
-            //        onHalfOpen);
-            //    return new CircuitBreakerPolicy<TResult>(
-            //        (action, context, cancellationToken) => CircuitBreakerEngine.Implementation(
-            //            action,
-            //            context,
-            //            cancellationToken,
-            //            policyBuilder.ExceptionPredicates,
-            //            policyBuilder.ResultPredicates,
-            //            breakerController),
-            //        policyBuilder.ExceptionPredicates,
-            //        policyBuilder.ResultPredicates,
-            //        breakerController
-            //        );
-            //}
     }
 }

--- a/src/Polly.Shared/CircuitBreaker/AdvancedCircuitBreakerTResultSyntaxAsync.cs
+++ b/src/Polly.Shared/CircuitBreaker/AdvancedCircuitBreakerTResultSyntaxAsync.cs
@@ -194,6 +194,46 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static CircuitBreakerPolicy<TResult> AdvancedCircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
         {
+            return policyBuilder.AdvancedCircuitBreakerAsync(
+                failureThreshold, samplingDuration, minimumThroughput,
+                durationOfBreak,
+                (outcome, state, timespan, context) => onBreak(outcome, timespan, context),
+                onReset,
+                onHalfOpen
+            );
+        }
+
+        /// <summary>
+        /// <para> Builds a <see cref="Policy"/> that will function like a Circuit Breaker.</para>
+        /// <para>The circuit will break if, within any timeslice of duration <paramref name="samplingDuration"/>, the proportion of actions resulting in a handled exception exceeds <paramref name="failureThreshold"/>, provided also that the number of actions through the circuit in the timeslice is at least <paramref name="minimumThroughput" />. </para>
+        /// <para>The circuit will stay broken for the <paramref name="durationOfBreak" />. Any attempt to execute this policy
+        /// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException" /> containing the exception or result
+        /// that broke the circuit.
+        /// </para>
+        /// <para>If the first action after the break duration period results in a handled exception or result, the circuit will break
+        /// again for another <paramref name="durationOfBreak" />; if no exception or handled result is encountered, the circuit will reset.
+        /// </para>
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="failureThreshold">The failure threshold at which the circuit will break (a number between 0 and 1; eg 0.5 represents breaking if 50% or more of actions result in a handled failure.</param>
+        /// <param name="samplingDuration">The duration of the timeslice over which failure ratios are assessed.</param>
+        /// <param name="minimumThroughput">The minimum throughput: this many actions or more must pass through the circuit in the timeslice, for statistics to be considered significant and the circuit-breaker to come into action.</param>
+        /// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
+        /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
+        /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
+        /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
+        /// <returns>The policy instance.</returns>
+        /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
+        /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
+        /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
+        /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
+        /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+        /// <exception cref="ArgumentNullException">onBreak</exception>
+        /// <exception cref="ArgumentNullException">onReset</exception>
+        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+        public static CircuitBreakerPolicy<TResult> AdvancedCircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
+        {
             var resolutionOfCircuit = TimeSpan.FromTicks(AdvancedCircuitController<EmptyStruct>.ResolutionOfCircuitTimer);
 
             if (failureThreshold <= 0) throw new ArgumentOutOfRangeException("failureThreshold", "Value must be greater than zero.");
@@ -228,113 +268,5 @@ namespace Polly
                 breakerController
             );
         }
-
-        // For v571onBreakDelegate : delete the overload above, and replace with the two below
-
-        ///// <summary>
-        ///// <para> Builds a <see cref="Policy"/> that will function like a Circuit Breaker.</para>
-        ///// <para>The circuit will break if, within any timeslice of duration <paramref name="samplingDuration"/>, the proportion of actions resulting in a handled exception exceeds <paramref name="failureThreshold"/>, provided also that the number of actions through the circuit in the timeslice is at least <paramref name="minimumThroughput" />. </para>
-        ///// <para>The circuit will stay broken for the <paramref name="durationOfBreak" />. Any attempt to execute this policy
-        ///// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException" /> containing the exception or result
-        ///// that broke the circuit.
-        ///// </para>
-        ///// <para>If the first action after the break duration period results in a handled exception or result, the circuit will break
-        ///// again for another <paramref name="durationOfBreak" />; if no exception or handled result is encountered, the circuit will reset.
-        ///// </para>
-        ///// </summary>
-        ///// <param name="policyBuilder">The policy builder.</param>
-        ///// <param name="failureThreshold">The failure threshold at which the circuit will break (a number between 0 and 1; eg 0.5 represents breaking if 50% or more of actions result in a handled failure.</param>
-        ///// <param name="samplingDuration">The duration of the timeslice over which failure ratios are assessed.</param>
-        ///// <param name="minimumThroughput">The minimum throughput: this many actions or more must pass through the circuit in the timeslice, for statistics to be considered significant and the circuit-breaker to come into action.</param>
-        ///// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
-        ///// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
-        ///// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
-        ///// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
-        ///// <returns>The policy instance.</returns>
-        ///// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
-        ///// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-        ///// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-        ///// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-        ///// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-        ///// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-        ///// <exception cref="ArgumentNullException">onBreak</exception>
-        ///// <exception cref="ArgumentNullException">onReset</exception>
-        ///// <exception cref="ArgumentNullException">onHalfOpen</exception>
-        //public static CircuitBreakerPolicy<TResult> AdvancedCircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
-        //{
-        //    return policyBuilder.AdvancedCircuitBreakerAsync(
-        //        failureThreshold, samplingDuration, minimumThroughput,
-        //        durationOfBreak,
-        //        (outcome, state, timespan, context) => onBreak(outcome, timespan, context),
-        //        onReset,
-        //        onHalfOpen
-        //    );
-        //}
-
-        ///// <summary>
-        ///// <para> Builds a <see cref="Policy"/> that will function like a Circuit Breaker.</para>
-        ///// <para>The circuit will break if, within any timeslice of duration <paramref name="samplingDuration"/>, the proportion of actions resulting in a handled exception exceeds <paramref name="failureThreshold"/>, provided also that the number of actions through the circuit in the timeslice is at least <paramref name="minimumThroughput" />. </para>
-        ///// <para>The circuit will stay broken for the <paramref name="durationOfBreak" />. Any attempt to execute this policy
-        ///// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException" /> containing the exception or result
-        ///// that broke the circuit.
-        ///// </para>
-        ///// <para>If the first action after the break duration period results in a handled exception or result, the circuit will break
-        ///// again for another <paramref name="durationOfBreak" />; if no exception or handled result is encountered, the circuit will reset.
-        ///// </para>
-        ///// </summary>
-        ///// <param name="policyBuilder">The policy builder.</param>
-        ///// <param name="failureThreshold">The failure threshold at which the circuit will break (a number between 0 and 1; eg 0.5 represents breaking if 50% or more of actions result in a handled failure.</param>
-        ///// <param name="samplingDuration">The duration of the timeslice over which failure ratios are assessed.</param>
-        ///// <param name="minimumThroughput">The minimum throughput: this many actions or more must pass through the circuit in the timeslice, for statistics to be considered significant and the circuit-breaker to come into action.</param>
-        ///// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
-        ///// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
-        ///// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
-        ///// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
-        ///// <returns>The policy instance.</returns>
-        ///// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
-        ///// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-        ///// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-        ///// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-        ///// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-        ///// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-        ///// <exception cref="ArgumentNullException">onBreak</exception>
-        ///// <exception cref="ArgumentNullException">onReset</exception>
-        ///// <exception cref="ArgumentNullException">onHalfOpen</exception>
-        //public static CircuitBreakerPolicy<TResult> AdvancedCircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
-        //{
-        //    var resolutionOfCircuit = TimeSpan.FromTicks(AdvancedCircuitController<EmptyStruct>.ResolutionOfCircuitTimer);
-
-        //    if (failureThreshold <= 0) throw new ArgumentOutOfRangeException("failureThreshold", "Value must be greater than zero.");
-        //    if (failureThreshold > 1) throw new ArgumentOutOfRangeException("failureThreshold", "Value must be less than or equal to one.");
-        //    if (samplingDuration < resolutionOfCircuit) throw new ArgumentOutOfRangeException("samplingDuration", String.Format("Value must be equal to or greater than {0} milliseconds. This is the minimum resolution of the CircuitBreaker timer.", resolutionOfCircuit.TotalMilliseconds));
-        //    if (minimumThroughput <= 1) throw new ArgumentOutOfRangeException("minimumThroughput", "Value must be greater than one.");
-        //    if (durationOfBreak < TimeSpan.Zero) throw new ArgumentOutOfRangeException("durationOfBreak", "Value must be greater than zero.");
-
-        //    if (onBreak == null) throw new ArgumentNullException("onBreak");
-        //    if (onReset == null) throw new ArgumentNullException("onReset");
-        //    if (onHalfOpen == null) throw new ArgumentNullException("onHalfOpen");
-
-        //    var breakerController = new AdvancedCircuitController<TResult>(
-        //        failureThreshold,
-        //        samplingDuration,
-        //        minimumThroughput,
-        //        durationOfBreak,
-        //        onBreak,
-        //        onReset,
-        //        onHalfOpen);
-        //    return new CircuitBreakerPolicy<TResult>(
-        //        (action, context, cancellationToken, continueOnCapturedContext) => CircuitBreakerEngine.ImplementationAsync(
-        //            action,
-        //            context,
-        //            policyBuilder.ExceptionPredicates,
-        //            policyBuilder.ResultPredicates,
-        //            breakerController,
-        //            cancellationToken,
-        //            continueOnCapturedContext),
-        //        policyBuilder.ExceptionPredicates,
-        //        policyBuilder.ResultPredicates,
-        //        breakerController
-        //    );
-        //}
     }
 }

--- a/src/Polly.Shared/CircuitBreaker/AdvancedCircuitController.cs
+++ b/src/Polly.Shared/CircuitBreaker/AdvancedCircuitController.cs
@@ -17,7 +17,7 @@ namespace Polly.CircuitBreaker
             TimeSpan samplingDuration, 
             int minimumThroughput, 
             TimeSpan durationOfBreak, 
-            Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, 
+            Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> onBreak, 
             Action<Context> onReset, 
             Action onHalfOpen
             ) : base(durationOfBreak, onBreak, onReset, onHalfOpen)

--- a/src/Polly.Shared/CircuitBreaker/CircuitBreakerSyntax.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitBreakerSyntax.cs
@@ -168,6 +168,41 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static CircuitBreakerPolicy CircuitBreaker(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
         {
+            return policyBuilder.CircuitBreaker(
+                exceptionsAllowedBeforeBreaking,
+                durationOfBreak,
+                (exception, state, timespan, context) => onBreak(exception, timespan, context),
+                onReset,
+                onHalfOpen
+            );
+        }
+
+        /// <summary>
+        /// <para> Builds a <see cref="Policy"/> that will function like a Circuit Breaker.</para>
+        /// <para>The circuit will break if <paramref name="exceptionsAllowedBeforeBreaking"/>
+        /// exceptions that are handled by this policy are raised consecutively. </para>
+        /// <para>The circuit will stay broken for the <paramref name="durationOfBreak"/>. Any attempt to execute this policy
+        /// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException"/> containing the exception 
+        /// that broke the circuit.
+        /// </para>
+        /// <para>If the first action after the break duration period results in a handled exception, the circuit will break
+        /// again for another <paramref name="durationOfBreak"/>; if no exception is thrown, the circuit will reset.
+        /// </para>
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="exceptionsAllowedBeforeBreaking">The number of exceptions that are allowed before opening the circuit.</param>
+        /// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
+        /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
+        /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
+        /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
+        /// <returns>The policy instance.</returns>
+        /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+        /// <exception cref="System.ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
+        /// <exception cref="ArgumentNullException">onBreak</exception>
+        /// <exception cref="ArgumentNullException">onReset</exception>
+        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+        public static CircuitBreakerPolicy CircuitBreaker(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
+        {
             if (exceptionsAllowedBeforeBreaking <= 0) throw new ArgumentOutOfRangeException("exceptionsAllowedBeforeBreaking", "Value must be greater than zero.");
             if (durationOfBreak < TimeSpan.Zero) throw new ArgumentOutOfRangeException("durationOfBreak", "Value must be greater than zero.");
 
@@ -176,111 +211,22 @@ namespace Polly
             if (onHalfOpen == null) throw new ArgumentNullException("onHalfOpen");
 
             var breakerController = new ConsecutiveCountCircuitController<EmptyStruct>(
-                exceptionsAllowedBeforeBreaking, 
+                exceptionsAllowedBeforeBreaking,
                 durationOfBreak,
-                (outcome, timespan, context) => onBreak(outcome.Exception, timespan, context),
-                onReset, 
+                (outcome, state, timespan, context) => onBreak(outcome.Exception, state, timespan, context),
+                onReset,
                 onHalfOpen);
             return new CircuitBreakerPolicy(
                 (action, context, cancellationToken) => CircuitBreakerEngine.Implementation(
                     (ctx, ct) => { action(ctx, ct); return EmptyStruct.Instance; },
                     context,
                     cancellationToken,
-                    policyBuilder.ExceptionPredicates, 
-                    PredicateHelper<EmptyStruct>.EmptyResultPredicates, 
-                    breakerController), 
-                policyBuilder.ExceptionPredicates, 
+                    policyBuilder.ExceptionPredicates,
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
+                    breakerController),
+                policyBuilder.ExceptionPredicates,
                 breakerController
                 );
         }
-
-        // For v571onBreakDelegate : delete the overload above, and replace with the two below
-
-        ///// <summary>
-        ///// <para> Builds a <see cref="Policy"/> that will function like a Circuit Breaker.</para>
-        ///// <para>The circuit will break if <paramref name="exceptionsAllowedBeforeBreaking"/>
-        ///// exceptions that are handled by this policy are raised consecutively. </para>
-        ///// <para>The circuit will stay broken for the <paramref name="durationOfBreak"/>. Any attempt to execute this policy
-        ///// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException"/> containing the exception 
-        ///// that broke the circuit.
-        ///// </para>
-        ///// <para>If the first action after the break duration period results in a handled exception, the circuit will break
-        ///// again for another <paramref name="durationOfBreak"/>; if no exception is thrown, the circuit will reset.
-        ///// </para>
-        ///// </summary>
-        ///// <param name="policyBuilder">The policy builder.</param>
-        ///// <param name="exceptionsAllowedBeforeBreaking">The number of exceptions that are allowed before opening the circuit.</param>
-        ///// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
-        ///// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
-        ///// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
-        ///// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
-        ///// <returns>The policy instance.</returns>
-        ///// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
-        ///// <exception cref="System.ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        ///// <exception cref="ArgumentNullException">onBreak</exception>
-        ///// <exception cref="ArgumentNullException">onReset</exception>
-        ///// <exception cref="ArgumentNullException">onHalfOpen</exception>
-        //public static CircuitBreakerPolicy CircuitBreaker(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
-        //{
-        //    return policyBuilder.CircuitBreaker(
-        //        exceptionsAllowedBeforeBreaking,
-        //        durationOfBreak,
-        //        (exception, state, timespan, context) => onBreak(exception, timespan, context),
-        //        onReset,
-        //        onHalfOpen
-        //    );
-        //}
-
-        ///// <summary>
-        ///// <para> Builds a <see cref="Policy"/> that will function like a Circuit Breaker.</para>
-        ///// <para>The circuit will break if <paramref name="exceptionsAllowedBeforeBreaking"/>
-        ///// exceptions that are handled by this policy are raised consecutively. </para>
-        ///// <para>The circuit will stay broken for the <paramref name="durationOfBreak"/>. Any attempt to execute this policy
-        ///// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException"/> containing the exception 
-        ///// that broke the circuit.
-        ///// </para>
-        ///// <para>If the first action after the break duration period results in a handled exception, the circuit will break
-        ///// again for another <paramref name="durationOfBreak"/>; if no exception is thrown, the circuit will reset.
-        ///// </para>
-        ///// </summary>
-        ///// <param name="policyBuilder">The policy builder.</param>
-        ///// <param name="exceptionsAllowedBeforeBreaking">The number of exceptions that are allowed before opening the circuit.</param>
-        ///// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
-        ///// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
-        ///// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
-        ///// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
-        ///// <returns>The policy instance.</returns>
-        ///// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
-        ///// <exception cref="System.ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        ///// <exception cref="ArgumentNullException">onBreak</exception>
-        ///// <exception cref="ArgumentNullException">onReset</exception>
-        ///// <exception cref="ArgumentNullException">onHalfOpen</exception>
-        //public static CircuitBreakerPolicy CircuitBreaker(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
-        //{
-        //    if (exceptionsAllowedBeforeBreaking <= 0) throw new ArgumentOutOfRangeException("exceptionsAllowedBeforeBreaking", "Value must be greater than zero.");
-        //    if (durationOfBreak < TimeSpan.Zero) throw new ArgumentOutOfRangeException("durationOfBreak", "Value must be greater than zero.");
-
-        //    if (onBreak == null) throw new ArgumentNullException("onBreak");
-        //    if (onReset == null) throw new ArgumentNullException("onReset");
-        //    if (onHalfOpen == null) throw new ArgumentNullException("onHalfOpen");
-
-        //    var breakerController = new ConsecutiveCountCircuitController<EmptyStruct>(
-        //        exceptionsAllowedBeforeBreaking, 
-        //        durationOfBreak,
-        //        (outcome, state, timespan, context) => onBreak(outcome.Exception, state, timespan, context),
-        //        onReset, 
-        //        onHalfOpen);
-        //    return new CircuitBreakerPolicy(
-        //        (action, context, cancellationToken) => CircuitBreakerEngine.Implementation(
-        //            (ctx, ct) => { action(ctx, ct); return EmptyStruct.Instance; },
-        //            context,
-        //            cancellationToken,
-        //            policyBuilder.ExceptionPredicates, 
-        //            PredicateHelper<EmptyStruct>.EmptyResultPredicates, 
-        //            breakerController), 
-        //        policyBuilder.ExceptionPredicates, 
-        //        breakerController
-        //        );
-        //}
     }
 }

--- a/src/Polly.Shared/CircuitBreaker/CircuitBreakerSyntaxAsync.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitBreakerSyntaxAsync.cs
@@ -169,6 +169,41 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static CircuitBreakerPolicy CircuitBreakerAsync(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
         {
+            return policyBuilder.CircuitBreakerAsync(
+                exceptionsAllowedBeforeBreaking,
+                durationOfBreak,
+                (exception, state, timespan, context) => onBreak(exception, timespan, context),
+                onReset,
+                onHalfOpen
+            );
+        }
+
+        /// <summary>
+        /// <para> Builds a <see cref="Policy"/> that will function like a Circuit Breaker.</para>
+        /// <para>The circuit will break if <paramref name="exceptionsAllowedBeforeBreaking"/>
+        /// exceptions that are handled by this policy are raised consecutively. </para>
+        /// <para>The circuit will stay broken for the <paramref name="durationOfBreak"/>. Any attempt to execute this policy
+        /// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException"/> containing the exception 
+        /// that broke the circuit.
+        /// </para>
+        /// <para>If the first action after the break duration period results in a handled exception, the circuit will break
+        /// again for another <paramref name="durationOfBreak"/>; if no exception is thrown, the circuit will reset.
+        /// </para>
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="exceptionsAllowedBeforeBreaking">The number of exceptions that are allowed before opening the circuit.</param>
+        /// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
+        /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
+        /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
+        /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
+        /// <returns>The policy instance.</returns>
+        /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+        /// <exception cref="System.ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
+        /// <exception cref="ArgumentNullException">onBreak</exception>
+        /// <exception cref="ArgumentNullException">onReset</exception>
+        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+        public static CircuitBreakerPolicy CircuitBreakerAsync(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
+        {
             if (exceptionsAllowedBeforeBreaking <= 0) throw new ArgumentOutOfRangeException("exceptionsAllowedBeforeBreaking", "Value must be greater than zero.");
             if (durationOfBreak < TimeSpan.Zero) throw new ArgumentOutOfRangeException("durationOfBreak", "Value must be greater than zero.");
 
@@ -177,116 +212,25 @@ namespace Polly
             if (onHalfOpen == null) throw new ArgumentNullException("onHalfOpen");
 
             var breakerController = new ConsecutiveCountCircuitController<EmptyStruct>(
-                exceptionsAllowedBeforeBreaking, 
+                exceptionsAllowedBeforeBreaking,
                 durationOfBreak,
-                (outcome, timespan, context) => onBreak(outcome.Exception, timespan, context),
-                onReset, 
+                (outcome, state, timespan, context) => onBreak(outcome.Exception, state, timespan, context),
+                onReset,
                 onHalfOpen);
             return new CircuitBreakerPolicy(
-                (action, context, cancellationToken, continueOnCapturedContext) => 
+                (action, context, cancellationToken, continueOnCapturedContext) =>
                   CircuitBreakerEngine.ImplementationAsync(
                     async (ctx, ct) => { await action(ctx, ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
-                      context, 
-                      policyBuilder.ExceptionPredicates, 
-                      PredicateHelper<EmptyStruct>.EmptyResultPredicates, 
-                      breakerController, 
-                      cancellationToken, 
+                      context,
+                      policyBuilder.ExceptionPredicates,
+                      PredicateHelper<EmptyStruct>.EmptyResultPredicates,
+                      breakerController,
+                      cancellationToken,
                       continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates,
                 breakerController
             );
         }
-
-        // For v571onBreakDelegate : delete the overload above, and replace with the two below
-
-        ///// <summary>
-        ///// <para> Builds a <see cref="Policy"/> that will function like a Circuit Breaker.</para>
-        ///// <para>The circuit will break if <paramref name="exceptionsAllowedBeforeBreaking"/>
-        ///// exceptions that are handled by this policy are raised consecutively. </para>
-        ///// <para>The circuit will stay broken for the <paramref name="durationOfBreak"/>. Any attempt to execute this policy
-        ///// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException"/> containing the exception 
-        ///// that broke the circuit.
-        ///// </para>
-        ///// <para>If the first action after the break duration period results in a handled exception, the circuit will break
-        ///// again for another <paramref name="durationOfBreak"/>; if no exception is thrown, the circuit will reset.
-        ///// </para>
-        ///// </summary>
-        ///// <param name="policyBuilder">The policy builder.</param>
-        ///// <param name="exceptionsAllowedBeforeBreaking">The number of exceptions that are allowed before opening the circuit.</param>
-        ///// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
-        ///// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
-        ///// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
-        ///// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
-        ///// <returns>The policy instance.</returns>
-        ///// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
-        ///// <exception cref="System.ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        ///// <exception cref="ArgumentNullException">onBreak</exception>
-        ///// <exception cref="ArgumentNullException">onReset</exception>
-        ///// <exception cref="ArgumentNullException">onHalfOpen</exception>
-        //public static CircuitBreakerPolicy CircuitBreakerAsync(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
-        //{
-        //    return policyBuilder.CircuitBreakerAsync(
-        //        exceptionsAllowedBeforeBreaking,
-        //        durationOfBreak,
-        //        (exception, state, timespan, context) => onBreak(exception, timespan, context),
-        //        onReset,
-        //        onHalfOpen
-        //    );
-        //}
-
-        ///// <summary>
-        ///// <para> Builds a <see cref="Policy"/> that will function like a Circuit Breaker.</para>
-        ///// <para>The circuit will break if <paramref name="exceptionsAllowedBeforeBreaking"/>
-        ///// exceptions that are handled by this policy are raised consecutively. </para>
-        ///// <para>The circuit will stay broken for the <paramref name="durationOfBreak"/>. Any attempt to execute this policy
-        ///// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException"/> containing the exception 
-        ///// that broke the circuit.
-        ///// </para>
-        ///// <para>If the first action after the break duration period results in a handled exception, the circuit will break
-        ///// again for another <paramref name="durationOfBreak"/>; if no exception is thrown, the circuit will reset.
-        ///// </para>
-        ///// </summary>
-        ///// <param name="policyBuilder">The policy builder.</param>
-        ///// <param name="exceptionsAllowedBeforeBreaking">The number of exceptions that are allowed before opening the circuit.</param>
-        ///// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
-        ///// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
-        ///// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
-        ///// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
-        ///// <returns>The policy instance.</returns>
-        ///// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
-        ///// <exception cref="System.ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        ///// <exception cref="ArgumentNullException">onBreak</exception>
-        ///// <exception cref="ArgumentNullException">onReset</exception>
-        ///// <exception cref="ArgumentNullException">onHalfOpen</exception>
-        //public static CircuitBreakerPolicy CircuitBreakerAsync(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
-        //{
-        //    if (exceptionsAllowedBeforeBreaking <= 0) throw new ArgumentOutOfRangeException("exceptionsAllowedBeforeBreaking", "Value must be greater than zero.");
-        //    if (durationOfBreak < TimeSpan.Zero) throw new ArgumentOutOfRangeException("durationOfBreak", "Value must be greater than zero.");
-
-        //    if (onBreak == null) throw new ArgumentNullException("onBreak");
-        //    if (onReset == null) throw new ArgumentNullException("onReset");
-        //    if (onHalfOpen == null) throw new ArgumentNullException("onHalfOpen");
-
-        //    var breakerController = new ConsecutiveCountCircuitController<EmptyStruct>(
-        //        exceptionsAllowedBeforeBreaking, 
-        //        durationOfBreak,
-        //        (outcome, state, timespan, context) => onBreak(outcome.Exception, state, timespan, context),
-        //        onReset, 
-        //        onHalfOpen);
-        //    return new CircuitBreakerPolicy(
-        //        (action, context, cancellationToken, continueOnCapturedContext) => 
-        //          CircuitBreakerEngine.ImplementationAsync(
-        //            async (ctx, ct) => { await action(ctx, ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
-        //              context, 
-        //              policyBuilder.ExceptionPredicates, 
-        //              PredicateHelper<EmptyStruct>.EmptyResultPredicates, 
-        //              breakerController, 
-        //              cancellationToken, 
-        //              continueOnCapturedContext),
-        //        policyBuilder.ExceptionPredicates,
-        //        breakerController
-        //    );
-        //}
     }
 }
 

--- a/src/Polly.Shared/CircuitBreaker/CircuitBreakerTResultSyntax.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitBreakerTResultSyntax.cs
@@ -166,6 +166,41 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static CircuitBreakerPolicy<TResult> CircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
         {
+            return policyBuilder.CircuitBreaker(
+                handledEventsAllowedBeforeBreaking,
+                durationOfBreak,
+                (outcome, state, timespan, context) => onBreak(outcome, timespan, context),
+                onReset,
+                onHalfOpen
+            );
+        }
+
+        /// <summary>
+        /// <para> Builds a <see cref="Policy"/> that will function like a Circuit Breaker.</para>
+        /// <para>The circuit will break if <paramref name="handledEventsAllowedBeforeBreaking"/>
+        /// exceptions or results that are handled by this policy are encountered consecutively. </para>
+        /// <para>The circuit will stay broken for the <paramref name="durationOfBreak"/>. Any attempt to execute this policy
+        /// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException"/> containing the exception or result 
+        /// that broke the circuit.
+        /// </para>
+        /// <para>If the first action after the break duration period results in a handled exception or result, the circuit will break
+        /// again for another <paramref name="durationOfBreak"/>; if no exception or handled result is encountered, the circuit will reset.
+        /// </para>
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="handledEventsAllowedBeforeBreaking">The number of exceptions or handled results that are allowed before opening the circuit.</param>
+        /// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
+        /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
+        /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
+        /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
+        /// <returns>The policy instance.</returns>
+        /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+        /// <exception cref="System.ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
+        /// <exception cref="ArgumentNullException">onBreak</exception>
+        /// <exception cref="ArgumentNullException">onReset</exception>
+        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+        public static CircuitBreakerPolicy<TResult> CircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
+        {
             if (handledEventsAllowedBeforeBreaking <= 0) throw new ArgumentOutOfRangeException("handledEventsAllowedBeforeBreaking", "Value must be greater than zero.");
             if (durationOfBreak < TimeSpan.Zero) throw new ArgumentOutOfRangeException("durationOfBreak", "Value must be greater than zero.");
 
@@ -192,95 +227,5 @@ namespace Polly
                 breakerController
                 );
         }
-
-        // For v571onBreakDelegate : delete the overload above, and replace with the two below
-
-        ///// <summary>
-        ///// <para> Builds a <see cref="Policy"/> that will function like a Circuit Breaker.</para>
-        ///// <para>The circuit will break if <paramref name="handledEventsAllowedBeforeBreaking"/>
-        ///// exceptions or results that are handled by this policy are encountered consecutively. </para>
-        ///// <para>The circuit will stay broken for the <paramref name="durationOfBreak"/>. Any attempt to execute this policy
-        ///// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException"/> containing the exception or result 
-        ///// that broke the circuit.
-        ///// </para>
-        ///// <para>If the first action after the break duration period results in a handled exception or result, the circuit will break
-        ///// again for another <paramref name="durationOfBreak"/>; if no exception or handled result is encountered, the circuit will reset.
-        ///// </para>
-        ///// </summary>
-        ///// <param name="policyBuilder">The policy builder.</param>
-        ///// <param name="handledEventsAllowedBeforeBreaking">The number of exceptions or handled results that are allowed before opening the circuit.</param>
-        ///// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
-        ///// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
-        ///// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
-        ///// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
-        ///// <returns>The policy instance.</returns>
-        ///// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
-        ///// <exception cref="System.ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        ///// <exception cref="ArgumentNullException">onBreak</exception>
-        ///// <exception cref="ArgumentNullException">onReset</exception>
-        ///// <exception cref="ArgumentNullException">onHalfOpen</exception>
-        //public static CircuitBreakerPolicy<TResult> CircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
-        //{
-        //    return policyBuilder.CircuitBreaker(
-        //        handledEventsAllowedBeforeBreaking,
-        //        durationOfBreak,
-        //        (outcome, state, timespan, context) => onBreak(outcome, timespan, context),
-        //        onReset,
-        //        onHalfOpen
-        //    );
-        //}
-
-        ///// <summary>
-        ///// <para> Builds a <see cref="Policy"/> that will function like a Circuit Breaker.</para>
-        ///// <para>The circuit will break if <paramref name="handledEventsAllowedBeforeBreaking"/>
-        ///// exceptions or results that are handled by this policy are encountered consecutively. </para>
-        ///// <para>The circuit will stay broken for the <paramref name="durationOfBreak"/>. Any attempt to execute this policy
-        ///// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException"/> containing the exception or result 
-        ///// that broke the circuit.
-        ///// </para>
-        ///// <para>If the first action after the break duration period results in a handled exception or result, the circuit will break
-        ///// again for another <paramref name="durationOfBreak"/>; if no exception or handled result is encountered, the circuit will reset.
-        ///// </para>
-        ///// </summary>
-        ///// <param name="policyBuilder">The policy builder.</param>
-        ///// <param name="handledEventsAllowedBeforeBreaking">The number of exceptions or handled results that are allowed before opening the circuit.</param>
-        ///// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
-        ///// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
-        ///// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
-        ///// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
-        ///// <returns>The policy instance.</returns>
-        ///// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
-        ///// <exception cref="System.ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        ///// <exception cref="ArgumentNullException">onBreak</exception>
-        ///// <exception cref="ArgumentNullException">onReset</exception>
-        ///// <exception cref="ArgumentNullException">onHalfOpen</exception>
-        //public static CircuitBreakerPolicy<TResult> CircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
-        //{
-        //    if (handledEventsAllowedBeforeBreaking <= 0) throw new ArgumentOutOfRangeException("handledEventsAllowedBeforeBreaking", "Value must be greater than zero.");
-        //    if (durationOfBreak < TimeSpan.Zero) throw new ArgumentOutOfRangeException("durationOfBreak", "Value must be greater than zero.");
-
-        //    if (onBreak == null) throw new ArgumentNullException("onBreak");
-        //    if (onReset == null) throw new ArgumentNullException("onReset");
-        //    if (onHalfOpen == null) throw new ArgumentNullException("onHalfOpen");
-
-        //    ICircuitController<TResult> breakerController = new ConsecutiveCountCircuitController<TResult>(
-        //        handledEventsAllowedBeforeBreaking,
-        //        durationOfBreak,
-        //        onBreak,
-        //        onReset,
-        //        onHalfOpen);
-        //    return new CircuitBreakerPolicy<TResult>(
-        //        (action, context, cancellationToken) => CircuitBreakerEngine.Implementation(
-        //            action,
-        //            context,
-        //            cancellationToken,
-        //            policyBuilder.ExceptionPredicates,
-        //            policyBuilder.ResultPredicates,
-        //            breakerController),
-        //        policyBuilder.ExceptionPredicates,
-        //        policyBuilder.ResultPredicates,
-        //        breakerController
-        //        );
-        //}
     }
 }

--- a/src/Polly.Shared/CircuitBreaker/CircuitBreakerTResultSyntaxAsync.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitBreakerTResultSyntaxAsync.cs
@@ -169,6 +169,41 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static CircuitBreakerPolicy<TResult> CircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
         {
+            return policyBuilder.CircuitBreakerAsync(
+                handledEventsAllowedBeforeBreaking,
+                durationOfBreak,
+                (outcome, state, timespan, context) => onBreak(outcome, timespan, context),
+                onReset,
+                onHalfOpen
+            );
+        }
+
+        /// <summary>
+        /// <para> Builds a <see cref="Policy"/> that will function like a Circuit Breaker.</para>
+        /// <para>The circuit will break if <paramref name="handledEventsAllowedBeforeBreaking"/>
+        /// exceptions or results that are handled by this policy are encountered consecutively. </para>
+        /// <para>The circuit will stay broken for the <paramref name="durationOfBreak"/>. Any attempt to execute this policy
+        /// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException"/> containing the exception or result 
+        /// that broke the circuit.
+        /// </para>
+        /// <para>If the first action after the break duration period results in a handled exception or result, the circuit will break
+        /// again for another <paramref name="durationOfBreak"/>; if no exception or handled result is encountered, the circuit will reset.
+        /// </para>
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="handledEventsAllowedBeforeBreaking">The number of exceptions or handled results that are allowed before opening the circuit.</param>
+        /// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
+        /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
+        /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
+        /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
+        /// <returns>The policy instance.</returns>
+        /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+        /// <exception cref="System.ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
+        /// <exception cref="ArgumentNullException">onBreak</exception>
+        /// <exception cref="ArgumentNullException">onReset</exception>
+        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+        public static CircuitBreakerPolicy<TResult> CircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
+        {
             if (handledEventsAllowedBeforeBreaking <= 0) throw new ArgumentOutOfRangeException("handledEventsAllowedBeforeBreaking", "Value must be greater than zero.");
             if (durationOfBreak < TimeSpan.Zero) throw new ArgumentOutOfRangeException("durationOfBreak", "Value must be greater than zero.");
 
@@ -177,118 +212,26 @@ namespace Polly
             if (onHalfOpen == null) throw new ArgumentNullException("onHalfOpen");
 
             var breakerController = new ConsecutiveCountCircuitController<TResult>(
-                handledEventsAllowedBeforeBreaking, 
+                handledEventsAllowedBeforeBreaking,
                 durationOfBreak,
                 onBreak,
-                onReset, 
+                onReset,
                 onHalfOpen);
             return new CircuitBreakerPolicy<TResult>(
-                (action, context, cancellationToken, continueOnCapturedContext) => 
+                (action, context, cancellationToken, continueOnCapturedContext) =>
                   CircuitBreakerEngine.ImplementationAsync(
                       action,
-                      context, 
-                      policyBuilder.ExceptionPredicates, 
-                      policyBuilder.ResultPredicates, 
-                      breakerController, 
-                      cancellationToken, 
+                      context,
+                      policyBuilder.ExceptionPredicates,
+                      policyBuilder.ResultPredicates,
+                      breakerController,
+                      cancellationToken,
                       continueOnCapturedContext),
                 policyBuilder.ExceptionPredicates,
                 policyBuilder.ResultPredicates,
                 breakerController
             );
         }
-
-        // For v571onBreakDelegate : delete the overload above, and replace with the two below
-
-        ///// <summary>
-        ///// <para> Builds a <see cref="Policy"/> that will function like a Circuit Breaker.</para>
-        ///// <para>The circuit will break if <paramref name="handledEventsAllowedBeforeBreaking"/>
-        ///// exceptions or results that are handled by this policy are encountered consecutively. </para>
-        ///// <para>The circuit will stay broken for the <paramref name="durationOfBreak"/>. Any attempt to execute this policy
-        ///// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException"/> containing the exception or result 
-        ///// that broke the circuit.
-        ///// </para>
-        ///// <para>If the first action after the break duration period results in a handled exception or result, the circuit will break
-        ///// again for another <paramref name="durationOfBreak"/>; if no exception or handled result is encountered, the circuit will reset.
-        ///// </para>
-        ///// </summary>
-        ///// <param name="policyBuilder">The policy builder.</param>
-        ///// <param name="handledEventsAllowedBeforeBreaking">The number of exceptions or handled results that are allowed before opening the circuit.</param>
-        ///// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
-        ///// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
-        ///// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
-        ///// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
-        ///// <returns>The policy instance.</returns>
-        ///// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
-        ///// <exception cref="System.ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        ///// <exception cref="ArgumentNullException">onBreak</exception>
-        ///// <exception cref="ArgumentNullException">onReset</exception>
-        ///// <exception cref="ArgumentNullException">onHalfOpen</exception>
-        //public static CircuitBreakerPolicy<TResult> CircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
-        //{
-        //    return policyBuilder.CircuitBreakerAsync(
-        //        handledEventsAllowedBeforeBreaking,
-        //        durationOfBreak,
-        //        (outcome, state, timespan, context) => onBreak(outcome, timespan, context),
-        //        onReset,
-        //        onHalfOpen
-        //    );
-        //}
-
-        ///// <summary>
-        ///// <para> Builds a <see cref="Policy"/> that will function like a Circuit Breaker.</para>
-        ///// <para>The circuit will break if <paramref name="handledEventsAllowedBeforeBreaking"/>
-        ///// exceptions or results that are handled by this policy are encountered consecutively. </para>
-        ///// <para>The circuit will stay broken for the <paramref name="durationOfBreak"/>. Any attempt to execute this policy
-        ///// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException"/> containing the exception or result 
-        ///// that broke the circuit.
-        ///// </para>
-        ///// <para>If the first action after the break duration period results in a handled exception or result, the circuit will break
-        ///// again for another <paramref name="durationOfBreak"/>; if no exception or handled result is encountered, the circuit will reset.
-        ///// </para>
-        ///// </summary>
-        ///// <param name="policyBuilder">The policy builder.</param>
-        ///// <param name="handledEventsAllowedBeforeBreaking">The number of exceptions or handled results that are allowed before opening the circuit.</param>
-        ///// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
-        ///// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
-        ///// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
-        ///// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
-        ///// <returns>The policy instance.</returns>
-        ///// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
-        ///// <exception cref="System.ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        ///// <exception cref="ArgumentNullException">onBreak</exception>
-        ///// <exception cref="ArgumentNullException">onReset</exception>
-        ///// <exception cref="ArgumentNullException">onHalfOpen</exception>
-        //public static CircuitBreakerPolicy<TResult> CircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
-        //{
-        //    if (handledEventsAllowedBeforeBreaking <= 0) throw new ArgumentOutOfRangeException("handledEventsAllowedBeforeBreaking", "Value must be greater than zero.");
-        //    if (durationOfBreak < TimeSpan.Zero) throw new ArgumentOutOfRangeException("durationOfBreak", "Value must be greater than zero.");
-
-        //    if (onBreak == null) throw new ArgumentNullException("onBreak");
-        //    if (onReset == null) throw new ArgumentNullException("onReset");
-        //    if (onHalfOpen == null) throw new ArgumentNullException("onHalfOpen");
-
-        //    var breakerController = new ConsecutiveCountCircuitController<TResult>(
-        //        handledEventsAllowedBeforeBreaking, 
-        //        durationOfBreak,
-        //        onBreak,
-        //        onReset, 
-        //        onHalfOpen);
-        //    return new CircuitBreakerPolicy<TResult>(
-        //        (action, context, cancellationToken, continueOnCapturedContext) => 
-        //          CircuitBreakerEngine.ImplementationAsync(
-        //              action,
-        //              context, 
-        //              policyBuilder.ExceptionPredicates, 
-        //              policyBuilder.ResultPredicates, 
-        //              breakerController, 
-        //              cancellationToken, 
-        //              continueOnCapturedContext),
-        //        policyBuilder.ExceptionPredicates,
-        //        policyBuilder.ResultPredicates,
-        //        breakerController
-        //    );
-        //}
     }
 }
 

--- a/src/Polly.Shared/CircuitBreaker/CircuitStateController.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitStateController.cs
@@ -11,7 +11,7 @@ namespace Polly.CircuitBreaker
         protected CircuitState _circuitState;
         protected DelegateResult<TResult> _lastOutcome;
 
-        protected readonly Action<DelegateResult<TResult>, TimeSpan, Context> _onBreak;
+        protected readonly Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> _onBreak;
         protected readonly Action<Context> _onReset;
         protected readonly Action _onHalfOpen;
 
@@ -19,7 +19,7 @@ namespace Polly.CircuitBreaker
 
         protected CircuitStateController(
             TimeSpan durationOfBreak, 
-            Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, 
+            Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> onBreak, 
             Action<Context> onReset, 
             Action onHalfOpen)
         {
@@ -105,9 +105,11 @@ namespace Polly.CircuitBreaker
             _blockedTill = willDurationTakeUsPastDateTimeMaxValue
                 ? DateTime.MaxValue.Ticks
                 : (SystemClock.UtcNow() + durationOfBreak).Ticks;
+
+            var transitionedState = _circuitState;
             _circuitState = CircuitState.Open;
 
-            _onBreak(_lastOutcome, durationOfBreak, context);
+            _onBreak(_lastOutcome, transitionedState, durationOfBreak, context);
         }
 
         public void Reset()

--- a/src/Polly.Shared/CircuitBreaker/ConsecutiveCountCircuitController.cs
+++ b/src/Polly.Shared/CircuitBreaker/ConsecutiveCountCircuitController.cs
@@ -11,7 +11,7 @@ namespace Polly.CircuitBreaker
         public ConsecutiveCountCircuitController(
             int exceptionsAllowedBeforeBreaking, 
             TimeSpan durationOfBreak, 
-            Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, 
+            Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> onBreak, 
             Action<Context> onReset, 
             Action onHalfOpen
             ) : base(durationOfBreak, onBreak, onReset, onHalfOpen)

--- a/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/CircuitBreaker/CircuitBreakerAsyncSpecs.cs
@@ -1051,6 +1051,76 @@ namespace Polly.Specs.CircuitBreaker
         }
 
         [Fact]
+        public void Should_call_onbreak_with_a_state_of_closed()
+        {
+            CircuitState? transitionedState = null;
+
+            Action<Exception, CircuitState, TimeSpan, Context> onBreak = (_, state, __, ___) => { transitionedState = state; };
+            Action<Context> onReset = _ => { };
+            Action onHalfOpen = () => { };
+
+            CircuitBreakerPolicy breaker = Policy
+                .Handle<DivideByZeroException>()
+                .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset, onHalfOpen);
+
+            breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
+                  .ShouldThrow<DivideByZeroException>();
+            breaker.CircuitState.Should().Be(CircuitState.Closed);
+
+            breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
+                  .ShouldThrow<DivideByZeroException>();
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+
+            transitionedState?.Should().Be(CircuitState.Closed);
+        }
+
+        [Fact]
+        public void Should_call_onbreak_with_a_state_of_half_open()
+        {
+            List<CircuitState> transitionedStates = new List<CircuitState>();
+
+            Action<Exception, CircuitState, TimeSpan, Context> onBreak = (_, state, __, ___) => { transitionedStates.Add(state); };
+            Action<Context> onReset = _ => { };
+            Action onHalfOpen = () => { };
+
+            var time = 1.January(2000);
+            SystemClock.UtcNow = () => time;
+
+            var durationOfBreak = TimeSpan.FromMinutes(1);
+
+            CircuitBreakerPolicy breaker = Policy
+                            .Handle<DivideByZeroException>()
+                            .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset, onHalfOpen);
+
+            breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
+                  .ShouldThrow<DivideByZeroException>();
+            breaker.CircuitState.Should().Be(CircuitState.Closed);
+
+            breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
+                  .ShouldThrow<DivideByZeroException>();
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+
+            // 2 exception raised, circuit is now open
+            breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
+                  .ShouldThrow<BrokenCircuitException>();
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+
+            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+
+            // duration has passed, circuit now half open
+            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+            // first call after duration raises an exception, so circuit should break again
+            breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
+                  .ShouldThrow<DivideByZeroException>();
+            breaker.CircuitState.Should().Be(CircuitState.Open);
+            breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
+                  .ShouldThrow<BrokenCircuitException>();
+
+            transitionedStates[0].Should().Be(CircuitState.Closed);
+            transitionedStates[1].Should().Be(CircuitState.HalfOpen);
+        }
+
+        [Fact]
         public void Should_rethrow_and_call_onbreak_with_the_last_raised_exception_unwrapped_if_matched_as_inner()
         {
             Exception passedException = null;

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -15,6 +15,10 @@
     <releaseNotes>
      v5.0 is a major release with significant new resilience policies: Timeout; Bulkhead Isolation; Fallback; Cache; and PolicyWrap.  See release notes back to v5.0.0 for full details.
 
+     5.7.1
+     ---------------------
+     - Add a new onBreak overload that provides the prior state on a transition to an open state
+      
      5.7.0
      ---------------------
      - Minor cache fixes


### PR DESCRIPTION
- Add a new delegate type that provides the previous transition state when the policy transitions to open
- new unit tests were provided for the advanced, basic / async, non-async circuit 
- All unit tests were run for all versions of the software 