### PR TITLE
simplify some defaults

### DIFF
--- a/src/Polly.Specs/Caching/CacheAsyncSpecs.cs
+++ b/src/Polly.Specs/Caching/CacheAsyncSpecs.cs
@@ -235,7 +235,7 @@ namespace Polly.Specs.Caching
         [Fact]
         public async Task Should_execute_delegate_and_put_value_in_cache_if_cache_does_not_hold_value__default_for_reference_type()
         {
-            ResultClass valueToReturn = default(ResultClass);
+            ResultClass valueToReturn = default;
             const string operationKey = "SomeOperationKey";
 
             IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
@@ -255,7 +255,7 @@ namespace Polly.Specs.Caching
         [Fact]
         public async Task Should_return_value_from_cache_and_not_execute_delegate_if_cache_holds_value__default_for_reference_type()
         {
-            ResultClass valueToReturnFromCache = default(ResultClass);
+            ResultClass valueToReturnFromCache = default;
             ResultClass valueToReturnFromExecution = new ResultClass(ResultPrimitive.Good);
             const string operationKey = "SomeOperationKey";
 
@@ -280,7 +280,7 @@ namespace Polly.Specs.Caching
         [Fact]
         public async Task Should_execute_delegate_and_put_value_in_cache_if_cache_does_not_hold_value__default_for_value_type()
         {
-            ResultPrimitive valueToReturn = default(ResultPrimitive);
+            ResultPrimitive valueToReturn = default;
             const string operationKey = "SomeOperationKey";
 
             IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
@@ -300,7 +300,7 @@ namespace Polly.Specs.Caching
         [Fact]
         public async Task Should_return_value_from_cache_and_not_execute_delegate_if_cache_holds_value__default_for_value_type()
         {
-            ResultPrimitive valueToReturnFromCache = default(ResultPrimitive);
+            ResultPrimitive valueToReturnFromCache = default;
             ResultPrimitive valueToReturnFromExecution = ResultPrimitive.Good;
             valueToReturnFromExecution.Should().NotBe(valueToReturnFromCache);
             const string operationKey = "SomeOperationKey";

--- a/src/Polly.Specs/Caching/CacheSpecs.cs
+++ b/src/Polly.Specs/Caching/CacheSpecs.cs
@@ -232,7 +232,7 @@ namespace Polly.Specs.Caching
         [Fact]
         public void Should_execute_delegate_and_put_value_in_cache_if_cache_does_not_hold_value__default_for_reference_type()
         {
-            ResultClass valueToReturn = default(ResultClass);
+            ResultClass valueToReturn = default;
             const string operationKey = "SomeOperationKey";
 
             ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
@@ -252,7 +252,7 @@ namespace Polly.Specs.Caching
         [Fact]
         public void Should_return_value_from_cache_and_not_execute_delegate_if_cache_holds_value__default_for_reference_type()
         {
-            ResultClass valueToReturnFromCache = default(ResultClass);
+            ResultClass valueToReturnFromCache = default;
             ResultClass valueToReturnFromExecution = new ResultClass(ResultPrimitive.Good);
             const string operationKey = "SomeOperationKey";
 
@@ -275,7 +275,7 @@ namespace Polly.Specs.Caching
         [Fact]
         public void Should_execute_delegate_and_put_value_in_cache_if_cache_does_not_hold_value__default_for_value_type()
         {
-            ResultPrimitive valueToReturn = default(ResultPrimitive);
+            ResultPrimitive valueToReturn = default;
             const string operationKey = "SomeOperationKey";
 
             ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
@@ -295,7 +295,7 @@ namespace Polly.Specs.Caching
         [Fact]
         public void Should_return_value_from_cache_and_not_execute_delegate_if_cache_holds_value__default_for_value_type()
         {
-            ResultPrimitive valueToReturnFromCache = default(ResultPrimitive); 
+            ResultPrimitive valueToReturnFromCache = default; 
             ResultPrimitive valueToReturnFromExecution = ResultPrimitive.Good;
             valueToReturnFromExecution.Should().NotBe(valueToReturnFromCache);
             const string operationKey = "SomeOperationKey";

--- a/src/Polly.Specs/Caching/CacheTResultAsyncSpecs.cs
+++ b/src/Polly.Specs/Caching/CacheTResultAsyncSpecs.cs
@@ -236,7 +236,7 @@ namespace Polly.Specs.Caching
         [Fact]
         public async Task Should_execute_delegate_and_put_value_in_cache_if_cache_does_not_hold_value__default_for_reference_type()
         {
-            ResultClass valueToReturn = default(ResultClass);
+            ResultClass valueToReturn = default;
             const string operationKey = "SomeOperationKey";
 
             IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
@@ -256,7 +256,7 @@ namespace Polly.Specs.Caching
         [Fact]
         public async Task Should_return_value_from_cache_and_not_execute_delegate_if_cache_holds_value__default_for_reference_type()
         {
-            ResultClass valueToReturnFromCache = default(ResultClass);
+            ResultClass valueToReturnFromCache = default;
             ResultClass valueToReturnFromExecution = new ResultClass(ResultPrimitive.Good);
             const string operationKey = "SomeOperationKey";
 
@@ -281,7 +281,7 @@ namespace Polly.Specs.Caching
         [Fact]
         public async Task Should_execute_delegate_and_put_value_in_cache_if_cache_does_not_hold_value__default_for_value_type()
         {
-            ResultPrimitive valueToReturn = default(ResultPrimitive);
+            ResultPrimitive valueToReturn = default;
             const string operationKey = "SomeOperationKey";
 
             IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
@@ -301,7 +301,7 @@ namespace Polly.Specs.Caching
         [Fact]
         public async Task Should_return_value_from_cache_and_not_execute_delegate_if_cache_holds_value__default_for_value_type()
         {
-            ResultPrimitive valueToReturnFromCache = default(ResultPrimitive);
+            ResultPrimitive valueToReturnFromCache = default;
             ResultPrimitive valueToReturnFromExecution = ResultPrimitive.Good;
             valueToReturnFromExecution.Should().NotBe(valueToReturnFromCache);
             const string operationKey = "SomeOperationKey";

--- a/src/Polly.Specs/Caching/CacheTResultSpecs.cs
+++ b/src/Polly.Specs/Caching/CacheTResultSpecs.cs
@@ -232,7 +232,7 @@ namespace Polly.Specs.Caching
         [Fact]
         public void Should_execute_delegate_and_put_value_in_cache_if_cache_does_not_hold_value__default_for_reference_type()
         {
-            ResultClass valueToReturn = default(ResultClass);
+            ResultClass valueToReturn = default;
             const string operationKey = "SomeOperationKey";
 
             ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
@@ -252,7 +252,7 @@ namespace Polly.Specs.Caching
         [Fact]
         public void Should_return_value_from_cache_and_not_execute_delegate_if_cache_holds_value__default_for_reference_type()
         {
-            ResultClass valueToReturnFromCache = default(ResultClass);
+            ResultClass valueToReturnFromCache = default;
             ResultClass valueToReturnFromExecution = new ResultClass(ResultPrimitive.Good);
             const string operationKey = "SomeOperationKey";
 
@@ -275,7 +275,7 @@ namespace Polly.Specs.Caching
         [Fact]
         public void Should_execute_delegate_and_put_value_in_cache_if_cache_does_not_hold_value__default_for_value_type()
         {
-            ResultPrimitive valueToReturn = default(ResultPrimitive);
+            ResultPrimitive valueToReturn = default;
             const string operationKey = "SomeOperationKey";
 
             ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
@@ -295,7 +295,7 @@ namespace Polly.Specs.Caching
         [Fact]
         public void Should_return_value_from_cache_and_not_execute_delegate_if_cache_holds_value__default_for_value_type()
         {
-            ResultPrimitive valueToReturnFromCache = default(ResultPrimitive);
+            ResultPrimitive valueToReturnFromCache = default;
             ResultPrimitive valueToReturnFromExecution = ResultPrimitive.Good;
             valueToReturnFromExecution.Should().NotBe(valueToReturnFromCache);
             const string operationKey = "SomeOperationKey";

--- a/src/Polly.Specs/Caching/SerializingCacheProviderAsyncSpecs.cs
+++ b/src/Polly.Specs/Caching/SerializingCacheProviderAsyncSpecs.cs
@@ -78,7 +78,7 @@ namespace Polly.Specs.Caching
                 deserialize: s => s.Original
             );
             StubCacheProvider stubCacheProvider = new StubCacheProvider();
-            object objectToCache = default(object);
+            object objectToCache = default;
             string key = "some key";
 
             AsyncSerializingCacheProvider<StubSerialized> serializingCacheProvider = new AsyncSerializingCacheProvider<StubSerialized>(stubCacheProvider.AsyncFor<StubSerialized>(), stubSerializer);
@@ -134,7 +134,7 @@ namespace Polly.Specs.Caching
 
             cacheHit.Should().BeFalse();
             deserializeInvoked.Should().BeFalse();
-            fromCache.Should().Be(default(object));
+            fromCache.Should().Be(default);
         }
 
         [Fact]
@@ -170,7 +170,7 @@ namespace Polly.Specs.Caching
                 deserialize: s => s.Original
             );
             StubCacheProvider stubCacheProvider = new StubCacheProvider();
-            object objectToCache = default(object);
+            object objectToCache = default;
             string key = "some key";
 
             AsyncSerializingCacheProvider<StubSerialized> serializingCacheProvider = stubCacheProvider.AsyncFor<StubSerialized>().WithSerializer(stubSerializer);
@@ -225,7 +225,7 @@ namespace Polly.Specs.Caching
 
             cacheHit.Should().BeFalse();
             deserializeInvoked.Should().BeFalse();
-            fromCache.Should().Be(default(object));
+            fromCache.Should().Be(default);
         }
 
         #endregion
@@ -297,7 +297,7 @@ namespace Polly.Specs.Caching
                 deserialize: s => s.Original
             );
             StubCacheProvider stubCacheProvider = new StubCacheProvider();
-            ResultPrimitive objectToCache = default(ResultPrimitive);
+            ResultPrimitive objectToCache = default;
             string key = "some key";
 
             AsyncSerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>> serializingCacheProvider = new AsyncSerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>>(stubCacheProvider.AsyncFor<StubSerialized<ResultPrimitive>>(), stubTResultSerializer);
@@ -388,7 +388,7 @@ namespace Polly.Specs.Caching
                 deserialize: s => s.Original
             );
             StubCacheProvider stubCacheProvider = new StubCacheProvider();
-            ResultPrimitive objectToCache = default(ResultPrimitive);
+            ResultPrimitive objectToCache = default;
             string key = "some key";
 
             AsyncSerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>> serializingCacheProvider =

--- a/src/Polly.Specs/Caching/SerializingCacheProviderSpecs.cs
+++ b/src/Polly.Specs/Caching/SerializingCacheProviderSpecs.cs
@@ -76,7 +76,7 @@ namespace Polly.Specs.Caching
                 deserialize: s => s.Original
             );
             StubCacheProvider stubCacheProvider = new StubCacheProvider();
-            object objectToCache = default(object);
+            object objectToCache = default;
             string key = "some key";
 
             SerializingCacheProvider<StubSerialized> serializingCacheProvider = new SerializingCacheProvider<StubSerialized>(stubCacheProvider.For<StubSerialized>(), stubSerializer);
@@ -132,7 +132,7 @@ namespace Polly.Specs.Caching
 
             cacheHit.Should().BeFalse();
             deserializeInvoked.Should().BeFalse();
-            fromCache.Should().Be(default(object));
+            fromCache.Should().Be(default);
         }
 
         [Fact]
@@ -168,7 +168,7 @@ namespace Polly.Specs.Caching
                 deserialize: s => s.Original
             );
             StubCacheProvider stubCacheProvider = new StubCacheProvider();
-            object objectToCache = default(object);
+            object objectToCache = default;
             string key = "some key";
 
             SerializingCacheProvider<StubSerialized> serializingCacheProvider = stubCacheProvider.For<StubSerialized>().WithSerializer(stubSerializer);
@@ -223,7 +223,7 @@ namespace Polly.Specs.Caching
 
             cacheHit.Should().BeFalse();
             deserializeInvoked.Should().BeFalse();
-            fromCache.Should().Be(default(object));
+            fromCache.Should().Be(default);
         }
 
         #endregion
@@ -295,7 +295,7 @@ namespace Polly.Specs.Caching
                 deserialize: s => s.Original
             );
             StubCacheProvider stubCacheProvider = new StubCacheProvider();
-            ResultPrimitive objectToCache = default(ResultPrimitive);
+            ResultPrimitive objectToCache = default;
             string key = "some key";
 
             SerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>> serializingCacheProvider = new SerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>>(stubCacheProvider.For<StubSerialized<ResultPrimitive>>(), stubTResultSerializer);
@@ -387,7 +387,7 @@ namespace Polly.Specs.Caching
                 deserialize: s => s.Original
             );
             StubCacheProvider stubCacheProvider = new StubCacheProvider();
-            ResultPrimitive objectToCache = default(ResultPrimitive);
+            ResultPrimitive objectToCache = default;
             string key = "some key";
 
             SerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>> serializingCacheProvider =

--- a/src/Polly.Specs/Helpers/Bulkhead/TraceableAction.cs
+++ b/src/Polly.Specs/Helpers/Bulkhead/TraceableAction.cs
@@ -106,7 +106,7 @@ namespace Polly.Specs.Helpers.Bulkhead
             }
             Status = TraceableActionStatus.StartRequested;
 
-            TResult result = default(TResult);
+            TResult result = default;
             return Task.Factory.StartNew(() =>
             {
                 try
@@ -121,7 +121,7 @@ namespace Polly.Specs.Helpers.Bulkhead
 
                         _testOutputHelper.WriteLine(_id + "Exiting execution.");
 
-                        return default(TResult);
+                        return default;
                     }, CancellationSource.Token);
                 }
                 catch (BulkheadRejectedException)
@@ -214,7 +214,7 @@ namespace Polly.Specs.Helpers.Bulkhead
             }
             Status = TraceableActionStatus.StartRequested;
 
-            TResult result = default(TResult);
+            TResult result = default;
             return Task.Factory.StartNew(async () =>
             {
                 try
@@ -229,7 +229,7 @@ namespace Polly.Specs.Helpers.Bulkhead
 
                         _testOutputHelper.WriteLine(_id + "Exiting execution.");
 
-                        return default(TResult);
+                        return default;
                     }, CancellationSource.Token).ConfigureAwait(true); 
                 }
                 catch (BulkheadRejectedException)

