### PR TITLE
Update documentation on sleepDurationProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1034,6 +1034,8 @@ When we discover an interesting write-up on Polly, we'll add it to this list. If
 * [Exception handling policies with Polly](http://putridparrot.com/blog/exception-handling-policies-with-polly/) - by [Mark Timmings](http://putridparrot.com/blog/about/)
 * [When you use the Polly circuit-breaker, make sure you share your Policy instances!](https://andrewlock.net/when-you-use-the-polly-circuit-breaker-make-sure-you-share-your-policy-instances-2/) - by [Andrew Lock](https://andrewlock.net/about/)
 * [Polly is Repetitive, and I love it!](http://www.appvnext.com/blog/2015/11/19/polly-is-repetitive-and-i-love-it) - by [Joel Hulen](http://www.thepollyproject.org/author/joel/)
+* [Using the Context to Obtain the Retry Count for Diagnostics](https://www.stevejgordon.co.uk/polly-using-context-to-obtain-retry-count-diagnostics) - by [Steve Gordon](https://twitter.com/stevejgordon)
+* [Passing an ILogger to Polly Policies](https://www.stevejgordon.co.uk/passing-an-ilogger-to-polly-policies) - by [Steve Gordon](https://twitter.com/stevejgordon)
 
 ## Podcasts
 

--- a/README.md
+++ b/README.md
@@ -1024,6 +1024,7 @@ When we discover an interesting write-up on Polly, we'll add it to this list. If
 * [Resilient network connectivity in Xamarin Forms](https://xamarinhelp.com/resilient-network-connectivity-xamarin-forms/) - by [Adam Pedley](http://xamarinhelp.com/contact/)
 * [Policy recommendations for Azure Cognitive Services](http://www.thepollyproject.org/2018/03/06/policy-recommendations-for-azure-cognitive-services/) - by [Joel Hulen](http://www.thepollyproject.org/author/joel/)
 * [Using Polly with F# async workflows](http://blog.ploeh.dk/2017/05/30/using-polly-with-f-async-workflows/) - by [Mark Seemann](http://blog.ploeh.dk/about/)
+* [Building resilient applications with Polly](http://elvanydev.com/resilience-with-polly/) (with focus on Azure SQL transient errors) - by [Geovanny Alzate Sandoval](https://github.com/vany0114)
 * [Azure SQL transient errors](https://hackernoon.com/azure-sql-transient-errors-7625ad6e0a06) - by [Mattias Karlsson](https://hackernoon.com/@devlead)
 * [Polly series on No Dogma blog](http://nodogmablog.bryanhogan.net/tag/polly/) - by [Bryan Hogan](https://twitter.com/bryanjhogan)
 * [Polly 5.0 - a wider resilience framework!](http://www.thepollyproject.org/2016/10/25/polly-5-0-a-wider-resilience-framework/) - by [Dylan Reisenberger](http://www.thepollyproject.org/author/dylan/)

--- a/src/Polly.Shared/Retry/RetrySyntax.cs
+++ b/src/Polly.Shared/Retry/RetrySyntax.cs
@@ -193,7 +193,7 @@ namespace Polly
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times.
         /// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
-        /// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// the current retry number (1 for first retry, 2 for second etc).
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -210,7 +210,7 @@ namespace Polly
         /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
         /// calling <paramref name="onRetry"/> on each retry with the raised exception and the current sleep duration.
         /// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
-        /// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// the current retry number (1 for first retry, 2 for second etc).
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -238,7 +238,7 @@ namespace Polly
         /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
         /// calling <paramref name="onRetry"/> on each retry with the raised exception, current sleep duration and context data.
         /// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
-        /// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// the current retry number (1 for first retry, 2 for second etc).
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -266,7 +266,7 @@ namespace Polly
         /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
         /// calling <paramref name="onRetry"/> on each retry with the raised exception, current sleep duration, retry count, and context data.
         /// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
-        /// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// the current retry number (1 for first retry, 2 for second etc).
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -302,7 +302,7 @@ namespace Polly
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times.
         /// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
-        /// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// the current retry number (1 for first retry, 2 for second etc) and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -319,7 +319,7 @@ namespace Polly
         /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
         /// calling <paramref name="onRetry"/> on each retry with the raised exception, current sleep duration and context data.
         /// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
-        /// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// the current retry number (1 for first retry, 2 for second etc) and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -343,12 +343,12 @@ namespace Polly
                 );
         }
 
-        
+
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
         /// calling <paramref name="onRetry"/> on each retry with the raised exception, current sleep duration, retry count, and context data.
         /// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
-        /// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// the current retry number (1 for first retry, 2 for second etc) and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -374,7 +374,7 @@ namespace Polly
         /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
         /// calling <paramref name="onRetry"/> on each retry with the raised exception, current sleep duration, retry count, and context data.
         /// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
-        /// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// the current retry number (1 for first retry, 2 for second etc), previous exception and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -496,6 +496,8 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc)
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
@@ -512,6 +514,8 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc) and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
@@ -529,6 +533,8 @@ namespace Polly
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
         /// calling <paramref name="onRetry"/> on each retry with the raised exception.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc)
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
@@ -550,6 +556,8 @@ namespace Polly
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
         /// calling <paramref name="onRetry"/> on each retry with the raised exception and retry count.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc)
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
@@ -570,8 +578,9 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
-        /// calling <paramref name="onRetry"/> on each retry with the raised exception and
-        /// execution context.
+        /// calling <paramref name="onRetry"/> on each retry with the raised exception and execution context.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc) and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
@@ -590,8 +599,9 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
-        /// calling <paramref name="onRetry"/> on each retry with the raised exception, retry count and
-        /// execution context.
+        /// calling <paramref name="onRetry"/> on each retry with the raised exception, retry count and execution context.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc) and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
@@ -610,8 +620,9 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
-        /// calling <paramref name="onRetry"/> on each retry with the raised exception and
-        /// execution context.
+        /// calling <paramref name="onRetry"/> on each retry with the raised exception and execution context.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc), previous exceution and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
@@ -638,8 +649,9 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
-        /// calling <paramref name="onRetry"/> on each retry with the raised exception, retry count and
-        /// execution context.
+        /// calling <paramref name="onRetry"/> on each retry with the raised exception, retry count and execution context.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc), previous exception and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>

--- a/src/Polly.Shared/Retry/RetrySyntaxAsync.cs
+++ b/src/Polly.Shared/Retry/RetrySyntaxAsync.cs
@@ -354,6 +354,7 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
+        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>
         /// <returns>The policy instance.</returns>
         public static RetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider)
         {
@@ -372,6 +373,7 @@ namespace Polly
         /// <param name="retryCount">The retry count.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
+        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>
         /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="System.ArgumentNullException">
@@ -402,6 +404,7 @@ namespace Polly
         /// <param name="retryCount">The retry count.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>
         /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="System.ArgumentNullException">
@@ -432,6 +435,7 @@ namespace Polly
         /// <param name="retryCount">The retry count.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
+        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>
         /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="System.ArgumentNullException">
@@ -463,7 +467,7 @@ namespace Polly
         /// <param name="retryCount">The retry count.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
-        /// <returns>The policy instance.</returns>
+        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="System.ArgumentNullException">
         ///     sleepDurationProvider
@@ -492,7 +496,7 @@ namespace Polly
         /// <param name="retryCount">The retry count.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
-        /// <returns>The policy instance.</returns>
+        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="System.ArgumentNullException">
         ///     sleepDurationProvider
@@ -522,7 +526,7 @@ namespace Polly
         /// <param name="retryCount">The retry count.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
-        /// <returns>The policy instance.</returns>
+        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="System.ArgumentNullException">
         ///     sleepDurationProvider
@@ -563,7 +567,7 @@ namespace Polly
         /// <param name="retryCount">The retry count.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
-        /// <returns>The policy instance.</returns>
+        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="System.ArgumentNullException">
         ///     sleepDurationProvider
@@ -594,7 +598,7 @@ namespace Polly
         /// <param name="retryCount">The retry count.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
-        /// <returns>The policy instance.</returns>
+        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="System.ArgumentNullException">
         ///     sleepDurationProvider
@@ -623,7 +627,7 @@ namespace Polly
         /// <param name="retryCount">The retry count.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
-        /// <returns>The policy instance.</returns>
+        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="System.ArgumentNullException">
         ///     sleepDurationProvider
@@ -653,7 +657,7 @@ namespace Polly
         /// <param name="retryCount">The retry count.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
-        /// <returns>The policy instance.</returns>
+        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="System.ArgumentNullException">
         ///     sleepDurationProvider
@@ -680,7 +684,7 @@ namespace Polly
         /// <param name="retryCount">The retry count.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
-        /// <returns>The policy instance.</returns>
+        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="System.ArgumentNullException">
         ///     sleepDurationProvider
@@ -898,7 +902,7 @@ namespace Polly
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
-        /// <returns>The policy instance.</returns>
+        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
         public static RetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, TimeSpan> sleepDurationProvider)
         {
@@ -914,7 +918,7 @@ namespace Polly
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
-        /// <returns>The policy instance.</returns>
+        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
         public static RetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider)
         {
@@ -932,7 +936,7 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
-        /// <returns>The policy instance.</returns>
+        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
         /// <exception cref="System.ArgumentNullException">onRetry</exception>
         public static RetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan> onRetry)
@@ -953,7 +957,7 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
-        /// <returns>The policy instance.</returns>
+        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
         /// <exception cref="System.ArgumentNullException">onRetry</exception>
         public static RetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, int, TimeSpan> onRetry)
@@ -974,7 +978,7 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
-        /// <returns>The policy instance.</returns>
+        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
         /// <exception cref="System.ArgumentNullException">onRetryAsync</exception>
         public static RetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, Task> onRetryAsync)
@@ -995,7 +999,7 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
-        /// <returns>The policy instance.</returns>
+        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
         /// <exception cref="System.ArgumentNullException">onRetryAsync</exception>
         public static RetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Func<Exception, int, TimeSpan, Task> onRetryAsync)
@@ -1017,7 +1021,7 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
-        /// <returns>The policy instance.</returns>
+        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
         /// <exception cref="System.ArgumentNullException">onRetry</exception>        
         public static RetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, Context> onRetry)
@@ -1041,7 +1045,7 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
-        /// <returns>The policy instance.</returns>
+        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
         /// <exception cref="System.ArgumentNullException">onRetry</exception>        
         public static RetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, int, TimeSpan, Context> onRetry)
@@ -1065,6 +1069,7 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>
         /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
         /// <exception cref="System.ArgumentNullException">onRetryAsync</exception>        
@@ -1085,6 +1090,7 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>
         /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
         /// <exception cref="System.ArgumentNullException">onRetryAsync</exception>        
@@ -1105,6 +1111,7 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>
         /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
         /// <exception cref="System.ArgumentNullException">onRetryAsync</exception>        
@@ -1137,6 +1144,7 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
+        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>
         /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
         /// <exception cref="System.ArgumentNullException">onRetryAsync</exception>        

--- a/src/Polly.Shared/Retry/RetrySyntaxAsync.cs
+++ b/src/Polly.Shared/Retry/RetrySyntaxAsync.cs
@@ -349,12 +349,11 @@ namespace Polly
         /// <summary>
         ///     Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times.
         ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
-        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///     the current retry number (1 for first retry, 2 for second etc).
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
-        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>
         /// <returns>The policy instance.</returns>
         public static RetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider)
         {
@@ -367,13 +366,12 @@ namespace Polly
         ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
         ///     calling <paramref name="onRetry" /> on each retry with the raised exception and the current sleep duration.
         ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///     the current retry number (1 for first retry, 2 for second etc).
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
-        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>
         /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="System.ArgumentNullException">
@@ -398,13 +396,12 @@ namespace Polly
         ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
         ///     calling <paramref name="onRetryAsync" /> on each retry with the raised exception and the current sleep duration.
         ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///     the current retry number (1 for first retry, 2 for second etc).
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
-        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>
         /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="System.ArgumentNullException">
@@ -429,13 +426,12 @@ namespace Polly
         ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
         ///     calling <paramref name="onRetry" /> on each retry with the raised exception, the current sleep duration and context data.
         ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///     the current retry number (1 for first retry, 2 for second etc).
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
-        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>
         /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="System.ArgumentNullException">
@@ -461,13 +457,13 @@ namespace Polly
         ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
         ///     calling <paramref name="onRetryAsync" /> on each retry with the raised exception, the current sleep duration and context data.
         ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///     the current retry number (1 for first retry, 2 for second etc).
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
-        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
+        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="System.ArgumentNullException">
         ///     sleepDurationProvider
@@ -490,13 +486,13 @@ namespace Polly
         ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
         ///     calling <paramref name="onRetry" /> on each retry with the raised exception, the current sleep duration, retry count, and context data.
         ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///     the current retry number (1 for first retry, 2 for second etc).
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
-        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
+        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="System.ArgumentNullException">
         ///     sleepDurationProvider
@@ -520,13 +516,13 @@ namespace Polly
         ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
         ///     calling <paramref name="onRetryAsync" /> on each retry with the raised exception, the current sleep duration, retry count, and context data.
         ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///     the current retry number (1 for first retry, 2 for second etc).
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
-        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
+        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="System.ArgumentNullException">
         ///     sleepDurationProvider
@@ -561,13 +557,13 @@ namespace Polly
         ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
         ///     calling <paramref name="onRetry" /> on each retry with the raised exception, the current sleep duration and context data.
         ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///     the current retry number (1 for first retry, 2 for second etc) and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
-        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
+        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="System.ArgumentNullException">
         ///     sleepDurationProvider
@@ -592,13 +588,13 @@ namespace Polly
         ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
         ///     calling <paramref name="onRetryAsync" /> on each retry with the raised exception, the current sleep duration and context data.
         ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///     the current retry number (1 for first retry, 2 for second etc) and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
-        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
+        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="System.ArgumentNullException">
         ///     sleepDurationProvider
@@ -621,13 +617,13 @@ namespace Polly
         ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
         ///     calling <paramref name="onRetry" /> on each retry with the raised exception, the current sleep duration, retry count, and context data.
         ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///     the current retry number (1 for first retry, 2 for second etc) and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
-        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
+        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="System.ArgumentNullException">
         ///     sleepDurationProvider
@@ -651,13 +647,13 @@ namespace Polly
         ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
         ///     calling <paramref name="onRetryAsync" /> on each retry with the raised exception, the current sleep duration, retry count, and context data.
         ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///     the current retry number (1 for first retry, 2 for second etc) and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
-        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
+        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="System.ArgumentNullException">
         ///     sleepDurationProvider
@@ -678,13 +674,13 @@ namespace Polly
         ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
         ///     calling <paramref name="onRetryAsync" /> on each retry with the raised exception, the current sleep duration, retry count, and context data.
         ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///     the current retry number (1 for first retry, 2 for second etc), previous exception and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
-        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
+        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="System.ArgumentNullException">
         ///     sleepDurationProvider
@@ -899,10 +895,12 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc)
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
-        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
+        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
         public static RetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, TimeSpan> sleepDurationProvider)
         {
@@ -915,10 +913,12 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc) and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
-        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
+        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
         public static RetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider)
         {
@@ -932,11 +932,13 @@ namespace Polly
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely
         /// calling <paramref name="onRetry"/> on each retry with the raised exception.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc)
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
-        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
+        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
         /// <exception cref="System.ArgumentNullException">onRetry</exception>
         public static RetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan> onRetry)
