### PR TITLE
Issue 338 - Extend `onTimeout/async` delegates to take the thrown exception

### DIFF
--- a/src/Polly.Shared/Timeout/TimeoutEngine.cs
+++ b/src/Polly.Shared/Timeout/TimeoutEngine.cs
@@ -18,7 +18,7 @@ namespace Polly.Timeout
             CancellationToken cancellationToken,
             Func<Context, TimeSpan> timeoutProvider,
             TimeoutStrategy timeoutStrategy,
-            Action<Context, TimeSpan, Task> onTimeout)
+            Action<Context, TimeSpan, Task, Exception> onTimeout)
         {
             cancellationToken.ThrowIfCancellationRequested();
             TimeSpan timeout = timeoutProvider(context);
@@ -68,7 +68,7 @@ namespace Polly.Timeout
                     {
                         if (timeoutCancellationTokenSource.IsCancellationRequested)
                         {
-                            onTimeout(context, timeout, actionTask);
+                            onTimeout(context, timeout, actionTask, ex);
                             throw new TimeoutRejectedException("The delegate executed through TimeoutPolicy did not complete within the timeout.", ex);
                         }
 

--- a/src/Polly.Shared/Timeout/TimeoutEngineAsync.cs
+++ b/src/Polly.Shared/Timeout/TimeoutEngineAsync.cs
@@ -12,7 +12,7 @@ namespace Polly.Timeout
             Context context, 
             Func<Context, TimeSpan> timeoutProvider,
             TimeoutStrategy timeoutStrategy,
-            Func<Context, TimeSpan, Task, Task> onTimeoutAsync, 
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync, 
             CancellationToken cancellationToken, 
             bool continueOnCapturedContext)
         {
@@ -55,7 +55,7 @@ namespace Polly.Timeout
                     {
                         if (timeoutCancellationTokenSource.IsCancellationRequested)
                         {
-                            await onTimeoutAsync(context, timeout, actionTask).ConfigureAwait(continueOnCapturedContext);
+                            await onTimeoutAsync(context, timeout, actionTask, e).ConfigureAwait(continueOnCapturedContext);
                             throw new TimeoutRejectedException("The delegate executed asynchronously through TimeoutPolicy did not complete within the timeout.", e);
                         }
 

--- a/src/Polly.Shared/Timeout/TimeoutSyntax.cs
+++ b/src/Polly.Shared/Timeout/TimeoutSyntax.cs
@@ -16,7 +16,7 @@ namespace Polly
         public static TimeoutPolicy Timeout(int seconds)
         {
             TimeoutValidator.ValidateSecondsTimeout(seconds);
-            Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
+            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
 
             return Timeout(ctx => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, doNothing);
         }
@@ -31,7 +31,7 @@ namespace Polly
         public static TimeoutPolicy Timeout(int seconds, TimeoutStrategy timeoutStrategy)
         {
             TimeoutValidator.ValidateSecondsTimeout(seconds);
-            Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
+            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
 
             return Timeout(ctx => TimeSpan.FromSeconds(seconds), timeoutStrategy, doNothing);
         }
@@ -48,6 +48,22 @@ namespace Polly
         public static TimeoutPolicy Timeout(int seconds, Action<Context, TimeSpan, Task> onTimeout)
         {
             TimeoutValidator.ValidateSecondsTimeout(seconds);
+
+            return Timeout(ctx => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, onTimeout);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="seconds">The number of seconds after which to timeout.</param>
+        /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task"/> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeout</exception>
+        public static TimeoutPolicy Timeout(int seconds, Action<Context, TimeSpan, Task, Exception> onTimeout)
+        {
+            if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
 
             return Timeout(ctx => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, onTimeout);
         }
@@ -70,6 +86,23 @@ namespace Polly
         }
 
         /// <summary>
+        /// Builds a <see cref="Policy" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="seconds">The number of seconds after which to timeout.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task" /> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeout</exception>
+        public static TimeoutPolicy Timeout(int seconds, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task, Exception> onTimeout)
+        {
+            if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
+
+            return Timeout(ctx => TimeSpan.FromSeconds(seconds), timeoutStrategy, onTimeout);
+        }
+
+        /// <summary>
         /// Builds a <see cref="Policy"/> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
         /// </summary>
         /// <param name="timeout">The timeout.</param>
@@ -78,7 +111,7 @@ namespace Polly
         public static TimeoutPolicy Timeout(TimeSpan timeout)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
-            Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
+            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
 
             return Timeout(ctx => timeout, TimeoutStrategy.Optimistic, doNothing);
         }
@@ -93,7 +126,7 @@ namespace Polly
         public static TimeoutPolicy Timeout(TimeSpan timeout, TimeoutStrategy timeoutStrategy)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
-            Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
+            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
 
             return Timeout(ctx => timeout, timeoutStrategy, doNothing);
         }
@@ -108,6 +141,22 @@ namespace Polly
         /// <exception cref="System.ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
         /// <exception cref="System.ArgumentNullException">onTimeout</exception>
         public static TimeoutPolicy Timeout(TimeSpan timeout, Action<Context, TimeSpan, Task> onTimeout)
+        {
+            TimeoutValidator.ValidateTimeSpanTimeout(timeout);
+
+            return Timeout(ctx => timeout, TimeoutStrategy.Optimistic, onTimeout);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeout">The timeout.</param>
+        /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task"/> capturing the abandoned, timed-out action, and captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">timeout;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeout</exception>
+        public static TimeoutPolicy Timeout(TimeSpan timeout, Action<Context, TimeSpan, Task, Exception> onTimeout)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
 
@@ -132,6 +181,23 @@ namespace Polly
         }
 
         /// <summary>
+        /// Builds a <see cref="Policy" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeout">The timeout.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task" /> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">timeout;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeout</exception>
+        public static TimeoutPolicy Timeout(TimeSpan timeout, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task, Exception> onTimeout)
+        {
+            TimeoutValidator.ValidateTimeSpanTimeout(timeout);
+
+            return Timeout(ctx => timeout, timeoutStrategy, onTimeout);
+        }
+
+        /// <summary>
         /// Builds a <see cref="Policy"/> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
         /// </summary>
         /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
@@ -141,7 +207,7 @@ namespace Polly
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
-            Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
+            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
             return Timeout(ctx => timeoutProvider(), TimeoutStrategy.Optimistic, doNothing);
         }
 
@@ -156,7 +222,7 @@ namespace Polly
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
-            Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
+            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
             return Timeout(ctx => timeoutProvider(), timeoutStrategy, doNothing);
         }
 
@@ -170,6 +236,22 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
         /// <exception cref="System.ArgumentNullException">onTimeout</exception>
         public static TimeoutPolicy Timeout(Func<TimeSpan> timeoutProvider, Action<Context, TimeSpan, Task> onTimeout)
+        {
+            if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
+
+            return Timeout(ctx => timeoutProvider(), TimeoutStrategy.Optimistic, onTimeout);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
+        /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task" /> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeout</exception>
+        public static TimeoutPolicy Timeout(Func<TimeSpan> timeoutProvider, Action<Context, TimeSpan, Task, Exception> onTimeout)
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
@@ -194,6 +276,23 @@ namespace Polly
         }
 
         /// <summary>
+        /// Builds a <see cref="Policy" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task" /> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeout</exception>
+        public static TimeoutPolicy Timeout(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task, Exception> onTimeout)
+        {
+            if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
+
+            return Timeout(ctx => timeoutProvider(), timeoutStrategy, onTimeout);
+        }
+
+        /// <summary>
         /// Builds a <see cref="Policy"/> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
         /// </summary>
         /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
@@ -201,7 +300,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static TimeoutPolicy Timeout(Func<Context, TimeSpan> timeoutProvider)
         {
-            Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
+            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
             return Timeout(timeoutProvider, TimeoutStrategy.Optimistic, doNothing);
         }
 
@@ -214,7 +313,7 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
         public static TimeoutPolicy Timeout(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy)
         {
-            Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
+            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
             return Timeout(timeoutProvider, timeoutStrategy, doNothing);
         }
 
@@ -236,6 +335,20 @@ namespace Polly
         /// Builds a <see cref="Policy" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
         /// </summary>
         /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
+        /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task" /> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeout</exception>
+        public static TimeoutPolicy Timeout(Func<Context, TimeSpan> timeoutProvider, Action<Context, TimeSpan, Task, Exception> onTimeout)
+        {
+            return Timeout(timeoutProvider, TimeoutStrategy.Optimistic, onTimeout);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
         /// <param name="timeoutStrategy">The timeout strategy.</param>
         /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task" /> capturing the abandoned, timed-out action.
         /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
@@ -243,6 +356,32 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
         /// <exception cref="System.ArgumentNullException">onTimeout</exception>
         public static TimeoutPolicy Timeout(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task> onTimeout)
+        {
+            if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
+            if (onTimeout == null) throw new ArgumentNullException(nameof(onTimeout));
+
+            return new TimeoutPolicy(
+                (action, context, cancellationToken) => TimeoutEngine.Implementation(
+                    (ctx, ct) => { action(ctx, ct); return EmptyStruct.Instance; },
+                    context,
+                    cancellationToken,
+                    timeoutProvider,
+                    timeoutStrategy,
+                    (ctx, timeout, task, ex) => onTimeout(ctx, timeout, task))
+                );
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task" /> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeout</exception>
+        public static TimeoutPolicy Timeout(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task, Exception> onTimeout)
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
             if (onTimeout == null) throw new ArgumentNullException(nameof(onTimeout));

--- a/src/Polly.Shared/Timeout/TimeoutSyntaxAsync.cs
+++ b/src/Polly.Shared/Timeout/TimeoutSyntaxAsync.cs
@@ -16,7 +16,7 @@ namespace Polly
         public static TimeoutPolicy TimeoutAsync(int seconds)
         {
             TimeoutValidator.ValidateSecondsTimeout(seconds);
-            Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.EmptyTask;
+            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => TaskHelper.EmptyTask;
 
             return TimeoutAsync(ctx => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, doNothingAsync);
         }
@@ -31,7 +31,7 @@ namespace Polly
         public static TimeoutPolicy TimeoutAsync(int seconds, TimeoutStrategy timeoutStrategy)
         {
             TimeoutValidator.ValidateSecondsTimeout(seconds);
-            Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.EmptyTask;
+            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => TaskHelper.EmptyTask;
 
             return TimeoutAsync(ctx => TimeSpan.FromSeconds(seconds), timeoutStrategy, doNothingAsync);
         }
@@ -55,6 +55,23 @@ namespace Polly
         }
 
         /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="seconds">The number of seconds after which to timeout.</param>
+        /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task"/> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
+        public static TimeoutPolicy TimeoutAsync(int seconds, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
+        {
+            if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
+            if (onTimeoutAsync == null) throw new ArgumentNullException(nameof(onTimeoutAsync));
+
+            return TimeoutAsync(ctx => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, onTimeoutAsync);
+        }
+
+        /// <summary>
         /// Builds a <see cref="Policy" /> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
         /// </summary>
         /// <param name="seconds">The number of seconds after which to timeout.</param>
@@ -72,6 +89,23 @@ namespace Polly
         }
 
         /// <summary>
+        /// Builds a <see cref="Policy" /> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="seconds">The number of seconds after which to timeout.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task" /> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentNullException">seconds;Value must be greater than zero.</exception>
+        public static TimeoutPolicy TimeoutAsync(int seconds, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
+        {
+            if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
+
+            return TimeoutAsync(ctx => TimeSpan.FromSeconds(seconds), timeoutStrategy, onTimeoutAsync);
+        }
+
+        /// <summary>
         /// Builds a <see cref="Policy"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
         /// </summary>
         /// <param name="timeout">The timeout.</param>
@@ -80,7 +114,7 @@ namespace Polly
         public static TimeoutPolicy TimeoutAsync(TimeSpan timeout)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
-            Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.EmptyTask;
+            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => TaskHelper.EmptyTask;
 
             return TimeoutAsync(ctx => timeout, TimeoutStrategy.Optimistic, doNothingAsync);
         }
@@ -95,7 +129,7 @@ namespace Polly
         public static TimeoutPolicy TimeoutAsync(TimeSpan timeout, TimeoutStrategy timeoutStrategy)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
-            Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.EmptyTask;
+            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => TaskHelper.EmptyTask;
 
             return TimeoutAsync(ctx => timeout, timeoutStrategy, doNothingAsync);
         }
