### PR TITLE
Removed useless using statements. Now using expression-bodied members…

### DIFF
--- a/src/Polly.Shared/Registry/PolicyRegistry.cs
+++ b/src/Polly.Shared/Registry/PolicyRegistry.cs
@@ -33,10 +33,7 @@ namespace Polly.Registry
         /// <typeparam name="TPolicy">The type of Policy.</typeparam>
         /// <exception cref="ArgumentNullException"><paramref name="key"/> is null.</exception>
         /// <exception cref="ArgumentException">A Policy with same <paramref name="key"/> already exists.</exception>
-        public void Add<TPolicy>(string key, TPolicy policy) where TPolicy : IsPolicy
-        {
-            _registry.Add(key, policy);
-        }
+        public void Add<TPolicy>(string key, TPolicy policy) where TPolicy : IsPolicy => _registry.Add(key, policy);
 
         /// <summary>
         /// Gets of sets the <see cref="IsPolicy"/> with the specified key.
@@ -48,14 +45,8 @@ namespace Polly.Registry
         /// <returns>The value associated with the specified key.</returns>
         public IsPolicy this[string key]
         {
-            get
-            {
-                return _registry[key];
-            }
-            set
-            {
-                _registry[key] = value;
-            }
+            get => _registry[key];
+            set => _registry[key] = value;
         }
 
         /// <summary>
@@ -65,10 +56,7 @@ namespace Polly.Registry
         /// <returns>The policy stored in the registry under the given key.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="key"/> is null.</exception>
         /// <exception cref="KeyNotFoundException">The given key was not present in the dictionary.</exception>
-        public TPolicy Get<TPolicy>(string key) where TPolicy : IsPolicy
-        {
-            return (TPolicy) _registry[key];
-        }
+        public TPolicy Get<TPolicy>(string key) where TPolicy : IsPolicy => (TPolicy) _registry[key];
 
         /// <summary>
         /// Gets the policy stored under the provided key, casting to <typeparamref name="TPolicy"/>.
@@ -83,8 +71,7 @@ namespace Polly.Registry
         /// <returns>True if Policy exists for the provided Key. False otherwise.</returns>
         public bool TryGet<TPolicy>(string key, out TPolicy policy) where TPolicy : IsPolicy
         {
-            IsPolicy value;
-            bool got = _registry.TryGetValue(key, out value);
+            bool got = _registry.TryGetValue(key, out IsPolicy value);
             policy = got ? (TPolicy)value : default(TPolicy);
             return got;
         }
@@ -92,8 +79,7 @@ namespace Polly.Registry
         /// <summary>
         /// Removes all keys and policies from registry.
         /// </summary>
-        public void Clear() =>
-            _registry.Clear();
+        public void Clear() => _registry.Clear();
 
         /// <summary>
         /// Determines whether the specified <paramref name="key"/> exists.
@@ -101,8 +87,7 @@ namespace Polly.Registry
         /// <param name="key">The key to locate in the registry.</param>
         /// <returns>True if <paramref name="key"/> exists otherwise false.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="key"/> is null.</exception>
-        public bool ContainsKey(string key) =>
-            _registry.ContainsKey(key);
+        public bool ContainsKey(string key) => _registry.ContainsKey(key);
 
         /// <summary>
         /// Removes the policy stored under the specified <paramref name="key"/> from the registry.

--- a/src/Polly.SharedSpecs/Registry/IReadOnlyPolicyRegistrySpecs.cs
+++ b/src/Polly.SharedSpecs/Registry/IReadOnlyPolicyRegistrySpecs.cs
@@ -12,8 +12,6 @@ namespace Polly.Specs.Registry
     {
         readonly IPolicyRegistry<string> _registry;
 
-        IReadOnlyPolicyRegistry<string> ReadOnlyRegistry { get{ return _registry; } }
-
         public IReadOnlyPolicyRegistrySpecs() => _registry = new PolicyRegistry();
 
         #region Tests for retrieving policy
@@ -25,7 +23,7 @@ namespace Polly.Specs.Registry
             string key = Guid.NewGuid().ToString();
 
             _registry.Add(key, policy);
-            ReadOnlyRegistry.TryGet(key, out Policy outPolicy).Should().BeTrue();
+            _registry.TryGet(key, out Policy outPolicy).Should().BeTrue();
             outPolicy.Should().BeSameAs(policy);
         }
 
@@ -36,7 +34,7 @@ namespace Polly.Specs.Registry
             string key = Guid.NewGuid().ToString();
 
             _registry.Add(key, policy);
-            ReadOnlyRegistry.TryGet(key, out Policy<ResultPrimitive> outPolicy).Should().BeTrue();
+            _registry.TryGet(key, out Policy<ResultPrimitive> outPolicy).Should().BeTrue();
             outPolicy.Should().BeSameAs(policy);
         }
 
