### PR TITLE
gitignore ionide'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ TestResults
 .vs/
 .vscode/
 .idea/
+.ionide/
 
 # Build results
 [Dd]ebug/


### PR DESCRIPTION
# The issue or feature being addressed

Git ignore .ionide folder which is automatically created by VsCode when ionide is installed

### Details on the issue fix or feature implementation

### Confirm the following

- [x]  I started this PR by branching from the head of the latest dev vX.Y branch, or I have rebased on the latest dev vX.Y branch, or I have merged the latest changes from the dev vX.Y branch
- [x]  I have targeted the PR to merge into the latest dev vX.Y branch as the base branch
- N/A  I have included unit tests for the issue/feature
- N/A  I have successfully run a local build
