### PR TITLE
Extract static SystemClock to interface

### DIFF
--- a/src/Polly.Specs/Caching/AbsoluteTtlSpecs.cs
+++ b/src/Polly.Specs/Caching/AbsoluteTtlSpecs.cs
@@ -10,6 +10,10 @@ namespace Polly.Specs.Caching
     [Collection(Constants.SystemClockDependentTestCollection)]
     public class AbsoluteTtlSpecs : IDisposable
     {
+        private readonly TestSystemClock _testSystemClock = new TestSystemClock();
+
+        public AbsoluteTtlSpecs() => SystemClock.Current = _testSystemClock;
+
         [Fact]
         public void Should_be_able_to_configure_for_near_future_time()
         {
@@ -37,7 +41,7 @@ namespace Polly.Specs.Caching
         [Fact]
         public void Should_return_zero_ttl_if_configured_to_expire_in_past()
         {
-            AbsoluteTtl ttlStrategy = new AbsoluteTtl(SystemClock.DateTimeOffsetUtcNow().Subtract(TimeSpan.FromTicks(1)));
+            AbsoluteTtl ttlStrategy = new AbsoluteTtl(SystemClock.Current.DateTimeOffsetUtcNow.Subtract(TimeSpan.FromTicks(1)));
 
             ttlStrategy.GetTtl(new Context("someOperationKey"), null).Timespan.Should().Be(TimeSpan.Zero);
         }
@@ -50,7 +54,7 @@ namespace Polly.Specs.Caching
 
             AbsoluteTtl ttlStrategy = new AbsoluteTtl(tomorrow);
 
-            SystemClock.DateTimeOffsetUtcNow = () => today;
+            _testSystemClock.DateTimeOffsetUtcNow = today;
             ttlStrategy.GetTtl(new Context("someOperationKey"), null).Timespan.Should().Be(TimeSpan.FromDays(1));
         }
 

--- a/src/Polly.Specs/Caching/CacheSpecs.cs
+++ b/src/Polly.Specs/Caching/CacheSpecs.cs
@@ -109,8 +109,9 @@ namespace Polly.Specs.Caching
                 return valueToReturn;
             };
 
-            DateTimeOffset fixedTime = SystemClock.DateTimeOffsetUtcNow();
-            SystemClock.DateTimeOffsetUtcNow = () => fixedTime;
+            DateTimeOffset fixedTime = SystemClock.Current.DateTimeOffsetUtcNow;
+            var testSystemClock = new TestSystemClock(fixedTime);
+            SystemClock.Current = testSystemClock;
 
             // First execution should execute delegate and put result in the cache.
             cache.Execute(func, new Context(operationKey)).Should().Be(valueToReturn);
@@ -122,12 +123,12 @@ namespace Polly.Specs.Caching
 
             // Second execution (before cache expires) should get it from the cache - no further delegate execution.
             // (Manipulate time so just prior cache expiry).
-            SystemClock.DateTimeOffsetUtcNow = () => fixedTime.Add(ttl).AddSeconds(-1);
+            testSystemClock.DateTimeOffsetUtcNow = fixedTime.Add(ttl).AddSeconds(-1);
             cache.Execute(func, new Context(operationKey)).Should().Be(valueToReturn);
             delegateInvocations.Should().Be(1);
 
             // Manipulate time to force cache expiry.
-            SystemClock.DateTimeOffsetUtcNow = () => fixedTime.Add(ttl).AddSeconds(1);
+            testSystemClock.DateTimeOffsetUtcNow = fixedTime.Add(ttl).AddSeconds(1);
 
             // Third execution (cache expired) should not get it from the cache - should cause further delegate execution.
             cache.Execute(func, new Context(operationKey)).Should().Be(valueToReturn);

--- a/src/Polly.Specs/Caching/CacheTResultAsyncSpecs.cs
+++ b/src/Polly.Specs/Caching/CacheTResultAsyncSpecs.cs
@@ -111,8 +111,9 @@ namespace Polly.Specs.Caching
                 return valueToReturn;
             };
 
-            DateTimeOffset fixedTime = SystemClock.DateTimeOffsetUtcNow();
-            SystemClock.DateTimeOffsetUtcNow = () => fixedTime;
+            DateTimeOffset fixedTime = SystemClock.Current.DateTimeOffsetUtcNow;
+            var testSystemClock = new TestSystemClock(fixedTime);
+            SystemClock.Current = testSystemClock;
 
             // First execution should execute delegate and put result in the cache.
             (await cache.ExecuteAsync(func, new Context(operationKey)).ConfigureAwait(false)).Should().Be(valueToReturn);
@@ -124,12 +125,12 @@ namespace Polly.Specs.Caching
 
             // Second execution (before cache expires) should get it from the cache - no further delegate execution.
             // (Manipulate time so just prior cache expiry).
-            SystemClock.DateTimeOffsetUtcNow = () => fixedTime.Add(ttl).AddSeconds(-1);
+            testSystemClock.DateTimeOffsetUtcNow = fixedTime.Add(ttl).AddSeconds(-1);
             (await cache.ExecuteAsync(func, new Context(operationKey)).ConfigureAwait(false)).Should().Be(valueToReturn);
             delegateInvocations.Should().Be(1);
 
             // Manipulate time to force cache expiry.
-            SystemClock.DateTimeOffsetUtcNow = () => fixedTime.Add(ttl).AddSeconds(1);
+            testSystemClock.DateTimeOffsetUtcNow = fixedTime.Add(ttl).AddSeconds(1);
 
             // Third execution (cache expired) should not get it from the cache - should cause further delegate execution.
             (await cache.ExecuteAsync(func, new Context(operationKey)).ConfigureAwait(false)).Should().Be(valueToReturn);

--- a/src/Polly.Specs/Caching/CacheTResultSpecs.cs
+++ b/src/Polly.Specs/Caching/CacheTResultSpecs.cs
@@ -108,8 +108,9 @@ namespace Polly.Specs.Caching
                 return valueToReturn;
             };
 
-            DateTimeOffset fixedTime = SystemClock.DateTimeOffsetUtcNow();
-            SystemClock.DateTimeOffsetUtcNow = () => fixedTime;
+            DateTimeOffset fixedTime = SystemClock.Current.DateTimeOffsetUtcNow;
+            var testSystemClock = new TestSystemClock(fixedTime);
+            SystemClock.Current = testSystemClock;
 
             // First execution should execute delegate and put result in the cache.
             cache.Execute(func, new Context(operationKey)).Should().Be(valueToReturn);
@@ -121,12 +122,12 @@ namespace Polly.Specs.Caching
 
             // Second execution (before cache expires) should get it from the cache - no further delegate execution.
             // (Manipulate time so just prior cache expiry).
-            SystemClock.DateTimeOffsetUtcNow = () => fixedTime.Add(ttl).AddSeconds(-1);
+            testSystemClock.DateTimeOffsetUtcNow = fixedTime.Add(ttl).AddSeconds(-1);
             cache.Execute(func, new Context(operationKey)).Should().Be(valueToReturn);
             delegateInvocations.Should().Be(1);
 
             // Manipulate time to force cache expiry.
-            SystemClock.DateTimeOffsetUtcNow = () => fixedTime.Add(ttl).AddSeconds(1);
+            testSystemClock.DateTimeOffsetUtcNow = fixedTime.Add(ttl).AddSeconds(1);
 
             // Third execution (cache expired) should not get it from the cache - should cause further delegate execution.
             cache.Execute(func, new Context(operationKey)).Should().Be(valueToReturn);

