### PR TITLE
Expose Exception... and ResultPredicates, for custom policies

### DIFF
--- a/src/Polly.Shared/PolicyBuilder.cs
+++ b/src/Polly.Shared/PolicyBuilder.cs
@@ -14,7 +14,10 @@ namespace Polly
             ExceptionPredicates.Add(exceptionPredicate);
         }
 
-        internal ExceptionPredicates ExceptionPredicates { get; }
+        /// <summary>
+        /// Predicates specifying exceptions that the policy is being configured to handle.
+        /// </summary>
+        public ExceptionPredicates ExceptionPredicates { get; }
 
         #region Hide object members
 
@@ -97,9 +100,15 @@ namespace Polly
             ExceptionPredicates = exceptionPredicates;
         }
 
-        internal ExceptionPredicates ExceptionPredicates { get; }
+        /// <summary>
+        /// Predicates specifying exceptions that the policy is being configured to handle.
+        /// </summary>
+        public ExceptionPredicates ExceptionPredicates { get; }
 
-        internal ResultPredicates<TResult> ResultPredicates { get; }
+        /// <summary>
+        /// Predicates specifying results that the policy is being configured to handle.
+        /// </summary>
+        public ResultPredicates<TResult> ResultPredicates { get; }
 
         #region Hide object members
 


### PR DESCRIPTION
### The issue or feature being addressed

`PolicyBuilder.ExceptionPredicates` and `.ResultPredicates` need to be public, in order that the standard `Policy.Handle<Exception>` and `.HandleResult(...)` syntax can be used to configure custom reactive policies (#551).

### Confirm the following

- [x]  I started this PR by branching from the head of the latest dev vX.Y branch, or I have rebased on the latest dev vX.Y branch, or I have merged the latest changes from the dev vX.Y branch
- [x]  I have targeted the PR to merge into the latest dev vX.Y branch as the base branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
