### PR TITLE
Cache bug fixes (internal, performance)

### DIFF
--- a/src/Polly.Shared/Caching/GenericCacheProvider.cs
+++ b/src/Polly.Shared/Caching/GenericCacheProvider.cs
@@ -12,14 +12,12 @@ namespace Polly.Caching
 
         internal GenericCacheProvider(ISyncCacheProvider nonGenericCacheProvider)
         {
-            if (nonGenericCacheProvider == null) throw new ArgumentNullException(nameof(nonGenericCacheProvider));
-
-            _wrappedCacheProvider = nonGenericCacheProvider;
+            _wrappedCacheProvider = nonGenericCacheProvider ?? throw new ArgumentNullException(nameof(nonGenericCacheProvider));
         }
 
         TCacheFormat ISyncCacheProvider<TCacheFormat>.Get(string key)
         {
-            return (TCacheFormat) _wrappedCacheProvider.Get(key);
+            return (TCacheFormat) (_wrappedCacheProvider.Get(key) ?? default(TCacheFormat));
         }
 
         void ISyncCacheProvider<TCacheFormat>.Put(string key, TCacheFormat value, Ttl ttl)

--- a/src/Polly.Shared/Caching/GenericCacheProviderAsync.cs
+++ b/src/Polly.Shared/Caching/GenericCacheProviderAsync.cs
@@ -14,14 +14,12 @@ namespace Polly.Caching
 
         internal GenericCacheProviderAsync(IAsyncCacheProvider nonGenericCacheProvider)
         {
-            if (nonGenericCacheProvider == null) throw new ArgumentNullException(nameof(nonGenericCacheProvider));
-
-            _wrappedCacheProvider = nonGenericCacheProvider;
+            _wrappedCacheProvider = nonGenericCacheProvider ?? throw new ArgumentNullException(nameof(nonGenericCacheProvider));
         }
 
         async Task<TCacheFormat> IAsyncCacheProvider<TCacheFormat>.GetAsync(string key, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
-            return (TCacheFormat) await _wrappedCacheProvider.GetAsync(key, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
+            return (TCacheFormat) (await _wrappedCacheProvider.GetAsync(key, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext) ?? default(TCacheFormat));
         }
 
         Task IAsyncCacheProvider<TCacheFormat>.PutAsync(string key, TCacheFormat value, Ttl ttl, CancellationToken cancellationToken, bool continueOnCapturedContext)

--- a/src/Polly.Shared/Caching/SerializingCacheProvider.cs
+++ b/src/Polly.Shared/Caching/SerializingCacheProvider.cs
@@ -20,11 +20,8 @@ namespace Polly.Caching
         /// <exception cref="System.ArgumentNullException">serializer </exception>
         public SerializingCacheProvider(ISyncCacheProvider<TSerialized> wrappedCacheProvider, ICacheItemSerializer<object, TSerialized> serializer)
         {
-            if (wrappedCacheProvider == null) throw new ArgumentNullException(nameof(wrappedCacheProvider));
-            if (serializer == null) throw new ArgumentNullException(nameof(serializer));
-
-            _wrappedCacheProvider = wrappedCacheProvider;
-            _serializer = serializer;
+            _wrappedCacheProvider = wrappedCacheProvider ?? throw new ArgumentNullException(nameof(wrappedCacheProvider));
+            _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
         }
 
         /// <summary>
@@ -34,7 +31,8 @@ namespace Polly.Caching
         /// <returns>The value from cache; or null, if none was found.</returns>
         public object Get(string key)
         {
-            return _serializer.Deserialize(_wrappedCacheProvider.Get(key));
+            TSerialized objectToDeserialize = _wrappedCacheProvider.Get(key);
+            return objectToDeserialize == null || objectToDeserialize.Equals(default(TSerialized)) ? null : _serializer.Deserialize(objectToDeserialize);
         }
 
         /// <summary>
@@ -45,7 +43,8 @@ namespace Polly.Caching
         /// <param name="ttl">The time-to-live for the cache entry.</param>
         public void Put(string key, object value, Ttl ttl)
         {
-            _wrappedCacheProvider.Put(key, _serializer.Serialize(value), ttl);
+            if (value != null)
+                _wrappedCacheProvider.Put(key, _serializer.Serialize(value), ttl);
         }
 
     }