--- a/src/Polly.Specs/Caching/RelativeTtlSpecs.cs
+++ b/src/Polly.Specs/Caching/RelativeTtlSpecs.cs
@@ -47,13 +47,13 @@ namespace Polly.Specs.Caching
         [Fact]
         public void Should_return_configured_timespan_from_time_requested()
         {
-            DateTimeOffset fixedTime = SystemClock.DateTimeOffsetUtcNow();
+            DateTimeOffset fixedTime = SystemClock.Current.DateTimeOffsetUtcNow;
             TimeSpan ttl = TimeSpan.FromSeconds(30);
             TimeSpan delay = TimeSpan.FromSeconds(5);
 
             RelativeTtl ttlStrategy = new RelativeTtl(ttl);
 
-            SystemClock.DateTimeOffsetUtcNow = () => fixedTime.Add(delay);
+            SystemClock.Current = new TestSystemClock(fixedTime.Add(delay));
 
             Ttl retrieved = ttlStrategy.GetTtl(new Context("someOperationKey"), null);
             retrieved.Timespan.Should().BeCloseTo(ttl);

--- a/src/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerAsyncSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerAsyncSpecs.cs
@@ -16,6 +16,10 @@ namespace Polly.Specs.CircuitBreaker
     [Collection(Constants.SystemClockDependentTestCollection)]
     public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
     {
+        private readonly TestSystemClock _testSystemClock = new TestSystemClock();
+
+        public AdvancedCircuitBreakerAsyncSpecs() => SystemClock.Current = _testSystemClock;
+
         #region Configuration tests
 
         [Fact]
@@ -173,7 +177,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_not_open_circuit_if_failure_threshold_and_minimum_threshold_is_equalled_but_last_call_is_success()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -209,7 +213,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_not_open_circuit_if_exceptions_raised_are_not_one_of_the_specified_exceptions()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -253,7 +257,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_blocking_executions_and_noting_the_last_raised_exception_if_failure_threshold_exceeded_and_throughput_threshold_equalled_within_timeslice_in_same_window()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -297,7 +301,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_exceeded_and_throughput_threshold_equalled_within_timeslice_in_different_windows()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var samplingDuration = TimeSpan.FromSeconds(10);
 
@@ -326,7 +330,7 @@ namespace Polly.Specs.CircuitBreaker
             // Placing the rest of the invocations ('samplingDuration' / 2) + 1 seconds later
             // ensures that even if there are only two windows, then the invocations are placed in the second.
             // They are still placed within same timeslice.
-            SystemClock.UtcNow = () => time.AddSeconds(samplingDuration.Seconds / 2d + 1);
+            _testSystemClock.DateTimeOffsetUtcNow = time.AddSeconds(samplingDuration.Seconds / 2d + 1);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
                 .Should().Throw<DivideByZeroException>();
@@ -344,7 +348,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_exceeded_though_not_all_are_failures_and_throughput_threshold_equalled_within_timeslice_in_same_window()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -385,7 +389,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_exceeded_though_not_all_are_failures_and_throughput_threshold_equalled_within_timeslice_in_different_windows()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var samplingDuration = TimeSpan.FromSeconds(10);
 
@@ -418,7 +422,7 @@ namespace Polly.Specs.CircuitBreaker
             // Placing the rest of the invocations ('samplingDuration' / 2) + 1 seconds later
             // ensures that even if there are only two windows, then the invocations are placed in the second.
             // They are still placed within same timeslice
-            SystemClock.UtcNow = () => time.AddSeconds(samplingDuration.Seconds / 2d + 1);
+            _testSystemClock.DateTimeOffsetUtcNow = time.AddSeconds(samplingDuration.Seconds / 2d + 1);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
                 .Should().Throw<BrokenCircuitException>()
@@ -432,7 +436,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_equalled_and_throughput_threshold_equalled_within_timeslice_in_same_window()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -473,7 +477,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_equalled_and_throughput_threshold_equalled_within_timeslice_in_different_windows()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var samplingDuration = TimeSpan.FromSeconds(10);
 
@@ -506,7 +510,7 @@ namespace Polly.Specs.CircuitBreaker
             // Placing the rest of the invocations ('samplingDuration' / 2) + 1 seconds later
             // ensures that even if there are only two windows, then the invocations are placed in the second.
             // They are still placed within same timeslice
-            SystemClock.UtcNow = () => time.AddSeconds(samplingDuration.Seconds / 2d + 1);
+            _testSystemClock.DateTimeOffsetUtcNow = time.AddSeconds(samplingDuration.Seconds / 2d + 1);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
                 .Should().Throw<BrokenCircuitException>()
@@ -520,7 +524,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_not_open_circuit_if_failure_threshold_exceeded_but_throughput_threshold_not_met_before_timeslice_expires()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var samplingDuration = TimeSpan.FromSeconds(10);
 
@@ -547,7 +551,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Adjust SystemClock so that timeslice (clearly) expires; fourth exception thrown in next-recorded timeslice.
-            SystemClock.UtcNow = () => time.Add(samplingDuration).Add(samplingDuration);
+            _testSystemClock.DateTimeOffsetUtcNow = time.Add(samplingDuration).Add(samplingDuration);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
                 .Should().Throw<DivideByZeroException>();
@@ -559,7 +563,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_not_open_circuit_if_failure_threshold_exceeded_but_throughput_threshold_not_met_before_timeslice_expires_even_if_timeslice_expires_only_exactly()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var samplingDuration = TimeSpan.FromSeconds(10);
 
@@ -586,7 +590,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Adjust SystemClock so that timeslice (just) expires; fourth exception thrown in following timeslice.
-            SystemClock.UtcNow = () => time.Add(samplingDuration);
+            _testSystemClock.DateTimeOffsetUtcNow = time.Add(samplingDuration);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
                 .Should().Throw<DivideByZeroException>();
@@ -598,7 +602,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_not_open_circuit_if_failure_threshold_exceeded_but_throughput_threshold_not_met_before_timeslice_expires_even_if_error_occurring_just_at_the_end_of_the_duration()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var samplingDuration = TimeSpan.FromSeconds(10);
 
@@ -623,14 +627,14 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Creates a new window right at the end of the original timeslice.
-            SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
+            _testSystemClock.DateTimeOffsetUtcNow = time.AddTicks(samplingDuration.Ticks - 1);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
                 .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Adjust SystemClock so that timeslice (just) expires; fourth exception thrown in following timeslice.  If timeslice/window rollover is precisely defined, this should cause first two actions to be forgotten from statistics (rolled out of the window of relevance), and thus the circuit not to break.
-            SystemClock.UtcNow = () => time.Add(samplingDuration);
+            _testSystemClock.DateTimeOffsetUtcNow = time.Add(samplingDuration);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
                 .Should().Throw<DivideByZeroException>();
@@ -642,7 +646,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_equalled_and_throughput_threshold_equalled_even_if_only_just_within_timeslice()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var samplingDuration = TimeSpan.FromSeconds(10);
 
@@ -669,7 +673,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Adjust SystemClock so that timeslice doesn't quite expire; fourth exception thrown in same timeslice.
-            SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
+            _testSystemClock.DateTimeOffsetUtcNow = time.AddTicks(samplingDuration.Ticks - 1);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
                 .Should().Throw<DivideByZeroException>();
@@ -687,7 +691,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_not_open_circuit_if_failure_threshold_not_met_and_throughput_threshold_not_met()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -717,7 +721,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_not_open_circuit_if_failure_threshold_not_met_but_throughput_threshold_met_before_timeslice_expires()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -751,7 +755,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_if_failures_at_end_of_last_timeslice_below_failure_threshold_and_failures_in_beginning_of_new_timeslice_where_total_equals_failure_threshold()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var samplingDuration = TimeSpan.FromSeconds(10);
 
@@ -772,7 +776,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // The time is set to just at the end of the sampling duration ensuring
             // the invocations are within the timeslice, but only barely.
-            SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
+            _testSystemClock.DateTimeOffsetUtcNow = time.AddTicks(samplingDuration.Ticks - 1);
 
             // Three of four actions in this test occur within the first timeslice.
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
@@ -788,7 +792,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Setting the time to just barely into the new timeslice
-            SystemClock.UtcNow = () => time.Add(samplingDuration);
+            _testSystemClock.DateTimeOffsetUtcNow = time.Add(samplingDuration);
 
             // This failure opens the circuit, because it is the second failure of four calls
             // equalling the failure threshold. The minimum threshold within the defined
@@ -802,7 +806,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_not_open_circuit_if_failures_at_end_of_last_timeslice_and_failures_in_beginning_of_new_timeslice_when_below_minimum_throughput_threshold()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var samplingDuration = TimeSpan.FromSeconds(10);
 
@@ -823,7 +827,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // The time is set to just at the end of the sampling duration ensuring
             // the invocations are within the timeslice, but only barely.
-            SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
+            _testSystemClock.DateTimeOffsetUtcNow = time.AddTicks(samplingDuration.Ticks - 1);
 
             // Two of three actions in this test occur within the first timeslice.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
@@ -835,7 +839,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Setting the time to just barely into the new timeslice
-            SystemClock.UtcNow = () => time.Add(samplingDuration);
+            _testSystemClock.DateTimeOffsetUtcNow = time.Add(samplingDuration);
 
             // A third failure occurs just at the beginning of the new timeslice making 
             // the number of failures above the failure threshold. However, the throughput is 
@@ -849,7 +853,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_if_failures_in_second_window_of_last_timeslice_and_failures_in_first_window_in_next_timeslice_exceeds_failure_threshold_and_minimum_threshold()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var samplingDuration = TimeSpan.FromSeconds(10);
             var numberOfWindowsDefinedInCircuitBreaker = 10;
@@ -870,7 +874,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Setting the time to the second window in the rolling metrics
-            SystemClock.UtcNow = () => time.AddSeconds(samplingDuration.Seconds / (double)numberOfWindowsDefinedInCircuitBreaker);
+            _testSystemClock.DateTimeOffsetUtcNow = time.AddSeconds(samplingDuration.Seconds / (double)numberOfWindowsDefinedInCircuitBreaker);
 
             // Three actions occur in the second window of the first timeslice
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
@@ -886,7 +890,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Setting the time to just barely into the new timeslice
-            SystemClock.UtcNow = () => time.Add(samplingDuration);
+            _testSystemClock.DateTimeOffsetUtcNow = time.Add(samplingDuration);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
                 .Should().Throw<DivideByZeroException>();
@@ -907,7 +911,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_exceeded_and_throughput_threshold_equalled_within_timeslice_low_sampling_duration()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -949,7 +953,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_exceeded_though_not_all_are_failures_and_throughput_threshold_equalled_within_timeslice_low_sampling_duration()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -990,7 +994,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_equalled_and_throughput_threshold_equalled_within_timeslice_low_sampling_duration()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -1031,7 +1035,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_not_open_circuit_if_failure_threshold_exceeded_but_throughput_threshold_not_met_before_timeslice_expires_low_sampling_duration()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var samplingDuration = TimeSpan.FromMilliseconds(199);
 
@@ -1058,7 +1062,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Adjust SystemClock so that timeslice (clearly) expires; fourth exception thrown in next-recorded timeslice.
-            SystemClock.UtcNow = () => time.Add(samplingDuration).Add(samplingDuration);
+            _testSystemClock.DateTimeOffsetUtcNow = time.Add(samplingDuration).Add(samplingDuration);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
                 .Should().Throw<DivideByZeroException>();
@@ -1070,7 +1074,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_not_open_circuit_if_failure_threshold_exceeded_but_throughput_threshold_not_met_before_timeslice_expires_even_if_timeslice_expires_only_exactly_low_sampling_duration()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var samplingDuration = TimeSpan.FromMilliseconds(199);
 
@@ -1097,7 +1101,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Adjust SystemClock so that timeslice (just) expires; fourth exception thrown in following timeslice.
-            SystemClock.UtcNow = () => time.Add(samplingDuration);
+            _testSystemClock.DateTimeOffsetUtcNow = time.Add(samplingDuration);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
                 .Should().Throw<DivideByZeroException>();
@@ -1109,7 +1113,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_equalled_and_throughput_threshold_equalled_even_if_only_just_within_timeslice_low_sampling_duration()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var samplingDuration = TimeSpan.FromMilliseconds(199);
 
@@ -1136,7 +1140,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Adjust SystemClock so that timeslice doesn't quite expire; fourth exception thrown in same timeslice.
-            SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
+            _testSystemClock.DateTimeOffsetUtcNow = time.AddTicks(samplingDuration.Ticks - 1);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
                 .Should().Throw<DivideByZeroException>();
@@ -1154,7 +1158,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_not_open_circuit_if_failure_threshold_not_met_and_throughput_threshold_not_met_low_sampling_duration()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -1184,7 +1188,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_not_open_circuit_if_failure_threshold_not_met_but_throughput_threshold_met_before_timeslice_expires_low_sampling_duration()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -1218,7 +1222,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_not_open_circuit_if_failures_at_end_of_last_timeslice_below_failure_threshold_and_failures_in_beginning_of_new_timeslice_where_total_equals_failure_threshold_low_sampling_duration()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var samplingDuration = TimeSpan.FromMilliseconds(199);
 
@@ -1239,7 +1243,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // The time is set to just at the end of the sampling duration ensuring
             // the invocations are within the timeslice, but only barely.
-            SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
+            _testSystemClock.DateTimeOffsetUtcNow = time.AddTicks(samplingDuration.Ticks - 1);
 
             // Three of four actions in this test occur within the first timeslice.
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
@@ -1255,7 +1259,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Setting the time to just barely into the new timeslice
-            SystemClock.UtcNow = () => time.Add(samplingDuration);
+            _testSystemClock.DateTimeOffsetUtcNow = time.Add(samplingDuration);
 
             // This failure does not open the circuit, because a new duration should have 
             // started and with such low sampling duration, windows should not be used.
@@ -1274,7 +1278,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_halfopen_circuit_after_the_specified_duration_has_passed_with_failures_in_same_window()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
 
@@ -1305,7 +1309,7 @@ namespace Polly.Specs.CircuitBreaker
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.DateTimeOffsetUtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -1317,7 +1321,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_halfopen_circuit_after_the_specified_duration_has_passed_with_failures_in_different_windows()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
             var samplingDuration = TimeSpan.FromSeconds(10);
@@ -1348,19 +1352,19 @@ namespace Polly.Specs.CircuitBreaker
             // ensures that even if there are only two windows, then the invocations are placed in the second.
             // They are still placed within same timeslice
             var anotherWindowDuration = samplingDuration.Seconds / 2d + 1;
-            SystemClock.UtcNow = () => time.AddSeconds(anotherWindowDuration);
+            _testSystemClock.DateTimeOffsetUtcNow = time.AddSeconds(anotherWindowDuration);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
                 .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.DateTimeOffsetUtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // Since the call that opened the circuit occurred in a later window, then the
             // break duration must be simulated as from that call.
-            SystemClock.UtcNow = () => time.Add(durationOfBreak).AddSeconds(anotherWindowDuration);
+            _testSystemClock.DateTimeOffsetUtcNow = time.Add(durationOfBreak).AddSeconds(anotherWindowDuration);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -1372,7 +1376,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_again_after_the_specified_duration_has_passed_if_the_next_call_raises_an_exception()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
 
@@ -1403,7 +1407,7 @@ namespace Polly.Specs.CircuitBreaker
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.DateTimeOffsetUtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -1421,7 +1425,7 @@ namespace Polly.Specs.CircuitBreaker
         public async Task Should_reset_circuit_after_the_specified_duration_has_passed_if_the_next_call_does_not_raise_an_exception()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
 
@@ -1452,7 +1456,7 @@ namespace Polly.Specs.CircuitBreaker
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.DateTimeOffsetUtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -1466,7 +1470,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_only_allow_single_execution_on_first_entering_halfopen_state__test_execution_permit_directly()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
             var breaker = Policy
@@ -1487,7 +1491,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // break duration passes, circuit now half open
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.DateTimeOffsetUtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
 
@@ -1504,7 +1508,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_allow_single_execution_per_break_duration_in_halfopen_state__test_execution_permit_directly()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
             var breaker = Policy
@@ -1525,7 +1529,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // break duration passes, circuit now half open
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.DateTimeOffsetUtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
 
@@ -1538,7 +1542,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // Allow another time window to pass (breaker should still be HalfOpen).
-            SystemClock.UtcNow = () => time.Add(durationOfBreak).Add(durationOfBreak);
+            _testSystemClock.DateTimeOffsetUtcNow = time.Add(durationOfBreak).Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should now permit another trial execution.
@@ -1550,7 +1554,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_only_allow_single_execution_on_first_entering_halfopen_state__integration_test()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
             var breaker = Policy
@@ -1571,7 +1575,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // break duration passes, circuit now half open
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.DateTimeOffsetUtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // Start one execution during the HalfOpen state, and request a second execution before the first has completed (ie still during the HalfOpen state).
@@ -1656,7 +1660,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_allow_single_execution_per_break_duration_in_halfopen_state__integration_test()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
             var breaker = Policy
@@ -1677,7 +1681,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // break duration passes, circuit now half open
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.DateTimeOffsetUtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // Start one execution during the HalfOpen state.
@@ -1722,7 +1726,7 @@ namespace Polly.Specs.CircuitBreaker
 
                     try
                     {
-                        SystemClock.UtcNow = () => time.Add(durationOfBreak).Add(durationOfBreak);
+                        _testSystemClock.DateTimeOffsetUtcNow = time.Add(durationOfBreak).Add(durationOfBreak);
 
                         await breaker.ExecuteAsync(async () =>
                         {
@@ -1789,7 +1793,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_hold_circuit_open_despite_elapsed_time_if_manual_override_open()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
             var breaker = Policy
@@ -1800,7 +1804,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Isolate();
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.DateTimeOffsetUtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
 
             bool delegateExecutedWhenBroken = false;
@@ -1813,7 +1817,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_close_circuit_again_on_reset_after_manual_override()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
             var breaker = Policy
@@ -1836,7 +1840,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_be_able_to_reset_automatically_opened_circuit_without_specified_duration_passing()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
 
@@ -1868,7 +1872,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // reset circuit, with no time having passed
             breaker.Reset();
-            SystemClock.UtcNow().Should().Be(time);
+            SystemClock.Current.UtcNow.Should().Be(time);
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
                 .Should().NotThrow();
@@ -1901,7 +1905,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onReset = () => { };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -1963,7 +1967,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onReset = () => { };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -2087,7 +2091,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onReset = () => { onResetCalled++; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
 
@@ -2123,7 +2127,7 @@ namespace Polly.Specs.CircuitBreaker
 
             onBreakCalled.Should().Be(1);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.DateTimeOffsetUtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -2170,7 +2174,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onHalfOpen = () => { onHalfOpenCalled++; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
 
@@ -2210,7 +2214,7 @@ namespace Polly.Specs.CircuitBreaker
 
             onBreakCalled.Should().Be(1);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.DateTimeOffsetUtcNow = time.Add(durationOfBreak);
             // duration has passed, circuit now half open
             onHalfOpenCalled.Should().Be(0); // not yet transitioned to half-open, because we have not queried state
 
@@ -2232,7 +2236,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onHalfOpen = () => { onHalfOpenCalled++; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
 
@@ -2272,7 +2276,7 @@ namespace Polly.Specs.CircuitBreaker
 
             onBreakCalled.Should().Be(1);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.DateTimeOffsetUtcNow = time.Add(durationOfBreak);
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
             onHalfOpenCalled.Should().Be(1);
@@ -2287,7 +2291,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onReset = () => { onResetCalled++; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
             var breaker = Policy
@@ -2406,7 +2410,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onHalfOpen = () => { };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
 
@@ -2440,7 +2444,7 @@ namespace Polly.Specs.CircuitBreaker
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.DateTimeOffsetUtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -2507,7 +2511,7 @@ namespace Polly.Specs.CircuitBreaker
             Action<Context> onReset = _ => { };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -2541,7 +2545,7 @@ namespace Polly.Specs.CircuitBreaker
             Action<Context> onReset = _ => { };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -2586,7 +2590,7 @@ namespace Polly.Specs.CircuitBreaker
             Action<Context> onReset = context => { contextData = context; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
 
@@ -2619,7 +2623,7 @@ namespace Polly.Specs.CircuitBreaker
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.DateTimeOffsetUtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
 
@@ -2641,7 +2645,7 @@ namespace Polly.Specs.CircuitBreaker
             Action<Context> onReset = _ => { };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -2686,7 +2690,7 @@ namespace Polly.Specs.CircuitBreaker
                 context => { contextValue = context.ContainsKey("key") ? context["key"].ToString() : null; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.DateTimeOffsetUtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
 
@@ -2719,7 +2723,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
             contextValue.Should().Be("original_value");
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.DateTimeOffsetUtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);

--- a/src/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerSpecs.cs
@@ -17,6 +17,10 @@ namespace Polly.Specs.CircuitBreaker
     [Collection(Constants.SystemClockDependentTestCollection)]
     public class AdvancedCircuitBreakerSpecs : IDisposable
     {
+        private readonly TestSystemClock _testSystemClock = new TestSystemClock();
+
+        public AdvancedCircuitBreakerSpecs() => SystemClock.Current = _testSystemClock;
+
         #region Configuration tests
 
         [Fact]
@@ -174,7 +178,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_not_open_circuit_if_failure_threshold_and_minimum_threshold_is_equalled_but_last_call_is_success()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             CircuitBreakerPolicy breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -210,7 +214,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_not_open_circuit_if_exceptions_raised_are_not_one_of_the_specified_exceptions()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             CircuitBreakerPolicy breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -254,7 +258,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_blocking_executions_and_noting_the_last_raised_exception_if_failure_threshold_exceeded_and_throughput_threshold_equalled_within_timeslice_in_same_window()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             CircuitBreakerPolicy breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -298,7 +302,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_exceeded_and_throughput_threshold_equalled_within_timeslice_in_different_windows()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var samplingDuration = TimeSpan.FromSeconds(10);
 
@@ -327,7 +331,7 @@ namespace Polly.Specs.CircuitBreaker
             // Placing the rest of the invocations ('samplingDuration' / 2) + 1 seconds later
             // ensures that even if there are only two windows, then the invocations are placed in the second.
             // They are still placed within same timeslice.
-            SystemClock.UtcNow = () => time.AddSeconds(samplingDuration.Seconds / 2d + 1);
+            _testSystemClock.UtcNow = time.AddSeconds(samplingDuration.Seconds / 2d + 1);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
                 .Should().Throw<DivideByZeroException>();
@@ -345,7 +349,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_exceeded_though_not_all_are_failures_and_throughput_threshold_equalled_within_timeslice_in_same_window()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             CircuitBreakerPolicy breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -386,7 +390,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_exceeded_though_not_all_are_failures_and_throughput_threshold_equalled_within_timeslice_in_different_windows()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var samplingDuration = TimeSpan.FromSeconds(10);
 
@@ -419,7 +423,7 @@ namespace Polly.Specs.CircuitBreaker
             // Placing the rest of the invocations ('samplingDuration' / 2) + 1 seconds later
             // ensures that even if there are only two windows, then the invocations are placed in the second.
             // They are still placed within same timeslice
-            SystemClock.UtcNow = () => time.AddSeconds(samplingDuration.Seconds / 2d + 1);
+            _testSystemClock.UtcNow = time.AddSeconds(samplingDuration.Seconds / 2d + 1);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
                 .Should().Throw<BrokenCircuitException>()
@@ -433,7 +437,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_equalled_and_throughput_threshold_equalled_within_timeslice_in_same_window()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             CircuitBreakerPolicy breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -474,7 +478,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_equalled_and_throughput_threshold_equalled_within_timeslice_in_different_windows()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var samplingDuration = TimeSpan.FromSeconds(10);
 
@@ -507,7 +511,7 @@ namespace Polly.Specs.CircuitBreaker
             // Placing the rest of the invocations ('samplingDuration' / 2) + 1 seconds later
             // ensures that even if there are only two windows, then the invocations are placed in the second.
             // They are still placed within same timeslice
-            SystemClock.UtcNow = () => time.AddSeconds(samplingDuration.Seconds / 2d + 1);
+            _testSystemClock.UtcNow = time.AddSeconds(samplingDuration.Seconds / 2d + 1);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
                 .Should().Throw<BrokenCircuitException>()
@@ -521,7 +525,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_not_open_circuit_if_failure_threshold_exceeded_but_throughput_threshold_not_met_before_timeslice_expires()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var samplingDuration = TimeSpan.FromSeconds(10);
 
@@ -548,7 +552,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Adjust SystemClock so that timeslice (clearly) expires; fourth exception thrown in next-recorded timeslice.
-            SystemClock.UtcNow = () => time.Add(samplingDuration).Add(samplingDuration);
+            _testSystemClock.UtcNow = time.Add(samplingDuration).Add(samplingDuration);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
                 .Should().Throw<DivideByZeroException>();
@@ -560,7 +564,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_not_open_circuit_if_failure_threshold_exceeded_but_throughput_threshold_not_met_before_timeslice_expires_even_if_timeslice_expires_only_exactly()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var samplingDuration = TimeSpan.FromSeconds(10);
 
@@ -587,7 +591,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Adjust SystemClock so that timeslice (just) expires; fourth exception thrown in following timeslice.
-            SystemClock.UtcNow = () => time.Add(samplingDuration);
+            _testSystemClock.UtcNow = time.Add(samplingDuration);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
                 .Should().Throw<DivideByZeroException>();
@@ -599,7 +603,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_not_open_circuit_if_failure_threshold_exceeded_but_throughput_threshold_not_met_before_timeslice_expires_even_if_error_occurring_just_at_the_end_of_the_duration()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var samplingDuration = TimeSpan.FromSeconds(10);
 
@@ -624,14 +628,14 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Creates a new window right at the end of the original timeslice.
-            SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
+            _testSystemClock.UtcNow = time.AddTicks(samplingDuration.Ticks - 1);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
                 .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Adjust SystemClock so that timeslice (just) expires; fourth exception thrown in following timeslice.  If timeslice/window rollover is precisely defined, this should cause first two actions to be forgotten from statistics (rolled out of the window of relevance), and thus the circuit not to break.
-            SystemClock.UtcNow = () => time.Add(samplingDuration);
+            _testSystemClock.UtcNow = time.Add(samplingDuration);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
                 .Should().Throw<DivideByZeroException>();
@@ -643,7 +647,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_equalled_and_throughput_threshold_equalled_even_if_only_just_within_timeslice()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var samplingDuration = TimeSpan.FromSeconds(10);
 
@@ -670,7 +674,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Adjust SystemClock so that timeslice doesn't quite expire; fourth exception thrown in same timeslice.
-            SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
+            _testSystemClock.UtcNow = time.AddTicks(samplingDuration.Ticks - 1);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
                 .Should().Throw<DivideByZeroException>();
@@ -688,7 +692,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_not_open_circuit_if_failure_threshold_not_met_and_throughput_threshold_not_met()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             CircuitBreakerPolicy breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -718,7 +722,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_not_open_circuit_if_failure_threshold_not_met_but_throughput_threshold_met_before_timeslice_expires()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             CircuitBreakerPolicy breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -752,7 +756,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_if_failures_at_end_of_last_timeslice_below_failure_threshold_and_failures_in_beginning_of_new_timeslice_where_total_equals_failure_threshold()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var samplingDuration = TimeSpan.FromSeconds(10);
 
@@ -773,7 +777,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // The time is set to just at the end of the sampling duration ensuring
             // the invocations are within the timeslice, but only barely.
-            SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
+            _testSystemClock.UtcNow = time.AddTicks(samplingDuration.Ticks - 1);
 
             // Three of four actions in this test occur within the first timeslice.
             breaker.Invoking(x => x.Execute(() => { }))
@@ -789,7 +793,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Setting the time to just barely into the new timeslice
-            SystemClock.UtcNow = () => time.Add(samplingDuration);
+            _testSystemClock.UtcNow = time.Add(samplingDuration);
 
             // This failure opens the circuit, because it is the second failure of four calls
             // equalling the failure threshold. The minimum threshold within the defined
@@ -803,7 +807,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_not_open_circuit_if_failures_at_end_of_last_timeslice_and_failures_in_beginning_of_new_timeslice_when_below_minimum_throughput_threshold()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var samplingDuration = TimeSpan.FromSeconds(10);
 
@@ -824,7 +828,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // The time is set to just at the end of the sampling duration ensuring
             // the invocations are within the timeslice, but only barely.
-            SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
+            _testSystemClock.UtcNow = time.AddTicks(samplingDuration.Ticks - 1);
 
             // Two of three actions in this test occur within the first timeslice.
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
@@ -836,7 +840,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Setting the time to just barely into the new timeslice
-            SystemClock.UtcNow = () => time.Add(samplingDuration);
+            _testSystemClock.UtcNow = time.Add(samplingDuration);
 
             // A third failure occurs just at the beginning of the new timeslice making 
             // the number of failures above the failure threshold. However, the throughput is 
@@ -850,7 +854,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_if_failures_in_second_window_of_last_timeslice_and_failures_in_first_window_in_next_timeslice_exceeds_failure_threshold_and_minimum_threshold()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var samplingDuration = TimeSpan.FromSeconds(10);
             var numberOfWindowsDefinedInCircuitBreaker = 10;
@@ -871,7 +875,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Setting the time to the second window in the rolling metrics
-            SystemClock.UtcNow = () => time.AddSeconds(samplingDuration.Seconds / (double)numberOfWindowsDefinedInCircuitBreaker);
+            _testSystemClock.UtcNow = time.AddSeconds(samplingDuration.Seconds / (double)numberOfWindowsDefinedInCircuitBreaker);
 
             // Three actions occur in the second window of the first timeslice
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
@@ -887,7 +891,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Setting the time to just barely into the new timeslice
-            SystemClock.UtcNow = () => time.Add(samplingDuration);
+            _testSystemClock.UtcNow = time.Add(samplingDuration);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
                 .Should().Throw<DivideByZeroException>();
@@ -908,7 +912,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_exceeded_and_throughput_threshold_equalled_within_timeslice_low_sampling_duration()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             CircuitBreakerPolicy breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -950,7 +954,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_exceeded_though_not_all_are_failures_and_throughput_threshold_equalled_within_timeslice_low_sampling_duration()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             CircuitBreakerPolicy breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -991,7 +995,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_equalled_and_throughput_threshold_equalled_within_timeslice_low_sampling_duration()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             CircuitBreakerPolicy breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -1032,7 +1036,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_not_open_circuit_if_failure_threshold_exceeded_but_throughput_threshold_not_met_before_timeslice_expires_low_sampling_duration()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var samplingDuration = TimeSpan.FromMilliseconds(199);
 
@@ -1059,7 +1063,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Adjust SystemClock so that timeslice (clearly) expires; fourth exception thrown in next-recorded timeslice.
-            SystemClock.UtcNow = () => time.Add(samplingDuration).Add(samplingDuration);
+            _testSystemClock.UtcNow = time.Add(samplingDuration).Add(samplingDuration);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
                 .Should().Throw<DivideByZeroException>();
@@ -1071,7 +1075,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_not_open_circuit_if_failure_threshold_exceeded_but_throughput_threshold_not_met_before_timeslice_expires_even_if_timeslice_expires_only_exactly_low_sampling_duration()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var samplingDuration = TimeSpan.FromMilliseconds(199);
 
@@ -1098,7 +1102,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Adjust SystemClock so that timeslice (just) expires; fourth exception thrown in following timeslice.
-            SystemClock.UtcNow = () => time.Add(samplingDuration);
+            _testSystemClock.UtcNow = time.Add(samplingDuration);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
                 .Should().Throw<DivideByZeroException>();
@@ -1110,7 +1114,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_equalled_and_throughput_threshold_equalled_even_if_only_just_within_timeslice_low_sampling_duration()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var samplingDuration = TimeSpan.FromMilliseconds(199);
 
@@ -1137,7 +1141,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Adjust SystemClock so that timeslice doesn't quite expire; fourth exception thrown in same timeslice.
-            SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
+            _testSystemClock.UtcNow = time.AddTicks(samplingDuration.Ticks - 1);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
                 .Should().Throw<DivideByZeroException>();
@@ -1155,7 +1159,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_not_open_circuit_if_failure_threshold_not_met_and_throughput_threshold_not_met_low_sampling_duration()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             CircuitBreakerPolicy breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -1185,7 +1189,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_not_open_circuit_if_failure_threshold_not_met_but_throughput_threshold_met_before_timeslice_expires_low_sampling_duration()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             CircuitBreakerPolicy breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -1219,7 +1223,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_not_open_circuit_if_failures_at_end_of_last_timeslice_below_failure_threshold_and_failures_in_beginning_of_new_timeslice_where_total_equals_failure_threshold_low_sampling_duration()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var samplingDuration = TimeSpan.FromMilliseconds(199);
 
@@ -1240,7 +1244,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // The time is set to just at the end of the sampling duration ensuring
             // the invocations are within the timeslice, but only barely.
-            SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
+            _testSystemClock.UtcNow = time.AddTicks(samplingDuration.Ticks - 1);
 
             // Three of four actions in this test occur within the first timeslice.
             breaker.Invoking(x => x.Execute(() => { }))
@@ -1256,7 +1260,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Setting the time to just barely into the new timeslice
-            SystemClock.UtcNow = () => time.Add(samplingDuration);
+            _testSystemClock.UtcNow = time.Add(samplingDuration);
 
             // This failure does not open the circuit, because a new duration should have 
             // started and with such low sampling duration, windows should not be used.
@@ -1275,7 +1279,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_halfopen_circuit_after_the_specified_duration_has_passed_with_failures_in_same_window()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
 
@@ -1306,7 +1310,7 @@ namespace Polly.Specs.CircuitBreaker
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -1318,7 +1322,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_halfopen_circuit_after_the_specified_duration_has_passed_with_failures_in_different_windows()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
             var samplingDuration = TimeSpan.FromSeconds(10);
@@ -1349,19 +1353,19 @@ namespace Polly.Specs.CircuitBreaker
             // ensures that even if there are only two windows, then the invocations are placed in the second.
             // They are still placed within same timeslice
             var anotherwindowDuration = samplingDuration.Seconds / 2d + 1;
-            SystemClock.UtcNow = () => time.AddSeconds(anotherwindowDuration);
+            _testSystemClock.UtcNow = time.AddSeconds(anotherwindowDuration);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
                 .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // Since the call that opened the circuit occurred in a later window, then the
             // break duration must be simulated as from that call.
-            SystemClock.UtcNow = () => time.Add(durationOfBreak).AddSeconds(anotherwindowDuration);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak).AddSeconds(anotherwindowDuration);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -1373,7 +1377,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_again_after_the_specified_duration_has_passed_if_the_next_call_raises_an_exception()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
 
@@ -1404,7 +1408,7 @@ namespace Polly.Specs.CircuitBreaker
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -1420,7 +1424,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_reset_circuit_after_the_specified_duration_has_passed_if_the_next_call_does_not_raise_an_exception()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
 
@@ -1451,7 +1455,7 @@ namespace Polly.Specs.CircuitBreaker
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -1465,7 +1469,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_only_allow_single_execution_on_first_entering_halfopen_state__test_execution_permit_directly()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
 
@@ -1487,7 +1491,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // break duration passes, circuit now half open
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
 
@@ -1504,7 +1508,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_allow_single_execution_per_break_duration_in_halfopen_state__test_execution_permit_directly()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
 
@@ -1526,7 +1530,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // break duration passes, circuit now half open
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
 
@@ -1539,7 +1543,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // Allow another time window to pass (breaker should still be HalfOpen).
-            SystemClock.UtcNow = () => time.Add(durationOfBreak).Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak).Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should now permit another trial execution.
@@ -1551,7 +1555,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_only_allow_single_execution_on_first_entering_halfopen_state__integration_test()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
 
@@ -1573,7 +1577,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // break duration passes, circuit now half open
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // Start one execution during the HalfOpen state, and request a second execution before the first has completed (ie still during the HalfOpen state).
@@ -1656,7 +1660,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_allow_single_execution_per_break_duration_in_halfopen_state__integration_test()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
 
@@ -1678,7 +1682,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // break duration passes, circuit now half open
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // Start one execution during the HalfOpen state.
@@ -1723,7 +1727,7 @@ namespace Polly.Specs.CircuitBreaker
 
                     try
                     {
-                        SystemClock.UtcNow = () => time.Add(durationOfBreak).Add(durationOfBreak);
+                        _testSystemClock.UtcNow = time.Add(durationOfBreak).Add(durationOfBreak);
 
                         breaker.Execute(() =>
                         {
@@ -1788,7 +1792,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_hold_circuit_open_despite_elapsed_time_if_manual_override_open()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
             CircuitBreakerPolicy breaker = Policy
@@ -1799,7 +1803,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Isolate();
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
 
             bool delegateExecutedWhenBroken = false;
@@ -1812,7 +1816,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_close_circuit_again_on_reset_after_manual_override()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
             CircuitBreakerPolicy breaker = Policy
@@ -1834,7 +1838,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_be_able_to_reset_automatically_opened_circuit_without_specified_duration_passing()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
 
@@ -1866,7 +1870,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // reset circuit, with no time having passed
             breaker.Reset();
-            SystemClock.UtcNow().Should().Be(time);
+            SystemClock.Current.UtcNow.Should().Be(time);
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             breaker.Invoking(x => x.Execute(() => { })).Should().NotThrow();
         }
@@ -1898,7 +1902,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onReset = () => { };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             CircuitBreakerPolicy breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -1960,7 +1964,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onReset = () => { };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             CircuitBreakerPolicy breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -2081,7 +2085,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onReset = () => { onResetCalled++; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
 
@@ -2117,7 +2121,7 @@ namespace Polly.Specs.CircuitBreaker
 
             onBreakCalled.Should().Be(1);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -2164,7 +2168,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onHalfOpen = () => { onHalfOpenCalled++; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
 
@@ -2204,7 +2208,7 @@ namespace Polly.Specs.CircuitBreaker
 
             onBreakCalled.Should().Be(1);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             // duration has passed, circuit now half open
             onHalfOpenCalled.Should().Be(0); // not yet transitioned to half-open, because we have not queried state
 
@@ -2226,7 +2230,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onHalfOpen = () => { onHalfOpenCalled++; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
 
@@ -2266,7 +2270,7 @@ namespace Polly.Specs.CircuitBreaker
 
             onBreakCalled.Should().Be(1);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
             onHalfOpenCalled.Should().Be(1);
@@ -2281,7 +2285,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onReset = () => { onResetCalled++; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
             CircuitBreakerPolicy breaker = Policy
@@ -2394,7 +2398,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onHalfOpen = () => { };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
 
@@ -2428,7 +2432,7 @@ namespace Polly.Specs.CircuitBreaker
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -2490,7 +2494,7 @@ namespace Polly.Specs.CircuitBreaker
             Action<Context> onReset = _ => { };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
             
             CircuitBreakerPolicy breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -2524,7 +2528,7 @@ namespace Polly.Specs.CircuitBreaker
             Action<Context> onReset = _ => { };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             CircuitBreakerPolicy breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -2569,7 +2573,7 @@ namespace Polly.Specs.CircuitBreaker
             Action<Context> onReset = context => { contextData = context; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
 
@@ -2602,7 +2606,7 @@ namespace Polly.Specs.CircuitBreaker
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
 
@@ -2624,7 +2628,7 @@ namespace Polly.Specs.CircuitBreaker
             Action<Context> onReset = _ => { };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             CircuitBreakerPolicy breaker = Policy
                 .Handle<DivideByZeroException>()
@@ -2669,7 +2673,7 @@ namespace Polly.Specs.CircuitBreaker
                 context => { contextValue = context.ContainsKey("key") ? context["key"].ToString() : null; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromSeconds(30);
 
@@ -2702,7 +2706,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
             contextValue.Should().Be("original_value");
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);

--- a/src/Polly.Specs/CircuitBreaker/CircuitBreakerAsyncSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/CircuitBreakerAsyncSpecs.cs
@@ -16,6 +16,10 @@ namespace Polly.Specs.CircuitBreaker
     [Collection(Constants.SystemClockDependentTestCollection)]
     public class CircuitBreakerAsyncSpecs : IDisposable
     {
+        private readonly TestSystemClock _testSystemClock = new TestSystemClock();
+
+        public CircuitBreakerAsyncSpecs() => SystemClock.Current = _testSystemClock;
+
         #region Configuration tests
 
         [Fact]
@@ -197,7 +201,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_halfopen_circuit_after_the_specified_duration_has_passed()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -218,7 +222,7 @@ namespace Polly.Specs.CircuitBreaker
                   .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -230,7 +234,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_again_after_the_specified_duration_has_passed_if_the_next_call_raises_an_exception()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -251,7 +255,7 @@ namespace Polly.Specs.CircuitBreaker
                   .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -268,7 +272,7 @@ namespace Polly.Specs.CircuitBreaker
         public async Task Should_reset_circuit_after_the_specified_duration_has_passed_if_the_next_call_does_not_raise_an_exception()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -289,7 +293,7 @@ namespace Polly.Specs.CircuitBreaker
                   .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -315,7 +319,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_only_allow_single_execution_on_first_entering_halfopen_state__test_execution_permit_directly()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
             var breaker = Policy
@@ -329,7 +333,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // break duration passes, circuit now half open
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
 
@@ -346,7 +350,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_allow_single_execution_per_break_duration_in_halfopen_state__test_execution_permit_directly()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
             var breaker = Policy
@@ -360,7 +364,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // break duration passes, circuit now half open
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
             
 
@@ -373,7 +377,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // Allow another time window to pass (breaker should still be HalfOpen).
-            SystemClock.UtcNow = () => time.Add(durationOfBreak).Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak).Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should now permit another trial execution.
@@ -385,7 +389,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_only_allow_single_execution_on_first_entering_halfopen_state__integration_test()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
             var breaker = Policy
@@ -399,7 +403,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // break duration passes, circuit now half open
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // Start one execution during the HalfOpen state, and request a second execution before the first has completed (ie still during the HalfOpen state).
@@ -484,7 +488,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_allow_single_execution_per_break_duration_in_halfopen_state__integration_test()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
             var breaker = Policy
@@ -498,7 +502,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // break duration passes, circuit now half open
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // Start one execution during the HalfOpen state.
@@ -543,7 +547,7 @@ namespace Polly.Specs.CircuitBreaker
 
                     try
                     {
-                        SystemClock.UtcNow = () => time.Add(durationOfBreak).Add(durationOfBreak);
+                        _testSystemClock.UtcNow = time.Add(durationOfBreak).Add(durationOfBreak);
 
                         await breaker.ExecuteAsync(async () =>
                         {
@@ -589,7 +593,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_and_block_calls_if_manual_override_open()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -616,7 +620,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_hold_circuit_open_despite_elapsed_time_if_manual_override_open()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -628,7 +632,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Isolate();
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
             bool delegateExecutedWhenBroken = false;
             breaker.Awaiting(async x => await x.ExecuteAsync(() => { delegateExecutedWhenBroken = true; return TaskHelper.EmptyTask; }))
@@ -640,7 +644,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_close_circuit_again_on_reset_after_manual_override()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -663,7 +667,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_be_able_to_reset_automatically_opened_circuit_without_specified_duration_passing()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -686,7 +690,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // reset circuit, with no time having passed
             breaker.Reset();
-            SystemClock.UtcNow().Should().Be(time);
+            SystemClock.Current.UtcNow.Should().Be(time);
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask)).Should().NotThrow();
         }
@@ -850,7 +854,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onReset = () => { onResetCalled++; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -874,7 +878,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -920,7 +924,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onHalfOpen = () => { onHalfOpenCalled++; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -944,7 +948,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             // duration has passed, circuit now half open
             onHalfOpenCalled.Should().Be(0); // not yet transitioned to half-open, because we have not queried state
 
@@ -966,7 +970,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onHalfOpen = () => { onHalfOpenCalled++; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -990,7 +994,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
             onHalfOpenCalled.Should().Be(1);
@@ -1005,7 +1009,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onReset = () => { onResetCalled++; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -1088,7 +1092,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onHalfOpen = () => { };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -1109,7 +1113,7 @@ namespace Polly.Specs.CircuitBreaker
                   .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -1186,7 +1190,7 @@ namespace Polly.Specs.CircuitBreaker
             Action<Context> onReset = _ => { };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var breaker = Policy
                             .Handle<DivideByZeroException>()
@@ -1239,7 +1243,7 @@ namespace Polly.Specs.CircuitBreaker
             Action<Context> onReset = context => { contextData = context; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -1253,7 +1257,7 @@ namespace Polly.Specs.CircuitBreaker
                   .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // first call after duration should invoke onReset, with context
@@ -1300,7 +1304,7 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -1313,7 +1317,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
             contextValue.Should().Be("original_value");
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);

--- a/src/Polly.Specs/CircuitBreaker/CircuitBreakerSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/CircuitBreakerSpecs.cs
@@ -14,6 +14,10 @@ namespace Polly.Specs.CircuitBreaker
     [Collection(Constants.SystemClockDependentTestCollection)]
     public class CircuitBreakerSpecs : IDisposable
     {
+        private readonly TestSystemClock _testSystemClock = new TestSystemClock();
+
+        public CircuitBreakerSpecs() => SystemClock.Current = _testSystemClock;
+
         #region Configuration tests
 
         [Fact]
@@ -194,7 +198,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_halfopen_circuit_after_the_specified_duration_has_passed()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -215,7 +219,7 @@ namespace Polly.Specs.CircuitBreaker
                   .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -227,7 +231,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_again_after_the_specified_duration_has_passed_if_the_next_call_raises_an_exception()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -248,7 +252,7 @@ namespace Polly.Specs.CircuitBreaker
                   .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -265,7 +269,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_reset_circuit_after_the_specified_duration_has_passed_if_the_next_call_does_not_raise_an_exception()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -286,7 +290,7 @@ namespace Polly.Specs.CircuitBreaker
                   .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -312,7 +316,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_only_allow_single_execution_on_first_entering_halfopen_state__test_execution_permit_directly()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
             CircuitBreakerPolicy breaker = Policy
@@ -326,7 +330,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // break duration passes, circuit now half open
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
 
@@ -343,7 +347,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_allow_single_execution_per_break_duration_in_halfopen_state__test_execution_permit_directly()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
             CircuitBreakerPolicy breaker = Policy
@@ -357,7 +361,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // break duration passes, circuit now half open
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
 
@@ -370,7 +374,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // Allow another time window to pass (breaker should still be HalfOpen).
-            SystemClock.UtcNow = () => time.Add(durationOfBreak).Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak).Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should now permit another trial execution.
@@ -382,7 +386,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_only_allow_single_execution_on_first_entering_halfopen_state__integration_test()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
             CircuitBreakerPolicy breaker = Policy
@@ -396,7 +400,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // break duration passes, circuit now half open
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // Start one execution during the HalfOpen state, and request a second execution before the first has completed (ie still during the HalfOpen state).
@@ -480,7 +484,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_allow_single_execution_per_break_duration_in_halfopen_state__integration_test()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
             CircuitBreakerPolicy breaker = Policy
@@ -494,7 +498,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // break duration passes, circuit now half open
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // Start one execution during the HalfOpen state.
@@ -539,7 +543,7 @@ namespace Polly.Specs.CircuitBreaker
 
                     try
                     {
-                        SystemClock.UtcNow = () => time.Add(durationOfBreak).Add(durationOfBreak);
+                        _testSystemClock.UtcNow = time.Add(durationOfBreak).Add(durationOfBreak);
 
                         breaker.Execute(() =>
                         {
@@ -583,7 +587,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_and_block_calls_if_manual_override_open()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -609,7 +613,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_hold_circuit_open_despite_elapsed_time_if_manual_override_open()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -621,7 +625,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Isolate();
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
             bool delegateExecutedWhenBroken = false;
             breaker.Invoking(x => x.Execute(() => { delegateExecutedWhenBroken = true; return ResultPrimitive.Good; }))
@@ -633,7 +637,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_close_circuit_again_on_reset_after_manual_override()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -656,7 +660,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_be_able_to_reset_automatically_opened_circuit_without_specified_duration_passing()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -679,7 +683,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // reset circuit, with no time having passed
             breaker.Reset();
-            SystemClock.UtcNow().Should().Be(time);
+            SystemClock.Current.UtcNow.Should().Be(time);
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             breaker.Invoking(x => x.Execute(() => { })).Should().NotThrow();
         }
@@ -841,7 +845,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onReset = () => { onResetCalled++; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -865,7 +869,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -911,7 +915,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onHalfOpen = () => { onHalfOpenCalled++; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -935,7 +939,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             // duration has passed, circuit now half open
             onHalfOpenCalled.Should().Be(0); // not yet transitioned to half-open, because we have not queried state
 
@@ -957,7 +961,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onHalfOpen = () => { onHalfOpenCalled++; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -981,7 +985,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
             onHalfOpenCalled.Should().Be(1);
@@ -996,7 +1000,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onReset = () => { onResetCalled++; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -1081,7 +1085,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onHalfOpen = () => { };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -1102,7 +1106,7 @@ namespace Polly.Specs.CircuitBreaker
                   .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -1179,7 +1183,7 @@ namespace Polly.Specs.CircuitBreaker
             Action<Context> onReset = _ => { };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -1234,7 +1238,7 @@ namespace Polly.Specs.CircuitBreaker
             Action<Context> onReset = context => { contextData = context; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -1248,7 +1252,7 @@ namespace Polly.Specs.CircuitBreaker
                 .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // first call after duration should invoke onReset, with context
@@ -1295,7 +1299,7 @@ namespace Polly.Specs.CircuitBreaker
                 .CircuitBreaker(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -1308,7 +1312,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
             contextValue.Should().Be("original_value");
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);

--- a/src/Polly.Specs/CircuitBreaker/CircuitBreakerTResultAsyncSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/CircuitBreakerTResultAsyncSpecs.cs
@@ -16,6 +16,10 @@ namespace Polly.Specs.CircuitBreaker
     [Collection(Constants.SystemClockDependentTestCollection)]
     public class CircuitBreakerTResultAsyncSpecs : IDisposable
     {
+        private readonly TestSystemClock _testSystemClock = new TestSystemClock();
+
+        public CircuitBreakerTResultAsyncSpecs() => SystemClock.Current = _testSystemClock;
+
         #region Configuration tests
 
         [Fact]
@@ -258,7 +262,7 @@ namespace Polly.Specs.CircuitBreaker
         public async Task Should_halfopen_circuit_after_the_specified_duration_has_passed()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -279,7 +283,7 @@ namespace Polly.Specs.CircuitBreaker
                 .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -291,7 +295,7 @@ namespace Polly.Specs.CircuitBreaker
         public async Task Should_open_circuit_again_after_the_specified_duration_has_passed_if_the_next_call_raises_a_fault()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -312,7 +316,7 @@ namespace Polly.Specs.CircuitBreaker
                   .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -330,7 +334,7 @@ namespace Polly.Specs.CircuitBreaker
         public async Task Should_reset_circuit_after_the_specified_duration_has_passed_if_the_next_call_does_not_return_a_fault()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -351,7 +355,7 @@ namespace Polly.Specs.CircuitBreaker
                   .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -378,7 +382,7 @@ namespace Polly.Specs.CircuitBreaker
         public async Task Should_only_allow_single_execution_on_first_entering_halfopen_state__test_execution_permit_directly()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
             var breaker = Policy
@@ -392,7 +396,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // break duration passes, circuit now half open
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
 
@@ -409,7 +413,7 @@ namespace Polly.Specs.CircuitBreaker
         public async Task Should_allow_single_execution_per_break_duration_in_halfopen_state__test_execution_permit_directly()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
             var breaker = Policy
@@ -423,7 +427,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // break duration passes, circuit now half open
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
 
@@ -436,7 +440,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // Allow another time window to pass (breaker should still be HalfOpen).
-            SystemClock.UtcNow = () => time.Add(durationOfBreak).Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak).Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should now permit another trial execution.
@@ -448,7 +452,7 @@ namespace Polly.Specs.CircuitBreaker
         public async Task Should_only_allow_single_execution_on_first_entering_halfopen_state__integration_test()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
             var breaker = Policy
@@ -462,7 +466,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // break duration passes, circuit now half open
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // Start one execution during the HalfOpen state, and request a second execution before the first has completed (ie still during the HalfOpen state).
@@ -551,7 +555,7 @@ namespace Polly.Specs.CircuitBreaker
         public async Task Should_allow_single_execution_per_break_duration_in_halfopen_state__integration_test()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
             var breaker = Policy
@@ -565,7 +569,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // break duration passes, circuit now half open
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // Start one execution during the HalfOpen state.
@@ -612,7 +616,7 @@ namespace Polly.Specs.CircuitBreaker
 
                     try
                     {
-                        SystemClock.UtcNow = () => time.Add(durationOfBreak).Add(durationOfBreak);
+                        _testSystemClock.UtcNow = time.Add(durationOfBreak).Add(durationOfBreak);
 
                         await breaker.ExecuteAsync(async () =>
                         {
@@ -660,7 +664,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_and_block_calls_if_manual_override_open()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -687,7 +691,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_hold_circuit_open_despite_elapsed_time_if_manual_override_open()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -699,7 +703,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Isolate();
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
 
             bool delegateExecutedWhenBroken = false;
@@ -712,7 +716,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_close_circuit_again_on_reset_after_manual_override()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -735,7 +739,7 @@ namespace Polly.Specs.CircuitBreaker
         public async Task Should_be_able_to_reset_automatically_opened_circuit_without_specified_duration_passing()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -758,7 +762,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // reset circuit, with no time having passed
             breaker.Reset();
-            SystemClock.UtcNow().Should().Be(time);
+            SystemClock.Current.UtcNow.Should().Be(time);
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             breaker.Awaiting(async x => await x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good))).Should().NotThrow();
         }
@@ -922,7 +926,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onReset = () => { onResetCalled++; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -946,7 +950,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -992,7 +996,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onHalfOpen = () => { onHalfOpenCalled++; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -1016,7 +1020,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             // duration has passed, circuit now half open
             onHalfOpenCalled.Should().Be(0); // not yet transitioned to half-open, because we have not queried state
 
@@ -1039,7 +1043,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onHalfOpen = () => { onHalfOpenCalled++; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -1063,7 +1067,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
             onHalfOpenCalled.Should().Be(1);
@@ -1078,7 +1082,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onReset = () => { onResetCalled++; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -1163,7 +1167,7 @@ namespace Polly.Specs.CircuitBreaker
             Action<Context> onReset = _ => { };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -1218,7 +1222,7 @@ namespace Polly.Specs.CircuitBreaker
             Action<Context> onReset = context => { contextData = context; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -1232,7 +1236,7 @@ namespace Polly.Specs.CircuitBreaker
                 .Should().Be(ResultPrimitive.Fault);
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // first call after duration should invoke onReset, with context
@@ -1279,7 +1283,7 @@ namespace Polly.Specs.CircuitBreaker
                 .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -1292,7 +1296,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
             contextValue.Should().Be("original_value");
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);

--- a/src/Polly.Specs/CircuitBreaker/CircuitBreakerTResultMixedResultExceptionSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/CircuitBreakerTResultMixedResultExceptionSpecs.cs
@@ -11,6 +11,10 @@ namespace Polly.Specs.CircuitBreaker
     [Collection(Constants.SystemClockDependentTestCollection)]
     public class CircuitBreakerTResultMixedResultExceptionSpecs : IDisposable
     {
+        private readonly TestSystemClock _testSystemClock = new TestSystemClock();
+
+        public CircuitBreakerTResultMixedResultExceptionSpecs() => SystemClock.Current = _testSystemClock;
+
         #region Circuit-breaker threshold-to-break tests
 
         [Fact]
@@ -340,7 +344,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_again_after_the_specified_duration_has_passed_if_the_next_call_raises_a_fault()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -362,7 +366,7 @@ namespace Polly.Specs.CircuitBreaker
                   .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -380,7 +384,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_again_after_the_specified_duration_has_passed_if_the_next_call_raises_an_exception()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -402,7 +406,7 @@ namespace Polly.Specs.CircuitBreaker
                   .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);

--- a/src/Polly.Specs/CircuitBreaker/CircuitBreakerTResultSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/CircuitBreakerTResultSpecs.cs
@@ -16,6 +16,10 @@ namespace Polly.Specs.CircuitBreaker
     [Collection(Constants.SystemClockDependentTestCollection)]
     public class CircuitBreakerTResultSpecs : IDisposable
     {
+        private readonly TestSystemClock _testSystemClock = new TestSystemClock();
+
+        public CircuitBreakerTResultSpecs() => SystemClock.Current = _testSystemClock;
+
         #region Configuration tests
 
         [Fact]
@@ -258,7 +262,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_halfopen_circuit_after_the_specified_duration_has_passed()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -279,7 +283,7 @@ namespace Polly.Specs.CircuitBreaker
                 .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -291,7 +295,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_again_after_the_specified_duration_has_passed_if_the_next_call_raises_a_fault()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -312,7 +316,7 @@ namespace Polly.Specs.CircuitBreaker
                   .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -330,7 +334,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_reset_circuit_after_the_specified_duration_has_passed_if_the_next_call_does_not_return_a_fault()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -351,7 +355,7 @@ namespace Polly.Specs.CircuitBreaker
                   .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -377,7 +381,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_only_allow_single_execution_on_first_entering_halfopen_state__test_execution_permit_directly()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
             CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
@@ -391,7 +395,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // break duration passes, circuit now half open
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
 
@@ -408,7 +412,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_allow_single_execution_per_break_duration_in_halfopen_state__test_execution_permit_directly()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
             CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
@@ -422,7 +426,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // break duration passes, circuit now half open
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
 
@@ -435,7 +439,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // Allow another time window to pass (breaker should still be HalfOpen).
-            SystemClock.UtcNow = () => time.Add(durationOfBreak).Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak).Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should now permit another trial execution.
@@ -447,7 +451,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_only_allow_single_execution_on_first_entering_halfopen_state__integration_test()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
             CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
@@ -461,7 +465,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // break duration passes, circuit now half open
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // Start one execution during the HalfOpen state, and request a second execution before the first has completed (ie still during the HalfOpen state).
@@ -547,7 +551,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_allow_single_execution_per_break_duration_in_halfopen_state__integration_test()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
             CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
@@ -561,7 +565,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // break duration passes, circuit now half open
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // Start one execution during the HalfOpen state.
@@ -607,7 +611,7 @@ namespace Polly.Specs.CircuitBreaker
 
                     try
                     {
-                        SystemClock.UtcNow = () => time.Add(durationOfBreak).Add(durationOfBreak);
+                        _testSystemClock.UtcNow = time.Add(durationOfBreak).Add(durationOfBreak);
 
                         breaker.Execute(() =>
                         {
@@ -653,7 +657,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_open_circuit_and_block_calls_if_manual_override_open()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -680,7 +684,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_hold_circuit_open_despite_elapsed_time_if_manual_override_open()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -692,7 +696,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Isolate();
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
 
             bool delegateExecutedWhenBroken = false;
@@ -705,7 +709,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_close_circuit_again_on_reset_after_manual_override()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -728,7 +732,7 @@ namespace Polly.Specs.CircuitBreaker
         public void Should_be_able_to_reset_automatically_opened_circuit_without_specified_duration_passing()
         {
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -751,7 +755,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // reset circuit, with no time having passed
             breaker.Reset();
-            SystemClock.UtcNow().Should().Be(time);
+            SystemClock.Current.UtcNow.Should().Be(time);
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             breaker.Invoking(x => x.Execute(() => ResultPrimitive.Good)).Should().NotThrow();
         }
@@ -913,7 +917,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onReset = () => { onResetCalled++; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -937,7 +941,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
@@ -983,7 +987,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onHalfOpen = () => { onHalfOpenCalled++; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -1007,7 +1011,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             // duration has passed, circuit now half open
             onHalfOpenCalled.Should().Be(0); // not yet transitioned to half-open, because we have not queried state
 
@@ -1029,7 +1033,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onHalfOpen = () => { onHalfOpenCalled++; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -1053,7 +1057,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
             onHalfOpenCalled.Should().Be(1);
@@ -1068,7 +1072,7 @@ namespace Polly.Specs.CircuitBreaker
             Action onReset = () => { onResetCalled++; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -1152,7 +1156,7 @@ namespace Polly.Specs.CircuitBreaker
             Action<Context> onReset = _ => { };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -1207,7 +1211,7 @@ namespace Polly.Specs.CircuitBreaker
             Action<Context> onReset = context => { contextData = context; };
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -1221,7 +1225,7 @@ namespace Polly.Specs.CircuitBreaker
                 .Should().Be(ResultPrimitive.Fault);
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // first call after duration should invoke onReset, with context
@@ -1268,7 +1272,7 @@ namespace Polly.Specs.CircuitBreaker
                 .CircuitBreaker(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
             var time = 1.January(2000);
-            SystemClock.UtcNow = () => time;
+            _testSystemClock.UtcNow = time;
 
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
@@ -1281,7 +1285,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
             contextValue.Should().Be("original_value");
 
-            SystemClock.UtcNow = () => time.Add(durationOfBreak);
+            _testSystemClock.UtcNow = time.Add(durationOfBreak);
 
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);

--- a/src/Polly.Specs/Helpers/Caching/StubCacheProvider.cs
+++ b/src/Polly.Specs/Helpers/Caching/StubCacheProvider.cs
@@ -16,7 +16,7 @@ namespace Polly.Specs.Helpers.Caching
         {
             public CacheItem(object value, Ttl ttl)
             {
-                Expiry = DateTimeOffset.MaxValue - SystemClock.DateTimeOffsetUtcNow() > ttl.Timespan ? SystemClock.DateTimeOffsetUtcNow().Add(ttl.Timespan) : DateTimeOffset.MaxValue;
+                Expiry = DateTimeOffset.MaxValue - SystemClock.Current.DateTimeOffsetUtcNow > ttl.Timespan ? SystemClock.Current.DateTimeOffsetUtcNow.Add(ttl.Timespan) : DateTimeOffset.MaxValue;
                 Value = value;
             }
 
@@ -30,7 +30,7 @@ namespace Polly.Specs.Helpers.Caching
         {
             if (cachedValues.ContainsKey(key))
             {
-                if (SystemClock.DateTimeOffsetUtcNow() < cachedValues[key].Expiry)
+                if (SystemClock.Current.DateTimeOffsetUtcNow < cachedValues[key].Expiry)
                 {
                     return (true, cachedValues[key].Value);
                 }

--- a/src/Polly.Specs/Retry/WaitAndRetryForeverTResultAsyncSpecs.cs
+++ b/src/Polly.Specs/Retry/WaitAndRetryForeverTResultAsyncSpecs.cs
@@ -15,7 +15,7 @@ namespace Polly.Specs.Retry
         public WaitAndRetryForeverTResultAsyncSpecs()
         {
             // do nothing on call to sleep
-            SystemClock.SleepAsync = (_, __) => TaskHelper.EmptyTask;
+            SystemClock.Current = new TestSystemClock();
         }
 
         [Fact]

--- a/src/Polly.Specs/Retry/WaitAndRetryForeverTResultSpecs.cs
+++ b/src/Polly.Specs/Retry/WaitAndRetryForeverTResultSpecs.cs
@@ -14,7 +14,7 @@ namespace Polly.Specs.Retry
         public WaitAndRetryForeverTResultSpecs()
         {
             // do nothing on call to sleep
-            SystemClock.Sleep = (_, __) => { };
+            SystemClock.Current = new TestSystemClock();
         }
 
         [Fact]

--- a/src/Polly.Specs/Retry/WaitAndRetryTResultAsyncSpecs.cs
+++ b/src/Polly.Specs/Retry/WaitAndRetryTResultAsyncSpecs.cs
@@ -14,8 +14,7 @@ namespace Polly.Specs.Retry
     {
         public WaitAndRetryTResultAsyncSpecs()
         {
-            // do nothing on call to sleep
-            SystemClock.SleepAsync = (_, __) => TaskHelper.EmptyTask;
+            SystemClock.Current = new TestSystemClock();
         }
 
         [Fact]

--- a/src/Polly.Specs/Retry/WaitAndRetryTResultSpecs.cs
+++ b/src/Polly.Specs/Retry/WaitAndRetryTResultSpecs.cs
@@ -14,7 +14,7 @@ namespace Polly.Specs.Retry
         public WaitAndRetryTResultSpecs()
         {
             // do nothing on call to sleep
-            SystemClock.Sleep = (_, __) => { };
+            SystemClock.Current = new TestSystemClock();
         }
 
         [Fact]

--- a/src/Polly.Specs/TestSystemClock.cs
+++ b/src/Polly.Specs/TestSystemClock.cs
@@ -1,0 +1,79 @@
+﻿using Polly.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Polly.Specs
+{
+    internal sealed class TestSystemClock : ISystemClock
+    {
+        // Track a CancellationTokenSource, and when it might be cancelled at.
+        private CancellationTokenSource _trackedTokenSource = null;
+        private DateTimeOffset _cancelAt = DateTimeOffset.MaxValue;
+
+        public TestSystemClock()
+            : this(DateTimeOffset.UtcNow)
+        { }
+
+        public TestSystemClock(DateTimeOffset utcNow)
+        {
+            DateTimeOffsetUtcNow = utcNow;
+        }
+
+        public DateTime UtcNow { get => DateTimeOffsetUtcNow.UtcDateTime; set => DateTimeOffsetUtcNow = value; }
+
+        public DateTimeOffset DateTimeOffsetUtcNow { get; set; }
+
+        public void CancelTokenAfter(CancellationTokenSource tokenSource, TimeSpan delay)
+        {
+            if (_trackedTokenSource != null && tokenSource != _trackedTokenSource) throw new InvalidOperationException("Timeout tests cannot track more than one timing out token at a time.");
+
+            _trackedTokenSource = tokenSource;
+
+            var newCancelAt = DateTimeOffsetUtcNow.Add(delay);
+            _cancelAt = newCancelAt < _cancelAt ? newCancelAt : _cancelAt;
+
+            Sleep(TimeSpan.Zero, CancellationToken.None); // Invoke our custom definition of sleep, to check for immediate cancellation.
+        }
+
+        public void Sleep(TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested) return;
+
+            if (_trackedTokenSource == null || _trackedTokenSource.IsCancellationRequested)
+            {
+                // Not tracking any CancellationToken (or already cancelled) - just advance time.
+                DateTimeOffsetUtcNow += timeout;
+            }
+            else
+            {
+                // Tracking something to cancel - does this sleep hit time to cancel?
+                var timeToCancellation = _cancelAt - DateTimeOffsetUtcNow;
+                if (timeout >= timeToCancellation)
+                {
+                    // Cancel!  (And advance time only to the instant of cancellation)
+                    DateTimeOffsetUtcNow += timeToCancellation;
+
+                    // (and stop tracking it after cancelling; it can't be cancelled twice, so there is no need, and the owner may dispose it)
+                    var copySource = _trackedTokenSource;
+                    _trackedTokenSource = null;
+                    copySource.Cancel();
+                    copySource.Token.ThrowIfCancellationRequested();
+                }
+                else
+                {
+                    // (not yet time to cancel - just advance time)
+                    DateTimeOffsetUtcNow += timeout;
+                }
+            }
+        }
+
+        public Task SleepAsync(TimeSpan delay, CancellationToken cancellationToken)
+        {
+            Sleep(delay, cancellationToken);
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/src/Polly.Specs/Timeout/TimeoutAsyncSpecs.cs
+++ b/src/Polly.Specs/Timeout/TimeoutAsyncSpecs.cs
@@ -207,7 +207,7 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async () =>
             {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
+                await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
 
             })).Should().Throw<TimeoutRejectedException>();
         }
@@ -242,7 +242,7 @@ namespace Polly.Specs.Timeout
             watch.Start();
             policy.Awaiting(async p => await p.ExecuteAsync(async () =>
             {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(10), CancellationToken.None).ConfigureAwait(false);
+                await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(10), CancellationToken.None).ConfigureAwait(false);
 
             }))
                 .Should().Throw<TimeoutRejectedException>();
@@ -274,7 +274,7 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async ct =>
             {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+                await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
                 
             }, userCancellationToken).ConfigureAwait(false))
             .Should().Throw<TimeoutRejectedException>();
@@ -290,7 +290,7 @@ namespace Polly.Specs.Timeout
             Func<Task> act = async () => {
                 result = await policy.ExecuteAsync(async ct =>
                     {
-                        await SystemClock.SleepAsync(TimeSpan.FromMilliseconds(500), ct).ConfigureAwait(false);
+                        await SystemClock.Current.SleepAsync(TimeSpan.FromMilliseconds(500), ct).ConfigureAwait(false);
                         return ResultPrimitive.Good;
                     }, userCancellationToken)
                     .ConfigureAwait(false);
@@ -314,7 +314,7 @@ namespace Polly.Specs.Timeout
             watch.Start();
             policy.Awaiting(async p => await p.ExecuteAsync(async ct =>
             {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(10), ct).ConfigureAwait(false);
+                await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(10), ct).ConfigureAwait(false);
                 
             }, userCancellationToken).ConfigureAwait(false))
                 .Should().Throw<TimeoutRejectedException>();
@@ -346,7 +346,7 @@ namespace Polly.Specs.Timeout
                 policy.Awaiting(async p => await p.ExecuteAsync(async
                     _ => {
                         userTokenSource.Cancel(); // User token cancels in the middle of execution ...
-                        await SystemClock.SleepAsync(TimeSpan.FromSeconds(timeout * 2), 
+                        await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(timeout * 2), 
                             CancellationToken.None // ... but if the executed delegate does not observe it
                             ).ConfigureAwait(false); 
                     }, userTokenSource.Token)
@@ -430,7 +430,7 @@ namespace Polly.Specs.Timeout
                 {
                     try
                     {
-                        await SystemClock.SleepAsync(shimTimeSpan + shimTimeSpan, CancellationToken.None);
+                        await SystemClock.Current.SleepAsync(shimTimeSpan + shimTimeSpan, CancellationToken.None);
                     }
                     catch
                     {
@@ -474,7 +474,7 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async () =>
             {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
+                await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
                 
             }))
             .Should().Throw<TimeoutRejectedException>();
@@ -500,7 +500,7 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async ctx =>
                 {
-                    await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
+                    await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
                 
                 }, contextPassedToExecute))
                 .Should().Throw<TimeoutRejectedException>();
@@ -529,7 +529,7 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async () =>
             {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
+                await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
             }))
             .Should().Throw<TimeoutRejectedException>();
 
@@ -558,7 +558,7 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async ctx =>
             {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
+                await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
             }, context))
             .Should().Throw<TimeoutRejectedException>();
 
@@ -580,7 +580,7 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async () =>
             {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
+                await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
             }))
             .Should().Throw<TimeoutRejectedException>();
 
@@ -609,12 +609,12 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async () =>
             {
-                await SystemClock.SleepAsync(thriceShimTimeSpan, CancellationToken.None).ConfigureAwait(false);
+                await SystemClock.Current.SleepAsync(thriceShimTimeSpan, CancellationToken.None).ConfigureAwait(false);
                 throw exceptionToThrow;
             }))
             .Should().Throw<TimeoutRejectedException>();
 
-            await SystemClock.SleepAsync(thriceShimTimeSpan, CancellationToken.None).ConfigureAwait(false);
+            await SystemClock.Current.SleepAsync(thriceShimTimeSpan, CancellationToken.None).ConfigureAwait(false);
             exceptionObservedFromTaskPassedToOnTimeout.Should().NotBeNull();
             exceptionObservedFromTaskPassedToOnTimeout.Should().Be(exceptionToThrow);
 
@@ -636,7 +636,7 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async () =>
                 {
-                    await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
+                    await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
 
                 }))
                 .Should().Throw<TimeoutRejectedException>();
@@ -666,7 +666,7 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async ct =>
             {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+                await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
 
             }, userCancellationToken).ConfigureAwait(false))
             .Should().Throw<TimeoutRejectedException>();
@@ -693,7 +693,7 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async (ctx, ct) =>
                 {
-                    await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+                    await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
 
                 }, contextPassedToExecute, userCancellationToken).ConfigureAwait(false))
                 .Should().Throw<TimeoutRejectedException>();
@@ -723,7 +723,7 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async ct =>
                 {
-                    await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+                    await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
 
                 }, userCancellationToken).ConfigureAwait(false))
                 .Should().Throw<TimeoutRejectedException>();
@@ -757,7 +757,7 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async (ctx, ct) =>
             {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+                await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
 
             }, context, userCancellationToken).ConfigureAwait(false))
                 .Should().Throw<TimeoutRejectedException>();
@@ -781,7 +781,7 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async ct =>
             {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+                await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
 
             }, userCancellationToken).ConfigureAwait(false))
             .Should().Throw<TimeoutRejectedException>();
@@ -806,7 +806,7 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async ct =>
             {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+                await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
 
             }, userCancellationToken).ConfigureAwait(false))
             .Should().Throw<TimeoutRejectedException>();

--- a/src/Polly.Specs/Timeout/TimeoutSpecs.cs
+++ b/src/Polly.Specs/Timeout/TimeoutSpecs.cs
@@ -221,7 +221,7 @@ namespace Polly.Specs.Timeout
         {
             var policy = Policy.Timeout(TimeSpan.FromMilliseconds(50), TimeoutStrategy.Pessimistic);
 
-            policy.Invoking(p => p.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None)))
+            policy.Invoking(p => p.Execute(() => SystemClock.Current.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None)))
                 .Should().Throw<TimeoutRejectedException>();
         }
 
@@ -236,7 +236,7 @@ namespace Polly.Specs.Timeout
             Action act = () => {
                 result = policy.Execute(ct =>
                 {
-                    SystemClock.Sleep(TimeSpan.FromMilliseconds(500), ct);
+                    SystemClock.Current.Sleep(TimeSpan.FromMilliseconds(500), ct);
                     return ResultPrimitive.Good;
                 }, userCancellationToken);
             };
@@ -256,7 +256,7 @@ namespace Polly.Specs.Timeout
             TimeSpan tolerance = TimeSpan.FromSeconds(3); // Consider increasing tolerance, if test fails transiently in different test/build environments.
 
             watch.Start();
-            policy.Invoking(p => p.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(10), CancellationToken.None)))
+            policy.Invoking(p => p.Execute(() => SystemClock.Current.Sleep(TimeSpan.FromSeconds(10), CancellationToken.None)))
                 .Should().Throw<TimeoutRejectedException>();
             watch.Stop();
 
@@ -362,7 +362,7 @@ namespace Polly.Specs.Timeout
             var policy = Policy.Timeout(TimeSpan.FromMilliseconds(50), TimeoutStrategy.Optimistic);
             var userCancellationToken = CancellationToken.None;
 
-            policy.Invoking(p => p.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(3), ct), userCancellationToken)) // Delegate observes cancellation token, so permitting optimistic cancellation. 
+            policy.Invoking(p => p.Execute(ct => SystemClock.Current.Sleep(TimeSpan.FromSeconds(3), ct), userCancellationToken)) // Delegate observes cancellation token, so permitting optimistic cancellation. 
                 .Should().Throw<TimeoutRejectedException>();
         }
 
@@ -376,7 +376,7 @@ namespace Polly.Specs.Timeout
             Action act = () => {
                 result = policy.Execute(ct =>
                     {
-                        SystemClock.Sleep(TimeSpan.FromMilliseconds(500), ct);
+                        SystemClock.Current.Sleep(TimeSpan.FromMilliseconds(500), ct);
                         return ResultPrimitive.Good;
                     }, userCancellationToken);
             };
@@ -397,7 +397,7 @@ namespace Polly.Specs.Timeout
             TimeSpan tolerance = TimeSpan.FromSeconds(3); // Consider increasing tolerance, if test fails transiently in different test/build environments.
 
             watch.Start();
-            policy.Invoking(p => p.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(10), ct), userCancellationToken)) // Delegate observes cancellation token, so permitting optimistic cancellation. 
+            policy.Invoking(p => p.Execute(ct => SystemClock.Current.Sleep(TimeSpan.FromSeconds(10), ct), userCancellationToken)) // Delegate observes cancellation token, so permitting optimistic cancellation. 
                 .Should().Throw<TimeoutRejectedException>();
             watch.Stop();
 
@@ -429,7 +429,7 @@ namespace Polly.Specs.Timeout
                     _ =>
                     {
                         userTokenSource.Cancel(); // User token cancels in the middle of execution ...
-                        SystemClock.Sleep(TimeSpan.FromSeconds(timeout * 2),
+                        SystemClock.Current.Sleep(TimeSpan.FromSeconds(timeout * 2),
                             CancellationToken.None // ... but if the executed delegate does not observe it
                             );
                     }
@@ -504,7 +504,7 @@ namespace Polly.Specs.Timeout
                 {
                     try
                     {
-                        SystemClock.Sleep(shimTimeSpan + shimTimeSpan, CancellationToken.None);
+                        SystemClock.Current.Sleep(shimTimeSpan + shimTimeSpan, CancellationToken.None);
                     }
                     catch
                     {
@@ -542,7 +542,7 @@ namespace Polly.Specs.Timeout
 
             var policy = Policy.Timeout(timeoutPassedToConfiguration, TimeoutStrategy.Pessimistic, onTimeout);
 
-            policy.Invoking(p => p.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None)))
+            policy.Invoking(p => p.Execute(() => SystemClock.Current.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None)))
                 .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutPassedToConfiguration);
@@ -560,7 +560,7 @@ namespace Polly.Specs.Timeout
             TimeSpan timeout = TimeSpan.FromMilliseconds(250);
             var policy = Policy.Timeout(timeout, TimeoutStrategy.Pessimistic, onTimeout);
 
-            policy.Invoking(p => p.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None), contextPassedToExecute))
+            policy.Invoking(p => p.Execute(ct => SystemClock.Current.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None), contextPassedToExecute))
                 .Should().Throw<TimeoutRejectedException>();
 
             contextPassedToOnTimeout.Should().NotBeNull();
