### PR TITLE
Adjust predicate and constructor visibility to support custom policies

### DIFF
--- a/src/Polly.Shared/AsyncPolicy.TResult.cs
+++ b/src/Polly.Shared/AsyncPolicy.TResult.cs
@@ -11,10 +11,19 @@
         /// </summary>
         /// <param name="exceptionPredicates">Predicates indicating which exceptions the policy should handle. </param>
         /// <param name="resultPredicates">Predicates indicating which results the policy should handle. </param>
-        protected AsyncPolicy(
+        internal AsyncPolicy(
             ExceptionPredicates exceptionPredicates,
             ResultPredicates<TResult> resultPredicates)
             : base(exceptionPredicates, resultPredicates)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new instance of a derived <see cref="AsyncPolicy{TResult}"/> type with the passed <paramref name="policyBuilder"/>. 
+        /// </summary>
+        /// <param name="policyBuilder">A <see cref="PolicyBuilder{TResult}"/> indicating which exceptions and results the policy should handle.</param>
+        protected AsyncPolicy(PolicyBuilder<TResult> policyBuilder = null)
+            : base(policyBuilder)
         {
         }
     }

--- a/src/Polly.Shared/AsyncPolicy.cs
+++ b/src/Polly.Shared/AsyncPolicy.cs
@@ -9,10 +9,18 @@
         /// Constructs a new instance of a derived <see cref="AsyncPolicy"/> type with the passed <paramref name="exceptionPredicates"/>. 
         /// </summary>
         /// <param name="exceptionPredicates">Predicates indicating which exceptions the policy should handle. </param>
-        protected AsyncPolicy(ExceptionPredicates exceptionPredicates)
+        internal AsyncPolicy(ExceptionPredicates exceptionPredicates)
             : base(exceptionPredicates)
         {
         }
 
+        /// <summary>
+        /// Constructs a new instance of a derived <see cref="AsyncPolicy"/> type with the passed <paramref name="policyBuilder"/>. 
+        /// </summary>
+        /// <param name="policyBuilder">A <see cref="PolicyBuilder"/> specifying which exceptions the policy should handle. </param>
+        protected AsyncPolicy(PolicyBuilder policyBuilder = null)
+            : base(policyBuilder)
+        {
+        }
     }
 }

--- a/src/Polly.Shared/Bulkhead/AsyncBulkheadPolicy.cs
+++ b/src/Polly.Shared/Bulkhead/AsyncBulkheadPolicy.cs
@@ -22,7 +22,6 @@ namespace Polly.Bulkhead
             SemaphoreSlim maxParallelizationSemaphore,
             SemaphoreSlim maxQueuedActionsSemaphore,
             Func<Context, Task> onBulkheadRejectedAsync)
-           : base(ExceptionPredicates.None)
         {
             _maxParallelization = maxParallelization;
             _maxQueueingActions = maxQueueingActions;
@@ -74,8 +73,7 @@ namespace Polly.Bulkhead
             int maxQueueingActions,
             SemaphoreSlim maxParallelizationSemaphore,
             SemaphoreSlim maxQueuedActionsSemaphore,
-            Func<Context, Task> onBulkheadRejectedAsync
-            ) : base(ExceptionPredicates.None, ResultPredicates<TResult>.None)
+            Func<Context, Task> onBulkheadRejectedAsync)
         {
             _maxParallelization = maxParallelization;
             _maxQueueingActions = maxQueueingActions;

--- a/src/Polly.Shared/Bulkhead/BulkheadPolicy.cs
+++ b/src/Polly.Shared/Bulkhead/BulkheadPolicy.cs
@@ -20,8 +20,7 @@ namespace Polly.Bulkhead
             int maxQueueingActions,
             SemaphoreSlim maxParallelizationSemaphore, 
             SemaphoreSlim maxQueuedActionsSemaphore,
-            Action<Context> onBulkheadRejected
-            ) : base(ExceptionPredicates.None)
+            Action<Context> onBulkheadRejected)
         {
             _maxParallelization = maxParallelization;
             _maxQueueingActions = maxQueueingActions;
@@ -73,8 +72,7 @@ namespace Polly.Bulkhead
             int maxQueueingActions,
             SemaphoreSlim maxParallelizationSemaphore,
             SemaphoreSlim maxQueuedActionsSemaphore,
-            Action<Context> onBulkheadRejected
-            ) : base(ExceptionPredicates.None, ResultPredicates<TResult>.None)
+            Action<Context> onBulkheadRejected)
         {
             _maxParallelization = maxParallelization;
             _maxQueueingActions = maxQueueingActions;

--- a/src/Polly.Shared/Caching/AsyncCachePolicy.cs
+++ b/src/Polly.Shared/Caching/AsyncCachePolicy.cs
@@ -29,7 +29,6 @@ namespace Polly.Caching
             Action<Context, string> onCachePut,
             Action<Context, string, Exception> onCacheGetError,
             Action<Context, string, Exception> onCachePutError)
-            : base(ExceptionPredicates.None)
         {
             _asyncCacheProvider = asyncCacheProvider;
             _ttlStrategy = ttlStrategy;
@@ -99,7 +98,6 @@ namespace Polly.Caching
             Action<Context, string> onCachePut,
             Action<Context, string, Exception> onCacheGetError,
             Action<Context, string, Exception> onCachePutError)
-            : base(ExceptionPredicates.None, ResultPredicates<TResult>.None)
         {
             _asyncCacheProvider = asyncCacheProvider;
             _ttlStrategy = ttlStrategy;

--- a/src/Polly.Shared/Caching/CachePolicy.cs
+++ b/src/Polly.Shared/Caching/CachePolicy.cs
@@ -28,7 +28,6 @@ namespace Polly.Caching
             Action<Context, string> onCachePut,
             Action<Context, string, Exception> onCacheGetError,
             Action<Context, string, Exception> onCachePutError)
-            : base(ExceptionPredicates.None)
         {
             _syncCacheProvider = syncCacheProvider;
             _ttlStrategy = ttlStrategy;
@@ -89,7 +88,6 @@ namespace Polly.Caching
             Action<Context, string> onCachePut,
             Action<Context, string, Exception> onCacheGetError,
             Action<Context, string, Exception> onCachePutError)