@@ -69,11 +68,8 @@ namespace Polly.Caching
         /// <exception cref="System.ArgumentNullException">serializer </exception>
         public SerializingCacheProvider(ISyncCacheProvider<TSerialized> wrappedCacheProvider, ICacheItemSerializer<TResult, TSerialized> serializer)
         {
-            if (wrappedCacheProvider == null) throw new ArgumentNullException(nameof(wrappedCacheProvider));
-            if (serializer == null) throw new ArgumentNullException(nameof(serializer));
-
-            _wrappedCacheProvider = wrappedCacheProvider;
-            _serializer = serializer;
+            _wrappedCacheProvider = wrappedCacheProvider ?? throw new ArgumentNullException(nameof(wrappedCacheProvider));
+            _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
         }
 
         /// <summary>
@@ -83,7 +79,8 @@ namespace Polly.Caching
         /// <returns>The value from cache; or null, if none was found.</returns>
         public TResult Get(string key)
         {
-            return _serializer.Deserialize(_wrappedCacheProvider.Get(key));
+            TSerialized objectToDeserialize = _wrappedCacheProvider.Get(key);
+            return objectToDeserialize == null || objectToDeserialize.Equals(default(TSerialized)) ? default(TResult) : _serializer.Deserialize(objectToDeserialize);
         }
 
         /// <summary>
@@ -94,7 +91,8 @@ namespace Polly.Caching
         /// <param name="ttl">The time-to-live for the cache entry.</param>
         public void Put(string key, TResult value, Ttl ttl)
         {
-            _wrappedCacheProvider.Put(key, _serializer.Serialize(value), ttl);
+            if (value != null && !value.Equals(default(TResult)))
+                _wrappedCacheProvider.Put(key, _serializer.Serialize(value), ttl);
         }
         
     }