@@ -953,11 +955,13 @@ namespace Polly
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely
         /// calling <paramref name="onRetry"/> on each retry with the raised exception and retry count.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc)
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
-        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
+        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
         /// <exception cref="System.ArgumentNullException">onRetry</exception>
         public static RetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, int, TimeSpan> onRetry)
@@ -974,11 +978,13 @@ namespace Polly
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely
         /// calling <paramref name="onRetryAsync"/> on each retry with the raised exception.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc)
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
-        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
+        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
         /// <exception cref="System.ArgumentNullException">onRetryAsync</exception>
         public static RetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, Task> onRetryAsync)
@@ -995,11 +1001,13 @@ namespace Polly
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely
         /// calling <paramref name="onRetryAsync"/> on each retry with the raised exception and retry count.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc)
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
-        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
+        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
         /// <exception cref="System.ArgumentNullException">onRetryAsync</exception>
         public static RetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Func<Exception, int, TimeSpan, Task> onRetryAsync)
@@ -1015,13 +1023,14 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely
-        /// calling <paramref name="onRetry"/> on each retry with the raised exception and
-        /// execution context.
+        /// calling <paramref name="onRetry"/> on each retry with the raised exception and execution context.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc) and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
-        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
+        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
         /// <exception cref="System.ArgumentNullException">onRetry</exception>        
         public static RetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, Context> onRetry)