-            : base(ExceptionPredicates.None, ResultPredicates<TResult>.None)
         {
             _syncCacheProvider = syncCacheProvider;
             _ttlStrategy = ttlStrategy;

--- a/src/Polly.Shared/CircuitBreaker/AdvancedCircuitBreakerSyntax.cs
+++ b/src/Polly.Shared/CircuitBreaker/AdvancedCircuitBreakerSyntax.cs
@@ -243,7 +243,7 @@ namespace Polly
                 onReset,
                 onHalfOpen);
             return new CircuitBreakerPolicy(
-                policyBuilder.ExceptionPredicates,
+                policyBuilder,
                 breakerController
                 );
         }

--- a/src/Polly.Shared/CircuitBreaker/AdvancedCircuitBreakerTResultSyntax.cs
+++ b/src/Polly.Shared/CircuitBreaker/AdvancedCircuitBreakerTResultSyntax.cs
@@ -245,8 +245,7 @@ namespace Polly
                 onReset,
                 onHalfOpen);
             return new CircuitBreakerPolicy<TResult>(
-                policyBuilder.ExceptionPredicates,
-                policyBuilder.ResultPredicates,
+                policyBuilder,
                 breakerController
                 );
         }

--- a/src/Polly.Shared/CircuitBreaker/AsyncAdvancedCircuitBreakerSyntax.cs
+++ b/src/Polly.Shared/CircuitBreaker/AsyncAdvancedCircuitBreakerSyntax.cs
@@ -247,7 +247,7 @@ namespace Polly
                 onReset,
                 onHalfOpen);
             return new AsyncCircuitBreakerPolicy(
-                policyBuilder.ExceptionPredicates,
+                policyBuilder,
                 breakerController
             );
         }

--- a/src/Polly.Shared/CircuitBreaker/AsyncAdvancedCircuitBreakerTResultSyntax.cs
+++ b/src/Polly.Shared/CircuitBreaker/AsyncAdvancedCircuitBreakerTResultSyntax.cs
@@ -246,8 +246,7 @@ namespace Polly
                 onReset,
                 onHalfOpen);
             return new CircuitBreakerPolicy<TResult>(
-                policyBuilder.ExceptionPredicates,
-                policyBuilder.ResultPredicates,
+                policyBuilder,
                 breakerController
             );
         }

--- a/src/Polly.Shared/CircuitBreaker/AsyncCircuitBreakerPolicy.cs
+++ b/src/Polly.Shared/CircuitBreaker/AsyncCircuitBreakerPolicy.cs
@@ -14,9 +14,9 @@ namespace Polly.CircuitBreaker
         internal readonly ICircuitController<EmptyStruct> _breakerController;
 
         internal AsyncCircuitBreakerPolicy(
-            ExceptionPredicates exceptionPredicates, 
+            PolicyBuilder policyBuilder, 
             ICircuitController<EmptyStruct> breakerController
-            ) : base(exceptionPredicates)
+            ) : base(policyBuilder)
         {
             _breakerController = breakerController;
         }
@@ -68,10 +68,9 @@ namespace Polly.CircuitBreaker
         internal readonly ICircuitController<TResult> _breakerController;
 
         internal AsyncCircuitBreakerPolicy(
-            ExceptionPredicates exceptionPredicates, 
-            ResultPredicates<TResult> resultPredicates, 
+            PolicyBuilder<TResult> policyBuilder, 
             ICircuitController<TResult> breakerController
-            ) : base(exceptionPredicates, resultPredicates)
+            ) : base(policyBuilder)
         {
             _breakerController = breakerController;
         }

--- a/src/Polly.Shared/CircuitBreaker/AsyncCircuitBreakerSyntax.cs
+++ b/src/Polly.Shared/CircuitBreaker/AsyncCircuitBreakerSyntax.cs
@@ -209,7 +209,7 @@ namespace Polly
                 onReset,
                 onHalfOpen);
             return new AsyncCircuitBreakerPolicy(
-                policyBuilder.ExceptionPredicates,
+                policyBuilder,
                 breakerController
             );
         }

--- a/src/Polly.Shared/CircuitBreaker/AsyncCircuitBreakerTResultSyntax.cs
+++ b/src/Polly.Shared/CircuitBreaker/AsyncCircuitBreakerTResultSyntax.cs
@@ -208,8 +208,7 @@ namespace Polly
                 onReset,
                 onHalfOpen);
             return new AsyncCircuitBreakerPolicy<TResult>(
-                policyBuilder.ExceptionPredicates,
-                policyBuilder.ResultPredicates,
+                policyBuilder,
                 breakerController
             );
         }

--- a/src/Polly.Shared/CircuitBreaker/CircuitBreakerPolicy.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitBreakerPolicy.cs
@@ -13,9 +13,9 @@ namespace Polly.CircuitBreaker
         internal readonly ICircuitController<EmptyStruct> _breakerController;
 
         internal CircuitBreakerPolicy(
-            ExceptionPredicates exceptionPredicates,
+            PolicyBuilder policyBuilder,
             ICircuitController<EmptyStruct> breakerController
-            ) : base(exceptionPredicates)
+            ) : base(policyBuilder)
             => _breakerController = breakerController;
 
         /// <summary>
@@ -63,10 +63,9 @@ namespace Polly.CircuitBreaker
         internal readonly ICircuitController<TResult> _breakerController;
 
         internal CircuitBreakerPolicy(
-            ExceptionPredicates exceptionPredicates, 
-            ResultPredicates<TResult> resultPredicates, 
+            PolicyBuilder<TResult> policyBuilder, 
             ICircuitController<TResult> breakerController
-            ) : base(exceptionPredicates, resultPredicates)
+            ) : base(policyBuilder)
             => _breakerController = breakerController;
 
         /// <summary>

--- a/src/Polly.Shared/CircuitBreaker/CircuitBreakerSyntax.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitBreakerSyntax.cs
@@ -210,7 +210,7 @@ namespace Polly
                 onReset,
                 onHalfOpen);
             return new CircuitBreakerPolicy(
-                policyBuilder.ExceptionPredicates,
+                policyBuilder,
                 breakerController
                 );
         }

--- a/src/Polly.Shared/CircuitBreaker/CircuitBreakerTResultSyntax.cs
+++ b/src/Polly.Shared/CircuitBreaker/CircuitBreakerTResultSyntax.cs
@@ -209,8 +209,7 @@ namespace Polly
                 onReset,
                 onHalfOpen);
             return new CircuitBreakerPolicy<TResult>(
-                policyBuilder.ExceptionPredicates,
-                policyBuilder.ResultPredicates,
+                policyBuilder,
                 breakerController
                 );
         }