--- a/src/Polly.SharedSpecs/Caching/GenericCacheProviderAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Caching/GenericCacheProviderAsyncSpecs.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Polly.Caching;
+using Polly.Specs.Helpers;
+using Polly.Specs.Helpers.Caching;
+using Polly.Utilities;
+using Polly.Wrap;
+using Xunit;
+
+namespace Polly.Specs.Caching
+{
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
+    public class GenericCacheProviderAsyncSpecs : IDisposable
+    {
+        [Fact]
+        public async Task Should_not_error_for_executions_on_non_nullable_types_if_cache_does_not_hold_value()
+        {
+            const string operationKey = "SomeOperationKey";
+
+            bool onErrorCalled = false;
+            Action<Context, string, Exception> onError = (ctx, key, exc) => { onErrorCalled = true; };
+
+            IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+            CachePolicy cache = Policy.CacheAsync(stubCacheProvider, TimeSpan.MaxValue, onError);
+
+            (await stubCacheProvider.GetAsync(operationKey, CancellationToken.None, false)).Should().BeNull();
+            ResultPrimitive result = await cache.ExecuteAsync(async ctx =>
+            {
+                await TaskHelper.EmptyTask.ConfigureAwait(false);
+                return ResultPrimitive.Substitute;
+            }, new Context(operationKey));
+
+            onErrorCalled.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task Should_execute_delegate_and_put_value_in_cache_for_non_nullable_types_if_cache_does_not_hold_value()
+        {
+            const ResultPrimitive valueToReturn = ResultPrimitive.Substitute;
+            const string operationKey = "SomeOperationKey";
+
+            IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+            CachePolicy cache = Policy.CacheAsync(stubCacheProvider, TimeSpan.MaxValue);
+
+            (await stubCacheProvider.GetAsync(operationKey, CancellationToken.None, false)).Should().BeNull();
+
+            (await cache.ExecuteAsync(async ctx =>
+            {
+                await TaskHelper.EmptyTask.ConfigureAwait(false);
+                return ResultPrimitive.Substitute;
+            }, new Context(operationKey))).Should().Be(valueToReturn);
+
+            (await stubCacheProvider.GetAsync(operationKey, CancellationToken.None, false)).Should().Be(valueToReturn);
+        }
+
+        public void Dispose()
+        {
+            SystemClock.Reset();
+        }
+    }
+}

--- a/src/Polly.SharedSpecs/Caching/GenericCacheProviderSpecs.cs
+++ b/src/Polly.SharedSpecs/Caching/GenericCacheProviderSpecs.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Polly.Caching;
+using Polly.Specs.Helpers;
+using Polly.Specs.Helpers.Caching;
+using Polly.Utilities;
+using Polly.Wrap;
+using Xunit;
+
+namespace Polly.Specs.Caching
+{
+    [Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
+    public class GenericCacheProviderSpecs : IDisposable
+    {
+        [Fact]
+        public void Should_not_error_for_executions_on_non_nullable_types_if_cache_does_not_hold_value()
+        {
+            const string operationKey = "SomeOperationKey";
+
+            bool onErrorCalled = false;
+            Action<Context, string, Exception> onError = (ctx, key, exc) => { onErrorCalled = true; };
+
+            ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+            CachePolicy cache = Policy.Cache(stubCacheProvider, TimeSpan.MaxValue, onError);
+
+            stubCacheProvider.Get(operationKey).Should().BeNull();
+            ResultPrimitive result = cache.Execute(ctx => ResultPrimitive.Substitute, new Context(operationKey));
+
+            onErrorCalled.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Should_execute_delegate_and_put_value_in_cache_for_non_nullable_types_if_cache_does_not_hold_value()
+        {
+            const ResultPrimitive valueToReturn = ResultPrimitive.Substitute;
+            const string operationKey = "SomeOperationKey";
+
+            ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+            CachePolicy cache = Policy.Cache(stubCacheProvider, TimeSpan.MaxValue);
+
+            stubCacheProvider.Get(operationKey).Should().BeNull();
+
+            cache.Execute(ctx => { return valueToReturn; }, new Context(operationKey)).Should().Be(valueToReturn);
+
+            stubCacheProvider.Get(operationKey).Should().Be(valueToReturn);
+        }
+
+        public void Dispose()
+        {
+            SystemClock.Reset();
+        }
+    }
+}

--- a/src/Polly.SharedSpecs/Caching/SerializingCacheProviderAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Caching/SerializingCacheProviderAsyncSpecs.cs
@@ -66,6 +66,25 @@ namespace Polly.Specs.Caching
         }
 
         [Fact]
+        public async Task Single_generic_SerializingCacheProvider_should_not_serialize_on_put_for_defaultTResult()
+        {
+            bool serializeInvoked = false;
+            StubSerializer<object, StubSerialized> stubSerializer = new StubSerializer<object, StubSerialized>(
+                serialize: o => { serializeInvoked = true; return new StubSerialized(o); },
+                deserialize: s => s.Original
+            );
+            StubCacheProvider stubCacheProvider = new StubCacheProvider();
+            object objectToCache = default(object);
+            string key = "some key";
+
+            SerializingCacheProviderAsync<StubSerialized> serializingCacheProvider = new SerializingCacheProviderAsync<StubSerialized>(stubCacheProvider.AsyncFor<StubSerialized>(), stubSerializer);
+            await serializingCacheProvider.PutAsync(key, objectToCache, new Ttl(TimeSpan.FromMinutes(1)), CancellationToken.None, false);
+
+            serializeInvoked.Should().Be(false);
+            stubCacheProvider.Get(key).Should().BeNull();
+        }
+
+        [Fact]
         public async Task Single_generic_SerializingCacheProvider_should_deserialize_on_get()
         {
             bool deserializeInvoked = false;
@@ -85,6 +104,26 @@ namespace Polly.Specs.Caching
 
             deserializeInvoked.Should().Be(true);
             fromCache.Should().Be(objectToCache);
+        }
+
+        [Fact]
+        public async Task Single_generic_SerializingCacheProvider_should_not_deserialize_on_get_when_item_not_in_cache()
+        {
+            bool deserializeInvoked = false;
+            StubSerializer<object, StubSerialized> stubSerializer = new StubSerializer<object, StubSerialized>(
+                serialize: o => new StubSerialized(o),
+                deserialize: s => { deserializeInvoked = true; return s.Original; }
+            );
+            var stubCacheProvider = new StubCacheProvider();
+            string key = "some key";
+
+            stubCacheProvider.Get(key).Should().BeNull();
+
+            SerializingCacheProviderAsync<StubSerialized> serializingCacheProvider = new SerializingCacheProviderAsync<StubSerialized>(stubCacheProvider.AsyncFor<StubSerialized>(), stubSerializer);
+            object fromCache = await serializingCacheProvider.GetAsync(key, CancellationToken.None, false);
+
+            deserializeInvoked.Should().Be(false);
+            fromCache.Should().Be(default(object));
         }
 
         [Fact]
@@ -108,6 +147,25 @@ namespace Polly.Specs.Caching
         }
 
         [Fact]
+        public async Task Single_generic_SerializingCacheProvider_from_extension_syntax_should_not_serialize_on_put_for_defaultTResult()
+        {
+            bool serializeInvoked = false;
+            StubSerializer<object, StubSerialized> stubSerializer = new StubSerializer<object, StubSerialized>(
+                serialize: o => { serializeInvoked = true; return new StubSerialized(o); },
+                deserialize: s => s.Original
+            );
+            StubCacheProvider stubCacheProvider = new StubCacheProvider();
+            object objectToCache = default(object);
+            string key = "some key";
+
+            SerializingCacheProviderAsync<StubSerialized> serializingCacheProvider = stubCacheProvider.AsyncFor<StubSerialized>().WithSerializer(stubSerializer);
+            await serializingCacheProvider.PutAsync(key, objectToCache, new Ttl(TimeSpan.FromMinutes(1)), CancellationToken.None, false);
+
+            serializeInvoked.Should().Be(false);
+            stubCacheProvider.Get(key).Should().BeNull();
+        }
+
+        [Fact]
         public async Task Single_generic_SerializingCacheProvider_from_extension_syntax_should_deserialize_on_get()
         {
             bool deserializeInvoked = false;
@@ -126,6 +184,26 @@ namespace Polly.Specs.Caching
 
             deserializeInvoked.Should().Be(true);
             fromCache.Should().Be(objectToCache);
+        }
+
+        [Fact]
+        public async Task Single_generic_SerializingCacheProvider_from_extension_syntax_should_not_deserialize_on_get_when_item_not_in_cache()
+        {
+            bool deserializeInvoked = false;
+            StubSerializer<object, StubSerialized> stubSerializer = new StubSerializer<object, StubSerialized>(
+                serialize: o => new StubSerialized(o),
+                deserialize: s => { deserializeInvoked = true; return s.Original; }
+            );
+            var stubCacheProvider = new StubCacheProvider();
+            string key = "some key";
+
+            stubCacheProvider.Get(key).Should().BeNull();
+
+            SerializingCacheProviderAsync<StubSerialized> serializingCacheProvider = stubCacheProvider.AsyncFor<StubSerialized>().WithSerializer(stubSerializer);
+            object fromCache = await serializingCacheProvider.GetAsync(key, CancellationToken.None, false);
+
+            deserializeInvoked.Should().Be(false);
+            fromCache.Should().Be(default(object));
         }
 
         #endregion
@@ -185,6 +263,25 @@ namespace Polly.Specs.Caching
         }
 
         [Fact]
