### PR TITLE
Converted one liner methods to expression bodied members (Timeout).

### DIFF
--- a/src/Polly.Shared/Timeout/AsyncTimeoutPolicy.cs
+++ b/src/Polly.Shared/Timeout/AsyncTimeoutPolicy.cs
@@ -10,9 +10,9 @@ namespace Polly.Timeout
     /// </summary>
     public class AsyncTimeoutPolicy : AsyncPolicy, ITimeoutPolicy
     {
-        private Func<Context, TimeSpan> _timeoutProvider;
-        private TimeoutStrategy _timeoutStrategy;
-        private Func<Context, TimeSpan, Task, Exception, Task> _onTimeoutAsync;
+        private readonly Func<Context, TimeSpan> _timeoutProvider;
+        private readonly TimeoutStrategy _timeoutStrategy;
+        private readonly Func<Context, TimeSpan, Task, Exception, Task> _onTimeoutAsync;
 
         internal AsyncTimeoutPolicy(
             Func<Context, TimeSpan> timeoutProvider,
@@ -73,8 +73,7 @@ namespace Polly.Timeout
             Context context, 
             CancellationToken cancellationToken,
             bool continueOnCapturedContext)
-        {
-            return AsyncTimeoutEngine.ImplementationAsync(
+            => AsyncTimeoutEngine.ImplementationAsync(
                 action,
                 context,
                 cancellationToken,
@@ -82,6 +81,5 @@ namespace Polly.Timeout
                 _timeoutStrategy,
                 _onTimeoutAsync,
                 continueOnCapturedContext);
-        }
     }
 }