@@ -581,7 +581,7 @@ namespace Polly.Specs.Timeout
 
             var policy = Policy.Timeout(timeoutFunc, TimeoutStrategy.Pessimistic, onTimeout);
 
-            policy.Invoking(p => p.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None)))
+            policy.Invoking(p => p.Execute(() => SystemClock.Current.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None)))
                 .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutFunc());
@@ -602,7 +602,7 @@ namespace Polly.Specs.Timeout
             // Supply a programatically-controlled timeout, via the execution context.
             Context context = new Context("SomeOperationKey") {["timeout"] = TimeSpan.FromMilliseconds(25* programaticallyControlledDelay) };
 
-            policy.Invoking(p => p.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None), context))
+            policy.Invoking(p => p.Execute(ct => SystemClock.Current.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None), context))
                 .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutProvider(context));
@@ -617,7 +617,7 @@ namespace Polly.Specs.Timeout
             TimeSpan timeout = TimeSpan.FromMilliseconds(250);
             var policy = Policy.Timeout(timeout, TimeoutStrategy.Pessimistic, onTimeout);
 
-            policy.Invoking(p => p.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None)))
+            policy.Invoking(p => p.Execute(() => SystemClock.Current.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None)))
                 .Should().Throw<TimeoutRejectedException>();
 
             taskPassedToOnTimeout.Should().NotBeNull();