+        public async Task Double_generic_SerializingCacheProvider_should_not_serialize_on_put_for_defaultTResult()
+        {
+            bool serializeInvoked = false;
+            StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>> stubTResultSerializer = new StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>>(
+                serialize: o => { serializeInvoked = true; return new StubSerialized<ResultPrimitive>(o); },
+                deserialize: s => s.Original
+            );
+            StubCacheProvider stubCacheProvider = new StubCacheProvider();
+            ResultPrimitive objectToCache = default(ResultPrimitive);
+            string key = "some key";
+
+            SerializingCacheProviderAsync<ResultPrimitive, StubSerialized<ResultPrimitive>> serializingCacheProvider = new SerializingCacheProviderAsync<ResultPrimitive, StubSerialized<ResultPrimitive>>(stubCacheProvider.AsyncFor<StubSerialized<ResultPrimitive>>(), stubTResultSerializer);
+            await serializingCacheProvider.PutAsync(key, objectToCache, new Ttl(TimeSpan.FromMinutes(1)), CancellationToken.None, false);
+
+            serializeInvoked.Should().Be(false);
+            stubCacheProvider.Get(key).Should().BeNull();
+        }
+
+        [Fact]
         public async Task Double_generic_SerializingCacheProvider_should_deserialize_on_get()
         {
             bool deserializeInvoked = false;
@@ -203,6 +300,26 @@ namespace Polly.Specs.Caching
 
             deserializeInvoked.Should().Be(true);
             fromCache.Should().Be(objectToCache);
+        }
+
+        [Fact]
+        public async Task Double_generic_SerializingCacheProvider_should_not_deserialize_on_get_when_item_not_in_cache()
+        {
+            bool deserializeInvoked = false;
+            StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>> stubTResultSerializer = new StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>>(
+                serialize: o => new StubSerialized<ResultPrimitive>(o),
+                deserialize: s => { deserializeInvoked = true; return s.Original; }
+            );
+            var stubCacheProvider = new StubCacheProvider();
+            string key = "some key";
+
+            stubCacheProvider.Get(key).Should().BeNull();
+
+            SerializingCacheProviderAsync<ResultPrimitive, StubSerialized<ResultPrimitive>> serializingCacheProvider = new SerializingCacheProviderAsync<ResultPrimitive, StubSerialized<ResultPrimitive>>(stubCacheProvider.AsyncFor<StubSerialized<ResultPrimitive>>(), stubTResultSerializer);
+            ResultPrimitive fromCache = await serializingCacheProvider.GetAsync(key, CancellationToken.None, false);
+
+            deserializeInvoked.Should().Be(false);
+            fromCache.Should().Be(default(ResultPrimitive));
         }
 
         [Fact]
