### PR TITLE
Expose exception and result predicates to custom reactive policies

### DIFF
--- a/src/Polly.Shared/AsyncPolicy.TResult.ExecuteOverloads.cs
+++ b/src/Polly.Shared/AsyncPolicy.TResult.ExecuteOverloads.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Polly
 {
-    public abstract partial class AsyncPolicy<TResult> : PolicyBase, IAsyncPolicy<TResult>
+    public abstract partial class AsyncPolicy<TResult> : IAsyncPolicy<TResult>
     {
 
         #region ExecuteAsync overloads

--- a/src/Polly.Shared/AsyncPolicy.TResult.cs
+++ b/src/Polly.Shared/AsyncPolicy.TResult.cs
@@ -4,10 +4,8 @@
     /// Transient exception handling policies that can be applied to asynchronous delegates
     /// </summary>
     /// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
-    public abstract partial class AsyncPolicy<TResult>
+    public abstract partial class AsyncPolicy<TResult> : PolicyBase<TResult>
     {
-        internal ResultPredicates<TResult> ResultPredicates { get; }
-
         /// <summary>
         /// Constructs a new instance of a derived <see cref="AsyncPolicy{TResult}"/> type with the passed <paramref name="exceptionPredicates"/> and <paramref name="resultPredicates"/>. 
         /// </summary>
@@ -16,9 +14,8 @@
         protected AsyncPolicy(
             ExceptionPredicates exceptionPredicates,
             ResultPredicates<TResult> resultPredicates)
+            : base(exceptionPredicates, resultPredicates)
         {
-            ExceptionPredicates = exceptionPredicates ?? ExceptionPredicates.None;
-            ResultPredicates = resultPredicates ?? ResultPredicates<TResult>.None;
         }
     }
 }

--- a/src/Polly.Shared/AsyncPolicy.cs
+++ b/src/Polly.Shared/AsyncPolicy.cs
@@ -10,8 +10,8 @@
         /// </summary>
         /// <param name="exceptionPredicates">Predicates indicating which exceptions the policy should handle. </param>
         protected AsyncPolicy(ExceptionPredicates exceptionPredicates)
+            : base(exceptionPredicates)
         {
-            ExceptionPredicates = exceptionPredicates ?? ExceptionPredicates.None;
         }
 
     }

--- a/src/Polly.Shared/Policy.TResult.cs
+++ b/src/Polly.Shared/Policy.TResult.cs
@@ -3,19 +3,16 @@
     /// <summary>
     /// Transient fault handling policies that can be applied to delegates returning results of type <typeparamref name="TResult"/>
     /// </summary>
-    public abstract partial class Policy<TResult> : PolicyBase
+    public abstract partial class Policy<TResult> : PolicyBase<TResult>
     {
-        internal ResultPredicates<TResult> ResultPredicates { get; }
-
         /// <summary>
         /// Constructs a new instance of a derived <see cref="Policy{TResult}"/> type with the passed <paramref name="exceptionPredicates"/> and <paramref name="resultPredicates"/>.
         /// </summary>
         /// <param name="exceptionPredicates">Predicates indicating which exceptions the policy should handle.</param>
         /// <param name="resultPredicates">Predicates indicating which results the policy should handle.</param>
         protected Policy(ExceptionPredicates exceptionPredicates, ResultPredicates<TResult> resultPredicates)
+        : base(exceptionPredicates, resultPredicates)
         {
-            ExceptionPredicates = exceptionPredicates ?? ExceptionPredicates.None;
-            ResultPredicates = resultPredicates ?? ResultPredicates<TResult>.None;
         }
     }
 

--- a/src/Polly.Shared/Policy.cs
+++ b/src/Polly.Shared/Policy.cs
@@ -10,8 +10,8 @@
         /// </summary>
         /// <param name="exceptionPredicates">Predicates indicating which exceptions the policy should handle. </param>
         protected Policy(ExceptionPredicates exceptionPredicates)
+            : base(exceptionPredicates)
         {
-            ExceptionPredicates = exceptionPredicates ?? ExceptionPredicates.None;
         }
     }
 }

--- a/src/Polly.Shared/PolicyBase.cs
+++ b/src/Polly.Shared/PolicyBase.cs
@@ -9,9 +9,9 @@ namespace Polly
     public abstract partial class PolicyBase
     {
         /// <summary>
-        /// Predicates indicating which exceptions the policy should handle.
+        /// Predicates indicating which exceptions the policy handles.
         /// </summary>
-        internal ExceptionPredicates ExceptionPredicates { get; set; }
+        public ExceptionPredicates ExceptionPredicates { get; }
 
         /// <summary>
         /// Defines a CancellationToken to use, when none is supplied.
@@ -32,5 +32,38 @@ namespace Polly
                 : ExceptionType.Unhandled;
         }
 
+        /// <summary>
+        /// Constructs a new instance of a derived type of <see cref="PolicyBase"/> with the passed <paramref name="exceptionPredicates"/>.
+        /// </summary>
+        /// <param name="exceptionPredicates">Predicates indicating which exceptions the policy should handle. </param>
+        protected PolicyBase(
+            ExceptionPredicates exceptionPredicates)
+        {
+            ExceptionPredicates = exceptionPredicates ?? ExceptionPredicates.None;
+        }
     }
+
+    /// <summary>
+    /// Implements elements common to sync and async generic policies.
+    /// </summary>
+    public abstract class PolicyBase<TResult> : PolicyBase
+    {
+        /// <summary>
+        /// Predicates indicating which results the policy handles.
+        /// </summary>
+        public ResultPredicates<TResult> ResultPredicates { get; }
+
+        /// <summary>
+        /// Constructs a new instance of a derived type of <see cref="PolicyBase{TResult}"/> with the passed <paramref name="exceptionPredicates"/> and <paramref name="resultPredicates"/>.
+        /// </summary>
+        /// <param name="exceptionPredicates">Predicates indicating which exceptions the policy should handle. </param>
+        /// <param name="resultPredicates">Predicates indicating which results the policy should handle. </param>
+        protected PolicyBase(
+            ExceptionPredicates exceptionPredicates,
+            ResultPredicates<TResult> resultPredicates)
+        : base(exceptionPredicates)
+        {
+            ResultPredicates = resultPredicates ?? ResultPredicates<TResult>.None;
+        }
+}
 }


### PR DESCRIPTION
### The issue or feature being addressed

+ Exposes exception and result predicates, for use by custom (#551) reactive policies.  
+ Limits setting them to via the constructor.

### Confirm the following

- [x]  I started this PR by branching from the head of the latest dev vX.Y branch, or I have rebased on the latest dev vX.Y branch, or I have merged the latest changes from the dev vX.Y branch
- [x]  I have targeted the PR to merge into the latest dev vX.Y branch as the base branch
- [n/a]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