@@ -644,12 +644,12 @@ namespace Polly.Specs.Timeout
 
             policy.Invoking(p => p.Execute(() =>
             {
-                SystemClock.Sleep(thriceShimTimeSpan, CancellationToken.None);
+                SystemClock.Current.Sleep(thriceShimTimeSpan, CancellationToken.None);
                 throw exceptionToThrow;
             }))
                 .Should().Throw<TimeoutRejectedException>();
 
-            SystemClock.Sleep(thriceShimTimeSpan, CancellationToken.None);
+            SystemClock.Current.Sleep(thriceShimTimeSpan, CancellationToken.None);
             exceptionObservedFromTaskPassedToOnTimeout.Should().NotBeNull();
             exceptionObservedFromTaskPassedToOnTimeout.Should().Be(exceptionToThrow);
 
@@ -665,7 +665,7 @@ namespace Polly.Specs.Timeout
 
             var policy = Policy.Timeout(timeoutPassedToConfiguration, TimeoutStrategy.Pessimistic, onTimeout);
 
-            policy.Invoking(p => p.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None)))
+            policy.Invoking(p => p.Execute(() => SystemClock.Current.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None)))
                 .Should().Throw<TimeoutRejectedException>();
 
             exceptionPassedToOnTimeout.Should().NotBeNull();