--- a/src/Polly.Shared/Timeout/AsyncTimeoutSyntax.cs
+++ b/src/Polly.Shared/Timeout/AsyncTimeoutSyntax.cs
@@ -332,9 +332,7 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
         /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
         public static AsyncTimeoutPolicy TimeoutAsync(Func<Context, TimeSpan> timeoutProvider, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
-        {
-            return TimeoutAsync(timeoutProvider, TimeoutStrategy.Optimistic, onTimeoutAsync);
-        }
+            => TimeoutAsync(timeoutProvider, TimeoutStrategy.Optimistic, onTimeoutAsync);
 
         /// <summary>
         /// Builds an <see cref="AsyncPolicy"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
@@ -346,9 +344,7 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
         /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
         public static AsyncTimeoutPolicy TimeoutAsync(Func<Context, TimeSpan> timeoutProvider, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
-        {
-            return TimeoutAsync(timeoutProvider, TimeoutStrategy.Optimistic, onTimeoutAsync);
-        }
+            => TimeoutAsync(timeoutProvider, TimeoutStrategy.Optimistic, onTimeoutAsync);
 
         /// <summary>
         /// Builds an <see cref="AsyncPolicy" /> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.

--- a/src/Polly.Shared/Timeout/AsyncTimeoutTResultSyntax.cs
+++ b/src/Polly.Shared/Timeout/AsyncTimeoutTResultSyntax.cs
@@ -328,9 +328,7 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
         /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
         public static AsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<Context, TimeSpan> timeoutProvider, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
-        {
-            return TimeoutAsync<TResult>(timeoutProvider, TimeoutStrategy.Optimistic, onTimeoutAsync);
-        }
+            => TimeoutAsync<TResult>(timeoutProvider, TimeoutStrategy.Optimistic, onTimeoutAsync);
 
         /// <summary>
         /// Builds an <see cref="AsyncPolicy{TResult}"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
@@ -342,9 +340,7 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
         /// <exception cref="System.ArgumentNullException">onTimeoutAsync</exception>
         public static AsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<Context, TimeSpan> timeoutProvider, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
-        {
-            return TimeoutAsync<TResult>(timeoutProvider, TimeoutStrategy.Optimistic, onTimeoutAsync);
-        }
+            => TimeoutAsync<TResult>(timeoutProvider, TimeoutStrategy.Optimistic, onTimeoutAsync);
 
         /// <summary>
         /// Builds an <see cref="AsyncPolicy{TResult}"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.

--- a/src/Polly.Shared/Timeout/TimeoutPolicy.cs
+++ b/src/Polly.Shared/Timeout/TimeoutPolicy.cs
@@ -28,15 +28,13 @@ namespace Polly.Timeout
         /// <inheritdoc/>
         [DebuggerStepThrough]
         protected override TResult Implementation<TResult>(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken)
-        {
-            return TimeoutEngine.Implementation(
+            => TimeoutEngine.Implementation(
                 action,
                 context,
                 cancellationToken,
                 _timeoutProvider,
                 _timeoutStrategy,
                 _onTimeout);
-        }
     }
 
     /// <summary>
@@ -61,14 +59,12 @@ namespace Polly.Timeout
 
         /// <inheritdoc/>
         protected override TResult Implementation(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken)
-        {
-            return TimeoutEngine.Implementation(
+            => TimeoutEngine.Implementation(
                 action,
                 context,
                 cancellationToken,
                 _timeoutProvider,
                 _timeoutStrategy,
                 _onTimeout);
-        }
     }
 }

--- a/src/Polly.Shared/Timeout/TimeoutSyntax.cs
+++ b/src/Polly.Shared/Timeout/TimeoutSyntax.cs
@@ -326,9 +326,7 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
         /// <exception cref="System.ArgumentNullException">onTimeout</exception>
         public static TimeoutPolicy Timeout(Func<Context, TimeSpan> timeoutProvider, Action<Context, TimeSpan, Task> onTimeout)
-        {
-            return Timeout(timeoutProvider, TimeoutStrategy.Optimistic, onTimeout);
-        }
+            => Timeout(timeoutProvider, TimeoutStrategy.Optimistic, onTimeout);
 
         /// <summary>
         /// Builds a <see cref="Policy" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
@@ -340,9 +338,7 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
         /// <exception cref="System.ArgumentNullException">onTimeout</exception>
         public static TimeoutPolicy Timeout(Func<Context, TimeSpan> timeoutProvider, Action<Context, TimeSpan, Task, Exception> onTimeout)
-        {
-            return Timeout(timeoutProvider, TimeoutStrategy.Optimistic, onTimeout);
-        }
+            => Timeout(timeoutProvider, TimeoutStrategy.Optimistic, onTimeout);
 
         /// <summary>
         /// Builds a <see cref="Policy" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.

--- a/src/Polly.Shared/Timeout/TimeoutTResultSyntax.cs
+++ b/src/Polly.Shared/Timeout/TimeoutTResultSyntax.cs
@@ -331,9 +331,7 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
         /// <exception cref="System.ArgumentNullException">onTimeout</exception>
         public static TimeoutPolicy<TResult> Timeout<TResult>(Func<Context, TimeSpan> timeoutProvider, Action<Context, TimeSpan, Task> onTimeout)
-        {
-            return Timeout<TResult>(timeoutProvider, TimeoutStrategy.Optimistic, onTimeout);
-        }
+            => Timeout<TResult>(timeoutProvider, TimeoutStrategy.Optimistic, onTimeout);
 
         /// <summary>
         /// Builds a <see cref="Policy{TResult}"/> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
@@ -345,9 +343,7 @@ namespace Polly
         /// <exception cref="System.ArgumentNullException">timeoutProvider</exception>
         /// <exception cref="System.ArgumentNullException">onTimeout</exception>
         public static TimeoutPolicy<TResult> Timeout<TResult>(Func<Context, TimeSpan> timeoutProvider, Action<Context, TimeSpan, Task, Exception> onTimeout)
-        {
-            return Timeout<TResult>(timeoutProvider, TimeoutStrategy.Optimistic, onTimeout);
-        }
+            => Timeout<TResult>(timeoutProvider, TimeoutStrategy.Optimistic, onTimeout);
 
         /// <summary>
         /// Builds a <see cref="Policy{TResult}" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.


### PR DESCRIPTION
AsyncTimeoutPolicy: Added readonly modifier.

<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors.  All non-trivial contributions get a public credit in the readme! -->

### The issue or feature being addressed

557, https://github.com/App-vNext/Polly/issues/557

### Details on the issue fix or feature implementation

### Confirm the following

- [x]  I started this PR by branching from the head of the latest dev v700 branch, or I have rebased on the latest dev v700 branch, or I have merged the latest changes from the dev v700 branch
- [x]  I have targeted the PR to merge into the latest dev v700 branch as the base branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