--- a/src/Polly.Shared/Fallback/AsyncFallbackPolicy.cs
+++ b/src/Polly.Shared/Fallback/AsyncFallbackPolicy.cs
@@ -14,11 +14,9 @@ namespace Polly.Fallback
         private Func<Exception, Context, Task> _onFallbackAsync;
         private Func<Exception, Context, CancellationToken, Task> _fallbackAction;
 
-        internal AsyncFallbackPolicy(
-            Func<Exception, Context, Task> onFallbackAsync,
-            Func<Exception, Context, CancellationToken, Task> fallbackAction,
-            ExceptionPredicates exceptionPredicates)
-           : base(exceptionPredicates)
+        internal AsyncFallbackPolicy(PolicyBuilder policyBuilder, Func<Exception, Context, Task> onFallbackAsync,
+            Func<Exception, Context, CancellationToken, Task> fallbackAction)
+           : base(policyBuilder)
         {
             _onFallbackAsync = onFallbackAsync ?? throw new ArgumentNullException(nameof(onFallbackAsync));
             _fallbackAction = fallbackAction ?? throw new ArgumentNullException(nameof(fallbackAction));
@@ -63,11 +61,10 @@ namespace Polly.Fallback
         private Func<DelegateResult<TResult>, Context, CancellationToken, Task<TResult>> _fallbackAction;
 
         internal AsyncFallbackPolicy(
-            ExceptionPredicates exceptionPredicates,
-            ResultPredicates<TResult> resultPredicates,
+            PolicyBuilder<TResult> policyBuilder,
             Func<DelegateResult<TResult>, Context, Task> onFallbackAsync, 
             Func<DelegateResult<TResult>, Context, CancellationToken, Task<TResult>> fallbackAction
-            ) : base(exceptionPredicates, resultPredicates)
+            ) : base(policyBuilder)
         {
             _onFallbackAsync = onFallbackAsync ?? throw new ArgumentNullException(nameof(onFallbackAsync));
             _fallbackAction = fallbackAction ?? throw new ArgumentNullException(nameof(fallbackAction));

--- a/src/Polly.Shared/Fallback/AsyncFallbackSyntax.cs
+++ b/src/Polly.Shared/Fallback/AsyncFallbackSyntax.cs
@@ -80,10 +80,7 @@ namespace Polly
             if (fallbackAction == null) throw new ArgumentNullException(nameof(fallbackAction));
             if (onFallbackAsync == null) throw new ArgumentNullException(nameof(onFallbackAsync));
 
-            return new AsyncFallbackPolicy(
-                    onFallbackAsync,
-                    fallbackAction, 
-                    policyBuilder.ExceptionPredicates);
+            return new AsyncFallbackPolicy(policyBuilder, onFallbackAsync, fallbackAction);
         }
     }
 
@@ -213,8 +210,7 @@ namespace Polly
             if (onFallbackAsync == null) throw new ArgumentNullException(nameof(onFallbackAsync));
 
             return new AsyncFallbackPolicy<TResult>(
-                    policyBuilder.ExceptionPredicates,
-                    policyBuilder.ResultPredicates,
+                    policyBuilder,
                     onFallbackAsync,
                     fallbackAction);
         }

--- a/src/Polly.Shared/Fallback/FallbackPolicy.cs
+++ b/src/Polly.Shared/Fallback/FallbackPolicy.cs
@@ -14,10 +14,10 @@ namespace Polly.Fallback
         private Action<Exception, Context, CancellationToken> _fallbackAction;
 
         internal FallbackPolicy(
-            ExceptionPredicates exceptionPredicates,
+            PolicyBuilder policyBuilder,
             Action<Exception, Context> onFallback,
             Action<Exception, Context, CancellationToken> fallbackAction)
-            : base(exceptionPredicates)
+            : base(policyBuilder)
         {
             _onFallback = onFallback ?? throw new ArgumentNullException(nameof(onFallback));
             _fallbackAction = fallbackAction ?? throw new ArgumentNullException(nameof(fallbackAction));
@@ -49,11 +49,10 @@ namespace Polly.Fallback
         private Func<DelegateResult<TResult>, Context, CancellationToken, TResult> _fallbackAction;
 
         internal FallbackPolicy(
-            ExceptionPredicates exceptionPredicates,
-            ResultPredicates<TResult> resultPredicates,
+            PolicyBuilder<TResult> policyBuilder,
             Action<DelegateResult<TResult>, Context> onFallback,
             Func<DelegateResult<TResult>, Context, CancellationToken, TResult> fallbackAction
-            ) : base(exceptionPredicates, resultPredicates)
+            ) : base(policyBuilder)
         {
             _onFallback = onFallback ?? throw new ArgumentNullException(nameof(onFallback));
             _fallbackAction = fallbackAction ?? throw new ArgumentNullException(nameof(fallbackAction));

--- a/src/Polly.Shared/Fallback/FallbackSyntax.cs
+++ b/src/Polly.Shared/Fallback/FallbackSyntax.cs
@@ -123,7 +123,7 @@ namespace Polly
             if (onFallback == null) throw new ArgumentNullException(nameof(onFallback));
 
             return new FallbackPolicy(
-                    policyBuilder.ExceptionPredicates,
+                    policyBuilder,
                     onFallback,
                     fallbackAction);
         }
@@ -289,8 +289,7 @@ namespace Polly
             if (onFallback == null) throw new ArgumentNullException(nameof(onFallback));
 
             return new FallbackPolicy<TResult>(
-                policyBuilder.ExceptionPredicates,
-                policyBuilder.ResultPredicates,
+                policyBuilder,
                 onFallback,
                 fallbackAction);
         }

