### PR TITLE
Make the IReadOnlyPolicyRegistry interface inherit IEnumerable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 7.0.0
 - Clarify separation of sync and async policies
 - Enable extensibility by custom policies hosted external to Polly
-     
+- Enable collection initialization syntax for PolicyRegistry
+
 ## 6.1.2
 - Bug Fix: Async continuation control for async executions (issue 540, affected only v6.1.1)
 

--- a/README.md
+++ b/README.md
@@ -1006,6 +1006,7 @@ For more detail see: [Polly and interfaces](https://github.com/App-vNext/Polly/w
 * [@flin-zap](https://github.com/flin-zap) - Catch missing async continuation control.
 * [@reisenberger](https://github.com/reisenberger) - Clarify separation of sync and async policies.
 * [@reisenberger](https://github.com/reisenberger) - Enable extensibility by custom policies hosted external to Polly.
+* [@seanfarrow](https://github.com/SeanFarrow) - Enable collection initialization syntax for PolicyRegistry.
 
 # Sample Projects
 

--- a/src/Polly.NetStandard11.Specs/Polly.NetStandard11.Specs.csproj
+++ b/src/Polly.NetStandard11.Specs/Polly.NetStandard11.Specs.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/src/Polly.NetStandard20.Specs/Polly.NetStandard20.Specs.csproj
+++ b/src/Polly.NetStandard20.Specs/Polly.NetStandard20.Specs.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/src/Polly.Shared/Registry/IPolicyRegistry.cs
+++ b/src/Polly.Shared/Registry/IPolicyRegistry.cs
@@ -7,7 +7,7 @@ namespace Polly.Registry
     /// Represents a collection of policies keyed by <typeparamref name="TKey"/>.
     /// </summary>
     /// <typeparam name="TKey">The type of keys in the policy registry.</typeparam>
-    public interface IPolicyRegistry<in TKey> : IReadOnlyPolicyRegistry<TKey>
+    public interface IPolicyRegistry<TKey> : IReadOnlyPolicyRegistry<TKey>
     {
         /// <summary>
         /// Adds an element with the provided key and policy to the registry.

--- a/src/Polly.Shared/Registry/IReadOnlyPolicyRegistry.cs
+++ b/src/Polly.Shared/Registry/IReadOnlyPolicyRegistry.cs
@@ -7,7 +7,7 @@ namespace Polly.Registry
     /// Represents a read-only collection of policies keyed by <typeparamref name="TKey"/>.
     /// </summary>
     /// <typeparam name="TKey">The type of keys in the policy registry.</typeparam>
-    public interface IReadOnlyPolicyRegistry<in TKey>
+    public interface IReadOnlyPolicyRegistry<TKey> : IEnumerable<KeyValuePair<TKey, IsPolicy>>
     {
         /// <summary>
         /// Gets the <see cref="IsPolicy"/> with the specified key.

--- a/src/Polly.Shared/Registry/PolicyRegistry.cs
+++ b/src/Polly.Shared/Registry/PolicyRegistry.cs
@@ -10,7 +10,7 @@ namespace Polly.Registry
     /// <remarks>Uses ConcurrentDictionary to store the collection.</remarks>
     public class PolicyRegistry : IPolicyRegistry<string>
     {
-        private readonly IDictionary<string, IsPolicy> _registry = new ConcurrentDictionary<string, IsPolicy>();
+        private readonly IDictionary<string, IsPolicy> _registry;
         
         /// <summary>
         /// 
@@ -18,15 +18,15 @@ namespace Polly.Registry
         /// <param name="registry"></param>
         internal PolicyRegistry(IDictionary<string, IsPolicy> registry =null)
         {
-            if (registry !=null)
+            if (registry == null)
             {
-                _registry = registry;
+                _registry = new ConcurrentDictionary<string, IsPolicy>();
             }
             else
             {
-                throw new NotImplementedException();
+                _registry = registry;
             }
-        }
+            }
         
         /// <summary>
         /// Total number of policies in the registry.

--- a/src/Polly.Shared/Registry/PolicyRegistry.cs
+++ b/src/Polly.Shared/Registry/PolicyRegistry.cs
@@ -22,7 +22,11 @@ namespace Polly.Registry
             {
                 _registry = registry;
             }
+            else
+            {
+                throw new NotImplementedException();
             }
+        }
         
         /// <summary>
         /// Total number of policies in the registry.

--- a/src/Polly.Shared/Registry/PolicyRegistry.cs
+++ b/src/Polly.Shared/Registry/PolicyRegistry.cs
@@ -18,7 +18,7 @@ namespace Polly.Registry
         /// A registry of policy policies with <see cref="System.String"/> keys.
         /// </summary>
         /// <param name="registry">a dictionary containing keys and policies used for testing.</param>
-        internal PolicyRegistry(IDictionary<string, IsPolicy> registry =null) => _registry = registry == null ? new ConcurrentDictionary<string, IsPolicy>() : registry;
+        internal PolicyRegistry(IDictionary<string, IsPolicy> registry = null) => _registry = registry ?? new ConcurrentDictionary<string, IsPolicy>();
 
         /// <summary>
         /// Total number of policies in the registry.
@@ -119,8 +119,10 @@ namespace Polly.Registry
         /// <remarks>
         /// The enumerator returned from the registry is safe to use concurrently with
         /// reads and writes to the registry, however it does not represent a moment-in-time snapshot
-        /// of the registries contents.  The contents exposed through the enumerator may contain modifications
+        /// of the registry's contents.  The contents exposed through the enumerator may contain modifications
         /// made to the dictionary after <see cref="GetEnumerator"/> was called.
+        /// This is not considered a significant issue as typical usage of PolicyRegistry is for bulk population at app startup, 
+        /// with only infrequent changes to the PolicyRegistry during app running, if using PolicyRegistry for dynamic updates during running.
         /// </remarks>
         public IEnumerator<KeyValuePair<string, IsPolicy>> GetEnumerator() => _registry.GetEnumerator();
 
@@ -130,8 +132,10 @@ namespace Polly.Registry
         /// <remarks>
         /// The enumerator returned from the registry is safe to use concurrently with
         /// reads and writes to the registry, however it does not represent a moment-in-time snapshot
-        /// of the registries contents.  The contents exposed through the enumerator may contain modifications
+        /// of the registry's contents.  The contents exposed through the enumerator may contain modifications
         /// made to the dictionary after <see cref="GetEnumerator"/> was called.
+        /// This is not considered a significant issue as typical usage of PolicyRegistry is for bulk population at app startup, 
+        /// with only infrequent changes to the PolicyRegistry during app running, if using PolicyRegistry for dynamic updates during running.
         /// </remarks>
         IEnumerator IEnumerable.GetEnumerator() => ((PolicyRegistry)this).GetEnumerator();
     }

--- a/src/Polly.Shared/Registry/PolicyRegistry.cs
+++ b/src/Polly.Shared/Registry/PolicyRegistry.cs
@@ -11,23 +11,13 @@ namespace Polly.Registry
     public class PolicyRegistry : IPolicyRegistry<string>
     {
         private readonly IDictionary<string, IsPolicy> _registry;
-        
+
         /// <summary>
-        /// 
+        /// A registry of policy policies with <see cref="System.String"/> keys.
         /// </summary>
-        /// <param name="registry"></param>
-        internal PolicyRegistry(IDictionary<string, IsPolicy> registry =null)
-        {
-            if (registry == null)
-            {
-                _registry = new ConcurrentDictionary<string, IsPolicy>();
-            }
-            else
-            {
-                _registry = registry;
-            }
-            }
-        
+        /// <param name="registry">a dictionary containing keys and policies used for testing.</param>
+        internal PolicyRegistry(IDictionary<string, IsPolicy> registry =null) => _registry = registry == null ? new ConcurrentDictionary<string, IsPolicy>() : registry;
+
         /// <summary>
         /// Total number of policies in the registry.
         /// </summary>

--- a/src/Polly.Shared/Registry/PolicyRegistry.cs
+++ b/src/Polly.Shared/Registry/PolicyRegistry.cs
@@ -11,7 +11,18 @@ namespace Polly.Registry
     public class PolicyRegistry : IPolicyRegistry<string>
     {
         private readonly IDictionary<string, IsPolicy> _registry = new ConcurrentDictionary<string, IsPolicy>();
-
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="registry"></param>
+        internal PolicyRegistry(IDictionary<string, IsPolicy> registry =null)
+        {
+            if (registry !=null)
+            {
+                throw new NotImplementedException();
+            }
+            }
+        
         /// <summary>
         /// Total number of policies in the registry.
         /// </summary>

--- a/src/Polly.Shared/Registry/PolicyRegistry.cs
+++ b/src/Polly.Shared/Registry/PolicyRegistry.cs
@@ -11,6 +11,7 @@ namespace Polly.Registry
     public class PolicyRegistry : IPolicyRegistry<string>
     {
         private readonly IDictionary<string, IsPolicy> _registry = new ConcurrentDictionary<string, IsPolicy>();
+        
         /// <summary>
         /// 
         /// </summary>
@@ -19,7 +20,7 @@ namespace Polly.Registry
         {
             if (registry !=null)
             {
-                throw new NotImplementedException();
+                _registry = registry;
             }
             }
         

--- a/src/Polly.Shared/Registry/PolicyRegistry.cs
+++ b/src/Polly.Shared/Registry/PolicyRegistry.cs
@@ -1,11 +1,13 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 
 namespace Polly.Registry
 {
+    /// <inheritdoc />
     /// <summary>
-    /// Stores a registry of <see cref="System.String"/> and policy pairs.
+    /// Stores a registry of <see cref="T:System.String" /> and policy pairs.
     /// </summary>
     /// <remarks>Uses ConcurrentDictionary to store the collection.</remarks>
     public class PolicyRegistry : IPolicyRegistry<string>
@@ -110,5 +112,33 @@ namespace Polly.Registry
         /// <exception cref="ArgumentNullException"><paramref name="key"/> is null.</exception>
         public bool Remove(string key) =>
             _registry.Remove(key);
+
+        /// <summary>Returns an enumerator that iterates through the policy objects inthe <see
+        /// cref="PolicyRegistry"/>.</summary>
+        /// <returns>An enumerator for the <see cref="PolicyRegistry"/>.</returns>
+        /// <remarks>
+        /// The enumerator returned from the registry is safe to use concurrently with
+        /// reads and writes to the registry, however it does not represent a moment-in-time snapshot
+        /// of the registries contents.  The contents exposed through the enumerator may contain modifications
+        /// made to the dictionary after <see cref="GetEnumerator"/> was called.
+        /// </remarks>
+        public IEnumerator<KeyValuePair<string, IsPolicy>> GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+        
+        /// <summary>Returns an enumerator that iterates through the policy objects inthe <see
+        /// cref="PolicyRegistry"/>.</summary>
+        /// <returns>An enumerator for the <see cref="PolicyRegistry"/>.</returns>
+        /// <remarks>
+        /// The enumerator returned from the registry is safe to use concurrently with
+        /// reads and writes to the registry, however it does not represent a moment-in-time snapshot
+        /// of the registries contents.  The contents exposed through the enumerator may contain modifications
+        /// made to the dictionary after <see cref="GetEnumerator"/> was called.
+        /// </remarks>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Polly.Shared/Registry/PolicyRegistry.cs
+++ b/src/Polly.Shared/Registry/PolicyRegistry.cs
@@ -113,7 +113,7 @@ namespace Polly.Registry
         public bool Remove(string key) =>
             _registry.Remove(key);
 
-        /// <summary>Returns an enumerator that iterates through the policy objects inthe <see
+        /// <summary>Returns an enumerator that iterates through the policy objects in the <see
         /// cref="PolicyRegistry"/>.</summary>
         /// <returns>An enumerator for the <see cref="PolicyRegistry"/>.</returns>
         /// <remarks>
@@ -122,12 +122,9 @@ namespace Polly.Registry
         /// of the registries contents.  The contents exposed through the enumerator may contain modifications
         /// made to the dictionary after <see cref="GetEnumerator"/> was called.
         /// </remarks>
-        public IEnumerator<KeyValuePair<string, IsPolicy>> GetEnumerator()
-        {
-            throw new NotImplementedException();
-        }
-        
-        /// <summary>Returns an enumerator that iterates through the policy objects inthe <see
+        public IEnumerator<KeyValuePair<string, IsPolicy>> GetEnumerator() => _registry.GetEnumerator();
+
+        /// <summary>Returns an enumerator that iterates through the policy objects in the <see
         /// cref="PolicyRegistry"/>.</summary>
         /// <returns>An enumerator for the <see cref="PolicyRegistry"/>.</returns>
         /// <remarks>
@@ -136,9 +133,6 @@ namespace Polly.Registry
         /// of the registries contents.  The contents exposed through the enumerator may contain modifications
         /// made to the dictionary after <see cref="GetEnumerator"/> was called.
         /// </remarks>
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            throw new NotImplementedException();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => ((PolicyRegistry)this).GetEnumerator();
     }
 }

--- a/src/Polly.SharedSpecs/Registry/IReadOnlyPolicyRegistrySpecs.cs
+++ b/src/Polly.SharedSpecs/Registry/IReadOnlyPolicyRegistrySpecs.cs
@@ -265,6 +265,22 @@ namespace Polly.Specs.Registry
             testRegistry.GetEnumerator();
             testDictionary.Verify(x => x.GetEnumerator(), Times.Once);
         }
-#endregion
+        #endregion
+
+        #region Collection initializer tests
+
+        [Fact]
+        public void PoliciesShouldBeAddedToTheRegistryWhenUsingCollectionInitializerSyntax()
+        {
+            string key = Guid.NewGuid().ToString();
+            var policy = Policy.NoOp();
+            var testRegistry = new PolicyRegistry
+            {
+                {key, policy}
+            };
+
+            testRegistry.Should().Equal(new KeyValuePair<string, IsPolicy>(key, policy));
+        }
+        #endregion
     }
 }

--- a/src/Polly.SharedSpecs/Registry/IReadOnlyPolicyRegistrySpecs.cs
+++ b/src/Polly.SharedSpecs/Registry/IReadOnlyPolicyRegistrySpecs.cs
@@ -257,23 +257,26 @@ namespace Polly.Specs.Registry
         #region Tests for the GetEnumerator method
 
         [Fact]
-        public void Calling_The_GetEnumerator_Method_Returning_A_IEnumerator_Of_KeyValuePair_Of_String_And_IsPolicy_Calls_The_Registries_GetEnumerator_Method()
+        public void Calling_The_GetEnumerator_Method_Returning_A_IEnumerator_Of_KeyValuePair_Of_String_And_IsPolicy_Calls_The_Registrys_GetEnumerator_Method()
         {
-            var testDictionary =new Mock<IDictionary<string, IsPolicy>>();
-            testDictionary.Setup(x =>x.GetEnumerator());
-            var testRegistry =new PolicyRegistry(testDictionary.Object);
+            var testDictionary = new Mock<IDictionary<string, IsPolicy>>();
+            var testRegistry = new PolicyRegistry(testDictionary.Object);
+
             testRegistry.GetEnumerator();
+
             testDictionary.Verify(x => x.GetEnumerator(), Times.Once);
         }
+
         #endregion
 
         #region Collection initializer tests
 
         [Fact]
-        public void PoliciesShouldBeAddedToTheRegistryWhenUsingCollectionInitializerSyntax()
+        public void Policies_Should_Be_Added_To_The_Registry_When_Using_Collection_Initializer_Syntax()
         {
             string key = Guid.NewGuid().ToString();
             var policy = Policy.NoOp();
+
             var testRegistry = new PolicyRegistry
             {
                 {key, policy}

--- a/src/Polly.SharedSpecs/Registry/IReadOnlyPolicyRegistrySpecs.cs
+++ b/src/Polly.SharedSpecs/Registry/IReadOnlyPolicyRegistrySpecs.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using FluentAssertions;
+using Moq;
 using Polly.Registry;
 using Polly.Specs.Helpers;
 using Xunit;
@@ -252,6 +253,18 @@ namespace Polly.Specs.Registry
                 .ShouldThrow<ArgumentNullException>();
         }
         #endregion
+        
+        #region Tests for the GetEnumerator method
 
+        [Fact]
+        public void Calling_The_GetEnumerator_Method_Returning_A_IEnumerator_Of_KeyValuePair_Of_String_And_IsPolicy_Calls_The_Registries_GetEnumerator_Method()
+        {
+            var testDictionary =new Mock<IDictionary<string, IsPolicy>>();
+            testDictionary.Setup(x =>x.GetEnumerator());
+            var testRegistry =new PolicyRegistry(testDictionary.Object);
+            testRegistry.GetEnumerator();
+            testDictionary.Verify(x => x.GetEnumerator(), Times.Once);
+        }
+#endregion
     }
 }

--- a/src/Polly.SharedSpecs/Registry/PolicyRegistrySpecs.cs
+++ b/src/Polly.SharedSpecs/Registry/PolicyRegistrySpecs.cs
@@ -447,12 +447,11 @@ namespace Polly.Specs.Registry
         public void Constructor_Called_With_A_Registry_Parameter_Should_Assign_The_Passed_In_Registry_To_The_Registry_Field()
         {
             var testDictionary = new Mock<IDictionary<string, IsPolicy>>();
-            var expectedDictionaryType = testDictionary.Object.GetType();
             var testRegistry = new PolicyRegistry(testDictionary.Object);
             //Generally, using reflection is a bad practice, but given we own the implementation, I don't think this is an issue.
             var registryField = typeof(PolicyRegistry).GetField("_registry", BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance);
             var registryFieldValue = registryField.GetValue(testRegistry);
-            registryFieldValue.Should().BeOfType(expectedDictionaryType);
+            registryFieldValue.Should().Be(testDictionary.Object);
         }
 
         [Fact]

--- a/src/Polly.SharedSpecs/Registry/PolicyRegistrySpecs.cs
+++ b/src/Polly.SharedSpecs/Registry/PolicyRegistrySpecs.cs
@@ -444,7 +444,7 @@ namespace Polly.Specs.Registry
         #endregion
         #region Tests for the constructor        
         [Fact]
-        public void Constructor_Called_With_A_Registry_Parameters_Should_Assign_A_ConcurrentDictionary_Of_TKey_And_IsPolicy_To_The_Registry_Field()
+        public void Constructor_Called_With_A_Registry_Parameter_Should_Assign_The_Passed_In_Registry_To_The_Registry_Field()
         {
             var testDictionary = new Mock<IDictionary<string, IsPolicy>>();
             var expectedDictionaryType = testDictionary.Object.GetType();

--- a/src/Polly.SharedSpecs/Registry/PolicyRegistrySpecs.cs
+++ b/src/Polly.SharedSpecs/Registry/PolicyRegistrySpecs.cs
@@ -454,7 +454,18 @@ namespace Polly.Specs.Registry
             var registryFieldValue = registryField.GetValue(testRegistry);
             registryFieldValue.Should().BeOfType(expectedDictionaryType);
         }
-        
+
+        [Fact]
+        public void Constructor_Called_With_Default_Parameters_Assigns_A_ConcurrentDictionary_Of_TKey_And_IsPolicy_To_The_Private_Registry_Field()
+        {
+            var expectedDictionaryType = typeof(ConcurrentDictionary<string, IsPolicy>);
+            var testRegistry = new PolicyRegistry();
+            //Generally, using reflection is a bad practice, but given we own the implementation, I don't think this is an issue.
+            var registryField = typeof(PolicyRegistry).GetField("_registry", BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance);
+            var registryFieldValue = registryField.GetValue(testRegistry);
+            registryFieldValue.Should().BeOfType(expectedDictionaryType);
+        }
+
         #endregion
     }
 }

--- a/src/Polly.SharedSpecs/Registry/PolicyRegistrySpecs.cs
+++ b/src/Polly.SharedSpecs/Registry/PolicyRegistrySpecs.cs
@@ -442,13 +442,15 @@ namespace Polly.Specs.Registry
                 .ShouldThrow<ArgumentNullException>();
         }
         #endregion
