### PR TITLE
#403 - RelativeTtl is relative to the time the TTL is requested

### DIFF
--- a/src/Polly.Shared/Caching/RelativeTtl.cs
+++ b/src/Polly.Shared/Caching/RelativeTtl.cs
@@ -1,30 +1,34 @@
 ﻿using System;
-using Polly.Utilities;
 
 namespace Polly.Caching
 {
     /// <summary>
-    /// Defines a ttl strategy which will cache items until the specified point-in-time.
+    /// Defines a ttl strategy which will cache items for the specified time.
     /// </summary>
-    public class RelativeTtl : NonSlidingTtl
+    public class RelativeTtl : ITtlStrategy
     {
-        private static readonly TimeSpan DateTimeOffSetMaxTimeSpan = DateTimeOffset.MaxValue.Subtract(DateTimeOffset.MinValue);
+        private readonly TimeSpan ttl;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RelativeTtl"/> class.
         /// </summary>
         /// <param name="ttl">The timespan for which to consider the cache item valid.</param>
-        public RelativeTtl(TimeSpan ttl) : base(
-            ttl < TimeSpan.Zero ? throw new ArgumentOutOfRangeException(nameof(ttl), "The ttl for items to cache must be greater than zero.")
-            : 
-            ttl == TimeSpan.MaxValue ? DateTimeOffset.MaxValue
-            : 
-            ttl >= DateTimeOffSetMaxTimeSpan ? DateTimeOffset.MaxValue 
-            : 
-            SystemClock.DateTimeOffsetUtcNow() > DateTimeOffset.MaxValue.Subtract(ttl) ? DateTimeOffset.MaxValue  
-            :
-            SystemClock.DateTimeOffsetUtcNow().Add(ttl))
+        public RelativeTtl(TimeSpan ttl)
         {
+            if (ttl < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(ttl), "The ttl for items to cache must be greater than zero.");
+
+            this.ttl = ttl;
+        }
+
+        /// <summary>
+        /// Gets a TTL for a cacheable item, given the current execution context.
+        /// </summary>
+        /// <param name="context">The execution context.</param>
+        /// <param name="result">The execution result.</param>
+        /// <returns>A <see cref="Ttl"/> representing the remaining Ttl of the cached item.</returns>
+        public Ttl GetTtl(Context context, object result)
+        {
+            return new Ttl(ttl);
         }
     }
 }

--- a/src/Polly.SharedSpecs/Caching/RelativeTtlSpecs.cs
+++ b/src/Polly.SharedSpecs/Caching/RelativeTtlSpecs.cs
@@ -1,8 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using FluentAssertions;
 using Polly.Caching;
+using Polly.Utilities;
 using Xunit;
 
 namespace Polly.Specs.Caching
@@ -39,6 +38,22 @@ namespace Polly.Specs.Caching
             TimeSpan ttl = TimeSpan.FromSeconds(30);
 
             RelativeTtl ttlStrategy = new RelativeTtl(ttl);
+
+            Ttl retrieved = ttlStrategy.GetTtl(new Context("someExecutionKey"), null);
+            retrieved.Timespan.Should().BeCloseTo(ttl);
+            retrieved.SlidingExpiration.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Should_return_configured_timespan_from_time_requested()
+        {
+            DateTimeOffset fixedTime = SystemClock.DateTimeOffsetUtcNow();
+            TimeSpan ttl = TimeSpan.FromSeconds(30);
+            TimeSpan delay = TimeSpan.FromSeconds(5);
+
+            RelativeTtl ttlStrategy = new RelativeTtl(ttl);
+
+            SystemClock.DateTimeOffsetUtcNow = () => fixedTime.Add(delay);
 
             Ttl retrieved = ttlStrategy.GetTtl(new Context("someExecutionKey"), null);
             retrieved.Timespan.Should().BeCloseTo(ttl);


### PR DESCRIPTION
The [Polly cache docs](https://github.com/App-vNext/Polly/wiki/Cache) state 

> `RelativeTtl`
>   ... a relative, non-sliding duration from the moment the item is put in the cache

This  PR addresses #403: modifies `RelativeTtl` to exhibit that behaviour by always returning a new `Ttl` of the required duration, instead of an absolute `Ttl`.