--- a/src/Polly.Shared/NoOp/AsyncNoOpPolicy.cs
+++ b/src/Polly.Shared/NoOp/AsyncNoOpPolicy.cs
@@ -11,7 +11,6 @@ namespace Polly.NoOp
     public class AsyncNoOpPolicy : AsyncPolicy, INoOpPolicy
     {
         internal AsyncNoOpPolicy() 
-            : base(ExceptionPredicates.None)
         {
         }
 
@@ -28,7 +27,6 @@ namespace Polly.NoOp
     public class AsyncNoOpPolicy<TResult> : AsyncPolicy<TResult>, INoOpPolicy<TResult>
     {
         internal AsyncNoOpPolicy() 
-            : base(ExceptionPredicates.None, ResultPredicates<TResult>.None)
         {
         }
 

--- a/src/Polly.Shared/NoOp/NoOpPolicy.cs
+++ b/src/Polly.Shared/NoOp/NoOpPolicy.cs
@@ -10,7 +10,6 @@ namespace Polly.NoOp
     public class NoOpPolicy : Policy, INoOpPolicy
     {
         internal NoOpPolicy()
-            : base(ExceptionPredicates.None)
         {
         }
 
@@ -26,7 +25,7 @@ namespace Polly.NoOp
     /// <typeparam name="TResult">The type of return values this policy will handle.</typeparam>
     public class NoOpPolicy<TResult> : Policy<TResult>, INoOpPolicy<TResult>
     {
-        internal NoOpPolicy() : base(ExceptionPredicates.None, ResultPredicates<TResult>.None)
+        internal NoOpPolicy()
         {
         }
 

--- a/src/Polly.Shared/Policy.TResult.cs
+++ b/src/Polly.Shared/Policy.TResult.cs
@@ -10,10 +10,18 @@
         /// </summary>
         /// <param name="exceptionPredicates">Predicates indicating which exceptions the policy should handle.</param>
         /// <param name="resultPredicates">Predicates indicating which results the policy should handle.</param>
-        protected Policy(ExceptionPredicates exceptionPredicates, ResultPredicates<TResult> resultPredicates)
+        internal Policy(ExceptionPredicates exceptionPredicates, ResultPredicates<TResult> resultPredicates)
         : base(exceptionPredicates, resultPredicates)
         {
         }
-    }
 
+        /// <summary>
+        /// Constructs a new instance of a derived <see cref="Policy{TResult}"/> type with the passed <paramref name="policyBuilder"/>.
+        /// </summary>
+        /// <param name="policyBuilder">A <see cref="PolicyBuilder{TResult}"/> indicating which exceptions and results the policy should handle.</param>
+        protected Policy(PolicyBuilder<TResult> policyBuilder = null)
+            : base(policyBuilder)
+        {
+        }
+    }
 }

--- a/src/Polly.Shared/Policy.cs
+++ b/src/Polly.Shared/Policy.cs
@@ -9,8 +9,17 @@
         /// Constructs a new instance of a derived <see cref="Policy"/> type with the passed <paramref name="exceptionPredicates"/>. 
         /// </summary>
         /// <param name="exceptionPredicates">Predicates indicating which exceptions the policy should handle. </param>
-        protected Policy(ExceptionPredicates exceptionPredicates)
+        internal Policy(ExceptionPredicates exceptionPredicates)
             : base(exceptionPredicates)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new instance of a derived <see cref="Policy"/> type with the passed <paramref name="policyBuilder"/>. 
+        /// </summary>
+        /// <param name="policyBuilder">A <see cref="PolicyBuilder"/> specifying which exceptions the policy should handle. </param>
+        protected Policy(PolicyBuilder policyBuilder = null)
+            : base(policyBuilder)
         {
         }
     }

--- a/src/Polly.Shared/PolicyBase.cs
+++ b/src/Polly.Shared/PolicyBase.cs
@@ -11,7 +11,7 @@ namespace Polly
         /// <summary>
         /// Predicates indicating which exceptions the policy handles.
         /// </summary>
-        public ExceptionPredicates ExceptionPredicates { get; }
+        protected internal ExceptionPredicates ExceptionPredicates { get; }
 
         /// <summary>
         /// Defines a CancellationToken to use, when none is supplied.
@@ -36,10 +36,18 @@ namespace Polly
         /// Constructs a new instance of a derived type of <see cref="PolicyBase"/> with the passed <paramref name="exceptionPredicates"/>.
         /// </summary>
         /// <param name="exceptionPredicates">Predicates indicating which exceptions the policy should handle. </param>
-        protected PolicyBase(
-            ExceptionPredicates exceptionPredicates)
+        internal PolicyBase(ExceptionPredicates exceptionPredicates)
         {
             ExceptionPredicates = exceptionPredicates ?? ExceptionPredicates.None;
+        }
+
+        /// <summary>
+        /// Constructs a new instance of a derived type of <see cref="PolicyBase"/> with the passed <paramref name="policyBuilder"/>.
+        /// </summary>
+        /// <param name="policyBuilder">A <see cref="PolicyBuilder"/> indicating which exceptions the policy should handle.</param>
+        protected PolicyBase(PolicyBuilder policyBuilder)
+            : this(policyBuilder?.ExceptionPredicates)
+        {
         }
     }
 
@@ -51,19 +59,28 @@ namespace Polly
         /// <summary>
         /// Predicates indicating which results the policy handles.
         /// </summary>
-        public ResultPredicates<TResult> ResultPredicates { get; }
+        protected internal ResultPredicates<TResult> ResultPredicates { get; }
 
         /// <summary>
-        /// Constructs a new instance of a derived type of <see cref="PolicyBase{TResult}"/> with the passed <paramref name="exceptionPredicates"/> and <paramref name="resultPredicates"/>.
+        /// Constructs a new instance of a derived type of <see cref="PolicyBase{TResult}"/>.
         /// </summary>
         /// <param name="exceptionPredicates">Predicates indicating which exceptions the policy should handle. </param>
         /// <param name="resultPredicates">Predicates indicating which results the policy should handle. </param>
-        protected PolicyBase(
+        internal PolicyBase(
             ExceptionPredicates exceptionPredicates,
             ResultPredicates<TResult> resultPredicates)
         : base(exceptionPredicates)
         {
             ResultPredicates = resultPredicates ?? ResultPredicates<TResult>.None;
         }
-}
+
+        /// <summary>
+        /// Constructs a new instance of a derived type of <see cref="PolicyBase{TResult}"/> with the passed <paramref name="policyBuilder"/>.
+        /// </summary>
+        /// <param name="policyBuilder">A <see cref="PolicyBuilder"/> indicating which exceptions the policy should handle.</param>
+        protected PolicyBase(PolicyBuilder<TResult> policyBuilder)
+            : this(policyBuilder?.ExceptionPredicates, policyBuilder?.ResultPredicates)
+        {
+        }
+    }
 }

--- a/src/Polly.Shared/PolicyBuilder.cs
+++ b/src/Polly.Shared/PolicyBuilder.cs
@@ -17,7 +17,7 @@ namespace Polly
         /// <summary>
         /// Predicates specifying exceptions that the policy is being configured to handle.
         /// </summary>
-        public ExceptionPredicates ExceptionPredicates { get; }
+        internal ExceptionPredicates ExceptionPredicates { get; }
 
         #region Hide object members
 
@@ -103,12 +103,12 @@ namespace Polly
         /// <summary>
         /// Predicates specifying exceptions that the policy is being configured to handle.
         /// </summary>