@@ -110,6 +144,22 @@ namespace Polly
         /// <exception cref="System.ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
         /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
         public static TimeoutPolicy TimeoutAsync(TimeSpan timeout, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
+        {
+            TimeoutValidator.ValidateTimeSpanTimeout(timeout);
+
+            return TimeoutAsync(ctx => timeout, TimeoutStrategy.Optimistic, onTimeoutAsync);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeout">The timeout.</param>
+        /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task"/> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>. 
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">timeout;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
+        public static TimeoutPolicy TimeoutAsync(TimeSpan timeout, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
 
@@ -134,6 +184,23 @@ namespace Polly
         }
 
         /// <summary>
+        /// Builds a <see cref="Policy" /> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeout">The timeout.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task" /> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">timeout;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
+        public static TimeoutPolicy TimeoutAsync(TimeSpan timeout, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
+        {
+            TimeoutValidator.ValidateTimeSpanTimeout(timeout);
+
+            return TimeoutAsync(ctx => timeout, timeoutStrategy, onTimeoutAsync);
+        }
+
+        /// <summary>
         /// Builds a <see cref="Policy"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
         /// </summary>
         /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
@@ -143,7 +210,7 @@ namespace Polly
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
-            Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.EmptyTask;
+            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => TaskHelper.EmptyTask;
             return TimeoutAsync(ctx => timeoutProvider(), TimeoutStrategy.Optimistic, doNothingAsync);
         }
 
@@ -158,7 +225,7 @@ namespace Polly
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
-            Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.EmptyTask;
+            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => TaskHelper.EmptyTask;
             return TimeoutAsync(ctx => timeoutProvider(), timeoutStrategy, doNothingAsync);
         }
 
@@ -172,6 +239,22 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
         /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
         public static TimeoutPolicy TimeoutAsync(Func<TimeSpan> timeoutProvider, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
+        {
+            if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
+
+            return TimeoutAsync(ctx => timeoutProvider(), TimeoutStrategy.Optimistic, onTimeoutAsync);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
+        /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task"/> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
+        public static TimeoutPolicy TimeoutAsync(Func<TimeSpan> timeoutProvider, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
@@ -196,6 +279,23 @@ namespace Polly
         }
 
         /// <summary>
+        /// Builds a <see cref="Policy" /> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task" /> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
+        public static TimeoutPolicy TimeoutAsync(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
+        {
+            if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
+
+            return TimeoutAsync(ctx => timeoutProvider(), timeoutStrategy, onTimeoutAsync);
+        }
+
+        /// <summary>
         /// Builds a <see cref="Policy"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
         /// </summary>
         /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
@@ -203,7 +303,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static TimeoutPolicy TimeoutAsync(Func<Context, TimeSpan> timeoutProvider)
         {
-            Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.EmptyTask;
+            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => TaskHelper.EmptyTask;
 
             return TimeoutAsync(timeoutProvider, TimeoutStrategy.Optimistic, doNothingAsync);
         }
@@ -217,7 +317,7 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
         public static TimeoutPolicy TimeoutAsync(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy)
         {
-            Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.EmptyTask;
+            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => TaskHelper.EmptyTask;
 
             return TimeoutAsync(timeoutProvider, timeoutStrategy, doNothingAsync);
         }
@@ -237,6 +337,20 @@ namespace Polly
         }
 
         /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
+        /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task"/> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
+        public static TimeoutPolicy TimeoutAsync(Func<Context, TimeSpan> timeoutProvider, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
+        {
+            return TimeoutAsync(timeoutProvider, TimeoutStrategy.Optimistic, onTimeoutAsync);
+        }
+
+        /// <summary>
         /// Builds a <see cref="Policy" /> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
         /// </summary>
         /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
@@ -247,6 +361,34 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
         /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
         public static TimeoutPolicy TimeoutAsync(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
+        {
+            if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
+            if (onTimeoutAsync == null) throw new ArgumentNullException(nameof(onTimeoutAsync));
+
+            return new TimeoutPolicy(
+                (action, context, cancellationToken, continueOnCapturedContext) => TimeoutEngine.ImplementationAsync(
+                    async (ctx, ct) => { await action(ctx, ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
+                    context,
+                    timeoutProvider,
+                    timeoutStrategy,
+                    (ctx, timeout, task, exception) => onTimeoutAsync(context, timeout, task),
+                    cancellationToken,
+                    continueOnCapturedContext)
+                );
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy" /> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task" /> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
+        public static TimeoutPolicy TimeoutAsync(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy
+            , Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
             if (onTimeoutAsync == null) throw new ArgumentNullException(nameof(onTimeoutAsync));

--- a/src/Polly.Shared/Timeout/TimeoutTResultSyntax.cs
+++ b/src/Polly.Shared/Timeout/TimeoutTResultSyntax.cs
@@ -16,7 +16,7 @@ namespace Polly
         public static TimeoutPolicy<TResult> Timeout<TResult>(int seconds)
         {
             TimeoutValidator.ValidateSecondsTimeout(seconds);
-            Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
+            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
 
             return Timeout<TResult>(ctx => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, doNothing);
         }
@@ -32,7 +32,7 @@ namespace Polly
         public static TimeoutPolicy<TResult> Timeout<TResult>(int seconds, TimeoutStrategy timeoutStrategy)
         {
             TimeoutValidator.ValidateSecondsTimeout(seconds);
-            Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
+            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
 
             return Timeout<TResult>(ctx => TimeSpan.FromSeconds(seconds), timeoutStrategy, doNothing);
         }
@@ -49,6 +49,21 @@ namespace Polly
         public static TimeoutPolicy<TResult> Timeout<TResult>(int seconds, Action<Context, TimeSpan, Task> onTimeout)
         {
             TimeoutValidator.ValidateSecondsTimeout(seconds);
+            return Timeout<TResult>(ctx => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, onTimeout);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy{TResult}"/> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="seconds">The number of seconds after which to timeout.</param>
+        /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task{TResult}"/> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeout</exception>
+        public static TimeoutPolicy<TResult> Timeout<TResult>(int seconds, Action<Context, TimeSpan, Task, Exception> onTimeout)
+        {
+            if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
             return Timeout<TResult>(ctx => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, onTimeout);
         }
 
@@ -71,6 +86,24 @@ namespace Polly
         }
 
         /// <summary>
+        /// Builds a <see cref="Policy{TResult}" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
+        /// <param name="seconds">The number of seconds after which to timeout.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task{TResult}" /> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeout</exception>
+        public static TimeoutPolicy<TResult> Timeout<TResult>(int seconds, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task, Exception> onTimeout)
+        {
+            if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
+
+            return Timeout<TResult>(ctx => TimeSpan.FromSeconds(seconds), timeoutStrategy, onTimeout);
+        }
+
+        /// <summary>
         /// Builds a <see cref="Policy{TResult}"/> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
         /// </summary>
         /// <param name="timeout">The timeout.</param>
@@ -79,7 +112,7 @@ namespace Polly
         public static TimeoutPolicy<TResult> Timeout<TResult>(TimeSpan timeout)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
-            Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
+            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
 
             return Timeout<TResult>(ctx => timeout, TimeoutStrategy.Optimistic, doNothing);
         }
@@ -95,7 +128,7 @@ namespace Polly
         public static TimeoutPolicy<TResult> Timeout<TResult>(TimeSpan timeout, TimeoutStrategy timeoutStrategy)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
-            Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
+            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
 
             return Timeout<TResult>(ctx => timeout, timeoutStrategy, doNothing);
         }
@@ -110,6 +143,21 @@ namespace Polly
         /// <exception cref="System.ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
         /// <exception cref="System.ArgumentNullException">onTimeout</exception>
         public static TimeoutPolicy<TResult> Timeout<TResult>(TimeSpan timeout, Action<Context, TimeSpan, Task> onTimeout)
+        {
+            TimeoutValidator.ValidateTimeSpanTimeout(timeout);
+            return Timeout<TResult>(ctx => timeout, TimeoutStrategy.Optimistic, onTimeout);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy{TResult}"/> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeout">The timeout.</param>
+        /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task{TResult}"/> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">timeout;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeout</exception>
+        public static TimeoutPolicy<TResult> Timeout<TResult>(TimeSpan timeout, Action<Context, TimeSpan, Task, Exception> onTimeout)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
             return Timeout<TResult>(ctx => timeout, TimeoutStrategy.Optimistic, onTimeout);
@@ -133,6 +181,23 @@ namespace Polly
         }
 
         /// <summary>
+        /// Builds a <see cref="Policy{TResult}" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
+        /// <param name="timeout">The timeout.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task{TResult}" /> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">timeout;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeout</exception>
+        public static TimeoutPolicy<TResult> Timeout<TResult>(TimeSpan timeout, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task, Exception> onTimeout)
+        {
+            TimeoutValidator.ValidateTimeSpanTimeout(timeout);
+            return Timeout<TResult>(ctx => timeout, timeoutStrategy, onTimeout);
+        }
+
+        /// <summary>
         /// Builds a <see cref="Policy{TResult}"/> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
         /// </summary>
         /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
@@ -142,7 +207,7 @@ namespace Polly
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
-            Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
+            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
             return Timeout<TResult>(ctx => timeoutProvider(), TimeoutStrategy.Optimistic, doNothing);
         }
 
@@ -158,7 +223,7 @@ namespace Polly
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
-            Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
+            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
             return Timeout<TResult>(ctx => timeoutProvider(), timeoutStrategy, doNothing);
         }
 
@@ -172,6 +237,22 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
         /// <exception cref="System.ArgumentNullException">onTimeout</exception>
         public static TimeoutPolicy<TResult> Timeout<TResult>(Func<TimeSpan> timeoutProvider, Action<Context, TimeSpan, Task> onTimeout)
+        {
+            if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
+
+            return Timeout<TResult>(ctx => timeoutProvider(), TimeoutStrategy.Optimistic, onTimeout);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy{TResult}"/> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
+        /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task{TResult}"/> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeout</exception>
+        public static TimeoutPolicy<TResult> Timeout<TResult>(Func<TimeSpan> timeoutProvider, Action<Context, TimeSpan, Task, Exception> onTimeout)
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
@@ -197,6 +278,24 @@ namespace Polly
         }
 
         /// <summary>
+        /// Builds a <see cref="Policy{TResult}" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
+        /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task{TResult}" /> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeout</exception>
+        public static TimeoutPolicy<TResult> Timeout<TResult>(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task, Exception> onTimeout)
+        {
+            if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
+
+            return Timeout<TResult>(ctx => timeoutProvider(), timeoutStrategy, onTimeout);
+        }
+
+        /// <summary>
         /// Builds a <see cref="Policy{TResult}"/> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
         /// </summary>
         /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
@@ -204,7 +303,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static TimeoutPolicy<TResult> Timeout<TResult>(Func<Context, TimeSpan> timeoutProvider)
         {
-            Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
+            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
             return Timeout<TResult>(timeoutProvider, TimeoutStrategy.Optimistic, doNothing);
         }
 
@@ -218,7 +317,7 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
         public static TimeoutPolicy<TResult> Timeout<TResult>(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy)
         {
-            Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
+            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
             return Timeout<TResult>(timeoutProvider, timeoutStrategy, doNothing);
         }
 
@@ -237,6 +336,20 @@ namespace Polly
         }
 
         /// <summary>
+        /// Builds a <see cref="Policy{TResult}"/> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
+        /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task{TResult}"/> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeout</exception>
+        public static TimeoutPolicy<TResult> Timeout<TResult>(Func<Context, TimeSpan> timeoutProvider, Action<Context, TimeSpan, Task, Exception> onTimeout)
+        {
+            return Timeout<TResult>(timeoutProvider, TimeoutStrategy.Optimistic, onTimeout);
+        }
+
+        /// <summary>
         /// Builds a <see cref="Policy{TResult}" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
         /// </summary>
         /// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
@@ -248,6 +361,33 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
         /// <exception cref="System.ArgumentNullException">onTimeout</exception>
         public static TimeoutPolicy<TResult> Timeout<TResult>(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task> onTimeout)
+        {
+            if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
+            if (onTimeout == null) throw new ArgumentNullException(nameof(onTimeout));
+
+            return new TimeoutPolicy<TResult>(
+                (action, context, cancellationToken) => TimeoutEngine.Implementation<TResult>(
+                    action,
+                    context,
+                    cancellationToken,
+                    timeoutProvider,
+                    timeoutStrategy,
+                    (ctx, timeout, task, ex) => onTimeout(ctx, timeout, task))
+                );
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy{TResult}" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
+        /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task{TResult}" /> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeout</exception>
+        public static TimeoutPolicy<TResult> Timeout<TResult>(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task, Exception> onTimeout)
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
             if (onTimeout == null) throw new ArgumentNullException(nameof(onTimeout));

--- a/src/Polly.Shared/Timeout/TimeoutTResultSyntaxAsync.cs
+++ b/src/Polly.Shared/Timeout/TimeoutTResultSyntaxAsync.cs
@@ -17,7 +17,7 @@ namespace Polly
         {
             TimeoutValidator.ValidateSecondsTimeout(seconds);
 
-            Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.FromResult(default(TResult));
+            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => TaskHelper.FromResult(default(TResult));
             return TimeoutAsync<TResult>(ctx => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, doNothingAsync);
         }
 
@@ -32,7 +32,7 @@ namespace Polly
         {
             TimeoutValidator.ValidateSecondsTimeout(seconds);
 
-            Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.FromResult(default(TResult));
+            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => TaskHelper.FromResult(default(TResult));
             return TimeoutAsync<TResult>(ctx => TimeSpan.FromSeconds(seconds), timeoutStrategy, doNothingAsync);
         }
 
@@ -48,6 +48,22 @@ namespace Polly
         public static TimeoutPolicy<TResult> TimeoutAsync<TResult>(int seconds, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
         {
             TimeoutValidator.ValidateSecondsTimeout(seconds);
+
+            return TimeoutAsync<TResult>(ctx => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, onTimeoutAsync);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy{TResult}"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="seconds">The number of seconds after which to timeout.</param>
+        /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task"/> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
+        public static TimeoutPolicy<TResult> TimeoutAsync<TResult>(int seconds, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
+        {
+            if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
 
             return TimeoutAsync<TResult>(ctx => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, onTimeoutAsync);
         }
@@ -72,6 +88,23 @@ namespace Polly
         /// <summary>
         /// Builds a <see cref="Policy{TResult}"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
         /// </summary>
+        /// <param name="seconds">The number of seconds after which to timeout.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task"/> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
+        public static TimeoutPolicy<TResult> TimeoutAsync<TResult>(int seconds, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
+        {
+            if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
+
+            return TimeoutAsync<TResult>(ctx => TimeSpan.FromSeconds(seconds), timeoutStrategy, onTimeoutAsync);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy{TResult}"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
         /// <param name="timeout">The timeout.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
@@ -79,7 +112,7 @@ namespace Polly
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
 
-            Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.FromResult(default(TResult));
+            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => TaskHelper.FromResult(default(TResult));
             return TimeoutAsync<TResult>(ctx => timeout, TimeoutStrategy.Optimistic, doNothingAsync);
         }
 
@@ -94,7 +127,7 @@ namespace Polly
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
 
-            Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.FromResult(default(TResult));
+            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => TaskHelper.FromResult(default(TResult));
             return TimeoutAsync<TResult>(ctx => timeout, timeoutStrategy, doNothingAsync);
         }
 
@@ -110,6 +143,23 @@ namespace Polly
         public static TimeoutPolicy<TResult> TimeoutAsync<TResult>(TimeSpan timeout, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
+            if (onTimeoutAsync == null) throw new ArgumentNullException(nameof(onTimeoutAsync));
+
+            return TimeoutAsync<TResult>(ctx => timeout, TimeoutStrategy.Optimistic, onTimeoutAsync);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy{TResult}"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeout">The timeout.</param>
+        /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task"/> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">timeout;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
+        public static TimeoutPolicy<TResult> TimeoutAsync<TResult>(TimeSpan timeout, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
+        {
+            if (timeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
             if (onTimeoutAsync == null) throw new ArgumentNullException(nameof(onTimeoutAsync));
 
             return TimeoutAsync<TResult>(ctx => timeout, TimeoutStrategy.Optimistic, onTimeoutAsync);
@@ -135,6 +185,23 @@ namespace Polly
         /// <summary>
         /// Builds a <see cref="Policy{TResult}"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
         /// </summary>
+        /// <param name="timeout">The timeout.</param>
+        /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task"/> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">timeout;Value must be greater than zero.</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
+        public static TimeoutPolicy<TResult> TimeoutAsync<TResult>(TimeSpan timeout, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
+        {
+            if (timeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
+
+            return TimeoutAsync<TResult>(ctx => timeout, timeoutStrategy, onTimeoutAsync);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy{TResult}"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
         /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
         /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
         /// <returns>The policy instance.</returns>
@@ -142,7 +209,7 @@ namespace Polly
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
-            Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.FromResult(default(TResult));
+            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => TaskHelper.FromResult(default(TResult));
             return TimeoutAsync<TResult>(ctx => timeoutProvider(), TimeoutStrategy.Optimistic, doNothingAsync);
         }
 
@@ -157,7 +224,7 @@ namespace Polly
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
-            Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.FromResult(default(TResult));
+            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => TaskHelper.FromResult(default(TResult));
             return TimeoutAsync<TResult>(ctx => timeoutProvider(), timeoutStrategy, doNothingAsync);
         }
 
@@ -181,6 +248,22 @@ namespace Polly
         /// Builds a <see cref="Policy{TResult}"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
         /// </summary>
         /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
+        /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task"/> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
+        public static TimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<TimeSpan> timeoutProvider, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
+        {
+            if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
+
+            return TimeoutAsync<TResult>(ctx => timeoutProvider(), TimeoutStrategy.Optimistic, onTimeoutAsync);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy{TResult}"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
         /// <param name="timeoutStrategy">The timeout strategy.</param>
         /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task"/> capturing the abandoned, timed-out action. 
         /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
@@ -188,6 +271,23 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
         /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
         public static TimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
+        {
+            if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
+
+            return TimeoutAsync<TResult>(ctx => timeoutProvider(), onTimeoutAsync);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy{TResult}"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task"/> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
+        public static TimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
@@ -202,7 +302,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static TimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<Context, TimeSpan> timeoutProvider)
         {
-            Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.FromResult(default(TResult));
+            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => TaskHelper.FromResult(default(TResult));
             return TimeoutAsync<TResult>(timeoutProvider, TimeoutStrategy.Optimistic, doNothingAsync);
         }
 
@@ -215,7 +315,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static TimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy)
         {
-            Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.FromResult(default(TResult));
+            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => TaskHelper.FromResult(default(TResult));
             return TimeoutAsync<TResult>(timeoutProvider, timeoutStrategy, doNothingAsync);
         }
 
@@ -229,6 +329,20 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
         /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
         public static TimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<Context, TimeSpan> timeoutProvider, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
+        {
+            return TimeoutAsync<TResult>(timeoutProvider, TimeoutStrategy.Optimistic, onTimeoutAsync);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy{TResult}"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
+        /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task"/> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>. 
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
+        public static TimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<Context, TimeSpan> timeoutProvider, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
         {
             return TimeoutAsync<TResult>(timeoutProvider, TimeoutStrategy.Optimistic, onTimeoutAsync);
         }
@@ -254,8 +368,35 @@ namespace Polly
                     context,
                     timeoutProvider,
                     timeoutStrategy,
-                    onTimeoutAsync,
+                    (ctx, timeout, task, exception) => onTimeoutAsync(ctx, timeout, task),
                     cancellationToken, 
+                    continueOnCapturedContext)
+                );
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy{TResult}"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
+        /// </summary>
+        /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
+        /// <param name="timeoutStrategy">The timeout strategy.</param>
+        /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task"/> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
+        /// <remarks>The Task parameter will be null if the executed action responded co-operatively to cancellation before the policy timed it out.</remarks></param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
+        public static TimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
+        {
+            if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
+            if (onTimeoutAsync == null) throw new ArgumentNullException(nameof(onTimeoutAsync));
+
+            return new TimeoutPolicy<TResult>(
+                (action, context, cancellationToken, continueOnCapturedContext) => TimeoutEngine.ImplementationAsync(
+                    action,
+                    context,
+                    timeoutProvider,
+                    timeoutStrategy,
+                    onTimeoutAsync,
+                    cancellationToken,
                     continueOnCapturedContext)
                 );
         }

--- a/src/Polly.SharedSpecs/Timeout/TimeoutAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Timeout/TimeoutAsyncSpecs.cs
@@ -120,7 +120,18 @@ namespace Polly.Specs.Timeout
         [Fact]
         public void Should_throw_when_onTimeout_is_null_with_timespan()
         {
-            Action policy = () => Policy.TimeoutAsync(TimeSpan.FromMinutes(0.5), null);
+            Func<Context, TimeSpan, Task, Task> onTimeout = null;
+            Action policy = () => Policy.TimeoutAsync(TimeSpan.FromMinutes(0.5), onTimeout);
+
+            policy.ShouldThrow<ArgumentNullException>()
+                .And.ParamName.Should().Be("onTimeoutAsync");
+        }
+
+        [Fact]
+        public void Should_throw_when_onTimeout_is_null_with_timespan_with_full_argument_list_onTimeout()
+        {
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeout = null;
+            Action policy = () => Policy.TimeoutAsync(TimeSpan.FromMinutes(0.5), onTimeout);
 
             policy.ShouldThrow<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeoutAsync");
@@ -129,7 +140,18 @@ namespace Polly.Specs.Timeout
         [Fact]
         public void Should_throw_when_onTimeout_is_null_with_seconds()
         {
-            Action policy = () => Policy.TimeoutAsync(30, null);
+            Func<Context, TimeSpan, Task, Task> onTimeout = null;
+            Action policy = () => Policy.TimeoutAsync(30, onTimeout);
+
+            policy.ShouldThrow<ArgumentNullException>()
+                .And.ParamName.Should().Be("onTimeoutAsync");
+        }
+
+        [Fact]
+        public void Should_throw_when_onTimeout_is_null_with_seconds_with_full_argument_list_onTimeout()
+        {
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeout = null;
+            Action policy = () => Policy.TimeoutAsync(30, onTimeout);
 
             policy.ShouldThrow<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeoutAsync");
@@ -147,7 +169,18 @@ namespace Polly.Specs.Timeout
         [Fact]
         public void Should_throw_when_onTimeout_is_null_with_timeoutprovider()
         {
-            Action policy = () => Policy.TimeoutAsync(() => TimeSpan.FromSeconds(30), null);
+            Func<Context, TimeSpan, Task, Task> onTimeout = null;
+            Action policy = () => Policy.TimeoutAsync(() => TimeSpan.FromSeconds(30), onTimeout);
+
+            policy.ShouldThrow<ArgumentNullException>()
+                .And.ParamName.Should().Be("onTimeoutAsync");
+        }
+
+        [Fact]
+        public void Should_throw_when_onTimeout_is_null_with_timeoutprovider_with_full_argument_list_onTimeout()
+        {
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeout = null;
+            Action policy = () => Policy.TimeoutAsync(() => TimeSpan.FromSeconds(30), onTimeout);
 
             policy.ShouldThrow<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeoutAsync");
@@ -705,8 +738,371 @@ namespace Polly.Specs.Timeout
 
             taskPassedToOnTimeout.Should().BeNull();
         }
-        
+
         #endregion
+
+
+        #region onTimeout full argument list - pessimistic
+
+        [Fact]
+        public void Should_call_ontimeout_full_argument_list_with_configured_timeout__pessimistic()
+        {
+            TimeSpan timeoutPassedToConfiguration = TimeSpan.FromMilliseconds(250);
+
+            TimeSpan? timeoutPassedToOnTimeout = null;
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = (ctx, span, task, exception) =>
+            {
+                timeoutPassedToOnTimeout = span;
+                return TaskHelper.EmptyTask;
+            };
+
+            var policy = Policy.TimeoutAsync(timeoutPassedToConfiguration, TimeoutStrategy.Pessimistic, onTimeoutAsync);
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async () =>
+            {
+                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
+
+            }))
+            .ShouldThrow<TimeoutRejectedException>();
+
+            timeoutPassedToOnTimeout.Should().Be(timeoutPassedToConfiguration);
+        }
+
+        [Fact]
+        public void Should_call_ontimeout_full_argument_list_with_non_null_exception__pessimistic()
+        {
+            TimeSpan timeoutPassedToConfiguration = TimeSpan.FromMilliseconds(250);
+
+            Exception exceptionPassedToOnTimeout = null;
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = (ctx, span, task, exception) =>
+            {
+                exceptionPassedToOnTimeout = exception;
+                return TaskHelper.EmptyTask;
+            };
+
+            var policy = Policy.TimeoutAsync(timeoutPassedToConfiguration, TimeoutStrategy.Pessimistic, onTimeoutAsync);
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async () =>
+            {
+                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
+
+            }))
+            .ShouldThrow<TimeoutRejectedException>();
+
+            exceptionPassedToOnTimeout.Should().NotBeNull();
+            exceptionPassedToOnTimeout.Should().BeOfType(typeof(OperationCanceledException));
+        }
+
+        [Fact]
+        public void Should_call_ontimeout_full_argument_list_with_passed_context__pessimistic()
+        {
+            string operationKey = Guid.NewGuid().ToString();
+            Context contextPassedToExecute = new Context(operationKey);
+
+            Context contextPassedToOnTimeout = null;
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = (ctx, span, task, exception) =>
+            {
+                contextPassedToOnTimeout = ctx;
+                return TaskHelper.EmptyTask;
+            };
+
+            TimeSpan timeout = TimeSpan.FromMilliseconds(250);
+            var policy = Policy.TimeoutAsync(timeout, TimeoutStrategy.Pessimistic, onTimeoutAsync);
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async (ctx) =>
+            {
+                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
+
+            }, contextPassedToExecute))
+                .ShouldThrow<TimeoutRejectedException>();
+
+            contextPassedToOnTimeout.Should().NotBeNull();
+            contextPassedToOnTimeout.OperationKey.Should().Be(operationKey);
+            contextPassedToOnTimeout.Should().BeSameAs(contextPassedToExecute);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void Should_call_ontimeout_full_argument_list_with_timeout_supplied_different_for_each_execution_by_evaluating_func__pessimistic(int programaticallyControlledDelay)
+        {
+            Func<TimeSpan> timeoutFunc = () => TimeSpan.FromMilliseconds(25 * programaticallyControlledDelay);
+
+            TimeSpan? timeoutPassedToOnTimeout = null;
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = (ctx, span, task, exception) =>
+            {
+                timeoutPassedToOnTimeout = span;
+                return TaskHelper.EmptyTask;
+            };
+
+            var policy = Policy.TimeoutAsync(timeoutFunc, TimeoutStrategy.Pessimistic, onTimeoutAsync);
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async () =>
+            {
+                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
+            }))
+            .ShouldThrow<TimeoutRejectedException>();
+
+            timeoutPassedToOnTimeout.Should().Be(timeoutFunc());
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void Should_call_ontimeout_full_argument_list_with_timeout_supplied_different_for_each_execution_by_evaluating_func_influenced_by_context__pessimistic(int programaticallyControlledDelay)
+        {
+            Func<Context, TimeSpan> timeoutProvider = ctx => (TimeSpan)ctx["timeout"];
+
+            TimeSpan? timeoutPassedToOnTimeout = null;
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = (ctx, span, task, exception) =>
+            {
+                timeoutPassedToOnTimeout = span;
+                return TaskHelper.EmptyTask;
+            };
+
+            var policy = Policy.TimeoutAsync(timeoutProvider, TimeoutStrategy.Pessimistic, onTimeoutAsync);
+
+            // Supply a programatically-controlled timeout, via the execution context.
+            Context context = new Context("SomeOperationKey") { ["timeout"] = TimeSpan.FromMilliseconds(25 * programaticallyControlledDelay) };
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async (ctx) =>
+            {
+                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
+            }, context))
+            .ShouldThrow<TimeoutRejectedException>();
+
+            timeoutPassedToOnTimeout.Should().Be(timeoutProvider(context));
+        }
+
+        [Fact]
+        public void Should_call_ontimeout_full_argument_list_with_task_wrapping_abandoned_action__pessimistic()
+        {
+            Task taskPassedToOnTimeout = null;
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = (ctx, span, task, exception) =>
+            {
+                taskPassedToOnTimeout = task;
+                return TaskHelper.EmptyTask;
+            };
+
+            TimeSpan timeout = TimeSpan.FromMilliseconds(250);
+            var policy = Policy.TimeoutAsync(timeout, TimeoutStrategy.Pessimistic, onTimeoutAsync);
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async () =>
+            {
+                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
+
+            }))
+            .ShouldThrow<TimeoutRejectedException>();
+
+            taskPassedToOnTimeout.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task Should_call_ontimeout_full_argument_list_with_task_wrapping_abandoned_action_allowing_capture_of_otherwise_unobserved_exception__pessimistic()
+        {
+            SystemClock.Reset(); // This is the only test which cannot work with the artificial SystemClock of TimeoutSpecsBase.  We want the invoked delegate to continue as far as: throw exceptionToThrow, to genuinely check that the walked-away-from task throws that, and that we pass it to onTimeoutAsync.  
+            // That means we can't use the SystemClock.SleepAsync(...) within the executed delegate to artificially trigger the timeout cancellation (as for example the test above does).
+            // In real execution, it is the .WhenAny() in the timeout implementation which throws for the timeout.  We don't want to go as far as abstracting Task.WhenAny() out into SystemClock, so we let this test run at real-world speed, not abstracted-clock speed.
+
+            Exception exceptionToThrow = new DivideByZeroException();
+
+            Exception exceptionObservedFromTaskPassedToOnTimeout = null;
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = (ctx, span, task, exception) =>
+            {
+                task.ContinueWith(t => exceptionObservedFromTaskPassedToOnTimeout = t.Exception.InnerException); // Intentionally not awaited: we want to assign the continuation, but let it run in its own time when the executed delegate eventually completes.
+                return TaskHelper.EmptyTask;
+            };
+
+            TimeSpan shimTimespan = TimeSpan.FromSeconds(1); // Consider increasing shimTimeSpan if test fails transiently in different environments.
+            TimeSpan thriceShimTimeSpan = shimTimespan + shimTimespan + shimTimespan;
+            var policy = Policy.TimeoutAsync(shimTimespan, TimeoutStrategy.Pessimistic, onTimeoutAsync);
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async () =>
+            {
+                await SystemClock.SleepAsync(thriceShimTimeSpan, CancellationToken.None).ConfigureAwait(false);
+                throw exceptionToThrow;
+            }))
+            .ShouldThrow<TimeoutRejectedException>();
+
+            await SystemClock.SleepAsync(thriceShimTimeSpan, CancellationToken.None).ConfigureAwait(false);
+            exceptionObservedFromTaskPassedToOnTimeout.Should().NotBeNull();
+            exceptionObservedFromTaskPassedToOnTimeout.Should().Be(exceptionToThrow);
+
+        }
+
+        #endregion
+
+        #region onTimeout full argument list - optimistic
+
+        [Fact]
+        public void Should_call_ontimeout_full_argument_list_with_configured_timeout__optimistic()
+        {
+            TimeSpan timeoutPassedToConfiguration = TimeSpan.FromMilliseconds(250);
+
+            TimeSpan? timeoutPassedToOnTimeout = null;
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = (ctx, span, task, exception) =>
+            {
+                timeoutPassedToOnTimeout = span;
+                return TaskHelper.EmptyTask;
+            };
+
+            var policy = Policy.TimeoutAsync(timeoutPassedToConfiguration, TimeoutStrategy.Optimistic, onTimeoutAsync);
+            var userCancellationToken = CancellationToken.None;
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async ct =>
+            {
+                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+
+            }, userCancellationToken).ConfigureAwait(false))
+            .ShouldThrow<TimeoutRejectedException>();
+
+            timeoutPassedToOnTimeout.Should().Be(timeoutPassedToConfiguration);
+        }
+
+        [Fact]
+        public void Should_call_ontimeout_full_argument_list_with_non_null_exception__optimistic()
+        {
+            TimeSpan timeoutPassedToConfiguration = TimeSpan.FromMilliseconds(250);
+
+            Exception exceptionPassedToOnTimeout = null;
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = (ctx, span, task, exception) =>
+            {
+                exceptionPassedToOnTimeout = exception;
+                return TaskHelper.EmptyTask;
+            };
+
+            var policy = Policy.TimeoutAsync(timeoutPassedToConfiguration, TimeoutStrategy.Optimistic, onTimeoutAsync);
+            var userCancellationToken = CancellationToken.None;
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async ct =>
+            {
+                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+
+            }, userCancellationToken).ConfigureAwait(false))
+            .ShouldThrow<TimeoutRejectedException>();
+            
+            exceptionPassedToOnTimeout.Should().NotBeNull();
+            exceptionPassedToOnTimeout.Should().BeOfType(typeof(OperationCanceledException));
+        }
+
+        [Fact]
+        public void Should_call_ontimeout_full_argument_list_with_passed_context__optimistic()
+        {
+            string opeationKey = Guid.NewGuid().ToString();
+            Context contextPassedToExecute = new Context(opeationKey);
+
+            Context contextPassedToOnTimeout = null;
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = (ctx, span, task, exception) =>
+            {
+                contextPassedToOnTimeout = ctx;
+                return TaskHelper.EmptyTask;
+            };
+
+            TimeSpan timeout = TimeSpan.FromMilliseconds(250);
+            var policy = Policy.TimeoutAsync(timeout, TimeoutStrategy.Optimistic, onTimeoutAsync);
+            var userCancellationToken = CancellationToken.None;
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async (ctx, ct) =>
+            {
+                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+
+            }, contextPassedToExecute, userCancellationToken).ConfigureAwait(false))
+                .ShouldThrow<TimeoutRejectedException>();
+
+            contextPassedToOnTimeout.Should().NotBeNull();
+            contextPassedToOnTimeout.OperationKey.Should().Be(opeationKey);
+            contextPassedToOnTimeout.Should().BeSameAs(contextPassedToExecute);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void Should_call_ontimeout_full_argument_list_with_timeout_supplied_different_for_each_execution_by_evaluating_func__optimistic(int programaticallyControlledDelay)
+        {
+            Func<TimeSpan> timeoutFunc = () => TimeSpan.FromMilliseconds(25 * programaticallyControlledDelay);
+
+            TimeSpan? timeoutPassedToOnTimeout = null;
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = (ctx, span, task, exception) =>
+            {
+                timeoutPassedToOnTimeout = span;
+                return TaskHelper.EmptyTask;
+            };
+
+            var policy = Policy.TimeoutAsync(timeoutFunc, TimeoutStrategy.Optimistic, onTimeoutAsync);
+            var userCancellationToken = CancellationToken.None;
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async ct =>
+            {
+                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+
+            }, userCancellationToken).ConfigureAwait(false))
+                .ShouldThrow<TimeoutRejectedException>();
+
+            timeoutPassedToOnTimeout.Should().Be(timeoutFunc());
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void Should_call_ontimeout_full_argument_list_with_timeout_supplied_different_for_each_execution_by_evaluating_func_influenced_by_context__optimistic(int programaticallyControlledDelay)
+        {
+            Func<Context, TimeSpan> timeoutProvider = ctx => (TimeSpan)ctx["timeout"];
+
+            TimeSpan? timeoutPassedToOnTimeout = null;
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = (ctx, span, task, exception) =>
+            {
+                timeoutPassedToOnTimeout = span;
+                return TaskHelper.EmptyTask;
+            };
+
+            var policy = Policy.TimeoutAsync(timeoutProvider, TimeoutStrategy.Optimistic, onTimeoutAsync);
+            var userCancellationToken = CancellationToken.None;
+
+            // Supply a programatically-controlled timeout, via the execution context.
+            Context context = new Context("SomeOperationKey")
+            {
+                ["timeout"] = TimeSpan.FromMilliseconds(25 * programaticallyControlledDelay)
+            };
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async (ctx, ct) =>
+            {
+                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+
+            }, context, userCancellationToken).ConfigureAwait(false))
+                .ShouldThrow<TimeoutRejectedException>();
+
+            timeoutPassedToOnTimeout.Should().Be(timeoutProvider(context));
+        }
+
+        [Fact]
+        public void Should_call_ontimeout_full_argument_list_but_not_with_task_wrapping_abandoned_action__optimistic()
+        {
+            Task taskPassedToOnTimeout = null;
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = (ctx, span, task, exception) =>
+            {
+                taskPassedToOnTimeout = task;
+                return TaskHelper.EmptyTask;
+            };
+
+            TimeSpan timeout = TimeSpan.FromMilliseconds(250);
+            var policy = Policy.TimeoutAsync(timeout, TimeoutStrategy.Optimistic, onTimeoutAsync);
+            var userCancellationToken = CancellationToken.None;
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async ct =>
+            {
+                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+
+            }, userCancellationToken).ConfigureAwait(false))
+            .ShouldThrow<TimeoutRejectedException>();
+
+            taskPassedToOnTimeout.Should().BeNull();
+        }
+
+#endregion
 
     }
 }