--- a/src/Polly.Specs/Helpers/ContextualPolicyExtensionsAsync.cs
+++ b/src/Polly.Specs/Helpers/ContextualPolicyExtensionsAsync.cs
@@ -9,7 +9,7 @@ namespace Polly.Specs.Helpers
     public static class ContextualPolicyExtensionsAsync
     {
 
-        public static Task RaiseExceptionAsync<TException>(this AsyncPolicy policy, int numberOfTimesToRaiseException, IDictionary<string, object> contextData, Action<TException, int> configureException = null, CancellationToken cancellationToken = default(CancellationToken)) where TException : Exception, new()
+        public static Task RaiseExceptionAsync<TException>(this AsyncPolicy policy, int numberOfTimesToRaiseException, IDictionary<string, object> contextData, Action<TException, int> configureException = null, CancellationToken cancellationToken = default) where TException : Exception, new()
         {
             int counter = 0;
 
@@ -32,7 +32,7 @@ namespace Polly.Specs.Helpers
             }, contextData, cancellationToken);
         }
 
-        public static Task RaiseExceptionAsync<TException>(this AsyncPolicy policy, IDictionary<string, object> contextData, Action<TException, int> configureException = null, CancellationToken cancellationToken = default(CancellationToken)) where TException : Exception, new()
+        public static Task RaiseExceptionAsync<TException>(this AsyncPolicy policy, IDictionary<string, object> contextData, Action<TException, int> configureException = null, CancellationToken cancellationToken = default) where TException : Exception, new()
         {
             return policy.RaiseExceptionAsync(1, contextData, configureException, cancellationToken);
         }

