### PR TITLE
Fix Context.PolicyKey issue 463

### DIFF
--- a/src/Polly.Shared/Policy.Async.ExecuteOverloads.cs
+++ b/src/Polly.Shared/Policy.Async.ExecuteOverloads.cs
@@ -117,9 +117,17 @@ namespace Polly
         public Task ExecuteAsync(Func<Context, CancellationToken, Task> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
-            SetPolicyContext(context);
 
-            return ExecuteAsyncInternal(action, context, cancellationToken, continueOnCapturedContext);
+            SetPolicyContext(context, out string priorPolicyWrapKey, out string priorPolicyKey);
+
+            try
+            {
+                return ExecuteAsyncInternal(action, context, cancellationToken, continueOnCapturedContext);
+            }
+            finally
+            {
+                RestorePolicyContext(context, priorPolicyWrapKey, priorPolicyKey);
+            }
         }
 
         #region Overloads method-generic in TResult
@@ -245,9 +253,17 @@ namespace Polly
         public Task<TResult> ExecuteAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
-            SetPolicyContext(context);
 
-            return ExecuteAsyncInternal(action, context, cancellationToken, continueOnCapturedContext);
+            SetPolicyContext(context, out string priorPolicyWrapKey, out string priorPolicyKey);
+
+            try
+            {
+                return ExecuteAsyncInternal(action, context, cancellationToken, continueOnCapturedContext);
+            }
+            finally
+            {
+                RestorePolicyContext(context, priorPolicyWrapKey, priorPolicyKey);
+            }
         }
 
         #endregion

--- a/src/Polly.Shared/Policy.Async.TResult.ExecuteOverloads.cs
+++ b/src/Polly.Shared/Policy.Async.TResult.ExecuteOverloads.cs
@@ -128,9 +128,17 @@ namespace Polly
         public Task<TResult> ExecuteAsync(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
-            SetPolicyContext(context);
 
-            return ExecuteAsyncInternal(action, context, cancellationToken, continueOnCapturedContext);
+            SetPolicyContext(context, out string priorPolicyWrapKey, out string priorPolicyKey);
+
+            try
+            {
+                return ExecuteAsyncInternal(action, context, cancellationToken, continueOnCapturedContext);
+            }
+            finally
+            {
+                RestorePolicyContext(context, priorPolicyWrapKey, priorPolicyKey);
+            }
         }
 
         #endregion

--- a/src/Polly.Shared/Policy.ContextAndKeys.cs
+++ b/src/Polly.Shared/Policy.ContextAndKeys.cs
@@ -21,9 +21,26 @@ namespace Polly
         /// Updates the execution <see cref="Context"/> with context from the executing <see cref="Policy"/>.
         /// </summary>
         /// <param name="executionContext">The execution <see cref="Context"/>.</param>
-        internal virtual void SetPolicyContext(Context executionContext)
+        /// <param name="priorPolicyWrapKey">The <see cref="M:Context.PolicyWrapKey"/> prior to changes by this method.</param>
+        /// <param name="priorPolicyKey">The <see cref="M:Context.PolicyKey"/> prior to changes by this method.</param>
+        internal virtual void SetPolicyContext(Context executionContext, out string priorPolicyWrapKey, out string priorPolicyKey) // priorPolicyWrapKey and priorPolicyKey could be handled as a (string, string) System.ValueTuple return type instead of out parameters, when our minimum supported target supports this.
         {
+            priorPolicyWrapKey = executionContext.PolicyWrapKey;
+            priorPolicyKey = executionContext.PolicyKey;
+
             executionContext.PolicyKey = PolicyKey;
+        }
+
+        /// <summary>
+        /// Restores the supplied keys to the execution <see cref="Context"/>.
+        /// </summary>
+        /// <param name="executionContext">The execution <see cref="Context"/>.</param>
+        /// <param name="priorPolicyWrapKey">The <see cref="M:Context.PolicyWrapKey"/> prior to execution through this policy.</param>
+        /// <param name="priorPolicyKey">The <see cref="M:Context.PolicyKey"/> prior to execution through this policy.</param>
+        internal void RestorePolicyContext(Context executionContext, string priorPolicyWrapKey, string priorPolicyKey)
+        {
+            executionContext.PolicyWrapKey = priorPolicyWrapKey;
+            executionContext.PolicyKey = priorPolicyKey;
         }
     }
 

--- a/src/Polly.Shared/Policy.ExecuteOverloads.cs
+++ b/src/Polly.Shared/Policy.ExecuteOverloads.cs
@@ -77,9 +77,16 @@ namespace Polly
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
-            SetPolicyContext(context);
+            SetPolicyContext(context, out string priorPolicyWrapKey, out string priorPolicyKey);
 
