### PR TITLE
Replaced one line methods with expression-bodied members. (Fallback)

### DIFF
--- a/src/Polly.Shared/Fallback/AsyncFallbackPolicy.cs
+++ b/src/Polly.Shared/Fallback/AsyncFallbackPolicy.cs
@@ -49,9 +49,8 @@ namespace Polly.Fallback
         /// <inheritdoc/>
         protected override Task<TResult> ImplementationAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken,
             bool continueOnCapturedContext)
-        {
+            => 
             throw new InvalidOperationException($"You have executed the generic .Execute<{nameof(TResult)}> method on a non-generic {nameof(FallbackPolicy)}.  A non-generic {nameof(FallbackPolicy)} only defines a fallback action which returns void; it can never return a substitute {nameof(TResult)} value.  To use {nameof(FallbackPolicy)} to provide fallback {nameof(TResult)} values you must define a generic fallback policy {nameof(FallbackPolicy)}<{nameof(TResult)}>.  For example, define the policy as Policy<{nameof(TResult)}>.Handle<Whatever>.Fallback<{nameof(TResult)}>(/* some {nameof(TResult)} value or Func<..., {nameof(TResult)}> */);");
-        }
     }
 
     /// <summary>
@@ -78,8 +77,7 @@ namespace Polly.Fallback
         [DebuggerStepThrough]
         protected override Task<TResult> ImplementationAsync(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken,
             bool continueOnCapturedContext)
-        {
-            return AsyncFallbackEngine.ImplementationAsync(
+            => AsyncFallbackEngine.ImplementationAsync(
                 action,
                 context,
                 cancellationToken,
@@ -88,6 +86,5 @@ namespace Polly.Fallback
                 _onFallbackAsync,
                 _fallbackAction,
                 continueOnCapturedContext);
-        }
     }
 }

--- a/src/Polly.Shared/Fallback/FallbackPolicy.cs
+++ b/src/Polly.Shared/Fallback/FallbackPolicy.cs
@@ -26,8 +26,7 @@ namespace Polly.Fallback
         /// <inheritdoc/>
         [DebuggerStepThrough]
         protected override void Implementation(Action<Context, CancellationToken> action, Context context, CancellationToken cancellationToken)
-        {
-            FallbackEngine.Implementation<EmptyStruct>(
+            => FallbackEngine.Implementation<EmptyStruct>(
                 (ctx, token) => { action(ctx, token); return EmptyStruct.Instance; }, 
                 context, 
                 cancellationToken, 
@@ -35,13 +34,10 @@ namespace Polly.Fallback
                 ResultPredicates<EmptyStruct>.None,
                 (outcome, ctx) => _onFallback(outcome.Exception, ctx),
                 (outcome, ctx, ct) => { _fallbackAction(outcome.Exception, ctx, ct); return EmptyStruct.Instance; });
-        }
 
         /// <inheritdoc/>
         protected override TResult Implementation<TResult>(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken)
-        {
-            throw new InvalidOperationException($"You have executed the generic .Execute<{nameof(TResult)}> method on a non-generic {nameof(FallbackPolicy)}.  A non-generic {nameof(FallbackPolicy)} only defines a fallback action which returns void; it can never return a substitute {nameof(TResult)} value.  To use {nameof(FallbackPolicy)} to provide fallback {nameof(TResult)} values you must define a generic fallback policy {nameof(FallbackPolicy)}<{nameof(TResult)}>.  For example, define the policy as Policy<{nameof(TResult)}>.Handle<Whatever>.Fallback<{nameof(TResult)}>(/* some {nameof(TResult)} value or Func<..., {nameof(TResult)}> */);");
-        }
+            => throw new InvalidOperationException($"You have executed the generic .Execute<{nameof(TResult)}> method on a non-generic {nameof(FallbackPolicy)}.  A non-generic {nameof(FallbackPolicy)} only defines a fallback action which returns void; it can never return a substitute {nameof(TResult)} value.  To use {nameof(FallbackPolicy)} to provide fallback {nameof(TResult)} values you must define a generic fallback policy {nameof(FallbackPolicy)}<{nameof(TResult)}>.  For example, define the policy as Policy<{nameof(TResult)}>.Handle<Whatever>.Fallback<{nameof(TResult)}>(/* some {nameof(TResult)} value or Func<..., {nameof(TResult)}> */);");
     }
 
     /// <summary>
@@ -66,8 +62,7 @@ namespace Polly.Fallback
         /// <inheritdoc/>
         [DebuggerStepThrough]
         protected override TResult Implementation(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken)
-        {
-            return FallbackEngine.Implementation(
+            => FallbackEngine.Implementation(
                 action,
                 context,
                 cancellationToken,
@@ -75,6 +70,5 @@ namespace Polly.Fallback
                 ResultPredicates,
                 _onFallback,
                 _fallbackAction);
-        }
     }
 }

--- a/src/Polly.Shared/Fallback/IFallbackPolicy.cs
+++ b/src/Polly.Shared/Fallback/IFallbackPolicy.cs
@@ -13,6 +13,5 @@
     /// </summary>
     public interface IFallbackPolicy<TResult> : IFallbackPolicy
     {
-
     }
 }


### PR DESCRIPTION
Replaced one line methods with expression-bodied members.
Removed useless empty lines.

<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors.  All non-trivial contributions get a public credit in the readme! -->

### The issue or feature being addressed

557, https://github.com/App-vNext/Polly/issues/557

### Details on the issue fix or feature implementation

### Confirm the following

- [x]  I started this PR by branching from the head of the latest dev v700 branch, or I have rebased on the latest dev v700 branch, or I have merged the latest changes from the dev v700 branch
- [x]  I have targeted the PR to merge into the latest dev v700 branch as the base branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