--- a/src/Polly.SharedSpecs/Timeout/TimeoutTResultAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Timeout/TimeoutTResultAsyncSpecs.cs
@@ -791,12 +791,7 @@ namespace Polly.Specs.Timeout
             .ShouldThrow<TimeoutRejectedException>();
 
             exceptionPassedToOnTimeout.Should().NotBeNull();
-            /*
-                This assertion fails on NET40 as the exception is of type TaskCanceledException
-                Unfortunately, using a #if NET40 switch is not viable as the Polly.Net40Async.Specs 
-                project is using NET45 conditional compilation symbols
-            */
-            // exceptionPassedToOnTimeout.Should().BeOfType(typeof(OperationCanceledException));
+            exceptionPassedToOnTimeout.Should().BeOfType(typeof(OperationCanceledException));
         }
 
         [Fact]
@@ -991,12 +986,7 @@ namespace Polly.Specs.Timeout
             .ShouldThrow<TimeoutRejectedException>();
 
             exceptionPassedToOnTimeout.Should().NotBeNull();
-            /*
-                This assertion fails on NET40 as the exception is of type TaskCanceledException
-                Unfortunately, using a #if NET40 switch is not viable as the Polly.Net40Async.Specs 
-                project is using NET45 conditional compilation symbols
-            */
-            // exceptionPassedToOnTimeout.Should().BeOfType(typeof(OperationCanceledException));
+            exceptionPassedToOnTimeout.Should().BeOfType(typeof(OperationCanceledException));
         }
 
         [Fact]