@@ -47,7 +45,7 @@ namespace Polly.Specs.Registry
             string key = Guid.NewGuid().ToString();
 
             _registry.Add(key, policy);
-            ReadOnlyRegistry.TryGet(key, out ISyncPolicy<ResultPrimitive> outPolicy).Should().BeTrue();
+            _registry.TryGet(key, out ISyncPolicy<ResultPrimitive> outPolicy).Should().BeTrue();
             outPolicy.Should().BeSameAs(policy);
         }
 
@@ -58,7 +56,7 @@ namespace Polly.Specs.Registry
             string key = Guid.NewGuid().ToString();
 
             _registry.Add(key, policy);
-            ReadOnlyRegistry.Get<Policy>(key).Should().BeSameAs(policy);
+            _registry.Get<Policy>(key).Should().BeSameAs(policy);
         }
 
         [Fact]
@@ -68,7 +66,7 @@ namespace Polly.Specs.Registry
             string key = Guid.NewGuid().ToString();
 
             _registry.Add(key, policy);
-            ReadOnlyRegistry.Get<Policy<ResultPrimitive>>(key).Should().BeSameAs(policy);
+            _registry.Get<Policy<ResultPrimitive>>(key).Should().BeSameAs(policy);
         }
 
         [Fact]
@@ -78,7 +76,7 @@ namespace Polly.Specs.Registry
             string key = Guid.NewGuid().ToString();
 
             _registry.Add(key, policy);
-            ReadOnlyRegistry.Get<ISyncPolicy<ResultPrimitive>>(key).Should().BeSameAs(policy);
+            _registry.Get<ISyncPolicy<ResultPrimitive>>(key).Should().BeSameAs(policy);
         }
 
         [Fact]
@@ -88,7 +86,7 @@ namespace Polly.Specs.Registry
             string key = Guid.NewGuid().ToString();
 
             _registry.Add(key, policy);
-            ReadOnlyRegistry[key].Should().BeSameAs(policy);
+            _registry[key].Should().BeSameAs(policy);
         }
 
         [Fact]
@@ -98,7 +96,7 @@ namespace Polly.Specs.Registry
             string key = Guid.NewGuid().ToString();
 
             _registry.Add(key, policy);
-            ReadOnlyRegistry[key].Should().BeSameAs(policy);
+            _registry[key].Should().BeSameAs(policy);
         }
 
         [Fact]
@@ -108,7 +106,7 @@ namespace Polly.Specs.Registry
             string key = Guid.NewGuid().ToString();
 
             _registry.Add(key, policy);
-            ReadOnlyRegistry[key].Should().BeSameAs(policy);
+            _registry[key].Should().BeSameAs(policy);
         }
 
         [Fact]
@@ -118,7 +116,7 @@ namespace Polly.Specs.Registry
             Policy outPolicy = null;
             bool result = false;
 
-            ReadOnlyRegistry.Invoking(r => result = r.TryGet(key, out outPolicy))
+            _registry.Invoking(r => result = r.TryGet(key, out outPolicy))
                 .ShouldNotThrow();
 
             result.Should().BeFalse();
@@ -131,7 +129,7 @@ namespace Polly.Specs.Registry
             Policy<ResultPrimitive> outPolicy = null;
             bool result = false;
 
-            ReadOnlyRegistry.Invoking(r => result = r.TryGet(key, out outPolicy))
+            _registry.Invoking(r => result = r.TryGet(key, out outPolicy))
                 .ShouldNotThrow();
 
             result.Should().BeFalse();
@@ -144,7 +142,7 @@ namespace Polly.Specs.Registry
             ISyncPolicy<ResultPrimitive> outPolicy = null;
             bool result = false;
 
-            ReadOnlyRegistry.Invoking(r => result = r.TryGet<ISyncPolicy<ResultPrimitive>>(key, out outPolicy))
+            _registry.Invoking(r => result = r.TryGet<ISyncPolicy<ResultPrimitive>>(key, out outPolicy))
                 .ShouldNotThrow();
 
             result.Should().BeFalse();
@@ -155,7 +153,7 @@ namespace Polly.Specs.Registry
         {
             string key = Guid.NewGuid().ToString();
             Policy policy = null;
-            ReadOnlyRegistry.Invoking(r => policy = r.Get<Policy>(key))
+            _registry.Invoking(r => policy = r.Get<Policy>(key))
                 .ShouldThrow<KeyNotFoundException>();
         }
 
