### PR TITLE
Fix Issue 510: Context.PolicyKey and Context.PolicyWrapKey in async PolicyWrap executions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.1.1
+- Bug Fix: Context.PolicyKey behaviour in PolicyWrap (issue 510)
+
 ## 6.1.0
 - Bug Fix: Context.PolicyKey behaviour in PolicyWrap (issue 463)
 - Bug Fix: CachePolicy behaviour with non-nullable types (issues 472, 475)

--- a/GitVersionConfig.yaml
+++ b/GitVersionConfig.yaml
@@ -1,1 +1,1 @@
-next-version: 6.1.0
+next-version: 6.1.1

--- a/src/Polly.NetStandard11/Properties/AssemblyInfo.cs
+++ b/src/Polly.NetStandard11/Properties/AssemblyInfo.cs
@@ -3,8 +3,8 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Polly")]
-[assembly: AssemblyInformationalVersion("6.1.0.0")]
-[assembly: AssemblyFileVersion("6.1.0.0")]
+[assembly: AssemblyInformationalVersion("6.1.1.0")]
+[assembly: AssemblyFileVersion("6.1.1.0")]
 [assembly: AssemblyVersion("6.0.0.0")]
 [assembly: CLSCompliant(true)]
 

--- a/src/Polly.NetStandard20/Properties/AssemblyInfo.cs
+++ b/src/Polly.NetStandard20/Properties/AssemblyInfo.cs
@@ -3,8 +3,8 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Polly")]
-[assembly: AssemblyInformationalVersion("6.1.0.0")]
-[assembly: AssemblyFileVersion("6.1.0.0")]
+[assembly: AssemblyInformationalVersion("6.1.1.0")]
+[assembly: AssemblyFileVersion("6.1.1.0")]
 [assembly: AssemblyVersion("6.0.0.0")]
 [assembly: CLSCompliant(true)]
 

--- a/src/Polly.Shared/Policy.Async.ExecuteOverloads.cs
+++ b/src/Polly.Shared/Policy.Async.ExecuteOverloads.cs
@@ -114,7 +114,7 @@ namespace Polly
         /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
         /// <exception cref="System.InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
         [DebuggerStepThrough]
