### PR TITLE
Add wait and retry forever overloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,8 +585,8 @@ For more detail see: [Bulkhead policy documentation](https://github.com/App-vNex
 ### Cache
 
 ```csharp
-// Define a cache Policy in the .NET Framework, using the Polly.Caching.MemoryCache nuget package.
-var memoryCacheProvider = new Polly.Caching.MemoryCache.MemoryCacheProvider(MemoryCache.Default);
+// Define a cache Policy in the .NET Framework, using the Polly.Caching.Memory nuget package.
+var memoryCacheProvider = new MemoryCacheProvider(MemoryCache.Default);
 var cachePolicy = Policy.Cache(memoryCacheProvider, TimeSpan.FromMinutes(5));
 
 // Define a cache policy with absolute expiration at midnight tonight.

--- a/README.md
+++ b/README.md
@@ -983,7 +983,9 @@ For full detailed of supported targets by version, see [supported targets](https
 
 # Sample Projects
 
-[Polly-Samples](https://github.com/App-vNext/Polly-Samples) contains practical examples for using various implementations of Polly. Please feel free to contribute to the Polly-Samples repository in order to assist others who are either learning Polly for the first time, or are seeking advanced examples and novel approaches provided by our generous community.
+* [Polly-Samples](https://github.com/App-vNext/Polly-Samples) contains practical examples for using various implementations of Polly. Please feel free to contribute to the Polly-Samples repository in order to assist others who are either learning Polly for the first time, or are seeking advanced examples and novel approaches provided by our generous community.
+
+* Microsoft's [eShopOnContainers project](https://github.com/dotnet-architecture/eShopOnContainers) is a sample project demonstrating a .NET Microservices architecture and using Polly for resilience
 
 # Instructions for Contributing
 
@@ -997,7 +999,7 @@ Also, we've stood up a [Slack](http://www.pollytalk.org) channel for easier real
 
 Licensed under the terms of the [New BSD License](http://opensource.org/licenses/BSD-3-Clause)
 
-# Blog posts, podcasts and videos about Polly
+# Blogs, podcasts, courses, ebooks, architecture samples and videos around Polly
 
 When we discover an interesting write-up on Polly, we'll add it to this list. If you have a blog post you'd like to share, please submit a PR!
 
@@ -1025,6 +1027,16 @@ When we discover an interesting write-up on Polly, we'll add it to this list. If
 ## PluralSight course
 
 * [Bryan Hogan](https://twitter.com/bryanjhogan) of the [NoDogmaBlog](http://nodogmablog.bryanhogan.net/) has authored a [PluralSight course on Polly](https://www.pluralsight.com/courses/polly-fault-tolerant-web-service-requests).  The course takes you through all the major features of Polly as at v5.6.1.  The course examples are based around using Polly for fault tolerance when calling remote web services, but the principles and techniques are applicable to any context in which Polly may be used.
+
+## Sample microservices architecture and ebook
+
+### Sample microservices architecture
+
+* [Cesar de la Torre](https://github.com/CESARDELATORRE) produced the Microsoft [eShopOnContainers project](https://github.com/dotnet-architecture/eShopOnContainers), a sample project demonstrating a .NET Microservices architecture. The project uses Polly retry and circuit-breaker policies for resilience in calls to microservices, and in establishing connections to transports such as RabbitMQ.  
+
+### ebook
+
+* Accompanying the project is a [.Net Microservices Architecture ebook](https://www.microsoft.com/net/download/thank-you/microservices-architecture-ebook) with an extensive section (section 8) on using Polly for resilience, to which [Dylan Reisenberger](https://twitter.com/softwarereisen) contributed.  The ebook and code is now (June 2018) updated for using the latest ASP NET Core 2.1 features, [Polly with IHttpClientFactory](https://github.com/App-vNext/Polly/wiki/Polly-and-HttpClientFactory).
 
 ## Twitter
 

--- a/README.md
+++ b/README.md
@@ -1022,7 +1022,9 @@ When we discover an interesting write-up on Polly, we'll add it to this list. If
 
 ## Podcasts
 
-* [Dylan Reisenberger](https://twitter.com/softwarereisen) sits down virtually with [Bryan Hogan](https://twitter.com/bryanjhogan) of [NoDogmaBlog](http://nodogmablog.bryanhogan.net/) for an [Introduction to Polly podcast](http://nodogmapodcast.bryanhogan.net/71-dylan-reisenberger-the-polly-project/).  Why do I need Polly?  History of the Polly project.  What do we mean by resilience and transient faults?  How retry and circuit-breaker help.  Exponential backoff.  Stability patterns.  Bulkhead isolation.  Future directions (as at April 2017).
+* June 2018: [DotNetRocks features Polly](https://www.dotnetrocks.com/?show=1556) as [Carl Franklin](https://twitter.com/carlfranklin) and [Richard Campbell](https://twitter.com/richcampbell) chat with [Dylan Reisenberger](https://twitter.com/softwarereisen) about policy patterns, and the new ASP NET Core 2.1 integration with IHttpClientFactory.  
+
+* April 2017: [Dylan Reisenberger](https://twitter.com/softwarereisen) sits down virtually with [Bryan Hogan](https://twitter.com/bryanjhogan) of [NoDogmaBlog](http://nodogmablog.bryanhogan.net/) for an [Introduction to Polly podcast](http://nodogmapodcast.bryanhogan.net/71-dylan-reisenberger-the-polly-project/).  Why do I need Polly?  History of the Polly project.  What do we mean by resilience and transient faults?  How retry and circuit-breaker help.  Exponential backoff.  Stability patterns.  Bulkhead isolation.  Future directions (as at April 2017).
 
 ## PluralSight course
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Polly is a .NET resilience and transient-fault-handling library that allows deve
 
 Polly targets .NET Standard 1.1 ([coverage](https://docs.microsoft.com/en-us/dotnet/standard/net-standard#net-implementation-support): .NET Framework 4.5-4.6.1, .NET Core 1.0, Mono, Xamarin, UWP, WP8.1+) and .NET Standard 2.0+  ([coverage](https://docs.microsoft.com/en-us/dotnet/standard/net-standard#net-implementation-support): .NET Framework 4.6.1, .NET Core 2.0+, and later Mono, Xamarin and UWP targets).
 
+For versions supporting earlier targets such as .NET4.0 and .NET3.5, see the [supported targets](https://github.com/App-vNext/Polly/wiki/Supported-targets) grid.
+
 [<img align="right" src="https://github.com/dotnet/swag/raw/master/logo/dotnetfoundation_v4_small.png" width="100" />](https://www.dotnetfoundation.org/)
 We are a member of the [.NET Foundation](https://www.dotnetfoundation.org/about)!
 
@@ -907,23 +909,11 @@ This allows collections of similar kinds of policy to be treated as one - for ex
 
 For more detail see: [Polly and interfaces](https://github.com/App-vNext/Polly/wiki/Polly-and-interfaces) on wiki.
 
-# .NET4.5 support
-
-From Polly v6.0.0, .NET4.5 support is provided [via the .Net Standard 1.1 target](https://docs.microsoft.com/en-us/dotnet/standard/net-standard#net-implementation-support).
-
-Polly versions up to [v5.9.0](https://www.nuget.org/packages/Polly/5.9.0) have direct target support for .NET Framework 4.5.
-
-# .NET4.0 support 
-
-The last version of Polly to support .NET4.0 is [v5.9.0](https://www.nuget.org/packages/Polly.Net40Async/5.9.0).  The .NET4.0 package uses `Microsoft.Bcl.Async` to add async support.  To minimise dependencies on the main Polly nuget package, the .NET4.0 version is available as separate Nuget packages `Polly.Net40Async` and `Polly.Net40Async-signed`.
-
-# .NET3.5 support 
-
-The last version of Polly to support .NET3.5 is [v4.3.0](https://www.nuget.org/packages/Polly/4.3.0). This includes all of the 4.x features, as it was the last version before v5.0. This package may be installed via the NuGet package manager by specifying its version: `Install-Package Polly -Version 4.3.0`.
-
 # Release notes
 
 For details of changes by release see the [change log](https://github.com/App-vNext/Polly/blob/master/CHANGELOG.md).  We also tag relevant Pull Requests and Issues with [milestones](https://github.com/App-vNext/Polly/milestones), which match to nuget package release numbers.
+
+For full detailed of supported targets by version, see [supported targets](https://github.com/App-vNext/Polly/wiki/Supported-targets).
 
 # 3rd Party Libraries and Contributions
 

--- a/src/Polly.Shared/Polly.Shared.projitems
+++ b/src/Polly.Shared/Polly.Shared.projitems
@@ -119,6 +119,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Registry\IPolicyRegistry.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ResultPredicate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Retry\IRetryPolicy.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Retry\RetryStateRetryForeverWithCountAsync.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Retry\RetryStateRetryForeverWithCount.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Retry\RetryStateWaitAndRetryForeverWithCount.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Retry\RetryStateWaitAndRetryForeverWithCountAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Retry\RetryStateWaitAndRetryWithProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Retry\RetryStateWaitAndRetryWithProviderAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Retry\RetrySyntax.cs" />

--- a/src/Polly.Shared/Retry/RetryStateRetryForeverWithCount.cs
+++ b/src/Polly.Shared/Retry/RetryStateRetryForeverWithCount.cs
@@ -17,7 +17,11 @@ namespace Polly.Retry
 
         public bool CanRetry(DelegateResult<TResult> delegateResult, CancellationToken cancellationToken)
         {
-            _errorCount += 1;
+            if (_errorCount < int.MaxValue)
+            {
+                _errorCount += 1;
+            }
+
             _onRetry(delegateResult, _errorCount, _context);
             return true;
         }

--- a/src/Polly.Shared/Retry/RetryStateRetryForeverWithCount.cs
+++ b/src/Polly.Shared/Retry/RetryStateRetryForeverWithCount.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Threading;
+
+namespace Polly.Retry
+{
+    internal partial class RetryStateRetryForeverWithCount<TResult> : IRetryPolicyState<TResult>
+    {
+        private int _errorCount;
+        private readonly Action<DelegateResult<TResult>, int, Context> _onRetry;
+        private readonly Context _context;
+
+        public RetryStateRetryForeverWithCount(Action<DelegateResult<TResult>, int, Context> onRetry, Context context)
+        {
+            _onRetry = onRetry;
+            _context = context;
+        }
+
+        public bool CanRetry(DelegateResult<TResult> delegateResult, CancellationToken cancellationToken)
+        {
+            _errorCount += 1;
+            _onRetry(delegateResult, _errorCount, _context);
+            return true;
+        }
+    }
+}

--- a/src/Polly.Shared/Retry/RetryStateRetryForeverWithCountAsync.cs
+++ b/src/Polly.Shared/Retry/RetryStateRetryForeverWithCountAsync.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Polly.Retry
+{
+    internal partial class RetryStateRetryForeverWithCount<TResult> : IRetryPolicyState<TResult>
+    {
+        private readonly Func<DelegateResult<TResult>, int, Context, Task> _onRetryAsync;
+
+        public RetryStateRetryForeverWithCount(Func<DelegateResult<TResult>, int, Context, Task> onRetryAsync, Context context)
+        {
+            _onRetryAsync = onRetryAsync;
+            _context = context;
+        }
+
+        public async Task<bool> CanRetryAsync(DelegateResult<TResult> delegateResult, CancellationToken ct, bool continueOnCapturedContext)
+        {
+            _errorCount += 1;
+            await _onRetryAsync(delegateResult, _errorCount, _context).ConfigureAwait(continueOnCapturedContext);
+            return true;
+        }
+    }
+}
+

--- a/src/Polly.Shared/Retry/RetryStateRetryForeverWithCountAsync.cs
+++ b/src/Polly.Shared/Retry/RetryStateRetryForeverWithCountAsync.cs
@@ -16,7 +16,11 @@ namespace Polly.Retry
 
         public async Task<bool> CanRetryAsync(DelegateResult<TResult> delegateResult, CancellationToken ct, bool continueOnCapturedContext)
         {
-            _errorCount += 1;
+            if (_errorCount < int.MaxValue)
+            {
+                _errorCount += 1;
+            }
+
             await _onRetryAsync(delegateResult, _errorCount, _context).ConfigureAwait(continueOnCapturedContext);
             return true;
         }

--- a/src/Polly.Shared/Retry/RetryStateWaitAndRetryForeverWithCount.cs
+++ b/src/Polly.Shared/Retry/RetryStateWaitAndRetryForeverWithCount.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Threading;
+using Polly.Utilities;
+
+namespace Polly.Retry
+{
+    internal partial class RetryStateWaitAndRetryForeverWithCount<TResult> : IRetryPolicyState<TResult>
+    {
+        private int _errorCount;
+        private readonly Func<int, DelegateResult<TResult>, Context, TimeSpan> _sleepDurationProvider;
+        private readonly Action<DelegateResult<TResult>, int, TimeSpan, Context> _onRetry;
+        private readonly Context _context;
+
+        public RetryStateWaitAndRetryForeverWithCount(Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, int, TimeSpan, Context> onRetry, Context context)
+        {
+            _sleepDurationProvider = sleepDurationProvider;
+            _onRetry = onRetry;
+            _context = context;
+        }
+
+        public bool CanRetry(DelegateResult<TResult> delegateResult, CancellationToken cancellationToken)
+        {
+            if (_errorCount < int.MaxValue)
+            {
+                _errorCount += 1;
+            }
+
+            TimeSpan waitTimeSpan = _sleepDurationProvider(_errorCount, delegateResult, _context);
+
+            _onRetry(delegateResult, _errorCount, waitTimeSpan, _context);
+
+            SystemClock.Sleep(waitTimeSpan, cancellationToken);
+            
+            return true;
+        }        
+    }
+}

--- a/src/Polly.Shared/Retry/RetryStateWaitAndRetryForeverWithCountAsync.cs
+++ b/src/Polly.Shared/Retry/RetryStateWaitAndRetryForeverWithCountAsync.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Polly.Utilities;
+
+namespace Polly.Retry
+{
+    internal partial class RetryStateWaitAndRetryForeverWithCount<TResult> : IRetryPolicyState<TResult>
+    {
+        private readonly Func<DelegateResult<TResult>, int, TimeSpan, Context, Task> _onRetryAsync;
+
+        public RetryStateWaitAndRetryForeverWithCount(Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, int, TimeSpan, Context, Task> onRetryAsync, Context context)
+        {
+            _sleepDurationProvider = sleepDurationProvider;
+            _onRetryAsync = onRetryAsync;
+            _context = context;
+        }
+        
+        public async Task<bool> CanRetryAsync(DelegateResult<TResult> delegateResult, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        {
+            if (_errorCount < int.MaxValue)
+            {
+                _errorCount += 1;
+            }
+
+            TimeSpan waitTimeSpan = _sleepDurationProvider(_errorCount, delegateResult, _context);
+
+            await _onRetryAsync(delegateResult, _errorCount, waitTimeSpan, _context).ConfigureAwait(continueOnCapturedContext);
+
+            await SystemClock.SleepAsync(waitTimeSpan, cancellationToken).ConfigureAwait(continueOnCapturedContext);
+
+            return true;
+        }        
+    }
+}
+

--- a/src/Polly.Shared/Retry/RetrySyntax.cs
+++ b/src/Polly.Shared/Retry/RetrySyntax.cs
@@ -128,7 +128,8 @@ namespace Polly
         {
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
-            return policyBuilder.RetryForever((outcome) => onRetry(outcome));
+            //return policyBuilder.RetryForever((outcome, ctx) => onRetry(outcome));
+            return policyBuilder.RetryForever((Exception outcome, Context ctx) => onRetry(outcome));
         }
 
         /// <summary>

--- a/src/Polly.Shared/Retry/RetrySyntax.cs
+++ b/src/Polly.Shared/Retry/RetrySyntax.cs
@@ -563,7 +563,7 @@ namespace Polly
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return policyBuilder.WaitAndRetryForever(
-                (retryCount, context) => sleepDurationProvider(retryCount),
+                (retryCount, exception, context) => sleepDurationProvider(retryCount),
                 (exception, i, timespan, context) => onRetry(exception, i, timespan)
             );
         }

--- a/src/Polly.Shared/Retry/RetrySyntax.cs
+++ b/src/Polly.Shared/Retry/RetrySyntax.cs
@@ -128,7 +128,6 @@ namespace Polly
         {
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
-            //return policyBuilder.RetryForever((outcome, ctx) => onRetry(outcome));
             return policyBuilder.RetryForever((Exception outcome, Context ctx) => onRetry(outcome));
         }
 

--- a/src/Polly.Shared/Retry/RetrySyntax.cs
+++ b/src/Polly.Shared/Retry/RetrySyntax.cs
@@ -128,7 +128,22 @@ namespace Polly
         {
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
-            return policyBuilder.RetryForever((outcome, ctx) => onRetry(outcome));
+            return policyBuilder.RetryForever((outcome) => onRetry(outcome));
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will retry indefinitely
+        /// calling <paramref name="onRetry"/> on each retry with the raised exception and retry count.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">onRetry</exception>
+        public static RetryPolicy RetryForever(this PolicyBuilder policyBuilder, Action<Exception, int> onRetry)
+        {
+            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
+
+            return policyBuilder.RetryForever((outcome, i, ctx) => onRetry(outcome, i));
         }
 
         /// <summary>
@@ -150,6 +165,28 @@ namespace Polly
                 policyBuilder.ExceptionPredicates,
                 PredicateHelper<EmptyStruct>.EmptyResultPredicates,
                 () => new RetryStateRetryForever<EmptyStruct>((outcome, ctx) => onRetry(outcome.Exception, ctx), context)
+            ), policyBuilder.ExceptionPredicates);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will retry indefinitely
+        /// calling <paramref name="onRetry"/> on each retry with the raised exception, retry count and context data.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">onRetry</exception>
+        public static RetryPolicy RetryForever(this PolicyBuilder policyBuilder, Action<Exception, int, Context> onRetry)
+        {
+            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
+
+            return new RetryPolicy((action, context, cancellationToken) => RetryEngine.Implementation(
+                (ctx, ct) => { action(ctx, ct); return EmptyStruct.Instance; },
+                context,
+                cancellationToken,
+                policyBuilder.ExceptionPredicates,
+                PredicateHelper<EmptyStruct>.EmptyResultPredicates,
+                () => new RetryStateRetryForeverWithCount<EmptyStruct>((outcome, i, ctx) => onRetry(outcome.Exception, i, ctx), context)
             ), policyBuilder.ExceptionPredicates);
         }
 
@@ -512,6 +549,27 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
+        /// calling <paramref name="onRetry"/> on each retry with the raised exception and retry count.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onRetry</exception>
+        public static RetryPolicy WaitAndRetryForever(this PolicyBuilder policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, int, TimeSpan> onRetry)
+        {
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
+
+            return policyBuilder.WaitAndRetryForever(
+                (retryCount, context) => sleepDurationProvider(retryCount),
+                (exception, i, timespan, context) => onRetry(exception, i, timespan)
+            );
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
         /// calling <paramref name="onRetry"/> on each retry with the raised exception and
         /// execution context.
         /// </summary>
@@ -522,6 +580,26 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
         /// <exception cref="System.ArgumentNullException">onRetry</exception>
         public static RetryPolicy WaitAndRetryForever(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, Context> onRetry)
+        {
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+            return policyBuilder.WaitAndRetryForever(
+                (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+                onRetry
+            );
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
+        /// calling <paramref name="onRetry"/> on each retry with the raised exception, retry count and
+        /// execution context.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onRetry</exception>
+        public static RetryPolicy WaitAndRetryForever(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, int, TimeSpan, Context> onRetry)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             return policyBuilder.WaitAndRetryForever(
@@ -555,6 +633,34 @@ namespace Polly
                 () => new RetryStateWaitAndRetryForever<EmptyStruct>(
                     (i, outcome, ctx) => sleepDurationProvider(i, outcome.Exception, ctx), 
                     (outcome, timespan, ctx) => onRetry(outcome.Exception, timespan, ctx), context)
+            ), policyBuilder.ExceptionPredicates);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
+        /// calling <paramref name="onRetry"/> on each retry with the raised exception, retry count and
+        /// execution context.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onRetry</exception>
+        public static RetryPolicy WaitAndRetryForever(this PolicyBuilder policyBuilder, Func<int, Exception, Context, TimeSpan> sleepDurationProvider, Action<Exception, int, TimeSpan, Context> onRetry)
+        {
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
+
+            return new RetryPolicy((action, context, cancellationToken) => RetryEngine.Implementation(
+                (ctx, ct) => { action(ctx, ct); return EmptyStruct.Instance; },
+                context,
+                cancellationToken,
+                policyBuilder.ExceptionPredicates,
+                PredicateHelper<EmptyStruct>.EmptyResultPredicates,
+                () => new RetryStateWaitAndRetryForeverWithCount<EmptyStruct>(
+                    (i, outcome, ctx) => sleepDurationProvider(i, outcome.Exception, ctx),
+                    (outcome, i, timespan, ctx) => onRetry(outcome.Exception, i, timespan, ctx), context)
             ), policyBuilder.ExceptionPredicates);
         }
     }

--- a/src/Polly.Shared/Retry/RetrySyntaxAsync.cs
+++ b/src/Polly.Shared/Retry/RetrySyntaxAsync.cs
@@ -169,7 +169,7 @@ namespace Polly
                 (action, context, cancellationToken, continueOnCapturedContext) =>
                   RetryEngine.ImplementationAsync(
                     async (ctx, ct) => { await action(ctx, ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
-                    context, 
+                    context,
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     PredicateHelper<EmptyStruct>.EmptyResultPredicates,
@@ -204,7 +204,26 @@ namespace Polly
 
             return policyBuilder.RetryForeverAsync(
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, ctx) => onRetry(outcome)
+                onRetryAsync: async (outcome) => onRetry(outcome)
+#pragma warning restore 1998
+            );
+        }
+
+        /// <summary>
+        ///     Builds a <see cref="Policy" /> that will retry indefinitely
+        ///     calling <paramref name="onRetry" /> on each retry with the raised exception and retry count.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">onRetry</exception>
+        public static RetryPolicy RetryForeverAsync(this PolicyBuilder policyBuilder, Action<Exception, int> onRetry)
+        {
+            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
+
+            return policyBuilder.RetryForeverAsync(
+#pragma warning disable 1998 // async method has no awaits, will run synchronously
+                onRetryAsync: async (outcome, i) => onRetry(outcome, i)
 #pragma warning restore 1998
             );
         }
@@ -221,7 +240,22 @@ namespace Polly
         {
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
-            return policyBuilder.RetryForeverAsync(onRetryAsync: (outcome, ctx) => onRetryAsync(outcome));
+            return policyBuilder.RetryForeverAsync(onRetryAsync: (outcome) => onRetryAsync(outcome));
+        }
+
+        /// <summary>
+        ///     Builds a <see cref="Policy" /> that will retry indefinitely
+        ///     calling <paramref name="onRetryAsync" /> on each retry with the raised exception and retry count.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">onRetryAsync</exception>
+        public static RetryPolicy RetryForeverAsync(this PolicyBuilder policyBuilder, Func<Exception, int, Task> onRetryAsync)
+        {
+            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
+
+            return policyBuilder.RetryForeverAsync(onRetryAsync: (outcome, i) => onRetryAsync(outcome, i));
         }
 
         /// <summary>
@@ -245,6 +279,25 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will retry indefinitely
+        /// calling <paramref name="onRetry"/> on each retry with the raised exception, retry count and context data.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">onRetry</exception>
+        public static RetryPolicy RetryForeverAsync(this PolicyBuilder policyBuilder, Action<Exception, int, Context> onRetry)
+        {
+            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
+
+            return policyBuilder.RetryForeverAsync(
+#pragma warning disable 1998 // async method has no awaits, will run synchronously
+                onRetryAsync: async (outcome, i, ctx) => onRetry(outcome, i, ctx)
+#pragma warning restore 1998
+            );
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will retry indefinitely
         /// calling <paramref name="onRetryAsync"/> on each retry with the raised exception and context data.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
@@ -259,11 +312,36 @@ namespace Polly
                 (action, context, cancellationToken, continueOnCapturedContext) =>
                   RetryEngine.ImplementationAsync(
                     async (ctx, ct) => { await action(ctx, ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
-                    context, 
+                    context,
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     PredicateHelper<EmptyStruct>.EmptyResultPredicates,
                 () => new RetryStateRetryForever<EmptyStruct>((outcome, ctx) => onRetryAsync(outcome.Exception, ctx), context),
+                continueOnCapturedContext
+            ), policyBuilder.ExceptionPredicates);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will retry indefinitely
+        /// calling <paramref name="onRetryAsync"/> on each retry with the raised exception, retry count and context data.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">onRetryAsync</exception>
+        public static RetryPolicy RetryForeverAsync(this PolicyBuilder policyBuilder, Func<Exception, int, Context, Task> onRetryAsync)
+        {
+            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
+
+            return new RetryPolicy(
+                (action, context, cancellationToken, continueOnCapturedContext) =>
+                  RetryEngine.ImplementationAsync(
+                    async (ctx, ct) => { await action(ctx, ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
+                    context,
+                    cancellationToken,
+                    policyBuilder.ExceptionPredicates,
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
+                () => new RetryStateRetryForeverWithCount<EmptyStruct>((outcome, i, ctx) => onRetryAsync(outcome.Exception, i, ctx), context),
                 continueOnCapturedContext
             ), policyBuilder.ExceptionPredicates);
         }
@@ -465,7 +543,7 @@ namespace Polly
                 (action, context, cancellationToken, continueOnCapturedContext) =>
                   RetryEngine.ImplementationAsync(
                     async (ctx, ct) => { await action(ctx, ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
-                    context, 
+                    context,
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     PredicateHelper<EmptyStruct>.EmptyResultPredicates,
@@ -805,7 +883,7 @@ namespace Polly
                 (action, context, cancellationToken, continueOnCapturedContext) =>
                   RetryEngine.ImplementationAsync(
                     async (ctx, ct) => { await action(ctx, ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
-                    context, 
+                    context,
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     PredicateHelper<EmptyStruct>.EmptyResultPredicates,
@@ -870,6 +948,27 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely
+        /// calling <paramref name="onRetry"/> on each retry with the raised exception and retry count.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onRetry</exception>
+        public static RetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, int, TimeSpan> onRetry)
+        {
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
+
+            return policyBuilder.WaitAndRetryForeverAsync(
+                (retryCount, context) => sleepDurationProvider(retryCount),
+                (exception, i, timespan, context) => onRetry(exception, i, timespan)
+            );
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait and retry indefinitely
         /// calling <paramref name="onRetryAsync"/> on each retry with the raised exception.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
@@ -886,6 +985,27 @@ namespace Polly
             return policyBuilder.WaitAndRetryForeverAsync(
              (retryCount, context) => sleepDurationProvider(retryCount),
              (exception, timespan, context) => onRetryAsync(exception, timespan)
+         );
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait and retry indefinitely
+        /// calling <paramref name="onRetryAsync"/> on each retry with the raised exception and retry count.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
+        /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onRetryAsync</exception>
+        public static RetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Func<Exception, int, TimeSpan, Task> onRetryAsync)
+        {
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
+
+            return policyBuilder.WaitAndRetryForeverAsync(
+             (retryCount, context) => sleepDurationProvider(retryCount),
+             (exception, i, timespan, context) => onRetryAsync(exception, i, timespan)
          );
         }
 
@@ -915,6 +1035,30 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely
+        /// calling <paramref name="onRetry"/> on each retry with the raised exception, retry count and
+        /// execution context.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onRetry</exception>        
+        public static RetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, int, TimeSpan, Context> onRetry)
+        {
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
+
+            return policyBuilder.WaitAndRetryForeverAsync(
+                sleepDurationProvider,
+#pragma warning disable 1998 // async method has no awaits, will run synchronously
+                async (exception, i, timespan, ctx) => onRetry(exception, i, timespan, ctx)
+#pragma warning restore 1998
+            );
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait and retry indefinitely
         /// calling <paramref name="onRetryAsync"/> on each retry with the raised exception and
         /// execution context.
         /// </summary>
@@ -925,6 +1069,26 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
         /// <exception cref="System.ArgumentNullException">onRetryAsync</exception>        
         public static RetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, Context, Task> onRetryAsync)
+        {
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+            return policyBuilder.WaitAndRetryForeverAsync(
+                (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+                onRetryAsync
+            );
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait and retry indefinitely
+        /// calling <paramref name="onRetryAsync"/> on each retry with the raised exception, retry count and
+        /// execution context.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
+        /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onRetryAsync</exception>        
+        public static RetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Func<Exception, int, TimeSpan, Context, Task> onRetryAsync)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             return policyBuilder.WaitAndRetryForeverAsync(
@@ -953,13 +1117,45 @@ namespace Polly
                 (action, context, cancellationToken, continueOnCapturedContext) =>
                   RetryEngine.ImplementationAsync(
                     async (ctx, ct) => { await action(ctx, ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
-                    context, 
+                    context,
                     cancellationToken,
                     policyBuilder.ExceptionPredicates,
                     PredicateHelper<EmptyStruct>.EmptyResultPredicates,
                     () => new RetryStateWaitAndRetryForever<EmptyStruct>(
                         (i, outcome, ctx) => sleepDurationProvider(i, outcome.Exception, ctx),
-                        (outcome, timespan, ctx) => onRetryAsync(outcome.Exception, timespan, ctx), 
+                        (outcome, timespan, ctx) => onRetryAsync(outcome.Exception, timespan, ctx),
+                        context),
+                    continueOnCapturedContext
+                  ), policyBuilder.ExceptionPredicates);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait and retry indefinitely
+        /// calling <paramref name="onRetryAsync"/> on each retry with the raised exception, retry count and
+        /// execution context.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
+        /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onRetryAsync</exception>        
+        public static RetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, Exception, Context, TimeSpan> sleepDurationProvider, Func<Exception, int, TimeSpan, Context, Task> onRetryAsync)
+        {
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
+
+            return new RetryPolicy(
+                (action, context, cancellationToken, continueOnCapturedContext) =>
+                  RetryEngine.ImplementationAsync(
+                    async (ctx, ct) => { await action(ctx, ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
+                    context,
+                    cancellationToken,
+                    policyBuilder.ExceptionPredicates,
+                    PredicateHelper<EmptyStruct>.EmptyResultPredicates,
+                    () => new RetryStateWaitAndRetryForeverWithCount<EmptyStruct>(
+                        (i, outcome, ctx) => sleepDurationProvider(i, outcome.Exception, ctx),
+                        (outcome, i, timespan, ctx) => onRetryAsync(outcome.Exception, i, timespan, ctx),
                         context),
                     continueOnCapturedContext
                   ), policyBuilder.ExceptionPredicates);

--- a/src/Polly.Shared/Retry/RetrySyntaxAsync.cs
+++ b/src/Polly.Shared/Retry/RetrySyntaxAsync.cs
@@ -204,7 +204,7 @@ namespace Polly
 
             return policyBuilder.RetryForeverAsync(
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome) => onRetry(outcome)
+                onRetryAsync: async (Exception outcome, Context ctx) => onRetry(outcome)
 #pragma warning restore 1998
             );
         }
@@ -240,7 +240,7 @@ namespace Polly
         {
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
-            return policyBuilder.RetryForeverAsync(onRetryAsync: (outcome) => onRetryAsync(outcome));
+            return policyBuilder.RetryForeverAsync(onRetryAsync: (Exception outcome, Context ctx) => onRetryAsync(outcome));
         }
 
         /// <summary>

--- a/src/Polly.Shared/Retry/RetrySyntaxAsync.cs
+++ b/src/Polly.Shared/Retry/RetrySyntaxAsync.cs
@@ -223,7 +223,7 @@ namespace Polly
 
             return policyBuilder.RetryForeverAsync(
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, i) => onRetry(outcome, i)
+                onRetryAsync: async (outcome, i, context) => onRetry(outcome, i)
 #pragma warning restore 1998
             );
         }
@@ -255,7 +255,7 @@ namespace Polly
         {
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
-            return policyBuilder.RetryForeverAsync(onRetryAsync: (outcome, i) => onRetryAsync(outcome, i));
+            return policyBuilder.RetryForeverAsync(onRetryAsync: (outcome, i, context) => onRetryAsync(outcome, i));
         }
 
         /// <summary>

--- a/src/Polly.Shared/Retry/RetryTResultSyntax.cs
+++ b/src/Polly.Shared/Retry/RetryTResultSyntax.cs
@@ -144,7 +144,7 @@ namespace Polly
         {
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
-            return policyBuilder.RetryForever((outcome, i) => onRetry(outcome, i));
+            return policyBuilder.RetryForever((outcome, i, context) => onRetry(outcome, i));
         }
 
         /// <summary>
@@ -616,8 +616,8 @@ namespace Polly
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return policyBuilder.WaitAndRetryForever(
-                (retryCount, context) => sleepDurationProvider(retryCount),
-                (exception, i, timespan, context) => onRetry(exception, i, timespan)
+                (retryCount, outcome, context) => sleepDurationProvider(retryCount),
+                (outcome, i, timespan, context) => onRetry(outcome, i, timespan)
             );
         }
 

--- a/src/Polly.Shared/Retry/RetryTResultSyntax.cs
+++ b/src/Polly.Shared/Retry/RetryTResultSyntax.cs
@@ -129,7 +129,7 @@ namespace Polly
         {
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
-            return policyBuilder.RetryForever((outcome) => onRetry(outcome));
+            return policyBuilder.RetryForever((DelegateResult<TResult> outcome, Context ctx) => onRetry(outcome));
         }
 
         /// <summary>

--- a/src/Polly.Shared/Retry/RetryTResultSyntax.cs
+++ b/src/Polly.Shared/Retry/RetryTResultSyntax.cs
@@ -129,7 +129,22 @@ namespace Polly
         {
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
-            return policyBuilder.RetryForever((outcome, ctx) => onRetry(outcome));
+            return policyBuilder.RetryForever((outcome) => onRetry(outcome));
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will retry indefinitely
+        /// calling <paramref name="onRetry"/> on each retry with the handled exception or result and retry count.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">onRetry</exception>
+        public static RetryPolicy<TResult> RetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>, int> onRetry)
+        {
+            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
+
+            return policyBuilder.RetryForever((outcome, i) => onRetry(outcome, i));
         }
 
         /// <summary>
@@ -153,6 +168,31 @@ namespace Polly
                     policyBuilder.ResultPredicates,
                     () => new RetryStateRetryForever<TResult>(onRetry, context)
                     ), 
+                policyBuilder.ExceptionPredicates,
+                policyBuilder.ResultPredicates);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will retry indefinitely
+        /// calling <paramref name="onRetry"/> on each retry with the handled exception or result, retry count and context data.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">onRetry</exception>
+        public static RetryPolicy<TResult> RetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>, int, Context> onRetry)
+        {
+            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
+
+            return new RetryPolicy<TResult>(
+                (action, context, cancellationToken) => RetryEngine.Implementation(
+                    action,
+                    context,
+                    cancellationToken,
+                    policyBuilder.ExceptionPredicates,
+                    policyBuilder.ResultPredicates,
+                    () => new RetryStateRetryForeverWithCount<TResult>(onRetry, context)
+                    ),
                 policyBuilder.ExceptionPredicates,
                 policyBuilder.ResultPredicates);
         }
@@ -562,6 +602,27 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
+        /// calling <paramref name="onRetry"/> on each retry with the handled exception or result and retry count.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onRetry</exception>
+        public static RetryPolicy<TResult> WaitAndRetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, int, TimeSpan> onRetry)
+        {
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
+
+            return policyBuilder.WaitAndRetryForever(
+                (retryCount, context) => sleepDurationProvider(retryCount),
+                (exception, i, timespan, context) => onRetry(exception, i, timespan)
+            );
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
         /// calling <paramref name="onRetry"/> on each retry with the handled exception or result and
         /// execution context.
         /// </summary>
@@ -572,6 +633,26 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
         /// <exception cref="System.ArgumentNullException">onRetry</exception>
         public static RetryPolicy<TResult> WaitAndRetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
+        {
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+            return policyBuilder.WaitAndRetryForever(
+                (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+                onRetry
+            );
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
+        /// calling <paramref name="onRetry"/> on each retry with the handled exception or result, retry count and
+        /// execution context.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onRetry</exception>
+        public static RetryPolicy<TResult> WaitAndRetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, int, TimeSpan, Context> onRetry)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             return policyBuilder.WaitAndRetryForever(
@@ -604,6 +685,36 @@ namespace Polly
                     policyBuilder.ExceptionPredicates,
                     policyBuilder.ResultPredicates,
                     () => new RetryStateWaitAndRetryForever<TResult>(sleepDurationProvider, onRetry, context)
+                ),
+                policyBuilder.ExceptionPredicates,
+                policyBuilder.ResultPredicates
+            );
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
+        /// calling <paramref name="onRetry"/> on each retry with the handled exception or result, retry count and
+        /// execution context.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onRetry</exception>
+        public static RetryPolicy<TResult> WaitAndRetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, int, TimeSpan, Context> onRetry)
+        {
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
+
+            return new RetryPolicy<TResult>(
+                (action, context, cancellationToken) => RetryEngine.Implementation(
+                    action,
+                    context,
+                    cancellationToken,
+                    policyBuilder.ExceptionPredicates,
+                    policyBuilder.ResultPredicates,
+                    () => new RetryStateWaitAndRetryForeverWithCount<TResult>(sleepDurationProvider, onRetry, context)
                 ),
                 policyBuilder.ExceptionPredicates,
                 policyBuilder.ResultPredicates

--- a/src/Polly.Shared/Retry/RetryTResultSyntaxAsync.cs
+++ b/src/Polly.Shared/Retry/RetryTResultSyntaxAsync.cs
@@ -205,7 +205,7 @@ namespace Polly
 
             return policyBuilder.RetryForeverAsync(
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome) => onRetry(outcome)
+                onRetryAsync: async (DelegateResult<TResult> outcome, Context ctx) => onRetry(outcome)
 #pragma warning restore 1998
                 );
         }
@@ -241,7 +241,7 @@ namespace Polly
         {
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
-            return policyBuilder.RetryForeverAsync(onRetryAsync: (outcome) => onRetryAsync(outcome));
+            return policyBuilder.RetryForeverAsync(onRetryAsync: (DelegateResult<TResult> outcome, Context ctx) => onRetryAsync(outcome));
         }
 
         /// <summary>

--- a/src/Polly.Shared/Retry/RetryTResultSyntaxAsync.cs
+++ b/src/Polly.Shared/Retry/RetryTResultSyntaxAsync.cs
@@ -224,7 +224,7 @@ namespace Polly
 
             return policyBuilder.RetryForeverAsync(
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, i) => onRetry(outcome, i)
+                onRetryAsync: async (outcome, i, context) => onRetry(outcome, i)
 #pragma warning restore 1998
                 );
         }
@@ -256,7 +256,7 @@ namespace Polly
         {
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
-            return policyBuilder.RetryForeverAsync(onRetryAsync: (outcome, i) => onRetryAsync(outcome, i));
+            return policyBuilder.RetryForeverAsync(onRetryAsync: (outcome, i, context) => onRetryAsync(outcome, i));
         }
 
         /// <summary>

--- a/src/Polly.Shared/Retry/RetryTResultSyntaxAsync.cs
+++ b/src/Polly.Shared/Retry/RetryTResultSyntaxAsync.cs
@@ -205,7 +205,26 @@ namespace Polly
 
             return policyBuilder.RetryForeverAsync(
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, ctx) => onRetry(outcome)
+                onRetryAsync: async (outcome) => onRetry(outcome)
+#pragma warning restore 1998
+                );
+        }
+
+        /// <summary>
+        ///     Builds a <see cref="Policy" /> that will retry indefinitely
+        ///     calling <paramref name="onRetry" /> on each retry with the handled exception or result and retry count.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">onRetry</exception>
+        public static RetryPolicy<TResult> RetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>, int> onRetry)
+        {
+            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
+
+            return policyBuilder.RetryForeverAsync(
+#pragma warning disable 1998 // async method has no awaits, will run synchronously
+                onRetryAsync: async (outcome, i) => onRetry(outcome, i)
 #pragma warning restore 1998
                 );
         }
@@ -222,7 +241,22 @@ namespace Polly
         {
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
-            return policyBuilder.RetryForeverAsync(onRetryAsync: (outcome, ctx) => onRetryAsync(outcome));
+            return policyBuilder.RetryForeverAsync(onRetryAsync: (outcome) => onRetryAsync(outcome));
+        }
+
+        /// <summary>
+        ///     Builds a <see cref="Policy" /> that will retry indefinitely
+        ///     calling <paramref name="onRetryAsync" /> on each retry with the handled exception or result and retry count.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">onRetryAsync</exception>
+        public static RetryPolicy<TResult> RetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<DelegateResult<TResult>, int, Task> onRetryAsync)
+        {
+            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
+
+            return policyBuilder.RetryForeverAsync(onRetryAsync: (outcome, i) => onRetryAsync(outcome, i));
         }
 
         /// <summary>
@@ -240,6 +274,25 @@ namespace Polly
             return policyBuilder.RetryForeverAsync(
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
                 onRetryAsync: async (outcome, ctx) => onRetry(outcome, ctx)
+#pragma warning restore 1998
+            );
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will retry indefinitely
+        /// calling <paramref name="onRetry"/> on each retry with the handled exception or result, retry count and context data.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">onRetry</exception>
+        public static RetryPolicy<TResult> RetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>, int, Context> onRetry)
+        {
+            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
+
+            return policyBuilder.RetryForeverAsync(
+#pragma warning disable 1998 // async method has no awaits, will run synchronously
+                onRetryAsync: async (outcome, i, ctx) => onRetry(outcome, i, ctx)
 #pragma warning restore 1998
             );
         }
@@ -267,6 +320,33 @@ namespace Polly
                     () => new RetryStateRetryForever<TResult>(onRetryAsync, context),
                     continueOnCapturedContext
                 ), 
+                policyBuilder.ExceptionPredicates,
+                policyBuilder.ResultPredicates);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will retry indefinitely
+        /// calling <paramref name="onRetryAsync"/> on each retry with the handled exception or result, retry count and context data.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">onRetryAsync</exception>
+        public static RetryPolicy<TResult> RetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<DelegateResult<TResult>, int, Context, Task> onRetryAsync)
+        {
+            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
+
+            return new RetryPolicy<TResult>(
+                (action, context, cancellationToken, continueOnCapturedContext) =>
+                  RetryEngine.ImplementationAsync(
+                    action,
+                    context,
+                    cancellationToken,
+                    policyBuilder.ExceptionPredicates,
+                    policyBuilder.ResultPredicates,
+                    () => new RetryStateRetryForeverWithCount<TResult>(onRetryAsync, context),
+                    continueOnCapturedContext
+                ),
                 policyBuilder.ExceptionPredicates,
                 policyBuilder.ResultPredicates);
         }
@@ -871,6 +951,27 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
+        /// calling <paramref name="onRetry"/> on each retry with the handled exception or result.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onRetry</exception>
+        public static RetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, int, TimeSpan> onRetry)
+        {
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
+
+            return policyBuilder.WaitAndRetryForeverAsync(
+                (retryCount, context) => sleepDurationProvider(retryCount),
+                (outcome, i, timespan, context) => onRetry(outcome, i, timespan)
+            );
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
         /// calling <paramref name="onRetryAsync"/> on each retry with the handled exception or result.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
@@ -887,6 +988,27 @@ namespace Polly
             return policyBuilder.WaitAndRetryForeverAsync(
                 (retryCount, context) => sleepDurationProvider(retryCount),
                 (outcome, timespan, context) => onRetryAsync(outcome, timespan)
+            );
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
+        /// calling <paramref name="onRetryAsync"/> on each retry with the handled exception or result and retry count.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
+        /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onRetryAsync</exception>
+        public static RetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, int, TimeSpan, Task> onRetryAsync)
+        {
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
+
+            return policyBuilder.WaitAndRetryForeverAsync(
+                (retryCount, context) => sleepDurationProvider(retryCount),
+                (outcome, i, timespan, context) => onRetryAsync(outcome, i, timespan)
             );
         }
 
@@ -915,6 +1037,29 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
+        /// calling <paramref name="onRetry"/> on each retry with the handled exception or result and
+        /// execution context.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
+        /// <param name="onRetry">The action to call on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onRetry</exception>        
+        public static RetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, int, TimeSpan, Context> onRetry)
+        {
+            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
+
+            return policyBuilder.WaitAndRetryForeverAsync(
+                sleepDurationProvider,
+#pragma warning disable 1998 // async method has no awaits, will run synchronously
+                async (outcome, i, timespan, ctx) => onRetry(outcome, i, timespan, ctx)
+#pragma warning restore 1998
+            );
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
         /// calling <paramref name="onRetryAsync"/> on each retry with the handled exception or result and
         /// execution context.
         /// </summary>
@@ -925,6 +1070,26 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
         /// <exception cref="System.ArgumentNullException">onRetryAsync</exception>        
         public static RetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, Context, Task> onRetryAsync)
+        {
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+            return policyBuilder.WaitAndRetryForeverAsync(
+                (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+                onRetryAsync
+            );
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
+        /// calling <paramref name="onRetryAsync"/> on each retry with the handled exception or result, retry count and
+        /// execution context.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
+        /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onRetryAsync</exception>        
+        public static RetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, int, TimeSpan, Context, Task> onRetryAsync)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             return policyBuilder.WaitAndRetryForeverAsync(
@@ -958,6 +1123,37 @@ namespace Polly
                         policyBuilder.ExceptionPredicates,
                         policyBuilder.ResultPredicates,
                         () => new RetryStateWaitAndRetryForever<TResult>(sleepDurationProvider, onRetryAsync, context),
+                        continueOnCapturedContext
+                    ),
+                policyBuilder.ExceptionPredicates,
+                policyBuilder.ResultPredicates);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
+        /// calling <paramref name="onRetryAsync"/> on each retry with the handled exception or result, retry count and
+        /// execution context.
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
+        /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
+        /// <exception cref="System.ArgumentNullException">onRetryAsync</exception>        
+        public static RetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, int, TimeSpan, Context, Task> onRetryAsync)
+        {
+            if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
+            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
+
+            return new RetryPolicy<TResult>(
+                (action, context, cancellationToken, continueOnCapturedContext) =>
+                    RetryEngine.ImplementationAsync(
+                        action,
+                        context,
+                        cancellationToken,
+                        policyBuilder.ExceptionPredicates,
+                        policyBuilder.ResultPredicates,
+                        () => new RetryStateWaitAndRetryForeverWithCount<TResult>(sleepDurationProvider, onRetryAsync, context),
                         continueOnCapturedContext
                     ),
                 policyBuilder.ExceptionPredicates,

--- a/src/Polly.SharedSpecs/Retry/RetryForeverAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/RetryForeverAsyncSpecs.cs
@@ -144,6 +144,22 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
+        public void Should_call_onretry_on_each_retry_with_the_current_retry_count()
+        {
+            var expectedRetryCounts = new[] { 1, 2, 3 };
+            var retryCounts = new List<int>();
+
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .RetryForeverAsync((_, retryCount) => retryCounts.Add(retryCount));
+
+            policy.RaiseExceptionAsync<DivideByZeroException>(3);
+
+            retryCounts.Should()
+                .ContainInOrder(expectedRetryCounts);
+        }
+
+        [Fact]
         public void Context_should_be_empty_if_execute_not_called_with_any_data()
         {
             Context capturedContext = null;

--- a/src/Polly.SharedSpecs/Retry/RetryForeverSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/RetryForeverSpecs.cs
@@ -198,6 +198,22 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
+        public void Should_call_onretry_on_each_retry_with_the_current_retry_count()
+        {
+            var expectedRetryCounts = new[] { 1, 2, 3 };
+            var retryCounts = new List<int>();
+
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .RetryForever((_, retryCount) => retryCounts.Add(retryCount));
+
+            policy.RaiseException<DivideByZeroException>(3);
+
+            retryCounts.Should()
+                .ContainInOrder(expectedRetryCounts);
+        }
+
+        [Fact]
         public void Should_not_call_onretry_when_no_retries_are_performed()
         {
             var retryExceptions = new List<Exception>();

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverAsyncSpecs.cs
@@ -219,6 +219,23 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
+        public void Should_call_onretry_on_each_retry_with_the_current_retry_count()
+        {
+            var expectedRetryCounts = new[] { 1, 2, 3 };
+            var retryCounts = new List<int>();
+            Func<int, TimeSpan> provider = i => TimeSpan.Zero;
+
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .WaitAndRetryForeverAsync(provider, (_, retryCount, __) => retryCounts.Add(retryCount));
+
+            policy.RaiseExceptionAsync<DivideByZeroException>(3);
+
+            retryCounts.Should()
+                .ContainInOrder(expectedRetryCounts);
+        }
+
+        [Fact]
         public void Should_not_call_onretry_when_no_retries_are_performed()
         {
             Func<int, TimeSpan> provider = i => 1.Seconds();

--- a/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverSpecs.cs
+++ b/src/Polly.SharedSpecs/Retry/WaitAndRetryForeverSpecs.cs
@@ -217,6 +217,23 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
+        public void Should_call_onretry_on_each_retry_with_the_current_retry_count()
+        {
+            var expectedRetryCounts = new[] { 1, 2, 3 };
+            var retryCounts = new List<int>();
+            Func<int, TimeSpan> provider = i => TimeSpan.Zero;
+
+            var policy = Policy
+                .Handle<DivideByZeroException>()
+                .WaitAndRetryForever(provider, (_, retryCount, __) => retryCounts.Add(retryCount));
+
+            policy.RaiseException<DivideByZeroException>(3);
+
+            retryCounts.Should()
+                .ContainInOrder(expectedRetryCounts);
+        }
+
+        [Fact]
         public void Should_not_call_onretry_when_no_retries_are_performed()
         {
             Func<int, TimeSpan> provider = i => 1.Seconds();


### PR DESCRIPTION
Adds the overload requested on #451, plus more to complete all posibilities.

As requested by @reisenberger, the overloads where added on all four variants

- RetrySyntax.cs
- RetrySyntaxAsync.cs
- RetryTResultSyntax.cs
- RetryTResultSyntaxAsync.cs