### PR TITLE
Replaced single line methods with expression-bodied members. (Circuit Breaker)

### DIFF
--- a/src/Polly.Shared/CircuitBreaker/AdvancedCircuitBreakerSyntax.cs
+++ b/src/Polly.Shared/CircuitBreaker/AdvancedCircuitBreakerSyntax.cs
@@ -72,14 +72,12 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onBreak</exception>
         /// <exception cref="ArgumentNullException">onReset</exception>
         public static CircuitBreakerPolicy AdvancedCircuitBreaker(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan> onBreak, Action onReset)
-        {
-            return policyBuilder.AdvancedCircuitBreaker(
+            => policyBuilder.AdvancedCircuitBreaker(
                 failureThreshold, samplingDuration, minimumThroughput, 
                 durationOfBreak, 
                 (exception, timespan, context) => onBreak(exception, timespan), 
                 context => onReset()
                 );
-        }
 
         /// <summary>
         /// <para>The circuit will break if, within any timeslice of duration <paramref name="samplingDuration"/>, the proportion of actions resulting in a handled exception exceeds <paramref name="failureThreshold"/>, provided also that the number of actions through the circuit in the timeslice is at least <paramref name="minimumThroughput" />. </para>
@@ -147,15 +145,13 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onReset</exception>
         /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static CircuitBreakerPolicy AdvancedCircuitBreaker(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan> onBreak, Action onReset, Action onHalfOpen)
-        {
-            return policyBuilder.AdvancedCircuitBreaker(
+            => policyBuilder.AdvancedCircuitBreaker(
                 failureThreshold, samplingDuration, minimumThroughput, 
                 durationOfBreak,
                 (exception, timespan, context) => onBreak(exception, timespan),
                 context => onReset(),
                 onHalfOpen
                 );
-        }
 
         /// <summary>
         /// <para> Builds a <see cref="Policy" /> that will function like a Circuit Breaker.</para>
@@ -187,15 +183,13 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         public static CircuitBreakerPolicy AdvancedCircuitBreaker(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
-        {
-            return policyBuilder.AdvancedCircuitBreaker(
+            => policyBuilder.AdvancedCircuitBreaker(
                 failureThreshold, samplingDuration, minimumThroughput,
                 durationOfBreak,
                 (exception, state, timespan, context) => onBreak(exception, timespan, context),
                 onReset,
                 onHalfOpen
             );
-        }
 
         /// <summary>
         /// <para> Builds a <see cref="Policy" /> that will function like a Circuit Breaker.</para>
@@ -253,6 +247,5 @@ namespace Polly
                 breakerController
                 );
         }
-
     }
 }

--- a/src/Polly.Shared/CircuitBreaker/AdvancedCircuitBreakerTResultSyntax.cs
+++ b/src/Polly.Shared/CircuitBreaker/AdvancedCircuitBreakerTResultSyntax.cs
@@ -72,14 +72,12 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onBreak</exception>
         /// <exception cref="ArgumentNullException">onReset</exception>
         public static CircuitBreakerPolicy<TResult> AdvancedCircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan> onBreak, Action onReset)
-        {
-            return policyBuilder.AdvancedCircuitBreaker(
+            => policyBuilder.AdvancedCircuitBreaker(
                 failureThreshold, samplingDuration, minimumThroughput,
                 durationOfBreak,
                 (outcome, timespan, context) => onBreak(outcome, timespan),
                 context => onReset()
                 );
-        }
 
         /// <summary>
         /// <para>The circuit will break if, within any timeslice of duration <paramref name="samplingDuration"/>, the proportion of actions resulting in a handled exception or result exceeds <paramref name="failureThreshold"/>, provided also that the number of actions through the circuit in the timeslice is at least <paramref name="minimumThroughput" />. </para>
@@ -147,15 +145,13 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onReset</exception>
         /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static CircuitBreakerPolicy<TResult> AdvancedCircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan> onBreak, Action onReset, Action onHalfOpen)