@@ -1039,13 +1048,14 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely
-        /// calling <paramref name="onRetry"/> on each retry with the raised exception, retry count and
-        /// execution context.
+        /// calling <paramref name="onRetry"/> on each retry with the raised exception, retry count and execution context.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc) and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
-        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>        /// <returns>The policy instance.</returns>
+        /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
         /// <exception cref="System.ArgumentNullException">onRetry</exception>        
         public static RetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, int, TimeSpan, Context> onRetry)
@@ -1063,13 +1073,13 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely
-        /// calling <paramref name="onRetryAsync"/> on each retry with the raised exception and
-        /// execution context.
+        /// calling <paramref name="onRetryAsync"/> on each retry with the raised exception and execution context.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc) and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
-        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>
         /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
         /// <exception cref="System.ArgumentNullException">onRetryAsync</exception>        
@@ -1084,13 +1094,13 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely
-        /// calling <paramref name="onRetryAsync"/> on each retry with the raised exception, retry count and
-        /// execution context.
+        /// calling <paramref name="onRetryAsync"/> on each retry with the raised exception, retry count and execution context.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc) and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
-        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>
         /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
         /// <exception cref="System.ArgumentNullException">onRetryAsync</exception>        
@@ -1105,13 +1115,13 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely
-        /// calling <paramref name="onRetryAsync"/> on each retry with the raised exception and
-        /// execution context.
+        /// calling <paramref name="onRetryAsync"/> on each retry with the raised exception and execution context.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc), previous exception and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
-        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>
         /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
         /// <exception cref="System.ArgumentNullException">onRetryAsync</exception>        