@@ -687,7 +687,7 @@ namespace Polly.Specs.Timeout
             var policy = Policy.Timeout(timeoutPassedToConfiguration, TimeoutStrategy.Optimistic, onTimeout);
             var userCancellationToken = CancellationToken.None;
 
-            policy.Invoking(p => p.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(1), ct), userCancellationToken))
+            policy.Invoking(p => p.Execute(ct => SystemClock.Current.Sleep(TimeSpan.FromSeconds(1), ct), userCancellationToken))
                 .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutPassedToConfiguration);
@@ -706,7 +706,7 @@ namespace Polly.Specs.Timeout
             var policy = Policy.Timeout(timeout, TimeoutStrategy.Optimistic, onTimeout);
             var userCancellationToken = CancellationToken.None;
 
-            policy.Invoking(p => p.Execute((ctx, ct) => SystemClock.Sleep(TimeSpan.FromSeconds(3), ct), contextPassedToExecute, userCancellationToken))
+            policy.Invoking(p => p.Execute((ctx, ct) => SystemClock.Current.Sleep(TimeSpan.FromSeconds(3), ct), contextPassedToExecute, userCancellationToken))
                 .Should().Throw<TimeoutRejectedException>();
 
             contextPassedToOnTimeout.Should().NotBeNull();
