### PR TITLE
Fix cake build breaking on deprecated addin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.1.1
+- Fix broken build
+
 ## 7.1.0
 - Add SourceLink debugger support.
 - Bug fix: PolicyRegistry with .NET Core services.AddPolicyRegistry() overload (affects Polly v7.0.1-3 only)

--- a/GitVersionConfig.yaml
+++ b/GitVersionConfig.yaml
@@ -1,1 +1,1 @@
-next-version: 7.1.0
+next-version: 7.1.1

--- a/build.cake
+++ b/build.cake
@@ -64,12 +64,8 @@ class GitVersionConfigYaml
 Setup(_ =>
 {
     Information("");
-    Information(" ██████╗  ██████╗ ██╗     ██╗  ██╗   ██╗");
-    Information(" ██╔══██╗██╔═══██╗██║     ██║  ╚██╗ ██╔╝");
-    Information(" ██████╔╝██║   ██║██║     ██║   ╚████╔╝ ");
-    Information(" ██╔═══╝ ██║   ██║██║     ██║    ╚██╔╝  ");
-    Information(" ██║     ╚██████╔╝███████╗███████╗██║   ");
-    Information(" ╚═╝      ╚═════╝ ╚══════╝╚══════╝╚═╝   ");
+    Information("Starting the cake build script");
+    Information("Building: " + projectName);
     Information("");
 });
 

--- a/build.cake
+++ b/build.cake
@@ -62,8 +62,10 @@ class GitVersionConfigYaml
 Setup(_ =>
 {
     Information("");
+    Information("----------------------------------------");
     Information("Starting the cake build script");
     Information("Building: " + projectName);
+    Information("----------------------------------------");
     Information("");
 });
 

--- a/build.cake
+++ b/build.cake
@@ -17,10 +17,8 @@ var configuration = Argument<string>("configuration", "Release");
 //////////////////////////////////////////////////////////////////////
 
 #addin "Cake.FileHelpers"
-#addin "System.Text.Json"
 #addin nuget:?package=Cake.Yaml
 #addin nuget:?package=YamlDotNet&version=5.2.1
-using System.Text.Json;
 
 ///////////////////////////////////////////////////////////////////////////////
 // GLOBAL VARIABLES
@@ -119,7 +117,7 @@ Task("__UpdateAssemblyVersionInformation")
         StartProcess(gitVersionPath, gitVersionSettings, out outputLines);
 
         var output = string.Join("\n", outputLines);
-        gitVersionOutput = new JsonParser().Parse<Dictionary<string, object>>(output);
+        gitVersionOutput = Newtonsoft.Json.JsonConvert.DeserializeObject<Dictionary<string, object>>(output);
     }
     catch
     {


### PR DESCRIPTION
### The issue or feature being addressed

#632 : Build failing on deprecated cake json addin

### Confirm the following

- [x]  I started this PR by branching from the head of the latest dev vX.Y branch, or I have rebased on the latest dev vX.Y branch, or I have merged the latest changes from the dev vX.Y branch
- [x]  I have targeted the PR to merge into the latest dev vX.Y branch as the base branch
- [n/a]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
