### PR TITLE
Adjusted tools path to fix build on OS X

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -302,6 +302,6 @@ RunTarget(target);
 //////////////////////////////////////////////////////////////////////
 
 string ToolsExePath(string exeFileName) {
-    var exePath = System.IO.Directory.GetFiles(@".\Tools", exeFileName, SearchOption.AllDirectories).FirstOrDefault();
+    var exePath = System.IO.Directory.GetFiles(@"./tools", exeFileName, SearchOption.AllDirectories).FirstOrDefault();
     return exePath;
 }


### PR DESCRIPTION
### Build on OS X

When trying to build Polly on OS X this error occurs:

`Error: One or more errors occurred.
        Could not find a part of the path '/Users/andrisak/ws/polly-project/Polly/.\Tools'.`

### Details on the issue fix or feature implementation

Adjusted the path to the tools folder.

### Confirm the following

- [X]  I have merged the latest changes from the dev vX.Y branch
- [X]  I have successfully run a local build
- [ ]  I have included unit tests for the issue/feature
- [X]  I have targeted the PR against the latest dev vX.Y branch