@@ -164,7 +162,7 @@ namespace Polly.Specs.Registry
         {
             string key = Guid.NewGuid().ToString();
             Policy<ResultPrimitive> policy = null;
-            ReadOnlyRegistry.Invoking(r => policy = r.Get<Policy<ResultPrimitive>>(key))
+            _registry.Invoking(r => policy = r.Get<Policy<ResultPrimitive>>(key))
                 .ShouldThrow<KeyNotFoundException>();
         }
 
@@ -173,7 +171,7 @@ namespace Polly.Specs.Registry
         {
             string key = Guid.NewGuid().ToString();
             ISyncPolicy<ResultPrimitive> policy = null;
-            ReadOnlyRegistry.Invoking(r => policy = r.Get<ISyncPolicy<ResultPrimitive>>(key))
+            _registry.Invoking(r => policy = r.Get<ISyncPolicy<ResultPrimitive>>(key))
                 .ShouldThrow<KeyNotFoundException>();
         }
 
@@ -182,7 +180,7 @@ namespace Polly.Specs.Registry
         {
             string key = Guid.NewGuid().ToString();
             IsPolicy outPolicy = null;
-            ReadOnlyRegistry.Invoking(r => outPolicy = r[key])
+            _registry.Invoking(r => outPolicy = r[key])
                 .ShouldThrow<KeyNotFoundException>();
         }
 
@@ -192,7 +190,7 @@ namespace Polly.Specs.Registry
         {
             string key = null;
             Policy policy = null;
-            ReadOnlyRegistry.Invoking(r => policy = r.Get<Policy>(key))
+            _registry.Invoking(r => policy = r.Get<Policy>(key))
                 .ShouldThrow<ArgumentNullException>();
         }
 
@@ -201,7 +199,7 @@ namespace Polly.Specs.Registry
         {
             string key = null;
             Policy<ResultPrimitive> policy = null;
-            ReadOnlyRegistry.Invoking(r => policy = r.Get<Policy<ResultPrimitive>>(key))
+            _registry.Invoking(r => policy = r.Get<Policy<ResultPrimitive>>(key))
                 .ShouldThrow<ArgumentNullException>();
         }
 
@@ -210,7 +208,7 @@ namespace Polly.Specs.Registry
         {
             string key = null;
             ISyncPolicy<ResultPrimitive> policy = null;
-            ReadOnlyRegistry.Invoking(r => policy = r.Get<ISyncPolicy<ResultPrimitive>>(key))
+            _registry.Invoking(r => policy = r.Get<ISyncPolicy<ResultPrimitive>>(key))
                 .ShouldThrow<ArgumentNullException>();
         }
 
@@ -219,7 +217,7 @@ namespace Polly.Specs.Registry
         {
             string key = null;
             IsPolicy policy = null;
-            ReadOnlyRegistry.Invoking(r => policy = r[key])
+            _registry.Invoking(r => policy = r[key])
                 .ShouldThrow<ArgumentNullException>();
         }
         #endregion
@@ -233,17 +231,17 @@ namespace Polly.Specs.Registry
             string key = Guid.NewGuid().ToString();
 
             _registry.Add(key, policy);
-            ReadOnlyRegistry.ContainsKey(key).Should().BeTrue();
+            _registry.ContainsKey(key).Should().BeTrue();
 
             string key2 = Guid.NewGuid().ToString();
-            ReadOnlyRegistry.ContainsKey(key2).Should().BeFalse();
+            _registry.ContainsKey(key2).Should().BeFalse();
         }
 
         [Fact]
         public void Should_throw_when_checking_if_key_exists_when_key_is_null()
         {
             string key = null;
-            ReadOnlyRegistry.Invoking(r => r.ContainsKey(key))
+            _registry.Invoking(r => r.ContainsKey(key))
                 .ShouldThrow<ArgumentNullException>();
         }
         #endregion