@@ -728,7 +728,7 @@ namespace Polly.Specs.Timeout
             var policy = Policy.Timeout(timeoutFunc, TimeoutStrategy.Optimistic, onTimeout);
             var userCancellationToken = CancellationToken.None;
 
-            policy.Invoking(p => p.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(3), ct), userCancellationToken))
+            policy.Invoking(p => p.Execute(ct => SystemClock.Current.Sleep(TimeSpan.FromSeconds(3), ct), userCancellationToken))
                 .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutFunc());
@@ -754,7 +754,7 @@ namespace Polly.Specs.Timeout
                 ["timeout"] = TimeSpan.FromMilliseconds(25 * programaticallyControlledDelay)
             };
 
-            policy.Invoking(p => p.Execute((ctx, ct) => SystemClock.Sleep(TimeSpan.FromSeconds(3), ct), context, userCancellationToken))
+            policy.Invoking(p => p.Execute((ctx, ct) => SystemClock.Current.Sleep(TimeSpan.FromSeconds(3), ct), context, userCancellationToken))
                 .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutProvider(context));
@@ -770,7 +770,7 @@ namespace Polly.Specs.Timeout
             var policy = Policy.Timeout(timeout, TimeoutStrategy.Optimistic, onTimeout);
             var userCancellationToken = CancellationToken.None;
 
