### PR TITLE
Include symbols in package

### DIFF
--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -18,6 +18,7 @@
     <Authors>Michael Wolfenden, App vNext</Authors>
     <AssemblyOriginatorKeyFile>..\Polly.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   <PropertyGroup Label="SourceLink">
     <PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
Given that the new portable PDBs generated for NS projects are really small for the added benefit of 
useful stacktraces on errors, it would complement the sourcelink that's already in place. 

In particular, for VS extensions that use this package, including symbols in the package makes it easier 
for crash dumps to contain useful stacktraces. i.e. see https://github.com/jeffkl/ManagedDism/pull/76

This would fix bug http://work.azdo.io/971173 too :)

<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors.  All non-trivial contributions get a public credit in the readme! -->

### The issue or feature being addressed

<!-- Please include the existing github issue number where relevant -->

### Details on the issue fix or feature implementation

### Confirm the following

- [x]  I started this PR by branching from the head of the latest dev vX.Y branch, or I have rebased on the latest dev vX.Y branch, or I have merged the latest changes from the dev vX.Y branch
- [x]  I have targeted the PR to merge into the latest dev vX.Y branch as the base branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build