@@ -227,6 +344,26 @@ namespace Polly.Specs.Caching
         }
 
         [Fact]
+        public async Task Double_generic_SerializingCacheProvider_from_extension_syntax_should_not_serialize_on_put_for_defaultTResult()
+        {
+            bool serializeInvoked = false;
+            StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>> stubTResultSerializer = new StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>>(
+                serialize: o => { serializeInvoked = true; return new StubSerialized<ResultPrimitive>(o); },
+                deserialize: s => s.Original
+            );
+            StubCacheProvider stubCacheProvider = new StubCacheProvider();
+            ResultPrimitive objectToCache = default(ResultPrimitive);
+            string key = "some key";
+
+            SerializingCacheProviderAsync<ResultPrimitive, StubSerialized<ResultPrimitive>> serializingCacheProvider =
+                stubCacheProvider.AsyncFor<StubSerialized<ResultPrimitive>>().WithSerializer(stubTResultSerializer);
+            await serializingCacheProvider.PutAsync(key, objectToCache, new Ttl(TimeSpan.FromMinutes(1)), CancellationToken.None, false);
+
+            serializeInvoked.Should().Be(false);
+            stubCacheProvider.Get(key).Should().BeNull();
+        }
+
+        [Fact]
         public async Task Double_generic_SerializingCacheProvider_from_extension_syntax_should_deserialize_on_get()
         {
             bool deserializeInvoked = false;
@@ -242,10 +379,31 @@ namespace Polly.Specs.Caching
                 stubCacheProvider.AsyncFor<StubSerialized<ResultPrimitive>>().WithSerializer(stubTResultSerializer);
 
             await stubCacheProvider.PutAsync(key, new StubSerialized<ResultPrimitive>(objectToCache), new Ttl(TimeSpan.FromMinutes(1)), CancellationToken.None, false);
-            object fromCache = await serializingCacheProvider.GetAsync(key, CancellationToken.None, false);
+            ResultPrimitive fromCache = await serializingCacheProvider.GetAsync(key, CancellationToken.None, false);
 
             deserializeInvoked.Should().Be(true);
             fromCache.Should().Be(objectToCache);
+        }
+
+        [Fact]
+        public async Task Double_generic_SerializingCacheProvider_from_extension_syntax_should_not_deserialize_on_get_when_item_not_in_cache()
+        {
+            bool deserializeInvoked = false;
+            StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>> stubTResultSerializer = new StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>>(
+                serialize: o => new StubSerialized<ResultPrimitive>(o),
+                deserialize: s => { deserializeInvoked = true; return s.Original; }
+            );
+            var stubCacheProvider = new StubCacheProvider();
+            string key = "some key";
+
+            stubCacheProvider.Get(key).Should().BeNull();
+
+            SerializingCacheProviderAsync<ResultPrimitive, StubSerialized<ResultPrimitive>> serializingCacheProvider =
+                stubCacheProvider.AsyncFor<StubSerialized<ResultPrimitive>>().WithSerializer(stubTResultSerializer);
+            ResultPrimitive fromCache = await serializingCacheProvider.GetAsync(key, CancellationToken.None, false);
+
+            deserializeInvoked.Should().Be(false);
+            fromCache.Should().Be(default(ResultPrimitive));
         }
 
         #endregion

