### PR TITLE
Added expression bodied members, null-ref checks (bulkhead policy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1009,6 +1009,7 @@ For more detail see: [Polly and interfaces](https://github.com/App-vNext/Polly/w
 * [@reisenberger](https://github.com/reisenberger) - Clarify separation of sync and async policies.
 * [@reisenberger](https://github.com/reisenberger) - Enable extensibility by custom policies hosted external to Polly.
 * [@seanfarrow](https://github.com/SeanFarrow) - Enable collection initialization syntax for PolicyRegistry.
+* [@moerwald](https://github.com/moerwald) - Code clean-ups, usage of more concise C# members.
 
 # Sample Projects
 

--- a/src/Polly.Shared/Bulkhead/AsyncBulkheadSyntax.cs
+++ b/src/Polly.Shared/Bulkhead/AsyncBulkheadSyntax.cs
@@ -31,9 +31,7 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">onBulkheadRejectedAsync</exception>
         /// <returns>The policy instance.</returns>
         public static AsyncBulkheadPolicy BulkheadAsync(int maxParallelization, Func<Context, Task> onBulkheadRejectedAsync)
-        {
-            return BulkheadAsync(maxParallelization, 0, onBulkheadRejectedAsync);
-        }
+            => BulkheadAsync(maxParallelization, 0, onBulkheadRejectedAsync);
 
         /// <summary>
         /// Builds a bulkhead isolation <see cref="Policy" />, which limits the maximum concurrency of actions executed through the policy.  Imposing a maximum concurrency limits the potential of governed actions, when faulting, to bring down the system.

--- a/src/Polly.Shared/Bulkhead/AsyncBulkheadTResultSyntax.cs
+++ b/src/Polly.Shared/Bulkhead/AsyncBulkheadTResultSyntax.cs
@@ -30,9 +30,7 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">onBulkheadRejectedAsync</exception>
         /// <returns>The policy instance.</returns>
         public static AsyncBulkheadPolicy<TResult> BulkheadAsync<TResult>(int maxParallelization, Func<Context, Task> onBulkheadRejectedAsync)
-        {
-            return BulkheadAsync<TResult>(maxParallelization, 0, onBulkheadRejectedAsync);
-        }
+            => BulkheadAsync<TResult>(maxParallelization, 0, onBulkheadRejectedAsync);
 
         /// <summary>
         /// Builds a bulkhead isolation <see cref="AsyncPolicy{TResult}" />, which limits the maximum concurrency of actions executed through the policy.  Imposing a maximum concurrency limits the potential of governed actions, when faulting, to bring down the system.

--- a/src/Polly.Shared/Bulkhead/BulkheadPolicy.cs
+++ b/src/Polly.Shared/Bulkhead/BulkheadPolicy.cs
@@ -13,7 +13,7 @@ namespace Polly.Bulkhead
         private readonly SemaphoreSlim _maxQueuedActionsSemaphore;
         private readonly int _maxParallelization;
         private readonly int _maxQueueingActions;
-        private Action<Context> _onBulkheadRejected;
+        private readonly Action<Context> _onBulkheadRejected;
 
         internal BulkheadPolicy(
             int maxParallelization,
@@ -25,17 +25,15 @@ namespace Polly.Bulkhead
         {
             _maxParallelization = maxParallelization;
             _maxQueueingActions = maxQueueingActions;
-            _maxParallelizationSemaphore = maxParallelizationSemaphore;
-            _maxQueuedActionsSemaphore = maxQueuedActionsSemaphore;
+            _maxParallelizationSemaphore = maxParallelizationSemaphore ?? throw new ArgumentNullException(nameof(maxParallelizationSemaphore));
+            _maxQueuedActionsSemaphore = maxQueuedActionsSemaphore ?? throw new ArgumentNullException(nameof(maxQueuedActionsSemaphore));
             _onBulkheadRejected = onBulkheadRejected ?? throw new ArgumentNullException(nameof(onBulkheadRejected));
         }
 
         /// <inheritdoc/>
         [DebuggerStepThrough]
         protected override TResult Implementation<TResult>(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken)
-        {
-            return BulkheadEngine.Implementation(action, context, _onBulkheadRejected, _maxParallelizationSemaphore, _maxQueuedActionsSemaphore, cancellationToken);
-        }
+            => BulkheadEngine.Implementation(action, context, _onBulkheadRejected, _maxParallelizationSemaphore, _maxQueuedActionsSemaphore, cancellationToken);
 
         /// <summary>
         /// Gets the number of slots currently available for executing actions through the bulkhead.
@@ -67,7 +65,7 @@ namespace Polly.Bulkhead
         private readonly SemaphoreSlim _maxQueuedActionsSemaphore;
         private readonly int _maxParallelization;
         private readonly int _maxQueueingActions;
-        private Action<Context> _onBulkheadRejected;
+        private readonly Action<Context> _onBulkheadRejected;
 
         /// <inheritdoc/>
         internal BulkheadPolicy(
@@ -80,17 +78,15 @@ namespace Polly.Bulkhead
         {
             _maxParallelization = maxParallelization;
             _maxQueueingActions = maxQueueingActions;
-            _maxParallelizationSemaphore = maxParallelizationSemaphore;
-            _maxQueuedActionsSemaphore = maxQueuedActionsSemaphore;
+            _maxParallelizationSemaphore = maxParallelizationSemaphore ?? throw new ArgumentNullException(nameof(maxParallelizationSemaphore));
+            _maxQueuedActionsSemaphore = maxQueuedActionsSemaphore ?? throw new ArgumentNullException(nameof(maxQueuedActionsSemaphore));
             _onBulkheadRejected = onBulkheadRejected ?? throw new ArgumentNullException(nameof(onBulkheadRejected));
         }
 
         /// <inheritdoc/>
         [DebuggerStepThrough]
         protected override TResult Implementation(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken)
-        {
-            return BulkheadEngine.Implementation(action, context, _onBulkheadRejected, _maxParallelizationSemaphore, _maxQueuedActionsSemaphore, cancellationToken);
-        }
+            => BulkheadEngine.Implementation(action, context, _onBulkheadRejected, _maxParallelizationSemaphore, _maxQueuedActionsSemaphore, cancellationToken);
 
         /// <summary>
         /// Gets the number of slots currently available for executing actions through the bulkhead.

--- a/src/Polly.Shared/Bulkhead/BulkheadSyntax.cs
+++ b/src/Polly.Shared/Bulkhead/BulkheadSyntax.cs
@@ -29,9 +29,7 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">onBulkheadRejected</exception>
         /// <returns>The policy instance.</returns>
         public static BulkheadPolicy Bulkhead(int maxParallelization, Action<Context> onBulkheadRejected)
-        {
-            return Bulkhead(maxParallelization, 0, onBulkheadRejected);
-        }
+            => Bulkhead(maxParallelization, 0, onBulkheadRejected);
 
         /// <summary>
         /// Builds a bulkhead isolation <see cref="Policy" />, which limits the maximum concurrency of actions executed through the policy.  Imposing a maximum concurrency limits the potential of governed actions, when faulting, to bring down the system.

--- a/src/Polly.Shared/Bulkhead/BulkheadTResultSyntax.cs
+++ b/src/Polly.Shared/Bulkhead/BulkheadTResultSyntax.cs
@@ -29,9 +29,7 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">onBulkheadRejected</exception>
         /// <returns>The policy instance.</returns>
         public static BulkheadPolicy<TResult> Bulkhead<TResult>(int maxParallelization, Action<Context> onBulkheadRejected)
-        {
-            return Bulkhead<TResult>(maxParallelization, 0, onBulkheadRejected);
-        }
+            => Bulkhead<TResult>(maxParallelization, 0, onBulkheadRejected);
 
         /// <summary>
         /// Builds a bulkhead isolation <see cref="Policy{TResult}" />, which limits the maximum concurrency of actions executed through the policy.  Imposing a maximum concurrency limits the potential of governed actions, when faulting, to bring down the system.


### PR DESCRIPTION


<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors.  All non-trivial contributions get a public credit in the readme! -->

### The issue or feature being addressed

557, https://github.com/App-vNext/Polly/issues/557

### Details on the issue fix or feature implementation

/src/Polly.Shared/Bulkhead/BulkheadPolicy.cs
   * Added null checks
   * Added readonly
   * Refactored to expression bodied members

Rest of the files:
   * Refactored to expression bodied members

### Confirm the following

- [x]  I started this PR by branching from the head of the latest dev vX.Y branch, or I have rebased on the latest dev vX.Y branch, or I have merged the latest changes from the dev vX.Y branch
- [x]  I have targeted the PR to merge into the latest dev vX.Y branch as the base branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