-        public Task ExecuteAsync(Func<Context, CancellationToken, Task> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        public async Task ExecuteAsync(Func<Context, CancellationToken, Task> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
@@ -122,7 +122,7 @@ namespace Polly
 
             try
             {
-                return ExecuteAsyncInternal(action, context, cancellationToken, continueOnCapturedContext);
+                await ExecuteAsyncInternal(action, context, cancellationToken, continueOnCapturedContext);
             }
             finally
             {
@@ -250,7 +250,7 @@ namespace Polly
         /// <returns>The value returned by the action</returns>
         /// <exception cref="System.InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
         [DebuggerStepThrough]
-        public Task<TResult> ExecuteAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        public async Task<TResult> ExecuteAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
@@ -258,7 +258,7 @@ namespace Polly
 
             try
             {
-                return ExecuteAsyncInternal(action, context, cancellationToken, continueOnCapturedContext);
+                return await ExecuteAsyncInternal(action, context, cancellationToken, continueOnCapturedContext);
             }
             finally
             {

--- a/src/Polly.Shared/Policy.Async.TResult.ExecuteOverloads.cs
+++ b/src/Polly.Shared/Policy.Async.TResult.ExecuteOverloads.cs
@@ -125,7 +125,7 @@ namespace Polly
         /// <returns>The value returned by the action</returns>
         /// <exception cref="System.InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
         [DebuggerStepThrough]
-        public Task<TResult> ExecuteAsync(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        public async Task<TResult> ExecuteAsync(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
@@ -133,7 +133,7 @@ namespace Polly
 
             try
             {
-                return ExecuteAsyncInternal(action, context, cancellationToken, continueOnCapturedContext);
+                return await ExecuteAsyncInternal(action, context, cancellationToken, continueOnCapturedContext);
             }
             finally
             {

--- a/src/Polly.SharedSpecs/Wrap/PolicyWrapContextAndKeySpecsAsync.cs
+++ b/src/Polly.SharedSpecs/Wrap/PolicyWrapContextAndKeySpecsAsync.cs
@@ -62,7 +62,7 @@ namespace Polly.Specs.Wrap
         }
 
         [Fact]
-        public void Should_restore_PolicyKey_of_outer_policy_to_execution_context_as_move_outwards_through_PolicyWrap()
+        public async Task Should_restore_PolicyKey_of_outer_policy_to_execution_context_as_move_outwards_through_PolicyWrap()
         {
             IAsyncPolicy fallback = Policy
                 .Handle<Exception>()
@@ -86,7 +86,35 @@ namespace Polly.Specs.Wrap
             IAsyncPolicy policyWrap = Policy.WrapAsync(fallback, retry)
                 .WithPolicyKey("PolicyWrap");
 
-            policyWrap.ExecuteAsync(() => throw new Exception());
+            await policyWrap.ExecuteAsync(() => throw new Exception());
+        }
+
+        [Fact]
+        public async Task Should_restore_PolicyKey_of_outer_policy_to_execution_context_as_move_outwards_through_PolicyWrap_with_deeper_async_execution()
+        {
+            IAsyncPolicy fallback = Policy
+                .Handle<Exception>()
+                .FallbackAsync((_, __) => TaskHelper.EmptyTask, (_, context) =>
+                {
+                    context.PolicyWrapKey.Should().Be("PolicyWrap");
+                    context.PolicyKey.Should().Be("FallbackPolicy");
+                    return TaskHelper.EmptyTask;
+                })
+                .WithPolicyKey("FallbackPolicy");
+
+            IAsyncPolicy retry = Policy
+                .Handle<Exception>()
+                .RetryAsync(1, onRetry: (result, retryCount, context) =>
+                {
+                    context.PolicyWrapKey.Should().Be("PolicyWrap");
+                    context.PolicyKey.Should().Be("RetryPolicy");
+                })
+                .WithPolicyKey("RetryPolicy");
+
+            IAsyncPolicy policyWrap = Policy.WrapAsync(fallback, retry)
+                .WithPolicyKey("PolicyWrap");
+
+            await policyWrap.ExecuteAsync(async () => await Task.Run(() => throw new Exception())); // Regression test for issue 510
         }
 
         [Fact]
@@ -221,7 +249,7 @@ namespace Polly.Specs.Wrap
         }
 
         [Fact]
-        public void Should_restore_PolicyKey_of_outer_policy_to_execution_context_as_move_outwards_through_PolicyWrap()
+        public async Task Should_restore_PolicyKey_of_outer_policy_to_execution_context_as_move_outwards_through_PolicyWrap()
         {
             IAsyncPolicy<ResultPrimitive> fallback = Policy<ResultPrimitive>
                 .Handle<Exception>()
@@ -245,8 +273,44 @@ namespace Polly.Specs.Wrap
             IAsyncPolicy<ResultPrimitive> policyWrap = Policy.WrapAsync(fallback, retry)
                 .WithPolicyKey("PolicyWrap");
 
-            policyWrap.ExecuteAsync(() => throw new Exception());
+            await policyWrap.ExecuteAsync(() => throw new Exception());
         }
+
+        [Fact]
+        public async Task Should_restore_PolicyKey_of_outer_policy_to_execution_context_as_move_outwards_through_PolicyWrap_with_deeper_async_execution()
+        {
+            IAsyncPolicy<ResultPrimitive> fallback = Policy<ResultPrimitive>
+                .Handle<Exception>()
+                .FallbackAsync((_, __) => Task.FromResult(ResultPrimitive.Undefined), (_, context) =>
+                {
+                    context.PolicyWrapKey.Should().Be("PolicyWrap");
+                    context.PolicyKey.Should().Be("FallbackPolicy");
+                    return TaskHelper.EmptyTask;
+                })
+                .WithPolicyKey("FallbackPolicy");
+
+            IAsyncPolicy<ResultPrimitive> retry = Policy<ResultPrimitive>
+                .Handle<Exception>()
+                .RetryAsync(1, onRetry: (result, retryCount, context) =>
+                {
+                    context.PolicyWrapKey.Should().Be("PolicyWrap");
+                    context.PolicyKey.Should().Be("RetryPolicy");
+                })
+                .WithPolicyKey("RetryPolicy");
+
+            IAsyncPolicy<ResultPrimitive> policyWrap = Policy.WrapAsync(fallback, retry)
+                .WithPolicyKey("PolicyWrap");
+
+            await policyWrap.ExecuteAsync(async () => await Task.Run(() => // Regression test for issue 510
+            {
+                throw new Exception();
+#pragma warning disable 0162 // unreachable code detected
+                return ResultPrimitive.WhateverButTooLate;
+#pragma warning restore 0162
+
+            }));
+        }
+
 
         [Fact]
         public async Task Should_pass_outmost_PolicyWrap_Key_as_PolicyWrapKey_ignoring_inner_PolicyWrap_keys_even_when_executing_policies_in_inner_WrapAsync()

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -13,6 +13,10 @@
     <tags>Exception Handling Resilience Transient Fault Policy Circuit Breaker CircuitBreaker Retry Wait Cache Cache-aside Bulkhead Fallback Timeout Throttle Parallelization</tags>
     <copyright>Copyright © 2018, App vNext</copyright>
     <releaseNotes>
+     6.1.1
+     ---------------------
+     - Bug Fix: Context.PolicyKey behaviour in PolicyWrap (issue 510)
+
      6.1.0
      ---------------------
      - Bug Fix: Context.PolicyKey behaviour in PolicyWrap


### PR DESCRIPTION
### The issue or feature being addressed

Fixes #510: In async `PolicyWrap` executions, `Context.PolicyKey` and `Context.PolicyWrapKey` may reset to values from a layer further out in the wrap ahead of the inner layer in the wrap completing execution.

### Details of the fix

Polly has long used async-await elision across the `ExecuteAsync(...)` overloads for performance gain. Eliding async-await where an async method is just a pass-through avoids creating extra async state machines.  When introducing the #485 fix for #463, key async execution methods changed from pass-through to not-merely-pass-through. This PR removes the async-await elision (re-introduces async-await) in these places, to ensure async PolicyWrap execution waits for inner-executed code to complete before restoring outer PolicyWrap context.

### Confirm the following

- [x]  I have merged the latest changes from the dev vX.Y branch
- [x]  I have successfully run a local build
- [x]  I have included unit tests for the issue/feature
- [x]  I have targeted the PR against the latest dev vX.Y branch
