### PR TITLE
Update ReadMe re HandleInner

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Policy
   .Or<ArgumentException>(ex => ex.ParamName == "example")
 
 // Inner exceptions of ordinary exceptions or AggregateException, with or without conditions
+// (HandleInner matches exceptions at both the top-level and inner exceptions)
 Policy
   .HandleInner<HttpRequestException>()
   .OrInner<OperationCanceledException>(ex => ex.CancellationToken != myToken)


### PR DESCRIPTION
### The issue or feature being addressed

Clarify doco as suggested in #621 : ReadMe should clarify that `.HandleInner<TException>(...)` checks whether both top-level exceptions and inner exceptions match.