-        public ExceptionPredicates ExceptionPredicates { get; }
+        internal ExceptionPredicates ExceptionPredicates { get; }
 
         /// <summary>
         /// Predicates specifying results that the policy is being configured to handle.
         /// </summary>
-        public ResultPredicates<TResult> ResultPredicates { get; }
+        internal ResultPredicates<TResult> ResultPredicates { get; }
 
         #region Hide object members
 

--- a/src/Polly.Shared/Retry/AsyncRetryPolicy.cs
+++ b/src/Polly.Shared/Retry/AsyncRetryPolicy.cs
@@ -17,13 +17,13 @@ namespace Polly.Retry
         private readonly Func<int, Exception, Context, TimeSpan> _sleepDurationProvider;
 
         internal AsyncRetryPolicy(
-            ExceptionPredicates exceptionPredicates,
+            PolicyBuilder policyBuilder,
             Func<Exception, TimeSpan, int, Context, Task> onRetryAsync,
             int permittedRetryCount = Int32.MaxValue,
             IEnumerable<TimeSpan> sleepDurationsEnumerable = null,
             Func<int, Exception, Context, TimeSpan> sleepDurationProvider = null
         )
-            : base(exceptionPredicates)
+            : base(policyBuilder)
         {
             _permittedRetryCount = permittedRetryCount;
             _sleepDurationsEnumerable = sleepDurationsEnumerable;
@@ -63,14 +63,13 @@ namespace Polly.Retry
         private readonly Func<int, DelegateResult<TResult>, Context, TimeSpan> _sleepDurationProvider;
 
         internal AsyncRetryPolicy(
-            ExceptionPredicates exceptionPredicates,
-            ResultPredicates<TResult> resultPredicates,
+            PolicyBuilder<TResult> policyBuilder,
             Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync,
             int permittedRetryCount = Int32.MaxValue,
             IEnumerable<TimeSpan> sleepDurationsEnumerable = null,
             Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider = null
         )
-            : base(exceptionPredicates, resultPredicates)
+            : base(policyBuilder)
         {
             _permittedRetryCount = permittedRetryCount;
             _sleepDurationsEnumerable = sleepDurationsEnumerable;

--- a/src/Polly.Shared/Retry/AsyncRetrySyntax.cs
+++ b/src/Polly.Shared/Retry/AsyncRetrySyntax.cs
@@ -155,7 +155,7 @@ namespace Polly
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             return new AsyncRetryPolicy(
-                policyBuilder.ExceptionPredicates,
+                policyBuilder,
                 (outcome, timespan, i, ctx) => onRetryAsync(outcome, i, ctx),
                 retryCount
             );
@@ -292,7 +292,7 @@ namespace Polly
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             return new AsyncRetryPolicy(
-                policyBuilder.ExceptionPredicates,
+                policyBuilder,
                 (outcome, timespan, i, ctx) => onRetryAsync(outcome, ctx)
             );
         }
@@ -310,7 +310,7 @@ namespace Polly
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             return new AsyncRetryPolicy(
-                policyBuilder.ExceptionPredicates,
+                policyBuilder,
                 (outcome, timespan, i, ctx) => onRetryAsync(outcome, i, ctx)
             );
         }
@@ -509,7 +509,7 @@ namespace Polly
                 .Select(sleepDurationProvider);
 
             return new AsyncRetryPolicy(
-                policyBuilder.ExceptionPredicates,
+                policyBuilder,
                 onRetryAsync,
                 retryCount,
                 sleepDurationsEnumerable: sleepDurations
@@ -658,7 +658,7 @@ namespace Polly
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
             
             return new AsyncRetryPolicy(
-                policyBuilder.ExceptionPredicates,
+                policyBuilder,
                 onRetryAsync,
                 retryCount,
                 sleepDurationProvider: sleepDurationProvider
@@ -833,7 +833,7 @@ namespace Polly
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             return new AsyncRetryPolicy(
-                policyBuilder.ExceptionPredicates,
+                policyBuilder,
                 onRetryAsync,
                 sleepDurationsEnumerable: sleepDurations
             );
@@ -1077,7 +1077,7 @@ namespace Polly
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             return new AsyncRetryPolicy(
-                policyBuilder.ExceptionPredicates,
+                policyBuilder,
                 (outcome, timespan, i, ctx) => onRetryAsync(outcome, timespan, ctx),
                 sleepDurationProvider: sleepDurationProvider);
         }
@@ -1100,7 +1100,7 @@ namespace Polly
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             return new AsyncRetryPolicy(
-                policyBuilder.ExceptionPredicates,
+                policyBuilder,
                 (exception, timespan, i, ctx) => onRetryAsync(exception, i, timespan, ctx),
                 sleepDurationProvider: sleepDurationProvider
             );

--- a/src/Polly.Shared/Retry/AsyncRetryTResultSyntax.cs
+++ b/src/Polly.Shared/Retry/AsyncRetryTResultSyntax.cs
@@ -155,8 +155,7 @@ namespace Polly
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             return new AsyncRetryPolicy<TResult>(
-                policyBuilder.ExceptionPredicates,
-                policyBuilder.ResultPredicates,
+                policyBuilder,
                 (outcome, timespan, i, ctx) => onRetryAsync(outcome, i, ctx),
                 retryCount
             );
@@ -293,8 +292,7 @@ namespace Polly
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             return new AsyncRetryPolicy<TResult>(
-                policyBuilder.ExceptionPredicates,
-                policyBuilder.ResultPredicates,
+                policyBuilder,
                 (outcome, timespan, i, ctx) => onRetryAsync(outcome, ctx)
             );
         }
@@ -312,8 +310,7 @@ namespace Polly
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             return new AsyncRetryPolicy<TResult>(
-                policyBuilder.ExceptionPredicates,
-                policyBuilder.ResultPredicates,
+                policyBuilder,
                 (outcome, timespan, i, ctx) => onRetryAsync(outcome, i, ctx)
             );
         }
