### PR TITLE
Correctly state System.ValueTuple dependency for NetStandard 1.1 tfm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.0.1
+- Explicitly state System.ValueTuple dependency in nuspec (for Net Standard 1.1)
+
 ## 7.0.0
 - Clarify separation of sync and async policies (breaking change)
 - Enable extensibility by custom policies hosted external to Polly

--- a/GitVersionConfig.yaml
+++ b/GitVersionConfig.yaml
@@ -1,1 +1,1 @@
-next-version: 7.0.0
+next-version: 7.0.1

--- a/src/Polly.NetStandard11/Properties/AssemblyInfo.cs
+++ b/src/Polly.NetStandard11/Properties/AssemblyInfo.cs
@@ -3,8 +3,8 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Polly")]
-[assembly: AssemblyInformationalVersion("7.0.0.0")]
-[assembly: AssemblyFileVersion("7.0.0.0")]
+[assembly: AssemblyInformationalVersion("7.0.1.0")]
+[assembly: AssemblyFileVersion("7.0.1.0")]
 [assembly: AssemblyVersion("7.0.0.0")]
 [assembly: CLSCompliant(true)]
 

--- a/src/Polly.NetStandard20/Properties/AssemblyInfo.cs
+++ b/src/Polly.NetStandard20/Properties/AssemblyInfo.cs
@@ -3,8 +3,8 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Polly")]
-[assembly: AssemblyInformationalVersion("7.0.0.0")]
-[assembly: AssemblyFileVersion("7.0.0.0")]
+[assembly: AssemblyInformationalVersion("7.0.1.0")]
+[assembly: AssemblyFileVersion("7.0.1.0")]
 [assembly: AssemblyVersion("7.0.0.0")]
 [assembly: CLSCompliant(true)]
 

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -13,6 +13,10 @@
     <tags>Exception Handling Resilience Transient Fault Policy Circuit Breaker CircuitBreaker Retry Wait Cache Cache-aside Bulkhead Fallback Timeout Throttle Parallelization</tags>
     <copyright>Copyright © 2018, App vNext</copyright>
     <releaseNotes>
+     7.0.1
+     ---------------------
+     - Explicitly state System.ValueTuple dependency in nuspec (for Net Standard 1.1)
+
      7.0.0
      ---------------------
      - Clarify separation of sync and async policies (breaking change)
@@ -168,6 +172,7 @@
     <dependencies>
       <group targetFramework="netstandard1.1">
         <dependency id="NETStandard.Library" version="1.6.1" />
+        <dependency id="System.ValueTuple" version="4.5.0" />
       </group>
       <group targetFramework="netstandard2.0"/>
     </dependencies>


### PR DESCRIPTION
### The issue or feature being addressed

Correctly state `System.ValueTuple` dependency (in nuspec) for NetStandard 1.1 tfm.  Affects only nuget installs against Net Standard 1.1 targeting projects (eg .NET Core 1.x)

### Confirm the following

- [x]  I started this PR by branching from the head of the latest dev vX.Y branch, or I have rebased on the latest dev vX.Y branch, or I have merged the latest changes from the dev vX.Y branch
- [n/a]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build and test install against a .NET Core 1.x project
