### PR TITLE
Migrate Fluent Assertions from v4 to v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1058,6 +1058,7 @@ Both templates contain a full project structure referencing Polly, Polly's defau
 * [@aprooks](https://github.com/aprooks) - Build script tweaks for Mac and mono.
 * [@kesmy](https://github.com/Kesmy) - Add Soucelink support, clean up cake build.
 * [@simluk](https://github.com/simluk) - Fix continueOnCaptureContext not being honored in async retry implementation (bug in v7.1.0 only).
+* [@jnyrup](https://github.com/jnyrup) - Upgrade tests to Fluent Assertions v5.9.0
 
 # Sample Projects
 

--- a/src/Polly.Specs/Bulkhead/BulkheadAsyncSpecs.cs
+++ b/src/Polly.Specs/Bulkhead/BulkheadAsyncSpecs.cs
@@ -24,7 +24,7 @@ namespace Polly.Specs.Bulkhead
             Action policy = () => Policy
                 .BulkheadAsync(0, 1);
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                 .ParamName.Should().Be("maxParallelization");
         }
 
@@ -34,7 +34,7 @@ namespace Polly.Specs.Bulkhead
             Action policy = () => Policy
                 .BulkheadAsync(1, -1);
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                 .ParamName.Should().Be("maxQueuingActions");
         }
 
@@ -44,7 +44,7 @@ namespace Polly.Specs.Bulkhead
             Action policy = () => Policy
                 .BulkheadAsync(1, 0, null);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                 .ParamName.Should().Be("onBulkheadRejectedAsync");
         }
 
@@ -75,7 +75,7 @@ namespace Polly.Specs.Bulkhead
 
                 Within(shimTimeSpan, () => bulkhead.BulkheadAvailableCount.Should().Be(0)); // Time for the other thread to kick up and take the bulkhead.
 
-                bulkhead.Awaiting(async b => await b.ExecuteAsync(ctx => TaskHelper.EmptyTask, contextPassedToExecute)).ShouldThrow<BulkheadRejectedException>();
+                bulkhead.Awaiting(async b => await b.ExecuteAsync(ctx => TaskHelper.EmptyTask, contextPassedToExecute)).Should().Throw<BulkheadRejectedException>();
 
                 cancellationSource.Cancel();
                 tcs.SetCanceled();

--- a/src/Polly.Specs/Bulkhead/BulkheadSpecs.cs
+++ b/src/Polly.Specs/Bulkhead/BulkheadSpecs.cs
@@ -23,7 +23,7 @@ namespace Polly.Specs.Bulkhead
             Action policy = () => Policy
                 .Bulkhead(0, 1);
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                 .ParamName.Should().Be("maxParallelization");
         }
 
@@ -33,7 +33,7 @@ namespace Polly.Specs.Bulkhead
             Action policy = () => Policy
                 .Bulkhead(1, -1);
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                 .ParamName.Should().Be("maxQueuingActions");
         }
 
@@ -43,7 +43,7 @@ namespace Polly.Specs.Bulkhead
             Action policy = () => Policy
                 .Bulkhead(1, 0, null);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                 .ParamName.Should().Be("onBulkheadRejected");
         }
 
@@ -74,7 +74,7 @@ namespace Polly.Specs.Bulkhead
 
                 Within(shimTimeSpan, () => bulkhead.BulkheadAvailableCount.Should().Be(0)); // Time for the other thread to kick up and take the bulkhead.
 
-                bulkhead.Invoking(b => b.Execute(ctx => { }, contextPassedToExecute)).ShouldThrow<BulkheadRejectedException>();
+                bulkhead.Invoking(b => b.Execute(ctx => { }, contextPassedToExecute)).Should().Throw<BulkheadRejectedException>();
 
                 cancellationSource.Cancel();
                 tcs.SetCanceled();

--- a/src/Polly.Specs/Bulkhead/BulkheadTResultAsyncSpecs.cs
+++ b/src/Polly.Specs/Bulkhead/BulkheadTResultAsyncSpecs.cs
@@ -24,7 +24,7 @@ namespace Polly.Specs.Bulkhead
             Action policy = () => Policy
                 .BulkheadAsync<int>(0, 1);
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                 .ParamName.Should().Be("maxParallelization");
         }
 
@@ -34,7 +34,7 @@ namespace Polly.Specs.Bulkhead
             Action policy = () => Policy
                 .BulkheadAsync<int>(1, -1);
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                 .ParamName.Should().Be("maxQueuingActions");
         }
 
@@ -44,7 +44,7 @@ namespace Polly.Specs.Bulkhead
             Action policy = () => Policy
                 .BulkheadAsync<int>(1, 0, null);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                 .ParamName.Should().Be("onBulkheadRejectedAsync");
         }
 
@@ -76,7 +76,7 @@ namespace Polly.Specs.Bulkhead
 
                 Within(shimTimeSpan, () => bulkhead.BulkheadAvailableCount.Should().Be(0)); // Time for the other thread to kick up and take the bulkhead.
 
-                bulkhead.Awaiting(async b => await b.ExecuteAsync(ctx => Task.FromResult(1), contextPassedToExecute)).ShouldThrow<BulkheadRejectedException>();
+                bulkhead.Awaiting(async b => await b.ExecuteAsync(ctx => Task.FromResult(1), contextPassedToExecute)).Should().Throw<BulkheadRejectedException>();
 
                 cancellationSource.Cancel();
                 tcs.SetCanceled();

--- a/src/Polly.Specs/Bulkhead/BulkheadTResultSpecs.cs
+++ b/src/Polly.Specs/Bulkhead/BulkheadTResultSpecs.cs
@@ -24,7 +24,7 @@ namespace Polly.Specs.Bulkhead
             Action policy = () => Policy
                 .Bulkhead<int>(0, 1);
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                 .ParamName.Should().Be("maxParallelization");
         }
 
@@ -34,7 +34,7 @@ namespace Polly.Specs.Bulkhead
             Action policy = () => Policy
                 .Bulkhead<int>(1, -1);
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                 .ParamName.Should().Be("maxQueuingActions");
         }
 
@@ -44,7 +44,7 @@ namespace Polly.Specs.Bulkhead
             Action policy = () => Policy
                 .Bulkhead<int>(1, 0, null);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                 .ParamName.Should().Be("onBulkheadRejected");
         }
 
@@ -76,7 +76,7 @@ namespace Polly.Specs.Bulkhead
 
                 Within(shimTimeSpan, () => bulkhead.BulkheadAvailableCount.Should().Be(0)); // Time for the other thread to kick up and take the bulkhead.
 
-                bulkhead.Invoking(b => b.Execute(ctx => 1, contextPassedToExecute)).ShouldThrow<BulkheadRejectedException>();
+                bulkhead.Invoking(b => b.Execute(ctx => 1, contextPassedToExecute)).Should().Throw<BulkheadRejectedException>();
 
                 cancellationSource.Cancel();
                 tcs.SetCanceled();

--- a/src/Polly.Specs/Caching/AbsoluteTtlSpecs.cs
+++ b/src/Polly.Specs/Caching/AbsoluteTtlSpecs.cs
@@ -14,7 +14,7 @@ namespace Polly.Specs.Caching
         {
             Action configure = () => new AbsoluteTtl(DateTime.Today.AddDays(1));
 
-            configure.ShouldNotThrow();
+            configure.Should().NotThrow();
         }
 
         [Fact]
@@ -22,7 +22,7 @@ namespace Polly.Specs.Caching
         {
             Action configure = () => new AbsoluteTtl(DateTimeOffset.MaxValue);
 
-            configure.ShouldNotThrow();
+            configure.Should().NotThrow();
         }
 
         [Fact]
@@ -30,7 +30,7 @@ namespace Polly.Specs.Caching
         {
             Action configure = () => new AbsoluteTtl(DateTimeOffset.MinValue);
 
-            configure.ShouldNotThrow();
+            configure.Should().NotThrow();
         }
 
         [Fact]

--- a/src/Polly.Specs/Caching/CacheAsyncSpecs.cs
+++ b/src/Polly.Specs/Caching/CacheAsyncSpecs.cs
@@ -20,7 +20,7 @@ namespace Polly.Specs.Caching
         {
             IAsyncCacheProvider cacheProvider = null;
             Action action = () => Policy.CacheAsync(cacheProvider, TimeSpan.MaxValue);
-            action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("cacheProvider");
+            action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("cacheProvider");
         }
 
         [Fact]
@@ -29,7 +29,7 @@ namespace Polly.Specs.Caching
             IAsyncCacheProvider cacheProvider = new StubCacheProvider();
             ITtlStrategy ttlStrategy = null;
             Action action = () => Policy.CacheAsync(cacheProvider, ttlStrategy);
-            action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("ttlStrategy");
+            action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("ttlStrategy");
         }
 
         [Fact]
@@ -38,7 +38,7 @@ namespace Polly.Specs.Caching
             IAsyncCacheProvider cacheProvider = new StubCacheProvider();
             Func<Context, string> cacheKeyStrategy = null;
             Action action = () => Policy.CacheAsync(cacheProvider, TimeSpan.MaxValue, cacheKeyStrategy);
-            action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("cacheKeyStrategy");
+            action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("cacheKeyStrategy");
         }
 
         #endregion
@@ -482,7 +482,7 @@ namespace Polly.Specs.Caching
             tokenSource.Cancel();
 
             cache.Awaiting(policy => policy.ExecuteAsync(func, new Context(operationKey), tokenSource.Token))
-                .ShouldThrow<OperationCanceledException>();
+                .Should().Throw<OperationCanceledException>();
             delegateInvocations.Should().Be(1);
         }
 
@@ -506,7 +506,7 @@ namespace Polly.Specs.Caching
             };
 
             cache.Awaiting(policy => policy.ExecuteAsync(func, new Context(operationKey), tokenSource.Token))
-                .ShouldThrow<OperationCanceledException>();
+                .Should().Throw<OperationCanceledException>();
 
             (bool cacheHit, object fromCache) = await stubCacheProvider.TryGetAsync(operationKey, CancellationToken.None, false).ConfigureAwait(false);
             cacheHit.Should().BeFalse();

--- a/src/Polly.Specs/Caching/CacheSpecs.cs
+++ b/src/Polly.Specs/Caching/CacheSpecs.cs
@@ -20,7 +20,7 @@ namespace Polly.Specs.Caching
         {
             ISyncCacheProvider cacheProvider = null;
             Action action = () => Policy.Cache(cacheProvider, TimeSpan.MaxValue);
-            action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("cacheProvider");
+            action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("cacheProvider");
         }
 
         [Fact]
@@ -29,7 +29,7 @@ namespace Polly.Specs.Caching
             ISyncCacheProvider cacheProvider = new StubCacheProvider();
             ITtlStrategy ttlStrategy = null;
             Action action = () => Policy.Cache(cacheProvider, ttlStrategy);
-            action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("ttlStrategy");
+            action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("ttlStrategy");
         }
 
         [Fact]
@@ -38,7 +38,7 @@ namespace Polly.Specs.Caching
             ISyncCacheProvider cacheProvider = new StubCacheProvider();
             Func<Context, string> cacheKeyStrategy = null;
             Action action = () => Policy.Cache(cacheProvider, TimeSpan.MaxValue, cacheKeyStrategy);
-            action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("cacheKeyStrategy");
+            action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("cacheKeyStrategy");
         }
 
         #endregion
@@ -468,7 +468,7 @@ namespace Polly.Specs.Caching
             tokenSource.Cancel();
 
             cache.Invoking(policy => policy.Execute(func, new Context(operationKey), tokenSource.Token))
-                .ShouldThrow<OperationCanceledException>();
+                .Should().Throw<OperationCanceledException>();
             delegateInvocations.Should().Be(1);
         }
 
@@ -491,7 +491,7 @@ namespace Polly.Specs.Caching
             };
 
             cache.Invoking(policy => policy.Execute(func, new Context(operationKey), tokenSource.Token))
-                .ShouldThrow<OperationCanceledException>();
+                .Should().Throw<OperationCanceledException>();
 
             (bool cacheHit, object fromCache) = stubCacheProvider.TryGet(operationKey);
             cacheHit.Should().BeFalse();

--- a/src/Polly.Specs/Caching/CacheTResultAsyncSpecs.cs
+++ b/src/Polly.Specs/Caching/CacheTResultAsyncSpecs.cs
@@ -20,7 +20,7 @@ namespace Polly.Specs.Caching
         {
             IAsyncCacheProvider cacheProvider = null;
             Action action = () => Policy.CacheAsync<ResultPrimitive>(cacheProvider, TimeSpan.MaxValue);
-            action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("cacheProvider");
+            action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("cacheProvider");
         }
 
         [Fact]
@@ -29,7 +29,7 @@ namespace Polly.Specs.Caching
             IAsyncCacheProvider cacheProvider = new StubCacheProvider();
             ITtlStrategy ttlStrategy = null;
             Action action = () => Policy.CacheAsync<ResultPrimitive>(cacheProvider, ttlStrategy);
-            action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("ttlStrategy");
+            action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("ttlStrategy");
         }
 
         [Fact]
@@ -38,7 +38,7 @@ namespace Polly.Specs.Caching
             IAsyncCacheProvider cacheProvider = new StubCacheProvider();
             Func<Context, string> cacheKeyStrategy = null;
             Action action = () => Policy.CacheAsync<ResultPrimitive>(cacheProvider, TimeSpan.MaxValue, cacheKeyStrategy);
-            action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("cacheKeyStrategy");
+            action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("cacheKeyStrategy");
         }
         #endregion
 
@@ -466,7 +466,7 @@ namespace Polly.Specs.Caching
             tokenSource.Cancel();
 
             cache.Awaiting(policy => policy.ExecuteAsync(func, new Context(operationKey), tokenSource.Token))
-                .ShouldThrow<OperationCanceledException>();
+                .Should().Throw<OperationCanceledException>();
             delegateInvocations.Should().Be(1);
         }
 
@@ -490,7 +490,7 @@ namespace Polly.Specs.Caching
             };
 
             cache.Awaiting(policy => policy.ExecuteAsync(func, new Context(operationKey), tokenSource.Token))
-                .ShouldThrow<OperationCanceledException>();
+                .Should().Throw<OperationCanceledException>();
 
             (bool cacheHit, object fromCache) = await stubCacheProvider.TryGetAsync(operationKey, CancellationToken.None, false).ConfigureAwait(false);
             cacheHit.Should().BeFalse();

--- a/src/Polly.Specs/Caching/CacheTResultSpecs.cs
+++ b/src/Polly.Specs/Caching/CacheTResultSpecs.cs
@@ -20,7 +20,7 @@ namespace Polly.Specs.Caching
         {
             ISyncCacheProvider cacheProvider = null;
             Action action = () => Policy.Cache<ResultPrimitive>(cacheProvider, TimeSpan.MaxValue);
-            action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("cacheProvider");
+            action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("cacheProvider");
         }
 
         [Fact]
@@ -29,7 +29,7 @@ namespace Polly.Specs.Caching
             ISyncCacheProvider cacheProvider = new StubCacheProvider();
             ITtlStrategy ttlStrategy = null;
             Action action = () => Policy.Cache<ResultPrimitive>(cacheProvider, ttlStrategy);
-            action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("ttlStrategy");
+            action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("ttlStrategy");
         }
         [Fact]
         public void Should_throw_when_cache_key_strategy_is_null()
@@ -37,7 +37,7 @@ namespace Polly.Specs.Caching
             ISyncCacheProvider cacheProvider = new StubCacheProvider();
             Func<Context, string> cacheKeyStrategy = null;
             Action action = () => Policy.Cache<ResultPrimitive>(cacheProvider, TimeSpan.MaxValue, cacheKeyStrategy);
-            action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("cacheKeyStrategy");
+            action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("cacheKeyStrategy");
         }
         
         #endregion
@@ -451,7 +451,7 @@ namespace Polly.Specs.Caching
             tokenSource.Cancel();
 
             cache.Invoking(policy => policy.Execute(func, new Context(operationKey), tokenSource.Token))
-                .ShouldThrow<OperationCanceledException>();
+                .Should().Throw<OperationCanceledException>();
             delegateInvocations.Should().Be(1);
         }
 
@@ -474,7 +474,7 @@ namespace Polly.Specs.Caching
             };
 
             cache.Invoking(policy => policy.Execute(func, new Context(operationKey), tokenSource.Token))
-                .ShouldThrow<OperationCanceledException>();
+                .Should().Throw<OperationCanceledException>();
 
             (bool cacheHit, object fromCache) = stubCacheProvider.TryGet(operationKey);
             cacheHit.Should().BeFalse();

--- a/src/Polly.Specs/Caching/RelativeTtlSpecs.cs
+++ b/src/Polly.Specs/Caching/RelativeTtlSpecs.cs
@@ -21,7 +21,7 @@ namespace Polly.Specs.Caching
         {
             Action configure = () => new RelativeTtl(TimeSpan.Zero);
 
-            configure.ShouldNotThrow();
+            configure.Should().NotThrow();
         }
 
         [Fact]
@@ -29,7 +29,7 @@ namespace Polly.Specs.Caching
         {
             Action configure = () => new RelativeTtl(TimeSpan.MaxValue);
 
-            configure.ShouldNotThrow();
+            configure.Should().NotThrow();
         }
 
         [Fact]

--- a/src/Polly.Specs/Caching/RelativeTtlSpecs.cs
+++ b/src/Polly.Specs/Caching/RelativeTtlSpecs.cs
@@ -13,7 +13,7 @@ namespace Polly.Specs.Caching
         {
             Action configure = () => new RelativeTtl(TimeSpan.FromMilliseconds(-1));
 
-            configure.ShouldThrow<ArgumentOutOfRangeException>().And.ParamName.Should().Be("ttl");
+            configure.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("ttl");
         }
 
         [Fact]

--- a/src/Polly.Specs/Caching/ResultTtlSpecs.cs
+++ b/src/Polly.Specs/Caching/ResultTtlSpecs.cs
@@ -28,7 +28,7 @@ namespace Polly.Specs.Caching
         {
             Action configure = () => new ResultTtl<object>((result) => new Ttl());
 
-            configure.ShouldNotThrow();
+            configure.Should().NotThrow();
         }
 
         [Fact]
@@ -36,7 +36,7 @@ namespace Polly.Specs.Caching
         {
             Action configure = () => new ResultTtl<object>((context, result) => new Ttl());
 
-            configure.ShouldNotThrow();
+            configure.Should().NotThrow();
         }
 
         [Fact]

--- a/src/Polly.Specs/Caching/ResultTtlSpecs.cs
+++ b/src/Polly.Specs/Caching/ResultTtlSpecs.cs
@@ -12,7 +12,7 @@ namespace Polly.Specs.Caching
         {
             Action configure = () => new ResultTtl<object>((Func<object, Ttl>)null);
 
-            configure.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("ttlFunc");
+            configure.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("ttlFunc");
         }
 
         [Fact]
@@ -20,7 +20,7 @@ namespace Polly.Specs.Caching
         {
             Action configure = () => new ResultTtl<object>((Func<Context, object, Ttl>)null);
 
-            configure.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("ttlFunc");
+            configure.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("ttlFunc");
         }
 
         [Fact]

--- a/src/Polly.Specs/Caching/SerializingCacheProviderAsyncSpecs.cs
+++ b/src/Polly.Specs/Caching/SerializingCacheProviderAsyncSpecs.cs
@@ -23,7 +23,7 @@ namespace Polly.Specs.Caching
 
             Action configure = () => new AsyncSerializingCacheProvider<StubSerialized>(null, stubObjectSerializer);
 
-            configure.ShouldThrow<ArgumentNullException>()
+            configure.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("wrappedCacheProvider");
         }
 
@@ -32,7 +32,7 @@ namespace Polly.Specs.Caching
         {
             Action configure = () => new AsyncSerializingCacheProvider<object>(new StubCacheProvider().AsyncFor<object>(), null);
 
-            configure.ShouldThrow<ArgumentNullException>()
+            configure.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("serializer");
         }
 
@@ -41,7 +41,7 @@ namespace Polly.Specs.Caching
         {
             Action configure = () => new StubCacheProvider().AsyncFor<object>().WithSerializer(null);
 
-            configure.ShouldThrow<ArgumentNullException>()
+            configure.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("serializer");
         }
 
@@ -242,7 +242,7 @@ namespace Polly.Specs.Caching
 
             Action configure = () => new AsyncSerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>>(null, stubTResultSerializer);
 
-            configure.ShouldThrow<ArgumentNullException>()
+            configure.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("wrappedCacheProvider");
         }
 
@@ -251,7 +251,7 @@ namespace Polly.Specs.Caching
         {
             Action configure = () => new AsyncSerializingCacheProvider<object, object>(new StubCacheProvider().AsyncFor<object>(), null);
 
-            configure.ShouldThrow<ArgumentNullException>()
+            configure.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("serializer");
         }
 
@@ -260,7 +260,7 @@ namespace Polly.Specs.Caching
         {
             Action configure = () => new StubCacheProvider().AsyncFor<object>().WithSerializer<object, object>(null);
 
-            configure.ShouldThrow<ArgumentNullException>()
+            configure.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("serializer");
         }
 

--- a/src/Polly.Specs/Caching/SerializingCacheProviderSpecs.cs
+++ b/src/Polly.Specs/Caching/SerializingCacheProviderSpecs.cs
@@ -21,7 +21,7 @@ namespace Polly.Specs.Caching
 
         Action configure = () => new SerializingCacheProvider<StubSerialized>(null, stubObjectSerializer);
 
-            configure.ShouldThrow<ArgumentNullException>()
+            configure.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("wrappedCacheProvider");
         }
 
@@ -30,7 +30,7 @@ namespace Polly.Specs.Caching
         {
             Action configure = () => new SerializingCacheProvider<object>(new StubCacheProvider().For<object>(), null);
 
-            configure.ShouldThrow<ArgumentNullException>()
+            configure.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("serializer");
         }
 
@@ -39,7 +39,7 @@ namespace Polly.Specs.Caching
         {
             Action configure = () => new StubCacheProvider().For<object>().WithSerializer(null);
 
-            configure.ShouldThrow<ArgumentNullException>()
+            configure.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("serializer");
         }
 
@@ -240,7 +240,7 @@ namespace Polly.Specs.Caching
 
         Action configure = () => new SerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>>(null, stubTResultSerializer);
 
-            configure.ShouldThrow<ArgumentNullException>()
+            configure.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("wrappedCacheProvider");
         }
 
@@ -249,7 +249,7 @@ namespace Polly.Specs.Caching
         {
             Action configure = () => new SerializingCacheProvider<object, object>(new StubCacheProvider().For<object>(), null);
 
-            configure.ShouldThrow<ArgumentNullException>()
+            configure.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("serializer");
         }
 
@@ -258,7 +258,7 @@ namespace Polly.Specs.Caching
         {
             Action configure = () => new StubCacheProvider().For<object>().WithSerializer<object, object>(null);
 
-            configure.ShouldThrow<ArgumentNullException>()
+            configure.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("serializer");
         }
 

--- a/src/Polly.Specs/Caching/SlidingTtlSpecs.cs
+++ b/src/Polly.Specs/Caching/SlidingTtlSpecs.cs
@@ -12,7 +12,7 @@ namespace Polly.Specs.Caching
         {
             Action configure = () => new SlidingTtl(TimeSpan.FromMilliseconds(-1));
 
-            configure.ShouldThrow<ArgumentOutOfRangeException>().And.ParamName.Should().Be("slidingTtl");
+            configure.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("slidingTtl");
         }
 
         [Fact]

--- a/src/Polly.Specs/Caching/SlidingTtlSpecs.cs
+++ b/src/Polly.Specs/Caching/SlidingTtlSpecs.cs
@@ -20,7 +20,7 @@ namespace Polly.Specs.Caching
         {
             Action configure = () => new SlidingTtl(TimeSpan.Zero);
 
-            configure.ShouldNotThrow();
+            configure.Should().NotThrow();
         }
 
         [Fact]
@@ -28,7 +28,7 @@ namespace Polly.Specs.Caching
         {
             Action configure = () => new SlidingTtl(TimeSpan.MaxValue);
 
-            configure.ShouldNotThrow();
+            configure.Should().NotThrow();
         }
 
         [Fact]

--- a/src/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerAsyncSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerAsyncSpecs.cs
@@ -2871,7 +2871,7 @@ namespace Polly.Specs.CircuitBreaker
             cancellationTokenSource.Cancel();
 
             breaker.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -2899,7 +2899,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -2927,7 +2927,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -2996,7 +2996,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -3028,7 +3028,7 @@ namespace Polly.Specs.CircuitBreaker
                 await TaskHelper.EmptyTask;
                 implicitlyCapturedActionCancellationToken.ThrowIfCancellationRequested();
             }, policyCancellationToken))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(implicitlyCapturedActionCancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -3088,7 +3088,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Awaiting(async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true).ConfigureAwait(false))
-                .Should().Throw<TaskCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
+                .Should().Throw<OperationCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
 
             result.Should().Be(null);
 

--- a/src/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerAsyncSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerAsyncSpecs.cs
@@ -59,7 +59,7 @@ namespace Polly.Specs.CircuitBreaker
                 .Handle<DivideByZeroException>()
                 .AdvancedCircuitBreakerAsync(1.0, TimeSpan.FromSeconds(10), 4, TimeSpan.FromSeconds(30));
 
-            action.ShouldNotThrow();
+            action.Should().NotThrow();
         }
 
         [Fact]
@@ -143,7 +143,7 @@ namespace Polly.Specs.CircuitBreaker
                 .Handle<DivideByZeroException>()
                 .AdvancedCircuitBreakerAsync(0.5, TimeSpan.FromSeconds(10), 4, TimeSpan.Zero);
 
-            action.ShouldNotThrow();
+            action.Should().NotThrow();
         }
 
         [Fact]
@@ -199,7 +199,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // Throughput threshold will be exceeded by the below successful call, but we never break on a successful call; hence don't break on this.
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
         }
@@ -356,7 +356,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // Three of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
@@ -399,7 +399,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // Three of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
@@ -444,11 +444,11 @@ namespace Polly.Specs.CircuitBreaker
 
             // Two of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
@@ -487,11 +487,11 @@ namespace Polly.Specs.CircuitBreaker
 
             // Two of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
@@ -534,11 +534,11 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures; but only the first three within the timeslice.
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
@@ -573,11 +573,11 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures; but only the first three within the timeslice.
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
@@ -614,11 +614,11 @@ namespace Polly.Specs.CircuitBreaker
 
             // Two actions at the start of the original timeslice.
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Creates a new window right at the end of the original timeslice.
@@ -699,11 +699,11 @@ namespace Polly.Specs.CircuitBreaker
 
             // One of three actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
@@ -729,15 +729,15 @@ namespace Polly.Specs.CircuitBreaker
 
             // One of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
@@ -766,7 +766,7 @@ namespace Polly.Specs.CircuitBreaker
             // Executing a single invocation to ensure timeslice is created
             // This invocation is not be counted against the threshold
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // The time is set to just at the end of the sampling duration ensuring
@@ -775,11 +775,11 @@ namespace Polly.Specs.CircuitBreaker
 
             // Three of four actions in this test occur within the first timeslice.
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
@@ -817,7 +817,7 @@ namespace Polly.Specs.CircuitBreaker
             // Executing a single invocation to ensure timeslice is created
             // This invocation is not be counted against the threshold
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // The time is set to just at the end of the sampling duration ensuring
@@ -865,7 +865,7 @@ namespace Polly.Specs.CircuitBreaker
             // Executing a single invocation to ensure timeslice is created
             // This invocation is not be counted against the threshold
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Setting the time to the second window in the rolling metrics
@@ -881,7 +881,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Setting the time to just barely into the new timeslice
@@ -961,7 +961,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // Three of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
@@ -1002,11 +1002,11 @@ namespace Polly.Specs.CircuitBreaker
 
             // Two of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
@@ -1084,11 +1084,11 @@ namespace Polly.Specs.CircuitBreaker
 
             // Two of four actions in this test throw handled failures; but only the first within the timeslice.
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
@@ -1166,11 +1166,11 @@ namespace Polly.Specs.CircuitBreaker
 
             // One of three actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
@@ -1196,15 +1196,15 @@ namespace Polly.Specs.CircuitBreaker
 
             // One of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
@@ -1233,7 +1233,7 @@ namespace Polly.Specs.CircuitBreaker
             // Executing a single invocation to ensure timeslice is created
             // This invocation is not be counted against the threshold
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // The time is set to just at the end of the sampling duration ensuring
@@ -1242,11 +1242,11 @@ namespace Polly.Specs.CircuitBreaker
 
             // Three of four actions in this test occur within the first timeslice.
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
@@ -1491,7 +1491,7 @@ namespace Polly.Specs.CircuitBreaker
 
 
             // OnActionPreExecute() should permit first execution.
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should reject a second execution. (tho still in half-open condition).
@@ -1529,7 +1529,7 @@ namespace Polly.Specs.CircuitBreaker
 
 
             // OnActionPreExecute() should permit first execution.
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should reject a second execution. (tho still in half-open condition).
@@ -1541,7 +1541,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should now permit another trial execution.
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
         }
 
@@ -1601,7 +1601,7 @@ namespace Polly.Specs.CircuitBreaker
                     await TaskHelper.EmptyTask;
                     firstExecutionActive = false;
 
-                })).ShouldNotThrow();
+                })).Should().NotThrow();
             }, TaskCreationOptions.LongRunning);
 
             // Attempt a second execution, signalled by the first execution to ensure they overlap: we should be able to verify it doesn't execute, and is rejected by a breaker in a HalfOpen state.
@@ -1706,7 +1706,7 @@ namespace Polly.Specs.CircuitBreaker
                     permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
                     await TaskHelper.EmptyTask;
                     firstExecutionActive = false;
-                })).ShouldNotThrow();
+                })).Should().NotThrow();
             }, TaskCreationOptions.LongRunning);
 
             // Attempt a second execution, signalled by the first execution to ensure they overlap; start it one breakDuration later.  We should be able to verify it does execute, though the breaker is still in a HalfOpen state.
@@ -1826,7 +1826,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Reset();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
         }
 
         [Fact]
@@ -1868,7 +1868,7 @@ namespace Polly.Specs.CircuitBreaker
             SystemClock.UtcNow().Should().Be(time);
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
         }
 
         #endregion
@@ -2303,7 +2303,7 @@ namespace Polly.Specs.CircuitBreaker
 
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldNotThrow();
+                .Should().NotThrow();
         }
 
         #region Tests of supplied parameters to onBreak delegate
@@ -2842,7 +2842,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             attemptsInvoked.Should().Be(1);
         }
@@ -3056,7 +3056,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Awaiting(async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true).ConfigureAwait(false))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             result.Should().BeTrue();
 

--- a/src/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerAsyncSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerAsyncSpecs.cs
@@ -25,7 +25,7 @@ namespace Polly.Specs.CircuitBreaker
                 .AdvancedCircuitBreakerAsync(0.5, TimeSpan.FromSeconds(10), 4, TimeSpan.MaxValue);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
         }
 
         [Fact]
@@ -35,7 +35,7 @@ namespace Polly.Specs.CircuitBreaker
                 .Handle<DivideByZeroException>()
                 .AdvancedCircuitBreakerAsync(0, TimeSpan.FromSeconds(10), 4, TimeSpan.FromSeconds(30));
 
-            action.ShouldThrow<ArgumentOutOfRangeException>()
+            action.Should().Throw<ArgumentOutOfRangeException>()
                 .And.ParamName.Should()
                 .Be("failureThreshold");
         }
@@ -47,7 +47,7 @@ namespace Polly.Specs.CircuitBreaker
                 .Handle<DivideByZeroException>()
                 .AdvancedCircuitBreakerAsync(-0.5, TimeSpan.FromSeconds(10), 4, TimeSpan.FromSeconds(30));
 
-            action.ShouldThrow<ArgumentOutOfRangeException>()
+            action.Should().Throw<ArgumentOutOfRangeException>()
                 .And.ParamName.Should()
                 .Be("failureThreshold");
         }
@@ -69,7 +69,7 @@ namespace Polly.Specs.CircuitBreaker
                 .Handle<DivideByZeroException>()
                 .AdvancedCircuitBreakerAsync(1.01, TimeSpan.FromSeconds(10), 4, TimeSpan.FromSeconds(30));
 
-            action.ShouldThrow<ArgumentOutOfRangeException>()
+            action.Should().Throw<ArgumentOutOfRangeException>()
                 .And.ParamName.Should()
                 .Be("failureThreshold");
         }
@@ -85,7 +85,7 @@ namespace Polly.Specs.CircuitBreaker
                     4, 
                     TimeSpan.FromSeconds(30));
 
-            action.ShouldThrow<ArgumentOutOfRangeException>()
+            action.Should().Throw<ArgumentOutOfRangeException>()
                 .And.ParamName.Should()
                 .Be("samplingDuration");
         }
@@ -107,7 +107,7 @@ namespace Polly.Specs.CircuitBreaker
                 .Handle<DivideByZeroException>()
                 .AdvancedCircuitBreakerAsync(0.5, TimeSpan.FromSeconds(10), 1, TimeSpan.FromSeconds(30));
 
-            action.ShouldThrow<ArgumentOutOfRangeException>()
+            action.Should().Throw<ArgumentOutOfRangeException>()
                 .And.ParamName.Should()
                 .Be("minimumThroughput");
         }
@@ -119,7 +119,7 @@ namespace Polly.Specs.CircuitBreaker
                 .Handle<DivideByZeroException>()
                 .AdvancedCircuitBreakerAsync(0.5, TimeSpan.FromSeconds(10), 0, TimeSpan.FromSeconds(30));
 
-            action.ShouldThrow<ArgumentOutOfRangeException>()
+            action.Should().Throw<ArgumentOutOfRangeException>()
                 .And.ParamName.Should()
                 .Be("minimumThroughput");
         }
@@ -131,7 +131,7 @@ namespace Polly.Specs.CircuitBreaker
                 .Handle<DivideByZeroException>()
                 .AdvancedCircuitBreakerAsync(0.5, TimeSpan.FromSeconds(10), 4, -TimeSpan.FromSeconds(1));
 
-            action.ShouldThrow<ArgumentOutOfRangeException>()
+            action.Should().Throw<ArgumentOutOfRangeException>()
                 .And.ParamName.Should()
                 .Be("durationOfBreak");
         }
@@ -185,15 +185,15 @@ namespace Polly.Specs.CircuitBreaker
 
             // Three of three actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             // Failure threshold exceeded, but throughput threshold not yet.
 
@@ -222,19 +222,19 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw unhandled failures.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentNullException>())
-                .ShouldThrow<ArgumentNullException>();
+                .Should().Throw<ArgumentNullException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentNullException>())
-                .ShouldThrow<ArgumentNullException>();
+                .Should().Throw<ArgumentNullException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentNullException>())
-                .ShouldThrow<ArgumentNullException>();
+                .Should().Throw<ArgumentNullException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentNullException>())
-                .ShouldThrow<ArgumentNullException>();
+                .Should().Throw<ArgumentNullException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
         }
 
@@ -265,26 +265,26 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             bool delegateExecutedWhenBroken = false;
             breaker.Awaiting(async x => await x.ExecuteAsync(() => { delegateExecutedWhenBroken = true; return TaskHelper.EmptyTask; }))
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -311,15 +311,15 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Placing the rest of the invocations ('samplingDuration' / 2) + 1 seconds later
@@ -328,11 +328,11 @@ namespace Polly.Specs.CircuitBreaker
             SystemClock.UtcNow = () => time.AddSeconds(samplingDuration.Seconds / 2d + 1);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -360,20 +360,20 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -403,15 +403,15 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // Placing the rest of the invocations ('samplingDuration' / 2) + 1 seconds later
@@ -420,7 +420,7 @@ namespace Polly.Specs.CircuitBreaker
             SystemClock.UtcNow = () => time.AddSeconds(samplingDuration.Seconds / 2d + 1);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -452,16 +452,16 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -495,11 +495,11 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // Placing the rest of the invocations ('samplingDuration' / 2) + 1 seconds later
@@ -508,7 +508,7 @@ namespace Polly.Specs.CircuitBreaker
             SystemClock.UtcNow = () => time.AddSeconds(samplingDuration.Seconds / 2d + 1);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -542,14 +542,14 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Adjust SystemClock so that timeslice (clearly) expires; fourth exception thrown in next-recorded timeslice.
             SystemClock.UtcNow = () => time.Add(samplingDuration).Add(samplingDuration);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
         }
@@ -581,14 +581,14 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Adjust SystemClock so that timeslice (just) expires; fourth exception thrown in following timeslice.
             SystemClock.UtcNow = () => time.Add(samplingDuration);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
         }
@@ -625,14 +625,14 @@ namespace Polly.Specs.CircuitBreaker
             SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Adjust SystemClock so that timeslice (just) expires; fourth exception thrown in following timeslice.  If timeslice/window rollover is precisely defined, this should cause first two actions to be forgotten from statistics (rolled out of the window of relevance), and thus the circuit not to break.
             SystemClock.UtcNow = () => time.Add(samplingDuration);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
         }
@@ -656,26 +656,26 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Adjust SystemClock so that timeslice doesn't quite expire; fourth exception thrown in same timeslice.
             SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -707,7 +707,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
         }
@@ -741,7 +741,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
         }
@@ -783,7 +783,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Setting the time to just barely into the new timeslice
@@ -793,7 +793,7 @@ namespace Polly.Specs.CircuitBreaker
             // equalling the failure threshold. The minimum threshold within the defined
             // sampling duration is met, when using rolling windows.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
         }
 
@@ -826,11 +826,11 @@ namespace Polly.Specs.CircuitBreaker
 
             // Two of three actions in this test occur within the first timeslice.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Setting the time to just barely into the new timeslice
@@ -840,7 +840,7 @@ namespace Polly.Specs.CircuitBreaker
             // the number of failures above the failure threshold. However, the throughput is 
             // below the minimum threshold as to open the circuit.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
         }
 
@@ -873,11 +873,11 @@ namespace Polly.Specs.CircuitBreaker
 
             // Three actions occur in the second window of the first timeslice
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
@@ -888,7 +888,7 @@ namespace Polly.Specs.CircuitBreaker
             SystemClock.UtcNow = () => time.Add(samplingDuration);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
         }
 
@@ -919,25 +919,25 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -965,20 +965,20 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -1010,16 +1010,16 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -1045,22 +1045,22 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures; but only the first within the timeslice.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Adjust SystemClock so that timeslice (clearly) expires; fourth exception thrown in next-recorded timeslice.
             SystemClock.UtcNow = () => time.Add(samplingDuration).Add(samplingDuration);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
         }
@@ -1092,14 +1092,14 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Adjust SystemClock so that timeslice (just) expires; fourth exception thrown in following timeslice.
             SystemClock.UtcNow = () => time.Add(samplingDuration);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
         }
@@ -1123,26 +1123,26 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Adjust SystemClock so that timeslice doesn't quite expire; fourth exception thrown in same timeslice.
             SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -1174,7 +1174,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
         }
@@ -1208,7 +1208,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
         }
@@ -1250,7 +1250,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Setting the time to just barely into the new timeslice
@@ -1259,7 +1259,7 @@ namespace Polly.Specs.CircuitBreaker
             // This failure does not open the circuit, because a new duration should have 
             // started and with such low sampling duration, windows should not be used.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
         }
 
@@ -1288,19 +1288,19 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
@@ -1309,7 +1309,7 @@ namespace Polly.Specs.CircuitBreaker
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
         }
 
         [Fact]
@@ -1332,15 +1332,15 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Placing the rest of the invocations ('samplingDuration' / 2) + 1 seconds later
@@ -1350,7 +1350,7 @@ namespace Polly.Specs.CircuitBreaker
             SystemClock.UtcNow = () => time.AddSeconds(anotherwindowDuration);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
@@ -1364,7 +1364,7 @@ namespace Polly.Specs.CircuitBreaker
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
         }
 
         [Fact]
@@ -1386,19 +1386,19 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
@@ -1409,10 +1409,10 @@ namespace Polly.Specs.CircuitBreaker
 
             // first call after duration raises an exception, so circuit should open again
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<BrokenCircuitException>();
+                .Should().Throw<BrokenCircuitException>();
 
         }
 
@@ -1435,19 +1435,19 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
@@ -1478,9 +1478,9 @@ namespace Polly.Specs.CircuitBreaker
                 );
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             // exception raised, circuit is now open.  
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -1495,7 +1495,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should reject a second execution. (tho still in half-open condition).
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldThrow<BrokenCircuitException>();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
         }
 
@@ -1516,9 +1516,9 @@ namespace Polly.Specs.CircuitBreaker
                 );
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             // exception raised, circuit is now open.  
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -1533,7 +1533,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should reject a second execution. (tho still in half-open condition).
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldThrow<BrokenCircuitException>();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // Allow another time window to pass (breaker should still be HalfOpen).
@@ -1562,9 +1562,9 @@ namespace Polly.Specs.CircuitBreaker
                 );
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             // exceptions raised, circuit is now open.  
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -1667,9 +1667,9 @@ namespace Polly.Specs.CircuitBreaker
                 );
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             // exception raised, circuit is now open.  
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -1776,7 +1776,7 @@ namespace Polly.Specs.CircuitBreaker
             // circuit manually broken: execution should be blocked; even non-exception-throwing executions should not reset circuit
             bool delegateExecutedWhenBroken = false;
             breaker.Awaiting(async x => await x.ExecuteAsync(() => { delegateExecutedWhenBroken = true; return TaskHelper.EmptyTask; }))
-                .ShouldThrow<IsolatedCircuitException>();
+                .Should().Throw<IsolatedCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
             breaker.LastException.Should().BeOfType<IsolatedCircuitException>();
             delegateExecutedWhenBroken.Should().BeFalse();
@@ -1802,7 +1802,7 @@ namespace Polly.Specs.CircuitBreaker
 
             bool delegateExecutedWhenBroken = false;
             breaker.Awaiting(async x => await x.ExecuteAsync(() => { delegateExecutedWhenBroken = true; return TaskHelper.EmptyTask; }))
-                .ShouldThrow<IsolatedCircuitException>();
+                .Should().Throw<IsolatedCircuitException>();
             delegateExecutedWhenBroken.Should().BeFalse();
         }
 
@@ -1821,7 +1821,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Isolate();
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldThrow<IsolatedCircuitException>();
+                .Should().Throw<IsolatedCircuitException>();
 
             breaker.Reset();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
@@ -1848,19 +1848,19 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // reset circuit, with no time having passed
@@ -1913,21 +1913,21 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             onBreakCalled.Should().BeTrue();
@@ -1975,31 +1975,31 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onBreakCalled.Should().Be(0);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onBreakCalled.Should().Be(0);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onBreakCalled.Should().Be(0);
 
             // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             onBreakCalled.Should().Be(1);
 
             // call through circuit when already broken - should not retrigger onBreak 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<BrokenCircuitException>();
+                .Should().Throw<BrokenCircuitException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
@@ -2045,7 +2045,7 @@ namespace Polly.Specs.CircuitBreaker
                     breaker.CircuitState.Should().Be(CircuitState.Open);
                     throw new DivideByZeroException();
 
-                })).ShouldThrow<DivideByZeroException>(); // However, since execution started when circuit was closed, BrokenCircuitException will not have been thrown on entry; the original exception will still be thrown.
+                })).Should().Throw<DivideByZeroException>(); // However, since execution started when circuit was closed, BrokenCircuitException will not have been thrown on entry; the original exception will still be thrown.
             }, TaskCreationOptions.LongRunning);
 
             permitMainThreadToOpenCircuit.WaitOne(testTimeoutToExposeDeadlocks).Should().BeTrue();
@@ -2054,9 +2054,9 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onBreakCalled.Should().Be(0);
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
@@ -2099,21 +2099,21 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             onBreakCalled.Should().Be(1);
@@ -2183,24 +2183,24 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onBreakCalled.Should().Be(0);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onBreakCalled.Should().Be(0);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onBreakCalled.Should().Be(0);
 
             // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             onBreakCalled.Should().Be(1);
@@ -2245,24 +2245,24 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onBreakCalled.Should().Be(0);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onBreakCalled.Should().Be(0);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onBreakCalled.Should().Be(0);
 
             // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             onBreakCalled.Should().Be(1);
@@ -2295,7 +2295,7 @@ namespace Polly.Specs.CircuitBreaker
 
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldThrow<IsolatedCircuitException>();
+                .Should().Throw<IsolatedCircuitException>();
 
             onResetCalled.Should().Be(0);
             breaker.Reset();
@@ -2329,21 +2329,21 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             passedException?.Should().BeOfType<DivideByZeroException>();
@@ -2371,21 +2371,21 @@ namespace Polly.Specs.CircuitBreaker
                 );
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             transitionedState?.Should().Be(CircuitState.Closed);
@@ -2419,19 +2419,19 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
@@ -2442,10 +2442,10 @@ namespace Polly.Specs.CircuitBreaker
 
             // first call after duration raises an exception, so circuit should open again
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<BrokenCircuitException>();
+                .Should().Throw<BrokenCircuitException>();
 
             transitionedStates[0].Should().Be(CircuitState.Closed);
             transitionedStates[1].Should().Be(CircuitState.HalfOpen);
@@ -2474,21 +2474,21 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             passedBreakTimespan.Should().Be(durationOfBreak);
@@ -2551,20 +2551,20 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>(
                 new { key1 = "value1", key2 = "value2" }.AsDictionary()
-                )).ShouldThrow<DivideByZeroException>();
+                )).Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             contextData.Should()
@@ -2598,19 +2598,19 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
@@ -2651,19 +2651,19 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
@@ -2698,19 +2698,19 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>(new { key = "original_value" }.AsDictionary()))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             contextValue.Should().Be("original_value");
 
@@ -2761,7 +2761,7 @@ namespace Polly.Specs.CircuitBreaker
                 );
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.LastException.Should().BeOfType<DivideByZeroException>();
@@ -2780,11 +2780,11 @@ namespace Polly.Specs.CircuitBreaker
                 );
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             breaker.LastException.Should().BeOfType<DivideByZeroException>();
@@ -2803,11 +2803,11 @@ namespace Polly.Specs.CircuitBreaker
                 );
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             breaker.LastException.Should().BeOfType<DivideByZeroException>();
@@ -2870,7 +2870,7 @@ namespace Polly.Specs.CircuitBreaker
             cancellationTokenSource.Cancel();
 
             breaker.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -2898,7 +2898,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -2926,7 +2926,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -2954,7 +2954,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             attemptsInvoked.Should().Be(1);
         }
@@ -2968,13 +2968,13 @@ namespace Polly.Specs.CircuitBreaker
                 .AdvancedCircuitBreakerAsync(0.5, TimeSpan.FromSeconds(10), 2, durationOfBreak);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<DivideByZeroException>();
             // Circuit is now broken.
@@ -2995,7 +2995,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -3027,7 +3027,7 @@ namespace Polly.Specs.CircuitBreaker
                 await TaskHelper.EmptyTask;
                 implicitlyCapturedActionCancellationToken.ThrowIfCancellationRequested();
             }, policyCancellationToken))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(implicitlyCapturedActionCancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -3087,7 +3087,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Awaiting(async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true).ConfigureAwait(false))
-                .ShouldThrow<TaskCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
+                .Should().Throw<TaskCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
 
             result.Should().Be(null);
 

--- a/src/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerAsyncSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerAsyncSpecs.cs
@@ -97,7 +97,7 @@ namespace Polly.Specs.CircuitBreaker
                 .Handle<DivideByZeroException>()
                 .AdvancedCircuitBreakerAsync(0.5, TimeSpan.FromMilliseconds(20), 4, TimeSpan.FromSeconds(30));
 
-            action.ShouldNotThrow<ArgumentOutOfRangeException>();
+            action.Should().NotThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]

--- a/src/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerAsyncSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerAsyncSpecs.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Polly.CircuitBreaker;
 using Polly.Specs.Helpers;
 using Polly.Utilities;

--- a/src/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerSpecs.cs
@@ -26,7 +26,7 @@ namespace Polly.Specs.CircuitBreaker
                 .AdvancedCircuitBreaker(0.5, TimeSpan.FromSeconds(10), 4, TimeSpan.MaxValue);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
         }
 
         [Fact]
@@ -36,7 +36,7 @@ namespace Polly.Specs.CircuitBreaker
                 .Handle<DivideByZeroException>()
                 .AdvancedCircuitBreaker(0, TimeSpan.FromSeconds(10), 4, TimeSpan.FromSeconds(30));
 
-            action.ShouldThrow<ArgumentOutOfRangeException>()
+            action.Should().Throw<ArgumentOutOfRangeException>()
                 .And.ParamName.Should()
                 .Be("failureThreshold");
         }
@@ -48,7 +48,7 @@ namespace Polly.Specs.CircuitBreaker
                 .Handle<DivideByZeroException>()
                 .AdvancedCircuitBreaker(-0.5, TimeSpan.FromSeconds(10), 4, TimeSpan.FromSeconds(30));
 
-            action.ShouldThrow<ArgumentOutOfRangeException>()
+            action.Should().Throw<ArgumentOutOfRangeException>()
                 .And.ParamName.Should()
                 .Be("failureThreshold");
         }
@@ -70,7 +70,7 @@ namespace Polly.Specs.CircuitBreaker
                 .Handle<DivideByZeroException>()
                 .AdvancedCircuitBreaker(1.01, TimeSpan.FromSeconds(10), 4, TimeSpan.FromSeconds(30));
 
-            action.ShouldThrow<ArgumentOutOfRangeException>()
+            action.Should().Throw<ArgumentOutOfRangeException>()
                 .And.ParamName.Should()
                 .Be("failureThreshold");
         }
@@ -86,7 +86,7 @@ namespace Polly.Specs.CircuitBreaker
                     4, 
                     TimeSpan.FromSeconds(30));
 
-            action.ShouldThrow<ArgumentOutOfRangeException>()
+            action.Should().Throw<ArgumentOutOfRangeException>()
                 .And.ParamName.Should()
                 .Be("samplingDuration");
         }
@@ -108,7 +108,7 @@ namespace Polly.Specs.CircuitBreaker
                 .Handle<DivideByZeroException>()
                 .AdvancedCircuitBreaker(0.5, TimeSpan.FromSeconds(10), 1, TimeSpan.FromSeconds(30));
 
-            action.ShouldThrow<ArgumentOutOfRangeException>()
+            action.Should().Throw<ArgumentOutOfRangeException>()
                 .And.ParamName.Should()
                 .Be("minimumThroughput");
         }
@@ -120,7 +120,7 @@ namespace Polly.Specs.CircuitBreaker
                 .Handle<DivideByZeroException>()
                 .AdvancedCircuitBreaker(0.5, TimeSpan.FromSeconds(10), 0, TimeSpan.FromSeconds(30));
 
-            action.ShouldThrow<ArgumentOutOfRangeException>()
+            action.Should().Throw<ArgumentOutOfRangeException>()
                 .And.ParamName.Should()
                 .Be("minimumThroughput");
         }
@@ -132,7 +132,7 @@ namespace Polly.Specs.CircuitBreaker
                 .Handle<DivideByZeroException>()
                 .AdvancedCircuitBreaker(0.5, TimeSpan.FromSeconds(10), 4, -TimeSpan.FromSeconds(1));
 
-            action.ShouldThrow<ArgumentOutOfRangeException>()
+            action.Should().Throw<ArgumentOutOfRangeException>()
                 .And.ParamName.Should()
                 .Be("durationOfBreak");
         }
@@ -186,15 +186,15 @@ namespace Polly.Specs.CircuitBreaker
 
             // Three of three actions in this test throw handled failures.
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             // Failure threshold exceeded, but throughput threshold not yet.
 
@@ -223,19 +223,19 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw unhandled failures.
             breaker.Invoking(x => x.RaiseException<ArgumentNullException>())
-                .ShouldThrow<ArgumentNullException>();
+                .Should().Throw<ArgumentNullException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<ArgumentNullException>())
-                .ShouldThrow<ArgumentNullException>();
+                .Should().Throw<ArgumentNullException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<ArgumentNullException>())
-                .ShouldThrow<ArgumentNullException>();
+                .Should().Throw<ArgumentNullException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<ArgumentNullException>())
-                .ShouldThrow<ArgumentNullException>();
+                .Should().Throw<ArgumentNullException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
         }
 
@@ -266,26 +266,26 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             bool delegateExecutedWhenBroken = false;
             breaker.Invoking(x => x.Execute(() => delegateExecutedWhenBroken = true))
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -312,15 +312,15 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Placing the rest of the invocations ('samplingDuration' / 2) + 1 seconds later
@@ -329,11 +329,11 @@ namespace Polly.Specs.CircuitBreaker
             SystemClock.UtcNow = () => time.AddSeconds(samplingDuration.Seconds / 2d + 1);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -361,20 +361,20 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -404,15 +404,15 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // Placing the rest of the invocations ('samplingDuration' / 2) + 1 seconds later
@@ -421,7 +421,7 @@ namespace Polly.Specs.CircuitBreaker
             SystemClock.UtcNow = () => time.AddSeconds(samplingDuration.Seconds / 2d + 1);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -453,16 +453,16 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -496,11 +496,11 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // Placing the rest of the invocations ('samplingDuration' / 2) + 1 seconds later
@@ -509,7 +509,7 @@ namespace Polly.Specs.CircuitBreaker
             SystemClock.UtcNow = () => time.AddSeconds(samplingDuration.Seconds / 2d + 1);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -543,14 +543,14 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Adjust SystemClock so that timeslice (clearly) expires; fourth exception thrown in next-recorded timeslice.
             SystemClock.UtcNow = () => time.Add(samplingDuration).Add(samplingDuration);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
         }
@@ -582,14 +582,14 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Adjust SystemClock so that timeslice (just) expires; fourth exception thrown in following timeslice.
             SystemClock.UtcNow = () => time.Add(samplingDuration);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
         }
@@ -626,14 +626,14 @@ namespace Polly.Specs.CircuitBreaker
             SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Adjust SystemClock so that timeslice (just) expires; fourth exception thrown in following timeslice.  If timeslice/window rollover is precisely defined, this should cause first two actions to be forgotten from statistics (rolled out of the window of relevance), and thus the circuit not to break.
             SystemClock.UtcNow = () => time.Add(samplingDuration);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
         }
@@ -657,26 +657,26 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Adjust SystemClock so that timeslice doesn't quite expire; fourth exception thrown in same timeslice.
             SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -708,7 +708,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
         }
@@ -742,7 +742,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
         }
@@ -784,7 +784,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Setting the time to just barely into the new timeslice
@@ -794,7 +794,7 @@ namespace Polly.Specs.CircuitBreaker
             // equalling the failure threshold. The minimum threshold within the defined
             // sampling duration is met, when using rolling windows.
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
         }
 
@@ -827,11 +827,11 @@ namespace Polly.Specs.CircuitBreaker
 
             // Two of three actions in this test occur within the first timeslice.
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Setting the time to just barely into the new timeslice
@@ -841,7 +841,7 @@ namespace Polly.Specs.CircuitBreaker
             // the number of failures above the failure threshold. However, the throughput is 
             // below the minimum threshold as to open the circuit.
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
         }
 
@@ -874,11 +874,11 @@ namespace Polly.Specs.CircuitBreaker
 
             // Three actions occur in the second window of the first timeslice
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.Execute(() => { }))
@@ -889,7 +889,7 @@ namespace Polly.Specs.CircuitBreaker
             SystemClock.UtcNow = () => time.Add(samplingDuration);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
         }
 
@@ -920,25 +920,25 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -966,20 +966,20 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -1011,16 +1011,16 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -1046,22 +1046,22 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures; but only the first within the timeslice.
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Adjust SystemClock so that timeslice (clearly) expires; fourth exception thrown in next-recorded timeslice.
             SystemClock.UtcNow = () => time.Add(samplingDuration).Add(samplingDuration);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
         }
@@ -1093,14 +1093,14 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Adjust SystemClock so that timeslice (just) expires; fourth exception thrown in following timeslice.
             SystemClock.UtcNow = () => time.Add(samplingDuration);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
         }
@@ -1124,26 +1124,26 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Adjust SystemClock so that timeslice doesn't quite expire; fourth exception thrown in same timeslice.
             SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -1175,7 +1175,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
         }
@@ -1209,7 +1209,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
         }
@@ -1251,7 +1251,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Setting the time to just barely into the new timeslice
@@ -1260,7 +1260,7 @@ namespace Polly.Specs.CircuitBreaker
             // This failure does not open the circuit, because a new duration should have 
             // started and with such low sampling duration, windows should not be used.
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
         }
 
@@ -1289,19 +1289,19 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
@@ -1310,7 +1310,7 @@ namespace Polly.Specs.CircuitBreaker
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
         }
 
         [Fact]
@@ -1333,15 +1333,15 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Placing the rest of the invocations ('samplingDuration' / 2) + 1 seconds later
@@ -1351,7 +1351,7 @@ namespace Polly.Specs.CircuitBreaker
             SystemClock.UtcNow = () => time.AddSeconds(anotherwindowDuration);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
@@ -1365,7 +1365,7 @@ namespace Polly.Specs.CircuitBreaker
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
         }
 
         [Fact]
@@ -1387,19 +1387,19 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
@@ -1410,7 +1410,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // first call after duration raises an exception, so circuit should open again
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
           
         }
@@ -1434,19 +1434,19 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
@@ -1478,9 +1478,9 @@ namespace Polly.Specs.CircuitBreaker
                 );
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             // exception raised, circuit is now open.  
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -1495,7 +1495,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should reject a second execution.
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldThrow<BrokenCircuitException>();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
         }
 
@@ -1517,9 +1517,9 @@ namespace Polly.Specs.CircuitBreaker
                 );
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             // exception raised, circuit is now open.  
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -1534,7 +1534,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should reject a second execution.
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldThrow<BrokenCircuitException>();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // Allow another time window to pass (breaker should still be HalfOpen).
@@ -1564,9 +1564,9 @@ namespace Polly.Specs.CircuitBreaker
                 );
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             // exceptions raised, circuit is now open.  
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -1668,9 +1668,9 @@ namespace Polly.Specs.CircuitBreaker
                 );
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             // exception raised, circuit is now open.  
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -1775,7 +1775,7 @@ namespace Polly.Specs.CircuitBreaker
             // circuit manually broken: execution should be blocked; even non-exception-throwing executions should not reset circuit
             bool delegateExecutedWhenBroken = false;
             breaker.Invoking(x => x.Execute(() => delegateExecutedWhenBroken = true))
-                .ShouldThrow<IsolatedCircuitException>();
+                .Should().Throw<IsolatedCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
             breaker.LastException.Should().BeOfType<IsolatedCircuitException>();
             delegateExecutedWhenBroken.Should().BeFalse();
@@ -1801,7 +1801,7 @@ namespace Polly.Specs.CircuitBreaker
 
             bool delegateExecutedWhenBroken = false;
             breaker.Invoking(x => x.Execute(() => delegateExecutedWhenBroken = true))
-                .ShouldThrow<IsolatedCircuitException>();
+                .Should().Throw<IsolatedCircuitException>();
             delegateExecutedWhenBroken.Should().BeFalse();
         }
 
@@ -1820,7 +1820,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Isolate();
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldThrow<IsolatedCircuitException>();
+                .Should().Throw<IsolatedCircuitException>();
 
             breaker.Reset();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
@@ -1846,19 +1846,19 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // reset circuit, with no time having passed
@@ -1910,21 +1910,21 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             onBreakCalled.Should().BeTrue();
@@ -1972,31 +1972,31 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onBreakCalled.Should().Be(0);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onBreakCalled.Should().Be(0);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onBreakCalled.Should().Be(0);
 
             // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             onBreakCalled.Should().Be(1);
 
             // call through circuit when already broken - should not retrigger onBreak 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<BrokenCircuitException>();
+                .Should().Throw<BrokenCircuitException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
@@ -2040,7 +2040,7 @@ namespace Polly.Specs.CircuitBreaker
                     breaker.CircuitState.Should().Be(CircuitState.Open);
                     throw new DivideByZeroException();
 
-                })).ShouldThrow<DivideByZeroException>(); // However, since execution started when circuit was closed, BrokenCircuitException will not have been thrown on entry; the original exception will still be thrown.
+                })).Should().Throw<DivideByZeroException>(); // However, since execution started when circuit was closed, BrokenCircuitException will not have been thrown on entry; the original exception will still be thrown.
             }, TaskCreationOptions.LongRunning);
 
             permitMainThreadToOpenCircuit.WaitOne(testTimeoutToExposeDeadlocks).Should().BeTrue();
@@ -2049,9 +2049,9 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onBreakCalled.Should().Be(0);
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
@@ -2094,21 +2094,21 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             onBreakCalled.Should().Be(1);
@@ -2178,24 +2178,24 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onBreakCalled.Should().Be(0);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onBreakCalled.Should().Be(0);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onBreakCalled.Should().Be(0);
 
             // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             onBreakCalled.Should().Be(1);
@@ -2240,24 +2240,24 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onBreakCalled.Should().Be(0);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onBreakCalled.Should().Be(0);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onBreakCalled.Should().Be(0);
 
             // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             onBreakCalled.Should().Be(1);
@@ -2290,7 +2290,7 @@ namespace Polly.Specs.CircuitBreaker
 
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldThrow<IsolatedCircuitException>();
+                .Should().Throw<IsolatedCircuitException>();
 
             onResetCalled.Should().Be(0);
             breaker.Reset();
@@ -2322,19 +2322,19 @@ namespace Polly.Specs.CircuitBreaker
                 );
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             passedException?.Should().BeOfType<DivideByZeroException>();
@@ -2362,19 +2362,19 @@ namespace Polly.Specs.CircuitBreaker
                 );
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             transitionedState?.Should().Be(CircuitState.Closed);
@@ -2408,19 +2408,19 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
@@ -2431,7 +2431,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // first call after duration raises an exception, so circuit should open again
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             transitionedStates[0].Should().Be(CircuitState.Closed);
@@ -2460,19 +2460,19 @@ namespace Polly.Specs.CircuitBreaker
                 );
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             passedBreakTimespan.Should().Be(durationOfBreak);
@@ -2535,20 +2535,20 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>(
                 new { key1 = "value1", key2 = "value2" }.AsDictionary()
-                )).ShouldThrow<DivideByZeroException>();
+                )).Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             contextData.Should()
@@ -2582,19 +2582,19 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
@@ -2635,19 +2635,19 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
@@ -2682,19 +2682,19 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures.
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>(new { key = "original_value" }.AsDictionary()))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             contextValue.Should().Be("original_value");
 
@@ -2744,7 +2744,7 @@ namespace Polly.Specs.CircuitBreaker
                 );
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.LastException.Should().BeOfType<DivideByZeroException>();
@@ -2763,11 +2763,11 @@ namespace Polly.Specs.CircuitBreaker
                 );
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             breaker.LastException.Should().BeOfType<DivideByZeroException>();
@@ -2786,11 +2786,11 @@ namespace Polly.Specs.CircuitBreaker
                 );
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             breaker.LastException.Should().BeOfType<DivideByZeroException>();
@@ -2853,7 +2853,7 @@ namespace Polly.Specs.CircuitBreaker
             cancellationTokenSource.Cancel();
 
             breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -2881,7 +2881,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -2909,7 +2909,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -2937,7 +2937,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             attemptsInvoked.Should().Be(1);
         }
@@ -2951,13 +2951,13 @@ namespace Polly.Specs.CircuitBreaker
                 .AdvancedCircuitBreaker(0.5, TimeSpan.FromSeconds(10), 2, durationOfBreak);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<DivideByZeroException>();
             // Circuit is now broken.
@@ -2978,7 +2978,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -3009,7 +3009,7 @@ namespace Polly.Specs.CircuitBreaker
                 attemptsInvoked++;
                 implicitlyCapturedActionCancellationToken.ThrowIfCancellationRequested();
             }, policyCancellationToken))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(implicitlyCapturedActionCancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -3069,7 +3069,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Invoking(x => result = x.RaiseExceptionAndOrCancellation<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true))
-                .ShouldThrow<OperationCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
+                .Should().Throw<OperationCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
 
             result.Should().Be(null);
 

--- a/src/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerSpecs.cs
@@ -98,7 +98,7 @@ namespace Polly.Specs.CircuitBreaker
                 .Handle<DivideByZeroException>()
                 .AdvancedCircuitBreaker(0.5, TimeSpan.FromMilliseconds(20), 4, TimeSpan.FromSeconds(30));
 
-            action.ShouldNotThrow<ArgumentOutOfRangeException>();
+            action.Should().NotThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]

--- a/src/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerSpecs.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Polly.CircuitBreaker;
 using Polly.Specs.Helpers;
 using Polly.Utilities;

--- a/src/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerSpecs.cs
@@ -60,7 +60,7 @@ namespace Polly.Specs.CircuitBreaker
                 .Handle<DivideByZeroException>()
                 .AdvancedCircuitBreaker(1.0, TimeSpan.FromSeconds(10), 4, TimeSpan.FromSeconds(30));
 
-            action.ShouldNotThrow();
+            action.Should().NotThrow();
         }
 
         [Fact]
@@ -144,7 +144,7 @@ namespace Polly.Specs.CircuitBreaker
                 .Handle<DivideByZeroException>()
                 .AdvancedCircuitBreaker(0.5, TimeSpan.FromSeconds(10), 4, TimeSpan.Zero);
 
-            action.ShouldNotThrow();
+            action.Should().NotThrow();
         }
 
         [Fact]
@@ -200,7 +200,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // Throughput threshold will be exceeded by the below successful call, but we never break on a successful call; hence don't break on this.
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
         }
@@ -357,7 +357,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // Three of four actions in this test throw handled failures.
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
@@ -400,7 +400,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // Three of four actions in this test throw handled failures.
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
@@ -445,11 +445,11 @@ namespace Polly.Specs.CircuitBreaker
 
             // Two of four actions in this test throw handled failures.
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
@@ -488,11 +488,11 @@ namespace Polly.Specs.CircuitBreaker
 
             // Two of four actions in this test throw handled failures.
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
@@ -535,11 +535,11 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures; but only the first three within the timeslice.
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
@@ -574,11 +574,11 @@ namespace Polly.Specs.CircuitBreaker
 
             // Four of four actions in this test throw handled failures; but only the first three within the timeslice.
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
@@ -615,11 +615,11 @@ namespace Polly.Specs.CircuitBreaker
 
             // Two actions at the start of the original timeslice.
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Creates a new window right at the end of the original timeslice.
@@ -700,11 +700,11 @@ namespace Polly.Specs.CircuitBreaker
 
             // One of three actions in this test throw handled failures.
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
@@ -730,15 +730,15 @@ namespace Polly.Specs.CircuitBreaker
 
             // One of four actions in this test throw handled failures.
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
@@ -767,7 +767,7 @@ namespace Polly.Specs.CircuitBreaker
             // Executing a single invocation to ensure timeslice is created
             // This invocation is not be counted against the threshold
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // The time is set to just at the end of the sampling duration ensuring
@@ -776,11 +776,11 @@ namespace Polly.Specs.CircuitBreaker
 
             // Three of four actions in this test occur within the first timeslice.
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
@@ -818,7 +818,7 @@ namespace Polly.Specs.CircuitBreaker
             // Executing a single invocation to ensure timeslice is created
             // This invocation is not be counted against the threshold
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // The time is set to just at the end of the sampling duration ensuring
@@ -866,7 +866,7 @@ namespace Polly.Specs.CircuitBreaker
             // Executing a single invocation to ensure timeslice is created
             // This invocation is not be counted against the threshold
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Setting the time to the second window in the rolling metrics
@@ -882,7 +882,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // Setting the time to just barely into the new timeslice
@@ -962,7 +962,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // Three of four actions in this test throw handled failures.
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
@@ -1003,11 +1003,11 @@ namespace Polly.Specs.CircuitBreaker
 
             // Two of four actions in this test throw handled failures.
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
@@ -1085,11 +1085,11 @@ namespace Polly.Specs.CircuitBreaker
 
             // Two of four actions in this test throw handled failures; but only the first within the timeslice.
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
@@ -1167,11 +1167,11 @@ namespace Polly.Specs.CircuitBreaker
 
             // One of three actions in this test throw handled failures.
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
@@ -1197,15 +1197,15 @@ namespace Polly.Specs.CircuitBreaker
 
             // One of four actions in this test throw handled failures.
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
@@ -1234,7 +1234,7 @@ namespace Polly.Specs.CircuitBreaker
             // Executing a single invocation to ensure timeslice is created
             // This invocation is not be counted against the threshold
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             // The time is set to just at the end of the sampling duration ensuring
@@ -1243,11 +1243,11 @@ namespace Polly.Specs.CircuitBreaker
 
             // Three of four actions in this test occur within the first timeslice.
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
@@ -1491,7 +1491,7 @@ namespace Polly.Specs.CircuitBreaker
 
 
             // OnActionPreExecute() should permit first execution.
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should reject a second execution.
@@ -1530,7 +1530,7 @@ namespace Polly.Specs.CircuitBreaker
 
 
             // OnActionPreExecute() should permit first execution.
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should reject a second execution.
@@ -1542,7 +1542,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should now permit another trial execution.
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
         }
 
@@ -1602,7 +1602,7 @@ namespace Polly.Specs.CircuitBreaker
                     permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
                     firstExecutionActive = false;
 
-                })).ShouldNotThrow();
+                })).Should().NotThrow();
             }, TaskCreationOptions.LongRunning);
 
             // Attempt a second execution, signalled by the first execution to ensure they overlap: we should be able to verify it doesn't execute, and is rejected by a breaker in a HalfOpen state.
@@ -1707,7 +1707,7 @@ namespace Polly.Specs.CircuitBreaker
                     permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
                     firstExecutionActive = false;
 
-                })).ShouldNotThrow();
+                })).Should().NotThrow();
             }, TaskCreationOptions.LongRunning);
 
             // Attempt a second execution, signalled by the first execution to ensure they overlap; start it one breakDuration later.  We should be able to verify it does execute, though the breaker is still in a HalfOpen state.
@@ -1824,7 +1824,7 @@ namespace Polly.Specs.CircuitBreaker
 
             breaker.Reset();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
-            breaker.Invoking(x => x.Execute(() => { })).ShouldNotThrow();
+            breaker.Invoking(x => x.Execute(() => { })).Should().NotThrow();
         }
 
         [Fact]
@@ -1865,7 +1865,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Reset();
             SystemClock.UtcNow().Should().Be(time);
             breaker.CircuitState.Should().Be(CircuitState.Closed);
-            breaker.Invoking(x => x.Execute(() => { })).ShouldNotThrow();
+            breaker.Invoking(x => x.Execute(() => { })).Should().NotThrow();
         }
 
         #endregion
@@ -2297,7 +2297,7 @@ namespace Polly.Specs.CircuitBreaker
             onResetCalled.Should().Be(1);
 
             breaker.CircuitState.Should().Be(CircuitState.Closed);
-            breaker.Invoking(x => x.Execute(() => { })).ShouldNotThrow();
+            breaker.Invoking(x => x.Execute(() => { })).Should().NotThrow();
         }
 
         #region Tests of supplied parameters to onBreak delegate
@@ -2825,7 +2825,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             attemptsInvoked.Should().Be(1);
         }
@@ -3038,7 +3038,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Invoking(x => result = x.RaiseExceptionAndOrCancellation<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             result.Should().BeTrue();
 

--- a/src/Polly.Specs/CircuitBreaker/CircuitBreakerAsyncSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/CircuitBreakerAsyncSpecs.cs
@@ -58,7 +58,7 @@ namespace Polly.Specs.CircuitBreaker
             Action action = () => Policy
                                      .Handle<DivideByZeroException>()
                                      .CircuitBreakerAsync(1, TimeSpan.Zero);
-            action.ShouldNotThrow();
+            action.Should().NotThrow();
         }
 
         [Fact]
@@ -88,7 +88,7 @@ namespace Polly.Specs.CircuitBreaker
                   .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
-            breaker.Awaiting(async b => await b.ExecuteAsync(() => TaskHelper.EmptyTask)).ShouldNotThrow();
+            breaker.Awaiting(async b => await b.ExecuteAsync(() => TaskHelper.EmptyTask)).Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
@@ -333,7 +333,7 @@ namespace Polly.Specs.CircuitBreaker
 
 
             // OnActionPreExecute() should permit first execution.
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should reject a second execution.
@@ -364,7 +364,7 @@ namespace Polly.Specs.CircuitBreaker
             
 
             // OnActionPreExecute() should permit first execution.
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should reject a second execution.
@@ -376,7 +376,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should now permit another trial execution.
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
         }
 
@@ -429,7 +429,7 @@ namespace Polly.Specs.CircuitBreaker
                     await TaskHelper.EmptyTask;
                     firstExecutionActive = false;
 
-                })).ShouldNotThrow();
+                })).Should().NotThrow();
             }, TaskCreationOptions.LongRunning);
 
             // Attempt a second execution, signalled by the first execution to ensure they overlap: we should be able to verify it doesn't execute, and is rejected by a breaker in a HalfOpen state.
@@ -527,7 +527,7 @@ namespace Polly.Specs.CircuitBreaker
                     permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
                     await TaskHelper.EmptyTask;
                     firstExecutionActive = false;
-                })).ShouldNotThrow();
+                })).Should().NotThrow();
             }, TaskCreationOptions.LongRunning);
 
             // Attempt a second execution, signalled by the first execution to ensure they overlap; start it one breakDuration later.  We should be able to verify it does execute, though the breaker is still in a HalfOpen state.
@@ -653,7 +653,7 @@ namespace Polly.Specs.CircuitBreaker
 
             breaker.Reset();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
-            breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask)).ShouldNotThrow();
+            breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask)).Should().NotThrow();
         }
 
         [Fact]
@@ -685,7 +685,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Reset();
             SystemClock.UtcNow().Should().Be(time);
             breaker.CircuitState.Should().Be(CircuitState.Closed);
-            breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask)).ShouldNotThrow();
+            breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask)).Should().NotThrow();
         }
 
         #endregion
@@ -1022,7 +1022,7 @@ namespace Polly.Specs.CircuitBreaker
             onResetCalled.Should().Be(1);
 
             breaker.CircuitState.Should().Be(CircuitState.Closed);
-            breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask)).ShouldNotThrow();
+            breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask)).Should().NotThrow();
         }
 
         #region Tests of supplied parameters to onBreak delegate
@@ -1435,7 +1435,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             attemptsInvoked.Should().Be(1);
         }
@@ -1645,7 +1645,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Awaiting(async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true).ConfigureAwait(false))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             result.Should().BeTrue();
 

--- a/src/Polly.Specs/CircuitBreaker/CircuitBreakerAsyncSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/CircuitBreakerAsyncSpecs.cs
@@ -25,7 +25,7 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreakerAsync(1, TimeSpan.MaxValue);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
         }
 
         [Fact]
@@ -35,7 +35,7 @@ namespace Polly.Specs.CircuitBreaker
                                     .Handle<DivideByZeroException>()
                                     .CircuitBreakerAsync(0, TimeSpan.FromSeconds(10));
 
-            action.ShouldThrow<ArgumentOutOfRangeException>()
+            action.Should().Throw<ArgumentOutOfRangeException>()
                   .And.ParamName.Should()
                   .Be("exceptionsAllowedBeforeBreaking");
         }
@@ -47,7 +47,7 @@ namespace Polly.Specs.CircuitBreaker
                                      .Handle<DivideByZeroException>()
                                      .CircuitBreakerAsync(1, -TimeSpan.FromSeconds(1));
 
-            action.ShouldThrow<ArgumentOutOfRangeException>()
+            action.Should().Throw<ArgumentOutOfRangeException>()
                 .And.ParamName.Should()
                 .Be("durationOfBreak");
         }
@@ -85,14 +85,14 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async b => await b.ExecuteAsync(() => TaskHelper.EmptyTask)).ShouldNotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
         }
 
@@ -104,16 +104,16 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             bool delegateExecutedWhenBroken = false;
             breaker.Awaiting(async x => await x.ExecuteAsync(() => { delegateExecutedWhenBroken = true; return TaskHelper.EmptyTask; }))
-                  .ShouldThrow<BrokenCircuitException>()
+                  .Should().Throw<BrokenCircuitException>()
                   .WithMessage("The circuit is now open and is not allowing calls.")
                   .WithInnerException<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -130,17 +130,17 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentOutOfRangeException>())
-                  .ShouldThrow<ArgumentOutOfRangeException>();
+                  .Should().Throw<ArgumentOutOfRangeException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // 2 exception raised, circuit is now open
             bool delegateExecutedWhenBroken = false;
             breaker.Awaiting(async x => await x.ExecuteAsync(() => { delegateExecutedWhenBroken = true; return TaskHelper.EmptyTask; }))
-                  .ShouldThrow<BrokenCircuitException>()
+                  .Should().Throw<BrokenCircuitException>()
                   .WithMessage("The circuit is now open and is not allowing calls.")
                   .WithInnerException<ArgumentOutOfRangeException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -155,15 +155,15 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentNullException>())
-                  .ShouldThrow<ArgumentNullException>();
+                  .Should().Throw<ArgumentNullException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentNullException>())
-                  .ShouldThrow<ArgumentNullException>();
+                  .Should().Throw<ArgumentNullException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentNullException>())
-                  .ShouldThrow<ArgumentNullException>();
+                  .Should().Throw<ArgumentNullException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
         }
 
@@ -176,15 +176,15 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentNullException>())
-                  .ShouldThrow<ArgumentNullException>();
+                  .Should().Throw<ArgumentNullException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentNullException>())
-                  .ShouldThrow<ArgumentNullException>();
+                  .Should().Throw<ArgumentNullException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentNullException>())
-                  .ShouldThrow<ArgumentNullException>();
+                  .Should().Throw<ArgumentNullException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
         }
 
@@ -205,16 +205,16 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreakerAsync(2, durationOfBreak);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // 2 exception raised, circuit is now open
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             SystemClock.UtcNow = () => time.Add(durationOfBreak);
@@ -222,7 +222,7 @@ namespace Polly.Specs.CircuitBreaker
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
         }
 
         [Fact]
@@ -238,16 +238,16 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreakerAsync(2, durationOfBreak);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // 2 exception raised, circuit is now open
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             SystemClock.UtcNow = () => time.Add(durationOfBreak);
@@ -256,10 +256,10 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
             // first call after duration raises an exception, so circuit should break again
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
 
         }
 
@@ -276,16 +276,16 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreakerAsync(2, durationOfBreak);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // 2 exception raised, circuit is now open
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             SystemClock.UtcNow = () => time.Add(durationOfBreak);
@@ -298,15 +298,15 @@ namespace Polly.Specs.CircuitBreaker
 
             // circuit has been reset so should once again allow 2 exceptions to be raised before breaking
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
         }
 
@@ -322,7 +322,7 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreakerAsync(1, durationOfBreak);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             // exception raised, circuit is now open.  
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -337,7 +337,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should reject a second execution.
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldThrow<BrokenCircuitException>();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
         }
 
@@ -353,7 +353,7 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreakerAsync(1, durationOfBreak);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             // exception raised, circuit is now open.  
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -368,7 +368,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should reject a second execution.
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldThrow<BrokenCircuitException>();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // Allow another time window to pass (breaker should still be HalfOpen).
@@ -392,7 +392,7 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreakerAsync(1, durationOfBreak);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             // exception raised, circuit is now open.  
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -490,7 +490,7 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreakerAsync(1, durationOfBreak);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             // exception raised, circuit is now open.  
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -602,7 +602,7 @@ namespace Polly.Specs.CircuitBreaker
             // circuit manually broken: execution should be blocked; even non-exception-throwing executions should not reset circuit
             bool delegateExecutedWhenBroken = false;
             breaker.Awaiting(async x => await x.ExecuteAsync(() => { delegateExecutedWhenBroken = true; return TaskHelper.EmptyTask; }))
-                .ShouldThrow<IsolatedCircuitException>();
+                .Should().Throw<IsolatedCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
             breaker.LastException.Should().BeOfType<IsolatedCircuitException>();
             delegateExecutedWhenBroken.Should().BeFalse();
@@ -629,7 +629,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
             bool delegateExecutedWhenBroken = false;
             breaker.Awaiting(async x => await x.ExecuteAsync(() => { delegateExecutedWhenBroken = true; return TaskHelper.EmptyTask; }))
-                .ShouldThrow<IsolatedCircuitException>();
+                .Should().Throw<IsolatedCircuitException>();
             delegateExecutedWhenBroken.Should().BeFalse();
         }
 
@@ -649,7 +649,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Isolate();
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldThrow<IsolatedCircuitException>();
+                .Should().Throw<IsolatedCircuitException>();
 
             breaker.Reset();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
@@ -669,16 +669,16 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreakerAsync(2, durationOfBreak);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // 2 exception raised, circuit is now open
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // reset circuit, with no time having passed
@@ -718,13 +718,13 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onBreakCalled.Should().BeFalse();
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().BeTrue();
@@ -759,20 +759,20 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onBreakCalled.Should().Be(0);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
             // call through circuit when already broken - should not retrigger onBreak 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
@@ -811,7 +811,7 @@ namespace Polly.Specs.CircuitBreaker
                     breaker.CircuitState.Should().Be(CircuitState.Open);
                     throw new DivideByZeroException();
 
-                })).ShouldThrow<DivideByZeroException>(); // However, since execution started when circuit was closed, BrokenCircuitException will not have been thrown on entry; the original exception will still be thrown.
+                })).Should().Throw<DivideByZeroException>(); // However, since execution started when circuit was closed, BrokenCircuitException will not have been thrown on entry; the original exception will still be thrown.
             }, TaskCreationOptions.LongRunning);
 
             permitMainThreadToOpenCircuit.WaitOne(testTimeoutToExposeDeadlocks).Should().BeTrue();
@@ -820,7 +820,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onBreakCalled.Should().Be(0);
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
@@ -857,16 +857,16 @@ namespace Polly.Specs.CircuitBreaker
             onBreakCalled.Should().Be(0);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             onBreakCalled.Should().Be(0);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             onBreakCalled.Should().Be(1);
 
             // 2 exception raised, circuit is now open
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
@@ -927,16 +927,16 @@ namespace Polly.Specs.CircuitBreaker
             onBreakCalled.Should().Be(0);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             onBreakCalled.Should().Be(0);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             onBreakCalled.Should().Be(1);
 
             // 2 exception raised, circuit is now open
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
@@ -973,16 +973,16 @@ namespace Polly.Specs.CircuitBreaker
             onBreakCalled.Should().Be(0);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             onBreakCalled.Should().Be(0);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             onBreakCalled.Should().Be(1);
 
             // 2 exception raised, circuit is now open
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
@@ -1015,7 +1015,7 @@ namespace Polly.Specs.CircuitBreaker
 
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
             breaker.Awaiting(async x => await x.ExecuteAsync(() => TaskHelper.EmptyTask))
-                .ShouldThrow<IsolatedCircuitException>();
+                .Should().Throw<IsolatedCircuitException>();
 
             onResetCalled.Should().Be(0);
             breaker.Reset();
@@ -1040,11 +1040,11 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             passedException?.Should().BeOfType<DivideByZeroException>();
@@ -1064,11 +1064,11 @@ namespace Polly.Specs.CircuitBreaker
                 .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset, onHalfOpen);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             transitionedState?.Should().Be(CircuitState.Closed);
@@ -1093,16 +1093,16 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset, onHalfOpen);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // 2 exception raised, circuit is now open
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             SystemClock.UtcNow = () => time.Add(durationOfBreak);
@@ -1111,10 +1111,10 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
             // first call after duration raises an exception, so circuit should break again
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
 
             transitionedStates[0].Should().Be(CircuitState.Closed);
             transitionedStates[1].Should().Be(CircuitState.HalfOpen);
@@ -1139,10 +1139,10 @@ namespace Polly.Specs.CircuitBreaker
             Exception withInner = new AggregateException(toRaiseAsInner);
 
             breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.Awaiting(x => x.RaiseExceptionAsync(withInner))
-                .ShouldThrow<DivideByZeroException>().Which.Should().BeSameAs(toRaiseAsInner);
+                .Should().Throw<DivideByZeroException>().Which.Should().BeSameAs(toRaiseAsInner);
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
@@ -1164,11 +1164,11 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreakerAsync(2, durationOfBreak, onBreak, onReset);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             passedBreakTimespan.Should().Be(durationOfBreak);
@@ -1213,11 +1213,11 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>(
                 new { key1 = "value1", key2 = "value2" }.AsDictionary()
-                )).ShouldThrow<DivideByZeroException>();
+                )).Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
@@ -1244,9 +1244,9 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreakerAsync(2, durationOfBreak, onBreak, onReset);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             SystemClock.UtcNow = () => time.Add(durationOfBreak);
@@ -1273,10 +1273,10 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
@@ -1301,11 +1301,11 @@ namespace Polly.Specs.CircuitBreaker
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             // 2 exception raised, circuit is now open
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>(new { key = "original_value" }.AsDictionary()))
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             contextValue.Should().Be("original_value");
 
@@ -1345,7 +1345,7 @@ namespace Polly.Specs.CircuitBreaker
                 .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
@@ -1363,7 +1363,7 @@ namespace Polly.Specs.CircuitBreaker
             Exception withInner = new AggregateException(toRaiseAsInner);
 
             breaker.Awaiting(x => x.RaiseExceptionAsync(withInner))
-                .ShouldThrow<DivideByZeroException>().Which.Should().BeSameAs(toRaiseAsInner);
+                .Should().Throw<DivideByZeroException>().Which.Should().BeSameAs(toRaiseAsInner);
 
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
@@ -1378,10 +1378,10 @@ namespace Polly.Specs.CircuitBreaker
                 .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
@@ -1396,10 +1396,10 @@ namespace Polly.Specs.CircuitBreaker
                 .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
@@ -1463,7 +1463,7 @@ namespace Polly.Specs.CircuitBreaker
             cancellationTokenSource.Cancel();
 
             breaker.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -1491,7 +1491,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -1519,7 +1519,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -1547,7 +1547,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             attemptsInvoked.Should().Be(1);
         }
@@ -1560,10 +1560,10 @@ namespace Polly.Specs.CircuitBreaker
                 .CircuitBreakerAsync(1, TimeSpan.FromMinutes(1));
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<DivideByZeroException>();
             // Circuit is now broken.
@@ -1584,7 +1584,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -1616,7 +1616,7 @@ namespace Polly.Specs.CircuitBreaker
                 await TaskHelper.EmptyTask;
                 implicitlyCapturedActionCancellationToken.ThrowIfCancellationRequested();
             }, policyCancellationToken))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(implicitlyCapturedActionCancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -1675,7 +1675,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Awaiting(async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true).ConfigureAwait(false))
-                .ShouldThrow<TaskCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
+                .Should().Throw<TaskCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
 
             result.Should().Be(null);
 

--- a/src/Polly.Specs/CircuitBreaker/CircuitBreakerAsyncSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/CircuitBreakerAsyncSpecs.cs
@@ -1464,7 +1464,7 @@ namespace Polly.Specs.CircuitBreaker
             cancellationTokenSource.Cancel();
 
             breaker.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -1492,7 +1492,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -1520,7 +1520,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -1585,7 +1585,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -1617,7 +1617,7 @@ namespace Polly.Specs.CircuitBreaker
                 await TaskHelper.EmptyTask;
                 implicitlyCapturedActionCancellationToken.ThrowIfCancellationRequested();
             }, policyCancellationToken))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(implicitlyCapturedActionCancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -1676,7 +1676,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Awaiting(async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true).ConfigureAwait(false))
-                .Should().Throw<TaskCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
+                .Should().Throw<OperationCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
 
             result.Should().Be(null);
 

--- a/src/Polly.Specs/CircuitBreaker/CircuitBreakerAsyncSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/CircuitBreakerAsyncSpecs.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Polly.CircuitBreaker;
 using Polly.Specs.Helpers;
 using Polly.Utilities;

--- a/src/Polly.Specs/CircuitBreaker/CircuitBreakerSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/CircuitBreakerSpecs.cs
@@ -23,7 +23,7 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreaker(1, TimeSpan.MaxValue);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
         }
 
         [Fact]
@@ -33,7 +33,7 @@ namespace Polly.Specs.CircuitBreaker
                                     .Handle<DivideByZeroException>()
                                     .CircuitBreaker(0, TimeSpan.FromSeconds(10));
 
-            action.ShouldThrow<ArgumentOutOfRangeException>()
+            action.Should().Throw<ArgumentOutOfRangeException>()
                   .And.ParamName.Should()
                   .Be("exceptionsAllowedBeforeBreaking");
         }
@@ -45,7 +45,7 @@ namespace Polly.Specs.CircuitBreaker
                                      .Handle<DivideByZeroException>()
                                      .CircuitBreaker(1, -TimeSpan.FromSeconds(1));
 
-            action.ShouldThrow<ArgumentOutOfRangeException>()
+            action.Should().Throw<ArgumentOutOfRangeException>()
                 .And.ParamName.Should()
                 .Be("durationOfBreak");
         }
@@ -83,14 +83,14 @@ namespace Polly.Specs.CircuitBreaker
                 .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(b => b.Execute(() =>{})).ShouldNotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
         }
 
@@ -102,16 +102,16 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             bool delegateExecutedWhenBroken = false;
             breaker.Invoking(x => x.Execute(() => delegateExecutedWhenBroken = true))
-                  .ShouldThrow<BrokenCircuitException>()
+                  .Should().Throw<BrokenCircuitException>()
                   .WithMessage("The circuit is now open and is not allowing calls.")
                   .WithInnerException<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -127,17 +127,17 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<ArgumentOutOfRangeException>())
-                  .ShouldThrow<ArgumentOutOfRangeException>();
+                  .Should().Throw<ArgumentOutOfRangeException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // 2 exception raised, circuit is now open
             bool delegateExecutedWhenBroken = false;
             breaker.Invoking(x => x.Execute(() => delegateExecutedWhenBroken = true))
-                  .ShouldThrow<BrokenCircuitException>()
+                  .Should().Throw<BrokenCircuitException>()
                   .WithMessage("The circuit is now open and is not allowing calls.")
                   .WithInnerException<ArgumentOutOfRangeException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -152,15 +152,15 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
             breaker.Invoking(x => x.RaiseException<ArgumentNullException>())
-                  .ShouldThrow<ArgumentNullException>();
+                  .Should().Throw<ArgumentNullException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<ArgumentNullException>())
-                  .ShouldThrow<ArgumentNullException>();
+                  .Should().Throw<ArgumentNullException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<ArgumentNullException>())
-                  .ShouldThrow<ArgumentNullException>();
+                  .Should().Throw<ArgumentNullException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
         }
 
@@ -173,15 +173,15 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
             breaker.Invoking(x => x.RaiseException<ArgumentNullException>())
-                  .ShouldThrow<ArgumentNullException>();
+                  .Should().Throw<ArgumentNullException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<ArgumentNullException>())
-                  .ShouldThrow<ArgumentNullException>();
+                  .Should().Throw<ArgumentNullException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<ArgumentNullException>())
-                  .ShouldThrow<ArgumentNullException>();
+                  .Should().Throw<ArgumentNullException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
         }
 
@@ -202,16 +202,16 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreaker(2, durationOfBreak);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // 2 exception raised, circuit is now open
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             SystemClock.UtcNow = () => time.Add(durationOfBreak);
@@ -219,7 +219,7 @@ namespace Polly.Specs.CircuitBreaker
             // duration has passed, circuit now half open
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
         }
 
         [Fact]
@@ -235,16 +235,16 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreaker(2, durationOfBreak);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // 2 exception raised, circuit is now open
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             SystemClock.UtcNow = () => time.Add(durationOfBreak);
@@ -253,10 +253,10 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
             // first call after duration raises an exception, so circuit should break again
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             
         }
 
@@ -273,16 +273,16 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreaker(2, durationOfBreak);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // 2 exception raised, circuit is now open
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             SystemClock.UtcNow = () => time.Add(durationOfBreak);
@@ -295,15 +295,15 @@ namespace Polly.Specs.CircuitBreaker
 
             // circuit has been reset so should once again allow 2 exceptions to be raised before breaking
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
         }
 
@@ -319,7 +319,7 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreaker(1, durationOfBreak);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             // exception raised, circuit is now open.  
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -334,7 +334,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should reject a second execution.
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldThrow<BrokenCircuitException>();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
         }
 
@@ -350,7 +350,7 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreaker(1, durationOfBreak);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             // exception raised, circuit is now open.  
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -365,7 +365,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should reject a second execution in the same time window.
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldThrow<BrokenCircuitException>();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // Allow another time window to pass (breaker should still be HalfOpen).
@@ -389,7 +389,7 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreaker(1, durationOfBreak);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             // exception raised, circuit is now open.  
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -485,7 +485,7 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreaker(1, durationOfBreak);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             // exception raised, circuit is now open.  
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -595,7 +595,7 @@ namespace Polly.Specs.CircuitBreaker
             // circuit manually broken: execution should be blocked; even non-exception-throwing executions should not reset circuit
             bool delegateExecutedWhenBroken = false;
             breaker.Invoking(x => x.Execute(() => delegateExecutedWhenBroken = true))
-                .ShouldThrow<IsolatedCircuitException>();
+                .Should().Throw<IsolatedCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
             breaker.LastException.Should().BeOfType<IsolatedCircuitException>();
             delegateExecutedWhenBroken.Should().BeFalse();
@@ -621,7 +621,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
             bool delegateExecutedWhenBroken = false;
             breaker.Invoking(x => x.Execute(() => { delegateExecutedWhenBroken = true; return ResultPrimitive.Good; }))
-                .ShouldThrow<IsolatedCircuitException>();
+                .Should().Throw<IsolatedCircuitException>();
             delegateExecutedWhenBroken.Should().BeFalse();
         }
 
@@ -641,7 +641,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Isolate();
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldThrow<IsolatedCircuitException>();
+                .Should().Throw<IsolatedCircuitException>();
 
             breaker.Reset();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
@@ -661,16 +661,16 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreaker(2, durationOfBreak);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // 2 exception raised, circuit is now open
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // reset circuit, with no time having passed
@@ -710,13 +710,13 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreaker(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onBreakCalled.Should().BeFalse();
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().BeTrue();
@@ -751,20 +751,20 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreaker(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onBreakCalled.Should().Be(0);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
             // call through circuit when already broken - should not retrigger onBreak 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
@@ -801,7 +801,7 @@ namespace Polly.Specs.CircuitBreaker
                     breaker.CircuitState.Should().Be(CircuitState.Open);
                     throw new DivideByZeroException();
 
-                })).ShouldThrow<DivideByZeroException>(); // However, since execution started when circuit was closed, BrokenCircuitException will not have been thrown on entry; the original exception will still be thrown.
+                })).Should().Throw<DivideByZeroException>(); // However, since execution started when circuit was closed, BrokenCircuitException will not have been thrown on entry; the original exception will still be thrown.
             }, TaskCreationOptions.LongRunning);
 
             permitMainThreadToOpenCircuit.WaitOne(testTimeoutToExposeDeadlocks).Should().BeTrue();
@@ -810,7 +810,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onBreakCalled.Should().Be(0);
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
@@ -847,16 +847,16 @@ namespace Polly.Specs.CircuitBreaker
             onBreakCalled.Should().Be(0);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             onBreakCalled.Should().Be(0);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             onBreakCalled.Should().Be(1);
 
             // 2 exception raised, circuit is now open
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
@@ -917,16 +917,16 @@ namespace Polly.Specs.CircuitBreaker
             onBreakCalled.Should().Be(0);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             onBreakCalled.Should().Be(0);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             onBreakCalled.Should().Be(1);
 
             // 2 exception raised, circuit is now open
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
@@ -963,16 +963,16 @@ namespace Polly.Specs.CircuitBreaker
             onBreakCalled.Should().Be(0);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             onBreakCalled.Should().Be(0);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             onBreakCalled.Should().Be(1);
 
             // 2 exception raised, circuit is now open
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
@@ -1005,7 +1005,7 @@ namespace Polly.Specs.CircuitBreaker
 
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
             breaker.Invoking(x => x.Execute(() => { }))
-                .ShouldThrow<IsolatedCircuitException>();
+                .Should().Throw<IsolatedCircuitException>();
 
             onResetCalled.Should().Be(0);
             breaker.Reset();
@@ -1032,10 +1032,10 @@ namespace Polly.Specs.CircuitBreaker
                 .CircuitBreaker(2, durationOfBreak, onBreak, onReset);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
@@ -1056,10 +1056,10 @@ namespace Polly.Specs.CircuitBreaker
                 .CircuitBreaker(2, TimeSpan.FromMinutes(1), onBreak, onReset, onHalfOpen);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
@@ -1085,16 +1085,16 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreaker(2, TimeSpan.FromMinutes(1), onBreak, onReset, onHalfOpen);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // 2 exception raised, circuit is now open
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             SystemClock.UtcNow = () => time.Add(durationOfBreak);
@@ -1103,10 +1103,10 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
             // first call after duration raises an exception, so circuit should break again
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
 
             transitionedStates[0].Should().Be(CircuitState.Closed);
             transitionedStates[1].Should().Be(CircuitState.HalfOpen);
@@ -1131,10 +1131,10 @@ namespace Polly.Specs.CircuitBreaker
             Exception withInner = new AggregateException(toRaiseAsInner);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.Invoking(x => x.RaiseException(withInner))
-                .ShouldThrow<DivideByZeroException>().Which.Should().BeSameAs(toRaiseAsInner);
+                .Should().Throw<DivideByZeroException>().Which.Should().BeSameAs(toRaiseAsInner);
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
@@ -1156,10 +1156,10 @@ namespace Polly.Specs.CircuitBreaker
                 .CircuitBreaker(2, durationOfBreak, onBreak, onReset);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
@@ -1207,11 +1207,11 @@ namespace Polly.Specs.CircuitBreaker
                 .CircuitBreaker(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>(
                 new {key1 = "value1", key2 = "value2"}.AsDictionary()
-                )).ShouldThrow<DivideByZeroException>();
+                )).Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
@@ -1238,9 +1238,9 @@ namespace Polly.Specs.CircuitBreaker
                 .CircuitBreaker(2, durationOfBreak, onBreak, onReset);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             SystemClock.UtcNow = () => time.Add(durationOfBreak);
@@ -1267,10 +1267,10 @@ namespace Polly.Specs.CircuitBreaker
                 .CircuitBreaker(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
@@ -1295,11 +1295,11 @@ namespace Polly.Specs.CircuitBreaker
             var durationOfBreak = TimeSpan.FromMinutes(1);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             // 2 exception raised, circuit is now open
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>(new {key = "original_value"}.AsDictionary()))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             contextValue.Should().Be("original_value");
 
@@ -1339,7 +1339,7 @@ namespace Polly.Specs.CircuitBreaker
                 .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
@@ -1358,7 +1358,7 @@ namespace Polly.Specs.CircuitBreaker
             Exception withInner = new AggregateException(toRaiseAsInner);
 
             breaker.Invoking(x => x.RaiseException(withInner))
-                .ShouldThrow<DivideByZeroException>().Which.Should().BeSameAs(toRaiseAsInner);
+                .Should().Throw<DivideByZeroException>().Which.Should().BeSameAs(toRaiseAsInner);
 
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
@@ -1373,10 +1373,10 @@ namespace Polly.Specs.CircuitBreaker
                 .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
@@ -1391,10 +1391,10 @@ namespace Polly.Specs.CircuitBreaker
                 .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
@@ -1479,7 +1479,7 @@ namespace Polly.Specs.CircuitBreaker
             cancellationTokenSource.Cancel();
 
             breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -1507,7 +1507,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -1535,7 +1535,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -1563,7 +1563,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             attemptsInvoked.Should().Be(1);
         }
@@ -1576,10 +1576,10 @@ namespace Polly.Specs.CircuitBreaker
                 .CircuitBreaker(1, TimeSpan.FromMinutes(1));
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<DivideByZeroException>();
             // Circuit is now broken.
@@ -1600,7 +1600,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -1631,7 +1631,7 @@ namespace Polly.Specs.CircuitBreaker
                 attemptsInvoked++;
                 implicitlyCapturedActionCancellationToken.ThrowIfCancellationRequested();
             }, policyCancellationToken))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(implicitlyCapturedActionCancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -1690,7 +1690,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Invoking(x => result = x.RaiseExceptionAndOrCancellation<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true))
-                .ShouldThrow<OperationCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
+                .Should().Throw<OperationCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
 
             result.Should().Be(null);
 

--- a/src/Polly.Specs/CircuitBreaker/CircuitBreakerSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/CircuitBreakerSpecs.cs
@@ -56,7 +56,7 @@ namespace Polly.Specs.CircuitBreaker
             Action action = () => Policy
                                      .Handle<DivideByZeroException>()
                                      .CircuitBreaker(1, TimeSpan.Zero);
-            action.ShouldNotThrow();
+            action.Should().NotThrow();
         }
 
         [Fact]
@@ -86,7 +86,7 @@ namespace Polly.Specs.CircuitBreaker
                 .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
-            breaker.Invoking(b => b.Execute(() =>{})).ShouldNotThrow();
+            breaker.Invoking(b => b.Execute(() =>{})).Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
@@ -330,7 +330,7 @@ namespace Polly.Specs.CircuitBreaker
 
 
             // OnActionPreExecute() should permit first execution.
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should reject a second execution.
@@ -361,7 +361,7 @@ namespace Polly.Specs.CircuitBreaker
 
 
             // OnActionPreExecute() should permit first execution.
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should reject a second execution in the same time window.
@@ -373,7 +373,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should now permit another trial execution.
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
         }
 
@@ -425,7 +425,7 @@ namespace Polly.Specs.CircuitBreaker
                     permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
                     firstExecutionActive = false;
 
-                })).ShouldNotThrow();
+                })).Should().NotThrow();
             }, TaskCreationOptions.LongRunning);
 
             // Attempt a second execution, signalled by the first execution to ensure they overlap: we should be able to verify it doesn't execute, and is rejected by a breaker in a HalfOpen state.
@@ -522,7 +522,7 @@ namespace Polly.Specs.CircuitBreaker
                     permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
                     firstExecutionActive = false;
 
-                })).ShouldNotThrow();
+                })).Should().NotThrow();
             }, TaskCreationOptions.LongRunning);
 
             // Attempt a second execution, signalled by the first execution to ensure they overlap; start it one breakDuration later.  We should be able to verify it does execute, though the breaker is still in a HalfOpen state.
@@ -645,7 +645,7 @@ namespace Polly.Specs.CircuitBreaker
 
             breaker.Reset();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
-            breaker.Invoking(x => x.Execute(() => { })).ShouldNotThrow();
+            breaker.Invoking(x => x.Execute(() => { })).Should().NotThrow();
         }
 
         [Fact]
@@ -677,7 +677,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Reset();
             SystemClock.UtcNow().Should().Be(time);
             breaker.CircuitState.Should().Be(CircuitState.Closed);
-            breaker.Invoking(x => x.Execute(() => { })).ShouldNotThrow();
+            breaker.Invoking(x => x.Execute(() => { })).Should().NotThrow();
         }
 
         #endregion
@@ -1012,7 +1012,7 @@ namespace Polly.Specs.CircuitBreaker
             onResetCalled.Should().Be(1);
 
             breaker.CircuitState.Should().Be(CircuitState.Closed);
-            breaker.Invoking(x => x.Execute(() => { })).ShouldNotThrow();
+            breaker.Invoking(x => x.Execute(() => { })).Should().NotThrow();
         }
 
         #region Tests of supplied parameters to onBreak delegate
@@ -1451,7 +1451,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             attemptsInvoked.Should().Be(1);
         }
@@ -1660,7 +1660,7 @@ namespace Polly.Specs.CircuitBreaker
             };
 
             breaker.Invoking(x => result = x.RaiseExceptionAndOrCancellation<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             result.Should().BeTrue();
 

--- a/src/Polly.Specs/CircuitBreaker/CircuitBreakerSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/CircuitBreakerSpecs.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Polly.CircuitBreaker;
 using Polly.Specs.Helpers;
 using Polly.Utilities;

--- a/src/Polly.Specs/CircuitBreaker/CircuitBreakerTResultAsyncSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/CircuitBreakerTResultAsyncSpecs.cs
@@ -58,7 +58,7 @@ namespace Polly.Specs.CircuitBreaker
             Action action = () => Policy
                                      .HandleResult(ResultPrimitive.Fault)
                                      .CircuitBreakerAsync(1, TimeSpan.Zero);
-            action.ShouldNotThrow();
+            action.Should().NotThrow();
         }
 
         [Fact]
@@ -396,7 +396,7 @@ namespace Polly.Specs.CircuitBreaker
 
 
             // OnActionPreExecute() should permit first execution.
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should reject a second execution.
@@ -427,7 +427,7 @@ namespace Polly.Specs.CircuitBreaker
 
 
             // OnActionPreExecute() should permit first execution.
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should reject a second execution.
@@ -439,7 +439,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should now permit another trial execution.
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
         }
 
@@ -493,7 +493,7 @@ namespace Polly.Specs.CircuitBreaker
                     firstExecutionActive = false;
 
                     return ResultPrimitive.Good;
-                })).ShouldNotThrow();
+                })).Should().NotThrow();
             }, TaskCreationOptions.LongRunning);
 
             // Attempt a second execution, signalled by the first execution to ensure they overlap: we should be able to verify it doesn't execute, and is rejected by a breaker in a HalfOpen state.
@@ -596,7 +596,7 @@ namespace Polly.Specs.CircuitBreaker
                     firstExecutionActive = false;
 
                     return ResultPrimitive.Good;
-                })).ShouldNotThrow();
+                })).Should().NotThrow();
             }, TaskCreationOptions.LongRunning);
 
             // Attempt a second execution, signalled by the first execution to ensure they overlap; start it one breakDuration later.  We should be able to verify it does execute, though the breaker is still in a HalfOpen state.
@@ -725,7 +725,7 @@ namespace Polly.Specs.CircuitBreaker
 
             breaker.Reset();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
-            breaker.Awaiting(async x => await x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good))).ShouldNotThrow();
+            breaker.Awaiting(async x => await x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good))).Should().NotThrow();
         }
 
         [Fact]
@@ -757,7 +757,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Reset();
             SystemClock.UtcNow().Should().Be(time);
             breaker.CircuitState.Should().Be(CircuitState.Closed);
-            breaker.Awaiting(async x => await x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good))).ShouldNotThrow();
+            breaker.Awaiting(async x => await x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good))).Should().NotThrow();
         }
 
         #endregion
@@ -950,7 +950,7 @@ namespace Polly.Specs.CircuitBreaker
             onResetCalled.Should().Be(0);
 
             // first call after duration is successful, so circuit should reset
-            breaker.Awaiting(async x => await x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good))).ShouldNotThrow();
+            breaker.Awaiting(async x => await x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good))).Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onResetCalled.Should().Be(1);
         }
@@ -968,11 +968,11 @@ namespace Polly.Specs.CircuitBreaker
 
             onResetCalled.Should().BeFalse();
 
-            breaker.Awaiting(async x => await x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good))).ShouldNotThrow();
+            breaker.Awaiting(async x => await x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good))).Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onResetCalled.Should().BeFalse();
 
-            breaker.Awaiting(async x => await x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good))).ShouldNotThrow();
+            breaker.Awaiting(async x => await x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good))).Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onResetCalled.Should().BeFalse();
         }
@@ -1018,7 +1018,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // first call after duration is successful, so circuit should reset
             breaker.Awaiting(async x => await x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             onHalfOpenCalled.Should().Be(1);
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             onResetCalled.Should().Be(1);
@@ -1096,7 +1096,7 @@ namespace Polly.Specs.CircuitBreaker
 
             breaker.CircuitState.Should().Be(CircuitState.Closed);
             breaker.Awaiting(async x => await x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)))
-                .ShouldNotThrow();
+                .Should().NotThrow();
         }
 
         #region Tests of supplied parameters to onBreak delegate

--- a/src/Polly.Specs/CircuitBreaker/CircuitBreakerTResultAsyncSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/CircuitBreakerTResultAsyncSpecs.cs
@@ -1433,7 +1433,7 @@ namespace Polly.Specs.CircuitBreaker
                ResultPrimitive.Fault,
                ResultPrimitive.Fault,
                ResultPrimitive.Good))
-            .Should().Throw<TaskCanceledException>()
+            .Should().Throw<OperationCanceledException>()
             .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -1462,7 +1462,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Awaiting(async x => await x.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute,
                    ResultPrimitive.Good,
                    ResultPrimitive.Good))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -1491,7 +1491,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Awaiting(async x => await x.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute,
                    ResultPrimitive.Fault,
                    ResultPrimitive.Good))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -1555,7 +1555,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Awaiting(async x => await x.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute,
                    ResultPrimitive.Fault,
                    ResultPrimitive.Good))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -1588,7 +1588,7 @@ namespace Polly.Specs.CircuitBreaker
                 implicitlyCapturedActionCancellationToken.ThrowIfCancellationRequested();
                 return ResultPrimitive.Good;
             }, policyCancellationToken))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(implicitlyCapturedActionCancellationToken);
 
             attemptsInvoked.Should().Be(1);

--- a/src/Polly.Specs/CircuitBreaker/CircuitBreakerTResultAsyncSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/CircuitBreakerTResultAsyncSpecs.cs
@@ -35,7 +35,7 @@ namespace Polly.Specs.CircuitBreaker
                                      .HandleResult(ResultPrimitive.Fault)
                                      .CircuitBreakerAsync(0, TimeSpan.FromSeconds(10));
 
-            action.ShouldThrow<ArgumentOutOfRangeException>()
+            action.Should().Throw<ArgumentOutOfRangeException>()
                   .And.ParamName.Should()
                   .Be("handledEventsAllowedBeforeBreaking");
         }
@@ -47,7 +47,7 @@ namespace Polly.Specs.CircuitBreaker
                                      .HandleResult(ResultPrimitive.Fault)
                                      .CircuitBreakerAsync(1, -TimeSpan.FromSeconds(1));
 
-            action.ShouldThrow<ArgumentOutOfRangeException>()
+            action.Should().Throw<ArgumentOutOfRangeException>()
                 .And.ParamName.Should()
                 .Be("durationOfBreak");
         }
@@ -113,7 +113,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             breaker.Awaiting(async b => await b.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-                .ShouldThrow<BrokenCircuitException<ResultPrimitive>>()
+                .Should().Throw<BrokenCircuitException<ResultPrimitive>>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .Where(e => e.Result == ResultPrimitive.Fault);
 
@@ -138,7 +138,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // 2 exception or fault raised, circuit is now open
             breaker.Awaiting(async b => await b.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-                .ShouldThrow<BrokenCircuitException<ResultPrimitive>>()
+                .Should().Throw<BrokenCircuitException<ResultPrimitive>>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .Where(e => e.Result == ResultPrimitive.FaultAgain);
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -160,7 +160,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             breaker.Awaiting(async b => await b.RaiseResultSequenceAsync(new ResultClass(ResultPrimitive.Good)))
-                .ShouldThrow<BrokenCircuitException<ResultClass>>()
+                .Should().Throw<BrokenCircuitException<ResultClass>>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .Where(e => e.Result.ResultCode == ResultPrimitive.Fault);
 
@@ -275,7 +275,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // 2 exception or fault raised, circuit is now open
             breaker.Awaiting(async b => await b.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-                .ShouldThrow<BrokenCircuitException>();
+                .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             SystemClock.UtcNow = () => time.Add(durationOfBreak);
@@ -308,7 +308,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // 2 exception or fault raised, circuit is now open
             breaker.Awaiting(async b => await b.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             SystemClock.UtcNow = () => time.Add(durationOfBreak);
@@ -321,7 +321,7 @@ namespace Polly.Specs.CircuitBreaker
                   .Should().Be(ResultPrimitive.Fault);
             breaker.CircuitState.Should().Be(CircuitState.Open);
             breaker.Awaiting(async b => await b.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
 
         }
 
@@ -347,7 +347,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // 2 exception or fault raised, circuit is now open
             breaker.Awaiting(async b => await b.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             SystemClock.UtcNow = () => time.Add(durationOfBreak);
@@ -369,7 +369,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             breaker.Awaiting(async b => await b.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
         }
 
@@ -400,7 +400,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should reject a second execution.
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldThrow<BrokenCircuitException>();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
         }
 
@@ -431,7 +431,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should reject a second execution.
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldThrow<BrokenCircuitException>();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // Allow another time window to pass (breaker should still be HalfOpen).
@@ -673,7 +673,7 @@ namespace Polly.Specs.CircuitBreaker
             // circuit manually broken: execution should be blocked; even non-fault-returning executions should not reset circuit
             bool delegateExecutedWhenBroken = false;
             breaker.Awaiting(async b => await b.ExecuteAsync(() => { delegateExecutedWhenBroken = true; return Task.FromResult(ResultPrimitive.Good); }).ConfigureAwait(false))
-                .ShouldThrow<IsolatedCircuitException>();
+                .Should().Throw<IsolatedCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
             breaker.LastException.Should().BeOfType<IsolatedCircuitException>();
             delegateExecutedWhenBroken.Should().BeFalse();
@@ -701,7 +701,7 @@ namespace Polly.Specs.CircuitBreaker
 
             bool delegateExecutedWhenBroken = false;
             breaker.Awaiting(async x => await x.ExecuteAsync(() => { delegateExecutedWhenBroken = true; return Task.FromResult(ResultPrimitive.Good); }))
-                .ShouldThrow<IsolatedCircuitException>();
+                .Should().Throw<IsolatedCircuitException>();
             delegateExecutedWhenBroken.Should().BeFalse();
         }
 
@@ -721,7 +721,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Isolate();
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
             breaker.Awaiting(async x => await x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)))
-                .ShouldThrow<IsolatedCircuitException>();
+                .Should().Throw<IsolatedCircuitException>();
 
             breaker.Reset();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
@@ -750,7 +750,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // 2 exception or fault raised, circuit is now open
             breaker.Awaiting(async x => await x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)))
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // reset circuit, with no time having passed
@@ -844,7 +844,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // call through circuit when already broken - should not retrigger onBreak 
             breaker.Awaiting(async x => await x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)))
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
@@ -938,7 +938,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // 2 exception or fault raised, circuit is now open
             breaker.Awaiting(async x => await x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)))
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
@@ -1008,7 +1008,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // 2 exception or fault raised, circuit is now open
             breaker.Awaiting(async x => await x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)))
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
@@ -1055,7 +1055,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // 2 exception or fault raised, circuit is now open
             breaker.Awaiting(async x => await x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)))
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
@@ -1088,7 +1088,7 @@ namespace Polly.Specs.CircuitBreaker
 
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
             breaker.Awaiting(async x => await x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)))
-                .ShouldThrow<IsolatedCircuitException>();
+                .Should().Throw<IsolatedCircuitException>();
 
             onResetCalled.Should().Be(0);
             breaker.Reset();
@@ -1432,7 +1432,7 @@ namespace Polly.Specs.CircuitBreaker
                ResultPrimitive.Fault,
                ResultPrimitive.Fault,
                ResultPrimitive.Good))
-            .ShouldThrow<TaskCanceledException>()
+            .Should().Throw<TaskCanceledException>()
             .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -1461,7 +1461,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Awaiting(async x => await x.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute,
                    ResultPrimitive.Good,
                    ResultPrimitive.Good))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -1490,7 +1490,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Awaiting(async x => await x.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute,
                    ResultPrimitive.Fault,
                    ResultPrimitive.Good))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -1533,7 +1533,7 @@ namespace Polly.Specs.CircuitBreaker
                 .Should().Be(ResultPrimitive.Fault);
 
             breaker.Awaiting(async x => await x.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.");
             // Circuit is now broken.
 
@@ -1554,7 +1554,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Awaiting(async x => await x.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute,
                    ResultPrimitive.Fault,
                    ResultPrimitive.Good))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -1587,7 +1587,7 @@ namespace Polly.Specs.CircuitBreaker
                 implicitlyCapturedActionCancellationToken.ThrowIfCancellationRequested();
                 return ResultPrimitive.Good;
             }, policyCancellationToken))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(implicitlyCapturedActionCancellationToken);
 
             attemptsInvoked.Should().Be(1);

--- a/src/Polly.Specs/CircuitBreaker/CircuitBreakerTResultAsyncSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/CircuitBreakerTResultAsyncSpecs.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Polly.CircuitBreaker;
 using Polly.Specs.Helpers;
 using Polly.Utilities;

--- a/src/Polly.Specs/CircuitBreaker/CircuitBreakerTResultMixedResultExceptionSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/CircuitBreakerTResultMixedResultExceptionSpecs.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Polly.CircuitBreaker;
 using Polly.Specs.Helpers;
 using Polly.Utilities;

--- a/src/Polly.Specs/CircuitBreaker/CircuitBreakerTResultMixedResultExceptionSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/CircuitBreakerTResultMixedResultExceptionSpecs.cs
@@ -20,15 +20,15 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
             breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Good))
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<DivideByZeroException>();
 
@@ -48,12 +48,12 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // 2 exception raised, circuit is now open
             breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Good))
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<DivideByZeroException>();
 
@@ -69,7 +69,7 @@ namespace Polly.Specs.CircuitBreaker
                             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
             breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.RaiseResultSequence(ResultPrimitive.Fault)
@@ -78,7 +78,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // 2 exception raised, circuit is now open
             breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Good))
-                .ShouldThrow<BrokenCircuitException<ResultPrimitive>>()
+                .Should().Throw<BrokenCircuitException<ResultPrimitive>>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .Where(e => e. Result == ResultPrimitive.Fault);
 
@@ -98,12 +98,12 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // 2 exception raised, circuit is now open
             breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Good))
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<DivideByZeroException>();
 
@@ -119,7 +119,7 @@ namespace Polly.Specs.CircuitBreaker
                 .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
             breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.RaiseResultSequence(ResultPrimitive.Fault)
@@ -128,7 +128,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // 2 exception raised, circuit is now open
             breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Good))
-                .ShouldThrow<BrokenCircuitException<ResultPrimitive>>()
+                .Should().Throw<BrokenCircuitException<ResultPrimitive>>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .Where(e => e.Result == ResultPrimitive.Fault);
 
@@ -144,7 +144,7 @@ namespace Polly.Specs.CircuitBreaker
                 .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
             breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new ArgumentException("message", "key")))
-                .ShouldThrow<ArgumentException>();
+                .Should().Throw<ArgumentException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.RaiseResultSequence(new ResultClass(ResultPrimitive.Fault))
@@ -153,7 +153,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // 2 exception raised, circuit is now open
             breaker.Invoking(b => b.RaiseResultSequence(new ResultClass(ResultPrimitive.Good)))
-                .ShouldThrow<BrokenCircuitException<ResultClass>>()
+                .Should().Throw<BrokenCircuitException<ResultClass>>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .Where(e => e.Result.ResultCode == ResultPrimitive.Fault);
 
@@ -190,15 +190,15 @@ namespace Polly.Specs.CircuitBreaker
                 .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
             breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new ArgumentException()))
-                .ShouldThrow<ArgumentException>();
+                .Should().Throw<ArgumentException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new ArgumentException()))
-                .ShouldThrow<ArgumentException>();
+                .Should().Throw<ArgumentException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new ArgumentException()))
-                .ShouldThrow<ArgumentException>();
+                .Should().Throw<ArgumentException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
         }
 
@@ -225,15 +225,15 @@ namespace Polly.Specs.CircuitBreaker
 
             // non-matched exception predicate
             breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new ArgumentException("message", "value")))
-                .ShouldThrow<ArgumentException>();
+                .Should().Throw<ArgumentException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new ArgumentException("message", "value")))
-                .ShouldThrow<ArgumentException>();
+                .Should().Throw<ArgumentException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new ArgumentException("message", "value")))
-                .ShouldThrow<ArgumentException>();
+                .Should().Throw<ArgumentException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
         }
 
@@ -251,7 +251,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.RaiseResultSequence(ResultPrimitive.FaultAgain)
@@ -259,12 +259,12 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new ArgumentException()))
-                .ShouldThrow<ArgumentException>();
+                .Should().Throw<ArgumentException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // 4 exception raised, circuit is now open
             breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Good))
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .WithInnerException<ArgumentException>();
 
@@ -282,7 +282,7 @@ namespace Polly.Specs.CircuitBreaker
                 .CircuitBreaker(4, TimeSpan.FromMinutes(1));
 
             breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.RaiseResultSequence(ResultPrimitive.Fault)
@@ -290,7 +290,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new ArgumentException()))
-                .ShouldThrow<ArgumentException>();
+                .Should().Throw<ArgumentException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.RaiseResultSequence(ResultPrimitive.FaultAgain)
@@ -299,7 +299,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // 4 exception raised, circuit is now open
             breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Good))
-                .ShouldThrow<BrokenCircuitException<ResultPrimitive>>()
+                .Should().Throw<BrokenCircuitException<ResultPrimitive>>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .Where(e => e.Result == ResultPrimitive.FaultAgain);
 
@@ -319,7 +319,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new ArgumentException()))
-                .ShouldThrow<ArgumentException>();
+                .Should().Throw<ArgumentException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.RaiseResultSequence(ResultPrimitive.FaultAgain)
@@ -327,7 +327,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new ArgumentException()))
-                .ShouldThrow<ArgumentException>();
+                .Should().Throw<ArgumentException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
         }
 
@@ -353,12 +353,12 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // 2 exception raised, circuit is now open
             breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Fault))
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             SystemClock.UtcNow = () => time.Add(durationOfBreak);
@@ -371,7 +371,7 @@ namespace Polly.Specs.CircuitBreaker
                   .Should().Be(ResultPrimitive.Fault);
             breaker.CircuitState.Should().Be(CircuitState.Open);
             breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Fault))
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
 
         }
 
@@ -393,12 +393,12 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
             breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // 2 exception raised, circuit is now open
             breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Fault))
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             SystemClock.UtcNow = () => time.Add(durationOfBreak);
@@ -408,10 +408,10 @@ namespace Polly.Specs.CircuitBreaker
 
             // first call after duration returns a fault, so circuit should break again
             breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Fault))
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
 
         }
 
@@ -437,7 +437,7 @@ namespace Polly.Specs.CircuitBreaker
                 .CircuitBreaker(2, durationOfBreak, onBreak, onReset);
 
             breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.RaiseResultSequence(ResultPrimitive.Fault)
                 .Should().Be(ResultPrimitive.Fault);
@@ -466,7 +466,7 @@ namespace Polly.Specs.CircuitBreaker
                 .Should().Be(ResultPrimitive.Fault);
 
             breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
@@ -517,7 +517,7 @@ namespace Polly.Specs.CircuitBreaker
                 .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
             breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Closed);
 
@@ -534,7 +534,7 @@ namespace Polly.Specs.CircuitBreaker
                 .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
             breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.RaiseResultSequence(ResultPrimitive.Fault)
                 .Should().Be(ResultPrimitive.Fault);
@@ -557,7 +557,7 @@ namespace Polly.Specs.CircuitBreaker
                 .Should().Be(ResultPrimitive.Fault);
 
             breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
@@ -574,7 +574,7 @@ namespace Polly.Specs.CircuitBreaker
                 .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
             breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             breaker.RaiseResultSequence(ResultPrimitive.Fault)
                 .Should().Be(ResultPrimitive.Fault);

--- a/src/Polly.Specs/CircuitBreaker/CircuitBreakerTResultSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/CircuitBreakerTResultSpecs.cs
@@ -58,7 +58,7 @@ namespace Polly.Specs.CircuitBreaker
             Action action = () => Policy
                                      .HandleResult(ResultPrimitive.Fault)
                                      .CircuitBreaker(1, TimeSpan.Zero);
-            action.ShouldNotThrow();
+            action.Should().NotThrow();
         }
 
         [Fact]
@@ -395,7 +395,7 @@ namespace Polly.Specs.CircuitBreaker
 
 
             // OnActionPreExecute() should permit first execution.
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should reject a second execution.
@@ -426,7 +426,7 @@ namespace Polly.Specs.CircuitBreaker
 
 
             // OnActionPreExecute() should permit first execution.
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should reject a second execution.
@@ -438,7 +438,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should now permit another trial execution.
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldNotThrow();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
         }
 
@@ -491,7 +491,7 @@ namespace Polly.Specs.CircuitBreaker
                     firstExecutionActive = false;
 
                     return ResultPrimitive.Good;
-                })).ShouldNotThrow();
+                })).Should().NotThrow();
             }, TaskCreationOptions.LongRunning);
 
             // Attempt a second execution, signalled by the first execution to ensure they overlap: we should be able to verify it doesn't execute, and is rejected by a breaker in a HalfOpen state.
@@ -591,7 +591,7 @@ namespace Polly.Specs.CircuitBreaker
                     firstExecutionActive = false;
 
                     return ResultPrimitive.Good;
-                })).ShouldNotThrow();
+                })).Should().NotThrow();
             }, TaskCreationOptions.LongRunning);
 
             // Attempt a second execution, signalled by the first execution to ensure they overlap; start it one breakDuration later.  We should be able to verify it does execute, though the breaker is still in a HalfOpen state.
@@ -718,7 +718,7 @@ namespace Polly.Specs.CircuitBreaker
 
             breaker.Reset();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
-            breaker.Invoking(x => x.Execute(() => ResultPrimitive.Good)).ShouldNotThrow();
+            breaker.Invoking(x => x.Execute(() => ResultPrimitive.Good)).Should().NotThrow();
         }
 
         [Fact]
@@ -750,7 +750,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Reset();
             SystemClock.UtcNow().Should().Be(time);
             breaker.CircuitState.Should().Be(CircuitState.Closed);
-            breaker.Invoking(x => x.Execute(() => ResultPrimitive.Good)).ShouldNotThrow();
+            breaker.Invoking(x => x.Execute(() => ResultPrimitive.Good)).Should().NotThrow();
         }
 
         #endregion
@@ -1085,7 +1085,7 @@ namespace Polly.Specs.CircuitBreaker
             onResetCalled.Should().Be(1);
 
             breaker.CircuitState.Should().Be(CircuitState.Closed);
-            breaker.Invoking(x => x.Execute(() => ResultPrimitive.Good)).ShouldNotThrow();
+            breaker.Invoking(x => x.Execute(() => ResultPrimitive.Good)).Should().NotThrow();
         }
 
         #region Tests of supplied parameters to onBreak delegate

--- a/src/Polly.Specs/CircuitBreaker/CircuitBreakerTResultSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/CircuitBreakerTResultSpecs.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Polly.CircuitBreaker;
 using Polly.Specs.Helpers;
 using Polly.Utilities;

--- a/src/Polly.Specs/CircuitBreaker/CircuitBreakerTResultSpecs.cs
+++ b/src/Polly.Specs/CircuitBreaker/CircuitBreakerTResultSpecs.cs
@@ -35,7 +35,7 @@ namespace Polly.Specs.CircuitBreaker
                                      .HandleResult(ResultPrimitive.Fault)
                                      .CircuitBreaker(0, TimeSpan.FromSeconds(10));
 
-            action.ShouldThrow<ArgumentOutOfRangeException>()
+            action.Should().Throw<ArgumentOutOfRangeException>()
                   .And.ParamName.Should()
                   .Be("handledEventsAllowedBeforeBreaking");
         }
@@ -47,7 +47,7 @@ namespace Polly.Specs.CircuitBreaker
                                      .HandleResult(ResultPrimitive.Fault)
                                      .CircuitBreaker(1, -TimeSpan.FromSeconds(1));
 
-            action.ShouldThrow<ArgumentOutOfRangeException>()
+            action.Should().Throw<ArgumentOutOfRangeException>()
                 .And.ParamName.Should()
                 .Be("durationOfBreak");
         }
@@ -113,7 +113,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Fault))
-                .ShouldThrow<BrokenCircuitException<ResultPrimitive>>()
+                .Should().Throw<BrokenCircuitException<ResultPrimitive>>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .Where(e => e.Result == ResultPrimitive.Fault);
 
@@ -138,7 +138,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // 2 exception raised, circuit is now open
             breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Fault))
-                .ShouldThrow<BrokenCircuitException<ResultPrimitive>>()
+                .Should().Throw<BrokenCircuitException<ResultPrimitive>>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .Where(e => e.Result == ResultPrimitive.FaultAgain);
             breaker.CircuitState.Should().Be(CircuitState.Open);
@@ -160,7 +160,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             breaker.Invoking(b => b.RaiseResultSequence(new ResultClass(ResultPrimitive.Good)))
-                .ShouldThrow<BrokenCircuitException<ResultClass>>()
+                .Should().Throw<BrokenCircuitException<ResultClass>>()
                 .WithMessage("The circuit is now open and is not allowing calls.")
                 .Where(e => e.Result.ResultCode == ResultPrimitive.Fault);
 
@@ -275,7 +275,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // 2 exception raised, circuit is now open
             breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Fault))
-                .ShouldThrow<BrokenCircuitException>();
+                .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             SystemClock.UtcNow = () => time.Add(durationOfBreak);
@@ -308,7 +308,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // 2 exception raised, circuit is now open
             breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Fault))
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             SystemClock.UtcNow = () => time.Add(durationOfBreak);
@@ -321,7 +321,7 @@ namespace Polly.Specs.CircuitBreaker
                   .Should().Be(ResultPrimitive.Fault);
             breaker.CircuitState.Should().Be(CircuitState.Open);
             breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Fault))
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
 
         }
 
@@ -347,7 +347,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // 2 exception raised, circuit is now open
             breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Fault))
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             SystemClock.UtcNow = () => time.Add(durationOfBreak);
@@ -368,7 +368,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Fault))
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
         }
 
@@ -399,7 +399,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should reject a second execution.
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldThrow<BrokenCircuitException>();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
         }
 
@@ -430,7 +430,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // OnActionPreExecute() should reject a second execution.
-            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).ShouldThrow<BrokenCircuitException>();
+            breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
             // Allow another time window to pass (breaker should still be HalfOpen).
@@ -666,7 +666,7 @@ namespace Polly.Specs.CircuitBreaker
             // circuit manually broken: execution should be blocked; even non-fault-returning executions should not reset circuit
             bool delegateExecutedWhenBroken = false;
             breaker.Invoking(x => x.Execute(() => { delegateExecutedWhenBroken = true; return ResultPrimitive.Good;}))
-                .ShouldThrow<IsolatedCircuitException>();
+                .Should().Throw<IsolatedCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
             breaker.LastException.Should().BeOfType<IsolatedCircuitException>();
             delegateExecutedWhenBroken.Should().BeFalse();
@@ -694,7 +694,7 @@ namespace Polly.Specs.CircuitBreaker
 
             bool delegateExecutedWhenBroken = false;
             breaker.Invoking(x => x.Execute(() => { delegateExecutedWhenBroken = true; return ResultPrimitive.Good; }))
-                .ShouldThrow<IsolatedCircuitException>();
+                .Should().Throw<IsolatedCircuitException>();
             delegateExecutedWhenBroken.Should().BeFalse();
         }
 
@@ -714,7 +714,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Isolate();
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
             breaker.Invoking(x => x.Execute(() => ResultPrimitive.Good))
-                .ShouldThrow<IsolatedCircuitException>();
+                .Should().Throw<IsolatedCircuitException>();
 
             breaker.Reset();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
@@ -743,7 +743,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // 2 exception raised, circuit is now open
             breaker.Invoking(x => x.Execute(() => ResultPrimitive.Good))
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // reset circuit, with no time having passed
@@ -837,7 +837,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // call through circuit when already broken - should not retrigger onBreak 
             breaker.Invoking(x => x.Execute(() => ResultPrimitive.Good))
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
 
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
@@ -929,7 +929,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // 2 exception raised, circuit is now open
             breaker.Invoking(x => x.Execute(() => ResultPrimitive.Good))
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
@@ -999,7 +999,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // 2 exception raised, circuit is now open
             breaker.Invoking(x => x.Execute(() => ResultPrimitive.Good))
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
@@ -1045,7 +1045,7 @@ namespace Polly.Specs.CircuitBreaker
 
             // 2 exception raised, circuit is now open
             breaker.Invoking(x => x.Execute(() => ResultPrimitive.Good))
-                  .ShouldThrow<BrokenCircuitException>();
+                  .Should().Throw<BrokenCircuitException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
             onBreakCalled.Should().Be(1);
 
@@ -1078,7 +1078,7 @@ namespace Polly.Specs.CircuitBreaker
 
             breaker.CircuitState.Should().Be(CircuitState.Isolated);
             breaker.Invoking(x => x.Execute(() => ResultPrimitive.Good))
-                .ShouldThrow<IsolatedCircuitException>();
+                .Should().Throw<IsolatedCircuitException>();
 
             onResetCalled.Should().Be(0);
             breaker.Reset();
@@ -1420,7 +1420,7 @@ namespace Polly.Specs.CircuitBreaker
                ResultPrimitive.Fault,
                ResultPrimitive.Fault,
                ResultPrimitive.Good))
-            .ShouldThrow<OperationCanceledException>()
+            .Should().Throw<OperationCanceledException>()
             .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -1449,7 +1449,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Invoking(x => x.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute,
                    ResultPrimitive.Good,
                    ResultPrimitive.Good))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -1478,7 +1478,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Invoking(x => x.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute,
                    ResultPrimitive.Fault,
                    ResultPrimitive.Good))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -1521,7 +1521,7 @@ namespace Polly.Specs.CircuitBreaker
                 .Should().Be(ResultPrimitive.Fault);
 
             breaker.Invoking(x => x.RaiseResultSequence(ResultPrimitive.Fault))
-                .ShouldThrow<BrokenCircuitException>()
+                .Should().Throw<BrokenCircuitException>()
                 .WithMessage("The circuit is now open and is not allowing calls.");
             // Circuit is now broken.
 
@@ -1542,7 +1542,7 @@ namespace Polly.Specs.CircuitBreaker
             breaker.Invoking(x => x.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute,
                    ResultPrimitive.Fault,
                    ResultPrimitive.Good))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -1574,7 +1574,7 @@ namespace Polly.Specs.CircuitBreaker
                 implicitlyCapturedActionCancellationToken.ThrowIfCancellationRequested();
                 return ResultPrimitive.Good;
             }, policyCancellationToken))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(implicitlyCapturedActionCancellationToken);
 
             attemptsInvoked.Should().Be(1);

--- a/src/Polly.Specs/ContextSpecs.cs
+++ b/src/Polly.Specs/ContextSpecs.cs
@@ -51,7 +51,7 @@ namespace Polly.Specs
             Guid retrieved1 = context.CorrelationId;
             Guid retrieved2 = context.CorrelationId;
 
-            retrieved1.ShouldBeEquivalentTo(retrieved2);
+            retrieved1.Should().Be(retrieved2);
         }
     }
 }

--- a/src/Polly.Specs/Custom/CustomAsyncSpecs.cs
+++ b/src/Polly.Specs/Custom/CustomAsyncSpecs.cs
@@ -70,7 +70,7 @@ namespace Polly.Specs.Custom
                 executed = true;
                 throw toThrow;
             }))
-                .ShouldThrow<Exception>().Which.Should().Be(toThrow);
+                .Should().Throw<Exception>().Which.Should().Be(toThrow);
 
             executed.Should().BeTrue();
             handled.Should().Be(toThrow);
@@ -90,7 +90,7 @@ namespace Polly.Specs.Custom
                     executed = true;
                     throw toThrow;
                 }))
-                .ShouldThrow<Exception>().Which.Should().Be(toThrow);
+                .Should().Throw<Exception>().Which.Should().Be(toThrow);
 
             executed.Should().BeTrue();
             handled.Should().Be(null);

--- a/src/Polly.Specs/Custom/CustomAsyncSpecs.cs
+++ b/src/Polly.Specs/Custom/CustomAsyncSpecs.cs
@@ -22,7 +22,7 @@ namespace Polly.Specs.Custom
                 });
             };
 
-            construct.ShouldNotThrow();
+            construct.Should().NotThrow();
         }
 
         [Fact]
@@ -34,7 +34,7 @@ namespace Polly.Specs.Custom
             bool executed = false;
 
             policy.Awaiting(x => x.ExecuteAsync(() => { executed = true; return Task.CompletedTask; }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             executed.Should().BeTrue();
             preExecuted.Should().BeTrue();
@@ -53,7 +53,7 @@ namespace Polly.Specs.Custom
                 });
             };
 
-            construct.ShouldNotThrow();
+            construct.Should().NotThrow();
         }
 
         [Fact]

--- a/src/Polly.Specs/Custom/CustomSpecs.cs
+++ b/src/Polly.Specs/Custom/CustomSpecs.cs
@@ -16,7 +16,7 @@ namespace Polly.Specs.Custom
                 PreExecutePolicy policy = PreExecutePolicy.Create(() => Console.WriteLine("Do something"));
             };
 
-            construct.ShouldNotThrow();
+            construct.Should().NotThrow();
         }
 
         [Fact]
@@ -28,7 +28,7 @@ namespace Polly.Specs.Custom
             bool executed = false;
 
             policy.Invoking(x => x.Execute(() => { executed = true; }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             executed.Should().BeTrue();
             preExecuted.Should().BeTrue();
@@ -42,7 +42,7 @@ namespace Polly.Specs.Custom
                 AddBehaviourIfHandlePolicy policy = Policy.Handle<Exception>().WithBehaviour(ex => Console.WriteLine("Handling " + ex.Message));
             };
 
-            construct.ShouldNotThrow();
+            construct.Should().NotThrow();
         }
 
         [Fact]

--- a/src/Polly.Specs/Custom/CustomSpecs.cs
+++ b/src/Polly.Specs/Custom/CustomSpecs.cs
@@ -58,7 +58,7 @@ namespace Polly.Specs.Custom
                     executed = true;
                     throw toThrow;
                 }))
-                .ShouldThrow<Exception>().Which.Should().Be(toThrow);
+                .Should().Throw<Exception>().Which.Should().Be(toThrow);
 
             executed.Should().BeTrue();
             handled.Should().Be(toThrow);
@@ -77,7 +77,7 @@ namespace Polly.Specs.Custom
                     executed = true;
                     throw toThrow;
                 }))
-                .ShouldThrow<Exception>().Which.Should().Be(toThrow);
+                .Should().Throw<Exception>().Which.Should().Be(toThrow);
 
             executed.Should().BeTrue();
             handled.Should().Be(null);

--- a/src/Polly.Specs/Custom/CustomTResultAsyncSpecs.cs
+++ b/src/Polly.Specs/Custom/CustomTResultAsyncSpecs.cs
@@ -23,7 +23,7 @@ namespace Polly.Specs.Custom
                 });
             };
 
-            construct.ShouldNotThrow();
+            construct.Should().NotThrow();
         }
 
         [Fact]
@@ -34,7 +34,7 @@ namespace Polly.Specs.Custom
 
             bool executed = false;
             policy.Awaiting(x => x.ExecuteAsync(async () => { executed = true; await Task.CompletedTask; return ResultPrimitive.Undefined; }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             executed.Should().BeTrue();
             preExecuted.Should().BeTrue();
@@ -53,7 +53,7 @@ namespace Polly.Specs.Custom
                 });
             };
 
-            construct.ShouldNotThrow();
+            construct.Should().NotThrow();
         }
 
         [Fact]

--- a/src/Polly.Specs/Custom/CustomTResultSpecs.cs
+++ b/src/Polly.Specs/Custom/CustomTResultSpecs.cs
@@ -17,7 +17,7 @@ namespace Polly.Specs.Custom
                 PreExecutePolicy<ResultPrimitive> policy = PreExecutePolicy<ResultPrimitive>.Create(() => Console.WriteLine("Do something"));
             };
 
-            construct.ShouldNotThrow();
+            construct.Should().NotThrow();
         }
 
         [Fact]
@@ -32,7 +32,7 @@ namespace Polly.Specs.Custom
                     executed = true;
                     return ResultPrimitive.Undefined;
                 }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             executed.Should().BeTrue();
             preExecuted.Should().BeTrue();
@@ -46,7 +46,7 @@ namespace Polly.Specs.Custom
                 AddBehaviourIfHandlePolicy<ResultPrimitive> policy = Policy.HandleResult<ResultPrimitive>(ResultPrimitive.Fault).WithBehaviour(outcome => Console.WriteLine("Handling " + outcome.Result));
             };
 
-            construct.ShouldNotThrow();
+            construct.Should().NotThrow();
         }
 
         [Fact]

--- a/src/Polly.Specs/Fallback/FallbackAsyncSpecs.cs
+++ b/src/Polly.Specs/Fallback/FallbackAsyncSpecs.cs
@@ -24,7 +24,7 @@ namespace Polly.Specs.Fallback
                 .Handle<DivideByZeroException>()
                 .FallbackAsync(fallbackActionAsync);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("fallbackAction");
         }
 
@@ -38,7 +38,7 @@ namespace Polly.Specs.Fallback
                 .Handle<DivideByZeroException>()
                 .FallbackAsync(fallbackActionAsync, onFallbackAsync);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("fallbackAction");
         }
 
@@ -52,7 +52,7 @@ namespace Polly.Specs.Fallback
                                     .Handle<DivideByZeroException>()
                                     .FallbackAsync(fallbackActionAsync, onFallbackAsync);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("fallbackAction");
         }
 
@@ -66,7 +66,7 @@ namespace Polly.Specs.Fallback
                                     .Handle<DivideByZeroException>()
                                     .FallbackAsync(fallbackActionAsync, onFallbackAsync);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onFallbackAsync");
         }
 
@@ -80,7 +80,7 @@ namespace Polly.Specs.Fallback
                                     .Handle<DivideByZeroException>()
                                     .FallbackAsync(fallbackActionAsync, onFallbackAsync);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onFallbackAsync");
         }
 
@@ -113,7 +113,7 @@ namespace Polly.Specs.Fallback
                                     .Handle<DivideByZeroException>()
                                     .FallbackAsync(fallbackActionAsync);
 
-            fallbackPolicy.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentNullException>()).ShouldThrow<ArgumentNullException>();
+            fallbackPolicy.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentNullException>()).Should().Throw<ArgumentNullException>();
 
             fallbackActionExecuted.Should().BeFalse();
         }
@@ -162,7 +162,7 @@ namespace Polly.Specs.Fallback
                                     .Or<NullReferenceException>()
                                     .FallbackAsync(fallbackActionAsync);
 
-            fallbackPolicy.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentNullException>()).ShouldThrow<ArgumentNullException>();
+            fallbackPolicy.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentNullException>()).Should().Throw<ArgumentNullException>();
 
             fallbackActionExecuted.Should().BeFalse();
         }
@@ -177,7 +177,7 @@ namespace Polly.Specs.Fallback
                                     .Handle<DivideByZeroException>(e => false)
                                     .FallbackAsync(fallbackActionAsync);
 
-            fallbackPolicy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>()).ShouldThrow<DivideByZeroException>();
+            fallbackPolicy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>()).Should().Throw<DivideByZeroException>();
 
             fallbackActionExecuted.Should().BeFalse();
         }
@@ -193,7 +193,7 @@ namespace Polly.Specs.Fallback
                                     .Or<ArgumentNullException>(e => false)
                                     .FallbackAsync(fallbackActionAsync);
 
-            fallbackPolicy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>()).ShouldThrow<DivideByZeroException>();
+            fallbackPolicy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>()).Should().Throw<DivideByZeroException>();
 
             fallbackActionExecuted.Should().BeFalse();
         }
@@ -245,7 +245,7 @@ namespace Polly.Specs.Fallback
                 .FallbackAsync(fallbackActionAsync);
 
             fallbackPolicy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>((e, i) => e.HelpLink = "FromExecuteDelegate"))
-                .ShouldThrow<DivideByZeroException>().And.HelpLink.Should().Be("FromFallbackAction");
+                .Should().Throw<DivideByZeroException>().And.HelpLink.Should().Be("FromFallbackAction");
 
             fallbackActionExecuted.Should().BeTrue();
         }
@@ -257,7 +257,7 @@ namespace Polly.Specs.Fallback
                 .Handle<DivideByZeroException>()
                 .FallbackAsync(_ => TaskHelper.EmptyTask);
 
-            fallbackPolicy.Awaiting(p => p.ExecuteAsync<int>(() => Task.FromResult(0))).ShouldThrow<InvalidOperationException>();
+            fallbackPolicy.Awaiting(p => p.ExecuteAsync<int>(() => Task.FromResult(0))).Should().Throw<InvalidOperationException>();
         }
 
         #endregion
@@ -565,7 +565,7 @@ namespace Polly.Specs.Fallback
                 .FallbackAsync(fallbackFunc, onFallback);
 
             fallbackPolicy.Awaiting(async p => await p.ExecuteAsync(() => { throw new ArgumentNullException(); }))
-                .ShouldThrow<ArgumentNullException>();
+                .Should().Throw<ArgumentNullException>();
 
             fallbackException.Should().BeNull();
         }
@@ -657,7 +657,7 @@ namespace Polly.Specs.Fallback
             cancellationTokenSource.Cancel();
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
             attemptsInvoked.Should().Be(0);
 
@@ -689,7 +689,7 @@ namespace Polly.Specs.Fallback
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
             attemptsInvoked.Should().Be(1);
 
@@ -784,7 +784,7 @@ namespace Polly.Specs.Fallback
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<NullReferenceException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<NullReferenceException>();
+                .Should().Throw<NullReferenceException>();
             attemptsInvoked.Should().Be(1);
 
             fallbackActionExecuted.Should().BeFalse();

--- a/src/Polly.Specs/Fallback/FallbackAsyncSpecs.cs
+++ b/src/Polly.Specs/Fallback/FallbackAsyncSpecs.cs
@@ -128,7 +128,7 @@ namespace Polly.Specs.Fallback
                                     .Handle<DivideByZeroException>()
                                     .FallbackAsync(fallbackActionAsync);
 
-            fallbackPolicy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>()).ShouldNotThrow();
+            fallbackPolicy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>()).Should().NotThrow();
 
             fallbackActionExecuted.Should().BeTrue();
         }
@@ -145,7 +145,7 @@ namespace Polly.Specs.Fallback
                                     .Or<ArgumentException>()
                                     .FallbackAsync(fallbackActionAsync);
 
-            fallbackPolicy.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentException>()).ShouldNotThrow();
+            fallbackPolicy.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentException>()).Should().NotThrow();
 
             fallbackActionExecuted.Should().BeTrue();
         }
@@ -208,7 +208,7 @@ namespace Polly.Specs.Fallback
                                     .Handle<DivideByZeroException>(e => true)
                                     .FallbackAsync(fallbackActionAsync);
 
-            fallbackPolicy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>()).ShouldNotThrow();
+            fallbackPolicy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>()).Should().NotThrow();
 
             fallbackActionExecuted.Should().BeTrue();
         }
@@ -225,7 +225,7 @@ namespace Polly.Specs.Fallback
                                     .Or<ArgumentNullException>()
                                     .FallbackAsync(fallbackActionAsync);
 
-            fallbackPolicy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>()).ShouldNotThrow();
+            fallbackPolicy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>()).Should().NotThrow();
 
             fallbackActionExecuted.Should().BeTrue();
         }
@@ -321,7 +321,7 @@ namespace Polly.Specs.Fallback
 
             fallbackPolicy.Awaiting(async p => await p.ExecuteAsync(ctx => { throw new ArgumentNullException(); },
                 new { key1 = "value1", key2 = "value2" }.AsDictionary()))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             contextData.Should()
                 .ContainKeys("key1", "key2").And
@@ -343,7 +343,7 @@ namespace Polly.Specs.Fallback
 
             fallbackPolicy.Awaiting(async p => await p.ExecuteAndCaptureAsync(ctx => { throw new ArgumentNullException(); },
                 new { key1 = "value1", key2 = "value2" }.AsDictionary()))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             contextData.Should()
                 .ContainKeys("key1", "key2").And
@@ -366,11 +366,11 @@ namespace Polly.Specs.Fallback
 
             fallbackPolicy.Awaiting(async 
                 p => await p.ExecuteAsync(ctx => { throw new ArgumentNullException(); }, new { key = "value1" }.AsDictionary()))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             fallbackPolicy.Awaiting(async 
                 p => await p.ExecuteAsync(ctx => { throw new DivideByZeroException(); }, new { key = "value2" }.AsDictionary()))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             contextData.Count.Should().Be(2);
             contextData.Keys.Should().Contain(typeof(ArgumentNullException));
@@ -415,7 +415,7 @@ namespace Polly.Specs.Fallback
 
             fallbackPolicy.Awaiting(async p => await p.ExecuteAsync(ctx => { throw new ArgumentNullException(); },
                     new { key1 = "value1", key2 = "value2" }.AsDictionary()))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             contextData.Should()
                 .ContainKeys("key1", "key2").And
@@ -437,7 +437,7 @@ namespace Polly.Specs.Fallback
 
             fallbackPolicy.Awaiting(async p => await p.ExecuteAndCaptureAsync(ctx => { throw new ArgumentNullException(); },
                     new { key1 = "value1", key2 = "value2" }.AsDictionary()))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             contextData.Should()
                 .ContainKeys("key1", "key2").And
@@ -484,7 +484,7 @@ namespace Polly.Specs.Fallback
 
             Exception instanceToThrow = new ArgumentNullException("myParam");
             fallbackPolicy.Awaiting(p => p.RaiseExceptionAsync(instanceToThrow))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             fallbackException.Should().Be(instanceToThrow);
         }
@@ -503,7 +503,7 @@ namespace Polly.Specs.Fallback
                 .FallbackAsync(fallbackFunc, onFallback);
 
             fallbackPolicy.Awaiting(async p => await p.ExecuteAndCaptureAsync(() => { throw new ArgumentNullException(); }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             fallbackException.Should().NotBeNull()
                 .And.BeOfType(typeof(ArgumentNullException));
@@ -525,7 +525,7 @@ namespace Polly.Specs.Fallback
             Exception instanceToCapture = new ArgumentNullException("myParam");
             Exception instanceToThrow = new Exception(String.Empty, instanceToCapture);
             fallbackPolicy.Awaiting(p => p.RaiseExceptionAsync(instanceToThrow))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             fallbackException.Should().Be(instanceToCapture);
         }
@@ -546,7 +546,7 @@ namespace Polly.Specs.Fallback
             Exception instanceToCapture = new ArgumentNullException("myParam");
             Exception instanceToThrow = new AggregateException(instanceToCapture);
             fallbackPolicy.Awaiting(p => p.RaiseExceptionAsync(instanceToThrow))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             fallbackException.Should().Be(instanceToCapture);
         }
@@ -597,7 +597,7 @@ namespace Polly.Specs.Fallback
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             attemptsInvoked.Should().Be(1);
 
             fallbackActionExecuted.Should().BeFalse();
@@ -626,7 +626,7 @@ namespace Polly.Specs.Fallback
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             attemptsInvoked.Should().Be(1);
 
             fallbackActionExecuted.Should().BeTrue();
@@ -721,7 +721,7 @@ namespace Polly.Specs.Fallback
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             attemptsInvoked.Should().Be(1);
 
             fallbackActionExecuted.Should().BeTrue();
@@ -752,7 +752,7 @@ namespace Polly.Specs.Fallback
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             attemptsInvoked.Should().Be(1);
 
             fallbackActionExecuted.Should().BeFalse();
@@ -816,7 +816,7 @@ namespace Polly.Specs.Fallback
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             attemptsInvoked.Should().Be(1);
 
             fallbackActionExecuted.Should().BeTrue();

--- a/src/Polly.Specs/Fallback/FallbackSpecs.cs
+++ b/src/Polly.Specs/Fallback/FallbackSpecs.cs
@@ -197,7 +197,7 @@ namespace Polly.Specs.Fallback
                 .Handle<DivideByZeroException>()
                 .Fallback(fallbackAction);
 
-            fallbackPolicy.Invoking(x => x.RaiseException<DivideByZeroException>()).ShouldNotThrow();
+            fallbackPolicy.Invoking(x => x.RaiseException<DivideByZeroException>()).Should().NotThrow();
 
             fallbackActionExecuted.Should().BeTrue();
         }
@@ -213,7 +213,7 @@ namespace Polly.Specs.Fallback
                 .Or<ArgumentException>()
                 .Fallback(fallbackAction);
 
-            fallbackPolicy.Invoking(x => x.RaiseException<ArgumentException>()).ShouldNotThrow();
+            fallbackPolicy.Invoking(x => x.RaiseException<ArgumentException>()).Should().NotThrow();
 
             fallbackActionExecuted.Should().BeTrue();
         }
@@ -275,7 +275,7 @@ namespace Polly.Specs.Fallback
                 .Handle<DivideByZeroException>(e => true)
                 .Fallback(fallbackAction);
 
-            fallbackPolicy.Invoking(x => x.RaiseException<DivideByZeroException>()).ShouldNotThrow();
+            fallbackPolicy.Invoking(x => x.RaiseException<DivideByZeroException>()).Should().NotThrow();
 
             fallbackActionExecuted.Should().BeTrue();
         }
@@ -291,7 +291,7 @@ namespace Polly.Specs.Fallback
                 .Or<ArgumentNullException>()
                 .Fallback(fallbackAction);
 
-            fallbackPolicy.Invoking(x => x.RaiseException<DivideByZeroException>()).ShouldNotThrow();
+            fallbackPolicy.Invoking(x => x.RaiseException<DivideByZeroException>()).Should().NotThrow();
 
             fallbackActionExecuted.Should().BeTrue();
         }
@@ -359,7 +359,7 @@ namespace Polly.Specs.Fallback
 
             Exception nonInner = new DivideByZeroException();
 
-            fallbackPolicy.Invoking(x => x.RaiseException(nonInner)).ShouldNotThrow();
+            fallbackPolicy.Invoking(x => x.RaiseException(nonInner)).Should().NotThrow();
 
             fallbackActionExecuted.Should().BeTrue();
         }
@@ -376,7 +376,7 @@ namespace Polly.Specs.Fallback
 
             Exception withInner = new Exception(String.Empty, new DivideByZeroException());
 
-            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldNotThrow();
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().NotThrow();
 
             fallbackActionExecuted.Should().BeTrue();
         }
@@ -394,7 +394,7 @@ namespace Polly.Specs.Fallback
 
             Exception withInner = new Exception(String.Empty, new ArgumentException());
 
-            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldNotThrow();
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().NotThrow();
 
             fallbackActionExecuted.Should().BeTrue();
         }
@@ -411,7 +411,7 @@ namespace Polly.Specs.Fallback
 
             Exception withInner = new Exception(String.Empty, new Exception(String.Empty, new Exception(String.Empty, new DivideByZeroException())));
 
-            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldNotThrow();
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().NotThrow();
 
             fallbackActionExecuted.Should().BeTrue();
         }
@@ -446,7 +446,7 @@ namespace Polly.Specs.Fallback
 
             Exception withInner = new Exception(String.Empty, new DivideByZeroException());
 
-            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldNotThrow();
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().NotThrow();
 
             fallbackActionExecuted.Should().BeTrue();
         }
@@ -463,7 +463,7 @@ namespace Polly.Specs.Fallback
 
             Exception withInner = new Exception(String.Empty, new Exception(String.Empty, new Exception(String.Empty, new DivideByZeroException())));
 
-            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldNotThrow();
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().NotThrow();
 
             fallbackActionExecuted.Should().BeTrue();
         }
@@ -482,7 +482,7 @@ namespace Polly.Specs.Fallback
 
             Exception withInner = new Exception(String.Empty, new ArgumentNullException());
 
-            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldNotThrow();
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().NotThrow();
 
             fallbackActionExecuted.Should().BeTrue();
         }
@@ -556,7 +556,7 @@ namespace Polly.Specs.Fallback
 
             Exception withInner = new AggregateException(new DivideByZeroException());
 
-            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldNotThrow();
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().NotThrow();
 
             fallbackActionExecuted.Should().BeTrue();
         }
@@ -574,7 +574,7 @@ namespace Polly.Specs.Fallback
 
             Exception withInner = new AggregateException(new ArgumentException());
 
-            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldNotThrow();
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().NotThrow();
 
             fallbackActionExecuted.Should().BeTrue();
         }
@@ -591,7 +591,7 @@ namespace Polly.Specs.Fallback
 
             Exception withInner = new AggregateException(new ArgumentException(), new DivideByZeroException(), new ArgumentNullException());
 
-            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldNotThrow();
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().NotThrow();
 
             fallbackActionExecuted.Should().BeTrue();
         }
@@ -608,7 +608,7 @@ namespace Polly.Specs.Fallback
 
             Exception withInner = new AggregateException(new AggregateException(new DivideByZeroException()));
 
-            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldNotThrow();
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().NotThrow();
 
             fallbackActionExecuted.Should().BeTrue();
         }
@@ -642,7 +642,7 @@ namespace Polly.Specs.Fallback
 
             Exception withInner = new AggregateException(new DivideByZeroException());
 
-            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldNotThrow();
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().NotThrow();
 
             fallbackActionExecuted.Should().BeTrue();
         }
@@ -659,7 +659,7 @@ namespace Polly.Specs.Fallback
 
             Exception withInner = new AggregateException(new AggregateException(new DivideByZeroException()));
 
-            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldNotThrow();
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().NotThrow();
 
             fallbackActionExecuted.Should().BeTrue();
         }
@@ -678,7 +678,7 @@ namespace Polly.Specs.Fallback
 
             Exception withInner = new AggregateException(new ArgumentNullException());
 
-            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldNotThrow();
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().NotThrow();
 
             fallbackActionExecuted.Should().BeTrue();
         }
@@ -779,7 +779,7 @@ namespace Polly.Specs.Fallback
 
             fallbackPolicy.Invoking(p => p.Execute(ctx => { throw new ArgumentNullException(); },
                 new {key1 = "value1", key2 = "value2"}.AsDictionary()))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             contextData.Should()
                 .ContainKeys("key1", "key2").And
@@ -801,7 +801,7 @@ namespace Polly.Specs.Fallback
 
             fallbackPolicy.Invoking(p => p.ExecuteAndCapture(ctx => { throw new ArgumentNullException(); },
                 new {key1 = "value1", key2 = "value2"}.AsDictionary()))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             contextData.Should()
                 .ContainKeys("key1", "key2").And
@@ -824,11 +824,11 @@ namespace Polly.Specs.Fallback
 
             fallbackPolicy.Invoking(
                 p => p.Execute(ctx => { throw new ArgumentNullException(); }, new {key = "value1"}.AsDictionary()))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             fallbackPolicy.Invoking(
                 p => p.Execute(ctx => { throw new DivideByZeroException(); }, new {key = "value2"}.AsDictionary()))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             contextData.Count.Should().Be(2);
             contextData.Keys.Should().Contain(typeof (ArgumentNullException));
@@ -873,7 +873,7 @@ namespace Polly.Specs.Fallback
 
             fallbackPolicy.Invoking(p => p.Execute(ctx => { throw new ArgumentNullException(); },
                     new { key1 = "value1", key2 = "value2" }.AsDictionary()))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             contextData.Should()
                 .ContainKeys("key1", "key2").And
@@ -895,7 +895,7 @@ namespace Polly.Specs.Fallback
 
             fallbackPolicy.Invoking(p => p.ExecuteAndCapture(ctx => { throw new ArgumentNullException(); },
                     new { key1 = "value1", key2 = "value2" }.AsDictionary()))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             contextData.Should()
                 .ContainKeys("key1", "key2").And
@@ -941,7 +941,7 @@ namespace Polly.Specs.Fallback
 
             Exception instanceToThrow = new ArgumentNullException("myParam");
             fallbackPolicy.Invoking(p => p.RaiseException(instanceToThrow))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             fallbackException.Should().Be(instanceToThrow);
         }
@@ -960,7 +960,7 @@ namespace Polly.Specs.Fallback
                 .Fallback(fallbackAction, onFallback);
 
             fallbackPolicy.Invoking(p => p.ExecuteAndCapture(() => { throw new ArgumentNullException(); }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             fallbackException.Should().NotBeNull()
                 .And.BeOfType(typeof(ArgumentNullException));
@@ -982,7 +982,7 @@ namespace Polly.Specs.Fallback
             Exception instanceToCapture = new ArgumentNullException("myParam");
             Exception instanceToThrow = new Exception(String.Empty, instanceToCapture);
             fallbackPolicy.Invoking(p => p.RaiseException(instanceToThrow))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             fallbackException.Should().Be(instanceToCapture);
         }
@@ -1003,7 +1003,7 @@ namespace Polly.Specs.Fallback
             Exception instanceToCapture = new ArgumentNullException("myParam");
             Exception instanceToThrow = new AggregateException(instanceToCapture);
             fallbackPolicy.Invoking(p => p.RaiseException(instanceToThrow))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             fallbackException.Should().Be(instanceToCapture);
         }
@@ -1055,7 +1055,7 @@ namespace Polly.Specs.Fallback
             };
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             attemptsInvoked.Should().Be(1);
 
             fallbackActionExecuted.Should().BeFalse();
@@ -1084,7 +1084,7 @@ namespace Polly.Specs.Fallback
             };
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             attemptsInvoked.Should().Be(1);
 
             fallbackActionExecuted.Should().BeTrue();
@@ -1179,7 +1179,7 @@ namespace Polly.Specs.Fallback
             };
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             attemptsInvoked.Should().Be(1);
 
             fallbackActionExecuted.Should().BeTrue();
@@ -1209,7 +1209,7 @@ namespace Polly.Specs.Fallback
             };
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             attemptsInvoked.Should().Be(1);
 
             fallbackActionExecuted.Should().BeFalse();
@@ -1269,7 +1269,7 @@ namespace Polly.Specs.Fallback
             };
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldNotThrow();
+                .Should().NotThrow();
             attemptsInvoked.Should().Be(1);
 
             fallbackActionExecuted.Should().BeTrue();

--- a/src/Polly.Specs/Fallback/FallbackSpecs.cs
+++ b/src/Polly.Specs/Fallback/FallbackSpecs.cs
@@ -23,7 +23,7 @@ namespace Polly.Specs.Fallback
                                     .Handle<DivideByZeroException>()
                                     .Fallback(fallbackAction);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("fallbackAction");
         }
 
@@ -36,7 +36,7 @@ namespace Polly.Specs.Fallback
                 .Handle<DivideByZeroException>()
                 .Fallback(fallbackAction);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("fallbackAction");
         }
 
@@ -50,7 +50,7 @@ namespace Polly.Specs.Fallback
                                     .Handle<DivideByZeroException>()
                                     .Fallback(fallbackAction, onFallback);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("fallbackAction");
         }
 
@@ -64,7 +64,7 @@ namespace Polly.Specs.Fallback
                 .Handle<DivideByZeroException>()
                 .Fallback(fallbackAction, onFallback);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("fallbackAction");
         }
 
@@ -78,7 +78,7 @@ namespace Polly.Specs.Fallback
                                     .Handle<DivideByZeroException>()
                                     .Fallback(fallbackAction, onFallback);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("fallbackAction");
         }
 
@@ -92,7 +92,7 @@ namespace Polly.Specs.Fallback
                                     .Handle<DivideByZeroException>()
                                     .Fallback(fallbackAction, onFallback);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("fallbackAction");
         }
 
@@ -106,7 +106,7 @@ namespace Polly.Specs.Fallback
                                     .Handle<DivideByZeroException>()
                                     .Fallback(fallbackAction, onFallback);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onFallback");
         }
 
@@ -120,7 +120,7 @@ namespace Polly.Specs.Fallback
                 .Handle<DivideByZeroException>()
                 .Fallback(fallbackAction, onFallback);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onFallback");
         }
 
@@ -134,7 +134,7 @@ namespace Polly.Specs.Fallback
                                     .Handle<DivideByZeroException>()
                                     .Fallback(fallbackAction, onFallback);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onFallback");
         }
 
@@ -148,7 +148,7 @@ namespace Polly.Specs.Fallback
                                     .Handle<DivideByZeroException>()
                                     .Fallback(fallbackAction, onFallback);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onFallback");
         }
 
@@ -181,7 +181,7 @@ namespace Polly.Specs.Fallback
                                     .Handle<DivideByZeroException>()
                                     .Fallback(fallbackAction);
 
-            fallbackPolicy.Invoking(x => x.RaiseException<ArgumentNullException>()).ShouldThrow<ArgumentNullException>();
+            fallbackPolicy.Invoking(x => x.RaiseException<ArgumentNullException>()).Should().Throw<ArgumentNullException>();
 
             fallbackActionExecuted.Should().BeFalse();
         }
@@ -229,7 +229,7 @@ namespace Polly.Specs.Fallback
                                     .Or<NullReferenceException>()
                                     .Fallback(fallbackAction);
 
-            fallbackPolicy.Invoking(x => x.RaiseException<ArgumentNullException>()).ShouldThrow<ArgumentNullException>();
+            fallbackPolicy.Invoking(x => x.RaiseException<ArgumentNullException>()).Should().Throw<ArgumentNullException>();
 
             fallbackActionExecuted.Should().BeFalse();
         }
@@ -244,7 +244,7 @@ namespace Polly.Specs.Fallback
                                     .Handle<DivideByZeroException>(e => false)
                                     .Fallback(fallbackAction);
 
-            fallbackPolicy.Invoking(x => x.RaiseException<DivideByZeroException>()).ShouldThrow<DivideByZeroException>();
+            fallbackPolicy.Invoking(x => x.RaiseException<DivideByZeroException>()).Should().Throw<DivideByZeroException>();
 
             fallbackActionExecuted.Should().BeFalse();
         }
@@ -260,7 +260,7 @@ namespace Polly.Specs.Fallback
                                     .Or<ArgumentNullException>(e => false)
                                     .Fallback(fallbackAction);
 
-            fallbackPolicy.Invoking(x => x.RaiseException<DivideByZeroException>()).ShouldThrow<DivideByZeroException>();
+            fallbackPolicy.Invoking(x => x.RaiseException<DivideByZeroException>()).Should().Throw<DivideByZeroException>();
 
             fallbackActionExecuted.Should().BeFalse();
         }
@@ -311,7 +311,7 @@ namespace Polly.Specs.Fallback
                 .Fallback(fallbackAction);
 
             fallbackPolicy.Invoking(x => x.RaiseException<DivideByZeroException>((e, i) => e.HelpLink = "FromExecuteDelegate"))
-                .ShouldThrow<DivideByZeroException>().And.HelpLink.Should().Be("FromFallbackAction");
+                .Should().Throw<DivideByZeroException>().And.HelpLink.Should().Be("FromFallbackAction");
 
             fallbackActionExecuted.Should().BeTrue();
         }
@@ -323,7 +323,7 @@ namespace Polly.Specs.Fallback
                 .Handle<DivideByZeroException>()
                 .Fallback(() => {});
 
-            fallbackPolicy.Invoking(p => p.Execute<int>(() => 0)).ShouldThrow<InvalidOperationException>();
+            fallbackPolicy.Invoking(p => p.Execute<int>(() => 0)).Should().Throw<InvalidOperationException>();
         }
 
         #endregion
@@ -342,7 +342,7 @@ namespace Polly.Specs.Fallback
 
             Exception withInner = new Exception(String.Empty, new DivideByZeroException());
 
-            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldThrow<Exception>().And.InnerException.Should().BeOfType<DivideByZeroException>();
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().Throw<Exception>().And.InnerException.Should().BeOfType<DivideByZeroException>();
 
             fallbackActionExecuted.Should().BeFalse();
         }
@@ -429,7 +429,7 @@ namespace Polly.Specs.Fallback
 
             Exception withInner = new Exception(String.Empty, new ArgumentException());
 
-            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldThrow<Exception>().And.InnerException.Should().BeOfType<ArgumentException>();
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().Throw<Exception>().And.InnerException.Should().BeOfType<ArgumentException>();
 
             fallbackActionExecuted.Should().BeFalse();
         }
@@ -499,7 +499,7 @@ namespace Polly.Specs.Fallback
 
             Exception withInner = new Exception(String.Empty, new DivideByZeroException());
 
-            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldThrow<Exception>().And.InnerException.Should().BeOfType<DivideByZeroException>();
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().Throw<Exception>().And.InnerException.Should().BeOfType<DivideByZeroException>();
 
             fallbackActionExecuted.Should().BeFalse();
         }
@@ -517,7 +517,7 @@ namespace Polly.Specs.Fallback
 
             Exception withInner = new Exception(String.Empty, new ArgumentNullException());
 
-            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldThrow<Exception>().And.InnerException.Should().BeOfType<ArgumentNullException>();
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().Throw<Exception>().And.InnerException.Should().BeOfType<ArgumentNullException>();
 
             fallbackActionExecuted.Should().BeFalse();
         }
@@ -539,7 +539,7 @@ namespace Polly.Specs.Fallback
 
             Exception withInner = new AggregateException(new DivideByZeroException());
 
-            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldThrow<AggregateException>().And.InnerExceptions.Should().ContainSingle(e => e is DivideByZeroException);
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().Throw<AggregateException>().And.InnerExceptions.Should().ContainSingle(e => e is DivideByZeroException);
 
             fallbackActionExecuted.Should().BeFalse();
         }
@@ -625,7 +625,7 @@ namespace Polly.Specs.Fallback
 
             Exception withInner = new AggregateException(new ArgumentException());
 
-            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldThrow<AggregateException>().And.InnerExceptions.Should().ContainSingle(e => e is ArgumentException);
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().Throw<AggregateException>().And.InnerExceptions.Should().ContainSingle(e => e is ArgumentException);
 
              fallbackActionExecuted.Should().BeFalse();
         }
@@ -695,7 +695,7 @@ namespace Polly.Specs.Fallback
 
             Exception withInner = new AggregateException(new DivideByZeroException());
 
-            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldThrow<AggregateException>().And.InnerExceptions.Should().ContainSingle(e => e is DivideByZeroException);
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().Throw<AggregateException>().And.InnerExceptions.Should().ContainSingle(e => e is DivideByZeroException);
 
             fallbackActionExecuted.Should().BeFalse();
         }
@@ -713,7 +713,7 @@ namespace Polly.Specs.Fallback
 
             Exception withInner = new AggregateException(new ArgumentNullException());
 
-            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).ShouldThrow<AggregateException>().And.InnerExceptions.Should().ContainSingle(e => e is ArgumentNullException);
+            fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().Throw<AggregateException>().And.InnerExceptions.Should().ContainSingle(e => e is ArgumentNullException);
 
             fallbackActionExecuted.Should().BeFalse();
         }
@@ -1023,7 +1023,7 @@ namespace Polly.Specs.Fallback
                 .Fallback(fallbackAction, onFallback);
 
             fallbackPolicy.Invoking(p => p.Execute(() => { throw new ArgumentNullException(); }))
-                .ShouldThrow<ArgumentNullException>();
+                .Should().Throw<ArgumentNullException>();
 
             fallbackException.Should().BeNull();
         }
@@ -1115,7 +1115,7 @@ namespace Polly.Specs.Fallback
             cancellationTokenSource.Cancel();
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
             attemptsInvoked.Should().Be(0);
 
@@ -1147,7 +1147,7 @@ namespace Polly.Specs.Fallback
             };
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
             attemptsInvoked.Should().Be(1);
 
@@ -1239,7 +1239,7 @@ namespace Polly.Specs.Fallback
             };
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<NullReferenceException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<NullReferenceException>();
+                .Should().Throw<NullReferenceException>();
             attemptsInvoked.Should().Be(1);
 
             fallbackActionExecuted.Should().BeFalse();

--- a/src/Polly.Specs/Fallback/FallbackTResultAsyncSpecs.cs
+++ b/src/Polly.Specs/Fallback/FallbackTResultAsyncSpecs.cs
@@ -474,7 +474,7 @@ namespace Polly.Specs.Fallback
 
             fallbackPolicy.Awaiting(async p => await p.ExecuteAndCaptureAsync(ctx => Task.FromResult(ResultPrimitive.Fault),
                     new { key1 = "value1", key2 = "value2" }.AsDictionary()))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             contextData.Should()
                 .ContainKeys("key1", "key2").And

--- a/src/Polly.Specs/Fallback/FallbackTResultAsyncSpecs.cs
+++ b/src/Polly.Specs/Fallback/FallbackTResultAsyncSpecs.cs
@@ -24,7 +24,7 @@ namespace Polly.Specs.Fallback
                                     .HandleResult(ResultPrimitive.Fault)
                                     .FallbackAsync(fallbackAction);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("fallbackAction");
         }
 
@@ -38,7 +38,7 @@ namespace Polly.Specs.Fallback
                                     .HandleResult(ResultPrimitive.Fault)
                                     .FallbackAsync(fallbackAction, onFallbackAsync);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("fallbackAction");
         }
 
@@ -52,7 +52,7 @@ namespace Polly.Specs.Fallback
                                     .HandleResult(ResultPrimitive.Fault)
                                     .FallbackAsync(fallbackAction, onFallbackAsync);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("fallbackAction");
         }
 
@@ -66,7 +66,7 @@ namespace Polly.Specs.Fallback
                                     .HandleResult(ResultPrimitive.Fault)
                                     .FallbackAsync(fallbackAction, onFallbackAsync);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onFallbackAsync");
         }
 
@@ -80,7 +80,7 @@ namespace Polly.Specs.Fallback
                 .HandleResult(ResultPrimitive.Fault)
                 .FallbackAsync(fallbackAction, onFallbackAsync);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onFallbackAsync");
         }
 
@@ -94,7 +94,7 @@ namespace Polly.Specs.Fallback
                                     .HandleResult(ResultPrimitive.Fault)
                                     .FallbackAsync(fallbackAction, onFallbackAsync);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onFallbackAsync");
         }
 
@@ -108,7 +108,7 @@ namespace Polly.Specs.Fallback
                                     .HandleResult(ResultPrimitive.Fault)
                                     .FallbackAsync(fallbackAction, onFallbackAsync);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onFallbackAsync");
         }
 
@@ -660,7 +660,7 @@ namespace Polly.Specs.Fallback
             cancellationTokenSource.Cancel();
 
             policy.Awaiting(x => x.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute, ResultPrimitive.Fault))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
             attemptsInvoked.Should().Be(0);
 
@@ -692,7 +692,7 @@ namespace Polly.Specs.Fallback
             };
 
             policy.Awaiting(x => x.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute, ResultPrimitive.Good))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
             attemptsInvoked.Should().Be(1);
 

--- a/src/Polly.Specs/Fallback/FallbackTResultSpecs.cs
+++ b/src/Polly.Specs/Fallback/FallbackTResultSpecs.cs
@@ -23,7 +23,7 @@ namespace Polly.Specs.Fallback
                                     .HandleResult(ResultPrimitive.Fault)
                                     .Fallback(fallbackAction);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("fallbackAction");
         }
 
@@ -36,7 +36,7 @@ namespace Polly.Specs.Fallback
                 .HandleResult(ResultPrimitive.Fault)
                 .Fallback(fallbackAction);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("fallbackAction");
         }
 
@@ -50,7 +50,7 @@ namespace Polly.Specs.Fallback
                                     .HandleResult(ResultPrimitive.Fault)
                                     .Fallback(fallbackAction, onFallback);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("fallbackAction");
         }
 
@@ -64,7 +64,7 @@ namespace Polly.Specs.Fallback
                 .HandleResult(ResultPrimitive.Fault)
                 .Fallback(fallbackAction, onFallback);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("fallbackAction");
         }
 
@@ -78,7 +78,7 @@ namespace Polly.Specs.Fallback
                                     .HandleResult(ResultPrimitive.Fault)
                                     .Fallback(fallbackAction, onFallback);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("fallbackAction");
         }
 
@@ -92,7 +92,7 @@ namespace Polly.Specs.Fallback
                                     .HandleResult(ResultPrimitive.Fault)
                                     .Fallback(fallbackAction, onFallback);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("fallbackAction");
         }
 
@@ -106,7 +106,7 @@ namespace Polly.Specs.Fallback
                                     .HandleResult(ResultPrimitive.Fault)
                                     .Fallback(fallbackAction, onFallback);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onFallback");
         }
 
@@ -120,7 +120,7 @@ namespace Polly.Specs.Fallback
                 .HandleResult(ResultPrimitive.Fault)
                 .Fallback(fallbackAction, onFallback);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onFallback");
         }
 
@@ -134,7 +134,7 @@ namespace Polly.Specs.Fallback
                                     .HandleResult(ResultPrimitive.Fault)
                                     .Fallback(fallbackAction, onFallback);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onFallback");
         }
 
@@ -148,7 +148,7 @@ namespace Polly.Specs.Fallback
                                     .HandleResult(ResultPrimitive.Fault)
                                     .Fallback(fallbackAction, onFallback);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onFallback");
         }
 
@@ -683,7 +683,7 @@ namespace Polly.Specs.Fallback
             cancellationTokenSource.Cancel();
 
             policy.Invoking(x => x.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute, ResultPrimitive.Fault))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
             attemptsInvoked.Should().Be(0);
 
@@ -715,7 +715,7 @@ namespace Polly.Specs.Fallback
             };
 
             policy.Invoking(x => x.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute, ResultPrimitive.Good))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
             attemptsInvoked.Should().Be(1);
 

--- a/src/Polly.Specs/IAsyncPolicyExtensionsSpecs.cs
+++ b/src/Polly.Specs/IAsyncPolicyExtensionsSpecs.cs
@@ -30,7 +30,7 @@ namespace Polly.Specs
 
             (await genericPolicy.ExecuteAsync(deleg)).Should().Be(ResultPrimitive.Good);
             breaker.Isolate();
-            genericPolicy.Awaiting(p => p.ExecuteAsync(deleg)).ShouldThrow<BrokenCircuitException>();
+            genericPolicy.Awaiting(p => p.ExecuteAsync(deleg)).Should().Throw<BrokenCircuitException>();
         }
     }
 

--- a/src/Polly.Specs/ISyncPolicyExtensionsSpecs.cs
+++ b/src/Polly.Specs/ISyncPolicyExtensionsSpecs.cs
@@ -29,7 +29,7 @@ namespace Polly.Specs
 
             genericPolicy.Execute(deleg).Should().Be(ResultPrimitive.Good);
             breaker.Isolate();
-            genericPolicy.Invoking(p => p.Execute(deleg)).ShouldThrow<BrokenCircuitException>();
+            genericPolicy.Invoking(p => p.Execute(deleg)).Should().Throw<BrokenCircuitException>();
         }
     }
 

--- a/src/Polly.Specs/NoOp/NoOpAsyncSpecs.cs
+++ b/src/Polly.Specs/NoOp/NoOpAsyncSpecs.cs
@@ -14,7 +14,7 @@ namespace Polly.Specs.NoOp
             bool executed = false;
 
             policy.Awaiting(async p => await p.ExecuteAsync(() => { executed = true; return TaskHelper.EmptyTask; }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             executed.Should().BeTrue();
         }
@@ -32,7 +32,7 @@ namespace Polly.Specs.NoOp
 
                 policy.Awaiting(async p => await p.ExecuteAsync(
                     ct => { executed = true; return TaskHelper.EmptyTask; }, cts.Token))
-                    .ShouldNotThrow();
+                    .Should().NotThrow();
             }
 
             executed.Should().BeTrue();

--- a/src/Polly.Specs/NoOp/NoOpSpecs.cs
+++ b/src/Polly.Specs/NoOp/NoOpSpecs.cs
@@ -14,7 +14,7 @@ namespace Polly.Specs.NoOp
             bool executed = false;
 
             policy.Invoking(x => x.Execute(() => { executed = true; }))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             executed.Should().BeTrue();
         }
@@ -30,7 +30,7 @@ namespace Polly.Specs.NoOp
                 cts.Cancel();
 
                 policy.Invoking(p => p.Execute(ct => { executed = true; }, cts.Token))
-                    .ShouldNotThrow();
+                    .Should().NotThrow();
             }
 
             executed.Should().BeTrue();

--- a/src/Polly.Specs/NoOp/NoOpTResultAsyncSpecs.cs
+++ b/src/Polly.Specs/NoOp/NoOpTResultAsyncSpecs.cs
@@ -14,7 +14,7 @@ namespace Polly.Specs.NoOp
             int? result = null;
 
             policy.Awaiting(async p => result = await p.ExecuteAsync(() => Task.FromResult((int?)10)))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             result.HasValue.Should().BeTrue();
             result.Should().Be(10);
@@ -31,7 +31,7 @@ namespace Polly.Specs.NoOp
                 cts.Cancel();
 
                 policy.Awaiting(async p => result = await p.ExecuteAsync(ct => Task.FromResult((int?)10), cts.Token))
-                    .ShouldNotThrow();
+                    .Should().NotThrow();
             }
 
             result.HasValue.Should().BeTrue();

--- a/src/Polly.Specs/NoOp/NoOpTResultSpecs.cs
+++ b/src/Polly.Specs/NoOp/NoOpTResultSpecs.cs
@@ -14,7 +14,7 @@ namespace Polly.Specs.NoOp
             int? result = null;
 
             policy.Invoking(x => result = x.Execute(() => 10))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             result.HasValue.Should().BeTrue();
             result.Should().Be(10);
@@ -31,7 +31,7 @@ namespace Polly.Specs.NoOp
                 cts.Cancel();
 
                 policy.Invoking(p => result = p.Execute(ct => 10, cts.Token))
-                   .ShouldNotThrow();
+                   .Should().NotThrow();
             }
 
             result.HasValue.Should().BeTrue();

--- a/src/Polly.Specs/PolicyAsyncSpecs.cs
+++ b/src/Polly.Specs/PolicyAsyncSpecs.cs
@@ -184,7 +184,7 @@ namespace Polly.Specs
                 .RetryAsync((_, __, ___) => { });
 
             policy.Awaiting(async p => await p.ExecuteAsync(ctx => TaskHelper.EmptyTask, (IDictionary<string, object>)null))
-                  .ShouldThrow<ArgumentNullException>();
+                  .Should().Throw<ArgumentNullException>();
         }
 
         [Fact]
@@ -195,7 +195,7 @@ namespace Polly.Specs
                 .RetryAsync((_, __, ___) => { });
 
             policy.Awaiting(async p => await p.ExecuteAsync(ctx => TaskHelper.EmptyTask, (Context)null))
-                .ShouldThrow<ArgumentNullException>().And
+                .Should().Throw<ArgumentNullException>().And
                 .ParamName.Should().Be("context");
         }
 
@@ -207,7 +207,7 @@ namespace Polly.Specs
                 .RetryAsync((_, __, ___) => { });
 
             policy.Awaiting(async p => await p.ExecuteAsync(ctx => Task.FromResult(2), (IDictionary<string, object>)null))
-                  .ShouldThrow<ArgumentNullException>();
+                  .Should().Throw<ArgumentNullException>();
         }
 
         [Fact]
@@ -218,7 +218,7 @@ namespace Polly.Specs
                 .RetryAsync((_, __, ___) => { });
 
             policy.Awaiting(async p => await p.ExecuteAsync(ctx => Task.FromResult(2), (Context)null))
-                  .ShouldThrow<ArgumentNullException>().And
+                  .Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("context");
         }
 
@@ -244,7 +244,7 @@ namespace Polly.Specs
                 .RetryAsync((_, __, ___) => { });
 
             policy.Awaiting(async p => await p.ExecuteAndCaptureAsync(ctx => TaskHelper.EmptyTask, (IDictionary<string, object>)null))
-                  .ShouldThrow<ArgumentNullException>();
+                  .Should().Throw<ArgumentNullException>();
         }
 
         [Fact]
@@ -255,7 +255,7 @@ namespace Polly.Specs
                 .RetryAsync((_, __, ___) => { });
 
             policy.Awaiting(async p => await p.ExecuteAndCaptureAsync(ctx => TaskHelper.EmptyTask, (Context)null))
-                .ShouldThrow<ArgumentNullException>().And
+                .Should().Throw<ArgumentNullException>().And
                 .ParamName.Should().Be("context");
         }
 
@@ -267,7 +267,7 @@ namespace Polly.Specs
                 .RetryAsync((_, __, ___) => { });
 
             policy.Awaiting(async p => await p.ExecuteAndCaptureAsync(ctx => Task.FromResult(2), (IDictionary<string, object>)null))
-                  .ShouldThrow<ArgumentNullException>();
+                  .Should().Throw<ArgumentNullException>();
         }
 
         [Fact]
@@ -278,7 +278,7 @@ namespace Polly.Specs
                 .RetryAsync((_, __, ___) => { });
 
             policy.Awaiting(async p => await p.ExecuteAndCaptureAsync(ctx => Task.FromResult(2), (Context)null))
-                  .ShouldThrow<ArgumentNullException>().And
+                  .Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("context");
         }
 

--- a/src/Polly.Specs/PolicyAsyncSpecs.cs
+++ b/src/Polly.Specs/PolicyAsyncSpecs.cs
@@ -55,12 +55,12 @@ namespace Polly.Specs
                 .RetryAsync((_, __) => { })
                 .ExecuteAndCaptureAsync(() => TaskHelper.EmptyTask);
 
-            result.ShouldBeEquivalentTo(new
+            result.Should().BeEquivalentTo(new
             {
                 Outcome = OutcomeType.Successful,
                 FinalException = (Exception)null,
                 ExceptionType = (ExceptionType?)null,
-            }, options => options.Excluding(o => o.Context));
+            });
         }
 
         [Fact]
@@ -76,12 +76,12 @@ namespace Polly.Specs
                     throw handledException;
                 });
 
-            result.ShouldBeEquivalentTo(new
+            result.Should().BeEquivalentTo(new
             {
                 Outcome = OutcomeType.Failure,
                 FinalException = handledException,
                 ExceptionType = ExceptionType.HandledByThisPolicy,
-            }, options => options.Excluding(o => o.Context));
+            });
         }
 
         [Fact]
@@ -97,12 +97,12 @@ namespace Polly.Specs
                     throw unhandledException;
                 });
 
-            result.ShouldBeEquivalentTo(new
+            result.Should().BeEquivalentTo(new
             {
                 Outcome = OutcomeType.Failure,
                 FinalException = unhandledException,
                 ExceptionType = ExceptionType.Unhandled
-            }, options => options.Excluding(o => o.Context));
+            });
         }
 
         [Fact]
@@ -113,7 +113,7 @@ namespace Polly.Specs
                 .RetryAsync((_, __) => { })
                 .ExecuteAndCaptureAsync(() => Task.FromResult(Int32.MaxValue));
 
-            result.ShouldBeEquivalentTo(new
+            result.Should().BeEquivalentTo(new
             {
                 Outcome = OutcomeType.Successful,
                 FinalException = (Exception)null,
@@ -121,7 +121,7 @@ namespace Polly.Specs
                 FaultType = (FaultType?)null,
                 FinalHandledResult = default(int),
                 Result = Int32.MaxValue
-            }, options => options.Excluding(o => o.Context));
+            });
         }
 
         [Fact]
@@ -137,7 +137,7 @@ namespace Polly.Specs
                     throw handledException;
                 });
 
-            result.ShouldBeEquivalentTo(new
+            result.Should().BeEquivalentTo(new
             {
                 Outcome = OutcomeType.Failure,
                 FinalException = handledException,
@@ -145,7 +145,7 @@ namespace Polly.Specs
                 FaultType = FaultType.ExceptionHandledByThisPolicy,
                 FinalHandledResult = default(int),
                 Result = default(int)
-            }, options => options.Excluding(o => o.Context));
+            });
         }
 
         [Fact]
@@ -161,7 +161,7 @@ namespace Polly.Specs
                     throw unhandledException;
                 });
 
-            result.ShouldBeEquivalentTo(new
+            result.Should().BeEquivalentTo(new
             {
                 Outcome = OutcomeType.Failure,
                 FinalException = unhandledException,
@@ -169,7 +169,7 @@ namespace Polly.Specs
                 FaultType = FaultType.UnhandledException,
                 FinalHandledResult = default(int),
                 Result = default(int)
-            }, options => options.Excluding(o => o.Context));
+            });
         }
 
         #endregion

--- a/src/Polly.Specs/PolicyContextAndKeyAsyncSpecs.cs
+++ b/src/Polly.Specs/PolicyContextAndKeyAsyncSpecs.cs
@@ -47,7 +47,7 @@ namespace Polly.Specs
 
             configure.ShouldNotThrow();
 
-            configure.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("policyKey");
+            configure.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policyKey");
         }
 
         [Fact]
@@ -95,7 +95,7 @@ namespace Polly.Specs
 
             Action configure = () => policy.WithPolicyKey(Guid.NewGuid().ToString());
 
-            configure.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("policyKey");
+            configure.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policyKey");
         }
 
         #endregion
@@ -230,7 +230,7 @@ namespace Polly.Specs
 
             configure.ShouldNotThrow();
 
-            configure.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("policyKey");
+            configure.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policyKey");
         }
 
         [Fact]
@@ -278,7 +278,7 @@ namespace Polly.Specs
 
             Action configure = () => policy.WithPolicyKey(Guid.NewGuid().ToString());
 
-            configure.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("policyKey");
+            configure.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policyKey");
         }
 
         #endregion

--- a/src/Polly.Specs/PolicyContextAndKeyAsyncSpecs.cs
+++ b/src/Polly.Specs/PolicyContextAndKeyAsyncSpecs.cs
@@ -45,7 +45,7 @@ namespace Polly.Specs
 
             Action configure = () => policy.WithPolicyKey(Guid.NewGuid().ToString());
 
-            configure.ShouldNotThrow();
+            configure.Should().NotThrow();
 
             configure.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policyKey");
         }
@@ -228,7 +228,7 @@ namespace Polly.Specs
 
             Action configure = () => policy.WithPolicyKey(Guid.NewGuid().ToString());
 
-            configure.ShouldNotThrow();
+            configure.Should().NotThrow();
 
             configure.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policyKey");
         }

--- a/src/Polly.Specs/PolicyContextAndKeySpecs.cs
+++ b/src/Polly.Specs/PolicyContextAndKeySpecs.cs
@@ -45,7 +45,7 @@ namespace Polly.Specs
 
             configure.ShouldNotThrow();
 
-            configure.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("policyKey");
+            configure.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policyKey");
         }
 
         [Fact]
@@ -94,7 +94,7 @@ namespace Polly.Specs
 
             Action configure = () => policy.WithPolicyKey(Guid.NewGuid().ToString());
 
-            configure.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("p" +
+            configure.Should().Throw<ArgumentException>().And.ParamName.Should().Be("p" +
                                                                                  "olicyKey");
         }
 
@@ -227,7 +227,7 @@ namespace Polly.Specs
 
             configure.ShouldNotThrow();
 
-            configure.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("policyKey");
+            configure.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policyKey");
         }
 
         [Fact]
@@ -276,7 +276,7 @@ namespace Polly.Specs
 
             Action configure = () => policy.WithPolicyKey(Guid.NewGuid().ToString());
 
-            configure.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("policyKey");
+            configure.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policyKey");
         }
 
         #endregion

--- a/src/Polly.Specs/PolicyContextAndKeySpecs.cs
+++ b/src/Polly.Specs/PolicyContextAndKeySpecs.cs
@@ -43,7 +43,7 @@ namespace Polly.Specs
 
             Action configure = () => policy.WithPolicyKey(Guid.NewGuid().ToString());
 
-            configure.ShouldNotThrow();
+            configure.Should().NotThrow();
 
             configure.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policyKey");
         }
@@ -225,7 +225,7 @@ namespace Polly.Specs
 
             Action configure = () => policy.WithPolicyKey(Guid.NewGuid().ToString());
 
-            configure.ShouldNotThrow();
+            configure.Should().NotThrow();
 
             configure.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policyKey");
         }

--- a/src/Polly.Specs/PolicySpecs.cs
+++ b/src/Polly.Specs/PolicySpecs.cs
@@ -49,12 +49,12 @@ namespace Polly.Specs
                 .Retry((_, __) => { })
                 .ExecuteAndCapture(() => { });
 
-            result.ShouldBeEquivalentTo(new
+            result.Should().BeEquivalentTo(new
             {
                 Outcome = OutcomeType.Successful,
                 FinalException = (Exception) null,
                 ExceptionType = (ExceptionType?) null,
-            }, options => options.Excluding(o => o.Context));
+            });
         }
 
         [Fact]
@@ -70,12 +70,12 @@ namespace Polly.Specs
                     throw handledException;
                 });
 
-            result.ShouldBeEquivalentTo(new
+            result.Should().BeEquivalentTo(new
             {
                 Outcome = OutcomeType.Failure,
                 FinalException = handledException,
                 ExceptionType = ExceptionType.HandledByThisPolicy
-            }, options => options.Excluding(o => o.Context));
+            });
         }
 
         [Fact]
@@ -91,12 +91,12 @@ namespace Polly.Specs
                     throw unhandledException;
                 });
 
-            result.ShouldBeEquivalentTo(new
+            result.Should().BeEquivalentTo(new
             {
                 Outcome = OutcomeType.Failure,
                 FinalException = unhandledException,
                 ExceptionType = ExceptionType.Unhandled
-            }, options => options.Excluding(o => o.Context));
+            });
         }
 
         [Fact]
@@ -107,7 +107,7 @@ namespace Polly.Specs
                 .Retry((_, __) => { })
                 .ExecuteAndCapture(() => Int32.MaxValue);
 
-            result.ShouldBeEquivalentTo(new
+            result.Should().BeEquivalentTo(new
             {
                 Outcome = OutcomeType.Successful,
                 FinalException = (Exception)null,
@@ -115,7 +115,7 @@ namespace Polly.Specs
                 FaultType = (FaultType?)null,
                 FinalHandledResult = default(int),
                 Result = Int32.MaxValue
-            }, options => options.Excluding(o => o.Context));
+            });
         }
 
         [Fact]
@@ -131,7 +131,7 @@ namespace Polly.Specs
                     throw handledException;
                 });
 
-            result.ShouldBeEquivalentTo(new
+            result.Should().BeEquivalentTo(new
             {
                 Outcome = OutcomeType.Failure,
                 FinalException = handledException,
@@ -139,7 +139,7 @@ namespace Polly.Specs
                 FaultType = FaultType.ExceptionHandledByThisPolicy,
                 FinalHandledResult = default(int),
                 Result = default(int)
-            }, options => options.Excluding(o => o.Context));
+            });
         }
 
         [Fact]
@@ -155,7 +155,7 @@ namespace Polly.Specs
                     throw unhandledException;
                 });
 
-            result.ShouldBeEquivalentTo(new
+            result.Should().BeEquivalentTo(new
             {
                 Outcome = OutcomeType.Failure,
                 FinalException = unhandledException,
@@ -163,7 +163,7 @@ namespace Polly.Specs
                 FaultType = FaultType.UnhandledException,
                 FinalHandledResult = default(int),
                 Result = default(int)
-            }, options => options.Excluding(o => o.Context));
+            });
         }
 
         #endregion

--- a/src/Polly.Specs/PolicySpecs.cs
+++ b/src/Polly.Specs/PolicySpecs.cs
@@ -178,7 +178,7 @@ namespace Polly.Specs
                 .Retry((_, __, ___) => { });
 
             policy.Invoking(p => p.Execute(ctx => { }, (IDictionary<string, object>)null))
-                  .ShouldThrow<ArgumentNullException>();
+                  .Should().Throw<ArgumentNullException>();
         }
 
         [Fact]
@@ -189,7 +189,7 @@ namespace Polly.Specs
                 .Retry((_, __, ___) => { });
 
             policy.Invoking(p => p.Execute(ctx => { }, (Context)null))
-                .ShouldThrow<ArgumentNullException>().And
+                .Should().Throw<ArgumentNullException>().And
                 .ParamName.Should().Be("context");
         }
 
@@ -201,7 +201,7 @@ namespace Polly.Specs
                 .Retry((_, __, ___) => { });
 
             policy.Invoking(p => p.Execute(ctx => 2, (IDictionary<string, object>)null))
-                .ShouldThrow<ArgumentNullException>();
+                .Should().Throw<ArgumentNullException>();
         }
 
         [Fact]
@@ -212,7 +212,7 @@ namespace Polly.Specs
                 .Retry((_, __, ___) => { });
 
             policy.Invoking(p => p.Execute(ctx => 2, (Context)null))
-                .ShouldThrow<ArgumentNullException>().And
+                .Should().Throw<ArgumentNullException>().And
                 .ParamName.Should().Be("context");
         }
 
@@ -238,7 +238,7 @@ namespace Polly.Specs
                 .Retry((_, __, ___) => { });
 
             policy.Invoking(p => p.ExecuteAndCapture(ctx => { }, (IDictionary<string, object>)null))
-                  .ShouldThrow<ArgumentNullException>();
+                  .Should().Throw<ArgumentNullException>();
         }
 
         [Fact]
@@ -249,7 +249,7 @@ namespace Polly.Specs
                 .Retry((_, __, ___) => { });
 
             policy.Invoking(p => p.ExecuteAndCapture(ctx => { }, (Context)null))
-                .ShouldThrow<ArgumentNullException>().And
+                .Should().Throw<ArgumentNullException>().And
                 .ParamName.Should().Be("context");
         }
 
@@ -261,7 +261,7 @@ namespace Polly.Specs
                 .Retry((_, __, ___) => { });
 
             policy.Invoking(p => p.ExecuteAndCapture(ctx => 2, (IDictionary<string, object>)null))
-                  .ShouldThrow<ArgumentNullException>();
+                  .Should().Throw<ArgumentNullException>();
         }
 
         [Fact]
@@ -272,7 +272,7 @@ namespace Polly.Specs
                 .Retry((_, __, ___) => { });
 
             policy.Invoking(p => p.ExecuteAndCapture(ctx => 2, (Context)null))
-                  .ShouldThrow<ArgumentNullException>().And
+                  .Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("context");
         }
 

--- a/src/Polly.Specs/PolicyTResultAsyncSpecs.cs
+++ b/src/Polly.Specs/PolicyTResultAsyncSpecs.cs
@@ -103,7 +103,7 @@ namespace Polly.Specs
                 .RetryAsync((_, __, ___) => { });
 
             policy.Awaiting(async p => await p.ExecuteAsync(ctx => Task.FromResult(ResultPrimitive.Good), (IDictionary<string, object>)null))
-                  .ShouldThrow<ArgumentNullException>();
+                  .Should().Throw<ArgumentNullException>();
         }
 
         [Fact]
@@ -114,7 +114,7 @@ namespace Polly.Specs
                 .RetryAsync((_, __, ___) => { });
 
             policy.Awaiting(async p => await p.ExecuteAsync(ctx => Task.FromResult(ResultPrimitive.Good), (Context)null))
-                  .ShouldThrow<ArgumentNullException>().And
+                  .Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("context");
         }
 
@@ -126,7 +126,7 @@ namespace Polly.Specs
                 .RetryAsync((_, __, ___) => { });
 
             policy.Awaiting(async p => await p.ExecuteAndCaptureAsync(ctx => Task.FromResult(ResultPrimitive.Good), (Context)null))
-                  .ShouldThrow<ArgumentNullException>().And
+                  .Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("context");
         }
 
@@ -152,7 +152,7 @@ namespace Polly.Specs
                 .RetryAsync((_, __, ___) => { });
 
             policy.Awaiting(async p => await p.ExecuteAndCaptureAsync(ctx => Task.FromResult(ResultPrimitive.Good), (Context)null))
-                  .ShouldThrow<ArgumentNullException>().And
+                  .Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("context");
         }
 

--- a/src/Polly.Specs/PolicyTResultAsyncSpecs.cs
+++ b/src/Polly.Specs/PolicyTResultAsyncSpecs.cs
@@ -36,7 +36,7 @@ namespace Polly.Specs
                 .RetryAsync((_, __) => { })
                 .ExecuteAndCaptureAsync(() => Task.FromResult(ResultPrimitive.Good));
 
-            result.ShouldBeEquivalentTo(new
+            result.Should().BeEquivalentTo(new
             {
                 Outcome = OutcomeType.Successful,
                 FinalException = (Exception)null,
@@ -44,7 +44,7 @@ namespace Polly.Specs
                 Result = ResultPrimitive.Good,
                 FinalHandledResult = default(ResultPrimitive),
                 FaultType = (FaultType?)null
-            }, options => options.Excluding(o => o.Context));
+            });
         }
 
         [Fact]
@@ -57,7 +57,7 @@ namespace Polly.Specs
                 .RetryAsync((_, __) => { })
                 .ExecuteAndCaptureAsync(() => Task.FromResult(handledResult));
 
-            result.ShouldBeEquivalentTo(new
+            result.Should().BeEquivalentTo(new
             {
                 Outcome = OutcomeType.Failure,
                 FinalException = (Exception)null,
@@ -65,7 +65,7 @@ namespace Polly.Specs
                 FaultType = FaultType.ResultHandledByThisPolicy,
                 FinalHandledResult = handledResult,
                 Result = default(ResultPrimitive)
-            }, options => options.Excluding(o => o.Context));
+            });
         }
 
         [Fact]
@@ -79,7 +79,7 @@ namespace Polly.Specs
                 .RetryAsync((_, __) => { })
                 .ExecuteAndCaptureAsync(() => Task.FromResult(unhandledResult));
 
-            result.ShouldBeEquivalentTo(new
+            result.Should().BeEquivalentTo(new
             {
                 Outcome = OutcomeType.Successful,
                 FinalException = (Exception)null,
@@ -87,7 +87,7 @@ namespace Polly.Specs
                 Result = unhandledResult,
                 FinalHandledResult = default(ResultPrimitive),
                 FaultType = (FaultType?)null
-            }, options => options.Excluding(o => o.Context));
+            });
         }
 
         #endregion

--- a/src/Polly.Specs/PolicyTResultSpecs.cs
+++ b/src/Polly.Specs/PolicyTResultSpecs.cs
@@ -102,7 +102,7 @@ namespace Polly.Specs
                 .Retry((_, __, ___) => { });
 
             policy.Invoking(p => p.Execute(ctx => ResultPrimitive.Good, (IDictionary<string, object>)null))
-                .ShouldThrow<ArgumentNullException>();
+                .Should().Throw<ArgumentNullException>();
         }
 
         [Fact]
@@ -113,7 +113,7 @@ namespace Polly.Specs
                 .Retry((_, __, ___) => { });
 
             policy.Invoking(p => p.Execute(ctx => ResultPrimitive.Good, (Context)null))
-                .ShouldThrow<ArgumentNullException>().And
+                .Should().Throw<ArgumentNullException>().And
                 .ParamName.Should().Be("context");
         }
 
@@ -139,7 +139,7 @@ namespace Polly.Specs
                 .Retry((_, __, ___) => { });
 
             policy.Invoking(p => p.ExecuteAndCapture(ctx => ResultPrimitive.Good, (IDictionary<string, object>)null))
-                  .ShouldThrow<ArgumentNullException>();
+                  .Should().Throw<ArgumentNullException>();
         }
 
         [Fact]
@@ -150,7 +150,7 @@ namespace Polly.Specs
                 .Retry((_, __, ___) => { });
 
             policy.Invoking(p => p.ExecuteAndCapture(ctx => ResultPrimitive.Good, (Context)null))
-                  .ShouldThrow<ArgumentNullException>().And
+                  .Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("context");
         }
 

--- a/src/Polly.Specs/PolicyTResultSpecs.cs
+++ b/src/Polly.Specs/PolicyTResultSpecs.cs
@@ -35,7 +35,7 @@ namespace Polly.Specs
                 .Retry((_, __) => { })
                 .ExecuteAndCapture(() => ResultPrimitive.Good);
 
-            result.ShouldBeEquivalentTo(new
+            result.Should().BeEquivalentTo(new
             {
                 Outcome = OutcomeType.Successful,
                 FinalException = (Exception)null,
@@ -43,7 +43,7 @@ namespace Polly.Specs
                 Result = ResultPrimitive.Good,
                 FinalHandledResult = default(ResultPrimitive),
                 FaultType = (FaultType?)null
-            }, options => options.Excluding(o => o.Context));
+            });
         }
 
         [Fact]
@@ -56,7 +56,7 @@ namespace Polly.Specs
                 .Retry((_, __) => { })
                 .ExecuteAndCapture(() => handledResult);
 
-            result.ShouldBeEquivalentTo(new
+            result.Should().BeEquivalentTo(new
             {
                 Outcome = OutcomeType.Failure,
                 FinalException = (Exception)null,
@@ -64,7 +64,7 @@ namespace Polly.Specs
                 FaultType = FaultType.ResultHandledByThisPolicy,
                 FinalHandledResult = handledResult,
                 Result = default(ResultPrimitive)
-            }, options => options.Excluding(o => o.Context));
+            });
         }
 
         [Fact]
@@ -78,7 +78,7 @@ namespace Polly.Specs
                 .Retry((_, __) => { })
                 .ExecuteAndCapture(() => unhandledResult);
 
-            result.ShouldBeEquivalentTo(new
+            result.Should().BeEquivalentTo(new
             {
                 Outcome = OutcomeType.Successful,
                 FinalException = (Exception)null,
@@ -86,7 +86,7 @@ namespace Polly.Specs
                 Result = unhandledResult,
                 FinalHandledResult = default(ResultPrimitive),
                 FaultType = (FaultType?)null
-            }, options => options.Excluding(o => o.Context));
+            });
         }
 
         #endregion

--- a/src/Polly.Specs/Polly.Specs.csproj
+++ b/src/Polly.Specs/Polly.Specs.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="4.19.3" />
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="xunit" Version="2.4.0" />

--- a/src/Polly.Specs/Registry/IReadOnlyPolicyRegistrySpecs.cs
+++ b/src/Polly.Specs/Registry/IReadOnlyPolicyRegistrySpecs.cs
@@ -125,7 +125,7 @@ namespace Polly.Specs.Registry
             bool result = false;
 
             ReadOnlyRegistry.Invoking(r => result = r.TryGet(key, out outPolicy))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             result.Should().BeFalse();
         }
@@ -138,7 +138,7 @@ namespace Polly.Specs.Registry
             bool result = false;
 
             ReadOnlyRegistry.Invoking(r => result = r.TryGet(key, out outPolicy))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             result.Should().BeFalse();
         }
@@ -151,7 +151,7 @@ namespace Polly.Specs.Registry
             bool result = false;
 
             ReadOnlyRegistry.Invoking(r => result = r.TryGet<ISyncPolicy<ResultPrimitive>>(key, out outPolicy))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             result.Should().BeFalse();
         }

--- a/src/Polly.Specs/Registry/IReadOnlyPolicyRegistrySpecs.cs
+++ b/src/Polly.Specs/Registry/IReadOnlyPolicyRegistrySpecs.cs
@@ -162,7 +162,7 @@ namespace Polly.Specs.Registry
             string key = Guid.NewGuid().ToString();
             Policy policy = null;
             ReadOnlyRegistry.Invoking(r => policy = r.Get<Policy>(key))
-                .ShouldThrow<KeyNotFoundException>();
+                .Should().Throw<KeyNotFoundException>();
         }
 
         [Fact]
@@ -171,7 +171,7 @@ namespace Polly.Specs.Registry
             string key = Guid.NewGuid().ToString();
             Policy<ResultPrimitive> policy = null;
             ReadOnlyRegistry.Invoking(r => policy = r.Get<Policy<ResultPrimitive>>(key))
-                .ShouldThrow<KeyNotFoundException>();
+                .Should().Throw<KeyNotFoundException>();
         }
 
         [Fact]
@@ -180,7 +180,7 @@ namespace Polly.Specs.Registry
             string key = Guid.NewGuid().ToString();
             ISyncPolicy<ResultPrimitive> policy = null;
             ReadOnlyRegistry.Invoking(r => policy = r.Get<ISyncPolicy<ResultPrimitive>>(key))
-                .ShouldThrow<KeyNotFoundException>();
+                .Should().Throw<KeyNotFoundException>();
         }
 
         [Fact]
@@ -189,7 +189,7 @@ namespace Polly.Specs.Registry
             string key = Guid.NewGuid().ToString();
             IsPolicy outPolicy = null;
             ReadOnlyRegistry.Invoking(r => outPolicy = r[key])
-                .ShouldThrow<KeyNotFoundException>();
+                .Should().Throw<KeyNotFoundException>();
         }
 
 
@@ -199,7 +199,7 @@ namespace Polly.Specs.Registry
             string key = null;
             Policy policy = null;
             ReadOnlyRegistry.Invoking(r => policy = r.Get<Policy>(key))
-                .ShouldThrow<ArgumentNullException>();
+                .Should().Throw<ArgumentNullException>();
         }
 
         [Fact]
@@ -208,7 +208,7 @@ namespace Polly.Specs.Registry
             string key = null;
             Policy<ResultPrimitive> policy = null;
             ReadOnlyRegistry.Invoking(r => policy = r.Get<Policy<ResultPrimitive>>(key))
-                .ShouldThrow<ArgumentNullException>();
+                .Should().Throw<ArgumentNullException>();
         }
 
         [Fact]
@@ -217,7 +217,7 @@ namespace Polly.Specs.Registry
             string key = null;
             ISyncPolicy<ResultPrimitive> policy = null;
             ReadOnlyRegistry.Invoking(r => policy = r.Get<ISyncPolicy<ResultPrimitive>>(key))
-                .ShouldThrow<ArgumentNullException>();
+                .Should().Throw<ArgumentNullException>();
         }
 
         [Fact]
@@ -226,7 +226,7 @@ namespace Polly.Specs.Registry
             string key = null;
             IsPolicy policy = null;
             ReadOnlyRegistry.Invoking(r => policy = r[key])
-                .ShouldThrow<ArgumentNullException>();
+                .Should().Throw<ArgumentNullException>();
         }
         #endregion
 
@@ -250,7 +250,7 @@ namespace Polly.Specs.Registry
         {
             string key = null;
             ReadOnlyRegistry.Invoking(r => r.ContainsKey(key))
-                .ShouldThrow<ArgumentNullException>();
+                .Should().Throw<ArgumentNullException>();
         }
         #endregion
         

--- a/src/Polly.Specs/Registry/PolicyRegistrySpecs.cs
+++ b/src/Polly.Specs/Registry/PolicyRegistrySpecs.cs
@@ -108,7 +108,7 @@ namespace Polly.Specs.Registry
             string key = Guid.NewGuid().ToString();
 
             _registry.Invoking(r => r.Add(key, policy))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             _registry.Invoking(r => r.Add(key, policy))
                 .Should().Throw<ArgumentException>();
@@ -272,7 +272,7 @@ namespace Polly.Specs.Registry
             bool result = false;
 
             _registry.Invoking(r => result = r.TryGet(key, out outPolicy))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             result.Should().BeFalse();
         }
@@ -285,7 +285,7 @@ namespace Polly.Specs.Registry
             bool result = false;
 
             _registry.Invoking(r => result = r.TryGet(key, out outPolicy))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             result.Should().BeFalse();
         }
@@ -298,7 +298,7 @@ namespace Polly.Specs.Registry
             bool result = false;
 
             _registry.Invoking(r => result = r.TryGet<ISyncPolicy<ResultPrimitive>>(key, out outPolicy))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             result.Should().BeFalse();
         }

--- a/src/Polly.Specs/Registry/PolicyRegistrySpecs.cs
+++ b/src/Polly.Specs/Registry/PolicyRegistrySpecs.cs
@@ -111,7 +111,7 @@ namespace Polly.Specs.Registry
                 .ShouldNotThrow();
 
             _registry.Invoking(r => r.Add(key, policy))
-                .ShouldThrow<ArgumentException>();
+                .Should().Throw<ArgumentException>();
 
             _registry.Count.Should().Be(1);
         }
@@ -152,7 +152,7 @@ namespace Polly.Specs.Registry
             string key = null;
             Policy policy = Policy.NoOp();
             _registry.Invoking(r => r.Add(key, policy))
-                .ShouldThrow<ArgumentNullException>();
+                .Should().Throw<ArgumentNullException>();
         }
 
         [Fact]
@@ -161,7 +161,7 @@ namespace Polly.Specs.Registry
             string key = null;
             Policy policy = Policy.NoOp();
             _registry.Invoking(r => r[key] = policy)
-                .ShouldThrow<ArgumentNullException>();
+                .Should().Throw<ArgumentNullException>();
         }
 
         #endregion
@@ -309,7 +309,7 @@ namespace Polly.Specs.Registry
             string key = Guid.NewGuid().ToString();
             Policy policy = null;
             _registry.Invoking(r => policy = r.Get<Policy>(key))
-                .ShouldThrow<KeyNotFoundException>();
+                .Should().Throw<KeyNotFoundException>();
         }
 
         [Fact]
@@ -318,7 +318,7 @@ namespace Polly.Specs.Registry
             string key = Guid.NewGuid().ToString();
             Policy<ResultPrimitive> policy = null;
             _registry.Invoking(r => policy = r.Get<Policy<ResultPrimitive>>(key))
-                .ShouldThrow<KeyNotFoundException>();
+                .Should().Throw<KeyNotFoundException>();
         }
 
         [Fact]
@@ -327,7 +327,7 @@ namespace Polly.Specs.Registry
             string key = Guid.NewGuid().ToString();
             ISyncPolicy<ResultPrimitive> policy = null;
             _registry.Invoking(r => policy = r.Get<ISyncPolicy<ResultPrimitive>>(key))
-                .ShouldThrow<KeyNotFoundException>();
+                .Should().Throw<KeyNotFoundException>();
         }
 
         [Fact]
@@ -336,7 +336,7 @@ namespace Polly.Specs.Registry
             string key = Guid.NewGuid().ToString();
             IsPolicy outPolicy = null;
             _registry.Invoking(r => outPolicy = r[key])
-                .ShouldThrow<KeyNotFoundException>();
+                .Should().Throw<KeyNotFoundException>();
         }
 
 
@@ -346,7 +346,7 @@ namespace Polly.Specs.Registry
             string key = null;
             Policy policy = null;
             _registry.Invoking(r => policy = r.Get<Policy>(key))
-                .ShouldThrow<ArgumentNullException>();
+                .Should().Throw<ArgumentNullException>();
         }
 
         [Fact]
@@ -355,7 +355,7 @@ namespace Polly.Specs.Registry
             string key = null;
             Policy<ResultPrimitive> policy = null;
             _registry.Invoking(r => policy = r.Get<Policy<ResultPrimitive>>(key))
-                .ShouldThrow<ArgumentNullException>();
+                .Should().Throw<ArgumentNullException>();
         }
 
         [Fact]
@@ -364,7 +364,7 @@ namespace Polly.Specs.Registry
             string key = null;
             ISyncPolicy<ResultPrimitive> policy = null;
             _registry.Invoking(r => policy = r.Get<ISyncPolicy<ResultPrimitive>>(key))
-                .ShouldThrow<ArgumentNullException>();
+                .Should().Throw<ArgumentNullException>();
         }
 
         [Fact]
@@ -373,7 +373,7 @@ namespace Polly.Specs.Registry
             string key = null;
             IsPolicy policy = null;
             _registry.Invoking(r => policy = r[key])
-                .ShouldThrow<ArgumentNullException>();
+                .Should().Throw<ArgumentNullException>();
         }
         #endregion
 
@@ -415,7 +415,7 @@ namespace Polly.Specs.Registry
         {
             string key = null;
             _registry.Invoking(r => r.Remove(key))
-                .ShouldThrow<ArgumentNullException>();
+                .Should().Throw<ArgumentNullException>();
         }
         #endregion
 
@@ -439,7 +439,7 @@ namespace Polly.Specs.Registry
         {
             string key = null;
             _registry.Invoking(r => r.ContainsKey(key))
-                .ShouldThrow<ArgumentNullException>();
+                .Should().Throw<ArgumentNullException>();
         }
         #endregion
 

--- a/src/Polly.Specs/Retry/RetryAsyncSpecs.cs
+++ b/src/Polly.Specs/Retry/RetryAsyncSpecs.cs
@@ -466,7 +466,7 @@ namespace Polly.Specs.Retry
             cancellationTokenSource.Cancel();
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -493,7 +493,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -520,7 +520,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -547,7 +547,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -574,7 +574,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(2);
@@ -601,7 +601,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(2);
@@ -628,7 +628,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1 + 3);
@@ -684,7 +684,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -742,7 +742,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true).ConfigureAwait(false))
-                .Should().Throw<TaskCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
+                .Should().Throw<OperationCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
 
             result.Should().Be(null);
 

--- a/src/Polly.Specs/Retry/RetryAsyncSpecs.cs
+++ b/src/Polly.Specs/Retry/RetryAsyncSpecs.cs
@@ -23,7 +23,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .RetryAsync(-1, onRetry);
         
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                   .ParamName.Should().Be("retryCount");
         }
 
@@ -81,7 +81,7 @@ namespace Polly.Specs.Retry
                 .RetryAsync(3);
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>(3 + 1))
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
         }
 
         [Fact]
@@ -93,7 +93,7 @@ namespace Polly.Specs.Retry
                 .RetryAsync(3);
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentException>(3 + 1))
-                  .ShouldThrow<ArgumentException>();
+                  .Should().Throw<ArgumentException>();
         }
 
         [Fact]
@@ -104,7 +104,7 @@ namespace Polly.Specs.Retry
                 .RetryAsync();
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<NullReferenceException>())
-                  .ShouldThrow<NullReferenceException>();
+                  .Should().Throw<NullReferenceException>();
         }
 
         [Fact]
@@ -116,7 +116,7 @@ namespace Polly.Specs.Retry
                 .RetryAsync();
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<NullReferenceException>())
-                  .ShouldThrow<NullReferenceException>();
+                  .Should().Throw<NullReferenceException>();
         }
 
         [Fact]
@@ -127,7 +127,7 @@ namespace Polly.Specs.Retry
                 .RetryAsync();
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
         }
 
         [Fact]
@@ -139,7 +139,7 @@ namespace Polly.Specs.Retry
                 .RetryAsync();
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentException>())
-                  .ShouldThrow<ArgumentException>();
+                  .Should().Throw<ArgumentException>();
         }
 
         [Fact]
@@ -226,7 +226,7 @@ namespace Polly.Specs.Retry
                 .RetryAsync((_, retryCount) => retryCounts.Add(retryCount));
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentException>())
-                  .ShouldThrow<ArgumentException>();
+                  .Should().Throw<ArgumentException>();
 
             retryCounts.Should()
                        .BeEmpty();
@@ -353,7 +353,7 @@ namespace Polly.Specs.Retry
                 .RetryAsync(0, onRetry);
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             retryInvoked.Should().BeFalse();
         }
@@ -386,7 +386,7 @@ namespace Polly.Specs.Retry
                 executeDelegateInvocations++;
                 await TaskHelper.EmptyTask.ConfigureAwait(false);
                 throw new DivideByZeroException();
-            })).ShouldThrow<DivideByZeroException>();
+            })).Should().Throw<DivideByZeroException>();
             
             while (executeDelegateInvocationsWhenOnRetryExits == 0) { } // Wait for the onRetry delegate to complete.
             
@@ -439,7 +439,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             attemptsInvoked.Should().Be(1 + 3);
         }
@@ -466,7 +466,7 @@ namespace Polly.Specs.Retry
             cancellationTokenSource.Cancel();
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -493,7 +493,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -520,7 +520,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -547,7 +547,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -574,7 +574,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(2);
@@ -601,7 +601,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(2);
@@ -628,7 +628,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1 + 3);
@@ -655,7 +655,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             attemptsInvoked.Should().Be(1 + 3);
         }
@@ -684,7 +684,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -742,7 +742,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true).ConfigureAwait(false))
-                .ShouldThrow<TaskCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
+                .Should().Throw<TaskCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
 
             result.Should().Be(null);
 

--- a/src/Polly.Specs/Retry/RetryAsyncSpecs.cs
+++ b/src/Polly.Specs/Retry/RetryAsyncSpecs.cs
@@ -35,7 +35,7 @@ namespace Polly.Specs.Retry
                 .RetryAsync(3);
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>(3))
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -47,7 +47,7 @@ namespace Polly.Specs.Retry
                 .RetryAsync(3);
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentException>(3))
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace Polly.Specs.Retry
                 .RetryAsync(3);
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -70,7 +70,7 @@ namespace Polly.Specs.Retry
                 .RetryAsync(3);
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -150,7 +150,7 @@ namespace Polly.Specs.Retry
                 .RetryAsync();
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -162,7 +162,7 @@ namespace Polly.Specs.Retry
                 .RetryAsync();
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -240,10 +240,10 @@ namespace Polly.Specs.Retry
                 .RetryAsync();
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -275,7 +275,7 @@ namespace Polly.Specs.Retry
 
             policy.Awaiting(async p => await p.ExecuteAndCaptureAsync(ctx => { throw new DivideByZeroException(); }, 
                 new { key1 = "value1", key2 = "value2" }.AsDictionary()))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             contextData.Should()
                 .ContainKeys("key1", "key2").And
@@ -291,7 +291,7 @@ namespace Polly.Specs.Retry
                 .Handle<DivideByZeroException>()
                 .RetryAsync((_, __, context) => capturedContext = context);
 
-            policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>()).ShouldNotThrow();
+            policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>()).Should().NotThrow();
 
             capturedContext.Should()
                            .BeEmpty();
@@ -330,13 +330,13 @@ namespace Polly.Specs.Retry
 
             policy.Awaiting(async p => await p.ExecuteAndCaptureAsync(ctx => { throw new DivideByZeroException(); }, 
                 new { key = "original_value" }.AsDictionary()))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             contextValue.Should().Be("original_value");
 
             policy.Awaiting(async p => await p.ExecuteAndCaptureAsync(ctx => { throw new DivideByZeroException(); },
                 new { key = "new_value" }.AsDictionary()))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             contextValue.Should().Be("new_value");
         }
@@ -414,7 +414,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             attemptsInvoked.Should().Be(1);
         }
@@ -712,7 +712,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true).ConfigureAwait(false))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             result.Should().BeTrue();
 

--- a/src/Polly.Specs/Retry/RetryForeverAsyncSpecs.cs
+++ b/src/Polly.Specs/Retry/RetryForeverAsyncSpecs.cs
@@ -292,7 +292,7 @@ namespace Polly.Specs.Retry
             cancellationTokenSource.Cancel();
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -319,7 +319,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -346,7 +346,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -373,7 +373,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -400,7 +400,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(2);
@@ -427,7 +427,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(2);
@@ -458,7 +458,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -516,7 +516,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true).ConfigureAwait(false))
-                .Should().Throw<TaskCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
+                .Should().Throw<OperationCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
 
             result.Should().Be(null);
 

--- a/src/Polly.Specs/Retry/RetryForeverAsyncSpecs.cs
+++ b/src/Polly.Specs/Retry/RetryForeverAsyncSpecs.cs
@@ -22,7 +22,7 @@ namespace Polly.Specs.Retry
                 .RetryForeverAsync();
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>(3))
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -34,7 +34,7 @@ namespace Polly.Specs.Retry
                 .RetryForeverAsync();
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentException>(3))
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -91,7 +91,7 @@ namespace Polly.Specs.Retry
                 .RetryForeverAsync();
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -103,7 +103,7 @@ namespace Polly.Specs.Retry
                 .RetryForeverAsync();
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -167,7 +167,7 @@ namespace Polly.Specs.Retry
                 .Handle<DivideByZeroException>()
                 .RetryForeverAsync((_, context) => capturedContext = context);
 
-            policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>()).ShouldNotThrow();
+            policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>()).Should().NotThrow();
 
             capturedContext.Should()
                            .BeEmpty();
@@ -237,7 +237,7 @@ namespace Polly.Specs.Retry
                 executeDelegateInvocations++;
                 await TaskHelper.EmptyTask.ConfigureAwait(false);
                 if (executeDelegateInvocations == 1) { throw new DivideByZeroException(); }
-            })).ShouldNotThrow();
+            })).Should().NotThrow();
 
             while (executeDelegateInvocationsWhenOnRetryExits == 0) { } // Wait for the onRetry delegate to complete.
 
@@ -265,7 +265,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             attemptsInvoked.Should().Be(1);
         }
@@ -486,7 +486,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true).ConfigureAwait(false))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             result.Should().BeTrue();
 

--- a/src/Polly.Specs/Retry/RetryForeverAsyncSpecs.cs
+++ b/src/Polly.Specs/Retry/RetryForeverAsyncSpecs.cs
@@ -45,7 +45,7 @@ namespace Polly.Specs.Retry
                 .RetryForeverAsync();
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<NullReferenceException>())
-                  .ShouldThrow<NullReferenceException>();
+                  .Should().Throw<NullReferenceException>();
         }
 
         [Fact]
@@ -57,7 +57,7 @@ namespace Polly.Specs.Retry
                 .RetryForeverAsync();
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<NullReferenceException>())
-                  .ShouldThrow<NullReferenceException>();
+                  .Should().Throw<NullReferenceException>();
         }
 
         [Fact]
@@ -68,7 +68,7 @@ namespace Polly.Specs.Retry
                 .RetryForeverAsync();
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
         }
 
         [Fact]
@@ -80,7 +80,7 @@ namespace Polly.Specs.Retry
                 .RetryForeverAsync();
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentException>())
-                  .ShouldThrow<ArgumentException>();
+                  .Should().Throw<ArgumentException>();
         }
 
         [Fact]
@@ -205,7 +205,7 @@ namespace Polly.Specs.Retry
                 .RetryForeverAsync(exception => retryExceptions.Add(exception));
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentException>())
-                  .ShouldThrow<ArgumentException>();
+                  .Should().Throw<ArgumentException>();
 
             retryExceptions.Should()
                            .BeEmpty();
@@ -292,7 +292,7 @@ namespace Polly.Specs.Retry
             cancellationTokenSource.Cancel();
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -319,7 +319,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -346,7 +346,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -373,7 +373,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -400,7 +400,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(2);
@@ -427,7 +427,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(2);
@@ -458,7 +458,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -516,7 +516,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true).ConfigureAwait(false))
-                .ShouldThrow<TaskCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
+                .Should().Throw<TaskCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
 
             result.Should().Be(null);
 

--- a/src/Polly.Specs/Retry/RetryForeverSpecs.cs
+++ b/src/Polly.Specs/Retry/RetryForeverSpecs.cs
@@ -18,7 +18,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .RetryForever(nullOnRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("onRetry");
         }
 
@@ -31,7 +31,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .RetryForever(nullOnRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("onRetry");
         }
 
@@ -66,7 +66,7 @@ namespace Polly.Specs.Retry
                 .RetryForever();
 
             policy.Invoking(x => x.RaiseException<NullReferenceException>())
-                  .ShouldThrow<NullReferenceException>();
+                  .Should().Throw<NullReferenceException>();
         }
 
         [Fact]
@@ -77,7 +77,7 @@ namespace Polly.Specs.Retry
                 .RetryForeverAsync();
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<NullReferenceException>())
-                  .ShouldThrow<NullReferenceException>();
+                  .Should().Throw<NullReferenceException>();
         }
 
         [Fact]
@@ -89,7 +89,7 @@ namespace Polly.Specs.Retry
                 .RetryForever();
 
             policy.Invoking(x => x.RaiseException<NullReferenceException>())
-                  .ShouldThrow<NullReferenceException>();
+                  .Should().Throw<NullReferenceException>();
         }
 
         [Fact]
@@ -100,7 +100,7 @@ namespace Polly.Specs.Retry
                 .RetryForever();
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
         }
 
         [Fact]
@@ -112,7 +112,7 @@ namespace Polly.Specs.Retry
                 .RetryForever();
 
             policy.Invoking(x => x.RaiseException<ArgumentException>())
-                  .ShouldThrow<ArgumentException>();
+                  .Should().Throw<ArgumentException>();
         }
 
         [Fact]
@@ -223,7 +223,7 @@ namespace Polly.Specs.Retry
                 .RetryForever(exception => retryExceptions.Add(exception));
 
             policy.Invoking(x => x.RaiseException<ArgumentException>())
-                  .ShouldThrow<ArgumentException>();
+                  .Should().Throw<ArgumentException>();
 
             retryExceptions.Should()
                            .BeEmpty();

--- a/src/Polly.Specs/Retry/RetryForeverSpecs.cs
+++ b/src/Polly.Specs/Retry/RetryForeverSpecs.cs
@@ -43,7 +43,7 @@ namespace Polly.Specs.Retry
                 .RetryForever();
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>(3))
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -55,7 +55,7 @@ namespace Polly.Specs.Retry
                 .RetryForever();
 
             policy.Invoking(x => x.RaiseException<ArgumentException>(3))
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -123,7 +123,7 @@ namespace Polly.Specs.Retry
                 .RetryForever();
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -134,7 +134,7 @@ namespace Polly.Specs.Retry
                 .RetryForeverAsync();
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -146,7 +146,7 @@ namespace Polly.Specs.Retry
                 .RetryForever();
 
             policy.Invoking(x => x.RaiseException<ArgumentException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -158,7 +158,7 @@ namespace Polly.Specs.Retry
                 .RetryForeverAsync();
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]

--- a/src/Polly.Specs/Retry/RetrySpecs.cs
+++ b/src/Polly.Specs/Retry/RetrySpecs.cs
@@ -19,7 +19,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .Retry(-1, onRetry);
         
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                   .ParamName.Should().Be("retryCount");
         }
 
@@ -32,7 +32,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .Retry(1, nullOnRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("onRetry");
         }
 
@@ -45,7 +45,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .Retry(-1, onRetry);
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                   .ParamName.Should().Be("retryCount");
         }
 
@@ -58,7 +58,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .Retry(1, nullOnRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("onRetry");
         }
 
@@ -116,7 +116,7 @@ namespace Polly.Specs.Retry
                 .Retry(3);
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>(3 + 1))
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
         }
         
         [Fact]
@@ -128,7 +128,7 @@ namespace Polly.Specs.Retry
                 .Retry(3);
 
             policy.Invoking(x => x.RaiseException<ArgumentException>(3 + 1))
-                  .ShouldThrow<ArgumentException>();
+                  .Should().Throw<ArgumentException>();
         }
         
         [Fact]
@@ -139,7 +139,7 @@ namespace Polly.Specs.Retry
                 .Retry();
 
             policy.Invoking(x => x.RaiseException<NullReferenceException>())
-                  .ShouldThrow<NullReferenceException>();
+                  .Should().Throw<NullReferenceException>();
         }
 
         [Fact]
@@ -151,7 +151,7 @@ namespace Polly.Specs.Retry
                 .Retry();
 
             policy.Invoking(x => x.RaiseException<NullReferenceException>())
-                  .ShouldThrow<NullReferenceException>();
+                  .Should().Throw<NullReferenceException>();
         }
 
         [Fact]
@@ -162,7 +162,7 @@ namespace Polly.Specs.Retry
                 .Retry();
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
         }
 
         [Fact]
@@ -174,7 +174,7 @@ namespace Polly.Specs.Retry
                 .Retry();
 
             policy.Invoking(x => x.RaiseException<ArgumentException>())
-                  .ShouldThrow<ArgumentException>();
+                  .Should().Throw<ArgumentException>();
         }
 
         [Fact]
@@ -261,7 +261,7 @@ namespace Polly.Specs.Retry
                 .Retry((_, retryCount) => retryCounts.Add(retryCount));
 
             policy.Invoking(x => x.RaiseException<ArgumentException>())
-                .ShouldThrow<ArgumentException>();
+                .Should().Throw<ArgumentException>();
 
             retryCounts.Should()
                 .BeEmpty();
@@ -388,7 +388,7 @@ namespace Polly.Specs.Retry
                 .Retry(0, onRetry);
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             retryInvoked.Should().BeFalse();
         }
@@ -405,7 +405,7 @@ namespace Polly.Specs.Retry
                 .Retry(0, onRetry);
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             retryInvoked.Should().BeFalse();
         }
@@ -458,7 +458,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             attemptsInvoked.Should().Be(1 + 3);
         }
@@ -485,7 +485,7 @@ namespace Polly.Specs.Retry
             cancellationTokenSource.Cancel();
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -512,7 +512,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -539,7 +539,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -566,7 +566,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -593,7 +593,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(2);
@@ -620,7 +620,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(2);
@@ -647,7 +647,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1 + 3);
@@ -674,7 +674,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             attemptsInvoked.Should().Be(1 + 3);
         }
@@ -703,7 +703,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -761,7 +761,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Invoking(x => result = x.RaiseExceptionAndOrCancellation<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true))
-                .ShouldThrow<OperationCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
+                .Should().Throw<OperationCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
 
             result.Should().Be(null);
 

--- a/src/Polly.Specs/Retry/RetrySpecs.cs
+++ b/src/Polly.Specs/Retry/RetrySpecs.cs
@@ -70,7 +70,7 @@ namespace Polly.Specs.Retry
                 .Retry(3);
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>(3))
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -82,7 +82,7 @@ namespace Polly.Specs.Retry
                 .Retry(3);
 
             policy.Invoking(x => x.RaiseException<ArgumentException>(3))
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -93,7 +93,7 @@ namespace Polly.Specs.Retry
                 .Retry(3);
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
         
         [Fact]
@@ -105,7 +105,7 @@ namespace Polly.Specs.Retry
                 .Retry(3);
 
             policy.Invoking(x => x.RaiseException<ArgumentException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
         
         [Fact]
@@ -185,7 +185,7 @@ namespace Polly.Specs.Retry
                 .Retry();
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -197,7 +197,7 @@ namespace Polly.Specs.Retry
                 .Retry();
 
             policy.Invoking(x => x.RaiseException<ArgumentException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -296,7 +296,7 @@ namespace Polly.Specs.Retry
 
             policy.Invoking(p => p.ExecuteAndCapture(ctx => { throw new DivideByZeroException();}, 
                 new { key1 = "value1", key2 = "value2" }.AsDictionary()))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             contextData.Should()
                 .ContainKeys("key1", "key2").And
@@ -351,13 +351,13 @@ namespace Polly.Specs.Retry
 
             policy.Invoking(p => p.ExecuteAndCapture(ctx => { throw new DivideByZeroException(); }, 
                 new { key = "original_value" }.AsDictionary()))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             contextValue.Should().Be("original_value");
 
             policy.Invoking(p => p.ExecuteAndCapture(ctx => { throw new DivideByZeroException(); },
                 new { key = "new_value" }.AsDictionary()))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             contextValue.Should().Be("new_value");
         }
@@ -370,10 +370,10 @@ namespace Polly.Specs.Retry
                 .Retry();
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-                .ShouldNotThrow();
+                .Should().NotThrow();
         }
 
         [Fact]
@@ -433,7 +433,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             attemptsInvoked.Should().Be(1);
         }
@@ -731,7 +731,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Invoking(x => result = x.RaiseExceptionAndOrCancellation<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             result.Should().BeTrue();
 

--- a/src/Polly.Specs/Retry/RetryTResultMixedResultExceptionSpecs.cs
+++ b/src/Polly.Specs/Retry/RetryTResultMixedResultExceptionSpecs.cs
@@ -24,7 +24,7 @@ namespace Polly.Specs.Retry
                 .Handle<DivideByZeroException>().Retry(1);
 
             policy.Invoking(p => p.RaiseResultAndOrExceptionSequence(new ArgumentException(), ResultPrimitive.Good))
-                .ShouldThrow<ArgumentException>();
+                .Should().Throw<ArgumentException>();
         }
 
         [Fact]
@@ -104,7 +104,7 @@ namespace Polly.Specs.Retry
                 .Retry(3);
 
             policy.Invoking(p => p.RaiseResultAndOrExceptionSequence(ResultPrimitive.Fault, new DivideByZeroException(), ResultPrimitive.FaultAgain, new ArgumentException(), ResultPrimitive.Good))
-                .ShouldThrow<ArgumentException>();
+                .Should().Throw<ArgumentException>();
         }
 
         [Fact]
@@ -132,7 +132,7 @@ namespace Polly.Specs.Retry
                 .Retry(3);
 
             policy.Invoking(p => p.RaiseResultAndOrExceptionSequence(ResultPrimitive.Fault, new DivideByZeroException(), ResultPrimitive.FaultAgain, new ArgumentException(), ResultPrimitive.Good))
-                .ShouldThrow<ArgumentException>();
+                .Should().Throw<ArgumentException>();
         }
 
         [Fact]
@@ -156,7 +156,7 @@ namespace Polly.Specs.Retry
                 .Retry(2);
 
             policy.Invoking(p => p.RaiseResultAndOrExceptionSequence(new ArgumentException(), ResultPrimitive.Good))
-                .ShouldThrow<ArgumentException>();
+                .Should().Throw<ArgumentException>();
         }
 
         [Fact]
@@ -180,7 +180,7 @@ namespace Polly.Specs.Retry
                 .Retry(2);
 
             policy.Invoking(p => p.RaiseResultAndOrExceptionSequence(new ResultClass(ResultPrimitive.Fault), new ArgumentException("message", "value"), new ResultClass(ResultPrimitive.Good)))
-                .ShouldThrow<ArgumentException>();
+                .Should().Throw<ArgumentException>();
         }
 
         [Fact]

--- a/src/Polly.Specs/Retry/RetryTResultSpecs.cs
+++ b/src/Polly.Specs/Retry/RetryTResultSpecs.cs
@@ -22,7 +22,7 @@ namespace Polly.Specs.Retry
                                       .HandleResult(ResultPrimitive.Fault)
                                       .Retry(-1, onRetry);
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                   .ParamName.Should().Be("retryCount");
         }
 
@@ -35,7 +35,7 @@ namespace Polly.Specs.Retry
                                       .HandleResult(ResultPrimitive.Fault)
                                       .Retry(1, nullOnRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("onRetry");
         }
 
@@ -48,7 +48,7 @@ namespace Polly.Specs.Retry
                                       .HandleResult(ResultPrimitive.Fault)
                                       .Retry(-1, onRetry);
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                   .ParamName.Should().Be("retryCount");
         }
 
@@ -61,7 +61,7 @@ namespace Polly.Specs.Retry
                                       .HandleResult(ResultPrimitive.Fault)
                                       .Retry(1, nullOnRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("onRetry");
         }
 
@@ -492,7 +492,7 @@ namespace Polly.Specs.Retry
                    ResultPrimitive.Fault,
                    ResultPrimitive.Fault,
                    ResultPrimitive.Good))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -522,7 +522,7 @@ namespace Polly.Specs.Retry
                    ResultPrimitive.Good,
                    ResultPrimitive.Good,
                    ResultPrimitive.Good))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -552,7 +552,7 @@ namespace Polly.Specs.Retry
                    ResultPrimitive.Fault,
                    ResultPrimitive.Fault,
                    ResultPrimitive.Good))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -582,7 +582,7 @@ namespace Polly.Specs.Retry
                    ResultPrimitive.Fault,
                    ResultPrimitive.Fault,
                    ResultPrimitive.Good))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -612,7 +612,7 @@ namespace Polly.Specs.Retry
                    ResultPrimitive.Fault,
                    ResultPrimitive.Fault,
                    ResultPrimitive.Good))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(2);
@@ -642,7 +642,7 @@ namespace Polly.Specs.Retry
                    ResultPrimitive.Fault,
                    ResultPrimitive.Fault,
                    ResultPrimitive.Good))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(2);
@@ -673,7 +673,7 @@ namespace Polly.Specs.Retry
                    ResultPrimitive.Fault,
                    ResultPrimitive.Fault,
                    ResultPrimitive.Good))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1 + 3);
@@ -736,7 +736,7 @@ namespace Polly.Specs.Retry
                    ResultPrimitive.Fault,
                    ResultPrimitive.Fault,
                    ResultPrimitive.Good))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);

--- a/src/Polly.Specs/Retry/RetryTResultSpecs.cs
+++ b/src/Polly.Specs/Retry/RetryTResultSpecs.cs
@@ -288,7 +288,7 @@ namespace Polly.Specs.Retry
                 ResultPrimitive.Fault, ResultPrimitive.Good
                 );
 
-            result.ShouldBeEquivalentTo(new 
+            result.Should().BeEquivalentTo(new 
             {                   
                 Outcome = OutcomeType.Successful,
                 FinalException = (Exception)null,
@@ -296,7 +296,7 @@ namespace Polly.Specs.Retry
                 FaultType = (FaultType?)null,
                 FinalHandledResult = default(ResultPrimitive),
                 Result = ResultPrimitive.Good
-            }, options => options.Excluding(o => o.Context));
+            });
 
             contextData.Should()
                 .ContainKeys("key1", "key2").And

--- a/src/Polly.Specs/Retry/RetryTResultSpecsAsync.cs
+++ b/src/Polly.Specs/Retry/RetryTResultSpecsAsync.cs
@@ -506,7 +506,7 @@ namespace Polly.Specs.Retry
                    ResultPrimitive.Fault,
                    ResultPrimitive.Fault,
                    ResultPrimitive.Good))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -536,7 +536,7 @@ namespace Polly.Specs.Retry
                    ResultPrimitive.Good,
                    ResultPrimitive.Good,
                    ResultPrimitive.Good))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -566,7 +566,7 @@ namespace Polly.Specs.Retry
                    ResultPrimitive.Fault,
                    ResultPrimitive.Fault,
                    ResultPrimitive.Good))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -596,7 +596,7 @@ namespace Polly.Specs.Retry
                    ResultPrimitive.Fault,
                    ResultPrimitive.Fault,
                    ResultPrimitive.Good))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -626,7 +626,7 @@ namespace Polly.Specs.Retry
                    ResultPrimitive.Fault,
                    ResultPrimitive.Fault,
                    ResultPrimitive.Good))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(2);
@@ -656,7 +656,7 @@ namespace Polly.Specs.Retry
                    ResultPrimitive.Fault,
                    ResultPrimitive.Fault,
                    ResultPrimitive.Good))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(2);
@@ -687,7 +687,7 @@ namespace Polly.Specs.Retry
                    ResultPrimitive.Fault,
                    ResultPrimitive.Fault,
                    ResultPrimitive.Good))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1 + 3);
@@ -750,7 +750,7 @@ namespace Polly.Specs.Retry
                    ResultPrimitive.Fault,
                    ResultPrimitive.Fault,
                    ResultPrimitive.Good))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);

--- a/src/Polly.Specs/Retry/RetryTResultSpecsAsync.cs
+++ b/src/Polly.Specs/Retry/RetryTResultSpecsAsync.cs
@@ -292,7 +292,7 @@ namespace Polly.Specs.Retry
                 ResultPrimitive.Fault, ResultPrimitive.Good
                 ).ConfigureAwait(false);
 
-            result.ShouldBeEquivalentTo(new
+            result.Should().BeEquivalentTo(new
             {
                 Outcome = OutcomeType.Successful,
                 FinalException = (Exception)null,
@@ -300,7 +300,7 @@ namespace Polly.Specs.Retry
                 FaultType = (FaultType?)null,
                 FinalHandledResult = default(ResultPrimitive),
                 Result = ResultPrimitive.Good
-            }, options => options.Excluding(o => o.Context));
+            });
 
             contextData.Should()
                 .ContainKeys("key1", "key2").And

--- a/src/Polly.Specs/Retry/RetryTResultSpecsAsync.cs
+++ b/src/Polly.Specs/Retry/RetryTResultSpecsAsync.cs
@@ -23,7 +23,7 @@ namespace Polly.Specs.Retry
                                       .HandleResult(ResultPrimitive.Fault)
                                       .RetryAsync(-1, onRetry);
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                   .ParamName.Should().Be("retryCount");
         }
 
@@ -36,7 +36,7 @@ namespace Polly.Specs.Retry
                                       .HandleResult(ResultPrimitive.Fault)
                                       .RetryAsync(1, nullOnRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("onRetry");
         }
 
@@ -49,7 +49,7 @@ namespace Polly.Specs.Retry
                                       .HandleResult(ResultPrimitive.Fault)
                                       .RetryAsync(-1, onRetry);
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                   .ParamName.Should().Be("retryCount");
         }
 
@@ -62,7 +62,7 @@ namespace Polly.Specs.Retry
                                       .HandleResult(ResultPrimitive.Fault)
                                       .RetryAsync(1, nullOnRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("onRetry");
         }
 
@@ -506,7 +506,7 @@ namespace Polly.Specs.Retry
                    ResultPrimitive.Fault,
                    ResultPrimitive.Fault,
                    ResultPrimitive.Good))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -536,7 +536,7 @@ namespace Polly.Specs.Retry
                    ResultPrimitive.Good,
                    ResultPrimitive.Good,
                    ResultPrimitive.Good))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -566,7 +566,7 @@ namespace Polly.Specs.Retry
                    ResultPrimitive.Fault,
                    ResultPrimitive.Fault,
                    ResultPrimitive.Good))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -596,7 +596,7 @@ namespace Polly.Specs.Retry
                    ResultPrimitive.Fault,
                    ResultPrimitive.Fault,
                    ResultPrimitive.Good))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -626,7 +626,7 @@ namespace Polly.Specs.Retry
                    ResultPrimitive.Fault,
                    ResultPrimitive.Fault,
                    ResultPrimitive.Good))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(2);
@@ -656,7 +656,7 @@ namespace Polly.Specs.Retry
                    ResultPrimitive.Fault,
                    ResultPrimitive.Fault,
                    ResultPrimitive.Good))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(2);
@@ -687,7 +687,7 @@ namespace Polly.Specs.Retry
                    ResultPrimitive.Fault,
                    ResultPrimitive.Fault,
                    ResultPrimitive.Good))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1 + 3);
@@ -750,7 +750,7 @@ namespace Polly.Specs.Retry
                    ResultPrimitive.Fault,
                    ResultPrimitive.Fault,
                    ResultPrimitive.Good))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);

--- a/src/Polly.Specs/Retry/WaitAndRetryAsyncSpecs.cs
+++ b/src/Polly.Specs/Retry/WaitAndRetryAsyncSpecs.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Polly.Specs.Helpers;
 using Polly.Utilities;
 using Xunit;

--- a/src/Polly.Specs/Retry/WaitAndRetryAsyncSpecs.cs
+++ b/src/Polly.Specs/Retry/WaitAndRetryAsyncSpecs.cs
@@ -61,7 +61,7 @@ namespace Polly.Specs.Retry
                 });
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>(3))
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -78,7 +78,7 @@ namespace Polly.Specs.Retry
                 });
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentException>(3))
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -94,7 +94,7 @@ namespace Polly.Specs.Retry
                 });
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>(2))
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -111,7 +111,7 @@ namespace Polly.Specs.Retry
                 });
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentException>(2))
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -204,7 +204,7 @@ namespace Polly.Specs.Retry
                 });
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -219,7 +219,7 @@ namespace Polly.Specs.Retry
                 });
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -420,10 +420,10 @@ namespace Polly.Specs.Retry
                 });
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -462,7 +462,7 @@ namespace Polly.Specs.Retry
                     2.Seconds(),
                     3.Seconds()
                 }, (_, __, context) => capturedContext = context);
-            policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>()).ShouldNotThrow();
+            policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>()).Should().NotThrow();
 
             capturedContext.Should()
                            .BeEmpty();
@@ -728,7 +728,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             attemptsInvoked.Should().Be(1);
         }
@@ -1068,7 +1068,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true).ConfigureAwait(false))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             result.Should().BeTrue();
 

--- a/src/Polly.Specs/Retry/WaitAndRetryAsyncSpecs.cs
+++ b/src/Polly.Specs/Retry/WaitAndRetryAsyncSpecs.cs
@@ -781,7 +781,7 @@ namespace Polly.Specs.Retry
             cancellationTokenSource.Cancel();
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -808,7 +808,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -835,7 +835,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1); 
@@ -862,7 +862,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -889,7 +889,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(2);
@@ -916,7 +916,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(2);
@@ -943,7 +943,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1 + 3);
@@ -1006,7 +1006,7 @@ namespace Polly.Specs.Retry
             cancellationTokenSource.CancelAfter(shimTimeSpan);
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                    .Should().Throw<TaskCanceledException>()
+                    .Should().Throw<OperationCanceledException>()
                     .And.CancellationToken.Should().Be(cancellationToken);
             watch.Stop();
 
@@ -1041,7 +1041,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -1099,7 +1099,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true).ConfigureAwait(false))
-                .Should().Throw<TaskCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
+                .Should().Throw<OperationCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
 
             result.Should().Be(null);
 

--- a/src/Polly.Specs/Retry/WaitAndRetryAsyncSpecs.cs
+++ b/src/Polly.Specs/Retry/WaitAndRetryAsyncSpecs.cs
@@ -31,7 +31,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetryAsync(null, onRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("sleepDurations");
         }
 
@@ -44,7 +44,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetryAsync(Enumerable.Empty<TimeSpan>(), nullOnRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("onRetry");
         }
         
@@ -127,7 +127,7 @@ namespace Polly.Specs.Retry
                 });
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>(3 + 1))
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
         }
 
         [Fact]
@@ -144,7 +144,7 @@ namespace Polly.Specs.Retry
                 });
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentException>(3 + 1))
-                  .ShouldThrow<ArgumentException>();
+                  .Should().Throw<ArgumentException>();
         }
 
         [Fact]
@@ -155,7 +155,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetryAsync(Enumerable.Empty<TimeSpan>());
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<NullReferenceException>())
-                  .ShouldThrow<NullReferenceException>();
+                  .Should().Throw<NullReferenceException>();
         }
 
         [Fact]
@@ -167,7 +167,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetryAsync(Enumerable.Empty<TimeSpan>());
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<NullReferenceException>())
-                  .ShouldThrow<NullReferenceException>();
+                  .Should().Throw<NullReferenceException>();
         }
 
         [Fact]
@@ -178,7 +178,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetryAsync(Enumerable.Empty<TimeSpan>());
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
         }
 
         [Fact]
@@ -190,7 +190,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetryAsync(Enumerable.Empty<TimeSpan>());
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentException>())
-                  .ShouldThrow<ArgumentException>();
+                  .Should().Throw<ArgumentException>();
         }
 
         [Fact]
@@ -269,7 +269,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>(3 + 1))
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             totalTimeSlept.Should()
                           .Be(1 + 2 + 3);
@@ -317,7 +317,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<NullReferenceException>())
-                  .ShouldThrow<NullReferenceException>();
+                  .Should().Throw<NullReferenceException>();
 
             totalTimeSlept.Should()
                           .Be(0);
@@ -404,7 +404,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetryAsync(Enumerable.Empty<TimeSpan>(), (exception, _) => retryExceptions.Add(exception));
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentException>())
-                  .ShouldThrow<ArgumentException>();
+                  .Should().Throw<ArgumentException>();
 
             retryExceptions.Should().BeEmpty();
         }
@@ -503,7 +503,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetryAsync(-1, _ => TimeSpan.Zero, onRetry);
                                            
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And                  
+            policy.Should().Throw<ArgumentOutOfRangeException>().And                  
                   .ParamName.Should().Be("retryCount");
         }
 
@@ -516,7 +516,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetryAsync(1, null, onRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("sleepDurationProvider");
         }
 
@@ -529,7 +529,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetryAsync(1, _ => TimeSpan.Zero, nullOnRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("onRetry");
         }
 
@@ -667,7 +667,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetryAsync(0, retryAttempt => TimeSpan.FromSeconds(1), onRetry);
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             retryInvoked.Should().BeFalse();
         }
@@ -700,7 +700,7 @@ namespace Polly.Specs.Retry
                 executeDelegateInvocations++;
                 await TaskHelper.EmptyTask.ConfigureAwait(false);
                 throw new DivideByZeroException(); 
-            })).ShouldThrow<DivideByZeroException>();
+            })).Should().Throw<DivideByZeroException>();
 
             while (executeDelegateInvocationsWhenOnRetryExits == 0) { } // Wait for the onRetry delegate to complete.
 
@@ -753,7 +753,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             attemptsInvoked.Should().Be(1 + 3);
         }
@@ -780,7 +780,7 @@ namespace Polly.Specs.Retry
             cancellationTokenSource.Cancel();
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -807,7 +807,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -834,7 +834,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1); 
@@ -861,7 +861,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -888,7 +888,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(2);
@@ -915,7 +915,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(2);
@@ -942,7 +942,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1 + 3);
@@ -969,7 +969,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             attemptsInvoked.Should().Be(1 + 3);
         }
@@ -1005,7 +1005,7 @@ namespace Polly.Specs.Retry
             cancellationTokenSource.CancelAfter(shimTimeSpan);
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                    .ShouldThrow<TaskCanceledException>()
+                    .Should().Throw<TaskCanceledException>()
                     .And.CancellationToken.Should().Be(cancellationToken);
             watch.Stop();
 
@@ -1040,7 +1040,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -1098,7 +1098,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true).ConfigureAwait(false))
-                .ShouldThrow<TaskCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
+                .Should().Throw<TaskCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
 
             result.Should().Be(null);
 

--- a/src/Polly.Specs/Retry/WaitAndRetryForeverAsyncSpecs.cs
+++ b/src/Polly.Specs/Retry/WaitAndRetryForeverAsyncSpecs.cs
@@ -83,7 +83,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetryForeverAsync(_ => TimeSpan.Zero);
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>(3))
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -95,7 +95,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetryForeverAsync(_ => TimeSpan.Zero);
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentException>(3))
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -162,7 +162,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetryForeverAsync(provider);
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -176,7 +176,7 @@ namespace Polly.Specs.Retry
                .WaitAndRetryForeverAsync(provider);
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -402,7 +402,7 @@ namespace Polly.Specs.Retry
                 executeDelegateInvocations++;
                 await TaskHelper.EmptyTask.ConfigureAwait(false);
                 if (executeDelegateInvocations == 1) { throw new DivideByZeroException(); }
-            })).ShouldNotThrow();
+            })).Should().NotThrow();
 
             while (executeDelegateInvocationsWhenOnRetryExits == 0) { } // Wait for the onRetry delegate to complete.
 
@@ -431,7 +431,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             attemptsInvoked.Should().Be(1);
         }
@@ -667,7 +667,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true).ConfigureAwait(false))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             result.Should().BeTrue();
 

--- a/src/Polly.Specs/Retry/WaitAndRetryForeverAsyncSpecs.cs
+++ b/src/Polly.Specs/Retry/WaitAndRetryForeverAsyncSpecs.cs
@@ -30,7 +30,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetryForeverAsync(null, onRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("sleepDurationProvider");
         }
 
@@ -43,7 +43,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetryForeverAsync(null, onRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("sleepDurationProvider");
         }
 
@@ -57,7 +57,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetryForeverAsync(provider, nullOnRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("onRetry");
         }
 
@@ -71,7 +71,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetryForeverAsync(provider, nullOnRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("onRetry");
         }
 
@@ -108,7 +108,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetryForeverAsync(provider);
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<NullReferenceException>())
-                  .ShouldThrow<NullReferenceException>();
+                  .Should().Throw<NullReferenceException>();
         }
 
         [Fact]
@@ -122,7 +122,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetryForeverAsync(provider);
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<NullReferenceException>())
-                  .ShouldThrow<NullReferenceException>();
+                  .Should().Throw<NullReferenceException>();
         }
 
         [Fact]
@@ -135,7 +135,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetryForeverAsync(provider);
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
         }
 
         [Fact]
@@ -149,7 +149,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetryForeverAsync(provider);
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentException>())
-                  .ShouldThrow<ArgumentException>();
+                  .Should().Throw<ArgumentException>();
         }
 
         [Fact]
@@ -193,7 +193,7 @@ namespace Polly.Specs.Retry
             SystemClock.Sleep = (span, ct) => totalTimeSlept += span.Seconds;
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<NullReferenceException>())
-                  .ShouldThrow<NullReferenceException>();
+                  .Should().Throw<NullReferenceException>();
 
             totalTimeSlept.Should()
                           .Be(0);
@@ -246,7 +246,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetryForeverAsync(provider, (excpetion, _) => retryExceptions.Add(excpetion));
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentException>())
-                  .ShouldThrow<ArgumentException>();
+                  .Should().Throw<ArgumentException>();
 
             retryExceptions.Should().BeEmpty();
         }
@@ -460,7 +460,7 @@ namespace Polly.Specs.Retry
             cancellationTokenSource.Cancel();
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -489,7 +489,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -518,7 +518,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -547,7 +547,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -576,7 +576,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(2);
@@ -605,7 +605,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(2);
@@ -638,7 +638,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<TaskCanceledException>()
+                .Should().Throw<TaskCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -699,7 +699,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true).ConfigureAwait(false))
-                .ShouldThrow<TaskCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
+                .Should().Throw<TaskCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
 
             result.Should().Be(null);
 

--- a/src/Polly.Specs/Retry/WaitAndRetryForeverAsyncSpecs.cs
+++ b/src/Polly.Specs/Retry/WaitAndRetryForeverAsyncSpecs.cs
@@ -461,7 +461,7 @@ namespace Polly.Specs.Retry
             cancellationTokenSource.Cancel();
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -490,7 +490,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -519,7 +519,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -548,7 +548,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -577,7 +577,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(2);
@@ -606,7 +606,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(2);
@@ -639,7 +639,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<TaskCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -700,7 +700,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Awaiting(async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true).ConfigureAwait(false))
-                .Should().Throw<TaskCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
+                .Should().Throw<OperationCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
 
             result.Should().Be(null);
 

--- a/src/Polly.Specs/Retry/WaitAndRetryForeverAsyncSpecs.cs
+++ b/src/Polly.Specs/Retry/WaitAndRetryForeverAsyncSpecs.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Polly.Specs.Helpers;
 using Polly.Utilities;
 using Xunit;

--- a/src/Polly.Specs/Retry/WaitAndRetryForeverSpecs.cs
+++ b/src/Polly.Specs/Retry/WaitAndRetryForeverSpecs.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Polly.Specs.Helpers;
 using Polly.Utilities;
 using Xunit;

--- a/src/Polly.Specs/Retry/WaitAndRetryForeverSpecs.cs
+++ b/src/Polly.Specs/Retry/WaitAndRetryForeverSpecs.cs
@@ -26,7 +26,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetryForever(null, onRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("sleepDurationProvider");
         }
 
@@ -41,7 +41,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetryForever(sleepDurationProvider, onRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("sleepDurationProvider");
         }
 
@@ -55,7 +55,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetryForever(provider, nullOnRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("onRetry");
         }
 
@@ -69,7 +69,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetryForever(provider, nullOnRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("onRetry");
         }
 
@@ -106,7 +106,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetryForever(provider);
 
             policy.Invoking(x => x.RaiseException<NullReferenceException>())
-                  .ShouldThrow<NullReferenceException>();
+                  .Should().Throw<NullReferenceException>();
         } 
 
         [Fact]
@@ -120,7 +120,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetryForever(provider);
 
             policy.Invoking(x => x.RaiseException<NullReferenceException>())
-                  .ShouldThrow<NullReferenceException>();
+                  .Should().Throw<NullReferenceException>();
         }
        
         [Fact]
@@ -133,7 +133,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetryForever(provider);
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
         }
 
         [Fact]
@@ -147,7 +147,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetryForever(provider);
 
             policy.Invoking(x => x.RaiseException<ArgumentException>())
-                  .ShouldThrow<ArgumentException>();
+                  .Should().Throw<ArgumentException>();
         }
 
         [Fact]
@@ -191,7 +191,7 @@ namespace Polly.Specs.Retry
             SystemClock.Sleep = (span, ct) => totalTimeSlept += span.Seconds;
 
             policy.Invoking(x => x.RaiseException<NullReferenceException>())
-                  .ShouldThrow<NullReferenceException>();
+                  .Should().Throw<NullReferenceException>();
 
             totalTimeSlept.Should()
                           .Be(0);
@@ -244,7 +244,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetryForever(provider, (exception, _) => retryExceptions.Add(exception));
 
             policy.Invoking(x => x.RaiseException<ArgumentException>())
-                  .ShouldThrow<ArgumentException>();
+                  .Should().Throw<ArgumentException>();
 
             retryExceptions.Should().BeEmpty();
         }

--- a/src/Polly.Specs/Retry/WaitAndRetryForeverSpecs.cs
+++ b/src/Polly.Specs/Retry/WaitAndRetryForeverSpecs.cs
@@ -81,7 +81,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetryForever(_ => new TimeSpan());
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>(3))
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -93,7 +93,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetryForever(_ => new TimeSpan());
 
             policy.Invoking(x => x.RaiseException<ArgumentException>(3))
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -160,7 +160,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetryForever(provider);
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
         
         [Fact]
@@ -174,7 +174,7 @@ namespace Polly.Specs.Retry
                .WaitAndRetryForever(provider);
 
             policy.Invoking(x => x.RaiseException<ArgumentException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]

--- a/src/Polly.Specs/Retry/WaitAndRetryForeverTResultAsyncSpecs.cs
+++ b/src/Polly.Specs/Retry/WaitAndRetryForeverTResultAsyncSpecs.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using Polly.Specs.Helpers;
 using Polly.Utilities;
 using Xunit;
+using FluentAssertions.Extensions;
 
 namespace Polly.Specs.Retry
 {

--- a/src/Polly.Specs/Retry/WaitAndRetryForeverTResultSpecs.cs
+++ b/src/Polly.Specs/Retry/WaitAndRetryForeverTResultSpecs.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Polly.Specs.Helpers;
 using Polly.Utilities;
 using Xunit;

--- a/src/Polly.Specs/Retry/WaitAndRetrySpecs.cs
+++ b/src/Polly.Specs/Retry/WaitAndRetrySpecs.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Polly.Specs.Helpers;
 using Polly.Utilities;
 using Xunit;

--- a/src/Polly.Specs/Retry/WaitAndRetrySpecs.cs
+++ b/src/Polly.Specs/Retry/WaitAndRetrySpecs.cs
@@ -29,7 +29,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetry(null, onRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("sleepDurations");
         }
 
@@ -42,7 +42,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetry(null, onRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("sleepDurations");
         }
 
@@ -55,7 +55,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetry(null, onRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("sleepDurations");
         }
 
@@ -68,7 +68,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetry(Enumerable.Empty<TimeSpan>(), nullOnRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("onRetry");
         }
 
@@ -81,7 +81,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetry(Enumerable.Empty<TimeSpan>(), nullOnRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("onRetry");
         }
 
@@ -94,7 +94,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetry(Enumerable.Empty<TimeSpan>(), nullOnRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("onRetry");
         }
 
@@ -177,7 +177,7 @@ namespace Polly.Specs.Retry
                 });
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>(3 + 1))
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
         }
 
         [Fact]
@@ -194,7 +194,7 @@ namespace Polly.Specs.Retry
                 });
 
             policy.Invoking(x => x.RaiseException<ArgumentException>(3 + 1))
-                  .ShouldThrow<ArgumentException>();
+                  .Should().Throw<ArgumentException>();
         }
 
         [Fact]
@@ -205,7 +205,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetry(Enumerable.Empty<TimeSpan>());
 
             policy.Invoking(x => x.RaiseException<NullReferenceException>())
-                  .ShouldThrow<NullReferenceException>();
+                  .Should().Throw<NullReferenceException>();
         }
 
         [Fact]
@@ -216,7 +216,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetryAsync(Enumerable.Empty<TimeSpan>());
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<NullReferenceException>())
-                  .ShouldThrow<NullReferenceException>();
+                  .Should().Throw<NullReferenceException>();
         }
 
         [Fact]
@@ -228,7 +228,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetry(Enumerable.Empty<TimeSpan>());
 
             policy.Invoking(x => x.RaiseException<NullReferenceException>())
-                  .ShouldThrow<NullReferenceException>();
+                  .Should().Throw<NullReferenceException>();
         }
 
         [Fact]
@@ -240,7 +240,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetryAsync(Enumerable.Empty<TimeSpan>());
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<NullReferenceException>())
-                  .ShouldThrow<NullReferenceException>();
+                  .Should().Throw<NullReferenceException>();
         }
 
         [Fact]
@@ -251,7 +251,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetry(Enumerable.Empty<TimeSpan>());
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
         }
 
         [Fact]
@@ -263,7 +263,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetry(Enumerable.Empty<TimeSpan>());
 
             policy.Invoking(x => x.RaiseException<ArgumentException>())
-                  .ShouldThrow<ArgumentException>();
+                  .Should().Throw<ArgumentException>();
         }
 
         [Fact]
@@ -363,7 +363,7 @@ namespace Polly.Specs.Retry
             SystemClock.Sleep = (span, ct) => totalTimeSlept += span.Seconds;
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>(3 + 1))
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             totalTimeSlept.Should()
                           .Be(1 + 2 + 3);
@@ -403,7 +403,7 @@ namespace Polly.Specs.Retry
             SystemClock.Sleep = (span, ct) => totalTimeSlept += span.Seconds;
 
             policy.Invoking(x => x.RaiseException<NullReferenceException>())
-                  .ShouldThrow<NullReferenceException>();
+                  .Should().Throw<NullReferenceException>();
 
             totalTimeSlept.Should()
                           .Be(0);
@@ -490,7 +490,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetry(Enumerable.Empty<TimeSpan>(), (exception, _) => retryExceptions.Add(exception));
 
             policy.Invoking(x => x.RaiseException<ArgumentException>())
-                  .ShouldThrow<ArgumentException>();
+                  .Should().Throw<ArgumentException>();
 
             retryExceptions.Should()
                        .BeEmpty();
@@ -571,7 +571,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetry(-1, _ => new TimeSpan(), onRetry);
                                            
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And                  
+            policy.Should().Throw<ArgumentOutOfRangeException>().And                  
                   .ParamName.Should().Be("retryCount");
         }
 
@@ -584,7 +584,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetry(-1, _ => new TimeSpan(), onRetry);
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                   .ParamName.Should().Be("retryCount");
         }
 
@@ -597,7 +597,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetry(-1, _ => new TimeSpan(), onRetry);
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                   .ParamName.Should().Be("retryCount");
         }
 
@@ -610,7 +610,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetry(1, null, onRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("sleepDurationProvider");
         }
 
@@ -623,7 +623,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetry(1, (Func<int, TimeSpan>) null, onRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("sleepDurationProvider");
         }
 
@@ -636,7 +636,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetry(1, (Func<int, TimeSpan>)null, onRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("sleepDurationProvider");
         }
 
@@ -649,7 +649,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetry(1, _ => new TimeSpan(), nullOnRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("onRetry");
         }
 
@@ -662,7 +662,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetry(1, _ => new TimeSpan(), nullOnRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("onRetry");
         }
 
@@ -675,7 +675,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetry(1, _ => new TimeSpan(), nullOnRetry);
 
-            policy.ShouldThrow<ArgumentNullException>().And
+            policy.Should().Throw<ArgumentNullException>().And
                   .ParamName.Should().Be("onRetry");
         }
 
@@ -801,7 +801,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetry(0, retryAttempt => TimeSpan.FromSeconds(1), onRetry);
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             retryInvoked.Should().BeFalse();
         }
@@ -818,7 +818,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetry(0, retryAttempt => TimeSpan.FromSeconds(1), onRetry);
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             retryInvoked.Should().BeFalse();
         }
@@ -835,7 +835,7 @@ namespace Polly.Specs.Retry
                 .WaitAndRetry(0, retryAttempt => TimeSpan.FromSeconds(1), onRetry);
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldThrow<DivideByZeroException>();
+                  .Should().Throw<DivideByZeroException>();
 
             retryInvoked.Should().BeFalse();
         }
@@ -864,7 +864,7 @@ namespace Polly.Specs.Retry
             cancellationTokenSource.Cancel();
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(0);
@@ -891,7 +891,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -918,7 +918,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -945,7 +945,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -972,7 +972,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(2);
@@ -999,7 +999,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(2);
@@ -1026,7 +1026,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1 + 3);
@@ -1053,7 +1053,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
 
             attemptsInvoked.Should().Be(1 + 3);
         }
@@ -1089,7 +1089,7 @@ namespace Polly.Specs.Retry
             cancellationTokenSource.CancelAfter(shimTimeSpan);
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                    .ShouldThrow<OperationCanceledException>()
+                    .Should().Throw<OperationCanceledException>()
                     .And.CancellationToken.Should().Be(cancellationToken);
             watch.Stop();
 
@@ -1124,7 +1124,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .ShouldThrow<OperationCanceledException>()
+                .Should().Throw<OperationCanceledException>()
                 .And.CancellationToken.Should().Be(cancellationToken);
 
             attemptsInvoked.Should().Be(1);
@@ -1182,7 +1182,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Invoking(x => result = x.RaiseExceptionAndOrCancellation<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true))
-                .ShouldThrow<OperationCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
+                .Should().Throw<OperationCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
 
             result.Should().Be(null);
 

--- a/src/Polly.Specs/Retry/WaitAndRetrySpecs.cs
+++ b/src/Polly.Specs/Retry/WaitAndRetrySpecs.cs
@@ -111,7 +111,7 @@ namespace Polly.Specs.Retry
                 });
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>(3))
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -128,7 +128,7 @@ namespace Polly.Specs.Retry
                 });
 
             policy.Invoking(x => x.RaiseException<ArgumentException>(3))
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -144,7 +144,7 @@ namespace Polly.Specs.Retry
                 });
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>(2))
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -161,7 +161,7 @@ namespace Polly.Specs.Retry
                 });
 
             policy.Invoking(x => x.RaiseException<ArgumentException>(2))
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -277,7 +277,7 @@ namespace Polly.Specs.Retry
                 });
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -291,7 +291,7 @@ namespace Polly.Specs.Retry
                 });
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -306,7 +306,7 @@ namespace Polly.Specs.Retry
                 });
 
             policy.Invoking(x => x.RaiseException<ArgumentException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -321,7 +321,7 @@ namespace Polly.Specs.Retry
                 });
 
             policy.Awaiting(async x => await x.RaiseExceptionAsync<ArgumentException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -507,10 +507,10 @@ namespace Polly.Specs.Retry
                 });
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
 
             policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-                  .ShouldNotThrow();
+                  .Should().NotThrow();
         }
 
         [Fact]
@@ -1152,7 +1152,7 @@ namespace Polly.Specs.Retry
             };
 
             policy.Invoking(x => result = x.RaiseExceptionAndOrCancellation<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true))
-                .ShouldNotThrow();
+                .Should().NotThrow();
 
             result.Should().BeTrue();
 

--- a/src/Polly.Specs/Retry/WaitAndRetryTResultAsyncSpecs.cs
+++ b/src/Polly.Specs/Retry/WaitAndRetryTResultAsyncSpecs.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using Polly.Specs.Helpers;
 using Polly.Utilities;
 using Xunit;
+using FluentAssertions.Extensions;
 
 namespace Polly.Specs.Retry
 {

--- a/src/Polly.Specs/Retry/WaitAndRetryTResultSpecs.cs
+++ b/src/Polly.Specs/Retry/WaitAndRetryTResultSpecs.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Polly.Specs.Helpers;
 using Polly.Utilities;
 using Xunit;

--- a/src/Polly.Specs/Timeout/TimeoutAsyncSpecs.cs
+++ b/src/Polly.Specs/Timeout/TimeoutAsyncSpecs.cs
@@ -56,7 +56,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.TimeoutAsync(TimeSpan.FromMilliseconds(1));
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -64,7 +64,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.TimeoutAsync(3);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.TimeoutAsync(TimeSpan.MaxValue);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -80,7 +80,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.TimeoutAsync(int.MaxValue);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -88,7 +88,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.TimeoutAsync(System.Threading.Timeout.InfiniteTimeSpan);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -96,7 +96,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.TimeoutAsync(System.Threading.Timeout.InfiniteTimeSpan, TimeoutStrategy.Optimistic);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -105,7 +105,7 @@ namespace Polly.Specs.Timeout
             Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.EmptyTask;
             Action policy = () => Policy.TimeoutAsync(System.Threading.Timeout.InfiniteTimeSpan, doNothingAsync);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -114,7 +114,7 @@ namespace Polly.Specs.Timeout
             Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.EmptyTask;
             Action policy = () => Policy.TimeoutAsync(System.Threading.Timeout.InfiniteTimeSpan, TimeoutStrategy.Optimistic, doNothingAsync);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -191,7 +191,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.TimeoutAsync(() => TimeSpan.FromSeconds(1));
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         #endregion
@@ -225,7 +225,7 @@ namespace Polly.Specs.Timeout
                     .ConfigureAwait(false);
             };
 
-            act.ShouldNotThrow();
+            act.Should().NotThrow();
             result.Should().Be(ResultPrimitive.Good);
         }
 

--- a/src/Polly.Specs/Timeout/TimeoutAsyncSpecs.cs
+++ b/src/Polly.Specs/Timeout/TimeoutAsyncSpecs.cs
@@ -20,7 +20,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.TimeoutAsync(TimeSpan.Zero);
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                 .ParamName.Should().Be("timeout");
         }
 
@@ -29,7 +29,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.TimeoutAsync(0);
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                 .ParamName.Should().Be("seconds");
         }
 
@@ -38,7 +38,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.TimeoutAsync(-TimeSpan.FromHours(1));
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                 .ParamName.Should().Be("timeout");
         }
 
@@ -47,7 +47,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.TimeoutAsync(-10);
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                 .ParamName.Should().Be("seconds");
         }
 
@@ -123,7 +123,7 @@ namespace Polly.Specs.Timeout
             Func<Context, TimeSpan, Task, Task> onTimeout = null;
             Action policy = () => Policy.TimeoutAsync(TimeSpan.FromMinutes(0.5), onTimeout);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeoutAsync");
         }
 
@@ -133,7 +133,7 @@ namespace Polly.Specs.Timeout
             Func<Context, TimeSpan, Task, Exception, Task> onTimeout = null;
             Action policy = () => Policy.TimeoutAsync(TimeSpan.FromMinutes(0.5), onTimeout);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeoutAsync");
         }
 
@@ -143,7 +143,7 @@ namespace Polly.Specs.Timeout
             Func<Context, TimeSpan, Task, Task> onTimeout = null;
             Action policy = () => Policy.TimeoutAsync(30, onTimeout);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeoutAsync");
         }
 
@@ -153,7 +153,7 @@ namespace Polly.Specs.Timeout
             Func<Context, TimeSpan, Task, Exception, Task> onTimeout = null;
             Action policy = () => Policy.TimeoutAsync(30, onTimeout);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeoutAsync");
         }
 
@@ -162,7 +162,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.TimeoutAsync((Func<TimeSpan>)null);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("timeoutProvider");
         }
 
@@ -172,7 +172,7 @@ namespace Polly.Specs.Timeout
             Func<Context, TimeSpan, Task, Task> onTimeout = null;
             Action policy = () => Policy.TimeoutAsync(() => TimeSpan.FromSeconds(30), onTimeout);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeoutAsync");
         }
 
@@ -182,7 +182,7 @@ namespace Polly.Specs.Timeout
             Func<Context, TimeSpan, Task, Exception, Task> onTimeout = null;
             Action policy = () => Policy.TimeoutAsync(() => TimeSpan.FromSeconds(30), onTimeout);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeoutAsync");
         }
 
@@ -209,7 +209,7 @@ namespace Polly.Specs.Timeout
             {
                 await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
 
-            })).ShouldThrow<TimeoutRejectedException>();
+            })).Should().Throw<TimeoutRejectedException>();
         }
 
         [Fact]
@@ -245,7 +245,7 @@ namespace Polly.Specs.Timeout
                 await SystemClock.SleepAsync(TimeSpan.FromSeconds(10), CancellationToken.None).ConfigureAwait(false);
 
             }))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
             watch.Stop();
 
             watch.Elapsed.Should().BeCloseTo(timeout, ((int)tolerance.TotalMilliseconds));
@@ -256,7 +256,7 @@ namespace Polly.Specs.Timeout
         {
             var policy = Policy.TimeoutAsync(TimeSpan.FromSeconds(10), TimeoutStrategy.Pessimistic);
 
-            policy.Awaiting(p => p.ExecuteAsync(() => { throw new NotImplementedException(); })).ShouldThrow<NotImplementedException>();
+            policy.Awaiting(p => p.ExecuteAsync(() => { throw new NotImplementedException(); })).Should().Throw<NotImplementedException>();
         }
 
         #endregion
@@ -277,7 +277,7 @@ namespace Polly.Specs.Timeout
                 await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
                 
             }, userCancellationToken).ConfigureAwait(false))
-            .ShouldThrow<TimeoutRejectedException>();
+            .Should().Throw<TimeoutRejectedException>();
         }
 
         [Fact]
@@ -317,7 +317,7 @@ namespace Polly.Specs.Timeout
                 await SystemClock.SleepAsync(TimeSpan.FromSeconds(10), ct).ConfigureAwait(false);
                 
             }, userCancellationToken).ConfigureAwait(false))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
             watch.Stop();
 
             watch.Elapsed.Should().BeCloseTo(timeout, ((int)tolerance.TotalMilliseconds));
@@ -328,7 +328,7 @@ namespace Polly.Specs.Timeout
         {
             var policy = Policy.TimeoutAsync(TimeSpan.FromSeconds(10), TimeoutStrategy.Optimistic);
 
-            policy.Awaiting(p => p.ExecuteAsync(() => { throw new NotImplementedException(); })).ShouldThrow<NotImplementedException>();
+            policy.Awaiting(p => p.ExecuteAsync(() => { throw new NotImplementedException(); })).Should().Throw<NotImplementedException>();
         }
 
         #endregion
@@ -350,7 +350,7 @@ namespace Polly.Specs.Timeout
                             CancellationToken.None // ... but if the executed delegate does not observe it
                             ).ConfigureAwait(false); 
                     }, userTokenSource.Token)
-                   ).ShouldThrow<TimeoutRejectedException>(); // ... it's still the timeout we expect.
+                   ).Should().Throw<TimeoutRejectedException>(); // ... it's still the timeout we expect.
             }
         }
 
@@ -370,7 +370,7 @@ namespace Polly.Specs.Timeout
                     executed = true;
                     return TaskHelper.EmptyTask;
                 }, cts.Token))
-                .ShouldThrow<OperationCanceledException>();
+                .Should().Throw<OperationCanceledException>();
             }
 
             executed.Should().BeFalse();
@@ -393,7 +393,7 @@ namespace Polly.Specs.Timeout
                         userTokenSource.Cancel(); ct.ThrowIfCancellationRequested();   // Simulate cancel in the middle of execution
                         return TaskHelper.EmptyTask;
                     }, userTokenSource.Token) // ... with user token.
-                   ).ShouldThrow<OperationCanceledException>();
+                   ).Should().Throw<OperationCanceledException>();
             }
         }
 
@@ -413,7 +413,7 @@ namespace Polly.Specs.Timeout
                     executed = true;
                     return TaskHelper.EmptyTask;
                 }, cts.Token))
-                .ShouldThrow<OperationCanceledException>();
+                .Should().Throw<OperationCanceledException>();
             }
 
             executed.Should().BeFalse();
@@ -442,7 +442,7 @@ namespace Polly.Specs.Timeout
                 await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
                 
             }))
-            .ShouldThrow<TimeoutRejectedException>();
+            .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutPassedToConfiguration);
         }
@@ -468,7 +468,7 @@ namespace Polly.Specs.Timeout
                     await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
                 
                 }, contextPassedToExecute))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             contextPassedToOnTimeout.Should().NotBeNull();
             contextPassedToOnTimeout.OperationKey.Should().Be(operationKey);
@@ -496,7 +496,7 @@ namespace Polly.Specs.Timeout
             {
                 await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
             }))
-            .ShouldThrow<TimeoutRejectedException>();
+            .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutFunc());
         }
@@ -525,7 +525,7 @@ namespace Polly.Specs.Timeout
             {
                 await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
             }, context))
-            .ShouldThrow<TimeoutRejectedException>();
+            .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutProvider(context));
         }
@@ -547,7 +547,7 @@ namespace Polly.Specs.Timeout
             {
                 await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
             }))
-            .ShouldThrow<TimeoutRejectedException>();
+            .Should().Throw<TimeoutRejectedException>();
 
             taskPassedToOnTimeout.Should().NotBeNull();
         }
@@ -577,7 +577,7 @@ namespace Polly.Specs.Timeout
                 await SystemClock.SleepAsync(thriceShimTimeSpan, CancellationToken.None).ConfigureAwait(false);
                 throw exceptionToThrow;
             }))
-            .ShouldThrow<TimeoutRejectedException>();
+            .Should().Throw<TimeoutRejectedException>();
 
             await SystemClock.SleepAsync(thriceShimTimeSpan, CancellationToken.None).ConfigureAwait(false);
             exceptionObservedFromTaskPassedToOnTimeout.Should().NotBeNull();
@@ -604,7 +604,7 @@ namespace Polly.Specs.Timeout
                     await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
 
                 }))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             exceptionPassedToOnTimeout.Should().NotBeNull();
             exceptionPassedToOnTimeout.Should().BeOfType(typeof(OperationCanceledException));
@@ -634,7 +634,7 @@ namespace Polly.Specs.Timeout
                 await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
 
             }, userCancellationToken).ConfigureAwait(false))
-            .ShouldThrow<TimeoutRejectedException>();
+            .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutPassedToConfiguration);
         }
@@ -661,7 +661,7 @@ namespace Polly.Specs.Timeout
                     await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
 
                 }, contextPassedToExecute, userCancellationToken).ConfigureAwait(false))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             contextPassedToOnTimeout.Should().NotBeNull();
             contextPassedToOnTimeout.OperationKey.Should().Be(operationKey);
@@ -691,7 +691,7 @@ namespace Polly.Specs.Timeout
                     await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
 
                 }, userCancellationToken).ConfigureAwait(false))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutFunc());
         }
@@ -725,7 +725,7 @@ namespace Polly.Specs.Timeout
                 await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
 
             }, context, userCancellationToken).ConfigureAwait(false))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutProvider(context));
         }
@@ -749,7 +749,7 @@ namespace Polly.Specs.Timeout
                 await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
 
             }, userCancellationToken).ConfigureAwait(false))
-            .ShouldThrow<TimeoutRejectedException>();
+            .Should().Throw<TimeoutRejectedException>();
 
             taskPassedToOnTimeout.Should().BeNull();
         }
@@ -774,7 +774,7 @@ namespace Polly.Specs.Timeout
                 await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
 
             }, userCancellationToken).ConfigureAwait(false))
-            .ShouldThrow<TimeoutRejectedException>();
+            .Should().Throw<TimeoutRejectedException>();
 
             exceptionPassedToOnTimeout.Should().NotBeNull();
             exceptionPassedToOnTimeout.Should().BeOfType(typeof(OperationCanceledException));

--- a/src/Polly.Specs/Timeout/TimeoutAsyncSpecs.cs
+++ b/src/Polly.Specs/Timeout/TimeoutAsyncSpecs.cs
@@ -296,7 +296,7 @@ namespace Polly.Specs.Timeout
                     .ConfigureAwait(false);
             };
             
-            act.ShouldNotThrow<TimeoutRejectedException>();
+            act.Should().NotThrow<TimeoutRejectedException>();
             result.Should().Be(ResultPrimitive.Good);
         }
 

--- a/src/Polly.Specs/Timeout/TimeoutSpecs.cs
+++ b/src/Polly.Specs/Timeout/TimeoutSpecs.cs
@@ -20,7 +20,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.Timeout(TimeSpan.Zero);
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                 .ParamName.Should().Be("timeout");
         }
 
@@ -29,7 +29,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.Timeout(0);
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                 .ParamName.Should().Be("seconds");
         }
 
@@ -38,7 +38,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.Timeout(-TimeSpan.FromHours(1));
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                 .ParamName.Should().Be("timeout");
         }
 
@@ -47,7 +47,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.Timeout(-10);
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                 .ParamName.Should().Be("seconds");
         }
 
@@ -141,7 +141,7 @@ namespace Polly.Specs.Timeout
             Action<Context, TimeSpan, Task> onTimeout = null;
             Action policy = () => Policy.Timeout(TimeSpan.FromMinutes(0.5), onTimeout);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeout");
         }
 
@@ -151,7 +151,7 @@ namespace Polly.Specs.Timeout
             Action<Context, TimeSpan, Task, Exception> onTimeout = null;
             Action policy = () => Policy.Timeout(TimeSpan.FromMinutes(0.5), onTimeout);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeout");
         }
 
@@ -161,7 +161,7 @@ namespace Polly.Specs.Timeout
             Action<Context, TimeSpan, Task> onTimeout = null;
             Action policy = () => Policy.Timeout(30, onTimeout);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeout");
         }
 
@@ -171,7 +171,7 @@ namespace Polly.Specs.Timeout
             Action<Context, TimeSpan, Task, Exception> onTimeout = null;
             Action policy = () => Policy.Timeout(30, onTimeout);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeout");
         }
 
@@ -180,7 +180,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.Timeout((Func<TimeSpan>)null);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("timeoutProvider");
         }
 
@@ -190,7 +190,7 @@ namespace Polly.Specs.Timeout
             Action<Context, TimeSpan, Task> onTimeout = null;
             Action policy = () => Policy.Timeout(() => TimeSpan.FromSeconds(30), onTimeout);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeout");
         }
 
@@ -200,7 +200,7 @@ namespace Polly.Specs.Timeout
             Action<Context, TimeSpan, Task, Exception> onTimeout = null;
             Action policy = () => Policy.Timeout(() => TimeSpan.FromSeconds(30), onTimeout);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeout");
         }
 
@@ -222,7 +222,7 @@ namespace Polly.Specs.Timeout
             var policy = Policy.Timeout(TimeSpan.FromMilliseconds(50), TimeoutStrategy.Pessimistic);
 
             policy.Invoking(p => p.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None)))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
         }
 
         [Fact]
@@ -257,7 +257,7 @@ namespace Polly.Specs.Timeout
 
             watch.Start();
             policy.Invoking(p => p.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(10), CancellationToken.None)))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
             watch.Stop();
 
             watch.Elapsed.Should().BeCloseTo(timeout, ((int)tolerance.TotalMilliseconds));
@@ -268,7 +268,7 @@ namespace Polly.Specs.Timeout
         {
             var policy = Policy.Timeout(TimeSpan.FromSeconds(10), TimeoutStrategy.Pessimistic);
 
-            policy.Invoking(p => p.Execute(() => { throw new NotImplementedException(); })).ShouldThrow<NotImplementedException>();
+            policy.Invoking(p => p.Execute(() => { throw new NotImplementedException(); })).Should().Throw<NotImplementedException>();
         }
 
         [Fact]
@@ -281,7 +281,7 @@ namespace Polly.Specs.Timeout
             AggregateException exception = new AggregateException(msg, new NotImplementedException());
 
             policy.Invoking(p => p.Execute(() => { Helper_ThrowException(exception); }))
-                .ShouldThrow<AggregateException>()
+                .Should().Throw<AggregateException>()
                 .WithMessage(exception.Message)
                 .WithInnerException<NotImplementedException>()
                 .And.StackTrace.Should().Contain(nameof(Helper_ThrowException));
@@ -299,11 +299,11 @@ namespace Polly.Specs.Timeout
             Action action = () => { throw aggregateException; };
 
             // Whether executing the delegate directly, or through the policy, exception behavior should be the same.
-            action.ShouldThrow<AggregateException>()
+            action.Should().Throw<AggregateException>()
                 .WithMessage(aggregateException.Message)
                 .And.InnerExceptions.Should().BeEquivalentTo<Exception>(new[] { innerException1, innerException2 });
 
-            policy.Invoking(p => p.Execute(action)).ShouldThrow<AggregateException>()
+            policy.Invoking(p => p.Execute(action)).Should().Throw<AggregateException>()
                 .WithMessage(aggregateException.Message)
                 .And.InnerExceptions.Should().BeEquivalentTo<Exception>(new[] { innerException1, innerException2 });
         }
@@ -323,10 +323,10 @@ namespace Polly.Specs.Timeout
             };
 
             // Whether executing the delegate directly, or through the policy, exception behavior should be the same.
-            action.ShouldThrow<AggregateException>()
+            action.Should().Throw<AggregateException>()
                 .And.InnerExceptions.Should().BeEquivalentTo<Exception>(new[] { innerException1, innerException2 });
 
-            policy.Invoking(p => p.Execute(action)).ShouldThrow<AggregateException>()
+            policy.Invoking(p => p.Execute(action)).Should().Throw<AggregateException>()
                 .And.InnerExceptions.Should().BeEquivalentTo<Exception>(new[] { innerException1, innerException2 });
         }
 
@@ -345,10 +345,10 @@ namespace Polly.Specs.Timeout
             };
 
             // Whether executing the delegate directly, or through the policy, exception behavior should be the same.
-            action.ShouldThrow<AggregateException>()
+            action.Should().Throw<AggregateException>()
                 .And.InnerExceptions.Should().BeEquivalentTo<Exception>(new[] { innerException1, innerException2 });
 
-            policy.Invoking(p => p.Execute(action)).ShouldThrow<AggregateException>()
+            policy.Invoking(p => p.Execute(action)).Should().Throw<AggregateException>()
                 .And.InnerExceptions.Should().BeEquivalentTo<Exception>(new[] { innerException1, innerException2 });
         }
 
@@ -363,7 +363,7 @@ namespace Polly.Specs.Timeout
             var userCancellationToken = CancellationToken.None;
 
             policy.Invoking(p => p.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(3), ct), userCancellationToken)) // Delegate observes cancellation token, so permitting optimistic cancellation. 
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
         }
 
         [Fact]
@@ -398,7 +398,7 @@ namespace Polly.Specs.Timeout
 
             watch.Start();
             policy.Invoking(p => p.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(10), ct), userCancellationToken)) // Delegate observes cancellation token, so permitting optimistic cancellation. 
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
             watch.Stop();
 
             watch.Elapsed.Should().BeCloseTo(timeout, ((int)tolerance.TotalMilliseconds));
@@ -409,7 +409,7 @@ namespace Polly.Specs.Timeout
         {
             var policy = Policy.Timeout(TimeSpan.FromSeconds(10), TimeoutStrategy.Optimistic);
 
-            policy.Invoking(p => p.Execute(() => { throw new NotImplementedException(); })).ShouldThrow<NotImplementedException>();
+            policy.Invoking(p => p.Execute(() => { throw new NotImplementedException(); })).Should().Throw<NotImplementedException>();
         }
 
         #endregion
@@ -433,7 +433,7 @@ namespace Polly.Specs.Timeout
                             );
                     }
                     , userTokenSource.Token)
-                   ).ShouldThrow<TimeoutRejectedException>(); // ... it's still the timeout we expect.
+                   ).Should().Throw<TimeoutRejectedException>(); // ... it's still the timeout we expect.
             }
         }
 
@@ -449,7 +449,7 @@ namespace Polly.Specs.Timeout
                 cts.Cancel();
 
                 policy.Invoking(p => p.Execute(ct => { executed = true; }, cts.Token))
-                    .ShouldThrow<OperationCanceledException>();
+                    .Should().Throw<OperationCanceledException>();
             }
 
             executed.Should().BeFalse();
@@ -470,7 +470,7 @@ namespace Polly.Specs.Timeout
                 policy.Invoking(p => p.Execute(
                     ct => { userTokenSource.Cancel(); ct.ThrowIfCancellationRequested(); } // Simulate cancel in the middle of execution
                     , userTokenSource.Token) // ... with user token.
-                   ).ShouldThrow<OperationCanceledException>(); // Not a TimeoutRejectedException; i.e. policy can distinguish user cancellation from timeout cancellation.
+                   ).Should().Throw<OperationCanceledException>(); // Not a TimeoutRejectedException; i.e. policy can distinguish user cancellation from timeout cancellation.
             }
         }
 
@@ -486,7 +486,7 @@ namespace Polly.Specs.Timeout
                 cts.Cancel();
 
                 policy.Invoking(p => p.Execute(ct => { executed = true; }, cts.Token))
-                    .ShouldThrow<OperationCanceledException>();
+                    .Should().Throw<OperationCanceledException>();
             }
 
             executed.Should().BeFalse();
@@ -507,7 +507,7 @@ namespace Polly.Specs.Timeout
             var policy = Policy.Timeout(timeoutPassedToConfiguration, TimeoutStrategy.Pessimistic, onTimeout);
 
             policy.Invoking(p => p.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None)))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutPassedToConfiguration);
         }
@@ -525,7 +525,7 @@ namespace Polly.Specs.Timeout
             var policy = Policy.Timeout(timeout, TimeoutStrategy.Pessimistic, onTimeout);
 
             policy.Invoking(p => p.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None), contextPassedToExecute))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             contextPassedToOnTimeout.Should().NotBeNull();
             contextPassedToOnTimeout.OperationKey.Should().Be(operationKey);
@@ -546,7 +546,7 @@ namespace Polly.Specs.Timeout
             var policy = Policy.Timeout(timeoutFunc, TimeoutStrategy.Pessimistic, onTimeout);
 
             policy.Invoking(p => p.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None)))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutFunc());
         }
@@ -567,7 +567,7 @@ namespace Polly.Specs.Timeout
             Context context = new Context("SomeOperationKey") {["timeout"] = TimeSpan.FromMilliseconds(25* programaticallyControlledDelay) };
 
             policy.Invoking(p => p.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None), context))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutProvider(context));
         }
@@ -582,7 +582,7 @@ namespace Polly.Specs.Timeout
             var policy = Policy.Timeout(timeout, TimeoutStrategy.Pessimistic, onTimeout);
 
             policy.Invoking(p => p.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None)))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             taskPassedToOnTimeout.Should().NotBeNull();
         }
@@ -611,7 +611,7 @@ namespace Polly.Specs.Timeout
                 SystemClock.Sleep(thriceShimTimeSpan, CancellationToken.None);
                 throw exceptionToThrow;
             }))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             SystemClock.Sleep(thriceShimTimeSpan, CancellationToken.None);
             exceptionObservedFromTaskPassedToOnTimeout.Should().NotBeNull();
@@ -630,7 +630,7 @@ namespace Polly.Specs.Timeout
             var policy = Policy.Timeout(timeoutPassedToConfiguration, TimeoutStrategy.Pessimistic, onTimeout);
 
             policy.Invoking(p => p.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None)))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             exceptionPassedToOnTimeout.Should().NotBeNull();
             exceptionPassedToOnTimeout.Should().BeOfType(typeof(OperationCanceledException));
@@ -652,7 +652,7 @@ namespace Polly.Specs.Timeout
             var userCancellationToken = CancellationToken.None;
 
             policy.Invoking(p => p.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(1), ct), userCancellationToken))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutPassedToConfiguration);
         }
@@ -671,7 +671,7 @@ namespace Polly.Specs.Timeout
             var userCancellationToken = CancellationToken.None;
 
             policy.Invoking(p => p.Execute((ctx, ct) => SystemClock.Sleep(TimeSpan.FromSeconds(3), ct), contextPassedToExecute, userCancellationToken))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             contextPassedToOnTimeout.Should().NotBeNull();
             contextPassedToOnTimeout.OperationKey.Should().Be(operationKey);
@@ -693,7 +693,7 @@ namespace Polly.Specs.Timeout
             var userCancellationToken = CancellationToken.None;
 
             policy.Invoking(p => p.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(3), ct), userCancellationToken))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutFunc());
         }
@@ -719,7 +719,7 @@ namespace Polly.Specs.Timeout
             };
 
             policy.Invoking(p => p.Execute((ctx, ct) => SystemClock.Sleep(TimeSpan.FromSeconds(3), ct), context, userCancellationToken))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutProvider(context));
         }
@@ -735,7 +735,7 @@ namespace Polly.Specs.Timeout
             var userCancellationToken = CancellationToken.None;
 
             policy.Invoking(p => p.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(3), ct), userCancellationToken))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             taskPassedToOnTimeout.Should().BeNull();
         }
@@ -752,7 +752,7 @@ namespace Polly.Specs.Timeout
             var userCancellationToken = CancellationToken.None;
 
             policy.Invoking(p => p.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(1), ct), userCancellationToken))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             exceptionPassedToOnTimeout.Should().NotBeNull();
             exceptionPassedToOnTimeout.Should().BeOfType(typeof(OperationCanceledException));

--- a/src/Polly.Specs/Timeout/TimeoutSpecs.cs
+++ b/src/Polly.Specs/Timeout/TimeoutSpecs.cs
@@ -56,7 +56,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.Timeout(TimeSpan.FromMilliseconds(1));
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -64,7 +64,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.Timeout(3);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.Timeout(TimeSpan.MaxValue);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -80,7 +80,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.Timeout(int.MaxValue);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -88,7 +88,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.Timeout(System.Threading.Timeout.InfiniteTimeSpan);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -96,7 +96,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.Timeout(System.Threading.Timeout.InfiniteTimeSpan, TimeoutStrategy.Optimistic);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -105,7 +105,7 @@ namespace Polly.Specs.Timeout
             Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
             Action policy = () => Policy.Timeout(System.Threading.Timeout.InfiniteTimeSpan, doNothing);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -114,7 +114,7 @@ namespace Polly.Specs.Timeout
             Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
             Action policy = () => Policy.Timeout(System.Threading.Timeout.InfiniteTimeSpan, doNothing);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -123,7 +123,7 @@ namespace Polly.Specs.Timeout
             Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
             Action policy = () => Policy.Timeout(System.Threading.Timeout.InfiniteTimeSpan, TimeoutStrategy.Optimistic, doNothing);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -132,7 +132,7 @@ namespace Polly.Specs.Timeout
             Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
             Action policy = () => Policy.Timeout(System.Threading.Timeout.InfiniteTimeSpan, TimeoutStrategy.Optimistic, doNothing);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -209,7 +209,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.Timeout(() => TimeSpan.FromSeconds(1));
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         #endregion

--- a/src/Polly.Specs/Timeout/TimeoutSpecs.cs
+++ b/src/Polly.Specs/Timeout/TimeoutSpecs.cs
@@ -241,7 +241,7 @@ namespace Polly.Specs.Timeout
                 }, userCancellationToken);
             };
 
-            act.ShouldNotThrow<TimeoutRejectedException>();
+            act.Should().NotThrow<TimeoutRejectedException>();
             result.Should().Be(ResultPrimitive.Good);
         }
 
@@ -381,7 +381,7 @@ namespace Polly.Specs.Timeout
                     }, userCancellationToken);
             };
 
-            act.ShouldNotThrow<TimeoutRejectedException>();
+            act.Should().NotThrow<TimeoutRejectedException>();
             result.Should().Be(ResultPrimitive.Good);
         }
 

--- a/src/Polly.Specs/Timeout/TimeoutSpecs.cs
+++ b/src/Polly.Specs/Timeout/TimeoutSpecs.cs
@@ -283,7 +283,7 @@ namespace Polly.Specs.Timeout
             policy.Invoking(p => p.Execute(() => { Helper_ThrowException(exception); }))
                 .Should().Throw<AggregateException>()
                 .WithMessage(exception.Message)
-                .WithInnerException<NotImplementedException>()
+                .Where(e => e.InnerException is NotImplementedException)
                 .And.StackTrace.Should().Contain(nameof(Helper_ThrowException));
         }
 

--- a/src/Polly.Specs/Timeout/TimeoutTResultAsyncSpecs.cs
+++ b/src/Polly.Specs/Timeout/TimeoutTResultAsyncSpecs.cs
@@ -56,7 +56,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(TimeSpan.FromMilliseconds(1));
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -64,7 +64,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(3);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(TimeSpan.MaxValue);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -80,7 +80,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(int.MaxValue);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -88,7 +88,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(System.Threading.Timeout.InfiniteTimeSpan);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -96,7 +96,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(System.Threading.Timeout.InfiniteTimeSpan, TimeoutStrategy.Optimistic);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -105,7 +105,7 @@ namespace Polly.Specs.Timeout
             Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.EmptyTask;
             Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(System.Threading.Timeout.InfiniteTimeSpan, doNothingAsync);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -114,7 +114,7 @@ namespace Polly.Specs.Timeout
             Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, __, ___) => TaskHelper.EmptyTask;
             Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(System.Threading.Timeout.InfiniteTimeSpan, TimeoutStrategy.Optimistic, doNothingAsync);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -192,7 +192,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(() => TimeSpan.FromSeconds(1));
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         #endregion
@@ -223,7 +223,7 @@ namespace Polly.Specs.Timeout
             Func<Task> act = async () => result = await policy.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good))
                     .ConfigureAwait(false);
 
-            act.ShouldNotThrow();
+            act.Should().NotThrow();
             result.Should().Be(ResultPrimitive.Good);
         }
 
@@ -285,7 +285,7 @@ namespace Polly.Specs.Timeout
             Func<Task> act = async () => result = await policy.ExecuteAsync(ct => Task.FromResult(ResultPrimitive.Good), userCancellationToken)
                 .ConfigureAwait(false);
             
-            act.ShouldNotThrow();
+            act.Should().NotThrow();
             result.Should().Be(ResultPrimitive.Good);
         }
 

--- a/src/Polly.Specs/Timeout/TimeoutTResultAsyncSpecs.cs
+++ b/src/Polly.Specs/Timeout/TimeoutTResultAsyncSpecs.cs
@@ -20,7 +20,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(TimeSpan.Zero);
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                 .ParamName.Should().Be("timeout");
         }
 
@@ -29,7 +29,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(0);
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                 .ParamName.Should().Be("seconds");
         }
 
@@ -38,7 +38,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(-TimeSpan.FromHours(1));
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                 .ParamName.Should().Be("timeout");
         }
 
@@ -47,7 +47,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(-10);
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                 .ParamName.Should().Be("seconds");
         }
 
@@ -123,7 +123,7 @@ namespace Polly.Specs.Timeout
             Func<Context, TimeSpan, Task, Task> onTimeout = null;
             Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(TimeSpan.FromMinutes(0.5), onTimeout);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeoutAsync");
         }
 
@@ -133,7 +133,7 @@ namespace Polly.Specs.Timeout
             Func<Context, TimeSpan, Task, Exception, Task> onTimeout = null;
             Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(TimeSpan.FromMinutes(0.5), onTimeout);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeoutAsync");
         }
 
@@ -143,7 +143,7 @@ namespace Polly.Specs.Timeout
             Func<Context, TimeSpan, Task, Task> onTimeout = null;
             Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(30, onTimeout);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeoutAsync");
         }
 
@@ -154,7 +154,7 @@ namespace Polly.Specs.Timeout
             Func<Context, TimeSpan, Task, Exception, Task> onTimeout = null;
             Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(30, onTimeout);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeoutAsync");
         }
 
@@ -163,7 +163,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.TimeoutAsync<ResultPrimitive>((Func<TimeSpan>)null);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("timeoutProvider");
         }
 
@@ -173,7 +173,7 @@ namespace Polly.Specs.Timeout
             Func<Context, TimeSpan, Task, Task> onTimeoutAsync = null;
             Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(() => TimeSpan.FromSeconds(30), onTimeoutAsync);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeoutAsync");
         }
 
@@ -183,7 +183,7 @@ namespace Polly.Specs.Timeout
             Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = null;
             Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(() => TimeSpan.FromSeconds(30), onTimeoutAsync);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeoutAsync");
         }
 
@@ -210,7 +210,7 @@ namespace Polly.Specs.Timeout
             {
                 await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
                 return ResultPrimitive.WhateverButTooLate;
-            }).ConfigureAwait(false)).ShouldThrow<TimeoutRejectedException>();
+            }).ConfigureAwait(false)).Should().Throw<TimeoutRejectedException>();
         }
 
         [Fact]
@@ -243,7 +243,7 @@ namespace Polly.Specs.Timeout
                 await SystemClock.SleepAsync(TimeSpan.FromSeconds(10), CancellationToken.None).ConfigureAwait(false);
                 return ResultPrimitive.WhateverButTooLate;
             }))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
             watch.Stop();
 
             watch.Elapsed.Should().BeCloseTo(timeout, ((int)tolerance.TotalMilliseconds));
@@ -254,7 +254,7 @@ namespace Polly.Specs.Timeout
         {
             var policy = Policy.TimeoutAsync<ResultPrimitive>(TimeSpan.FromSeconds(10), TimeoutStrategy.Pessimistic);
 
-            policy.Awaiting(p => p.ExecuteAsync(() => { throw new NotImplementedException(); })).ShouldThrow<NotImplementedException>();
+            policy.Awaiting(p => p.ExecuteAsync(() => { throw new NotImplementedException(); })).Should().Throw<NotImplementedException>();
         }
 
         #endregion
@@ -271,7 +271,7 @@ namespace Polly.Specs.Timeout
             {
                 await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
                 return ResultPrimitive.WhateverButTooLate;
-            }, userCancellationToken).ConfigureAwait(false)).ShouldThrow<TimeoutRejectedException>();
+            }, userCancellationToken).ConfigureAwait(false)).Should().Throw<TimeoutRejectedException>();
         }
 
         [Fact]
@@ -306,7 +306,7 @@ namespace Polly.Specs.Timeout
                 await SystemClock.SleepAsync(TimeSpan.FromSeconds(10), ct).ConfigureAwait(false);
                 return ResultPrimitive.WhateverButTooLate;
             }, userCancellationToken).ConfigureAwait(false))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
             watch.Stop();
 
             watch.Elapsed.Should().BeCloseTo(timeout, ((int)tolerance.TotalMilliseconds));
@@ -317,7 +317,7 @@ namespace Polly.Specs.Timeout
         {
             var policy = Policy.TimeoutAsync<ResultPrimitive>(TimeSpan.FromSeconds(10), TimeoutStrategy.Optimistic);
 
-            policy.Awaiting(p => p.ExecuteAsync(() => { throw new NotImplementedException(); })).ShouldThrow<NotImplementedException>();
+            policy.Awaiting(p => p.ExecuteAsync(() => { throw new NotImplementedException(); })).Should().Throw<NotImplementedException>();
         }
 
         #endregion
@@ -340,7 +340,7 @@ namespace Polly.Specs.Timeout
                             ).ConfigureAwait(false);
                         return ResultPrimitive.WhateverButTooLate;
                     }, userTokenSource.Token)
-                   ).ShouldThrow<TimeoutRejectedException>(); // ... it's still the timeout we expect.
+                   ).Should().Throw<TimeoutRejectedException>(); // ... it's still the timeout we expect.
             }
         }
 
@@ -361,7 +361,7 @@ namespace Polly.Specs.Timeout
                     await TaskHelper.EmptyTask.ConfigureAwait(false);
                     return ResultPrimitive.WhateverButTooLate;
                 }, cts.Token))
-                .ShouldThrow<OperationCanceledException>();
+                .Should().Throw<OperationCanceledException>();
             }
 
             executed.Should().BeFalse();
@@ -383,7 +383,7 @@ namespace Polly.Specs.Timeout
                         userTokenSource.Cancel(); ct.ThrowIfCancellationRequested();   // Simulate cancel in the middle of execution
                         return Task.FromResult(ResultPrimitive.WhateverButTooLate);
                     }, userTokenSource.Token) // ... with user token.
-                   ).ShouldThrow<OperationCanceledException>();
+                   ).Should().Throw<OperationCanceledException>();
             }
         }
 
@@ -404,7 +404,7 @@ namespace Polly.Specs.Timeout
                     await TaskHelper.EmptyTask.ConfigureAwait(false);
                     return ResultPrimitive.WhateverButTooLate;
                 }, cts.Token))
-                .ShouldThrow<OperationCanceledException>();
+                .Should().Throw<OperationCanceledException>();
             }
 
             executed.Should().BeFalse();
@@ -433,7 +433,7 @@ namespace Polly.Specs.Timeout
                 await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
                 return ResultPrimitive.WhateverButTooLate;
             }))
-            .ShouldThrow<TimeoutRejectedException>();
+            .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutPassedToConfiguration);
         }
@@ -459,7 +459,7 @@ namespace Polly.Specs.Timeout
                     await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
                     return ResultPrimitive.WhateverButTooLate;
                 }, contextPassedToExecute))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             contextPassedToOnTimeout.Should().NotBeNull();
             contextPassedToOnTimeout.OperationKey.Should().Be(operationKey);
@@ -488,7 +488,7 @@ namespace Polly.Specs.Timeout
                     await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
                     return ResultPrimitive.WhateverButTooLate;
                 }))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutFunc());
         }
@@ -518,7 +518,7 @@ namespace Polly.Specs.Timeout
                 await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
                 return ResultPrimitive.WhateverButTooLate;
             }, context))
-            .ShouldThrow<TimeoutRejectedException>();
+            .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutProvider(context));
         }
@@ -541,7 +541,7 @@ namespace Polly.Specs.Timeout
                 await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
                 return ResultPrimitive.WhateverButTooLate;
             }))
-            .ShouldThrow<TimeoutRejectedException>();
+            .Should().Throw<TimeoutRejectedException>();
 
             taskPassedToOnTimeout.Should().NotBeNull();
         }
@@ -571,7 +571,7 @@ namespace Polly.Specs.Timeout
                 await SystemClock.SleepAsync(thriceShimTimeSpan, CancellationToken.None).ConfigureAwait(false);
                 throw exceptionToThrow;
             }))
-            .ShouldThrow<TimeoutRejectedException>();
+            .Should().Throw<TimeoutRejectedException>();
 
             await SystemClock.SleepAsync(thriceShimTimeSpan, CancellationToken.None).ConfigureAwait(false);
             exceptionObservedFromTaskPassedToOnTimeout.Should().NotBeNull();
@@ -598,7 +598,7 @@ namespace Polly.Specs.Timeout
                     await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken.None).ConfigureAwait(false);
                     return ResultPrimitive.WhateverButTooLate;
                 }))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             exceptionPassedToOnTimeout.Should().NotBeNull();
             exceptionPassedToOnTimeout.Should().BeOfType(typeof(OperationCanceledException));
@@ -628,7 +628,7 @@ namespace Polly.Specs.Timeout
                 await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
                 return ResultPrimitive.WhateverButTooLate;
             }, userCancellationToken).ConfigureAwait(false))
-            .ShouldThrow<TimeoutRejectedException>();
+            .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutPassedToConfiguration);
         }
@@ -655,7 +655,7 @@ namespace Polly.Specs.Timeout
                     await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
                     return ResultPrimitive.WhateverButTooLate;
                 }, contextPassedToExecute, userCancellationToken).ConfigureAwait(false))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             contextPassedToOnTimeout.Should().NotBeNull();
             contextPassedToOnTimeout.OperationKey.Should().Be(operationKey);
@@ -686,7 +686,7 @@ namespace Polly.Specs.Timeout
                     await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
                     return ResultPrimitive.WhateverButTooLate;
                 }, userCancellationToken).ConfigureAwait(false))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutFunc());
         }
@@ -720,7 +720,7 @@ namespace Polly.Specs.Timeout
                 await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
                 return ResultPrimitive.WhateverButTooLate;
             }, context, userCancellationToken).ConfigureAwait(false))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutProvider(context));
         }
@@ -744,7 +744,7 @@ namespace Polly.Specs.Timeout
                 await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
                 return ResultPrimitive.WhateverButTooLate;
             }, userCancellationToken).ConfigureAwait(false))
-            .ShouldThrow<TimeoutRejectedException>();
+            .Should().Throw<TimeoutRejectedException>();
 
             taskPassedToOnTimeout.Should().BeNull();
         }
@@ -769,7 +769,7 @@ namespace Polly.Specs.Timeout
                     await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
                     return ResultPrimitive.WhateverButTooLate;
                 }, userCancellationToken).ConfigureAwait(false))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             exceptionPassedToOnTimeout.Should().NotBeNull();
             exceptionPassedToOnTimeout.Should().BeOfType(typeof(OperationCanceledException));

--- a/src/Polly.Specs/Timeout/TimeoutTResultSpecs.cs
+++ b/src/Polly.Specs/Timeout/TimeoutTResultSpecs.cs
@@ -274,7 +274,7 @@ namespace Polly.Specs.Timeout
             policy.Invoking(p => p.Execute(() => { Helper_ThrowException(exception); return ResultPrimitive.WhateverButTooLate; }))
                 .Should().Throw<AggregateException>()
                 .WithMessage(exception.Message)
-                .WithInnerException<NotImplementedException>()
+                .Where(e => e.InnerException is NotImplementedException)
                 .And.StackTrace.Should().Contain(nameof(Helper_ThrowException));
         }
 

--- a/src/Polly.Specs/Timeout/TimeoutTResultSpecs.cs
+++ b/src/Polly.Specs/Timeout/TimeoutTResultSpecs.cs
@@ -228,7 +228,7 @@ namespace Polly.Specs.Timeout
                 }, userCancellationToken);
             };
 
-            act.ShouldNotThrow<TimeoutRejectedException>();
+            act.Should().NotThrow<TimeoutRejectedException>();
             result.Should().Be(ResultPrimitive.Good);
         }
 
@@ -378,7 +378,7 @@ namespace Polly.Specs.Timeout
                 }, userCancellationToken);
             };
 
-            act.ShouldNotThrow<TimeoutRejectedException>();
+            act.Should().NotThrow<TimeoutRejectedException>();
             result.Should().Be(ResultPrimitive.Good);
         }
 

--- a/src/Polly.Specs/Timeout/TimeoutTResultSpecs.cs
+++ b/src/Polly.Specs/Timeout/TimeoutTResultSpecs.cs
@@ -288,10 +288,9 @@ namespace Polly.Specs.Timeout
             Exception innerException2 = new DivideByZeroException();
             AggregateException aggregateException = new AggregateException(msg, innerException1, innerException2);
             Func<ResultPrimitive> func = () => { Helper_ThrowException(aggregateException); return ResultPrimitive.WhateverButTooLate; };
-            Action action = () => { ResultPrimitive throwAway = func(); }; // Helper, because .ShouldThrow<>() does not exist in FluentAssertions on Func<T>.  See https://github.com/fluentassertions/fluentassertions/issues/422
 
             // Whether executing the delegate directly, or through the policy, exception behavior should be the same.
-            action.ShouldThrow<AggregateException>()
+            func.ShouldThrow<AggregateException>()
                 .WithMessage(aggregateException.Message)
                 .And.InnerExceptions.Should().BeEquivalentTo<Exception>(new[] { innerException1, innerException2 });
 
@@ -314,10 +313,9 @@ namespace Polly.Specs.Timeout
                 Task.WhenAll(task1, task2).Wait();
                 return ResultPrimitive.WhateverButTooLate;
             };
-            Action action = () => { ResultPrimitive throwAway = func(); }; // Helper, because .ShouldThrow<>() does not exist in FluentAssertions on Func<T>.  See https://github.com/fluentassertions/fluentassertions/issues/422
 
             // Whether executing the delegate directly, or through the policy, exception behavior should be the same.
-            action.ShouldThrow<AggregateException>()
+            func.ShouldThrow<AggregateException>()
                 .And.InnerExceptions.Should().BeEquivalentTo<Exception>(new[] { innerException1, innerException2 });
 
             policy.Invoking(p => p.Execute(func)).ShouldThrow<AggregateException>()
@@ -338,10 +336,9 @@ namespace Polly.Specs.Timeout
                 Parallel.Invoke(action1, action2);
                 return ResultPrimitive.WhateverButTooLate;
             };
-            Action action = () => { ResultPrimitive throwAway = func(); }; // Helper, because .ShouldThrow<>() does not exist in FluentAssertions on Func<T>.  See https://github.com/fluentassertions/fluentassertions/issues/422
 
             // Whether executing the delegate directly, or through the policy, exception behavior should be the same.
-            action.ShouldThrow<AggregateException>()
+            func.ShouldThrow<AggregateException>()
                 .And.InnerExceptions.Should().BeEquivalentTo<Exception>(new[] { innerException1, innerException2 });
 
             policy.Invoking(p => p.Execute(func)).ShouldThrow<AggregateException>()

--- a/src/Polly.Specs/Timeout/TimeoutTResultSpecs.cs
+++ b/src/Polly.Specs/Timeout/TimeoutTResultSpecs.cs
@@ -56,7 +56,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.Timeout<ResultPrimitive>(TimeSpan.FromMilliseconds(1));
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -64,7 +64,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.Timeout<ResultPrimitive>(3);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.Timeout<ResultPrimitive>(TimeSpan.MaxValue);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -80,7 +80,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.Timeout<ResultPrimitive>(int.MaxValue);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -88,7 +88,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.Timeout<ResultPrimitive>(System.Threading.Timeout.InfiniteTimeSpan);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -96,7 +96,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.Timeout<ResultPrimitive>(System.Threading.Timeout.InfiniteTimeSpan, TimeoutStrategy.Optimistic);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -105,7 +105,7 @@ namespace Polly.Specs.Timeout
             Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
             Action policy = () => Policy.Timeout<ResultPrimitive>(System.Threading.Timeout.InfiniteTimeSpan, doNothing);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -114,7 +114,7 @@ namespace Polly.Specs.Timeout
             Action<Context, TimeSpan, Task> doNothing = (_, __, ___) => { };
             Action policy = () => Policy.Timeout<ResultPrimitive>(System.Threading.Timeout.InfiniteTimeSpan, TimeoutStrategy.Optimistic, doNothing);
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -191,7 +191,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.Timeout<ResultPrimitive>(() => TimeSpan.FromSeconds(1));
 
-            policy.ShouldNotThrow();
+            policy.Should().NotThrow();
         }
 
         #endregion

--- a/src/Polly.Specs/Timeout/TimeoutTResultSpecs.cs
+++ b/src/Polly.Specs/Timeout/TimeoutTResultSpecs.cs
@@ -20,7 +20,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.Timeout<ResultPrimitive>(TimeSpan.Zero);
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                 .ParamName.Should().Be("timeout");
         }
 
@@ -29,7 +29,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.Timeout<ResultPrimitive>(0);
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                 .ParamName.Should().Be("seconds");
         }
 
@@ -38,7 +38,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.Timeout<ResultPrimitive>(-TimeSpan.FromHours(1));
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                 .ParamName.Should().Be("timeout");
         }
 
@@ -47,7 +47,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.Timeout<ResultPrimitive>(-10);
 
-            policy.ShouldThrow<ArgumentOutOfRangeException>().And
+            policy.Should().Throw<ArgumentOutOfRangeException>().And
                 .ParamName.Should().Be("seconds");
         }
 
@@ -123,7 +123,7 @@ namespace Polly.Specs.Timeout
             Action<Context, TimeSpan, Task> onTimeout = null;
             Action policy = () => Policy.Timeout<ResultPrimitive>(TimeSpan.FromMinutes(0.5), onTimeout);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeout");
         }
 
@@ -133,7 +133,7 @@ namespace Polly.Specs.Timeout
             Action<Context, TimeSpan, Task, Exception> onTimeout = null;
             Action policy = () => Policy.Timeout<ResultPrimitive>(TimeSpan.FromMinutes(0.5), onTimeout);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeout");
         }
 
@@ -143,7 +143,7 @@ namespace Polly.Specs.Timeout
             Action<Context, TimeSpan, Task> onTimeout = null;
             Action policy = () => Policy.Timeout<ResultPrimitive>(30, onTimeout);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeout");
         }
 
@@ -153,7 +153,7 @@ namespace Polly.Specs.Timeout
             Action<Context, TimeSpan, Task, Exception> onTimeout = null;
             Action policy = () => Policy.Timeout<ResultPrimitive>(30, onTimeout);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeout");
         }
 
@@ -162,7 +162,7 @@ namespace Polly.Specs.Timeout
         {
             Action policy = () => Policy.Timeout<ResultPrimitive>((Func<TimeSpan>)null);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("timeoutProvider");
         }
 
@@ -172,7 +172,7 @@ namespace Polly.Specs.Timeout
             Action<Context, TimeSpan, Task> onTimeout = null;
             Action policy = () => Policy.Timeout<ResultPrimitive>(() => TimeSpan.FromSeconds(30), onTimeout);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeout");
         }
 
@@ -182,7 +182,7 @@ namespace Polly.Specs.Timeout
             Action<Context, TimeSpan, Task, Exception> onTimeout = null;
             Action policy = () => Policy.Timeout<ResultPrimitive>(() => TimeSpan.FromSeconds(30), onTimeout);
 
-            policy.ShouldThrow<ArgumentNullException>()
+            policy.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("onTimeout");
         }
 
@@ -209,7 +209,7 @@ namespace Polly.Specs.Timeout
             {
                 SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None);
                 return ResultPrimitive.WhateverButTooLate;
-            })).ShouldThrow<TimeoutRejectedException>();
+            })).Should().Throw<TimeoutRejectedException>();
         }
 
         [Fact]
@@ -248,7 +248,7 @@ namespace Polly.Specs.Timeout
                 SystemClock.Sleep(TimeSpan.FromSeconds(10), CancellationToken.None);
                 return ResultPrimitive.WhateverButTooLate;
             }))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
             watch.Stop();
 
             watch.Elapsed.Should().BeCloseTo(timeout, ((int)tolerance.TotalMilliseconds));
@@ -259,7 +259,7 @@ namespace Polly.Specs.Timeout
         {
             var policy = Policy.Timeout<ResultPrimitive>(TimeSpan.FromSeconds(10), TimeoutStrategy.Pessimistic);
 
-            policy.Invoking(p => p.Execute(() => { throw new NotImplementedException(); })).ShouldThrow<NotImplementedException>();
+            policy.Invoking(p => p.Execute(() => { throw new NotImplementedException(); })).Should().Throw<NotImplementedException>();
         }
 
         [Fact]
@@ -272,7 +272,7 @@ namespace Polly.Specs.Timeout
             AggregateException exception = new AggregateException(msg, new NotImplementedException());
 
             policy.Invoking(p => p.Execute(() => { Helper_ThrowException(exception); return ResultPrimitive.WhateverButTooLate; }))
-                .ShouldThrow<AggregateException>()
+                .Should().Throw<AggregateException>()
                 .WithMessage(exception.Message)
                 .WithInnerException<NotImplementedException>()
                 .And.StackTrace.Should().Contain(nameof(Helper_ThrowException));
@@ -290,11 +290,11 @@ namespace Polly.Specs.Timeout
             Func<ResultPrimitive> func = () => { Helper_ThrowException(aggregateException); return ResultPrimitive.WhateverButTooLate; };
 
             // Whether executing the delegate directly, or through the policy, exception behavior should be the same.
-            func.ShouldThrow<AggregateException>()
+            func.Should().Throw<AggregateException>()
                 .WithMessage(aggregateException.Message)
                 .And.InnerExceptions.Should().BeEquivalentTo<Exception>(new[] { innerException1, innerException2 });
 
-            policy.Invoking(p => p.Execute(func)).ShouldThrow<AggregateException>()
+            policy.Invoking(p => p.Execute(func)).Should().Throw<AggregateException>()
                 .WithMessage(aggregateException.Message)
                 .And.InnerExceptions.Should().BeEquivalentTo<Exception>(new[] { innerException1, innerException2 });
         }
@@ -315,10 +315,10 @@ namespace Polly.Specs.Timeout
             };
 
             // Whether executing the delegate directly, or through the policy, exception behavior should be the same.
-            func.ShouldThrow<AggregateException>()
+            func.Should().Throw<AggregateException>()
                 .And.InnerExceptions.Should().BeEquivalentTo<Exception>(new[] { innerException1, innerException2 });
 
-            policy.Invoking(p => p.Execute(func)).ShouldThrow<AggregateException>()
+            policy.Invoking(p => p.Execute(func)).Should().Throw<AggregateException>()
                 .And.InnerExceptions.Should().BeEquivalentTo<Exception>(new[] { innerException1, innerException2 });
         }
 
@@ -338,10 +338,10 @@ namespace Polly.Specs.Timeout
             };
 
             // Whether executing the delegate directly, or through the policy, exception behavior should be the same.
-            func.ShouldThrow<AggregateException>()
+            func.Should().Throw<AggregateException>()
                 .And.InnerExceptions.Should().BeEquivalentTo<Exception>(new[] { innerException1, innerException2 });
 
-            policy.Invoking(p => p.Execute(func)).ShouldThrow<AggregateException>()
+            policy.Invoking(p => p.Execute(func)).Should().Throw<AggregateException>()
                 .And.InnerExceptions.Should().BeEquivalentTo<Exception>(new[] { innerException1, innerException2 });
         }
 
@@ -360,7 +360,7 @@ namespace Polly.Specs.Timeout
                 SystemClock.Sleep(TimeSpan.FromSeconds(3), ct);
                 return ResultPrimitive.WhateverButTooLate;
             }, userCancellationToken))
-            .ShouldThrow<TimeoutRejectedException>();
+            .Should().Throw<TimeoutRejectedException>();
         }
 
         [Fact]
@@ -399,7 +399,7 @@ namespace Polly.Specs.Timeout
                 SystemClock.Sleep(TimeSpan.FromSeconds(10), ct);
                 return ResultPrimitive.WhateverButTooLate;
             }, userCancellationToken))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
             watch.Stop();
 
             watch.Elapsed.Should().BeCloseTo(timeout, ((int)tolerance.TotalMilliseconds));
@@ -410,7 +410,7 @@ namespace Polly.Specs.Timeout
         {
             var policy = Policy.Timeout<ResultPrimitive>(TimeSpan.FromSeconds(10), TimeoutStrategy.Optimistic);
 
-            policy.Invoking(p => p.Execute(() => { throw new NotImplementedException(); })).ShouldThrow<NotImplementedException>();
+            policy.Invoking(p => p.Execute(() => { throw new NotImplementedException(); })).Should().Throw<NotImplementedException>();
         }
 
         #endregion
@@ -433,7 +433,7 @@ namespace Polly.Specs.Timeout
                            );
                         return ResultPrimitive.WhateverButTooLate;
                     }, userTokenSource.Token) 
-                   ).ShouldThrow<TimeoutRejectedException>(); // ... it's still the timeout we expect.
+                   ).Should().Throw<TimeoutRejectedException>(); // ... it's still the timeout we expect.
             }
         }
 
@@ -453,7 +453,7 @@ namespace Polly.Specs.Timeout
                     executed = true;
                     return ResultPrimitive.WhateverButTooLate;
                 }, cts.Token))
-                .ShouldThrow<OperationCanceledException>();
+                .Should().Throw<OperationCanceledException>();
             }
 
             executed.Should().BeFalse();
@@ -475,7 +475,7 @@ namespace Polly.Specs.Timeout
                         userTokenSource.Cancel(); ct.ThrowIfCancellationRequested(); // Simulate cancel in the middle of execution
                         return ResultPrimitive.WhateverButTooLate;
                     }, userTokenSource.Token) // ... with user token.
-                   ).ShouldThrow<OperationCanceledException>(); // Not a TimeoutRejectedException; i.e. policy can distinguish user cancellation from timeout cancellation.
+                   ).Should().Throw<OperationCanceledException>(); // Not a TimeoutRejectedException; i.e. policy can distinguish user cancellation from timeout cancellation.
             }
         }
 
@@ -495,7 +495,7 @@ namespace Polly.Specs.Timeout
                     executed = true;
                     return ResultPrimitive.WhateverButTooLate;
                 }, cts.Token))
-                .ShouldThrow<OperationCanceledException>();
+                .Should().Throw<OperationCanceledException>();
             }
 
             executed.Should().BeFalse();
@@ -520,7 +520,7 @@ namespace Polly.Specs.Timeout
                 SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None);
                 return ResultPrimitive.WhateverButTooLate;
             }))
-            .ShouldThrow<TimeoutRejectedException>();
+            .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutPassedToConfiguration);
         }
@@ -542,7 +542,7 @@ namespace Polly.Specs.Timeout
                     SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None);
                     return ResultPrimitive.WhateverButTooLate;
                 }, contextPassedToExecute))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             contextPassedToOnTimeout.Should().NotBeNull();
             contextPassedToOnTimeout.OperationKey.Should().Be(operationKey);
@@ -568,7 +568,7 @@ namespace Polly.Specs.Timeout
                     SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None);
                     return ResultPrimitive.WhateverButTooLate;
                 }))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutFunc());
 
@@ -594,7 +594,7 @@ namespace Polly.Specs.Timeout
                     SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None);
                     return ResultPrimitive.WhateverButTooLate;
                 }, context))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutProvider(context));
         }
@@ -613,7 +613,7 @@ namespace Polly.Specs.Timeout
                 SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None);
                 return ResultPrimitive.WhateverButTooLate;
             }))
-            .ShouldThrow<TimeoutRejectedException>();
+            .Should().Throw<TimeoutRejectedException>();
 
             taskPassedToOnTimeout.Should().NotBeNull();
         }
@@ -642,7 +642,7 @@ namespace Polly.Specs.Timeout
                 SystemClock.Sleep(thriceShimTimeSpan, CancellationToken.None);
                 throw exceptionToThrow;
             }))
-            .ShouldThrow<TimeoutRejectedException>();
+            .Should().Throw<TimeoutRejectedException>();
 
             SystemClock.Sleep(thriceShimTimeSpan, CancellationToken.None);
             exceptionObservedFromTaskPassedToOnTimeout.Should().NotBeNull();
@@ -665,7 +665,7 @@ namespace Polly.Specs.Timeout
                     SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken.None);
                     return ResultPrimitive.WhateverButTooLate;
                 }))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             exceptionPassedToOnTimeout.Should().NotBeNull();
             exceptionPassedToOnTimeout.Should().BeOfType(typeof(OperationCanceledException));
@@ -692,7 +692,7 @@ namespace Polly.Specs.Timeout
                 SystemClock.Sleep(TimeSpan.FromSeconds(1), ct);
                 return ResultPrimitive.WhateverButTooLate;
             }, userCancellationToken))
-            .ShouldThrow<TimeoutRejectedException>();
+            .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutPassedToConfiguration);
         }
@@ -715,7 +715,7 @@ namespace Polly.Specs.Timeout
                     SystemClock.Sleep(TimeSpan.FromSeconds(3), ct);
                     return ResultPrimitive.WhateverButTooLate;
                 }, contextPassedToExecute, userCancellationToken))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             contextPassedToOnTimeout.Should().NotBeNull();
             contextPassedToOnTimeout.OperationKey.Should().Be(operationKey);
@@ -741,7 +741,7 @@ namespace Polly.Specs.Timeout
                     SystemClock.Sleep(TimeSpan.FromSeconds(3), ct);
                     return ResultPrimitive.WhateverButTooLate;
                 }, userCancellationToken))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutFunc());
         }
@@ -770,7 +770,7 @@ namespace Polly.Specs.Timeout
                     SystemClock.Sleep(TimeSpan.FromSeconds(3), ct);
                     return ResultPrimitive.WhateverButTooLate;
                 }, context, userCancellationToken))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             timeoutPassedToOnTimeout.Should().Be(timeoutProvider(context));
         }
@@ -790,7 +790,7 @@ namespace Polly.Specs.Timeout
                 SystemClock.Sleep(TimeSpan.FromSeconds(3), ct);
                 return ResultPrimitive.WhateverButTooLate;
             }, userCancellationToken))
-            .ShouldThrow<TimeoutRejectedException>();
+            .Should().Throw<TimeoutRejectedException>();
 
             taskPassedToOnTimeout.Should().BeNull();
         }
@@ -811,7 +811,7 @@ namespace Polly.Specs.Timeout
                     SystemClock.Sleep(TimeSpan.FromSeconds(1), ct);
                     return ResultPrimitive.WhateverButTooLate;
                 }, userCancellationToken))
-                .ShouldThrow<TimeoutRejectedException>();
+                .Should().Throw<TimeoutRejectedException>();
 
             exceptionPassedToOnTimeout.Should().NotBeNull();
             exceptionPassedToOnTimeout.Should().BeOfType(typeof(OperationCanceledException));

--- a/src/Polly.Specs/Wrap/IPolicyWrapExtensionSpecs.cs
+++ b/src/Polly.Specs/Wrap/IPolicyWrapExtensionSpecs.cs
@@ -36,7 +36,11 @@ namespace Polly.Specs.Wrap
             Policy policyB = Policy.NoOp();
             PolicyWrap wrap = Policy.Wrap(policyA, policyB);
 
-            wrap.GetPolicies().Should().BeEquivalentTo(new[] { policyA, policyB }, options => options.WithStrictOrdering());
+            wrap.GetPolicies().Should().BeEquivalentTo(new[] { policyA, policyB },
+                options => options
+                    .WithStrictOrdering()
+                    .Using<IsPolicy>(ctx => ctx.Subject.Should().BeSameAs(ctx.Expectation))
+                    .WhenTypeIs<IsPolicy>());
         }
 
         [Fact]
@@ -47,7 +51,11 @@ namespace Polly.Specs.Wrap
             Policy policyC = Policy.NoOp();
             PolicyWrap wrap = Policy.Wrap(policyA, policyB, policyC);
 
-            wrap.GetPolicies().Should().BeEquivalentTo(new[] { policyA, policyB, policyC }, options => options.WithStrictOrdering());
+            wrap.GetPolicies().Should().BeEquivalentTo(new[] { policyA, policyB, policyC },
+                options => options
+                    .WithStrictOrdering()
+                    .Using<IsPolicy>(ctx => ctx.Subject.Should().BeSameAs(ctx.Expectation))
+                    .WhenTypeIs<IsPolicy>());
         }
 
         [Fact]
@@ -58,7 +66,11 @@ namespace Polly.Specs.Wrap
             Policy policyC = Policy.NoOp();
             PolicyWrap wrap = policyA.Wrap(policyB).Wrap(policyC);
 
-            wrap.GetPolicies().Should().BeEquivalentTo(new[] { policyA, policyB, policyC }, options => options.WithStrictOrdering());
+            wrap.GetPolicies().Should().BeEquivalentTo(new[] { policyA, policyB, policyC },
+                options => options
+                    .WithStrictOrdering()
+                    .Using<IsPolicy>(ctx => ctx.Subject.Should().BeSameAs(ctx.Expectation))
+                    .WhenTypeIs<IsPolicy>());
         }
 
         [Fact]
@@ -69,7 +81,11 @@ namespace Polly.Specs.Wrap
             Policy policyC = Policy.NoOp();
             PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
 
-            wrap.GetPolicies().Should().BeEquivalentTo(new[] { policyA, policyB, policyC }, options => options.WithStrictOrdering());
+            wrap.GetPolicies().Should().BeEquivalentTo(new[] { policyA, policyB, policyC },
+                options => options
+                    .WithStrictOrdering()
+                    .Using<IsPolicy>(ctx => ctx.Subject.Should().BeSameAs(ctx.Expectation))
+                    .WhenTypeIs<IsPolicy>());
         }
 
         [Fact]
@@ -80,7 +96,11 @@ namespace Polly.Specs.Wrap
             Policy policyC = Policy.NoOp();
             PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
 
-            wrap.GetPolicies<RetryPolicy>().Should().BeEquivalentTo(new[] { policyB }, options => options.WithStrictOrdering());
+            wrap.GetPolicies<RetryPolicy>().Should().BeEquivalentTo(new[] { policyB },
+                options => options
+                    .WithStrictOrdering()
+                    .Using<IsPolicy>(ctx => ctx.Subject.Should().BeSameAs(ctx.Expectation))
+                    .WhenTypeIs<IsPolicy>());
         }
 
         [Fact]
@@ -102,7 +122,11 @@ namespace Polly.Specs.Wrap
             Policy policyC = Policy.NoOp();
             PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
 
-            wrap.GetPolicies<NoOpPolicy>().Should().BeEquivalentTo(new[] { policyA, policyC }, options => options.WithStrictOrdering());
+            wrap.GetPolicies<NoOpPolicy>().Should().BeEquivalentTo(new[] { policyA, policyC },
+                options => options
+                    .WithStrictOrdering()
+                    .Using<IsPolicy>(ctx => ctx.Subject.Should().BeSameAs(ctx.Expectation))
+                    .WhenTypeIs<IsPolicy>());
         }
 
         [Fact]
@@ -116,7 +140,11 @@ namespace Polly.Specs.Wrap
 
             PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
 
-            wrap.GetPolicies<CircuitBreakerPolicy>(p => p.CircuitState == CircuitState.Closed).Should().BeEquivalentTo(new[] { policyC }, options => options.WithStrictOrdering());
+            wrap.GetPolicies<CircuitBreakerPolicy>(p => p.CircuitState == CircuitState.Closed).Should().BeEquivalentTo(new[] { policyC },
+                options => options
+                    .WithStrictOrdering()
+                    .Using<IsPolicy>(ctx => ctx.Subject.Should().BeSameAs(ctx.Expectation))
+                    .WhenTypeIs<IsPolicy>());
         }
 
         [Fact]
@@ -139,7 +167,11 @@ namespace Polly.Specs.Wrap
             Policy policyC = Policy.NoOp();
             PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
 
-            wrap.GetPolicies<NoOpPolicy>(_ => true).Should().BeEquivalentTo(new[] { policyA, policyC }, options => options.WithStrictOrdering());
+            wrap.GetPolicies<NoOpPolicy>(_ => true).Should().BeEquivalentTo(new[] { policyA, policyC },
+                options => options
+                    .WithStrictOrdering()
+                    .Using<IsPolicy>(ctx => ctx.Subject.Should().BeSameAs(ctx.Expectation))
+                    .WhenTypeIs<IsPolicy>());
         }
 
         [Fact]

--- a/src/Polly.Specs/Wrap/IPolicyWrapExtensionSpecs.cs
+++ b/src/Polly.Specs/Wrap/IPolicyWrapExtensionSpecs.cs
@@ -36,7 +36,7 @@ namespace Polly.Specs.Wrap
             Policy policyB = Policy.NoOp();
             PolicyWrap wrap = Policy.Wrap(policyA, policyB);
 
-            wrap.GetPolicies().ShouldBeEquivalentTo(new[] { policyA, policyB }, options => options.WithStrictOrdering());
+            wrap.GetPolicies().Should().BeEquivalentTo(new[] { policyA, policyB }, options => options.WithStrictOrdering());
         }
 
         [Fact]
@@ -47,7 +47,7 @@ namespace Polly.Specs.Wrap
             Policy policyC = Policy.NoOp();
             PolicyWrap wrap = Policy.Wrap(policyA, policyB, policyC);
 
-            wrap.GetPolicies().ShouldBeEquivalentTo(new[] { policyA, policyB, policyC }, options => options.WithStrictOrdering());
+            wrap.GetPolicies().Should().BeEquivalentTo(new[] { policyA, policyB, policyC }, options => options.WithStrictOrdering());
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace Polly.Specs.Wrap
             Policy policyC = Policy.NoOp();
             PolicyWrap wrap = policyA.Wrap(policyB).Wrap(policyC);
 
-            wrap.GetPolicies().ShouldBeEquivalentTo(new[] { policyA, policyB, policyC }, options => options.WithStrictOrdering());
+            wrap.GetPolicies().Should().BeEquivalentTo(new[] { policyA, policyB, policyC }, options => options.WithStrictOrdering());
         }
 
         [Fact]
@@ -69,7 +69,7 @@ namespace Polly.Specs.Wrap
             Policy policyC = Policy.NoOp();
             PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
 
-            wrap.GetPolicies().ShouldBeEquivalentTo(new[] { policyA, policyB, policyC }, options => options.WithStrictOrdering());
+            wrap.GetPolicies().Should().BeEquivalentTo(new[] { policyA, policyB, policyC }, options => options.WithStrictOrdering());
         }
 
         [Fact]
@@ -80,7 +80,7 @@ namespace Polly.Specs.Wrap
             Policy policyC = Policy.NoOp();
             PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
 
-            wrap.GetPolicies<RetryPolicy>().ShouldBeEquivalentTo(new[] { policyB }, options => options.WithStrictOrdering());
+            wrap.GetPolicies<RetryPolicy>().Should().BeEquivalentTo(new[] { policyB }, options => options.WithStrictOrdering());
         }
 
         [Fact]
@@ -102,7 +102,7 @@ namespace Polly.Specs.Wrap
             Policy policyC = Policy.NoOp();
             PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
 
-            wrap.GetPolicies<NoOpPolicy>().ShouldBeEquivalentTo(new[] { policyA, policyC }, options => options.WithStrictOrdering());
+            wrap.GetPolicies<NoOpPolicy>().Should().BeEquivalentTo(new[] { policyA, policyC }, options => options.WithStrictOrdering());
         }
 
         [Fact]
@@ -116,7 +116,7 @@ namespace Polly.Specs.Wrap
 
             PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
 
-            wrap.GetPolicies<CircuitBreakerPolicy>(p => p.CircuitState == CircuitState.Closed).ShouldBeEquivalentTo(new[] { policyC }, options => options.WithStrictOrdering());
+            wrap.GetPolicies<CircuitBreakerPolicy>(p => p.CircuitState == CircuitState.Closed).Should().BeEquivalentTo(new[] { policyC }, options => options.WithStrictOrdering());
         }
 
         [Fact]
@@ -139,7 +139,7 @@ namespace Polly.Specs.Wrap
             Policy policyC = Policy.NoOp();
             PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
 
-            wrap.GetPolicies<NoOpPolicy>(_ => true).ShouldBeEquivalentTo(new[] { policyA, policyC }, options => options.WithStrictOrdering());
+            wrap.GetPolicies<NoOpPolicy>(_ => true).Should().BeEquivalentTo(new[] { policyA, policyC }, options => options.WithStrictOrdering());
         }
 
         [Fact]

--- a/src/Polly.Specs/Wrap/IPolicyWrapExtensionSpecs.cs
+++ b/src/Polly.Specs/Wrap/IPolicyWrapExtensionSpecs.cs
@@ -151,7 +151,7 @@ namespace Polly.Specs.Wrap
 
             Action configure = () => wrap.GetPolicies<NoOpPolicy>(null);
             
-            configure.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("filter");
+            configure.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("filter");
         }
 
         [Fact]
@@ -184,7 +184,7 @@ namespace Polly.Specs.Wrap
             Policy policyC = Policy.NoOp();
             PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
 
-            wrap.Invoking(p => p.GetPolicy<NoOpPolicy>()).ShouldThrow<InvalidOperationException>();
+            wrap.Invoking(p => p.GetPolicy<NoOpPolicy>()).Should().Throw<InvalidOperationException>();
         }
 
         [Fact]
@@ -221,7 +221,7 @@ namespace Polly.Specs.Wrap
             Policy policyC = Policy.NoOp();
             PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
 
-            wrap.Invoking(p => p.GetPolicy<NoOpPolicy>(_ => true)).ShouldThrow<InvalidOperationException>();
+            wrap.Invoking(p => p.GetPolicy<NoOpPolicy>(_ => true)).Should().Throw<InvalidOperationException>();
         }
 
         [Fact]
@@ -233,7 +233,7 @@ namespace Polly.Specs.Wrap
 
             Action configure = () => wrap.GetPolicy<NoOpPolicy>(null);
 
-            configure.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("filter");
+            configure.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("filter");
         }
     }
 }

--- a/src/Polly.Specs/Wrap/PolicyWrapSpecs.cs
+++ b/src/Polly.Specs/Wrap/PolicyWrapSpecs.cs
@@ -274,7 +274,7 @@ namespace Polly.Specs.Wrap
             Policy breaker = Policy.Handle<Exception>().CircuitBreaker(1, TimeSpan.FromSeconds(10));
             Action config = () => Policy.Wrap(new[] {retry, breaker});
 
-            config.ShouldNotThrow();
+            config.Should().NotThrow();
         }
 
         [Fact]
@@ -286,7 +286,7 @@ namespace Polly.Specs.Wrap
 
             Action config = () => Policy.Wrap(new[] {divideByZeroRetry, retry, breaker});
 
-            config.ShouldNotThrow();
+            config.Should().NotThrow();
         }
 
         [Fact]
@@ -329,7 +329,7 @@ namespace Polly.Specs.Wrap
             Policy<int> breaker = Policy<int>.Handle<Exception>().CircuitBreaker(1, TimeSpan.FromSeconds(10));
             Action config = () => Policy.Wrap<int>(new[] { retry, breaker });
 
-            config.ShouldNotThrow();
+            config.Should().NotThrow();
         }
 
         [Fact]
@@ -341,7 +341,7 @@ namespace Polly.Specs.Wrap
 
             Action config = () => Policy.Wrap<int>(new[] { divideByZeroRetry, retry, breaker });
 
-            config.ShouldNotThrow();
+            config.Should().NotThrow();
         }
 
         [Fact]

--- a/src/Polly.Specs/Wrap/PolicyWrapSpecs.cs
+++ b/src/Polly.Specs/Wrap/PolicyWrapSpecs.cs
@@ -20,7 +20,7 @@ namespace Polly.Specs.Wrap
 
             Action config = () => retry.Wrap((Policy)null);
 
-            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+            config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
         }
 
         [Fact]
@@ -30,7 +30,7 @@ namespace Polly.Specs.Wrap
 
             Action config = () => retry.Wrap<int>((Policy<int>)null);
 
-            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+            config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
         }
 
         [Fact]
@@ -68,7 +68,7 @@ namespace Polly.Specs.Wrap
 
             Action config = () => retry.Wrap((Policy)null);
 
-            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+            config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
         }
 
 
@@ -79,7 +79,7 @@ namespace Polly.Specs.Wrap
 
             Action config = () => retry.Wrap((Policy<int>)null);
 
-            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+            config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
         }
 
         [Fact]
@@ -118,7 +118,7 @@ namespace Polly.Specs.Wrap
 
             Action config = () => outerNull.Wrap(retry);
 
-            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
+            config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
         }
 
         [Fact]
@@ -129,7 +129,7 @@ namespace Polly.Specs.Wrap
 
             Action config = () => outerNull.Wrap<int>(retry);
 
-            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
+            config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
         }
 
         [Fact]
@@ -139,7 +139,7 @@ namespace Polly.Specs.Wrap
 
             Action config = () => retry.Wrap((Policy)null);
 
-            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+            config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
         }
 
         [Fact]
@@ -149,7 +149,7 @@ namespace Polly.Specs.Wrap
 
             Action config = () => retry.Wrap<int>((Policy<int>)null);
 
-            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+            config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
         }
 
         [Fact]
@@ -188,7 +188,7 @@ namespace Polly.Specs.Wrap
 
             Action config = () => outerNull.Wrap(retry);
 
-            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
+            config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
         }
 
         [Fact]
@@ -199,7 +199,7 @@ namespace Polly.Specs.Wrap
 
             Action config = () => outerNull.Wrap<int>(retry);
 
-            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
+            config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
         }
 
         [Fact]
@@ -209,7 +209,7 @@ namespace Polly.Specs.Wrap
 
             Action config = () => retry.Wrap((Policy)null);
 
-            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+            config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
         }
 
         [Fact]
@@ -219,7 +219,7 @@ namespace Polly.Specs.Wrap
 
             Action config = () => retry.Wrap((Policy<int>)null);
 
-            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+            config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
         }
 
         [Fact]
@@ -255,7 +255,7 @@ namespace Polly.Specs.Wrap
         {
             Action config = () => Policy.Wrap();
 
-            config.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("policies");
+            config.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policies");
         }
 
         [Fact]
@@ -264,7 +264,7 @@ namespace Polly.Specs.Wrap
             Policy singlePolicy = Policy.Handle<Exception>().Retry();
             Action config = () => Policy.Wrap(new[] {singlePolicy});
 
-            config.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("policies");
+            config.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policies");
         }
 
         [Fact]
@@ -310,7 +310,7 @@ namespace Polly.Specs.Wrap
         {
             Action config = () => Policy.Wrap<int>();
 
-            config.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("policies");
+            config.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policies");
         }
 
         [Fact]
@@ -319,7 +319,7 @@ namespace Polly.Specs.Wrap
             Policy<int> singlePolicy = Policy<int>.Handle<Exception>().Retry();
             Action config = () => Policy.Wrap<int>(new[] { singlePolicy });
 
-            config.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("policies");
+            config.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policies");
         }
 
         [Fact]
@@ -372,13 +372,13 @@ namespace Polly.Specs.Wrap
             // When the retry wraps the breaker, the retry (being outer) should cause the call to be put through the breaker twice - causing the breaker to break.
             breaker.Reset();
             retryWrappingBreaker.Invoking(x => x.RaiseException<DivideByZeroException>(2))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // When the breaker wraps the retry, the retry (being inner) should retry twice before throwing the exception back on the breaker - the exception only hits the breaker once - so the breaker should not break.
             breaker.Reset();
             breakerWrappingRetry.Invoking(x => x.RaiseException<DivideByZeroException>(2))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
         }
 
@@ -420,13 +420,13 @@ namespace Polly.Specs.Wrap
             // When the retry wraps the breaker, the retry (being outer) should cause the call to be put through the breaker twice - causing the breaker to break.
             breaker.Reset();
             retryWrappingBreaker.Invoking(x => x.RaiseException<DivideByZeroException>(2))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // When the breaker wraps the retry, the retry (being inner) should retry twice before throwing the exception back on the breaker - the exception only hits the breaker once - so the breaker should not break.
             breaker.Reset();
             breakerWrappingRetry.Invoking(x => x.RaiseException<DivideByZeroException>(2))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
         }
 

--- a/src/Polly.Specs/Wrap/PolicyWrapSpecsAsync.cs
+++ b/src/Polly.Specs/Wrap/PolicyWrapSpecsAsync.cs
@@ -20,7 +20,7 @@ namespace Polly.Specs.Wrap
 
             Action config = () => retry.WrapAsync((AsyncPolicy)null);
 
-            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+            config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
         }
 
         [Fact]
@@ -30,7 +30,7 @@ namespace Polly.Specs.Wrap
 
             Action config = () => retry.WrapAsync<int>((AsyncPolicy<int>)null);
 
-            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+            config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
         }
 
         [Fact]
@@ -68,7 +68,7 @@ namespace Polly.Specs.Wrap
 
             Action config = () => retry.WrapAsync((AsyncPolicy)null);
 
-            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+            config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
         }
 
         [Fact]
@@ -78,7 +78,7 @@ namespace Polly.Specs.Wrap
 
             Action config = () => retry.WrapAsync((AsyncPolicy<int>)null);
 
-            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+            config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
         }
 
         [Fact]
@@ -117,7 +117,7 @@ namespace Polly.Specs.Wrap
 
             Action config = () => outerNull.WrapAsync(retry);
 
-            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
+            config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
         }
 
         [Fact]
@@ -128,7 +128,7 @@ namespace Polly.Specs.Wrap
 
             Action config = () => outerNull.WrapAsync<int>(retry);
 
-            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
+            config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
         }
 
         [Fact]
@@ -138,7 +138,7 @@ namespace Polly.Specs.Wrap
 
             Action config = () => retry.WrapAsync((AsyncPolicy)null);
 
-            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+            config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
         }
 
         [Fact]
@@ -148,7 +148,7 @@ namespace Polly.Specs.Wrap
 
             Action config = () => retry.WrapAsync<int>((AsyncPolicy<int>)null);
 
-            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+            config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
         }
 
         [Fact]
@@ -187,7 +187,7 @@ namespace Polly.Specs.Wrap
 
             Action config = () => outerNull.WrapAsync(retry);
 
-            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
+            config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
         }
 
         [Fact]
@@ -198,7 +198,7 @@ namespace Polly.Specs.Wrap
 
             Action config = () => outerNull.WrapAsync<int>(retry);
 
-            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
+            config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
         }
 
         [Fact]
@@ -208,7 +208,7 @@ namespace Polly.Specs.Wrap
 
             Action config = () => retry.WrapAsync((AsyncPolicy)null);
 
-            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+            config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
         }
 
         [Fact]
@@ -218,7 +218,7 @@ namespace Polly.Specs.Wrap
 
             Action config = () => retry.WrapAsync((AsyncPolicy<int>)null);
 
-            config.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+            config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
         }
 
         [Fact]
@@ -254,7 +254,7 @@ namespace Polly.Specs.Wrap
         {
             Action config = () => Policy.WrapAsync();
 
-            config.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("policies");
+            config.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policies");
         }
 
         [Fact]
@@ -263,7 +263,7 @@ namespace Polly.Specs.Wrap
             AsyncPolicy singlePolicy = Policy.Handle<Exception>().RetryAsync();
             Action config = () => Policy.WrapAsync(new[] { singlePolicy });
 
-            config.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("policies");
+            config.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policies");
         }
 
         [Fact]
@@ -309,7 +309,7 @@ namespace Polly.Specs.Wrap
         {
             Action config = () => Policy.WrapAsync<int>();
 
-            config.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("policies");
+            config.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policies");
         }
 
         [Fact]
@@ -318,7 +318,7 @@ namespace Polly.Specs.Wrap
             AsyncPolicy<int> singlePolicy = Policy<int>.Handle<Exception>().RetryAsync();
             Action config = () => Policy.WrapAsync<int>(new[] { singlePolicy });
 
-            config.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("policies");
+            config.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policies");
         }
 
         [Fact]
@@ -371,13 +371,13 @@ namespace Polly.Specs.Wrap
             // When the retry wraps the breaker, the retry (being outer) should cause the call to be put through the breaker twice - causing the breaker to break.
             breaker.Reset();
             retryWrappingBreaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>(2))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // When the breaker wraps the retry, the retry (being inner) should retry twice before throwing the exception back on the breaker - the exception only hits the breaker once - so the breaker should not break.
             breaker.Reset();
             breakerWrappingRetry.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>(2))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
         }
 
@@ -419,13 +419,13 @@ namespace Polly.Specs.Wrap
             // When the retry wraps the breaker, the retry (being outer) should cause the call to be put through the breaker twice - causing the breaker to break.
             breaker.Reset();
             retryWrappingBreaker.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>(2))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Open);
 
             // When the breaker wraps the retry, the retry (being inner) should retry twice before throwing the exception back on the breaker - the exception only hits the breaker once - so the breaker should not break.
             breaker.Reset();
             breakerWrappingRetry.Awaiting(async x => await x.RaiseExceptionAsync<DivideByZeroException>(2))
-                .ShouldThrow<DivideByZeroException>();
+                .Should().Throw<DivideByZeroException>();
             breaker.CircuitState.Should().Be(CircuitState.Closed);
         }
 

--- a/src/Polly.Specs/Wrap/PolicyWrapSpecsAsync.cs
+++ b/src/Polly.Specs/Wrap/PolicyWrapSpecsAsync.cs
@@ -273,7 +273,7 @@ namespace Polly.Specs.Wrap
             AsyncPolicy breaker = Policy.Handle<Exception>().CircuitBreakerAsync(1, TimeSpan.FromSeconds(10));
             Action config = () => Policy.WrapAsync(new[] { retry, breaker });
 
-            config.ShouldNotThrow();
+            config.Should().NotThrow();
         }
 
         [Fact]
@@ -285,7 +285,7 @@ namespace Polly.Specs.Wrap
 
             Action config = () => Policy.WrapAsync(new[] { divideByZeroRetry, retry, breaker });
 
-            config.ShouldNotThrow();
+            config.Should().NotThrow();
         }
 
         [Fact]
@@ -328,7 +328,7 @@ namespace Polly.Specs.Wrap
             AsyncPolicy<int> breaker = Policy<int>.Handle<Exception>().CircuitBreakerAsync(1, TimeSpan.FromSeconds(10));
             Action config = () => Policy.WrapAsync<int>(new[] { retry, breaker });
 
-            config.ShouldNotThrow();
+            config.Should().NotThrow();
         }
 
         [Fact]
@@ -340,7 +340,7 @@ namespace Polly.Specs.Wrap
 
             Action config = () => Policy.WrapAsync<int>(new[] { divideByZeroRetry, retry, breaker });
 
-            config.ShouldNotThrow();
+            config.Should().NotThrow();
         }
 
         [Fact]


### PR DESCRIPTION
### The issue or feature being addressed

I stumbled upon a comment in the tests about `Func<T>` not being supported in Fluent Assertions... but we added that in version [5.5.1](https://github.com/fluentassertions/fluentassertions/releases/tag/5.5.1) about a year ago :).

### Details on the issue fix or feature implementation
I've split the PR into several commits, which should make it easier to review, but as the commits aren't atomic, they should probably be squashed before merging.

Some behavioral changes in Fluent Assertions: 
* In `BeEquivalentTo` the expectation now drives the comparison. So for all the tests where a subject is compared against an anonymous class, only the members of the anonymous class are used in the comparison.
* Fluent Assertions returns the proper exception from async methods, so when `ThrowIfCancellationRequested` throws an `OperationCanceledException`, the assertions can assert on that type instead of `TaskCanceledException`.
* `WithInnerException` returns the inner exception instead of the outer exception.

Other changes:
* When asserting on the returned policies from `GetPolices` using `BeEquivalentTo`, I've changed the comparison of elements to use reference equality.
* `Guid` has native support for comparison, so they can be compared using `Be` instead of `BeEquivalentTo`.
*

An overview about changes in version 5 are described [here](https://www.continuousimprover.com/2018/02/fluent-assertions-50-best-unit-test.html).
### Confirm the following

- [x]  I started this PR by branching from the head of the latest dev vX.Y branch, or I have rebased on the latest dev vX.Y branch, or I have merged the latest changes from the dev vX.Y branch
- [x]  I have targeted the PR to merge into the latest dev vX.Y branch as the base branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
