### PR TITLE
IConcurrentPolicyRegistry additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.2.0
+- Add test target netcoreapp3.0
+- Extend PolicyRegistry with concurrent method support: TryAdd, TryRemove, TryUpdate, GetOrAdd, AddOrUpdate
+
 ## 7.1.1
 - Bug fix: ensure async retry policies honor continueOnCapturedContext setting (affected v7.1.0 only).
 - Remove deprecated cake add-in from build

--- a/README.md
+++ b/README.md
@@ -1059,6 +1059,8 @@ Both templates contain a full project structure referencing Polly, Polly's defau
 * [@kesmy](https://github.com/Kesmy) - Add Soucelink support, clean up cake build.
 * [@simluk](https://github.com/simluk) - Fix continueOnCaptureContext not being honored in async retry implementation (bug in v7.1.0 only).
 * [@jnyrup](https://github.com/jnyrup) - Upgrade tests to Fluent Assertions v5.9.0
+* [@SimonCropp](https://github.com/SimonCropp) - Add netcoreapp3.0 target; code clean-ups.
+* [@aerotog](https://github.com/aerotog) and [@reisenberger](https://github.com/reisenberger) - IConcurrentPolicyRegistry methods on PolicyRegistry
 
 # Sample Projects
 

--- a/src/Polly.Specs/Registry/ConcurrentPolicyRegistrySpecs.cs
+++ b/src/Polly.Specs/Registry/ConcurrentPolicyRegistrySpecs.cs
@@ -1,0 +1,264 @@
+﻿using System;
+using FluentAssertions;
+using Polly.NoOp;
+using Polly.Registry;
+using Polly.Specs.Helpers;
+using Xunit;
+
+namespace Polly.Specs.Registry
+{
+    public class ConcurrentPolicyRegistrySpecs
+    {
+        IConcurrentPolicyRegistry<string> _registry;
+
+        public ConcurrentPolicyRegistrySpecs()
+        {
+            _registry = new PolicyRegistry();
+        }
+
+        [Fact]
+        public void Should_be_able_to_add_Policy_using_TryAdd()
+        {
+            Policy policy = Policy.NoOp();
+            string key = Guid.NewGuid().ToString();
+
+            var insert = _registry.TryAdd(key, policy);
+            _registry.Count.Should().Be(1);
+            insert.Should().Be(true);
+
+            Policy policy2 = Policy.NoOp();
+            string key2 = Guid.NewGuid().ToString();
+
+            var insert2 = _registry.TryAdd(key2, policy2);
+            _registry.Count.Should().Be(2);
+            insert2.Should().Be(true);
+        }
+
+        [Fact]
+        public void Should_be_able_to_add_PolicyTResult_using_TryAdd()
+        {
+            Policy policy = Policy.NoOp();
+            string key = Guid.NewGuid().ToString();
+
+            var insert = _registry.TryAdd(key, policy);
+            _registry.Count.Should().Be(1);
+            insert.Should().Be(true);
+
+            Policy<ResultPrimitive> policy2 = Policy<ResultPrimitive>.HandleResult(ResultPrimitive.Fault).Retry();
+            string key2 = Guid.NewGuid().ToString();
+
+            var insert2 = _registry.TryAdd(key2, policy2);
+            _registry.Count.Should().Be(2);
+            insert2.Should().Be(true);
+        }
+
+        [Fact]
+        public void Should_be_able_to_add_Policy_by_interface_using_TryAdd()
+        {
+            Policy policy = Policy.NoOp();
+            string key = Guid.NewGuid().ToString();
+
+            var insert = _registry.TryAdd(key, policy);
+            _registry.Count.Should().Be(1);
+            insert.Should().Be(true);
+
+            ISyncPolicy<ResultPrimitive> policy2 = Policy<ResultPrimitive>.HandleResult(ResultPrimitive.Fault).Retry();
+            string key2 = Guid.NewGuid().ToString();
+
+            var insert2 = _registry.TryAdd(key2, policy2);
+            _registry.Count.Should().Be(2);
+            insert2.Should().Be(true);
+        }
+
+        [Fact]
+        public void Should_be_able_to_remove_policy_with_TryRemove()
+        {
+            Policy policy = Policy.NoOp();
+            string key = Guid.NewGuid().ToString();
+
+            _registry.Add(key, policy);
+            _registry.Count.Should().Be(1);
+
+            bool removed = _registry.TryRemove(key, out IsPolicy removedPolicy);
+            _registry.Count.Should().Be(0);
+            removedPolicy.Should().BeSameAs(policy);
+            removed.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Should_report_false_from_TryRemove_if_no_Policy()
+        {
+            string key = Guid.NewGuid().ToString();
+
+            bool removed = _registry.TryRemove(key, out IsPolicy removedPolicy);
+            removed.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Should_be_able_to_update_policy_with_TryUpdate()
+        {
+            Policy existingPolicy = Policy.NoOp();
+            string key = Guid.NewGuid().ToString();
+            _registry.Add(key, existingPolicy);
+
+            Policy<ResultClass> newPolicy = Policy.NoOp<ResultClass>();
+
+            bool updated = _registry.TryUpdate<IsPolicy>(key, newPolicy, existingPolicy);
+
+            updated.Should().BeTrue();
+            _registry[key].Should().BeSameAs(newPolicy);
+        }
+
+        [Fact]
+        public void Should_not_update_policy_with_TryUpdate_when_existingPolicy_mismatch()
+        {
+            Policy existingPolicy = Policy.NoOp();
+            string key = Guid.NewGuid().ToString();
+            _registry.Add(key, existingPolicy);
+
+            NoOpPolicy<ResultPrimitive> someOtherPolicy = Policy.NoOp<ResultPrimitive>();
+            Policy<ResultClass> newPolicy = Policy.NoOp<ResultClass>();
+
+            bool updated = _registry.TryUpdate<IsPolicy>(key, newPolicy, someOtherPolicy);
+
+            updated.Should().BeFalse();
+            _registry[key].Should().BeSameAs(existingPolicy);
+        }
+
+        [Fact]
+        public void Should_not_update_policy_with_TryUpdate_when_no_existing_value()
+        {
+            string key = Guid.NewGuid().ToString();
+
+            NoOpPolicy<ResultPrimitive> someOtherPolicy = Policy.NoOp<ResultPrimitive>();
+            Policy<ResultClass> newPolicy = Policy.NoOp<ResultClass>();
+
+            bool updated = _registry.TryUpdate<IsPolicy>(key, newPolicy, someOtherPolicy);
+
+            updated.Should().BeFalse();
+            _registry.ContainsKey(key).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Should_add_with_GetOrAdd_with_value_when_no_existing_policy()
+        {
+            Policy newPolicy = Policy.NoOp();
+            string key = Guid.NewGuid().ToString();
+
+            var returnedPolicy = _registry.GetOrAdd(key, newPolicy);
+
+            returnedPolicy.Should().BeSameAs(newPolicy);
+        }
+
+        [Fact]
+        public void Should_add_with_GetOrAdd_with_factory_when_no_existing_policy()
+        {
+            Policy newPolicy = Policy.NoOp();
+            string key = Guid.NewGuid().ToString();
+
+            var returnedPolicy = _registry.GetOrAdd(key, k => newPolicy);
+
+            returnedPolicy.Should().BeSameAs(newPolicy);
+        }
+
+        [Fact]
+        public void Should_return_existing_with_GetOrAdd_with_value_when_existing_policy()
+        {
+            Policy existingPolicy = Policy.NoOp();
+            string key = Guid.NewGuid().ToString();
+            _registry.Add(key, existingPolicy);
+
+            Policy newPolicy = Policy.NoOp();
+
+            var returnedPolicy = _registry.GetOrAdd(key, newPolicy);
+
+            returnedPolicy.Should().BeSameAs(existingPolicy);
+        }
+
+        [Fact]
+        public void Should_return_existing_with_GetOrAdd_with_factory_when_existing_policy()
+        {
+            Policy existingPolicy = Policy.NoOp();
+            string key = Guid.NewGuid().ToString();
+            _registry.Add(key, existingPolicy);
+
+            Policy newPolicy = Policy.NoOp();
+
+            var returnedPolicy = _registry.GetOrAdd(key, k => newPolicy);
+
+            returnedPolicy.Should().BeSameAs(existingPolicy);
+        }
+
+        [Fact]
+        public void Should_add_with_AddOrUpdate_with_value_when_no_existing_policy()
+        {
+            Policy newPolicy = Policy.NoOp();
+            string key = Guid.NewGuid().ToString();
+
+            var returnedPolicy = _registry.AddOrUpdate(
+                key, 
+                newPolicy,
+                (k, existing) => throw new InvalidOperationException("Update factory should not be called in this test."));
+
+            returnedPolicy.Should().BeSameAs(newPolicy);
+        }
+
+        [Fact]
+        public void Should_add_with_AddOrUpdate_with_addfactory_when_no_existing_policy()
+        {
+            Policy newPolicy = Policy.NoOp();
+            string key = Guid.NewGuid().ToString();
+
+
+            var returnedPolicy = _registry.AddOrUpdate(
+                key,
+                k => newPolicy, 
+                (k, existing) => throw new InvalidOperationException("Update factory should not be called in this test."));
+
+            returnedPolicy.Should().BeSameAs(newPolicy);
+        }
+
+        [Fact]
+        public void Should_update_with_AddOrUpdate_with_updatefactory_ignoring_addvalue_when_existing_policy()
+        {
+            Policy existingPolicy = Policy.NoOp();
+            string key = Guid.NewGuid().ToString();
+            _registry.Add(key, existingPolicy);
+
+            const string policyKeyToDecorate = "SomePolicyKey";
+
+            Policy otherPolicyNotExpectingToAdd = Policy.Handle<Exception>().Retry();
+
+            var returnedPolicy = _registry.AddOrUpdate(
+                key,
+                otherPolicyNotExpectingToAdd,
+                (k, existing) => existingPolicy.WithPolicyKey(policyKeyToDecorate));
+
+            returnedPolicy.Should().NotBeSameAs(otherPolicyNotExpectingToAdd);
+            returnedPolicy.Should().BeSameAs(existingPolicy);
+            returnedPolicy.PolicyKey.Should().Be(policyKeyToDecorate);
+        }
+
+        [Fact]
+        public void Should_update_with_AddOrUpdate_with_updatefactory_ignoring_addfactory_when_existing_policy()
+        {
+            Policy existingPolicy = Policy.NoOp();
+            string key = Guid.NewGuid().ToString();
+            _registry.Add(key, existingPolicy);
+
+            const string policyKeyToDecorate = "SomePolicyKey";
+
+            Policy otherPolicyNotExpectingToAdd = Policy.Handle<Exception>().Retry();
+
+            var returnedPolicy = _registry.AddOrUpdate(
+                key,
+                k => otherPolicyNotExpectingToAdd,
+                (k, existing) => existingPolicy.WithPolicyKey(policyKeyToDecorate));
+
+            returnedPolicy.Should().NotBeSameAs(otherPolicyNotExpectingToAdd);
+            returnedPolicy.Should().BeSameAs(existingPolicy);
+            returnedPolicy.PolicyKey.Should().Be(policyKeyToDecorate);
+        }
+
+    }
+}

--- a/src/Polly.Specs/Registry/PolicyRegistrySpecs.cs
+++ b/src/Polly.Specs/Registry/PolicyRegistrySpecs.cs
@@ -70,60 +70,6 @@ namespace Polly.Specs.Registry
         }
         
         [Fact]
-        public void Should_be_able_to_add_Policy_using_TryAdd()
-        {
-            Policy policy = Policy.NoOp();
-            string key = Guid.NewGuid().ToString();
-
-            var insert = _registry.TryAdd(key, policy);
-            _registry.Count.Should().Be(1);
-            insert.Should().Be(true);
-
-            Policy policy2 = Policy.NoOp();
-            string key2 = Guid.NewGuid().ToString();
-
-            var insert2 = _registry.TryAdd(key2, policy2);
-            _registry.Count.Should().Be(2);
-            insert2.Should().Be(true);
-        }
-
-        [Fact]
-        public void Should_be_able_to_add_PolicyTResult_using_TryAdd()
-        {
-            Policy policy = Policy.NoOp();
-            string key = Guid.NewGuid().ToString();
-
-            var insert = _registry.TryAdd(key, policy);
-            _registry.Count.Should().Be(1);
-            insert.Should().Be(true);
-
-            Policy<ResultPrimitive> policy2 = Policy<ResultPrimitive>.HandleResult(ResultPrimitive.Fault).Retry();
-            string key2 = Guid.NewGuid().ToString();
-
-            var insert2 = _registry.TryAdd(key2, policy2);
-            _registry.Count.Should().Be(2);
-            insert2.Should().Be(true);
-        }
-
-        [Fact]
-        public void Should_be_able_to_add_Policy_by_interface_using_TryAdd()
-        {
-            Policy policy = Policy.NoOp();
-            string key = Guid.NewGuid().ToString();
-
-            var insert = _registry.TryAdd(key, policy);
-            _registry.Count.Should().Be(1);
-            insert.Should().Be(true);
-
-            ISyncPolicy<ResultPrimitive> policy2 = Policy<ResultPrimitive>.HandleResult(ResultPrimitive.Fault).Retry();
-            string key2 = Guid.NewGuid().ToString();
-
-            var insert2 = _registry.TryAdd(key2, policy2);
-            _registry.Count.Should().Be(2);
-            insert2.Should().Be(true);
-        }
-
-        [Fact]
         public void Should_be_able_to_add_Policy_using_Indexer()
         {
             Policy policy = Policy.NoOp();
@@ -462,20 +408,6 @@ namespace Polly.Specs.Registry
 
             _registry.Remove(key);
             _registry.Count.Should().Be(0);
-        }
-        
-        [Fact]
-        public void Should_be_able_to_remove_policy_with_TryRemove()
-        {
-            Policy policy = Policy.NoOp();
-            string key = Guid.NewGuid().ToString();
-
-            _registry.Add(key, policy);
-            _registry.Count.Should().Be(1);
-
-            _registry.TryRemove(key, out policy);
-            _registry.Count.Should().Be(0);
-            policy.Should().Be(policy);
         }
 
         [Fact]

--- a/src/Polly.Specs/Registry/ReadOnlyPolicyRegistrySpecs.cs
+++ b/src/Polly.Specs/Registry/ReadOnlyPolicyRegistrySpecs.cs
@@ -8,13 +8,13 @@ using Xunit;
 
 namespace Polly.Specs.Registry
 {
-    public class IReadOnlyPolicyRegistrySpecs
+    public class ReadOnlyPolicyRegistrySpecs
     {
         IPolicyRegistry<string> _registry;
 
         IReadOnlyPolicyRegistry<string> ReadOnlyRegistry { get{ return _registry; } }
 
-        public IReadOnlyPolicyRegistrySpecs()
+        public ReadOnlyPolicyRegistrySpecs()
         {
             _registry = new PolicyRegistry();
         }

--- a/src/Polly/Registry/IConcurrentPolicyRegistry.cs
+++ b/src/Polly/Registry/IConcurrentPolicyRegistry.cs
@@ -1,0 +1,90 @@
+﻿using System;
+
+namespace Polly.Registry
+{
+    /// <summary>
+    /// Represents a collection of policies keyed by <typeparamref name="TKey"/> which can be updated and consumed in a thread-safe manner.
+    /// </summary>
+    /// <typeparam name="TKey">The type of keys in the policy registry.</typeparam>
+    public interface IConcurrentPolicyRegistry<TKey> : IPolicyRegistry<TKey>
+    {
+        /// <summary>
+        /// Adds an element with the provided key and policy to the registry.
+        /// </summary>
+        /// <param name="key">The key for the policy.</param>
+        /// <param name="policy">The policy to store in the registry.</param>
+        /// <typeparam name="TPolicy">The type of Policy.</typeparam>
+        /// <returns>True if Policy was added. False otherwise.</returns>
+        bool TryAdd<TPolicy>(TKey key, TPolicy policy) where TPolicy : IsPolicy;
+
+        /// <summary>
+        /// Removes the policy stored under the specified <paramref name="key"/> from the registry.
+        /// </summary>
+        /// <param name="key">The <paramref name="key"/> of the policy to remove.</param>
+        /// <param name="policy">
+        /// This method returns the policy associated with the specified <paramref name="key"/>, if the
+        /// key is found; otherwise null.
+        /// This parameter is passed uninitialized.
+        /// </param>
+        /// <typeparam name="TPolicy">The type of Policy.</typeparam>
+        /// <returns>True if the policy is successfully removed. Otherwise false.</returns>
+        bool TryRemove<TPolicy>(TKey key, out TPolicy policy) where TPolicy : IsPolicy;
+
+        /// <summary>
+        /// Compares the existing policy for the specified key with a specified policy, and if they are equal, updates the policy with a third value.
+        /// </summary>
+        /// <typeparam name="TPolicy"></typeparam>
+        /// <param name="key">The key whose value is compared with comparisonPolicy, and possibly replaced.</param>
+        /// <param name="newPolicy">The policy that replaces the value for the specified <paramref name="key"/>, if the comparison results in equality.</param>
+        /// <param name="comparisonPolicy">The policy that is compared to the existing policy at the specified key.</param>
+        /// <returns></returns>
+        bool TryUpdate<TPolicy>(TKey key, TPolicy newPolicy, TPolicy comparisonPolicy) where TPolicy : IsPolicy;
+
+        /// <summary>
+        /// Adds a policy with the provided key and policy to the registry
+        /// if the key does not already exist.
+        /// </summary>
+        /// <param name="key">The key of the policy to add.</param>
+        /// <param name="policyFactory">The function used to generate a policy for the key</param>
+        /// <returns>The policy for the key.  This will be either the existing policy for the key if the
+        /// key is already in the registry, or the new policy for the key as returned by policyFactory
+        /// if the key was not in the registry.</returns>
+        TPolicy GetOrAdd<TPolicy>(TKey key, Func<TKey, TPolicy> policyFactory) where TPolicy : IsPolicy;
+
+        /// <summary>
+        /// Adds a key/policy pair to the registry
+        /// if the key does not already exist.
+        /// </summary>
+        /// <param name="key">The key of the policy to add.</param>
+        /// <param name="policy">the value to be added, if the key does not already exist</param>
+        /// <returns>The policy for the key.  This will be either the existing policy for the key if the 
+        /// key is already in the registry, or the new policy if the key was not in the registry.</returns>
+        TPolicy GetOrAdd<TPolicy>(TKey key, TPolicy policy) where TPolicy : IsPolicy;
+
+        /// <summary>
+        /// Adds a key/policy pair to the registry if the key does not already 
+        /// exist, or updates a key/policy pair in the registry if the key 
+        /// already exists.
+        /// </summary>
+        /// <param name="key">The key to be added or whose policy should be updated</param>
+        /// <param name="addPolicyFactory">The function used to generate a policy for an absent key</param>
+        /// <param name="updatePolicyFactory">The function used to generate a new policy for an existing key
+        /// based on the key's existing value</param>
+        /// <returns>The new policy for the key.  This will be either be the result of addPolicyFactory (if the key was 
+        /// absent) or the result of updatePolicyFactory (if the key was present).</returns>
+        TPolicy AddOrUpdate<TPolicy>(TKey key, Func<TKey, TPolicy> addPolicyFactory, Func<TKey, TPolicy, TPolicy> updatePolicyFactory) where TPolicy : IsPolicy;
+
+        /// <summary>
+        /// Adds a key/policy pair to the registry if the key does not already 
+        /// exist, or updates a key/policy pair in the registry if the key 
+        /// already exists.
+        /// </summary>
+        /// <param name="key">The key to be added or whose policy should be updated</param>
+        /// <param name="addPolicy">The policy to be added for an absent key</param>
+        /// <param name="updatePolicyFactory">The function used to generate a new policy for an existing key based on 
+        /// the key's existing value</param>
+        /// <returns>The new policy for the key.  This will be either be addPolicy (if the key was 
+        /// absent) or the result of updatePolicyFactory (if the key was present).</returns>
+        TPolicy AddOrUpdate<TPolicy>(TKey key, TPolicy addPolicy, Func<TKey, TPolicy, TPolicy> updatePolicyFactory) where TPolicy : IsPolicy;
+    }
+}

--- a/src/Polly/Registry/IPolicyRegistry.cs
+++ b/src/Polly/Registry/IPolicyRegistry.cs
@@ -20,15 +20,6 @@ namespace Polly.Registry
         void Add<TPolicy>(TKey key, TPolicy policy) where TPolicy : IsPolicy;
 
         /// <summary>
-        /// Adds an element with the provided key and policy to the registry.
-        /// </summary>
-        /// <param name="key">The key for the policy.</param>
-        /// <param name="policy">The policy to store in the registry.</param>
-        /// <typeparam name="TPolicy">The type of Policy.</typeparam>
-        /// <returns>True if Policy was added. False otherwise.</returns>
-        bool TryAdd<TPolicy>(string key, TPolicy policy) where TPolicy : IsPolicy;
-
-        /// <summary>
         /// Gets or sets the <see cref="IsPolicy"/> with the specified key.
         /// <remarks>To retrieve a policy directly as a particular Policy type or Policy interface (avoiding a cast), use the <see cref="IReadOnlyPolicyRegistry{TKey}.Get{TPolicy}"/> method.</remarks>
         /// </summary>
@@ -45,19 +36,6 @@ namespace Polly.Registry
         /// <returns>True if the policy is successfully removed. Otherwise false.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="key"/> is null.</exception>
         bool Remove(TKey key);
-
-        /// <summary>
-        /// Removes the policy stored under the specified <paramref name="key"/> from the registry.
-        /// </summary>
-        /// <param name="key">The <paramref name="key"/> of the policy to remove.</param>
-        /// <param name="policy">
-        /// This method returns the policy associated with the specified <paramref name="key"/>, if the
-        /// key is found; otherwise null.
-        /// This parameter is passed uninitialized.
-        /// </param>
-        /// <typeparam name="TPolicy">The type of Policy.</typeparam>
-        /// <returns>True if the policy is successfully removed. Otherwise false.</returns>
-        bool TryRemove<TPolicy>(string key, out TPolicy policy) where TPolicy : IsPolicy;
 
         /// <summary>
         /// Removes all keys and policies from registry.

--- a/src/Polly/Registry/PolicyRegistry.cs
+++ b/src/Polly/Registry/PolicyRegistry.cs
@@ -40,7 +40,7 @@ namespace Polly.Registry
         public int Count => _registry.Count;
 
         /// <summary>
-        /// Adds an element with the provided key and policy to the registry.
+        /// Adds a policy with the provided key and policy to the registry.
         /// </summary>
         /// <param name="key">The key for the policy.</param>
         /// <param name="policy">The policy to store in the registry.</param>
@@ -51,7 +51,7 @@ namespace Polly.Registry
             _registry.Add(key, policy);
 
         /// <summary>
-        /// Adds an element with the provided key and policy to the registry.
+        /// Adds a policy with the provided key and policy to the registry.
         /// </summary>
         /// <param name="key">The key for the policy.</param>
         /// <param name="policy">The policy to store in the registry.</param>
@@ -72,10 +72,10 @@ namespace Polly.Registry
         /// Gets of sets the <see cref="IsPolicy"/> with the specified key.
         /// <remarks>To retrieve a policy directly as a particular Policy type or Policy interface (avoiding a cast), use the <see cref="Get{TPolicy}"/> method.</remarks>
         /// </summary>
-        /// <param name="key">The key of the value to get or set.</param>
+        /// <param name="key">The key of the policy to get or set.</param>
         /// <exception cref="T:System.ArgumentNullException"><paramref name="key" /> is null.</exception>
-        /// <exception cref="KeyNotFoundException">The given key was not present in the dictionary.</exception>
-        /// <returns>The value associated with the specified key.</returns>
+        /// <exception cref="KeyNotFoundException">The given key was not present in the registry.</exception>
+        /// <returns>The policy associated with the specified key.</returns>
         public IsPolicy this[string key]
         {
             get => _registry[key];
@@ -88,7 +88,7 @@ namespace Polly.Registry
         /// <typeparam name="TPolicy">The type of Policy.</typeparam>
         /// <returns>The policy stored in the registry under the given key.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="key"/> is null.</exception>
-        /// <exception cref="KeyNotFoundException">The given key was not present in the dictionary.</exception>
+        /// <exception cref="KeyNotFoundException">The given key was not present in the registry.</exception>
         public TPolicy Get<TPolicy>(string key) where TPolicy : IsPolicy => 
             (TPolicy) _registry[key];
 
@@ -165,7 +165,7 @@ namespace Polly.Registry
         /// The enumerator returned from the registry is safe to use concurrently with
         /// reads and writes to the registry, however it does not represent a moment-in-time snapshot
         /// of the registry's contents.  The contents exposed through the enumerator may contain modifications
-        /// made to the dictionary after <see cref="GetEnumerator"/> was called.
+        /// made to the registry after <see cref="GetEnumerator"/> was called.
         /// This is not considered a significant issue as typical usage of PolicyRegistry is for bulk population at app startup, 
         /// with only infrequent changes to the PolicyRegistry during app running, if using PolicyRegistry for dynamic updates during running.
         /// </remarks>
@@ -178,7 +178,7 @@ namespace Polly.Registry
         /// The enumerator returned from the registry is safe to use concurrently with
         /// reads and writes to the registry, however it does not represent a moment-in-time snapshot
         /// of the registry's contents.  The contents exposed through the enumerator may contain modifications
-        /// made to the dictionary after <see cref="GetEnumerator"/> was called.
+        /// made to the registry after <see cref="GetEnumerator"/> was called.
         /// This is not considered a significant issue as typical usage of PolicyRegistry is for bulk population at app startup, 
         /// with only infrequent changes to the PolicyRegistry during app running, if using PolicyRegistry for dynamic updates during running.
         /// </remarks>

--- a/src/Polly/Registry/PolicyRegistry.cs
+++ b/src/Polly/Registry/PolicyRegistry.cs
@@ -15,7 +15,7 @@ namespace Polly.Registry
         private readonly IDictionary<string, IsPolicy> _registry = new ConcurrentDictionary<string, IsPolicy>();
 
         /// <summary>
-        /// A registry of policy policies with <see cref="String"/> keys.
+        /// Creates a registry of policies with <see cref="String"/> keys.
         /// </summary>
         public PolicyRegistry()
         {
@@ -26,7 +26,8 @@ namespace Polly.Registry
         }
 
         /// <summary>
-        /// A registry of policy policies with <see cref="String"/> keys.
+        /// Creates a registry of policies with <see cref="String"/> keys.
+        /// <remarks>This internal constructor exists solely to facilitate testing of the GetEnumerator() methods, which allow us to support collection initialisation syntax.</remarks>
         /// </summary>
         /// <param name="registry">a dictionary containing keys and policies used for testing.</param>
         internal PolicyRegistry(IDictionary<string, IsPolicy> registry) 


### PR DESCRIPTION
### The issue or feature being addressed

Closes #645 concurrent write overloads for PolicyRegistry

Thanks also to @aerotog for earlier work on this feature.

### Details on the issue fix or feature implementation

+ `IConcurrentPolicyRegistry<TKey>` implementation
+ Add further methods for concurrent usage on PolicyRegistry: `TryUpdate`, `GetOrAdd` and `AddOrUpdate`
+ v7.2.0 readme updates and credits

### Confirm the following

- [x]  I started this PR by branching from the head of the latest dev vX.Y branch, or I have rebased on the latest dev vX.Y branch, or I have merged the latest changes from the dev vX.Y branch
- [x]  I have targeted the PR to merge into the latest dev vX.Y branch as the base branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