--- a/src/Polly.SharedSpecs/Timeout/TimeoutTResultAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Timeout/TimeoutTResultAsyncSpecs.cs
@@ -120,7 +120,18 @@ namespace Polly.Specs.Timeout
         [Fact]
         public void Should_throw_when_onTimeout_is_null_with_timespan()
         {
-            Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(TimeSpan.FromMinutes(0.5), null);
+            Func<Context, TimeSpan, Task, Task> onTimeout = null;
+            Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(TimeSpan.FromMinutes(0.5), onTimeout);
+
+            policy.ShouldThrow<ArgumentNullException>()
+                .And.ParamName.Should().Be("onTimeoutAsync");
+        }
+
+        [Fact]
+        public void Should_throw_when_onTimeout_is_null_with_timespan_with_full_argument_list_onTimeout()
+        {
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeout = null;
+            Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(TimeSpan.FromMinutes(0.5), onTimeout);
 
             policy.ShouldThrow<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeoutAsync");
@@ -129,7 +140,19 @@ namespace Polly.Specs.Timeout
         [Fact]
         public void Should_throw_when_onTimeout_is_null_with_seconds()
         {
-            Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(30, null);
+            Func<Context, TimeSpan, Task, Task> onTimeout = null;
+            Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(30, onTimeout);
+
+            policy.ShouldThrow<ArgumentNullException>()
+                .And.ParamName.Should().Be("onTimeoutAsync");
+        }
+
+
+        [Fact]
+        public void Should_throw_when_onTimeout_is_null_with_seconds_with_full_argument_list_onTimeout()
+        {
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeout = null;
+            Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(30, onTimeout);
 
             policy.ShouldThrow<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeoutAsync");
@@ -147,7 +170,18 @@ namespace Polly.Specs.Timeout
         [Fact]
         public void Should_throw_when_onTimeout_is_null_with_timeoutprovider()
         {
-            Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(() => TimeSpan.FromSeconds(30), null);
+            Func<Context, TimeSpan, Task, Task> onTimeoutAsync = null;
+            Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(() => TimeSpan.FromSeconds(30), onTimeoutAsync);
+
+            policy.ShouldThrow<ArgumentNullException>()
+                .And.ParamName.Should().Be("onTimeoutAsync");
+        }
+
+        [Fact]
+        public void Should_throw_when_onTimeout_is_null_with_timeoutprovider_for_full_argument_list_onTimeout()
+        {
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = null;
+            Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(() => TimeSpan.FromSeconds(30), onTimeoutAsync);
 
             policy.ShouldThrow<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeoutAsync");
@@ -687,6 +721,380 @@ namespace Polly.Specs.Timeout
         {
             Task taskPassedToOnTimeout = null;
             Func<Context, TimeSpan, Task, Task> onTimeoutAsync = (ctx, span, task) =>
+            {
+                taskPassedToOnTimeout = task;
+                return TaskHelper.EmptyTask;
+            };
+
+            TimeSpan timeout = TimeSpan.FromMilliseconds(250);
+            var policy = Policy.TimeoutAsync<ResultPrimitive>(timeout, TimeoutStrategy.Optimistic, onTimeoutAsync);
+            var userCancellationToken = CancellationToken.None;
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async ct =>
+            {
+                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+                return ResultPrimitive.WhateverButTooLate;
+            }, userCancellationToken).ConfigureAwait(false))
+            .ShouldThrow<TimeoutRejectedException>();
+
+            taskPassedToOnTimeout.Should().BeNull();
+        }
+
+
+        #endregion
+
+        #region onTimeout full argument list - pessimistic
+
+        [Fact]
+        public void Should_call_ontimeout_full_argument_list_with_configured_timeout__pessimistic()
+        {
+            TimeSpan timeoutPassedToConfiguration = TimeSpan.FromMilliseconds(250);
+
+            TimeSpan? timeoutPassedToOnTimeout = null;
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = (ctx, span, task, exception) =>
+            {
+                timeoutPassedToOnTimeout = span;
+                return TaskHelper.EmptyTask;
+            };
+
+            var policy = Policy.TimeoutAsync<ResultPrimitive>(timeoutPassedToConfiguration, TimeoutStrategy.Pessimistic, onTimeoutAsync);
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async () =>
+            {
+                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
+                return ResultPrimitive.WhateverButTooLate;
+            }))
+            .ShouldThrow<TimeoutRejectedException>();
+
+            timeoutPassedToOnTimeout.Should().Be(timeoutPassedToConfiguration);
+        }
+
+        [Fact]
+        public void Should_call_ontimeout_full_argument_list_with_non_null_exception__pessimistic()
+        {
+            TimeSpan timeoutPassedToConfiguration = TimeSpan.FromMilliseconds(250);
+
+            Exception exceptionPassedToOnTimeout = null;
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = (ctx, span, task, exception) =>
+            {
+                exceptionPassedToOnTimeout = exception;
+                return TaskHelper.EmptyTask;
+            };
+
+            var policy = Policy.TimeoutAsync<ResultPrimitive>(timeoutPassedToConfiguration, TimeoutStrategy.Pessimistic, onTimeoutAsync);
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async () =>
+            {
+                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
+                return ResultPrimitive.WhateverButTooLate;
+            }))
+            .ShouldThrow<TimeoutRejectedException>();
+
+            exceptionPassedToOnTimeout.Should().NotBeNull();
+            /*
+                This assertion fails on NET40 as the exception is of type TaskCanceledException
+                Unfortunately, using a #if NET40 switch is not viable as the Polly.Net40Async.Specs 
+                project is using NET45 conditional compilation symbols
+            */
+            // exceptionPassedToOnTimeout.Should().BeOfType(typeof(OperationCanceledException));
+        }
+
+        [Fact]
+        public void Should_call_ontimeout_full_argument_llist_with_passed_context__pessimistic()
+        {
+            string operationKey = Guid.NewGuid().ToString();
+            Context contextPassedToExecute = new Context(operationKey);
+
+            Context contextPassedToOnTimeout = null;
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = (ctx, span, task, exception) =>
+            {
+                contextPassedToOnTimeout = ctx;
+                return TaskHelper.EmptyTask;
+            };
+
+            TimeSpan timeout = TimeSpan.FromMilliseconds(250);
+            var policy = Policy.TimeoutAsync<ResultPrimitive>(timeout, TimeoutStrategy.Pessimistic, onTimeoutAsync);
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async (ctx) =>
+            {
+                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
+                return ResultPrimitive.WhateverButTooLate;
+            }, contextPassedToExecute))
+                .ShouldThrow<TimeoutRejectedException>();
+
+            contextPassedToOnTimeout.Should().NotBeNull();
+            contextPassedToOnTimeout.OperationKey.Should().Be(operationKey);
+            contextPassedToOnTimeout.Should().BeSameAs(contextPassedToExecute);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void Should_call_ontimeout_full_argument_list_with_timeout_supplied_different_for_each_execution_by_evaluating_func__pessimistic(int programaticallyControlledDelay)
+        {
+            Func<TimeSpan> timeoutFunc = () => TimeSpan.FromMilliseconds(25 * programaticallyControlledDelay);
+
+            TimeSpan? timeoutPassedToOnTimeout = null;
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = (ctx, span, task, exception) =>
+            {
+                timeoutPassedToOnTimeout = span;
+                return TaskHelper.EmptyTask;
+            };
+
+            var policy = Policy.TimeoutAsync<ResultPrimitive>(timeoutFunc, TimeoutStrategy.Pessimistic, onTimeoutAsync);
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async () =>
+            {
+                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
+                return ResultPrimitive.WhateverButTooLate;
+            }))
+                .ShouldThrow<TimeoutRejectedException>();
+
+            timeoutPassedToOnTimeout.Should().Be(timeoutFunc());
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void Should_call_ontimeout_full_argument_list_with_timeout_supplied_different_for_each_execution_by_evaluating_func_influenced_by_context__pessimistic(int programaticallyControlledDelay)
+        {
+            Func<Context, TimeSpan> timeoutProvider = ctx => (TimeSpan)ctx["timeout"];
+
+            TimeSpan? timeoutPassedToOnTimeout = null;
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = (ctx, span, task, exception) =>
+            {
+                timeoutPassedToOnTimeout = span;
+                return TaskHelper.EmptyTask;
+            };
+
+            var policy = Policy.TimeoutAsync<ResultPrimitive>(timeoutProvider, TimeoutStrategy.Pessimistic, onTimeoutAsync);
+
+            // Supply a programatically-controlled timeout, via the execution context.
+            Context context = new Context("SomeOperationKey") { ["timeout"] = TimeSpan.FromMilliseconds(25 * programaticallyControlledDelay) };
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async (ctx) =>
+            {
+                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
+                return ResultPrimitive.WhateverButTooLate;
+            }, context))
+            .ShouldThrow<TimeoutRejectedException>();
+
+            timeoutPassedToOnTimeout.Should().Be(timeoutProvider(context));
+        }
+
+        [Fact]
+        public void Should_call_ontimeout_full_argument_list_with_task_wrapping_abandoned_action__pessimistic()
+        {
+            Task taskPassedToOnTimeout = null;
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = (ctx, span, task, exception) =>
+            {
+                taskPassedToOnTimeout = task;
+                return TaskHelper.EmptyTask;
+            };
+
+            TimeSpan timeout = TimeSpan.FromMilliseconds(250);
+            var policy = Policy.TimeoutAsync<ResultPrimitive>(timeout, TimeoutStrategy.Pessimistic, onTimeoutAsync);
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async () =>
+            {
+                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
+                return ResultPrimitive.WhateverButTooLate;
+            }))
+            .ShouldThrow<TimeoutRejectedException>();
+
+            taskPassedToOnTimeout.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task Should_call_ontimeout_full_argument_list_with_task_wrapping_abandoned_action_allowing_capture_of_otherwise_unobserved_exception__pessimistic()
+        {
+            SystemClock.Reset(); // This is the only test which cannot work with the artificial SystemClock of TimeoutSpecsBase.  We want the invoked delegate to continue as far as: throw exceptionToThrow, to genuinely check that the walked-away-from task throws that, and that we pass it to onTimeoutAsync.  
+            // That means we can't use the SystemClock.SleepAsync(...) within the executed delegate to artificially trigger the timeout cancellation (as for example the test above does).
+            // In real execution, it is the .WhenAny() in the timeout implementation which throws for the timeout.  We don't want to go as far as abstracting Task.WhenAny() out into SystemClock, so we let this test run at real-world speed, not abstracted-clock speed.
+
+            Exception exceptionToThrow = new DivideByZeroException();
+
+            Exception exceptionObservedFromTaskPassedToOnTimeout = null;
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = (ctx, span, task, exception) =>
+            {
+                task.ContinueWith(t => exceptionObservedFromTaskPassedToOnTimeout = task.Exception.InnerException); // Intentionally not awaited: we want to assign the continuation, but let it run in its own time when the executed delegate eventually completes.
+                return TaskHelper.EmptyTask;
+            };
+
+            TimeSpan shimTimespan = TimeSpan.FromSeconds(1); // Consider increasing shimTimeSpan if test fails transiently in different environments.
+            TimeSpan thriceShimTimeSpan = shimTimespan + shimTimespan + shimTimespan;
+            var policy = Policy.TimeoutAsync<ResultPrimitive>(shimTimespan, TimeoutStrategy.Pessimistic, onTimeoutAsync);
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async () =>
+            {
+                await SystemClock.SleepAsync(thriceShimTimeSpan, CancellationToken.None).ConfigureAwait(false);
+                throw exceptionToThrow;
+            }))
+            .ShouldThrow<TimeoutRejectedException>();
+
+            await SystemClock.SleepAsync(thriceShimTimeSpan, CancellationToken.None).ConfigureAwait(false);
+            exceptionObservedFromTaskPassedToOnTimeout.Should().NotBeNull();
+            exceptionObservedFromTaskPassedToOnTimeout.Should().Be(exceptionToThrow);
+        }
+
+        #endregion
+
+        #region onTimeout full argument list - optimistic
+
+        [Fact]
+        public void Should_call_ontimeout_full_argument_list_with_configured_timeout__optimistic()
+        {
+            TimeSpan timeoutPassedToConfiguration = TimeSpan.FromMilliseconds(250);
+
+            TimeSpan? timeoutPassedToOnTimeout = null;
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = (ctx, span, task, exception) =>
+            {
+                timeoutPassedToOnTimeout = span;
+                return TaskHelper.EmptyTask;
+            };
+
+            var policy = Policy.TimeoutAsync<ResultPrimitive>(timeoutPassedToConfiguration, TimeoutStrategy.Optimistic, onTimeoutAsync);
+            var userCancellationToken = CancellationToken.None;
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async ct =>
+            {
+                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+                return ResultPrimitive.WhateverButTooLate;
+            }, userCancellationToken).ConfigureAwait(false))
+            .ShouldThrow<TimeoutRejectedException>();
+
+            timeoutPassedToOnTimeout.Should().Be(timeoutPassedToConfiguration);
+        }
+
+        [Fact]
+        public void Should_call_ontimeout_full_argument_list_with_non_null_exception__optimistic()
+        {
+            TimeSpan timeoutPassedToConfiguration = TimeSpan.FromMilliseconds(250);
+
+            Exception exceptionPassedToOnTimeout = null;
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = (ctx, span, task, exception) =>
+            {
+                exceptionPassedToOnTimeout = exception;
+                return TaskHelper.EmptyTask;
+            };
+
+            var policy = Policy.TimeoutAsync<ResultPrimitive>(timeoutPassedToConfiguration, TimeoutStrategy.Optimistic, onTimeoutAsync);
+            var userCancellationToken = CancellationToken.None;
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async ct =>
+            {
+                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+                return ResultPrimitive.WhateverButTooLate;
+            }, userCancellationToken).ConfigureAwait(false))
+            .ShouldThrow<TimeoutRejectedException>();
+
+            exceptionPassedToOnTimeout.Should().NotBeNull();
+            /*
+                This assertion fails on NET40 as the exception is of type TaskCanceledException
+                Unfortunately, using a #if NET40 switch is not viable as the Polly.Net40Async.Specs 
+                project is using NET45 conditional compilation symbols
+            */
+            // exceptionPassedToOnTimeout.Should().BeOfType(typeof(OperationCanceledException));
+        }
+
+        [Fact]
+        public void Should_call_ontimeout_full_argument_list_with_passed_context__optimistic()
+        {
+            string operationKey = Guid.NewGuid().ToString();
+            Context contextPassedToExecute = new Context(operationKey);
+
+            Context contextPassedToOnTimeout = null;
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = (ctx, span, task, exception) =>
+            {
+                contextPassedToOnTimeout = ctx;
+                return TaskHelper.EmptyTask;
+            };
+
+            TimeSpan timeout = TimeSpan.FromMilliseconds(250);
+            var policy = Policy.TimeoutAsync<ResultPrimitive>(timeout, TimeoutStrategy.Optimistic, onTimeoutAsync);
+            var userCancellationToken = CancellationToken.None;
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async (ctx, ct) =>
+            {
+                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+                return ResultPrimitive.WhateverButTooLate;
+            }, contextPassedToExecute, userCancellationToken).ConfigureAwait(false))
+                .ShouldThrow<TimeoutRejectedException>();
+
+            contextPassedToOnTimeout.Should().NotBeNull();
+            contextPassedToOnTimeout.OperationKey.Should().Be(operationKey);
+            contextPassedToOnTimeout.Should().BeSameAs(contextPassedToExecute);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void Should_call_ontimeout_full_argument_list_with_timeout_supplied_different_for_each_execution_by_evaluating_func__optimistic(int programaticallyControlledDelay)
+        {
+            Func<TimeSpan> timeoutFunc = () => TimeSpan.FromMilliseconds(25 * programaticallyControlledDelay);
+
+            TimeSpan? timeoutPassedToOnTimeout = null;
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = (ctx, span, task, Exception) =>
+            {
+                timeoutPassedToOnTimeout = span;
+                return TaskHelper.EmptyTask;
+            };
+
+            var policy = Policy.TimeoutAsync<ResultPrimitive>(timeoutFunc, TimeoutStrategy.Optimistic, onTimeoutAsync);
+            var userCancellationToken = CancellationToken.None;
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async ct =>
+            {
+                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+                return ResultPrimitive.WhateverButTooLate;
+            }, userCancellationToken).ConfigureAwait(false))
+                .ShouldThrow<TimeoutRejectedException>();
+
+            timeoutPassedToOnTimeout.Should().Be(timeoutFunc());
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void Should_call_ontimeout_full_argument_list_with_timeout_supplied_different_for_each_execution_by_evaluating_func_influenced_by_context__optimistic(int programaticallyControlledDelay)
+        {
+            Func<Context, TimeSpan> timeoutProvider = ctx => (TimeSpan)ctx["timeout"];
+
+            TimeSpan? timeoutPassedToOnTimeout = null;
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = (ctx, span, task, exception) =>
+            {
+                timeoutPassedToOnTimeout = span;
+                return TaskHelper.EmptyTask;
+            };
+
+            var policy = Policy.TimeoutAsync<ResultPrimitive>(timeoutProvider, TimeoutStrategy.Optimistic, onTimeoutAsync);
+            var userCancellationToken = CancellationToken.None;
+
+            // Supply a programatically-controlled timeout, via the execution context.
+            Context context = new Context("SomeOperationKey")
+            {
+                ["timeout"] = TimeSpan.FromMilliseconds(25 * programaticallyControlledDelay)
+            };
+
+            policy.Awaiting(async p => await p.ExecuteAsync(async (ctx, ct) =>
+            {
+                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+                return ResultPrimitive.WhateverButTooLate;
+            }, context, userCancellationToken).ConfigureAwait(false))
+                .ShouldThrow<TimeoutRejectedException>();
+
+            timeoutPassedToOnTimeout.Should().Be(timeoutProvider(context));
+        }
+
+        [Fact]
+        public void Should_call_ontimeout_full_argument_list_but_not_with_task_wrapping_abandoned_action__optimistic()
+        {
+            Task taskPassedToOnTimeout = null;
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = (ctx, span, task, exception) =>
             {
                 taskPassedToOnTimeout = task;
                 return TaskHelper.EmptyTask;

--- a/src/Polly.SharedSpecs/Timeout/TimeoutTResultSpecs.cs
+++ b/src/Polly.SharedSpecs/Timeout/TimeoutTResultSpecs.cs
@@ -120,7 +120,18 @@ namespace Polly.Specs.Timeout
         [Fact]
         public void Should_throw_when_onTimeout_is_null_with_timespan()
         {
-            Action policy = () => Policy.Timeout<ResultPrimitive>(TimeSpan.FromMinutes(0.5), null);
+            Action<Context, TimeSpan, Task> onTimeout = null;
+            Action policy = () => Policy.Timeout<ResultPrimitive>(TimeSpan.FromMinutes(0.5), onTimeout);
+
+            policy.ShouldThrow<ArgumentNullException>()
+                .And.ParamName.Should().Be("onTimeout");
+        }
+
+        [Fact]
+        public void Should_throw_when_onTimeout_is_null_with_timespan_and_onTimeout_is_full_argument_set()
+        {
+            Action<Context, TimeSpan, Task, Exception> onTimeout = null;
+            Action policy = () => Policy.Timeout<ResultPrimitive>(TimeSpan.FromMinutes(0.5), onTimeout);
 
             policy.ShouldThrow<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeout");
@@ -129,7 +140,18 @@ namespace Polly.Specs.Timeout
         [Fact]
         public void Should_throw_when_onTimeout_is_null_with_seconds()
         {
-            Action policy = () => Policy.Timeout<ResultPrimitive>(30, null);
+            Action<Context, TimeSpan, Task> onTimeout = null;
+            Action policy = () => Policy.Timeout<ResultPrimitive>(30, onTimeout);
+
+            policy.ShouldThrow<ArgumentNullException>()
+                .And.ParamName.Should().Be("onTimeout");
+        }
+
+        [Fact]
+        public void Should_throw_when_onTimeout_is_null_with_seconds_and_onTimeout_is_full_argument_set()
+        {
+            Action<Context, TimeSpan, Task, Exception> onTimeout = null;
+            Action policy = () => Policy.Timeout<ResultPrimitive>(30, onTimeout);
 
             policy.ShouldThrow<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeout");
@@ -147,7 +169,18 @@ namespace Polly.Specs.Timeout
         [Fact]
         public void Should_throw_when_onTimeout_is_null_with_timeoutprovider()
         {
-            Action policy = () => Policy.Timeout<ResultPrimitive>(() => TimeSpan.FromSeconds(30), null);
+            Action<Context, TimeSpan, Task> onTimeout = null;
+            Action policy = () => Policy.Timeout<ResultPrimitive>(() => TimeSpan.FromSeconds(30), onTimeout);
+
+            policy.ShouldThrow<ArgumentNullException>()
+                .And.ParamName.Should().Be("onTimeout");
+        }
+
+        [Fact]
+        public void Should_throw_when_onTimeout_is_null_with_timeoutprovider_and_onTimeout_is_full_argument_set()
+        {
+            Action<Context, TimeSpan, Task, Exception> onTimeout = null;
+            Action policy = () => Policy.Timeout<ResultPrimitive>(() => TimeSpan.FromSeconds(30), onTimeout);
 
             policy.ShouldThrow<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeout");
@@ -736,5 +769,319 @@ namespace Polly.Specs.Timeout
 
         #endregion
 
+
+        #region onTimeout full argument list - pessimistic
+
+        [Fact]
+        public void Should_call_ontimeout_full_argument_llist_with_configured_timeout__pessimistic()
+        {
+            TimeSpan timeoutPassedToConfiguration = TimeSpan.FromMilliseconds(250);
+
+            TimeSpan? timeoutPassedToOnTimeout = null;
+            Action<Context, TimeSpan, Task, Exception> onTimeout = (ctx, span, task, exception) => { timeoutPassedToOnTimeout = span; };
+
+            var policy = Policy.Timeout<ResultPrimitive>(timeoutPassedToConfiguration, TimeoutStrategy.Pessimistic, onTimeout);
+
+            policy.Invoking(p => p.Execute(() =>
+            {
+                SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None);
+                return ResultPrimitive.WhateverButTooLate;
+            }))
+            .ShouldThrow<TimeoutRejectedException>();
+
+            timeoutPassedToOnTimeout.Should().Be(timeoutPassedToConfiguration);
+        }
+
+        [Fact]
+        public void Should_call_ontimeout_full_argument_llist_with_non_null_exception__pessimistic()
+        {
+            TimeSpan timeoutPassedToConfiguration = TimeSpan.FromMilliseconds(250);
+
+            Exception exceptionPassedToOnTimeout = null;
+            Action<Context, TimeSpan, Task, Exception> onTimeout = (ctx, span, task, exception) => { exceptionPassedToOnTimeout = exception; };
+
+            var policy = Policy.Timeout<ResultPrimitive>(timeoutPassedToConfiguration, TimeoutStrategy.Pessimistic, onTimeout);
+
+            policy.Invoking(p => p.Execute(() =>
+            {
+                SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None);
+                return ResultPrimitive.WhateverButTooLate;
+            }))
+            .ShouldThrow<TimeoutRejectedException>();
+
+            exceptionPassedToOnTimeout.Should().NotBeNull();
+            exceptionPassedToOnTimeout.Should().BeOfType(typeof(OperationCanceledException));
+        }
+
+        [Fact]
+        public void Should_call_ontimeout_full_argument_list_with_passed_context__pessimistic()
+        {
+            string operationKey = Guid.NewGuid().ToString();
+            Context contextPassedToExecute = new Context(operationKey);
+
+            Context contextPassedToOnTimeout = null;
+            Action<Context, TimeSpan, Task, Exception> onTimeout = (ctx, span, task, exception) => { contextPassedToOnTimeout = ctx; };
+
+            TimeSpan timeout = TimeSpan.FromMilliseconds(250);
+            var policy = Policy.Timeout<ResultPrimitive>(timeout, TimeoutStrategy.Pessimistic, onTimeout);
+
+            policy.Invoking(p => p.Execute((ctx) =>
+            {
+                SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None);
+                return ResultPrimitive.WhateverButTooLate;
+            }, contextPassedToExecute))
+                .ShouldThrow<TimeoutRejectedException>();
+
+            contextPassedToOnTimeout.Should().NotBeNull();
+            contextPassedToOnTimeout.OperationKey.Should().Be(operationKey);
+            contextPassedToOnTimeout.Should().BeSameAs(contextPassedToExecute);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void Should_call_ontimeout_full_argument_list_with_timeout_supplied_different_for_each_execution_by_evaluating_func__pessimistic(int programaticallyControlledDelay)
+        {
+            Func<TimeSpan> timeoutFunc = () => TimeSpan.FromMilliseconds(25 * programaticallyControlledDelay);
+
+            TimeSpan? timeoutPassedToOnTimeout = null;
+            Action<Context, TimeSpan, Task, Exception> onTimeout = (ctx, span, task, exception) => { timeoutPassedToOnTimeout = span; };
+
+            var policy = Policy.Timeout<ResultPrimitive>(timeoutFunc, TimeoutStrategy.Pessimistic, onTimeout);
+
+            policy.Invoking(p => p.Execute(() =>
+            {
+                SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None);
+                return ResultPrimitive.WhateverButTooLate;
+            }))
+                .ShouldThrow<TimeoutRejectedException>();
+
+            timeoutPassedToOnTimeout.Should().Be(timeoutFunc());
+
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void Should_call_ontimeout_full_argument_list_with_timeout_supplied_different_for_each_execution_by_evaluating_func_influenced_by_context__pessimistic(int programaticallyControlledDelay)
+        {
+            Func<Context, TimeSpan> timeoutProvider = ctx => (TimeSpan)ctx["timeout"];
+
+            TimeSpan? timeoutPassedToOnTimeout = null;
+            Action<Context, TimeSpan, Task, Exception> onTimeout = (ctx, span, task, exception) => { timeoutPassedToOnTimeout = span; };
+            var policy = Policy.Timeout<ResultPrimitive>(timeoutProvider, TimeoutStrategy.Pessimistic, onTimeout);
+
+            // Supply a programatically-controlled timeout, via the execution context.
+            Context context = new Context("SomeOperationKey") { ["timeout"] = TimeSpan.FromMilliseconds(25 * programaticallyControlledDelay) };
+
+            policy.Invoking(p => p.Execute((ctx) =>
+            {
+                SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None);
+                return ResultPrimitive.WhateverButTooLate;
+            }, context))
+                .ShouldThrow<TimeoutRejectedException>();
+
+            timeoutPassedToOnTimeout.Should().Be(timeoutProvider(context));
+        }
+
+        [Fact]
+        public void Should_call_ontimeout_full_argument_list_with_task_wrapping_abandoned_action__pessimistic()
+        {
+            Task taskPassedToOnTimeout = null;
+            Action<Context, TimeSpan, Task, Exception> onTimeout = (ctx, span, task, exception) => { taskPassedToOnTimeout = task; };
+
+            TimeSpan timeout = TimeSpan.FromMilliseconds(250);
+            var policy = Policy.Timeout<ResultPrimitive>(timeout, TimeoutStrategy.Pessimistic, onTimeout);
+
+            policy.Invoking(p => p.Execute(() =>
+            {
+                SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None);
+                return ResultPrimitive.WhateverButTooLate;
+            }))
+            .ShouldThrow<TimeoutRejectedException>();
+
+            taskPassedToOnTimeout.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void Should_call_ontimeout_full_argument_list_with_task_wrapping_abandoned_action_allowing_capture_of_otherwise_unobserved_exception__pessimistic()
+        {
+            SystemClock.Reset(); // This is the only test which cannot work with the artificial SystemClock of TimeoutSpecsBase.  We want the invoked delegate to continue as far as: throw exceptionToThrow, to genuinely check that the walked-away-from task throws that, and that we pass it to onTimeout.  
+            // That means we can't use the SystemClock.Sleep(...) within the executed delegate to artificially trigger the timeout cancellation (as for example the test above does).
+            // In real execution, it is the .Wait(timeoutCancellationTokenSource.Token) in the timeout implementation which throws for the timeout.  We don't want to go as far as abstracting Task.Wait() out into SystemClock, so we let this test run at real-world speed, not abstracted-clock speed.
+
+            Exception exceptionToThrow = new DivideByZeroException();
+
+            Exception exceptionObservedFromTaskPassedToOnTimeout = null;
+            Action<Context, TimeSpan, Task, Exception> onTimeout = (ctx, span, task, exception) =>
+            {
+                task.ContinueWith(t => exceptionObservedFromTaskPassedToOnTimeout = t.Exception.InnerException);
+            };
+
+            TimeSpan shimTimespan = TimeSpan.FromSeconds(1); // Consider increasing shimTimeSpan if test fails transiently in different environments.
+            TimeSpan thriceShimTimeSpan = shimTimespan + shimTimespan + shimTimespan;
+            var policy = Policy.Timeout<ResultPrimitive>(shimTimespan, TimeoutStrategy.Pessimistic, onTimeout);
+
+            policy.Invoking(p => p.Execute(() =>
+            {
+                SystemClock.Sleep(thriceShimTimeSpan, CancellationToken.None);
+                throw exceptionToThrow;
+            }))
+            .ShouldThrow<TimeoutRejectedException>();
+
+            SystemClock.Sleep(thriceShimTimeSpan, CancellationToken.None);
+            exceptionObservedFromTaskPassedToOnTimeout.Should().NotBeNull();
+            exceptionObservedFromTaskPassedToOnTimeout.Should().Be(exceptionToThrow);
+
+        }
+
+        #endregion
+
+        #region onTimeout full argument list - optimistic
+
+        [Fact]
+        public void Should_call_ontimeout_full_argument_list_with_configured_timeout__optimistic()
+        {
+            TimeSpan timeoutPassedToConfiguration = TimeSpan.FromMilliseconds(250);
+
+            TimeSpan? timeoutPassedToOnTimeout = null;
+            Action<Context, TimeSpan, Task, Exception> onTimeout = (ctx, span, task, exception) => { timeoutPassedToOnTimeout = span; };
+
+            var policy = Policy.Timeout<ResultPrimitive>(timeoutPassedToConfiguration, TimeoutStrategy.Optimistic, onTimeout);
+            var userCancellationToken = CancellationToken.None;
+
+            policy.Invoking(p => p.Execute(ct =>
+            {
+                SystemClock.Sleep(TimeSpan.FromSeconds(1), ct);
+                return ResultPrimitive.WhateverButTooLate;
+            }, userCancellationToken))
+            .ShouldThrow<TimeoutRejectedException>();
+
+            timeoutPassedToOnTimeout.Should().Be(timeoutPassedToConfiguration);
+        }
+
+        [Fact]
+        public void Should_call_ontimeout_full_argument_list_with_non_null_exception__optimistic()
+        {
+            TimeSpan timeoutPassedToConfiguration = TimeSpan.FromMilliseconds(250);
+
+            Exception exceptionPassedToOnTimeout = null;
+            Action<Context, TimeSpan, Task, Exception> onTimeout = (ctx, span, task, exception) => { exceptionPassedToOnTimeout = exception; };
+
+            var policy = Policy.Timeout<ResultPrimitive>(timeoutPassedToConfiguration, TimeoutStrategy.Optimistic, onTimeout);
+            var userCancellationToken = CancellationToken.None;
+
+            policy.Invoking(p => p.Execute(ct =>
+            {
+                SystemClock.Sleep(TimeSpan.FromSeconds(1), ct);
+                return ResultPrimitive.WhateverButTooLate;
+            }, userCancellationToken))
+            .ShouldThrow<TimeoutRejectedException>();
+
+            exceptionPassedToOnTimeout.Should().NotBeNull();
+            exceptionPassedToOnTimeout.Should().BeOfType(typeof(OperationCanceledException));
+        }
+
+        [Fact]
+        public void Should_call_ontimeout_full_argument_list_with_passed_context__optimistic()
+        {
+            string operationKeyy = Guid.NewGuid().ToString();
+            Context contextPassedToExecute = new Context(operationKeyy);
+
+            Context contextPassedToOnTimeout = null;
+            Action<Context, TimeSpan, Task, Exception> onTimeout = (ctx, span, task, exception) => { contextPassedToOnTimeout = ctx; };
+
+            TimeSpan timeout = TimeSpan.FromMilliseconds(250);
+            var policy = Policy.Timeout<ResultPrimitive>(timeout, TimeoutStrategy.Optimistic, onTimeout);
+            var userCancellationToken = CancellationToken.None;
+
+            policy.Invoking(p => p.Execute((ctx, ct) =>
+            {
+                SystemClock.Sleep(TimeSpan.FromSeconds(3), ct);
+                return ResultPrimitive.WhateverButTooLate;
+            }, contextPassedToExecute, userCancellationToken))
+                .ShouldThrow<TimeoutRejectedException>();
+
+            contextPassedToOnTimeout.Should().NotBeNull();
+            contextPassedToOnTimeout.OperationKey.Should().Be(operationKeyy);
+            contextPassedToOnTimeout.Should().BeSameAs(contextPassedToExecute);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void Should_call_ontimeout_full_argument_list_with_timeout_supplied_different_for_each_execution_by_evaluating_func__optimistic(int programaticallyControlledDelay)
+        {
+            Func<TimeSpan> timeoutFunc = () => TimeSpan.FromMilliseconds(25 * programaticallyControlledDelay);
+
+            TimeSpan? timeoutPassedToOnTimeout = null;
+            Action<Context, TimeSpan, Task, Exception> onTimeout = (ctx, span, task, exception) => { timeoutPassedToOnTimeout = span; };
+
+            var policy = Policy.Timeout<ResultPrimitive>(timeoutFunc, TimeoutStrategy.Optimistic, onTimeout);
+            var userCancellationToken = CancellationToken.None;
+
+            policy.Invoking(p => p.Execute(ct =>
+            {
+                SystemClock.Sleep(TimeSpan.FromSeconds(3), ct);
+                return ResultPrimitive.WhateverButTooLate;
+            }, userCancellationToken))
+                .ShouldThrow<TimeoutRejectedException>();
+
+            timeoutPassedToOnTimeout.Should().Be(timeoutFunc());
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void Should_call_ontimeout_full_argument_list_with_timeout_supplied_different_for_each_execution_by_evaluating_func_influenced_by_context__optimistic(int programaticallyControlledDelay)
+        {
+            Func<Context, TimeSpan> timeoutProvider = ctx => (TimeSpan)ctx["timeout"];
+
+            TimeSpan? timeoutPassedToOnTimeout = null;
+            Action<Context, TimeSpan, Task, Exception> onTimeout = (ctx, span, task, exception) => { timeoutPassedToOnTimeout = span; };
+            var policy = Policy.Timeout<ResultPrimitive>(timeoutProvider, TimeoutStrategy.Optimistic, onTimeout);
+            var userCancellationToken = CancellationToken.None;
+
+            // Supply a programatically-controlled timeout, via the execution context.
+            Context context = new Context("SomeOperationKey")
+            {
+                ["timeout"] = TimeSpan.FromMilliseconds(25 * programaticallyControlledDelay)
+            };
+
+            policy.Invoking(p => p.Execute((ctx, ct) =>
+            {
+                SystemClock.Sleep(TimeSpan.FromSeconds(3), ct);
+                return ResultPrimitive.WhateverButTooLate;
+            }, context, userCancellationToken))
+                .ShouldThrow<TimeoutRejectedException>();
+
+            timeoutPassedToOnTimeout.Should().Be(timeoutProvider(context));
+        }
+
+        [Fact]
+        public void Should_call_ontimeout_full_argument_list_but_not_with_task_wrapping_abandoned_action__optimistic()
+        {
+            Task taskPassedToOnTimeout = null;
+            Action<Context, TimeSpan, Task, Exception> onTimeout = (ctx, span, task, exception) => { taskPassedToOnTimeout = task; };
+
+            TimeSpan timeout = TimeSpan.FromMilliseconds(250);
+            var policy = Policy.Timeout<ResultPrimitive>(timeout, TimeoutStrategy.Optimistic, onTimeout);
+            var userCancellationToken = CancellationToken.None;
+
+            policy.Invoking(p => p.Execute(ct =>
+            {
+                SystemClock.Sleep(TimeSpan.FromSeconds(3), ct);
+                return ResultPrimitive.WhateverButTooLate;
+            }, userCancellationToken))
+            .ShouldThrow<TimeoutRejectedException>();
+
+            taskPassedToOnTimeout.Should().BeNull();
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Extend `onTimeout/async` delegates to take the thrown `OperationCanceledException` as an input parameter (Issue #338)

* Added overloads to all sync/async timeout syntax classes to allow passing of exception in onTimeout delegates
* Added unit tests