+
         #region Tests for the constructor        
         [Fact]
         public void Constructor_Called_With_A_Registry_Parameter_Should_Assign_The_Passed_In_Registry_To_The_Registry_Field()
         {
             var testDictionary = new Mock<IDictionary<string, IsPolicy>>();
             var testRegistry = new PolicyRegistry(testDictionary.Object);
-            //Generally, using reflection is a bad practice, but given we own the implementation, I don't think this is an issue.
+
+            //Generally, using reflection is a bad practice, but we are accepting it given we own the implementation.
             var registryField = typeof(PolicyRegistry).GetField("_registry", BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance);
             var registryFieldValue = registryField.GetValue(testRegistry);
             registryFieldValue.Should().Be(testDictionary.Object);
@@ -459,7 +461,8 @@ namespace Polly.Specs.Registry
         {
             var expectedDictionaryType = typeof(ConcurrentDictionary<string, IsPolicy>);
             var testRegistry = new PolicyRegistry();
-            //Generally, using reflection is a bad practice, but given we own the implementation, I don't think this is an issue.
+
+            //Generally, using reflection is a bad practice, but we are accepting it given we own the implementation.
             var registryField = typeof(PolicyRegistry).GetField("_registry", BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance);
             var registryFieldValue = registryField.GetValue(testRegistry);
             registryFieldValue.Should().BeOfType(expectedDictionaryType);

--- a/src/Polly.SharedSpecs/Registry/PolicyRegistrySpecs.cs
+++ b/src/Polly.SharedSpecs/Registry/PolicyRegistrySpecs.cs
@@ -1,9 +1,12 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Reflection;
 using Xunit;
 using FluentAssertions;
 using Polly.Registry;
 using Polly.Specs.Helpers;
+using Moq;
 
 namespace Polly.Specs.Registry
 {
@@ -437,6 +440,19 @@ namespace Polly.Specs.Registry
             string key = null;
             _registry.Invoking(r => r.ContainsKey(key))
                 .ShouldThrow<ArgumentNullException>();
+        }
+        #endregion
+        #region Tests for the constructor        
+        [Fact]
+        public void Constructor_Called_With_Default_Parameters_Should_Assign_A_ConcurrentDictionary_Of_TKey_And_IsPolicy_To_The_Registry_Field()
+        {
+            var testDictionary = new Mock<IDictionary<string, IsPolicy>>();
+            var expectedDictionaryType = testDictionary.Object.GetType();
+            var testRegistry = new PolicyRegistry(testDictionary.Object);
+            //Generally, using reflection is a bad practice, but given we own the implementation, I don't think this is an issue.
+            var registryField = typeof(PolicyRegistry).GetField("_registry", BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance);
+            var registryFieldValue = registryField.GetValue(testRegistry);
+            registryFieldValue.Should().BeOfType(expectedDictionaryType);
         }
         #endregion
     }

--- a/src/Polly.SharedSpecs/Registry/PolicyRegistrySpecs.cs
+++ b/src/Polly.SharedSpecs/Registry/PolicyRegistrySpecs.cs
@@ -444,7 +444,7 @@ namespace Polly.Specs.Registry
         #endregion
         #region Tests for the constructor        
         [Fact]
-        public void Constructor_Called_With_Default_Parameters_Should_Assign_A_ConcurrentDictionary_Of_TKey_And_IsPolicy_To_The_Registry_Field()
+        public void Constructor_Called_With_A_Registry_Parameters_Should_Assign_A_ConcurrentDictionary_Of_TKey_And_IsPolicy_To_The_Registry_Field()
         {
             var testDictionary = new Mock<IDictionary<string, IsPolicy>>();
             var expectedDictionaryType = testDictionary.Object.GetType();
@@ -454,6 +454,7 @@ namespace Polly.Specs.Registry
             var registryFieldValue = registryField.GetValue(testRegistry);
             registryFieldValue.Should().BeOfType(expectedDictionaryType);
         }
+        
         #endregion
     }
 }

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -17,6 +17,7 @@
      ---------------------
      - Clarify separation of sync and async policies
      - Enable extensibility by custom policies hosted external to Polly
+     - Enable collection initialization syntax for PolicyRegistry
 
      6.1.2
      ---------------------


### PR DESCRIPTION
Fixes #520 to enable the use of IEnumerable<KeyValuePair<TKey, IsPolicy>> in the IReadOnlyPolicyRegistry interface.

This also allows the .Net collection initializer syntax to be used.