--- a/src/Polly.Specs/Helpers/PolicyExtensionsAsync.cs
+++ b/src/Polly.Specs/Helpers/PolicyExtensionsAsync.cs
@@ -33,7 +33,7 @@ namespace Polly.Specs.Helpers
             return policy.RaiseExceptionAsync(1, configureException);
         }
 
-        public static Task RaiseExceptionAsync<TException>(this AsyncPolicy policy, int numberOfTimesToRaiseException, Action<TException, int> configureException = null, CancellationToken cancellationToken = default(CancellationToken)) where TException : Exception, new()
+        public static Task RaiseExceptionAsync<TException>(this AsyncPolicy policy, int numberOfTimesToRaiseException, Action<TException, int> configureException = null, CancellationToken cancellationToken = default) where TException : Exception, new()
         {
             ExceptionAndOrCancellationScenario scenario = new ExceptionAndOrCancellationScenario
             {

--- a/src/Polly.Specs/Helpers/PolicyTResultExtensionsAsync.cs
+++ b/src/Polly.Specs/Helpers/PolicyTResultExtensionsAsync.cs
@@ -17,7 +17,7 @@ namespace Polly.Specs.Helpers
 
         public static Task<TResult> RaiseResultSequenceAsync<TResult>(this AsyncPolicy<TResult> policy, IEnumerable<TResult> resultsToRaise)
         {
-            return policy.RaiseResultSequenceAsync(default(CancellationToken), resultsToRaise);
+            return policy.RaiseResultSequenceAsync(default, resultsToRaise);
         }
 
         public static async Task<TResult> RaiseResultSequenceAsync<TResult>(this AsyncPolicy<TResult> policy,

--- a/src/Polly/Caching/AsyncCacheEngine.cs
+++ b/src/Polly/Caching/AsyncCacheEngine.cs
@@ -37,7 +37,7 @@ namespace Polly.Caching
             catch (Exception ex)
             {
                 cacheHit = false;
-                valueFromCache = default(TResult);
+                valueFromCache = default;
                 onCacheGetError(context, cacheKey, ex);
             }
             if (cacheHit)

--- a/src/Polly/Caching/AsyncSerializingCacheProvider.cs
+++ b/src/Polly/Caching/AsyncSerializingCacheProvider.cs
@@ -100,7 +100,7 @@ namespace Polly.Caching
         public async Task<(bool, TResult)> TryGetAsync(string key, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
             (bool cacheHit, TSerialized objectToDeserialize) = await _wrappedCacheProvider.TryGetAsync(key, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
-            return (cacheHit, cacheHit ? _serializer.Deserialize(objectToDeserialize) : default(TResult));
+            return (cacheHit, cacheHit ? _serializer.Deserialize(objectToDeserialize) : default);
         }
 
         /// <summary>

--- a/src/Polly/Caching/CacheEngine.cs
+++ b/src/Polly/Caching/CacheEngine.cs
@@ -35,7 +35,7 @@ namespace Polly.Caching
             catch (Exception ex)
             {
                 cacheHit = false;
-                valueFromCache = default(TResult);
+                valueFromCache = default;
                 onCacheGetError(context, cacheKey, ex);
             }
             if (cacheHit)

--- a/src/Polly/Caching/SerializingCacheProvider.cs
+++ b/src/Polly/Caching/SerializingCacheProvider.cs
@@ -85,7 +85,7 @@ namespace Polly.Caching
         public (bool, TResult) TryGet(string key)
         {
             (bool cacheHit, TSerialized objectToDeserialize) = _wrappedCacheProvider.TryGet(key);
-            return (cacheHit, cacheHit ? _serializer.Deserialize(objectToDeserialize) : default(TResult));
+            return (cacheHit, cacheHit ? _serializer.Deserialize(objectToDeserialize) : default);
         }
 
         /// <summary>

--- a/src/Polly/CircuitBreaker/AsyncCircuitBreakerPolicy.cs
+++ b/src/Polly/CircuitBreaker/AsyncCircuitBreakerPolicy.cs
@@ -46,7 +46,7 @@ namespace Polly.CircuitBreaker
         protected override async Task<TResult> ImplementationAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken,
             bool continueOnCapturedContext)
         {
-            TResult result = default(TResult);
+            TResult result = default;
             await AsyncCircuitBreakerEngine.ImplementationAsync<EmptyStruct>(
                 async (ctx, ct) => { result = await action(ctx, ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
                 context,

--- a/src/Polly/CircuitBreaker/CircuitBreakerPolicy.cs
+++ b/src/Polly/CircuitBreaker/CircuitBreakerPolicy.cs
@@ -43,7 +43,7 @@ namespace Polly.CircuitBreaker
         [DebuggerStepThrough]
         protected override TResult Implementation<TResult>(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken)
         {
-            TResult result = default(TResult);
+            TResult result = default;
             CircuitBreakerEngine.Implementation<EmptyStruct>(
                 (ctx, ct) => { result = action(ctx, ct); return EmptyStruct.Instance; },
                 context,

--- a/src/Polly/CircuitBreaker/CircuitStateController.cs
+++ b/src/Polly/CircuitBreaker/CircuitStateController.cs
@@ -71,7 +71,7 @@ namespace Polly.CircuitBreaker
                 using (TimedLock.Lock(_lock))
                 {
                     return _lastOutcome != null 
-                        ? _lastOutcome.Result : default(TResult);
+                        ? _lastOutcome.Result : default;
                 }
             }
         }

--- a/src/Polly/PolicyResult.cs
+++ b/src/Polly/PolicyResult.cs
@@ -64,7 +64,7 @@ namespace Polly
     public class PolicyResult<TResult>
     {
         internal PolicyResult(TResult result, OutcomeType outcome, Exception finalException, ExceptionType? exceptionType, Context context)
-            : this(result, outcome, finalException, exceptionType, default(TResult), null, context)
+            : this(result, outcome, finalException, exceptionType, default, null, context)
         {
 
         }
@@ -136,7 +136,7 @@ namespace Polly
         /// A <see cref="PolicyResult" /> representing a failed execution through the policy.
         /// </returns>
         public static PolicyResult<TResult> Failure(Exception exception, ExceptionType exceptionType, Context context)
-            => new PolicyResult<TResult>(default(TResult), OutcomeType.Failure, exception, exceptionType, default(TResult), 
+            => new PolicyResult<TResult>(default, OutcomeType.Failure, exception, exceptionType, default, 
                 exceptionType == Polly.ExceptionType.HandledByThisPolicy 
                 ? Polly.FaultType.ExceptionHandledByThisPolicy 
                 : Polly.FaultType.UnhandledException,
@@ -151,7 +151,7 @@ namespace Polly
         /// A <see cref="PolicyResult" /> representing a failed execution through the policy.
         /// </returns>
         public static PolicyResult<TResult> Failure(TResult handledResult, Context context)
-            => new PolicyResult<TResult>(default(TResult), OutcomeType.Failure, null, null, handledResult, Polly.FaultType.ResultHandledByThisPolicy, context);
+            => new PolicyResult<TResult>(default, OutcomeType.Failure, null, null, handledResult, Polly.FaultType.ResultHandledByThisPolicy, context);
     }
 
     /// <summary>

--- a/src/Polly/Registry/PolicyRegistry.cs
+++ b/src/Polly/Registry/PolicyRegistry.cs
@@ -88,7 +88,7 @@ namespace Polly.Registry
         public bool TryGet<TPolicy>(string key, out TPolicy policy) where TPolicy : IsPolicy
         {
             bool got = _registry.TryGetValue(key, out IsPolicy value);
-            policy = got ? (TPolicy)value : default(TPolicy);
+            policy = got ? (TPolicy)value : default;
             return got;
         }
 


### PR DESCRIPTION
my preference is to omit the type when using `default(Type)` where possible. thoughts?