### PR TITLE
remove strange string split in PolicyContextAndKeySpecs.cs

### DIFF
--- a/src/Polly.Specs/PolicyContextAndKeySpecs.cs
+++ b/src/Polly.Specs/PolicyContextAndKeySpecs.cs
@@ -94,8 +94,7 @@ namespace Polly.Specs
 
             Action configure = () => policy.WithPolicyKey(Guid.NewGuid().ToString());
 
-            configure.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("p" +
-                                                                                 "olicyKey");
+            configure.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("policyKey");
         }
 
         #endregion

--- a/src/Polly.Specs/PolicyContextAndKeySpecs.cs
+++ b/src/Polly.Specs/PolicyContextAndKeySpecs.cs
@@ -94,7 +94,7 @@ namespace Polly.Specs
 
             Action configure = () => policy.WithPolicyKey(Guid.NewGuid().ToString());
 
-            configure.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("policyKey");
+            configure.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policyKey");
         }
 
         #endregion


### PR DESCRIPTION
not sure why this string is split