--- a/src/Polly.SharedSpecs/Registry/IReadOnlyPolicyRegistrySpecs.cs
+++ b/src/Polly.SharedSpecs/Registry/IReadOnlyPolicyRegistrySpecs.cs
@@ -10,14 +10,11 @@ namespace Polly.Specs.Registry
 {
     public class IReadOnlyPolicyRegistrySpecs
     {
-        IPolicyRegistry<string> _registry;
+        readonly IPolicyRegistry<string> _registry;
 
         IReadOnlyPolicyRegistry<string> ReadOnlyRegistry { get{ return _registry; } }
 
-        public IReadOnlyPolicyRegistrySpecs()
-        {
-            _registry = new PolicyRegistry();
-        }
+        public IReadOnlyPolicyRegistrySpecs() => _registry = new PolicyRegistry();
 
         #region Tests for retrieving policy
 
@@ -26,10 +23,9 @@ namespace Polly.Specs.Registry
         {
             Policy policy = Policy.NoOp();
             string key = Guid.NewGuid().ToString();
-            Policy outPolicy = null;
 
             _registry.Add(key, policy);
-            ReadOnlyRegistry.TryGet(key, out outPolicy).Should().BeTrue();
+            ReadOnlyRegistry.TryGet(key, out Policy outPolicy).Should().BeTrue();
             outPolicy.Should().BeSameAs(policy);
         }
 
@@ -38,10 +34,9 @@ namespace Polly.Specs.Registry
         {
             Policy<ResultPrimitive> policy = Policy<ResultPrimitive>.HandleResult(ResultPrimitive.Fault).Retry();
             string key = Guid.NewGuid().ToString();
-            Policy<ResultPrimitive> outPolicy = null;
 
             _registry.Add(key, policy);
-            ReadOnlyRegistry.TryGet(key, out outPolicy).Should().BeTrue();
+            ReadOnlyRegistry.TryGet(key, out Policy<ResultPrimitive> outPolicy).Should().BeTrue();
             outPolicy.Should().BeSameAs(policy);
         }
 
@@ -50,10 +45,9 @@ namespace Polly.Specs.Registry
         {
             ISyncPolicy<ResultPrimitive> policy = Policy<ResultPrimitive>.HandleResult(ResultPrimitive.Fault).Retry();
             string key = Guid.NewGuid().ToString();
-            ISyncPolicy<ResultPrimitive> outPolicy = null;
 
             _registry.Add(key, policy);
-            ReadOnlyRegistry.TryGet(key, out outPolicy).Should().BeTrue();
+            ReadOnlyRegistry.TryGet(key, out ISyncPolicy<ResultPrimitive> outPolicy).Should().BeTrue();
             outPolicy.Should().BeSameAs(policy);
         }
 

--- a/src/Polly.SharedSpecs/Registry/PolicyRegistrySpecs.cs
+++ b/src/Polly.SharedSpecs/Registry/PolicyRegistrySpecs.cs
@@ -12,12 +12,9 @@ namespace Polly.Specs.Registry
 {
     public class PolicyRegistrySpecs
     {
-        IPolicyRegistry<string> _registry;
+        readonly IPolicyRegistry<string> _registry;
 
-        public PolicyRegistrySpecs()
-        {
-            _registry = new PolicyRegistry();
-        }
+        public PolicyRegistrySpecs() => _registry = new PolicyRegistry();
 
         #region Tests for adding Policy
 
@@ -173,10 +170,9 @@ namespace Polly.Specs.Registry
         {
             Policy policy = Policy.NoOp();
             string key = Guid.NewGuid().ToString();
-            Policy outPolicy = null;
 
             _registry.Add(key, policy);
-            _registry.TryGet(key, out outPolicy).Should().BeTrue();
+            _registry.TryGet(key, out Policy outPolicy).Should().BeTrue();
             outPolicy.Should().BeSameAs(policy);
         }
 
@@ -185,10 +181,9 @@ namespace Polly.Specs.Registry
         {
             Policy<ResultPrimitive> policy = Policy<ResultPrimitive>.HandleResult(ResultPrimitive.Fault).Retry();
             string key = Guid.NewGuid().ToString();
-            Policy<ResultPrimitive> outPolicy = null;
 
             _registry.Add(key, policy);
-            _registry.TryGet(key, out outPolicy).Should().BeTrue();
+            _registry.TryGet(key, out Policy<ResultPrimitive> outPolicy).Should().BeTrue();
             outPolicy.Should().BeSameAs(policy);
         }
 
@@ -197,10 +192,9 @@ namespace Polly.Specs.Registry
         {
             ISyncPolicy<ResultPrimitive> policy = Policy<ResultPrimitive>.HandleResult(ResultPrimitive.Fault).Retry();
             string key = Guid.NewGuid().ToString();
-            ISyncPolicy<ResultPrimitive> outPolicy = null;
 
             _registry.Add(key, policy);
-            _registry.TryGet(key, out outPolicy).Should().BeTrue();
+            _registry.TryGet(key, out ISyncPolicy<ResultPrimitive> outPolicy).Should().BeTrue();
             outPolicy.Should().BeSameAs(policy);
         }
 


### PR DESCRIPTION
* Polly.Shared/Registry
* Polly.SharedSpecs/Registry


<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors.  All non-trivial contributions get a public credit in the readme! -->

557, https://github.com/App-vNext/Polly/issues/557

### Details on the issue fix or feature implementation

* Removed useless using statements. 
* Now using expression-bodied members and inline-out variables


### Confirm the following

- [ ]  I have merged the latest changes from the dev vX.Y branch
- [x]  I have successfully run a local build
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have targeted the PR against the latest dev vX.Y branch
