### PR TITLE
Add TryAdd and TryRemove to PolicyRegistry

### DIFF
--- a/src/Polly.Specs/Registry/PolicyRegistrySpecs.cs
+++ b/src/Polly.Specs/Registry/PolicyRegistrySpecs.cs
@@ -68,6 +68,60 @@ namespace Polly.Specs.Registry
             _registry.Add<ISyncPolicy<ResultPrimitive>>(key2, policy2);
             _registry.Count.Should().Be(2);
         }
+        
+        [Fact]
+        public void Should_be_able_to_add_Policy_using_TryAdd()
+        {
+            Policy policy = Policy.NoOp();
+            string key = Guid.NewGuid().ToString();
+
+            var insert = _registry.TryAdd(key, policy);
+            _registry.Count.Should().Be(1);
+            insert.Should().Be(true);
+
+            Policy policy2 = Policy.NoOp();
+            string key2 = Guid.NewGuid().ToString();
+
+            var insert2 = _registry.TryAdd(key2, policy2);
+            _registry.Count.Should().Be(2);
+            insert2.Should().Be(true);
+        }
+
+        [Fact]
+        public void Should_be_able_to_add_PolicyTResult_using_TryAdd()
+        {
+            Policy policy = Policy.NoOp();
+            string key = Guid.NewGuid().ToString();
+
+            var insert = _registry.TryAdd(key, policy);
+            _registry.Count.Should().Be(1);
+            insert.Should().Be(true);
+
+            Policy<ResultPrimitive> policy2 = Policy<ResultPrimitive>.HandleResult(ResultPrimitive.Fault).Retry();
+            string key2 = Guid.NewGuid().ToString();
+
+            var insert2 = _registry.TryAdd(key2, policy2);
+            _registry.Count.Should().Be(2);
+            insert2.Should().Be(true);
+        }
+
+        [Fact]
+        public void Should_be_able_to_add_Policy_by_interface_using_TryAdd()
+        {
+            Policy policy = Policy.NoOp();
+            string key = Guid.NewGuid().ToString();
+
+            var insert = _registry.TryAdd(key, policy);
+            _registry.Count.Should().Be(1);
+            insert.Should().Be(true);
+
+            ISyncPolicy<ResultPrimitive> policy2 = Policy<ResultPrimitive>.HandleResult(ResultPrimitive.Fault).Retry();
+            string key2 = Guid.NewGuid().ToString();
+
+            var insert2 = _registry.TryAdd(key2, policy2);
+            _registry.Count.Should().Be(2);
+            insert2.Should().Be(true);
+        }
 
         [Fact]
         public void Should_be_able_to_add_Policy_using_Indexer()
@@ -408,6 +462,20 @@ namespace Polly.Specs.Registry
 
             _registry.Remove(key);
             _registry.Count.Should().Be(0);
+        }
+        
+        [Fact]
+        public void Should_be_able_to_remove_policy_with_TryRemove()
+        {
+            Policy policy = Policy.NoOp();
+            string key = Guid.NewGuid().ToString();
+
+            _registry.Add(key, policy);
+            _registry.Count.Should().Be(1);
+
+            _registry.TryRemove(key, out policy);
+            _registry.Count.Should().Be(0);
+            policy.Should().Be(policy);
         }
 
         [Fact]

--- a/src/Polly/Registry/IPolicyRegistry.cs
+++ b/src/Polly/Registry/IPolicyRegistry.cs
@@ -20,6 +20,15 @@ namespace Polly.Registry
         void Add<TPolicy>(TKey key, TPolicy policy) where TPolicy : IsPolicy;
 
         /// <summary>
+        /// Adds an element with the provided key and policy to the registry.
+        /// </summary>
+        /// <param name="key">The key for the policy.</param>
+        /// <param name="policy">The policy to store in the registry.</param>
+        /// <typeparam name="TPolicy">The type of Policy.</typeparam>
+        /// <returns>True if Policy was added. False otherwise.</returns>
+        bool TryAdd<TPolicy>(string key, TPolicy policy) where TPolicy : IsPolicy;
+
+        /// <summary>
         /// Gets or sets the <see cref="IsPolicy"/> with the specified key.
         /// <remarks>To retrieve a policy directly as a particular Policy type or Policy interface (avoiding a cast), use the <see cref="IReadOnlyPolicyRegistry{TKey}.Get{TPolicy}"/> method.</remarks>
         /// </summary>