@@ -1138,13 +1148,13 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely
-        /// calling <paramref name="onRetryAsync"/> on each retry with the raised exception, retry count and
-        /// execution context.
+        /// calling <paramref name="onRetryAsync"/> on each retry with the raised exception, retry count and execution context.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc), previous exception and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
-        /// <remarks>The first parameter in sleepDurationProvider is the retry count, and it's value is one (1) for the first attempt.</remarks>
         /// <returns>The policy instance.</returns>
         /// <exception cref="System.ArgumentNullException">sleepDurationProvider</exception>
         /// <exception cref="System.ArgumentNullException">onRetryAsync</exception>        

--- a/src/Polly.Shared/Retry/RetryTResultSyntax.cs
+++ b/src/Polly.Shared/Retry/RetryTResultSyntax.cs
@@ -200,7 +200,7 @@ namespace Polly
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times.
         /// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
-        /// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// the current retry number (1 for first retry, 2 for second etc).
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -217,7 +217,7 @@ namespace Polly
         /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
         /// calling <paramref name="onRetry"/> on each retry with the handled exception or result and the current sleep duration.
         /// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
-        /// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// the current retry number (1 for first retry, 2 for second etc).
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -245,7 +245,7 @@ namespace Polly
         /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
         /// calling <paramref name="onRetry"/> on each retry with the handled exception or result, current sleep duration and context data.
         /// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