--- a/src/Polly.SharedSpecs/Caching/SerializingCacheProviderSpecs.cs
+++ b/src/Polly.SharedSpecs/Caching/SerializingCacheProviderSpecs.cs
@@ -64,6 +64,25 @@ namespace Polly.Specs.Caching
         }
 
         [Fact]
+        public void Single_generic_SerializingCacheProvider_should_not_serialize_on_put_for_defaultTResult()
+        {
+            bool serializeInvoked = false;
+            StubSerializer<object, StubSerialized> stubSerializer = new StubSerializer<object, StubSerialized>(
+                serialize: o => { serializeInvoked = true; return new StubSerialized(o); },
+                deserialize: s => s.Original
+            );
+            StubCacheProvider stubCacheProvider = new StubCacheProvider();
+            object objectToCache = default(object);
+            string key = "some key";
+
+            SerializingCacheProvider<StubSerialized> serializingCacheProvider = new SerializingCacheProvider<StubSerialized>(stubCacheProvider.For<StubSerialized>(), stubSerializer);
+            serializingCacheProvider.Put(key, objectToCache, new Ttl(TimeSpan.FromMinutes(1)));
+
+            serializeInvoked.Should().Be(false);
+            stubCacheProvider.Get(key).Should().BeNull();
+        }
+
+        [Fact]
         public void Single_generic_SerializingCacheProvider_should_deserialize_on_get()
         {
             bool deserializeInvoked = false;
@@ -83,6 +102,26 @@ namespace Polly.Specs.Caching
 
             deserializeInvoked.Should().Be(true);
             fromCache.Should().Be(objectToCache);
+        }
+
+        [Fact]
+        public void Single_generic_SerializingCacheProvider_should_not_deserialize_on_get_when_item_not_in_cache()
+        {
+            bool deserializeInvoked = false;
+            StubSerializer<object, StubSerialized> stubSerializer = new StubSerializer<object, StubSerialized>(
+                serialize: o => new StubSerialized(o),
+                deserialize: s => { deserializeInvoked = true; return s.Original; }
+            );
+            var stubCacheProvider = new StubCacheProvider();
+            string key = "some key";
+
+            stubCacheProvider.Get(key).Should().BeNull();
+
+            SerializingCacheProvider<StubSerialized> serializingCacheProvider = new SerializingCacheProvider<StubSerialized>(stubCacheProvider.For<StubSerialized>(), stubSerializer);
+            object fromCache = serializingCacheProvider.Get(key);
+
+            deserializeInvoked.Should().Be(false);
+            fromCache.Should().Be(default(object));
         }
 
         [Fact]
