### PR TITLE
Add .AsPolicy<TResult> and .AsAsyncPolicy<TResult>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 5.9.0
 - Allow Timeout.InfiniteTimeSpan (no timeout) for TimeoutPolicy. 
+- Add .AsPolicy&lt;TResult&gt; and .AsAsyncPolicy&lt;TResult&gt; methods for converting non-generic policies to generic policies.
 - Per Semver, indicates deprecation of overloads and properties intended to be removed or renamed in Polly v6.
 
 ## 5.8.0

--- a/src/Polly.Net40Async.nuspec
+++ b/src/Polly.Net40Async.nuspec
@@ -18,6 +18,7 @@
      5.9.0
      ---------------------
      - Allow Timeout.InfiniteTimeSpan (no timeout) for TimeoutPolicy. 
+     - Add .AsPolicy&lt;TResult&gt; and .AsAsyncPolicy&lt;TResult&gt; methods for converting non-generic policies to generic policies.
      - Per Semver, indicates deprecation of overloads and properties intended to be removed or renamed in Polly v6.
      
      5.8.0

--- a/src/Polly.Shared/IAsyncPolicy.Extensions.cs
+++ b/src/Polly.Shared/IAsyncPolicy.Extensions.cs
@@ -1,0 +1,20 @@
+﻿namespace Polly
+{
+    /// <summary>
+    /// Contains extensions methods on <see cref="IAsyncPolicy"/>
+    /// </summary>
+    public static class IAsyncPolicyExtensions
+    {
+        /// <summary>
+        /// Converts a non-generic <see cref="IAsyncPolicy"/> into a generic <see cref="IAsyncPolicy{TResult}"/> for handling only executions returning <typeparamref name="TResult"/>.
+        /// </summary>
+        /// <remarks>This method allows you to convert a non-generic <see cref="IAsyncPolicy"/> into a generic <see cref="IAsyncPolicy{TResult}"/> for contexts such as variables or parameters which may explicitly require a generic <see cref="IAsyncPolicy{TResult}"/>. </remarks>
+        /// <param name="policy">The non-generic <see cref="IAsyncPolicy"/>  to convert to a generic <see cref="IAsyncPolicy{TResult}"/>.</param>
+        /// <returns>A generic <see cref="IAsyncPolicy{TResult}"/> version of the supplied non-generic <see cref="IAsyncPolicy"/>.</returns>
+        public static IAsyncPolicy<TResult> AsAsyncPolicy<TResult>(this IAsyncPolicy policy)
+        {
+            return policy.WrapAsync(Policy.NoOpAsync<TResult>());
+        }
+    }
+
+}

--- a/src/Polly.Shared/ISyncPolicy.Extensions.cs
+++ b/src/Polly.Shared/ISyncPolicy.Extensions.cs
@@ -1,0 +1,20 @@
+﻿namespace Polly
+{
+    /// <summary>
+    /// Contains extensions methods on <see cref="ISyncPolicy"/>
+    /// </summary>
+    public static class ISyncPolicyExtensions
+    {
+        /// <summary>
+        /// Converts a non-generic <see cref="ISyncPolicy"/> into a generic <see cref="ISyncPolicy{TResult}"/> for handling only executions returning <typeparamref name="TResult"/>.
+        /// </summary>
+        /// <remarks>This method allows you to convert a non-generic <see cref="ISyncPolicy"/> into a generic <see cref="ISyncPolicy{TResult}"/> for contexts such as variables or parameters which may explicitly require a generic <see cref="ISyncPolicy{TResult}"/>. </remarks>
+        /// <param name="policy">The non-generic <see cref="ISyncPolicy"/>  to convert to a generic <see cref="ISyncPolicy{TResult}"/>.</param>
+        /// <returns>A generic <see cref="ISyncPolicy{TResult}"/> version of the supplied non-generic <see cref="ISyncPolicy"/>.</returns>
+        public static ISyncPolicy<TResult> AsPolicy<TResult>(this ISyncPolicy policy)
+        {
+            return policy.Wrap(Policy.NoOp<TResult>());
+        }
+    }
+
+}

--- a/src/Polly.Shared/Polly.Shared.projitems
+++ b/src/Polly.Shared/Polly.Shared.projitems
@@ -85,6 +85,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Fallback\FallbackPolicyAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Fallback\IFallbackPolicy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IAsyncPolicy.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)IAsyncPolicy.Extensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IAsyncPolicy.TResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ISyncPolicy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IsPolicy.cs" />
@@ -98,6 +99,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)NoOp\NoOpTResultSyntaxAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NoOp\NoOpTResultSyntax.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NoOp\NoOpSyntax.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ISyncPolicy.Extensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Policy.Async.ExecuteOverloads.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Policy.Async.TResult.ExecuteOverloads.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Policy.cs" />

