### PR TITLE
Change licenseUrl to license tag in nuspec file

### DIFF
--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -7,7 +7,7 @@
       Polly is a .NET Standard 1.1 and .NET Standard 2.0 library that allows developers to express resilience and transient fault handling policies such as Retry, Circuit Breaker, Timeout, Bulkhead Isolation and Fallback in a fluent and thread-safe manner.
     </description>
     <language>en-US</language>
-    <licenseUrl>https://raw.github.com/App-vNext/Polly/master/LICENSE.txt</licenseUrl>
+    <license type="expression">BSD-3-Clause</license>
     <iconUrl>https://raw.github.com/App-vNext/Polly/master/Polly.png</iconUrl>
     <projectUrl>https://github.com/App-vNext/Polly</projectUrl>
     <tags>Exception Handling Resilience Transient Fault Policy Circuit Breaker CircuitBreaker Retry Wait Cache Cache-aside Bulkhead Fallback Timeout Throttle Parallelization</tags>


### PR DESCRIPTION
Changed lincenseUrl to license, as described in https://github.com/App-vNext/Polly/issues/560

<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors.  All non-trivial contributions get a public credit in the readme! -->

### The issue or feature being addressed

560

### Details on the issue fix or feature implementation

### Confirm the following

- [ ]  I have merged the latest changes from the dev vX.Y branch
- [ ]  I have successfully run a local build
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have targeted the PR against the latest dev vX.Y branch