@@ -106,6 +145,25 @@ namespace Polly.Specs.Caching
         }
 
         [Fact]
+        public void Single_generic_SerializingCacheProvider_from_extension_syntax_should_not_serialize_on_put_for_defaultTResult()
+        {
+            bool serializeInvoked = false;
+            StubSerializer<object, StubSerialized> stubSerializer = new StubSerializer<object, StubSerialized>(
+                serialize: o => { serializeInvoked = true; return new StubSerialized(o); },
+                deserialize: s => s.Original
+            );
+            StubCacheProvider stubCacheProvider = new StubCacheProvider();
+            object objectToCache = default(object);
+            string key = "some key";
+
+            SerializingCacheProvider<StubSerialized> serializingCacheProvider = stubCacheProvider.For<StubSerialized>().WithSerializer(stubSerializer);
+            serializingCacheProvider.Put(key, objectToCache, new Ttl(TimeSpan.FromMinutes(1)));
+
+            serializeInvoked.Should().Be(false);
+            stubCacheProvider.Get(key).Should().BeNull();
+        }
+
+        [Fact]
         public void Single_generic_SerializingCacheProvider_from_extension_syntax_should_deserialize_on_get()
         {
             bool deserializeInvoked = false;
@@ -124,6 +182,26 @@ namespace Polly.Specs.Caching
 
             deserializeInvoked.Should().Be(true);
             fromCache.Should().Be(objectToCache);
+        }
+
+        [Fact]
+        public void Single_generic_SerializingCacheProvider_from_extension_syntax_should_not_deserialize_on_get_when_item_not_in_cache()
+        {
+            bool deserializeInvoked = false;
+            StubSerializer<object, StubSerialized> stubSerializer = new StubSerializer<object, StubSerialized>(
+                serialize: o => new StubSerialized(o),
+                deserialize: s => { deserializeInvoked = true; return s.Original; }
+            );
+            var stubCacheProvider = new StubCacheProvider();
+            string key = "some key";
+
+            stubCacheProvider.Get(key).Should().BeNull();
+
+            SerializingCacheProvider<StubSerialized> serializingCacheProvider = stubCacheProvider.For<StubSerialized>().WithSerializer(stubSerializer);
+            object fromCache = serializingCacheProvider.Get(key);
+
+            deserializeInvoked.Should().Be(false);
+            fromCache.Should().Be(default(object));
         }
 
         #endregion
@@ -183,6 +261,25 @@ namespace Polly.Specs.Caching
         }
 
         [Fact]
+        public void Double_generic_SerializingCacheProvider_should_not_serialize_on_put_for_defaultTResult()
+        {
+            bool serializeInvoked = false;
+            StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>> stubTResultSerializer = new StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>>(
+                serialize: o => { serializeInvoked = true; return new StubSerialized<ResultPrimitive>(o); },
+                deserialize: s => s.Original
+            );
+            StubCacheProvider stubCacheProvider = new StubCacheProvider();
+            ResultPrimitive objectToCache = default(ResultPrimitive);
+            string key = "some key";
+
+            SerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>> serializingCacheProvider = new SerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>>(stubCacheProvider.For<StubSerialized<ResultPrimitive>>(), stubTResultSerializer);
+            serializingCacheProvider.Put(key, objectToCache, new Ttl(TimeSpan.FromMinutes(1)));
+
+            serializeInvoked.Should().Be(false);
+            stubCacheProvider.Get(key).Should().BeNull();
+        }
+
+        [Fact]
         public void Double_generic_SerializingCacheProvider_should_deserialize_on_get()
         {
             bool deserializeInvoked = false;
@@ -201,6 +298,26 @@ namespace Polly.Specs.Caching
 
             deserializeInvoked.Should().Be(true);
             fromCache.Should().Be(objectToCache);
+        }
+
+        [Fact]
+        public void Double_generic_SerializingCacheProvider_should_not_deserialize_on_get_when_item_not_in_cache()
+        {
+            bool deserializeInvoked = false;
+            StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>> stubTResultSerializer = new StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>>(
+                serialize: o => new StubSerialized<ResultPrimitive>(o),
+                deserialize: s => { deserializeInvoked = true; return s.Original; }
+            );
+            var stubCacheProvider = new StubCacheProvider();
+            string key = "some key";
+
+            stubCacheProvider.Get(key).Should().BeNull();
+
+            SerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>> serializingCacheProvider = new SerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>>(stubCacheProvider.For<StubSerialized<ResultPrimitive>>(), stubTResultSerializer);
+            ResultPrimitive fromCache = serializingCacheProvider.Get(key);
+
+            deserializeInvoked.Should().Be(false);
+            fromCache.Should().Be(default(ResultPrimitive));
         }
 
         [Fact]
