### PR TITLE
Fix issue 611: MissingMethodException with services.AddPolicyRegistry()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 7.0.4
+- Bug fix: PolicyRegistry with .NET Core services.AddPolicyRegistry() overload (affects Polly v7.0.1-3 only)
 - Rationalise solution layout
 - Add explicit .NET framework 4.6.2 and 4.7.2 test runs
 

--- a/src/Polly.nuspec
+++ b/src/Polly.nuspec
@@ -15,8 +15,7 @@
     <releaseNotes>
      7.0.4
      ---------------------
-     - Rationalise solution layout
-     - Add explicit .NET framework 4.6.2 and 4.7.2 test runs
+     - Bug fix: PolicyRegistry with .NET Core services.AddPolicyRegistry() overload (affects Polly v7.0.1-3 only)
 
      7.0.3
      ---------------------

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -4,11 +4,11 @@
     <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
     <AssemblyName>Polly</AssemblyName>
     <RootNamespace>Polly</RootNamespace>
-    <Version>7.0.4-v704consolidates0001</Version>
+    <Version>7.0.4</Version>
     <AssemblyVersion>7.0.0.0</AssemblyVersion>
     <FileVersion>7.0.4.0</FileVersion>
     <InformationalVersion>7.0.4.0</InformationalVersion>
-    <PackageVersion>7.0.4-v704consolidates0001</PackageVersion>
+    <PackageVersion>7.0.4</PackageVersion>
     <Company>App vNext</Company>
     <Copyright>Copyright (c) 2019, App vNext</Copyright>
     <Description>Polly is a library that allows developers to express resilience and transient fault handling policies such as Retry, Circuit Breaker, Timeout, Bulkhead Isolation, and Fallback in a fluent and thread-safe manner.</Description>

--- a/src/Polly/Registry/PolicyRegistry.cs
+++ b/src/Polly/Registry/PolicyRegistry.cs
@@ -12,13 +12,27 @@ namespace Polly.Registry
     /// <remarks>Uses ConcurrentDictionary to store the collection.</remarks>
     public class PolicyRegistry : IPolicyRegistry<string>
     {
-        private readonly IDictionary<string, IsPolicy> _registry;
+        private readonly IDictionary<string, IsPolicy> _registry = new ConcurrentDictionary<string, IsPolicy>();
+
+        /// <summary>
+        /// A registry of policy policies with <see cref="System.String"/> keys.
+        /// </summary>
+        public PolicyRegistry()
+        {
+            // This empty public constructor must be retained while the adjacent internal constructor exists for testing.
+            // The integration with HttpClientFactory, method services.AddPolicyRegistry(), depends on this empty public constructor.
+            // Do not collapse the two constructors into a constructor with optional parameter registry == null.
+            // That breaks the requirement for a noargs public constructor, against which nuget-published .NET Core dlls have been compiled.
+        }
 
         /// <summary>
         /// A registry of policy policies with <see cref="System.String"/> keys.
         /// </summary>
         /// <param name="registry">a dictionary containing keys and policies used for testing.</param>
-        public PolicyRegistry(IDictionary<string, IsPolicy> registry = null) => _registry = registry ?? new ConcurrentDictionary<string, IsPolicy>();
+        internal PolicyRegistry(IDictionary<string, IsPolicy> registry) 
+        {
+            _registry = registry ?? throw new NullReferenceException(nameof(registry));
+        }
 
         /// <summary>
         /// Total number of policies in the registry.


### PR DESCRIPTION
### The issue or feature being addressed

#611 `MissingMethodException` when using `services.AddPolicyRegistry()`

### Confirm the following

- [x]  I started this PR by branching from the head of the latest dev vX.Y branch, or I have rebased on the latest dev vX.Y branch, or I have merged the latest changes from the dev vX.Y branch
- [x]  I have targeted the PR to merge into the latest dev vX.Y branch as the base branch
- [x]  I have ~included unit tests for the issue/feature~ integration-tested the change against relevant public .NET Core Nuget packages
- [x]  I have successfully run a local build
