### PR TITLE
Fix 584; release notes for v7.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-## 7.0.1
-- Explicitly state System.ValueTuple dependency in nuspec (for Net Standard 1.1)
+## 7.0.2
+- Bug fix for PolicyRegistry (issue affecting v7.0.1 only)
 
-## 7.0.0
+## 7.0.1
 - Clarify separation of sync and async policies (breaking change)
 - Enable extensibility by custom policies hosted external to Polly
 - Enable collection initialization syntax for PolicyRegistry

--- a/GitVersionConfig.yaml
+++ b/GitVersionConfig.yaml
@@ -1,1 +1,1 @@
-next-version: 7.0.1
+next-version: 7.0.2

--- a/src/Polly.NetStandard11/Properties/AssemblyInfo.cs
+++ b/src/Polly.NetStandard11/Properties/AssemblyInfo.cs
@@ -3,8 +3,8 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Polly")]
-[assembly: AssemblyInformationalVersion("7.0.1.0")]
-[assembly: AssemblyFileVersion("7.0.1.0")]
+[assembly: AssemblyInformationalVersion("7.0.2.0")]
+[assembly: AssemblyFileVersion("7.0.2.0")]
 [assembly: AssemblyVersion("7.0.0.0")]
 [assembly: CLSCompliant(true)]
 

--- a/src/Polly.NetStandard20/Properties/AssemblyInfo.cs
+++ b/src/Polly.NetStandard20/Properties/AssemblyInfo.cs
@@ -3,8 +3,8 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Polly")]
-[assembly: AssemblyInformationalVersion("7.0.1.0")]
-[assembly: AssemblyFileVersion("7.0.1.0")]
+[assembly: AssemblyInformationalVersion("7.0.2.0")]
+[assembly: AssemblyFileVersion("7.0.2.0")]
 [assembly: AssemblyVersion("7.0.0.0")]
 [assembly: CLSCompliant(true)]
 

--- a/src/Polly.Shared/Registry/PolicyRegistry.cs
+++ b/src/Polly.Shared/Registry/PolicyRegistry.cs
@@ -18,7 +18,7 @@ namespace Polly.Registry
         /// A registry of policy policies with <see cref="System.String"/> keys.
         /// </summary>
         /// <param name="registry">a dictionary containing keys and policies used for testing.</param>
-        internal PolicyRegistry(IDictionary<string, IsPolicy> registry = null) => _registry = registry ?? new ConcurrentDictionary<string, IsPolicy>();
+        public PolicyRegistry(IDictionary<string, IsPolicy> registry = null) => _registry = registry ?? new ConcurrentDictionary<string, IsPolicy>();
 
         /// <summary>
         /// Total number of policies in the registry.

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -13,11 +13,11 @@
     <tags>Exception Handling Resilience Transient Fault Policy Circuit Breaker CircuitBreaker Retry Wait Cache Cache-aside Bulkhead Fallback Timeout Throttle Parallelization</tags>
     <copyright>Copyright © 2018, App vNext</copyright>
     <releaseNotes>
-     7.0.1
+     7.0.2
      ---------------------
-     - Explicitly state System.ValueTuple dependency in nuspec (for Net Standard 1.1)
+     - Bug fix for PolicyRegistry (issue affecting v7.0.1 only)
 
-     7.0.0
+     7.0.1
      ---------------------
      - Clarify separation of sync and async policies (breaking change)
      - Enable extensibility by custom policies hosted external to Polly


### PR DESCRIPTION
### The issue or feature being addressed

+ #584 PolicyRegistry constructor mistakenly became `internal`

### Confirm the following

- [x]  I started this PR by branching from the head of the latest dev vX.Y branch, or I have rebased on the latest dev vX.Y branch, or I have merged the latest changes from the dev vX.Y branch
- [x]  I have targeted the PR to merge into the latest dev vX.Y branch as the base branch
- [n/a]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