-            policy.Invoking(p => p.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(3), ct), userCancellationToken))
+            policy.Invoking(p => p.Execute(ct => SystemClock.Current.Sleep(TimeSpan.FromSeconds(3), ct), userCancellationToken))
                 .Should().Throw<TimeoutRejectedException>();
 
             taskPassedToOnTimeout.Should().BeNull();
@@ -787,7 +787,7 @@ namespace Polly.Specs.Timeout
             var policy = Policy.Timeout(timeoutPassedToConfiguration, TimeoutStrategy.Optimistic, onTimeout);
             var userCancellationToken = CancellationToken.None;
 
-            policy.Invoking(p => p.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(1), ct), userCancellationToken))
+            policy.Invoking(p => p.Execute(ct => SystemClock.Current.Sleep(TimeSpan.FromSeconds(1), ct), userCancellationToken))
                 .Should().Throw<TimeoutRejectedException>();
 
             exceptionPassedToOnTimeout.Should().NotBeNull();

--- a/src/Polly.Specs/Timeout/TimeoutSpecsBase.cs
+++ b/src/Polly.Specs/Timeout/TimeoutSpecsBase.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 using Polly.Utilities;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Polly.Specs.Timeout
 {
@@ -14,75 +12,9 @@ namespace Polly.Specs.Timeout
     /// </summary>
     public abstract class TimeoutSpecsBase : IDisposable
     {
-        // xUnit creates a new class instance per test, so these variables are isolated per test.
-
-        // Track a CancellationTokenSource, and when it might be cancelled at.
-        private CancellationTokenSource _trackedTokenSource;
-        private DateTimeOffset _cancelAt = DateTimeOffset.MaxValue;
-
-        private DateTimeOffset _offsetUtcNow = DateTimeOffset.UtcNow;
-        private DateTime _utcNow = DateTime.UtcNow;
-        
         protected TimeoutSpecsBase()
         {
-            // Override the SystemClock, to return time stored in variables we manipulate.
-            SystemClock.DateTimeOffsetUtcNow = () => _offsetUtcNow;
-            SystemClock.UtcNow = () => _utcNow;
-
-            // Override SystemClock.CancelTokenAfter to record when the policy wants the token to cancel.
-            SystemClock.CancelTokenAfter = (tokenSource, timespan) =>
-            {
-                if (_trackedTokenSource != null && tokenSource != _trackedTokenSource) throw new InvalidOperationException("Timeout tests cannot track more than one timing out token at a time.");
-
-                _trackedTokenSource = tokenSource;
-
-                DateTimeOffset newCancelAt = _offsetUtcNow.Add(timespan);
-                _cancelAt = newCancelAt < _cancelAt ? newCancelAt : _cancelAt;
-
-                SystemClock.Sleep(TimeSpan.Zero, CancellationToken.None); // Invoke our custom definition of sleep, to check for immediate cancellation.
-            };
-
-            // Override SystemClock.Sleep, to manipulate our artificial clock.  And - if it means sleeping beyond the time when a tracked token should cancel - cancel it!
-            SystemClock.Sleep = (sleepTimespan, sleepCancellationToken) =>
-            {
-                if (sleepCancellationToken.IsCancellationRequested) return;
-
-                if (_trackedTokenSource == null || _trackedTokenSource.IsCancellationRequested)
-                {
-                    // Not tracking any CancellationToken (or already cancelled) - just advance time.
-                    _utcNow += sleepTimespan;
-                    _offsetUtcNow += sleepTimespan;
-                }
-                else
-                {
-                    // Tracking something to cancel - does this sleep hit time to cancel?
-                    TimeSpan timeToCancellation = _cancelAt - _offsetUtcNow;
-                    if (sleepTimespan >= timeToCancellation)
-                    {
-                        // Cancel!  (And advance time only to the instant of cancellation)
-                        _offsetUtcNow += timeToCancellation;
-                        _utcNow += timeToCancellation;
-
-                        // (and stop tracking it after cancelling; it can't be cancelled twice, so there is no need, and the owner may dispose it)
-                        CancellationTokenSource copySource = _trackedTokenSource;
-                        _trackedTokenSource = null;
-                        copySource.Cancel();
-                        copySource.Token.ThrowIfCancellationRequested();
-                    }
-                    else
-                    {
-                        // (not yet time to cancel - just advance time)
-                        _utcNow += sleepTimespan;
-                        _offsetUtcNow += sleepTimespan;
-                    }
-                }
-            };
-
-            SystemClock.SleepAsync = (sleepTimespan, cancellationToken) =>
-            {
-                SystemClock.Sleep(sleepTimespan, cancellationToken);
-                return Task.FromResult(true);
-            };
+            SystemClock.Current = new TestSystemClock();
         }
 
         public void Dispose()

--- a/src/Polly.Specs/Timeout/TimeoutTResultAsyncSpecs.cs
+++ b/src/Polly.Specs/Timeout/TimeoutTResultAsyncSpecs.cs
@@ -208,7 +208,7 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async () =>
             {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
+                await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
                 return ResultPrimitive.WhateverButTooLate;
             }).ConfigureAwait(false)).Should().Throw<TimeoutRejectedException>();
         }
@@ -240,7 +240,7 @@ namespace Polly.Specs.Timeout
             watch.Start();
             policy.Awaiting(async p => await p.ExecuteAsync(async () =>
             {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(10), CancellationToken.None).ConfigureAwait(false);
+                await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(10), CancellationToken.None).ConfigureAwait(false);
                 return ResultPrimitive.WhateverButTooLate;
             }))
                 .Should().Throw<TimeoutRejectedException>();
@@ -269,7 +269,7 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async ct =>
             {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+                await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
                 return ResultPrimitive.WhateverButTooLate;
             }, userCancellationToken).ConfigureAwait(false)).Should().Throw<TimeoutRejectedException>();
         }
@@ -303,7 +303,7 @@ namespace Polly.Specs.Timeout
             watch.Start();
             policy.Awaiting(async p => await p.ExecuteAsync(async ct =>
             {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(10), ct).ConfigureAwait(false);
+                await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(10), ct).ConfigureAwait(false);
                 return ResultPrimitive.WhateverButTooLate;
             }, userCancellationToken).ConfigureAwait(false))
                 .Should().Throw<TimeoutRejectedException>();
@@ -335,7 +335,7 @@ namespace Polly.Specs.Timeout
                 policy.Awaiting(async p => await p.ExecuteAsync(async
                     _ => {
                         userTokenSource.Cancel(); // User token cancels in the middle of execution ...
-                        await SystemClock.SleepAsync(TimeSpan.FromSeconds(timeout * 2),
+                        await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(timeout * 2),
                             CancellationToken.None // ... but if the executed delegate does not observe it
                             ).ConfigureAwait(false);
                         return ResultPrimitive.WhateverButTooLate;
@@ -430,7 +430,7 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async () =>
             {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
+                await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
                 return ResultPrimitive.WhateverButTooLate;
             }))
             .Should().Throw<TimeoutRejectedException>();
@@ -456,7 +456,7 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async ctx =>
                 {
-                    await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
+                    await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
                     return ResultPrimitive.WhateverButTooLate;
                 }, contextPassedToExecute))
                 .Should().Throw<TimeoutRejectedException>();
@@ -485,7 +485,7 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async () =>
                 {
-                    await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
+                    await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
                     return ResultPrimitive.WhateverButTooLate;
                 }))
                 .Should().Throw<TimeoutRejectedException>();
@@ -515,7 +515,7 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async ctx =>
             {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
+                await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
                 return ResultPrimitive.WhateverButTooLate;
             }, context))
             .Should().Throw<TimeoutRejectedException>();
@@ -538,7 +538,7 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async () =>
             {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
+                await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
                 return ResultPrimitive.WhateverButTooLate;
             }))
             .Should().Throw<TimeoutRejectedException>();
@@ -568,12 +568,12 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async () =>
             {
-                await SystemClock.SleepAsync(thriceShimTimeSpan, CancellationToken.None).ConfigureAwait(false);
+                await SystemClock.Current.SleepAsync(thriceShimTimeSpan, CancellationToken.None).ConfigureAwait(false);
                 throw exceptionToThrow;
             }))
             .Should().Throw<TimeoutRejectedException>();
 
-            await SystemClock.SleepAsync(thriceShimTimeSpan, CancellationToken.None).ConfigureAwait(false);
+            await SystemClock.Current.SleepAsync(thriceShimTimeSpan, CancellationToken.None).ConfigureAwait(false);
             exceptionObservedFromTaskPassedToOnTimeout.Should().NotBeNull();
             exceptionObservedFromTaskPassedToOnTimeout.Should().Be(exceptionToThrow);
 
@@ -595,7 +595,7 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async () =>
                 {
-                    await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
+                    await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
                     return ResultPrimitive.WhateverButTooLate;
                 }))
                 .Should().Throw<TimeoutRejectedException>();
@@ -625,7 +625,7 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async ct =>
             {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+                await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
                 return ResultPrimitive.WhateverButTooLate;
             }, userCancellationToken).ConfigureAwait(false))
             .Should().Throw<TimeoutRejectedException>();
@@ -652,7 +652,7 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async (ctx, ct) =>
                 {
-                    await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+                    await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
                     return ResultPrimitive.WhateverButTooLate;
                 }, contextPassedToExecute, userCancellationToken).ConfigureAwait(false))
                 .Should().Throw<TimeoutRejectedException>();
@@ -683,7 +683,7 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async ct =>
                 {
-                    await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+                    await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
                     return ResultPrimitive.WhateverButTooLate;
                 }, userCancellationToken).ConfigureAwait(false))
                 .Should().Throw<TimeoutRejectedException>();
@@ -717,7 +717,7 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async (ctx, ct) =>
             {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+                await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
                 return ResultPrimitive.WhateverButTooLate;
             }, context, userCancellationToken).ConfigureAwait(false))
                 .Should().Throw<TimeoutRejectedException>();
@@ -741,7 +741,7 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async ct =>
             {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+                await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
                 return ResultPrimitive.WhateverButTooLate;
             }, userCancellationToken).ConfigureAwait(false))
             .Should().Throw<TimeoutRejectedException>();
@@ -766,7 +766,7 @@ namespace Polly.Specs.Timeout
 
             policy.Awaiting(async p => await p.ExecuteAsync(async ct =>
                 {
-                    await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+                    await SystemClock.Current.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
                     return ResultPrimitive.WhateverButTooLate;
                 }, userCancellationToken).ConfigureAwait(false))
                 .Should().Throw<TimeoutRejectedException>();

--- a/src/Polly.Specs/Timeout/TimeoutTResultSpecs.cs
+++ b/src/Polly.Specs/Timeout/TimeoutTResultSpecs.cs
@@ -207,7 +207,7 @@ namespace Polly.Specs.Timeout
 
             policy.Invoking(p => p.Execute(() =>
             {
-                SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None);
+                SystemClock.Current.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None);
                 return ResultPrimitive.WhateverButTooLate;
             })).Should().Throw<TimeoutRejectedException>();
         }
@@ -223,7 +223,7 @@ namespace Polly.Specs.Timeout
             Action act = () => {
                 result = policy.Execute(ct =>
                 {
-                    SystemClock.Sleep(TimeSpan.FromMilliseconds(500), ct);
+                    SystemClock.Current.Sleep(TimeSpan.FromMilliseconds(500), ct);
                     return ResultPrimitive.Good;
                 }, userCancellationToken);
             };
@@ -245,7 +245,7 @@ namespace Polly.Specs.Timeout
             watch.Start();
             policy.Invoking(p => p.Execute(() =>
             {
-                SystemClock.Sleep(TimeSpan.FromSeconds(10), CancellationToken.None);
+                SystemClock.Current.Sleep(TimeSpan.FromSeconds(10), CancellationToken.None);
                 return ResultPrimitive.WhateverButTooLate;
             }))
                 .Should().Throw<TimeoutRejectedException>();