-        /// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// the current retry number (1 for first retry, 2 for second etc).
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -273,7 +273,7 @@ namespace Polly
         /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
         /// calling <paramref name="onRetry"/> on each retry with the handled exception or result, current sleep duration, retry count, and context data.
         /// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
-        /// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// the current retry number (1 for first retry, 2 for second etc).
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -311,7 +311,7 @@ namespace Polly
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times.
         /// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
-        /// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// the current retry number (1 for first retry, 2 for second etc) and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -328,7 +328,7 @@ namespace Polly
         /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
         /// calling <paramref name="onRetry"/> on each retry with the handled exception or result, current sleep duration and context data.
         /// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
-        /// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// the current retry number (1 for first retry, 2 for second etc) and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -356,7 +356,7 @@ namespace Polly
         /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
         /// calling <paramref name="onRetry"/> on each retry with the handled exception or result, current sleep duration, retry count, and context data.
         /// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
-        /// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// the current retry number (1 for first retry, 2 for second etc) and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -381,7 +381,7 @@ namespace Polly
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times.
         /// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
-        /// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// the current retry number (1 for first retry, 2 for second etc), previous execution result and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -398,7 +398,7 @@ namespace Polly
         /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
         /// calling <paramref name="onRetry"/> on each retry with the handled exception or result, current sleep duration and context data.
         /// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