@@ -225,6 +342,27 @@ namespace Polly.Specs.Caching
         }
 
         [Fact]
+        public void Double_generic_SerializingCacheProvider_from_extension_syntax_should_not_serialize_on_put_for_defaultTResult()
+        {
+            bool serializeInvoked = false;
+            StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>> stubTResultSerializer = new StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>>(
+                serialize: o => { serializeInvoked = true; return new StubSerialized<ResultPrimitive>(o); },
+                deserialize: s => s.Original
+            );
+            StubCacheProvider stubCacheProvider = new StubCacheProvider();
+            ResultPrimitive objectToCache = default(ResultPrimitive);
+            string key = "some key";
+
+            SerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>> serializingCacheProvider =
+                stubCacheProvider.For<StubSerialized<ResultPrimitive>>().WithSerializer(stubTResultSerializer);
+
+            serializingCacheProvider.Put(key, objectToCache, new Ttl(TimeSpan.FromMinutes(1)));
+
+            serializeInvoked.Should().Be(false);
+            stubCacheProvider.Get(key).Should().BeNull();
+        }
+
+        [Fact]
         public void Double_generic_SerializingCacheProvider_from_extension_syntax_should_deserialize_on_get()
         {
             bool deserializeInvoked = false;
@@ -244,6 +382,27 @@ namespace Polly.Specs.Caching
 
             deserializeInvoked.Should().Be(true);
             fromCache.Should().Be(objectToCache);
+        }
+
+        [Fact]
+        public void Double_generic_SerializingCacheProvider_from_extension_syntax_should_not_deserialize_on_get_when_item_not_in_cache()
+        {
+            bool deserializeInvoked = false;
+            StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>> stubTResultSerializer = new StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>>(
+                serialize: o => new StubSerialized<ResultPrimitive>(o),
+                deserialize: s => { deserializeInvoked = true; return s.Original; }
+            );
+            var stubCacheProvider = new StubCacheProvider();
+            string key = "some key";
+
+            stubCacheProvider.Get(key).Should().BeNull();
+
+            SerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>> serializingCacheProvider =
+                stubCacheProvider.For<StubSerialized<ResultPrimitive>>().WithSerializer(stubTResultSerializer);
+            ResultPrimitive fromCache = serializingCacheProvider.Get(key);
+
+            deserializeInvoked.Should().Be(false);
+            fromCache.Should().Be(default(ResultPrimitive));
         }
 
         #endregion

--- a/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
+++ b/src/Polly.SharedSpecs/Polly.SharedSpecs.projitems
@@ -24,6 +24,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Caching\CacheTResultSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\ContextualTtlSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\DefaultCacheKeyStrategySpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Caching\GenericCacheProviderAsyncSpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Caching\GenericCacheProviderSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\RelativeTtlSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\ResultTtlSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Caching\SerializingCacheProviderAsyncSpecs.cs" />


### PR DESCRIPTION
Fixes #472 : possible `NullReferenceException` (internally, affecting perfomance) when non-generic cache policy used for non-nullable types, when cache does not hold value

Fixes #475: possible `NullReferenceException` (internally, affecting perfomance), when using a cache serializer with a non-nullable type, and cache does not hold value