@@ -512,8 +509,7 @@ namespace Polly
                 .Select(sleepDurationProvider);
 
             return new AsyncRetryPolicy<TResult>(
-                policyBuilder.ExceptionPredicates,
-                policyBuilder.ResultPredicates,
+                policyBuilder,
                 onRetryAsync,
                 retryCount,
                 sleepDurationsEnumerable: sleepDurations
@@ -661,8 +657,7 @@ namespace Polly
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             return new AsyncRetryPolicy<TResult>(
-                policyBuilder.ExceptionPredicates,
-                policyBuilder.ResultPredicates,
+                policyBuilder,
                 onRetryAsync,
                 retryCount,
                 sleepDurationProvider: sleepDurationProvider
@@ -837,8 +832,7 @@ namespace Polly
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             return new AsyncRetryPolicy<TResult>(
-                policyBuilder.ExceptionPredicates,
-                policyBuilder.ResultPredicates,
+                policyBuilder,
                 onRetryAsync,
                 sleepDurationsEnumerable: sleepDurations
             );
@@ -1080,8 +1074,7 @@ namespace Polly
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             return new AsyncRetryPolicy<TResult>(
-                policyBuilder.ExceptionPredicates,
-                policyBuilder.ResultPredicates,
+                policyBuilder,
                 (outcome, timespan, i, ctx) => onRetryAsync(outcome, timespan, ctx),
                 sleepDurationProvider: sleepDurationProvider);
         }
@@ -1104,8 +1097,7 @@ namespace Polly
             if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             return new AsyncRetryPolicy<TResult>(
-                policyBuilder.ExceptionPredicates,
-                policyBuilder.ResultPredicates,
+                policyBuilder,
                 (exception, timespan, i, ctx) => onRetryAsync(exception, i, timespan, ctx),
                 sleepDurationProvider: sleepDurationProvider
             );

--- a/src/Polly.Shared/Retry/RetryPolicy.cs
+++ b/src/Polly.Shared/Retry/RetryPolicy.cs
@@ -16,13 +16,13 @@ namespace Polly.Retry
         private readonly Func<int, Exception, Context, TimeSpan> _sleepDurationProvider;
 
         internal RetryPolicy(
-            ExceptionPredicates exceptionPredicates,
+            PolicyBuilder policyBuilder,
             Action<Exception, TimeSpan, int, Context> onRetry, 
             int permittedRetryCount = Int32.MaxValue,
             IEnumerable<TimeSpan> sleepDurationsEnumerable = null,
             Func<int, Exception, Context, TimeSpan> sleepDurationProvider = null
             ) 
-            : base(exceptionPredicates)
+            : base(policyBuilder)
         {
             _permittedRetryCount = permittedRetryCount;
             _sleepDurationsEnumerable = sleepDurationsEnumerable;
@@ -58,14 +58,13 @@ namespace Polly.Retry
         private readonly Func<int, DelegateResult<TResult>, Context, TimeSpan> _sleepDurationProvider;
 
         internal RetryPolicy(
-            ExceptionPredicates exceptionPredicates,
-            ResultPredicates<TResult> resultPredicates,
+            PolicyBuilder<TResult> policyBuilder,
             Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry,
             int permittedRetryCount = Int32.MaxValue,
             IEnumerable<TimeSpan> sleepDurationsEnumerable = null,
             Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider = null
         )
-            : base(exceptionPredicates, resultPredicates)
+            : base(policyBuilder)
         {
             _permittedRetryCount = permittedRetryCount;
             _sleepDurationsEnumerable = sleepDurationsEnumerable;

--- a/src/Polly.Shared/Retry/RetrySyntax.cs
+++ b/src/Polly.Shared/Retry/RetrySyntax.cs
@@ -87,7 +87,7 @@ namespace Polly
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return new RetryPolicy(
-                policyBuilder.ExceptionPredicates,
+                policyBuilder,
                 (outcome, timespan, i, ctx) => onRetry(outcome, i, ctx),
                 retryCount);
         }
@@ -147,7 +147,7 @@ namespace Polly
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
                 return new RetryPolicy(
-                    policyBuilder.ExceptionPredicates,
+                    policyBuilder,
                     (outcome, timespan, i, ctx) => onRetry(outcome, ctx)
                     );
         }
@@ -165,7 +165,7 @@ namespace Polly
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return new RetryPolicy(
-                policyBuilder.ExceptionPredicates,
+                policyBuilder,
                 (outcome, timespan, i, ctx) => onRetry(outcome, i, ctx)
             );
         }
@@ -269,7 +269,7 @@ namespace Polly
                                            .Select(sleepDurationProvider);
 
             return new RetryPolicy(
-                policyBuilder.ExceptionPredicates,
+                policyBuilder,
                 onRetry,
                 retryCount, 
                 sleepDurationsEnumerable: sleepDurations
@@ -371,7 +371,7 @@ namespace Polly
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
                 return new RetryPolicy(
-                    policyBuilder.ExceptionPredicates,
+                    policyBuilder,
                     onRetry,
                     retryCount,
                     sleepDurationProvider: sleepDurationProvider
@@ -454,7 +454,7 @@ namespace Polly
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return new RetryPolicy(
-                policyBuilder.ExceptionPredicates,
+                policyBuilder,
                 onRetry,
                 sleepDurationsEnumerable: sleepDurations
                 );
@@ -602,7 +602,7 @@ namespace Polly
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return new RetryPolicy(
-                policyBuilder.ExceptionPredicates,
+                policyBuilder,
                 (outcome, timespan, i, ctx) => onRetry(outcome, timespan, ctx),
                 sleepDurationProvider: sleepDurationProvider);
         }
@@ -625,7 +625,7 @@ namespace Polly
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return new RetryPolicy(
-                policyBuilder.ExceptionPredicates, 
+                policyBuilder, 
                 (exception, timespan, i, ctx) => onRetry(exception, i, timespan, ctx),
                 sleepDurationProvider: sleepDurationProvider
                 );

--- a/src/Polly.Shared/Retry/RetryTResultSyntax.cs
+++ b/src/Polly.Shared/Retry/RetryTResultSyntax.cs
@@ -87,8 +87,7 @@ namespace Polly
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return new RetryPolicy<TResult>(
-                policyBuilder.ExceptionPredicates,
-                policyBuilder.ResultPredicates,
+                policyBuilder,
                 (outcome, timespan, i, ctx) => onRetry(outcome, i, ctx),
                 retryCount);
         }
@@ -148,8 +147,7 @@ namespace Polly
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return new RetryPolicy<TResult>(
-                policyBuilder.ExceptionPredicates,
-                policyBuilder.ResultPredicates,
+                policyBuilder,
                 (outcome, timespan, i, ctx) => onRetry(outcome, ctx)
                 );
         }
@@ -167,8 +165,7 @@ namespace Polly
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return new RetryPolicy<TResult>(
-                policyBuilder.ExceptionPredicates,
-                policyBuilder.ResultPredicates,
+                policyBuilder,
                 (outcome, timespan, i, ctx) => onRetry(outcome, i, ctx)
             );
         }
