### PR TITLE
v6.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 6.1.2
-- Bug Fix: Async continuation control for async executions (issue 540)
+- Bug Fix: Async continuation control for async executions (issue 540, affected only v6.1.1)
 
 ## 6.1.1
 - Bug Fix: Context.PolicyKey behaviour in PolicyWrap (issue 510)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.1.2
+- Bug Fix: Async continuation control for async executions (issue 540)
+
 ## 6.1.1
 - Bug Fix: Context.PolicyKey behaviour in PolicyWrap (issue 510)
 

--- a/GitVersionConfig.yaml
+++ b/GitVersionConfig.yaml
@@ -1,1 +1,1 @@
-next-version: 6.1.1
+next-version: 6.1.2

--- a/README.md
+++ b/README.md
@@ -991,7 +991,8 @@ For full detailed of supported targets by version, see [supported targets](https
 * [@urig](https://github.com/urig) - Allow TimeoutPolicy to be configured with Timeout.InfiniteTimeSpan.
 * [@reisenberger](https://github.com/reisenberger) - Integration with [IHttpClientFactory](https://github.com/aspnet/HttpClientFactory/) for ASPNET Core 2.1.
 * [@freakazoid182](https://github.com/Freakazoid182) - WaitAnd/RetryForever overloads where onRetry takes the retry number as a parameter.
-* [@dustyhoppe](https://github.com/dustyhoppe) - Overloads where onTimeout takes thrown exception as a parameter 
+* [@dustyhoppe](https://github.com/dustyhoppe) - Overloads where onTimeout takes thrown exception as a parameter.
+* [@flin-zap](https://github.com/flin-zap) - Catch missing async continuation control.
 
 # Sample Projects
 

--- a/src/Polly.Shared/Policy.Async.ExecuteOverloads.cs
+++ b/src/Polly.Shared/Policy.Async.ExecuteOverloads.cs
@@ -122,7 +122,7 @@ namespace Polly
 
             try
             {
-                await ExecuteAsyncInternal(action, context, cancellationToken, continueOnCapturedContext);
+                await ExecuteAsyncInternal(action, context, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
             }
             finally
             {
@@ -258,7 +258,7 @@ namespace Polly
 
             try
             {
-                return await ExecuteAsyncInternal(action, context, cancellationToken, continueOnCapturedContext);
+                return await ExecuteAsyncInternal(action, context, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
             }
             finally
             {

--- a/src/Polly.Shared/Policy.Async.TResult.ExecuteOverloads.cs
+++ b/src/Polly.Shared/Policy.Async.TResult.ExecuteOverloads.cs
@@ -133,7 +133,7 @@ namespace Polly
 
             try
             {
-                return await ExecuteAsyncInternal(action, context, cancellationToken, continueOnCapturedContext);
+                return await ExecuteAsyncInternal(action, context, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
             }
             finally
             {

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -12,7 +12,10 @@
     <projectUrl>https://github.com/App-vNext/Polly</projectUrl>
     <tags>Exception Handling Resilience Transient Fault Policy Circuit Breaker CircuitBreaker Retry Wait Cache Cache-aside Bulkhead Fallback Timeout Throttle Parallelization</tags>
     <copyright>Copyright © 2018, App vNext</copyright>
-    <releaseNotes>
+    <releaseNotes>     6.1.2
+     ---------------------
+     - Bug Fix: Async continuation control for async executions (issue 540)
+
      6.1.1
      ---------------------
      - Bug Fix: Context.PolicyKey behaviour in PolicyWrap (issue 510)

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -14,7 +14,7 @@
     <copyright>Copyright © 2018, App vNext</copyright>
     <releaseNotes>     6.1.2
      ---------------------
-     - Bug Fix: Async continuation control for async executions (issue 540)
+     - Bug Fix: Async continuation control for async executions (issue 540, affected only v6.1.1)
 
      6.1.1
      ---------------------


### PR DESCRIPTION
Fixes #540 Missing ConfigureAwait()s on async execution fix of preceding #510 .

Issue affected only v6.1.1

### Confirm the following

- [x]  I have merged the latest changes from the dev vX.Y branch
- [x]  I have successfully run a local build
- [n/a]  I have included unit tests for the issue/feature