-        {
-            return policyBuilder.AdvancedCircuitBreaker(
+            => policyBuilder.AdvancedCircuitBreaker(
                 failureThreshold, samplingDuration, minimumThroughput,
                 durationOfBreak,
                 (outcome, timespan, context) => onBreak(outcome, timespan),
                 context => onReset(),
                 onHalfOpen
                 );
-        }
 
         /// <summary>
         /// <para> Builds a <see cref="Policy{TResult}" /> that will function like a Circuit Breaker.</para>
@@ -188,15 +184,13 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         public static CircuitBreakerPolicy<TResult> AdvancedCircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
-        {
-            return policyBuilder.AdvancedCircuitBreaker(
+            => policyBuilder.AdvancedCircuitBreaker(
                 failureThreshold, samplingDuration, minimumThroughput,
                 durationOfBreak,
                 (outcome, state, timespan, context) => onBreak(outcome, timespan, context),
                 onReset,
                 onHalfOpen
             );
-        }
 
         /// <summary>
         /// <para> Builds a <see cref="Policy{TResult}" /> that will function like a Circuit Breaker.</para>

--- a/src/Polly.Shared/CircuitBreaker/AdvancedCircuitController.cs
+++ b/src/Polly.Shared/CircuitBreaker/AdvancedCircuitController.cs
@@ -100,12 +100,7 @@ namespace Polly.CircuitBreaker
                     default:
                         throw new InvalidOperationException("Unhandled CircuitState.");
                 }
-
-
-
             }
         }
-
-
     }
 }

--- a/src/Polly.Shared/CircuitBreaker/AsyncAdvancedCircuitBreakerSyntax.cs
+++ b/src/Polly.Shared/CircuitBreaker/AsyncAdvancedCircuitBreakerSyntax.cs
@@ -74,14 +74,12 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onBreak</exception>
         /// <exception cref="ArgumentNullException">onReset</exception>
         public static AsyncCircuitBreakerPolicy AdvancedCircuitBreakerAsync(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan> onBreak, Action onReset)