@@ -272,8 +269,7 @@ namespace Polly
                                            .Select(sleepDurationProvider);
 
             return new RetryPolicy<TResult>(
-                policyBuilder.ExceptionPredicates,
-                policyBuilder.ResultPredicates,
+                policyBuilder,
                 onRetry,
                 retryCount,
                 sleepDurationsEnumerable: sleepDurations
@@ -416,8 +412,7 @@ namespace Polly
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return new RetryPolicy<TResult>(
-                policyBuilder.ExceptionPredicates,
-                policyBuilder.ResultPredicates,
+                policyBuilder,
                 onRetry,
                 retryCount,
                 sleepDurationProvider: sleepDurationProvider
@@ -500,8 +495,7 @@ namespace Polly
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return new RetryPolicy<TResult>(
-                policyBuilder.ExceptionPredicates,
-                policyBuilder.ResultPredicates,
+                policyBuilder,
                 onRetry,
                 sleepDurationsEnumerable: sleepDurations
             );
@@ -649,8 +643,7 @@ namespace Polly
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return new RetryPolicy<TResult>(
-                policyBuilder.ExceptionPredicates,
-                policyBuilder.ResultPredicates,
+                policyBuilder,
                 (outcome, timespan, i, ctx) => onRetry(outcome, timespan, ctx),
                 sleepDurationProvider: sleepDurationProvider);
         }
@@ -673,8 +666,7 @@ namespace Polly
             if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return new RetryPolicy<TResult>(
-                policyBuilder.ExceptionPredicates,
-                policyBuilder.ResultPredicates,
+                policyBuilder,
                 (exception, timespan, i, ctx) => onRetry(exception, i, timespan, ctx),
                 sleepDurationProvider: sleepDurationProvider
                 );

--- a/src/Polly.Shared/Timeout/AsyncTimeoutPolicy.cs
+++ b/src/Polly.Shared/Timeout/AsyncTimeoutPolicy.cs
@@ -19,7 +19,6 @@ namespace Polly.Timeout
             TimeoutStrategy timeoutStrategy,
             Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync
             )
-           : base(ExceptionPredicates.None)
         {
             _timeoutProvider = timeoutProvider ?? throw new ArgumentNullException(nameof(timeoutProvider));
             _timeoutStrategy = timeoutStrategy;
@@ -58,8 +57,7 @@ namespace Polly.Timeout
         internal AsyncTimeoutPolicy(
             Func<Context, TimeSpan> timeoutProvider,
             TimeoutStrategy timeoutStrategy,
-            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync
-            ) : base(ExceptionPredicates.None, ResultPredicates<TResult>.None)
+            Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
         {
             _timeoutProvider = timeoutProvider ?? throw new ArgumentNullException(nameof(timeoutProvider));
             _timeoutStrategy = timeoutStrategy;

--- a/src/Polly.Shared/Timeout/TimeoutPolicy.cs
+++ b/src/Polly.Shared/Timeout/TimeoutPolicy.cs
@@ -18,7 +18,6 @@ namespace Polly.Timeout
             Func<Context, TimeSpan> timeoutProvider,
             TimeoutStrategy timeoutStrategy,
             Action<Context, TimeSpan, Task, Exception> onTimeout) 
-            : base(ExceptionPredicates.None)
         {
             _timeoutProvider = timeoutProvider ?? throw new ArgumentNullException(nameof(timeoutProvider));
             _timeoutStrategy = timeoutStrategy;
@@ -49,8 +48,7 @@ namespace Polly.Timeout
         internal TimeoutPolicy(
             Func<Context, TimeSpan> timeoutProvider,
             TimeoutStrategy timeoutStrategy,
-            Action<Context, TimeSpan, Task, Exception> onTimeout) 
-            : base(ExceptionPredicates.None, ResultPredicates<TResult>.None)
+            Action<Context, TimeSpan, Task, Exception> onTimeout)
         {
             _timeoutProvider = timeoutProvider ?? throw new ArgumentNullException(nameof(timeoutProvider));
             _timeoutStrategy = timeoutStrategy;

--- a/src/Polly.SharedSpecs/Helpers/Custom/AddBehaviourIfHandle/AddBehaviourIfHandlePolicy.cs
+++ b/src/Polly.SharedSpecs/Helpers/Custom/AddBehaviourIfHandle/AddBehaviourIfHandlePolicy.cs
@@ -7,8 +7,8 @@ namespace Polly.Specs.Helpers.Custom.AddBehaviourIfHandle
     {
         private readonly Action<Exception> _behaviourIfHandle;
 
-        internal AddBehaviourIfHandlePolicy(Action<Exception> behaviourIfHandle, ExceptionPredicates handleExceptionPredicates)
-            : base(handleExceptionPredicates)
+        internal AddBehaviourIfHandlePolicy(Action<Exception> behaviourIfHandle, PolicyBuilder policyBuilder)
+            : base(policyBuilder)
         {
             _behaviourIfHandle = behaviourIfHandle ?? throw new ArgumentNullException(nameof(behaviourIfHandle));
         }
@@ -35,9 +35,8 @@ namespace Polly.Specs.Helpers.Custom.AddBehaviourIfHandle
 
         internal AddBehaviourIfHandlePolicy(
             Action<DelegateResult<TResult>> behaviourIfHandle,
-            ExceptionPredicates handleExceptionPredicates, 
-            ResultPredicates<TResult> handleResultPredicates)
-            : base(handleExceptionPredicates, handleResultPredicates)
+            PolicyBuilder<TResult> policyBuilder)
+            : base(policyBuilder)
         {
             _behaviourIfHandle = behaviourIfHandle ?? throw new ArgumentNullException(nameof(behaviourIfHandle));
         }

--- a/src/Polly.SharedSpecs/Helpers/Custom/AddBehaviourIfHandle/AddBehaviourIfHandleSyntax.cs
+++ b/src/Polly.SharedSpecs/Helpers/Custom/AddBehaviourIfHandle/AddBehaviourIfHandleSyntax.cs
@@ -8,14 +8,14 @@ namespace Polly.Specs.Helpers.Custom.AddBehaviourIfHandle
         {
             if (behaviourIfHandle == null) throw new ArgumentNullException(nameof(behaviourIfHandle));
 
-            return new AddBehaviourIfHandlePolicy(behaviourIfHandle, policyBuilder.ExceptionPredicates);
+            return new AddBehaviourIfHandlePolicy(behaviourIfHandle, policyBuilder);
         }
 
         internal static AddBehaviourIfHandlePolicy<TResult> WithBehaviour<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>> behaviourIfHandle)
         {
             if (behaviourIfHandle == null) throw new ArgumentNullException(nameof(behaviourIfHandle));
 
-            return new AddBehaviourIfHandlePolicy<TResult>(behaviourIfHandle, policyBuilder.ExceptionPredicates, policyBuilder.ResultPredicates);
+            return new AddBehaviourIfHandlePolicy<TResult>(behaviourIfHandle, policyBuilder);
         }
     }
 }