@@ -357,7 +357,7 @@ namespace Polly.Specs.Timeout
 
             policy.Invoking(p => p.Execute(ct =>
             {
-                SystemClock.Sleep(TimeSpan.FromSeconds(3), ct);
+                SystemClock.Current.Sleep(TimeSpan.FromSeconds(3), ct);
                 return ResultPrimitive.WhateverButTooLate;
             }, userCancellationToken))
             .Should().Throw<TimeoutRejectedException>();
@@ -373,7 +373,7 @@ namespace Polly.Specs.Timeout
             Action act = () => {
                 result = policy.Execute(ct =>
                 {
-                    SystemClock.Sleep(TimeSpan.FromMilliseconds(500), ct);
+                    SystemClock.Current.Sleep(TimeSpan.FromMilliseconds(500), ct);
                     return ResultPrimitive.Good;
                 }, userCancellationToken);
             };
@@ -396,7 +396,7 @@ namespace Polly.Specs.Timeout
             watch.Start();
             policy.Invoking(p => p.Execute(ct =>
             {
-                SystemClock.Sleep(TimeSpan.FromSeconds(10), ct);
+                SystemClock.Current.Sleep(TimeSpan.FromSeconds(10), ct);
                 return ResultPrimitive.WhateverButTooLate;
             }, userCancellationToken))
                 .Should().Throw<TimeoutRejectedException>();
@@ -428,7 +428,7 @@ namespace Polly.Specs.Timeout
                 policy.Invoking(p => p.Execute(
                     _ => {
                         userTokenSource.Cancel(); // User token cancels in the middle of execution ...
-                        SystemClock.Sleep(TimeSpan.FromSeconds(timeout * 2),
+                        SystemClock.Current.Sleep(TimeSpan.FromSeconds(timeout * 2),
                             CancellationToken.None // ... but if the executed delegate does not observe it
                            );
                         return ResultPrimitive.WhateverButTooLate;
@@ -517,7 +517,7 @@ namespace Polly.Specs.Timeout
 
             policy.Invoking(p => p.Execute(() =>
             {
-                SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None);
+                SystemClock.Current.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None);
                 return ResultPrimitive.WhateverButTooLate;
             }))
             .Should().Throw<TimeoutRejectedException>();
@@ -539,7 +539,7 @@ namespace Polly.Specs.Timeout
 
             policy.Invoking(p => p.Execute(ctx =>
                 {
-                    SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None);
+                    SystemClock.Current.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None);
                     return ResultPrimitive.WhateverButTooLate;
                 }, contextPassedToExecute))
                 .Should().Throw<TimeoutRejectedException>();
@@ -565,7 +565,7 @@ namespace Polly.Specs.Timeout
 
             policy.Invoking(p => p.Execute(() =>
                 {
-                    SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None);
+                    SystemClock.Current.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None);
                     return ResultPrimitive.WhateverButTooLate;
                 }))
                 .Should().Throw<TimeoutRejectedException>();
@@ -591,7 +591,7 @@ namespace Polly.Specs.Timeout
 
             policy.Invoking(p => p.Execute(ctx =>
                 {
-                    SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None);
+                    SystemClock.Current.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None);
                     return ResultPrimitive.WhateverButTooLate;
                 }, context))
                 .Should().Throw<TimeoutRejectedException>();
@@ -610,7 +610,7 @@ namespace Polly.Specs.Timeout
 
             policy.Invoking(p => p.Execute(() =>
             {
-                SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None);
+                SystemClock.Current.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None);
                 return ResultPrimitive.WhateverButTooLate;
             }))
             .Should().Throw<TimeoutRejectedException>();
@@ -639,12 +639,12 @@ namespace Polly.Specs.Timeout
 
             policy.Invoking(p => p.Execute(() =>
             {
-                SystemClock.Sleep(thriceShimTimeSpan, CancellationToken.None);
+                SystemClock.Current.Sleep(thriceShimTimeSpan, CancellationToken.None);
                 throw exceptionToThrow;
             }))
             .Should().Throw<TimeoutRejectedException>();
 
-            SystemClock.Sleep(thriceShimTimeSpan, CancellationToken.None);
+            SystemClock.Current.Sleep(thriceShimTimeSpan, CancellationToken.None);
             exceptionObservedFromTaskPassedToOnTimeout.Should().NotBeNull();
             exceptionObservedFromTaskPassedToOnTimeout.Should().Be(exceptionToThrow);
 
@@ -662,7 +662,7 @@ namespace Polly.Specs.Timeout
 
             policy.Invoking(p => p.Execute(() =>
                 {
-                    SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None);
+                    SystemClock.Current.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None);
                     return ResultPrimitive.WhateverButTooLate;
                 }))
                 .Should().Throw<TimeoutRejectedException>();
@@ -689,7 +689,7 @@ namespace Polly.Specs.Timeout
 
             policy.Invoking(p => p.Execute(ct =>
             {
-                SystemClock.Sleep(TimeSpan.FromSeconds(1), ct);
+                SystemClock.Current.Sleep(TimeSpan.FromSeconds(1), ct);
                 return ResultPrimitive.WhateverButTooLate;
             }, userCancellationToken))
             .Should().Throw<TimeoutRejectedException>();
@@ -712,7 +712,7 @@ namespace Polly.Specs.Timeout
 
             policy.Invoking(p => p.Execute((ctx, ct) =>
                 {
-                    SystemClock.Sleep(TimeSpan.FromSeconds(3), ct);
+                    SystemClock.Current.Sleep(TimeSpan.FromSeconds(3), ct);
                     return ResultPrimitive.WhateverButTooLate;
                 }, contextPassedToExecute, userCancellationToken))
                 .Should().Throw<TimeoutRejectedException>();
@@ -738,7 +738,7 @@ namespace Polly.Specs.Timeout
 
             policy.Invoking(p => p.Execute(ct =>
                 {
-                    SystemClock.Sleep(TimeSpan.FromSeconds(3), ct);
+                    SystemClock.Current.Sleep(TimeSpan.FromSeconds(3), ct);
                     return ResultPrimitive.WhateverButTooLate;
                 }, userCancellationToken))
                 .Should().Throw<TimeoutRejectedException>();
@@ -767,7 +767,7 @@ namespace Polly.Specs.Timeout
 
             policy.Invoking(p => p.Execute((ctx, ct) =>
                 {
-                    SystemClock.Sleep(TimeSpan.FromSeconds(3), ct);
+                    SystemClock.Current.Sleep(TimeSpan.FromSeconds(3), ct);
                     return ResultPrimitive.WhateverButTooLate;
                 }, context, userCancellationToken))
                 .Should().Throw<TimeoutRejectedException>();
@@ -787,7 +787,7 @@ namespace Polly.Specs.Timeout
 
             policy.Invoking(p => p.Execute(ct =>
             {
-                SystemClock.Sleep(TimeSpan.FromSeconds(3), ct);
+                SystemClock.Current.Sleep(TimeSpan.FromSeconds(3), ct);
                 return ResultPrimitive.WhateverButTooLate;
             }, userCancellationToken))
             .Should().Throw<TimeoutRejectedException>();
@@ -808,7 +808,7 @@ namespace Polly.Specs.Timeout
 
             policy.Invoking(p => p.Execute(ct =>
                 {
-                    SystemClock.Sleep(TimeSpan.FromSeconds(1), ct);
+                    SystemClock.Current.Sleep(TimeSpan.FromSeconds(1), ct);
                     return ResultPrimitive.WhateverButTooLate;
                 }, userCancellationToken))
                 .Should().Throw<TimeoutRejectedException>();

--- a/src/Polly/Caching/NonSlidingTtl.cs
+++ b/src/Polly/Caching/NonSlidingTtl.cs
@@ -28,7 +28,7 @@ namespace Polly.Caching
         /// <returns>A <see cref="Ttl"/> representing the remaining Ttl of the cached item.</returns>
         public Ttl GetTtl(Context context, object result)
         {
-            TimeSpan untilPointInTime = absoluteExpirationTime.Subtract(SystemClock.DateTimeOffsetUtcNow());
+            TimeSpan untilPointInTime = absoluteExpirationTime.Subtract(SystemClock.Current.DateTimeOffsetUtcNow);
             TimeSpan remaining = untilPointInTime > TimeSpan.Zero ? untilPointInTime : TimeSpan.Zero;
             return new Ttl(remaining, false);
         }

--- a/src/Polly/CircuitBreaker/RollingHealthMetrics.cs
+++ b/src/Polly/CircuitBreaker/RollingHealthMetrics.cs
@@ -62,7 +62,7 @@ namespace Polly.CircuitBreaker
 
         private void ActualiseCurrentMetric_NeedsLock()
         {
-            long now = SystemClock.UtcNow().Ticks;
+            long now = SystemClock.Current.UtcNow.Ticks;
             if (_currentWindow == null || now - _currentWindow.StartedAt >= _windowDuration)
             {
                 _currentWindow = new HealthCount { StartedAt = now };

--- a/src/Polly/CircuitBreaker/SingleHealthMetrics.cs
+++ b/src/Polly/CircuitBreaker/SingleHealthMetrics.cs
@@ -36,7 +36,7 @@ namespace Polly.CircuitBreaker
 
         private void ActualiseCurrentMetric_NeedsLock()
         {
-            long now = SystemClock.UtcNow().Ticks;
+            long now = SystemClock.Current.UtcNow.Ticks;
             if (_current == null || now - _current.StartedAt >= _samplingDuration)
             {
                 _current = new HealthCount { StartedAt = now };

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -17,6 +17,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Michael Wolfenden, App vNext</Authors>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Label="SourceLink">
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/Polly/Retry/AsyncRetryEngine.cs
+++ b/src/Polly/Retry/AsyncRetryEngine.cs
@@ -77,7 +77,7 @@ namespace Polly.Retry
 
                     if (waitDuration > TimeSpan.Zero)
                     {
-                        await SystemClock.SleepAsync(waitDuration, cancellationToken).ConfigureAwait(continueOnCapturedContext);
+                        await SystemClock.Current.SleepAsync(waitDuration, cancellationToken).ConfigureAwait(continueOnCapturedContext);
                     }
                 }
             }

--- a/src/Polly/Retry/RetryEngine.cs
+++ b/src/Polly/Retry/RetryEngine.cs
@@ -75,7 +75,7 @@ namespace Polly.Retry
 
                     if (waitDuration > TimeSpan.Zero)
                     {
-                        SystemClock.Sleep(waitDuration, cancellationToken);
+                        SystemClock.Current.Sleep(waitDuration, cancellationToken);
                     }
                 }
 

--- a/src/Polly/Timeout/AsyncTimeoutEngine.cs
+++ b/src/Polly/Timeout/AsyncTimeoutEngine.cs
@@ -30,7 +30,7 @@ namespace Polly.Timeout
                     {
                         if (timeoutStrategy == TimeoutStrategy.Optimistic)
                         {
-                            SystemClock.CancelTokenAfter(timeoutCancellationTokenSource, timeout);
+                            SystemClock.Current.CancelTokenAfter(timeoutCancellationTokenSource, timeout);
                             return await action(context, combinedToken).ConfigureAwait(continueOnCapturedContext);
                         }
 
@@ -38,7 +38,7 @@ namespace Polly.Timeout
 
                         Task<TResult> timeoutTask = timeoutCancellationTokenSource.Token.AsTask<TResult>();
 
-                        SystemClock.CancelTokenAfter(timeoutCancellationTokenSource, timeout);
+                        SystemClock.Current.CancelTokenAfter(timeoutCancellationTokenSource, timeout);
 
                         actionTask = action(context, combinedToken);
 

--- a/src/Polly/Timeout/TimeoutEngine.cs
+++ b/src/Polly/Timeout/TimeoutEngine.cs
@@ -30,13 +30,13 @@ namespace Polly.Timeout
                     {
                         if (timeoutStrategy == TimeoutStrategy.Optimistic)
                         {
-                            SystemClock.CancelTokenAfter(timeoutCancellationTokenSource, timeout);
+                            SystemClock.Current.CancelTokenAfter(timeoutCancellationTokenSource, timeout);
                             return action(context, combinedToken);
                         }
 
                         // else: timeoutStrategy == TimeoutStrategy.Pessimistic
 
-                        SystemClock.CancelTokenAfter(timeoutCancellationTokenSource, timeout);
+                        SystemClock.Current.CancelTokenAfter(timeoutCancellationTokenSource, timeout);
 
                         actionTask = Task.Run(() =>
                             action(context, combinedToken)       // cancellation token here allows the user delegate to react to cancellation: possibly clear up; then throw an OperationCanceledException.

--- a/src/Polly/Utilities/ISystemClock.cs
+++ b/src/Polly/Utilities/ISystemClock.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Polly.Utilities
+{
+    /// <summary>
+    /// Time related delegates used to support different compilation targets and to improve testability of the code.
+    /// </summary>
+    public interface ISystemClock
+    {
+        /// <summary>
+        /// Allows the setting of a custom Thread.Sleep implementation for testing.
+        /// By default this will use the <see cref="CancellationToken"/>'s <see cref="WaitHandle"/>.
+        /// </summary>
+        void Sleep(TimeSpan timeout, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Allows the setting of a custom async Sleep implementation for testing.
+        /// By default this will be a call to <see cref="M:Task.Delay"/> taking a <see cref="CancellationToken"/>
+        /// </summary>
+        Task SleepAsync(TimeSpan delay, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Allows the setting of a custom DateTime.UtcNow implementation for testing.
+        /// By default this will be a call to <see cref="DateTime.UtcNow"/>
+        /// </summary>
+        DateTime UtcNow { get; }
+
+        /// <summary>
+        /// Allows the setting of a custom DateTimeOffset.UtcNow implementation for testing.
+        /// By default this will be a call to <see cref="DateTime.UtcNow"/>
+        /// </summary>
+        DateTimeOffset DateTimeOffsetUtcNow { get; }
+
+        /// <summary>
+        /// Allows the setting of a custom method for cancelling tokens after a timespan, for use in testing.
+        /// By default this will be a call to CancellationTokenSource.CancelAfter(timespan)
+        /// </summary>
+        void CancelTokenAfter(CancellationTokenSource tokenSource, TimeSpan delay);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors.  All non-trivial contributions get a public credit in the readme! -->

### The issue or feature being addressed

I'd like to propose extracting static `SystemClock` to an interface.

### Details on the issue fix or feature implementation

These are initial commits with the end goal to eventually get rid of the ambient `SystemClock` instance by allowing specifying one when the policies gets created. This will allow to run all tests in parallel and will restrict _rogue_ system clock injection during runtime.

### Confirm the following

- [x]  I started this PR by branching from the head of the latest dev vX.Y branch, or I have rebased on the latest dev vX.Y branch, or I have merged the latest changes from the dev vX.Y branch
- [x]  I have targeted the PR to merge into the latest dev vX.Y branch as the base branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