@@ -36,6 +45,19 @@ namespace Polly.Registry
         /// <returns>True if the policy is successfully removed. Otherwise false.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="key"/> is null.</exception>
         bool Remove(TKey key);
+
+        /// <summary>
+        /// Removes the policy stored under the specified <paramref name="key"/> from the registry.
+        /// </summary>
+        /// <param name="key">The <paramref name="key"/> of the policy to remove.</param>
+        /// <param name="policy">
+        /// This method returns the policy associated with the specified <paramref name="key"/>, if the
+        /// key is found; otherwise null.
+        /// This parameter is passed uninitialized.
+        /// </param>
+        /// <typeparam name="TPolicy">The type of Policy.</typeparam>
+        /// <returns>True if the policy is successfully removed. Otherwise false.</returns>
+        bool TryRemove<TPolicy>(string key, out TPolicy policy) where TPolicy : IsPolicy;
 
         /// <summary>
         /// Removes all keys and policies from registry.

--- a/src/Polly/Registry/PolicyRegistry.cs
+++ b/src/Polly/Registry/PolicyRegistry.cs
@@ -51,6 +51,24 @@ namespace Polly.Registry
             _registry.Add(key, policy);
 
         /// <summary>
+        /// Adds an element with the provided key and policy to the registry.
+        /// </summary>
+        /// <param name="key">The key for the policy.</param>
+        /// <param name="policy">The policy to store in the registry.</param>
+        /// <typeparam name="TPolicy">The type of Policy.</typeparam>
+        /// <returns>True if Policy was added. False otherwise.</returns>
+        public bool TryAdd<TPolicy>(string key, TPolicy policy) where TPolicy : IsPolicy
+        {
+            if (_registry is ConcurrentDictionary<string, IsPolicy> registry)
+            {
+                bool got = registry.TryAdd(key, policy);
+                return got;
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Gets of sets the <see cref="IsPolicy"/> with the specified key.
         /// <remarks>To retrieve a policy directly as a particular Policy type or Policy interface (avoiding a cast), use the <see cref="Get{TPolicy}"/> method.</remarks>
         /// </summary>
@@ -115,6 +133,30 @@ namespace Polly.Registry
         /// <exception cref="ArgumentNullException"><paramref name="key"/> is null.</exception>
         public bool Remove(string key) =>
             _registry.Remove(key);
+
+        /// <summary>
+        /// Removes the policy stored under the specified <paramref name="key"/> from the registry.
+        /// </summary>
+        /// <param name="key">The <paramref name="key"/> of the policy to remove.</param>
+        /// <param name="policy">
+        /// This method returns the policy associated with the specified <paramref name="key"/>, if the
+        /// key is found; otherwise null.
+        /// This parameter is passed uninitialized.
+        /// </param>
+        /// <typeparam name="TPolicy">The type of Policy.</typeparam>
+        /// <returns>True if the policy is successfully removed. Otherwise false.</returns>
+        public bool TryRemove<TPolicy>(string key, out TPolicy policy) where TPolicy : IsPolicy
+        {
+            if (_registry is ConcurrentDictionary<string, IsPolicy> registry)
+            {
+                bool got = registry.TryRemove(key, out IsPolicy value);
+                policy = got ? (TPolicy)value : default;
+                return got;
+            }
+
+            policy = default;
+            return false;
+        }
 
         /// <summary>Returns an enumerator that iterates through the policy objects in the <see
         /// cref="PolicyRegistry"/>.</summary>


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors.  All non-trivial contributions get a public credit in the readme! -->

### The issue or feature being addressed
Resolves #645. Adds TryAdd(), TryRemove(), and tests for PolicyRegistry.

<!-- Please include the existing github issue number where relevant -->

### Details on the issue fix or feature implementation
Pretty straight forward, but there are a few casts that are only necessary because of the internal constructor. We could remove them but it would require significant refactoring of the tests that use the constructor.

### Confirm the following

- [X]  I started this PR by branching from the head of the latest dev vX.Y branch, or I have rebased on the latest dev vX.Y branch, or I have merged the latest changes from the dev vX.Y branch
- [X]  I have targeted the PR to merge into the latest dev vX.Y branch as the base branch
- [X]  I have included unit tests for the issue/feature
- [X]  I have successfully run a local build