-        {
-            return policyBuilder.AdvancedCircuitBreakerAsync(
+            => policyBuilder.AdvancedCircuitBreakerAsync(
                 failureThreshold, samplingDuration, minimumThroughput, 
                 durationOfBreak,
                 (exception, timespan, context) => onBreak(exception, timespan),
                 context => onReset()
                 );
-        }
 
         /// <summary>
         /// <para> Builds a <see cref="AsyncPolicy"/> that will function like a Circuit Breaker.</para>
@@ -151,15 +149,13 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onBreak</exception>
         /// <exception cref="ArgumentNullException">onReset</exception>
         public static AsyncCircuitBreakerPolicy AdvancedCircuitBreakerAsync(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan> onBreak, Action onReset, Action onHalfOpen)
-        {
-            return policyBuilder.AdvancedCircuitBreakerAsync(
+            => policyBuilder.AdvancedCircuitBreakerAsync(
                 failureThreshold, samplingDuration, minimumThroughput, 
                 durationOfBreak,
                 (exception, timespan, context) => onBreak(exception, timespan),
                 context => onReset(),
                 onHalfOpen
                 );
-        }
 
         /// <summary>
         /// <para> Builds a <see cref="AsyncPolicy"/> that will function like a Circuit Breaker.</para>
@@ -191,15 +187,13 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onReset</exception>
         /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static AsyncCircuitBreakerPolicy AdvancedCircuitBreakerAsync(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
-        {
-            return policyBuilder.AdvancedCircuitBreakerAsync(
+            => policyBuilder.AdvancedCircuitBreakerAsync(
                 failureThreshold, samplingDuration, minimumThroughput,
                 durationOfBreak,
                 (exception, state, timespan, context) => onBreak(exception, timespan, context),
                 onReset,
                 onHalfOpen
             );
-        }
 
         /// <summary>
         /// <para> Builds a <see cref="AsyncPolicy"/> that will function like a Circuit Breaker.</para>

--- a/src/Polly.Shared/CircuitBreaker/AsyncAdvancedCircuitBreakerTResultSyntax.cs
+++ b/src/Polly.Shared/CircuitBreaker/AsyncAdvancedCircuitBreakerTResultSyntax.cs
@@ -73,14 +73,12 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onBreak</exception>
         /// <exception cref="ArgumentNullException">onReset</exception>
         public static CircuitBreakerPolicy<TResult> AdvancedCircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan> onBreak, Action onReset)
-        {
-            return policyBuilder.AdvancedCircuitBreakerAsync(
+            => policyBuilder.AdvancedCircuitBreakerAsync(
                 failureThreshold, samplingDuration, minimumThroughput,
                 durationOfBreak,
                 (outcome, timespan, context) => onBreak(outcome, timespan),
                 context => onReset()
                 );
-        }
 
         /// <summary>
         /// <para> Builds a <see cref="AsyncPolicy{TResult}"/> that will function like a Circuit Breaker.</para>
@@ -150,15 +148,13 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onBreak</exception>
         /// <exception cref="ArgumentNullException">onReset</exception>
         public static CircuitBreakerPolicy<TResult> AdvancedCircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan> onBreak, Action onReset, Action onHalfOpen)
-        {
-            return policyBuilder.AdvancedCircuitBreakerAsync(
+            => policyBuilder.AdvancedCircuitBreakerAsync(
                 failureThreshold, samplingDuration, minimumThroughput,
                 durationOfBreak,
                 (outcome, timespan, context) => onBreak(outcome, timespan),
                 context => onReset(),
                 onHalfOpen
                 );
-        }
 
         /// <summary>
         /// <para> Builds a <see cref="AsyncPolicy{TResult}"/> that will function like a Circuit Breaker.</para>
@@ -190,15 +186,13 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onReset</exception>
         /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static CircuitBreakerPolicy<TResult> AdvancedCircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
-        {
-            return policyBuilder.AdvancedCircuitBreakerAsync(
+            => policyBuilder.AdvancedCircuitBreakerAsync(
                 failureThreshold, samplingDuration, minimumThroughput,
                 durationOfBreak,
                 (outcome, state, timespan, context) => onBreak(outcome, timespan, context),
                 onReset,
                 onHalfOpen
             );
-        }
 
         /// <summary>
         /// <para> Builds a <see cref="AsyncPolicy{TResult}"/> that will function like a Circuit Breaker.</para>

--- a/src/Polly.Shared/CircuitBreaker/AsyncCircuitBreakerEngine.cs
+++ b/src/Polly.Shared/CircuitBreaker/AsyncCircuitBreakerEngine.cs
@@ -48,9 +48,7 @@ namespace Polly.CircuitBreaker
                 handledException.RethrowWithOriginalStackTraceIfDiffersFrom(ex);
                 throw;
             }
-
         }
-
     }
 }
 

--- a/src/Polly.Shared/CircuitBreaker/AsyncCircuitBreakerPolicy.cs
+++ b/src/Polly.Shared/CircuitBreaker/AsyncCircuitBreakerPolicy.cs
@@ -35,18 +35,12 @@ namespace Polly.CircuitBreaker
         /// <summary>
         /// Isolates (opens) the circuit manually, and holds it in this state until a call to <see cref="Reset()"/> is made.
         /// </summary>
-        public void Isolate()
-        {
-            _breakerController.Isolate();
-        }
+        public void Isolate() => _breakerController.Isolate();
 
         /// <summary>
         /// Closes the circuit, and resets any statistics controlling automated circuit-breaking.
         /// </summary>
-        public void Reset()
-        {
-            _breakerController.Reset();
-        }
+        public void Reset() => _breakerController.Reset();
 
         /// <inheritdoc/>
         protected override async Task<TResult> ImplementationAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken,
@@ -102,25 +96,18 @@ namespace Polly.CircuitBreaker
         /// <summary>
         /// Isolates (opens) the circuit manually, and holds it in this state until a call to <see cref="Reset()"/> is made.
         /// </summary>
-        public void Isolate()
-        {
-            _breakerController.Isolate();
-        }
+        public void Isolate() => _breakerController.Isolate();
 
         /// <summary>
         /// Closes the circuit, and resets any statistics controlling automated circuit-breaking.
         /// </summary>
-        public void Reset()
-        {
-            _breakerController.Reset();
-        }
+        public void Reset() => _breakerController.Reset();
 
         /// <inheritdoc/>
         [DebuggerStepThrough]
         protected override Task<TResult> ImplementationAsync(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken,
             bool continueOnCapturedContext)
-        {
-            return AsyncCircuitBreakerEngine.ImplementationAsync(
+            => AsyncCircuitBreakerEngine.ImplementationAsync(
                 action,
                 context,
                 cancellationToken,
@@ -128,6 +115,5 @@ namespace Polly.CircuitBreaker
                 ExceptionPredicates,
                 ResultPredicates,
                 _breakerController);
-        }
     }
 }

