### PR TITLE
.gitignore mac and rider related files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ TestResults
 *.sln.docstates
 .vs/
 .vscode/
+.idea/
 
 # Build results
 [Dd]ebug/
@@ -64,7 +65,7 @@ _ReSharper*
 # GhostDoc
 *.GhostDoc.xml
 
-# Installshield output folder 
+# Installshield output folder
 [Ee]xpress
 
 # DocProject is a documentation generator add-in
@@ -104,6 +105,8 @@ ClientBin
 [Ss]tyle[Cc]op.*
 ~$*
 *.dbmdl
+.DS_Store
+
 Generated_Code #added for RIA/Silverlight projects
 
 # Backup & report files from converting an old project file to a newer


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors.  All non-trivial contributions get a public credit in the readme! -->

### The issue or feature being addressed

A quick fix to .gitignore. 

Cleans up files created by Rider and MacOs and not required for development

### Details on the issue fix or feature implementation

none

### Confirm the following

- [X]  I started this PR by branching from the head of the latest dev vX.Y branch, or I have rebased on the latest dev vX.Y branch, or I have merged the latest changes from the dev vX.Y branch
- [X]  I have targeted the PR to merge into the latest dev vX.Y branch as the base branch
- [ ]  I have included unit tests for the issue/feature
- [X]  I have successfully run a local build