-        /// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// the current retry number (1 for first retry, 2 for second etc), previous execution result and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -426,7 +426,7 @@ namespace Polly
         /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
         /// calling <paramref name="onRetry"/> on each retry with the handled exception or result, current sleep duration, retry count, and context data.
         /// On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
-        /// the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        /// the current retry number (1 for first retry, 2 for second etc), previous execution result and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -549,6 +549,8 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc)
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
@@ -565,6 +567,8 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc) and execution context
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
@@ -582,6 +586,8 @@ namespace Polly
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
         /// calling <paramref name="onRetry"/> on each retry with the handled exception or result.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc)
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
@@ -603,6 +609,8 @@ namespace Polly
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
         /// calling <paramref name="onRetry"/> on each retry with the handled exception or result and retry count.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc)
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
@@ -623,8 +631,9 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
-        /// calling <paramref name="onRetry"/> on each retry with the handled exception or result and
-        /// execution context.
+        /// calling <paramref name="onRetry"/> on each retry with the handled exception or result and execution context.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc) and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
@@ -643,8 +652,9 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
-        /// calling <paramref name="onRetry"/> on each retry with the handled exception or result, retry count and
-        /// execution context.
+        /// calling <paramref name="onRetry"/> on each retry with the handled exception or result, retry count and execution context.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc) and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
@@ -663,8 +673,9 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
-        /// calling <paramref name="onRetry"/> on each retry with the handled exception or result and
-        /// execution context.
+        /// calling <paramref name="onRetry"/> on each retry with the handled exception or result and execution context.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc), previous execution result and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
@@ -693,8 +704,9 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
-        /// calling <paramref name="onRetry"/> on each retry with the handled exception or result, retry count and
-        /// execution context.
+        /// calling <paramref name="onRetry"/> on each retry with the handled exception or result, retry count and execution context.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc), previous execution result and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>

--- a/src/Polly.Shared/Retry/RetryTResultSyntaxAsync.cs
+++ b/src/Polly.Shared/Retry/RetryTResultSyntaxAsync.cs
@@ -354,7 +354,7 @@ namespace Polly
         /// <summary>
         ///     Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times.
         ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider"/> with
-        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///     the current retry number (1 for first retry, 2 for second etc).
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -371,7 +371,7 @@ namespace Polly
         ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
         ///     calling <paramref name="onRetry" /> on each retry with the handled exception or result and the current sleep duration.
         ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///     the current retry number (1 for first retry, 2 for second etc)
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -402,7 +402,7 @@ namespace Polly
         ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
         ///     calling <paramref name="onRetryAsync" /> on each retry with the handled exception or result and the current sleep duration.
         ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///     the current retry number (1 for first retry, 2 for second etc).
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -432,7 +432,7 @@ namespace Polly
         ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
         ///     calling <paramref name="onRetry" /> on each retry with the handled exception or result, the current sleep duration and context data.
         ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///     the current retry number (1 for first retry, 2 for second etc).
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -463,7 +463,7 @@ namespace Polly
         ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
         ///     calling <paramref name="onRetryAsync" /> on each retry with the handled exception or result, the current sleep duration and context data.
         ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///     the current retry number (1 for first retry, 2 for second etc).
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -491,7 +491,7 @@ namespace Polly
         ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
         ///     calling <paramref name="onRetry" /> on each retry with the handled exception or result, the current sleep duration, retry count, and context data.
         ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///     the current retry number (1 for first retry, 2 for second etc).
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -521,7 +521,7 @@ namespace Polly
         ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
         ///     calling <paramref name="onRetryAsync" /> on each retry with the handled exception or result, the current sleep duration, retry count, and context data.
         ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///     the current retry number (1 for first retry, 2 for second etc).
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -563,7 +563,7 @@ namespace Polly
         ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
         ///     calling <paramref name="onRetry" /> on each retry with the handled exception or result, the current sleep duration and context data.
         ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///     the current retry number (1 for first retry, 2 for second etc) and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -594,7 +594,7 @@ namespace Polly
         ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
         ///     calling <paramref name="onRetryAsync" /> on each retry with the handled exception or result, the current sleep duration and context data.
         ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///     the current retry number (1 for first retry, 2 for second etc) and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -622,7 +622,7 @@ namespace Polly
         ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
         ///     calling <paramref name="onRetry" /> on each retry with the handled exception or result, the current sleep duration, retry count, and context data.
         ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///     the current retry number (1 for first retry, 2 for second etc) and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -652,7 +652,7 @@ namespace Polly
         ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
         ///     calling <paramref name="onRetryAsync" /> on each retry with the handled exception or result, the current sleep duration, retry count, and context data.
         ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///     the current retry number (1 for first retry, 2 for second etc) and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -679,7 +679,7 @@ namespace Polly
         ///     Builds a <see cref="Policy" /> that will wait and retry <paramref name="retryCount" /> times
         ///     calling <paramref name="onRetryAsync" /> on each retry with the handled exception or result, the current sleep duration, retry count, and context data.
         ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-        ///     the current retry attempt allowing an exponentially increasing wait time (exponential backoff).