--- a/src/Polly.Shared/CircuitBreaker/AsyncCircuitBreakerSyntax.cs
+++ b/src/Polly.Shared/CircuitBreaker/AsyncCircuitBreakerSyntax.cs
@@ -63,14 +63,12 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onBreak</exception>
         /// <exception cref="ArgumentNullException">onReset</exception>
         public static AsyncCircuitBreakerPolicy CircuitBreakerAsync(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, TimeSpan> onBreak, Action onReset)
-        {
-            return policyBuilder.CircuitBreakerAsync(
+            => policyBuilder.CircuitBreakerAsync(
                 exceptionsAllowedBeforeBreaking,
                 durationOfBreak,
                 (exception, timespan, context) => onBreak(exception, timespan),
                 context => onReset()
                 );
-        }
 
         /// <summary>
         /// <para> Builds a <see cref="AsyncPolicy"/> that will function like a Circuit Breaker.</para>
@@ -130,15 +128,13 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onBreak</exception>
         /// <exception cref="ArgumentNullException">onReset</exception>
         public static AsyncCircuitBreakerPolicy CircuitBreakerAsync(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, TimeSpan> onBreak, Action onReset, Action onHalfOpen)
-        {
-            return policyBuilder.CircuitBreakerAsync(
+            => policyBuilder.CircuitBreakerAsync(
                 exceptionsAllowedBeforeBreaking,
                 durationOfBreak,
                 (exception, timespan, context) => onBreak(exception, timespan),
                 context => onReset(),
                 onHalfOpen
                 );
-        }
 
         /// <summary>
         /// <para> Builds a <see cref="AsyncPolicy"/> that will function like a Circuit Breaker.</para>
@@ -165,15 +161,13 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onReset</exception>
         /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static AsyncCircuitBreakerPolicy CircuitBreakerAsync(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
-        {
-            return policyBuilder.CircuitBreakerAsync(
+            => policyBuilder.CircuitBreakerAsync(
                 exceptionsAllowedBeforeBreaking,
                 durationOfBreak,
                 (exception, state, timespan, context) => onBreak(exception, timespan, context),
                 onReset,
                 onHalfOpen
             );
-        }
 
         /// <summary>
         /// <para> Builds a <see cref="AsyncPolicy"/> that will function like a Circuit Breaker.</para>

--- a/src/Polly.Shared/CircuitBreaker/AsyncCircuitBreakerTResultSyntax.cs
+++ b/src/Polly.Shared/CircuitBreaker/AsyncCircuitBreakerTResultSyntax.cs
@@ -62,14 +62,12 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onBreak</exception>
         /// <exception cref="ArgumentNullException">onReset</exception>
         public static AsyncCircuitBreakerPolicy<TResult> CircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan> onBreak, Action onReset)
-        {
-            return policyBuilder.CircuitBreakerAsync(
+            => policyBuilder.CircuitBreakerAsync(
                 handledEventsAllowedBeforeBreaking,
                 durationOfBreak,
                 (outcome, timespan, context) => onBreak(outcome, timespan),
                 context => onReset()
                 );
-        }
 
         /// <summary>
         /// <para> Builds a <see cref="AsyncPolicy{TResult}"/> that will function like a Circuit Breaker.</para>
@@ -129,15 +127,13 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onBreak</exception>
         /// <exception cref="ArgumentNullException">onReset</exception>
         public static AsyncCircuitBreakerPolicy<TResult> CircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan> onBreak, Action onReset, Action onHalfOpen)
-        {
-            return policyBuilder.CircuitBreakerAsync(
+            => policyBuilder.CircuitBreakerAsync(
                 handledEventsAllowedBeforeBreaking,
                 durationOfBreak,
                 (outcome, timespan, context) => onBreak(outcome, timespan),
                 context => onReset(),
                 onHalfOpen
                 );
-        }
 
         /// <summary>
         /// <para> Builds a <see cref="AsyncPolicy{TResult}"/> that will function like a Circuit Breaker.</para>
@@ -164,15 +160,13 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onReset</exception>
         /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static AsyncCircuitBreakerPolicy<TResult> CircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
-        {
-            return policyBuilder.CircuitBreakerAsync(
+            => policyBuilder.CircuitBreakerAsync(
                 handledEventsAllowedBeforeBreaking,
                 durationOfBreak,
                 (outcome, state, timespan, context) => onBreak(outcome, timespan, context),
                 onReset,
                 onHalfOpen
             );
-        }
 
         /// <summary>
         /// <para> Builds a <see cref="AsyncPolicy{TResult}"/> that will function like a Circuit Breaker.</para>

--- a/src/Polly.Shared/CircuitBreaker/BrokenCircuitException.cs
+++ b/src/Polly.Shared/CircuitBreaker/BrokenCircuitException.cs
@@ -68,9 +68,7 @@ namespace Polly.CircuitBreaker
         /// </summary>
         /// <param name="result">The result which caused the circuit to break.</param>
         public BrokenCircuitException(TResult result) : base()
-        {
-            this.result = result;
-        }
+            => this.result = result;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BrokenCircuitException{TResult}"/> class.
@@ -78,14 +76,12 @@ namespace Polly.CircuitBreaker
         /// <param name="message">The message that describes the error.</param>
         /// <param name="result">The result which caused the circuit to break.</param>
         public BrokenCircuitException(string message, TResult result) : base(message)
-        {
-            this.result = result;
-        }
+            => this.result = result;
 
         /// <summary>
         /// The result value which was considered a handled fault, by the policy.
         /// </summary>
-        public TResult Result { get { return result; } }
+        public TResult Result { get => result; } 
 
 #if NETSTANDARD2_0
         /// <summary>

--- a/src/Polly.Shared/CircuitBreaker/CircuitBreakerPolicy.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitBreakerPolicy.cs
@@ -16,9 +16,7 @@ namespace Polly.CircuitBreaker
             ExceptionPredicates exceptionPredicates,
             ICircuitController<EmptyStruct> breakerController
             ) : base(exceptionPredicates)
-        {
-            _breakerController = breakerController;
-        }
+            => _breakerController = breakerController;
 
         /// <summary>
         /// Gets the state of the underlying circuit.
@@ -34,18 +32,12 @@ namespace Polly.CircuitBreaker
         /// <summary>
         /// Isolates (opens) the circuit manually, and holds it in this state until a call to <see cref="Reset()"/> is made.
         /// </summary>
-        public void Isolate()
-        {
-            _breakerController.Isolate();
-        }
+        public void Isolate() => _breakerController.Isolate();
 
         /// <summary>
         /// Closes the circuit, and resets any statistics controlling automated circuit-breaking.
         /// </summary>
-        public void Reset()
-        {
-            _breakerController.Reset();
-        }
+        public void Reset() => _breakerController.Reset();
 
         /// <inheritdoc/>
         [DebuggerStepThrough]
@@ -75,9 +67,7 @@ namespace Polly.CircuitBreaker
             ResultPredicates<TResult> resultPredicates, 
             ICircuitController<TResult> breakerController
             ) : base(exceptionPredicates, resultPredicates)
-        {
-            _breakerController = breakerController;
-        }
+            => _breakerController = breakerController;
 
         /// <summary>
         /// Gets the state of the underlying circuit.
@@ -99,31 +89,22 @@ namespace Polly.CircuitBreaker
         /// <summary>
         /// Isolates (opens) the circuit manually, and holds it in this state until a call to <see cref="Reset()"/> is made.
         /// </summary>
-        public void Isolate()
-        {
-            _breakerController.Isolate();
-        }
+        public void Isolate() => _breakerController.Isolate();
 
         /// <summary>
         /// Closes the circuit, and resets any statistics controlling automated circuit-breaking.
         /// </summary>
-        public void Reset()
-        {
-            _breakerController.Reset();
-        }
+        public void Reset() => _breakerController.Reset();
 
         /// <inheritdoc/>
         [DebuggerStepThrough]
         protected override TResult Implementation(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken)
-        {
-            return CircuitBreakerEngine.Implementation(
+            => CircuitBreakerEngine.Implementation(
                 action,
                 context,
                 cancellationToken,
                 ExceptionPredicates,
                 ResultPredicates,
                 _breakerController);
-        }
     }
-
 }

--- a/src/Polly.Shared/CircuitBreaker/CircuitBreakerSyntax.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitBreakerSyntax.cs
@@ -65,14 +65,12 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onBreak</exception>
         /// <exception cref="ArgumentNullException">onReset</exception>
         public static CircuitBreakerPolicy CircuitBreaker(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, TimeSpan> onBreak, Action onReset)
-        {
-            return policyBuilder.CircuitBreaker(
+            => policyBuilder.CircuitBreaker(
                 exceptionsAllowedBeforeBreaking, 
                 durationOfBreak, 
                 (exception, timespan, context) => onBreak(exception, timespan), 
                 context => onReset()
                 );
-        }
 
         /// <summary>
         /// <para> Builds a <see cref="Policy"/> that will function like a Circuit Breaker.</para>
@@ -131,15 +129,13 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onBreak</exception>
         /// <exception cref="ArgumentNullException">onReset</exception>
         public static CircuitBreakerPolicy CircuitBreaker(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, TimeSpan> onBreak, Action onReset, Action onHalfOpen)
-        {
-            return policyBuilder.CircuitBreaker(
+            => policyBuilder.CircuitBreaker(
                 exceptionsAllowedBeforeBreaking,
                 durationOfBreak,
                 (exception, timespan, context) => onBreak(exception, timespan),
                 context => onReset(),
                 onHalfOpen
                 );
-        }
 
         /// <summary>
         /// <para> Builds a <see cref="Policy"/> that will function like a Circuit Breaker.</para>
@@ -166,15 +162,13 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onReset</exception>
         /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static CircuitBreakerPolicy CircuitBreaker(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
-        {
-            return policyBuilder.CircuitBreaker(
+            => policyBuilder.CircuitBreaker(
                 exceptionsAllowedBeforeBreaking,
                 durationOfBreak,
                 (exception, state, timespan, context) => onBreak(exception, timespan, context),
                 onReset,
                 onHalfOpen
             );
-        }
 
         /// <summary>
         /// <para> Builds a <see cref="Policy"/> that will function like a Circuit Breaker.</para>

--- a/src/Polly.Shared/CircuitBreaker/CircuitBreakerTResultSyntax.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitBreakerTResultSyntax.cs
@@ -64,14 +64,12 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onBreak</exception>
         /// <exception cref="ArgumentNullException">onReset</exception>
         public static CircuitBreakerPolicy<TResult> CircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan> onBreak, Action onReset)
-        {
-            return policyBuilder.CircuitBreaker(
+            => policyBuilder.CircuitBreaker(
                 handledEventsAllowedBeforeBreaking,
                 durationOfBreak,
                 (outcome, timespan, context) => onBreak(outcome, timespan),
                 context => onReset()
                 );
-        }
 
         /// <summary>
         /// <para> Builds a <see cref="Policy{TResult}"/> that will function like a Circuit Breaker.</para>
@@ -130,15 +128,13 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onBreak</exception>
         /// <exception cref="ArgumentNullException">onReset</exception>
         public static CircuitBreakerPolicy<TResult> CircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan> onBreak, Action onReset, Action onHalfOpen)
-        {
-            return policyBuilder.CircuitBreaker(
+            => policyBuilder.CircuitBreaker(
                 handledEventsAllowedBeforeBreaking,
                 durationOfBreak,
                 (outcome, timespan, context) => onBreak(outcome, timespan),
                 context => onReset(),
                 onHalfOpen
                 );
-        }
 
         /// <summary>
         /// <para> Builds a <see cref="Policy{TResult}"/> that will function like a Circuit Breaker.</para>
@@ -165,15 +161,13 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onReset</exception>
         /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static CircuitBreakerPolicy<TResult> CircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
-        {
-            return policyBuilder.CircuitBreaker(
+            => policyBuilder.CircuitBreaker(
                 handledEventsAllowedBeforeBreaking,
                 durationOfBreak,
                 (outcome, state, timespan, context) => onBreak(outcome, timespan, context),
                 onReset,
                 onHalfOpen
             );
-        }
 
         /// <summary>
         /// <para> Builds a <see cref="Policy{TResult}"/> that will function like a Circuit Breaker.</para>

--- a/src/Polly.Shared/CircuitBreaker/CircuitStateController.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitStateController.cs
@@ -94,10 +94,7 @@ namespace Polly.CircuitBreaker
             }
         }
 
-        protected void Break_NeedsLock(Context context)
-        {
-            BreakFor_NeedsLock(_durationOfBreak, context);
-        }
+        protected void Break_NeedsLock(Context context) => BreakFor_NeedsLock(_durationOfBreak, context);
 
         private void BreakFor_NeedsLock(TimeSpan durationOfBreak, Context context)
         {
@@ -112,10 +109,7 @@ namespace Polly.CircuitBreaker
             _onBreak(_lastOutcome, transitionedState, durationOfBreak, context);
         }
 
-        public void Reset()
-        {
-            OnCircuitReset(Context.None());
-        }
+        public void Reset() => OnCircuitReset(Context.None());
 
         protected void ResetInternal_NeedsLock(Context context)
         {
@@ -143,11 +137,9 @@ namespace Polly.CircuitBreaker
         }
 
         private BrokenCircuitException GetBreakingException()
-        {
-            return _lastOutcome.Exception != null
+            => _lastOutcome.Exception != null
                 ? new BrokenCircuitException("The circuit is now open and is not allowing calls.", _lastOutcome.Exception)
                 : new BrokenCircuitException<TResult>("The circuit is now open and is not allowing calls.", _lastOutcome.Result);
-        }
 
         public void OnActionPreExecute()
         {

--- a/src/Polly.Shared/CircuitBreaker/ConsecutiveCountCircuitController.cs
+++ b/src/Polly.Shared/CircuitBreaker/ConsecutiveCountCircuitController.cs
@@ -80,8 +80,6 @@ namespace Polly.CircuitBreaker
                     default:
                         throw new InvalidOperationException("Unhandled CircuitState.");
                 }
-
-
             }
         }
     }

--- a/src/Polly.Shared/CircuitBreaker/SingleHealthMetrics.cs
+++ b/src/Polly.Shared/CircuitBreaker/SingleHealthMetrics.cs
@@ -9,10 +9,7 @@ namespace Polly.CircuitBreaker
 
         private HealthCount _current;
 
-        public SingleHealthMetrics(TimeSpan samplingDuration)
-        {
-            _samplingDuration = samplingDuration.Ticks;
-        }
+        public SingleHealthMetrics(TimeSpan samplingDuration) => _samplingDuration = samplingDuration.Ticks;
 
         public void IncrementSuccess_NeedsLock()
         {
@@ -28,10 +25,7 @@ namespace Polly.CircuitBreaker
             _current.Failures++;
         }
 
-        public void Reset_NeedsLock()
-        {
-            _current = null;
-        }
+        public void Reset_NeedsLock() => _current = null;
 
         public HealthCount GetHealthCount_NeedsLock()
         {


### PR DESCRIPTION
Replaced single line methods with expression-bodied members.
Removed empty useless line.

### The issue or feature being addressed

557, https://github.com/App-vNext/Polly/issues/557

### Details on the issue fix or feature implementation

### Confirm the following

- [x]  I started this PR by branching from the head of the latest dev v700 branch, or I have rebased on the latest dev vX.Y branch, or I have merged the latest changes from the dev v700 branch
- [x]  I have targeted the PR to merge into the latest dev v700 branch as the base branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