-            ExecuteInternal(action, context, cancellationToken);
+            try
+            {
+                ExecuteInternal(action, context, cancellationToken);
+            }
+            finally
+            {
+                RestorePolicyContext(context, priorPolicyWrapKey, priorPolicyKey);
+            }
         }
 
         #region Overloads method-generic in TResult
@@ -171,9 +178,16 @@ namespace Polly
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
-            SetPolicyContext(context);
+            SetPolicyContext(context, out string priorPolicyWrapKey, out string priorPolicyKey);
 
-            return ExecuteInternal(action, context, cancellationToken);
+            try
+            {
+                return ExecuteInternal(action, context, cancellationToken);
+            }
+            finally
+            {
+                RestorePolicyContext(context, priorPolicyWrapKey, priorPolicyKey);
+            }
         }
 
         #endregion

--- a/src/Polly.Shared/Policy.TResult.ExecuteOverloads.cs
+++ b/src/Polly.Shared/Policy.TResult.ExecuteOverloads.cs
@@ -92,9 +92,17 @@ namespace Polly
         public TResult Execute(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
-            SetPolicyContext(context);
 
-            return ExecuteInternal(action, context, cancellationToken);
+            SetPolicyContext(context, out string priorPolicyWrapKey, out string priorPolicyKey);
+
+            try
+            {
+                return ExecuteInternal(action, context, cancellationToken);
+            }
+            finally
+            {
+                RestorePolicyContext(context, priorPolicyWrapKey, priorPolicyKey);
+            }
         }
 
         #endregion

--- a/src/Polly.Shared/Wrap/PolicyWrap.ContextAndKeys.cs
+++ b/src/Polly.Shared/Wrap/PolicyWrap.ContextAndKeys.cs
@@ -10,11 +10,16 @@ namespace Polly.Wrap
         /// Updates the execution <see cref="Context"/> with context from the executing <see cref="PolicyWrap"/>.
         /// </summary>
         /// <param name="executionContext">The execution <see cref="Context"/>.</param>
-        internal override void SetPolicyContext(Context executionContext)
+        /// <param name="priorPolicyWrapKey">The <see cref="M:Context.PolicyWrapKey"/> prior to changes by this method.</param>
+        /// <param name="priorPolicyKey">The <see cref="M:Context.PolicyKey"/> prior to changes by this method.</param>
+        internal override void SetPolicyContext(Context executionContext, out string priorPolicyWrapKey, out string priorPolicyKey)
         {
+            priorPolicyWrapKey = executionContext.PolicyWrapKey;
+            priorPolicyKey = executionContext.PolicyKey;
+
             if (executionContext.PolicyWrapKey == null) executionContext.PolicyWrapKey = PolicyKey;
 
-            base.SetPolicyContext(executionContext);
+            base.SetPolicyContext(executionContext, out _, out _);
         }
     }
 
@@ -24,11 +29,16 @@ namespace Polly.Wrap
         /// Updates the execution <see cref="Context"/> with context from the executing <see cref="PolicyWrap{TResult}"/>.
         /// </summary>
         /// <param name="executionContext">The execution <see cref="Context"/>.</param>
-        internal override void SetPolicyContext(Context executionContext)
+        /// <param name="priorPolicyWrapKey">The <see cref="M:Context.PolicyWrapKey"/> prior to changes by this method.</param>
+        /// <param name="priorPolicyKey">The <see cref="M:Context.PolicyKey"/> prior to changes by this method.</param>
+        internal override void SetPolicyContext(Context executionContext, out string priorPolicyWrapKey, out string priorPolicyKey)
         {
+            priorPolicyWrapKey = executionContext.PolicyWrapKey;
+            priorPolicyKey = executionContext.PolicyKey;
+
             if (executionContext.PolicyWrapKey == null) executionContext.PolicyWrapKey = PolicyKey;
 
-            base.SetPolicyContext(executionContext);
+            base.SetPolicyContext(executionContext, out _, out _);
         }
     }
 }


### PR DESCRIPTION
### The issue or feature being addressed

Fix `Context.PolicyKey` such that, as execution bubbles back outwards through a `PolicyWrap`, `Context.PolicyKey` correctly adopts the value of the policies in play during the outward journey through the wrap.  Fixes #463

### Confirm the following

- [x]  I have merged the latest changes from the dev vX.Y branch
- [x]  I have successfully run a local build
- [x]  I have included unit tests for the issue/feature
- [x]  I have targeted the PR against the latest dev vX.Y branch