--- a/src/Polly.SharedSpecs/Helpers/Custom/AddBehaviourIfHandle/AsyncAddBehaviourIfHandlePolicy.cs
+++ b/src/Polly.SharedSpecs/Helpers/Custom/AddBehaviourIfHandle/AsyncAddBehaviourIfHandlePolicy.cs
@@ -9,8 +9,8 @@ namespace Polly.Specs.Helpers.Custom.AddBehaviourIfHandle
 
         internal AsyncAddBehaviourIfHandlePolicy(
             Func<Exception, Task> behaviourIfHandle, 
-            ExceptionPredicates handleExceptionPredicates)
-            : base(handleExceptionPredicates)
+            PolicyBuilder policyBuilder)
+            : base(policyBuilder)
         {
             _behaviourIfHandle = behaviourIfHandle ?? throw new ArgumentNullException(nameof(behaviourIfHandle));
         }
@@ -36,9 +36,8 @@ namespace Polly.Specs.Helpers.Custom.AddBehaviourIfHandle
 
         internal AsyncAddBehaviourIfHandlePolicy(
             Func<DelegateResult<TResult>, Task> behaviourIfHandle,
-            ExceptionPredicates handleExceptionPredicates, 
-            ResultPredicates<TResult> handleResultPredicates)
-            : base(handleExceptionPredicates, handleResultPredicates)
+            PolicyBuilder<TResult> policyBuilder)
+            : base(policyBuilder)
         {
             _behaviourIfHandle = behaviourIfHandle ?? throw new ArgumentNullException(nameof(behaviourIfHandle));
 

--- a/src/Polly.SharedSpecs/Helpers/Custom/AddBehaviourIfHandle/AsyncAddBehaviourIfHandleSyntax.cs
+++ b/src/Polly.SharedSpecs/Helpers/Custom/AddBehaviourIfHandle/AsyncAddBehaviourIfHandleSyntax.cs
@@ -11,7 +11,7 @@ namespace Polly.Specs.Helpers.Custom.AddBehaviourIfHandle
         {
             if (behaviourIfHandle == null) throw new ArgumentNullException(nameof(behaviourIfHandle));
 
-            return new AsyncAddBehaviourIfHandlePolicy(behaviourIfHandle, policyBuilder.ExceptionPredicates);
+            return new AsyncAddBehaviourIfHandlePolicy(behaviourIfHandle, policyBuilder);
         }
 
         internal static AsyncAddBehaviourIfHandlePolicy<TResult> WithBehaviourAsync<TResult>(
@@ -20,7 +20,7 @@ namespace Polly.Specs.Helpers.Custom.AddBehaviourIfHandle
         {
             if (behaviourIfHandle == null) throw new ArgumentNullException(nameof(behaviourIfHandle));
 
-            return new AsyncAddBehaviourIfHandlePolicy<TResult>(behaviourIfHandle, policyBuilder.ExceptionPredicates, policyBuilder.ResultPredicates);
+            return new AsyncAddBehaviourIfHandlePolicy<TResult>(behaviourIfHandle, policyBuilder);
         }
     }
 }

--- a/src/Polly.SharedSpecs/Helpers/Custom/PreExecute/AsyncPreExecutePolicy.cs
+++ b/src/Polly.SharedSpecs/Helpers/Custom/PreExecute/AsyncPreExecutePolicy.cs
@@ -14,7 +14,6 @@ namespace Polly.Specs.Helpers.Custom.PreExecute
         }
 
         internal AsyncPreExecutePolicy(Func<Task> preExecute)
-            :base(ExceptionPredicates.None)
         {
             _preExecute = preExecute ?? throw new ArgumentNullException(nameof(preExecute));
         }
@@ -36,7 +35,6 @@ namespace Polly.Specs.Helpers.Custom.PreExecute
         }
 
         internal AsyncPreExecutePolicy(Func<Task> preExecute)
-            : base(ExceptionPredicates.None, ResultPredicates<TResult>.None)
         {
             _preExecute = preExecute ?? throw new ArgumentNullException(nameof(preExecute));
         }

--- a/src/Polly.SharedSpecs/Helpers/Custom/PreExecute/PreExecutePolicy.cs
+++ b/src/Polly.SharedSpecs/Helpers/Custom/PreExecute/PreExecutePolicy.cs
@@ -13,7 +13,6 @@ namespace Polly.Specs.Helpers.Custom.PreExecute
         }
 
         internal PreExecutePolicy(Action preExecute)
-            :base(ExceptionPredicates.None)
         {
             _preExecute = preExecute ?? throw new ArgumentNullException(nameof(preExecute));
         }
@@ -34,7 +33,6 @@ namespace Polly.Specs.Helpers.Custom.PreExecute
         }
 
         internal PreExecutePolicy(Action preExecute)
-            : base(ExceptionPredicates.None, ResultPredicates<TResult>.None)
         {
             _preExecute = preExecute ?? throw new ArgumentNullException(nameof(preExecute));
         }


### PR DESCRIPTION
### The issue or feature being addressed

`ExceptionPredicates` and `ResultPredicates` should not be visible on `PolicyBuilder`, because this confuses syntax when building policies.  

The base classes for constructing policies and custom policies (#551) thus need to take `PolicyBuilder` and `PolicyBuilder<TResult>` instances instead of `ExceptionPredicates` and `ResultPredicates`.

Some base policy class constructors taking `ExceptionPredicates` and `ResultPredicates` have to be maintained to support `PolicyWrap` with `ExecuteAndCapture(...)`. Those ctors are made `internal`, to prevent external access.

The policy base classes also gain no-arg ctors for the first time, making constructing proactive (non-reactive) policies more intuitive.

### Confirm the following

- [x]  I started this PR by branching from the head of the latest dev vX.Y branch, or I have rebased on the latest dev vX.Y branch, or I have merged the latest changes from the dev vX.Y branch
- [x]  I have targeted the PR to merge into the latest dev vX.Y branch as the base branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
