### PR TITLE
Refactoring timeoutasync optimistic test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1034,6 +1034,8 @@ When we discover an interesting write-up on Polly, we'll add it to this list. If
 * [Exception handling policies with Polly](http://putridparrot.com/blog/exception-handling-policies-with-polly/) - by [Mark Timmings](http://putridparrot.com/blog/about/)
 * [When you use the Polly circuit-breaker, make sure you share your Policy instances!](https://andrewlock.net/when-you-use-the-polly-circuit-breaker-make-sure-you-share-your-policy-instances-2/) - by [Andrew Lock](https://andrewlock.net/about/)
 * [Polly is Repetitive, and I love it!](http://www.appvnext.com/blog/2015/11/19/polly-is-repetitive-and-i-love-it) - by [Joel Hulen](http://www.thepollyproject.org/author/joel/)
+* [Using the Context to Obtain the Retry Count for Diagnostics](https://www.stevejgordon.co.uk/polly-using-context-to-obtain-retry-count-diagnostics) - by [Steve Gordon](https://twitter.com/stevejgordon)
+* [Passing an ILogger to Polly Policies](https://www.stevejgordon.co.uk/passing-an-ilogger-to-polly-policies) - by [Steve Gordon](https://twitter.com/stevejgordon)
 
 ## Podcasts
 

--- a/src/Polly.SharedSpecs/Timeout/TimeoutAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Timeout/TimeoutAsyncSpecs.cs
@@ -219,13 +219,13 @@ namespace Polly.Specs.Timeout
 
             ResultPrimitive result = ResultPrimitive.Undefined;
 
-            policy.Awaiting(async p =>
+            Func<Task> act = async () =>
             {
-                result = await p.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good))
+                result = await policy.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good))
                     .ConfigureAwait(false);
-            })
-                .ShouldNotThrow();
+            };
 
+            act.ShouldNotThrow();
             result.Should().Be(ResultPrimitive.Good);
         }
 
@@ -287,16 +287,16 @@ namespace Polly.Specs.Timeout
             var result = ResultPrimitive.Undefined;
             var userCancellationToken = CancellationToken.None;
 
-            policy.Awaiting(async p => {
+            Func<Task> act = async () => {
                 result = await policy.ExecuteAsync(async ct =>
                     {
                         await SystemClock.SleepAsync(TimeSpan.FromMilliseconds(500), ct).ConfigureAwait(false);
                         return ResultPrimitive.Good;
                     }, userCancellationToken)
                     .ConfigureAwait(false);
-            })
-                .ShouldNotThrow<TimeoutRejectedException>();
-
+            };
+            
+            act.ShouldNotThrow<TimeoutRejectedException>();
             result.Should().Be(ResultPrimitive.Good);
         }
 

--- a/src/Polly.SharedSpecs/Timeout/TimeoutTResultAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Timeout/TimeoutTResultAsyncSpecs.cs
@@ -214,24 +214,16 @@ namespace Polly.Specs.Timeout
         }
 
         [Fact]
-        public async Task Should_not_throw_when_timeout_is_greater_than_execution_duration__pessimistic()
+        public void Should_not_throw_when_timeout_is_greater_than_execution_duration__pessimistic()
         {
             var policy = Policy.TimeoutAsync<ResultPrimitive>(TimeSpan.FromSeconds(1), TimeoutStrategy.Pessimistic);
 
             ResultPrimitive result = ResultPrimitive.Undefined;
-            Exception ex = null;
 
-            try
-            {
-                result = await policy.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good))
-                    .ConfigureAwait(false);
-            }
-            catch (Exception e)
-            {
-                ex = e;
-            }
+            policy.Awaiting(async p => result = await p.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good))
+                    .ConfigureAwait(false))
+                .ShouldNotThrow();
 
-            ex.Should().BeNull();
             result.Should().Be(ResultPrimitive.Good);
         }
 
@@ -283,25 +275,17 @@ namespace Polly.Specs.Timeout
         }
 
         [Fact]
-        public async Task Should_not_throw_when_timeout_is_greater_than_execution_duration__optimistic()
+        public void Should_not_throw_when_timeout_is_greater_than_execution_duration__optimistic()
         {
             var policy = Policy.TimeoutAsync<ResultPrimitive>(TimeSpan.FromSeconds(1), TimeoutStrategy.Optimistic);
 
             ResultPrimitive result = ResultPrimitive.Undefined;
-            Exception ex = null;
             var userCancellationToken = CancellationToken.None;
 
-            try
-            {
-                result = await policy.ExecuteAsync(ct => Task.FromResult(ResultPrimitive.Good), userCancellationToken)
-                    .ConfigureAwait(false);
-            }
-            catch (Exception e)
-            {
-                ex = e;
-            }
-
-            ex.Should().BeNull();
+            policy.Awaiting(async p => result = await policy.ExecuteAsync(ct => Task.FromResult(ResultPrimitive.Good), userCancellationToken)
+                .ConfigureAwait(false))
+                .ShouldNotThrow();
+            
             result.Should().Be(ResultPrimitive.Good);
         }
 

--- a/src/Polly.SharedSpecs/Timeout/TimeoutTResultAsyncSpecs.cs
+++ b/src/Polly.SharedSpecs/Timeout/TimeoutTResultAsyncSpecs.cs
@@ -220,10 +220,10 @@ namespace Polly.Specs.Timeout
 
             ResultPrimitive result = ResultPrimitive.Undefined;
 
-            policy.Awaiting(async p => result = await p.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good))
-                    .ConfigureAwait(false))
-                .ShouldNotThrow();
+            Func<Task> act = async () => result = await policy.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good))
+                    .ConfigureAwait(false);
 
+            act.ShouldNotThrow();
             result.Should().Be(ResultPrimitive.Good);
         }
 
@@ -282,10 +282,10 @@ namespace Polly.Specs.Timeout
             ResultPrimitive result = ResultPrimitive.Undefined;
             var userCancellationToken = CancellationToken.None;
 
-            policy.Awaiting(async p => result = await policy.ExecuteAsync(ct => Task.FromResult(ResultPrimitive.Good), userCancellationToken)
-                .ConfigureAwait(false))
-                .ShouldNotThrow();
+            Func<Task> act = async () => result = await policy.ExecuteAsync(ct => Task.FromResult(ResultPrimitive.Good), userCancellationToken)
+                .ConfigureAwait(false);
             
+            act.ShouldNotThrow();
             result.Should().Be(ResultPrimitive.Good);
         }
 


### PR DESCRIPTION
### Details on the issue fix or feature implementation

I am looking into why adding a Policy.TimeoutAsync<HttpResponseMessage>() to HttpClientFactory (from the AddPolicy() extension method in Microsoft.Extensions.Http.Polly library) does not allow the HttpClient to do its work and always ends up timing out.  

In the process of confirming the existing tests, I found that the test for TimeoutAsync that does not timeout when optimistically calling an async method was not really doing any work that could show blocking and the test was not properly using FluentAssertions ability to check for an exception for async tasks.  I have refactored the test to support these. 

Happily, I found that the policy works, just not in the context of the HttpClientFactory - so, I will be going to that code base next to validate.

Hope it helps.

### Confirm the following

- [x]  I have merged the latest changes from the dev vX.Y branch
- [x]  I have successfully run a local build
- [x]  I have included unit tests for the issue/feature
- [x]  I have targeted the PR against the latest dev vX.Y branch