+        ///     the current retry number (1 for first retry, 2 for second etc), result of previous execution, and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="retryCount">The retry count.</param>
@@ -898,6 +898,8 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc).
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
@@ -914,6 +916,8 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc).
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
@@ -931,6 +935,8 @@ namespace Polly
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
         /// calling <paramref name="onRetry"/> on each retry with the handled exception or result.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc).
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
@@ -952,6 +958,8 @@ namespace Polly
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
         /// calling <paramref name="onRetry"/> on each retry with the handled exception or result.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc).
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
@@ -973,6 +981,8 @@ namespace Polly
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
         /// calling <paramref name="onRetryAsync"/> on each retry with the handled exception or result.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc).
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
@@ -994,6 +1004,8 @@ namespace Polly
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
         /// calling <paramref name="onRetryAsync"/> on each retry with the handled exception or result and retry count.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc).
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
@@ -1014,8 +1026,9 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
-        /// calling <paramref name="onRetry"/> on each retry with the handled exception or result and
-        /// execution context.
+        /// calling <paramref name="onRetry"/> on each retry with the handled exception or result and execution context.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc) and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
@@ -1037,8 +1050,9 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
-        /// calling <paramref name="onRetry"/> on each retry with the handled exception or result and
-        /// execution context.
+        /// calling <paramref name="onRetry"/> on each retry with the handled exception or result and execution context.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc) and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
@@ -1060,8 +1074,9 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
-        /// calling <paramref name="onRetryAsync"/> on each retry with the handled exception or result and
-        /// execution context.
+        /// calling <paramref name="onRetryAsync"/> on each retry with the handled exception or result and execution context.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc) and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
@@ -1080,8 +1095,9 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
-        /// calling <paramref name="onRetryAsync"/> on each retry with the handled exception or result, retry count and
-        /// execution context.
+        /// calling <paramref name="onRetryAsync"/> on each retry with the handled exception or result, retry count and execution context.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc) and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
@@ -1100,8 +1116,9 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
-        /// calling <paramref name="onRetryAsync"/> on each retry with the handled exception or result and
-        /// execution context.
+        /// calling <paramref name="onRetryAsync"/> on each retry with the handled exception or result and execution context.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc), previous execution result and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
@@ -1131,8 +1148,9 @@ namespace Polly
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds, 
-        /// calling <paramref name="onRetryAsync"/> on each retry with the handled exception or result, retry count and
-        /// execution context.
+        /// calling <paramref name="onRetryAsync"/> on each retry with the handled exception or result, retry count and execution context.
+        ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with 
+        ///     the current retry number (1 for first retry, 2 for second etc), previous execution result and execution context.
         /// </summary>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>


### PR DESCRIPTION
This commit will add information that the retry index provided to the
sleepDurationProvider function is one (1) for the first retry attempt.

I feel that I always wonder if the first attempt is zero or one.

<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors.  All non-trivial contributions get a public credit in the readme! -->

### The issue or feature being addressed

<!-- Please include the existing github issue number where relevant -->

### Details on the issue fix or feature implementation

### Confirm the following

- [ ?]  I have merged the latest changes from the dev vX.Y branch
- [ No]  I have successfully run a local build
- [ No]  I have included unit tests for the issue/feature
- [ No, master]  I have targeted the PR against the latest dev vX.Y branch

This is a trivial change, so maybe this is ok.  Please let me know otherwise.