--- a/src/Polly.SharedSpecs/IAsyncPolicyExtensionsSpecs.cs
+++ b/src/Polly.SharedSpecs/IAsyncPolicyExtensionsSpecs.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Polly.CircuitBreaker;
+using Polly.Specs.Helpers;
+using Polly.Utilities;
+using Xunit;
+
+namespace Polly.Specs
+{
+    public class IAsyncPolicyExtensionsSpecs
+    {
+        [Fact]
+        public void Converting_a_nongeneric_IAsyncPolicy_to_generic_should_return_a_generic_IAsyncPolicyTResult()
+        {
+            IAsyncPolicy nonGenericPolicy = Policy.TimeoutAsync(10);
+            var genericPolicy = nonGenericPolicy.AsAsyncPolicy<ResultClass>();
+
+            genericPolicy.Should().BeAssignableTo<IAsyncPolicy<ResultClass>>();
+        }
+
+        [Fact]
+        public async Task Converting_a_nongeneric_IAsyncPolicy_to_generic_should_return_an_IAsyncPolicyTResult_version_of_the_supplied_nongeneric_policy_instance()
+        {
+            // Use a CircuitBreaker as a policy which we can easily manipulate to demonstrate that the executions are passing through the underlying non-generic policy.
+
+            CircuitBreakerPolicy breaker = Policy.Handle<Exception>().CircuitBreakerAsync(1, TimeSpan.Zero);
+            IAsyncPolicy nonGenericPolicy = breaker;
+            var genericPolicy = nonGenericPolicy.AsAsyncPolicy<ResultPrimitive>();
+            Func<Task<ResultPrimitive>> deleg = () => TaskHelper.FromResult(ResultPrimitive.Good);
+
+            (await genericPolicy.ExecuteAsync(deleg)).Should().Be(ResultPrimitive.Good);
+            breaker.Isolate();
+            genericPolicy.Awaiting(p => p.ExecuteAsync(deleg)).ShouldThrow<BrokenCircuitException>();
+        }
+    }
+
+}

--- a/src/Polly.SharedSpecs/ISyncPolicyExtensionsSpecs.cs
+++ b/src/Polly.SharedSpecs/ISyncPolicyExtensionsSpecs.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using FluentAssertions;
+using Polly.CircuitBreaker;
+using Polly.Specs.Helpers;
+using Xunit;
+
+namespace Polly.Specs
+{
+    public class ISyncPolicyExtensionsSpecs
+    {
+        [Fact]
+        public void Converting_a_nongeneric_ISyncPolicy_to_generic_should_return_a_generic_ISyncPolicyTResult()
+        {
+            ISyncPolicy nonGenericPolicy = Policy.Timeout(10);
+            var genericPolicy = nonGenericPolicy.AsPolicy<ResultClass>();
+
+            genericPolicy.Should().BeAssignableTo<ISyncPolicy<ResultClass>>();
+        }
+
+        [Fact]
+        public void Converting_a_nongeneric_ISyncPolicy_to_generic_should_return_an_ISyncPolicyTResult_version_of_the_supplied_nongeneric_policy_instance()
+        {
+            // Use a CircuitBreaker as a policy which we can easily manipulate to demonstrate that the executions are passing through the underlying non-generic policy.
+
+            CircuitBreakerPolicy breaker = Policy.Handle<Exception>().CircuitBreaker(1, TimeSpan.Zero);
+            ISyncPolicy nonGenericPolicy = breaker;
+            var genericPolicy = nonGenericPolicy.AsPolicy<ResultPrimitive>();
+            Func<ResultPrimitive> deleg = () => ResultPrimitive.Good;
+
+            genericPolicy.Execute(deleg).Should().Be(ResultPrimitive.Good);
+            breaker.Isolate();
+            genericPolicy.Invoking(p => p.Execute(deleg)).ShouldThrow<BrokenCircuitException>();
+        }
+    }
+
+}

--- a/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
+++ b/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
@@ -61,6 +61,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\PolicyTResultExtensionsAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ResultClass.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ResultPrimitive.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)IAsyncPolicyExtensionsSpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ISyncPolicyExtensionsSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NoOp\NoOpTResultSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NoOp\NoOpTResultAsyncSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NoOp\NoOpAsyncSpecs.cs" />

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -18,6 +18,7 @@
      5.9.0
      ---------------------
      - Allow Timeout.InfiniteTimeSpan (no timeout) for TimeoutPolicy. 
+     - Add .AsPolicy&lt;TResult&gt; and .AsAsyncPolicy&lt;TResult&gt; methods for converting non-generic policies to generic policies.
      - Per Semver, indicates deprecation of overloads and properties intended to be removed or renamed in Polly v6.
 
      5.8.0


### PR DESCRIPTION
Add `.AsPolicy&lt;TResult&gt;()` and `.AsAsyncPolicy&lt;TResult&gt;()` methods for converting non-generic policies to generic policies.