### PR TITLE
Fix, tests and doco for issue 620 - edge race case when timeout occurs while user exception is being marshalled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 7.2.0
 - Add test target netcoreapp3.0
 - Extend PolicyRegistry with concurrent method support: TryAdd, TryRemove, TryUpdate, GetOrAdd, AddOrUpdate
+- TimeoutPolicy: if timeout occurs while a user exception is being marshalled (edge case race condition), do not mask user exception (issue 620)
 
 ## 7.1.1
 - Bug fix: ensure async retry policies honor continueOnCapturedContext setting (affected v7.1.0 only).

--- a/src/Polly.Specs/Timeout/TimeoutAsyncSpecs.cs
+++ b/src/Polly.Specs/Timeout/TimeoutAsyncSpecs.cs
@@ -419,6 +419,41 @@ namespace Polly.Specs.Timeout
             executed.Should().BeFalse();
         }
 
+        [Fact]
+        public void Should_not_mask_user_exception_if_user_exception_overlaps_with_timeout()
+        {
+            var userException = new Exception();
+            var shimTimeSpan = TimeSpan.FromSeconds(0.2);
+            var policy = Policy.TimeoutAsync(shimTimeSpan, TimeoutStrategy.Optimistic);
+
+            var thrown = policy.Awaiting(p => p.ExecuteAsync(async ct =>
+                {
+                    try
+                    {
+                        await SystemClock.SleepAsync(shimTimeSpan + shimTimeSpan, CancellationToken.None);
+                    }
+                    catch
+                    {
+                        // Throw a different exception - this exception should not be masked.
+                        // The issue of more interest for issue 620 is an edge-case race condition where a user exception is thrown
+                        // quasi-simultaneously to timeout (rather than in a manual catch of a timeout as here), but this is a good way to simulate it.
+                        // A real-world case can be if timeout occurs while code is marshalling a user-exception into or through the catch block in TimeoutEngine.
+                        throw userException;
+                    }
+
+                    throw new InvalidOperationException("This exception should not be thrown. Test should throw for timeout earlier.");
+
+                }, CancellationToken.None))
+                .Should()
+                .Throw<Exception>()
+                .Which;
+
+            thrown.Should().NotBeOfType<OperationCanceledException>();
+            thrown.Should().NotBeOfType<TimeoutRejectedException>();
+            thrown.Should().NotBeOfType<InvalidOperationException>();
+            thrown.Should().BeSameAs(userException);
+        }
+
         #endregion
 
         #region onTimeout overload - pessimistic

--- a/src/Polly.Specs/Timeout/TimeoutSpecsBase.cs
+++ b/src/Polly.Specs/Timeout/TimeoutSpecsBase.cs
@@ -42,7 +42,7 @@ namespace Polly.Specs.Timeout
                 SystemClock.Sleep(TimeSpan.Zero, CancellationToken.None); // Invoke our custom definition of sleep, to check for immediate cancellation.
             };
 
-            // Override SysteClock.Sleep, to manipulate our artificial clock.  And - if it means sleeping beyond the time when a tracked token should cancel - cancel it!
+            // Override SystemClock.Sleep, to manipulate our artificial clock.  And - if it means sleeping beyond the time when a tracked token should cancel - cancel it!
             SystemClock.Sleep = (sleepTimespan, sleepCancellationtoken) =>
             {
                 if (sleepCancellationtoken.IsCancellationRequested) return;

--- a/src/Polly/Timeout/AsyncTimeoutEngine.cs
+++ b/src/Polly/Timeout/AsyncTimeoutEngine.cs
@@ -47,7 +47,9 @@ namespace Polly.Timeout
                     }
                     catch (Exception ex)
                     {
-                        if (timeoutCancellationTokenSource.IsCancellationRequested)
+                        // Note that we cannot rely on testing (operationCanceledException.CancellationToken == combinedToken || operationCanceledException.CancellationToken == timeoutCancellationTokenSource.Token)
+                        // as either of those tokens could have been onward combined with another token by executed code, and so may not be the token expressed on operationCanceledException.CancellationToken.
+                        if (ex is OperationCanceledException && timeoutCancellationTokenSource.IsCancellationRequested)
                         {
                             await onTimeoutAsync(context, timeout, actionTask, ex).ConfigureAwait(continueOnCapturedContext);
                             throw new TimeoutRejectedException("The delegate executed asynchronously through TimeoutPolicy did not complete within the timeout.", ex);

--- a/src/Polly/Timeout/TimeoutEngine.cs
+++ b/src/Polly/Timeout/TimeoutEngine.cs
@@ -54,7 +54,9 @@ namespace Polly.Timeout
                     }
                     catch (Exception ex)
                     {
-                        if (timeoutCancellationTokenSource.IsCancellationRequested)
+                        // Note that we cannot rely on testing (operationCanceledException.CancellationToken == combinedToken || operationCanceledException.CancellationToken == timeoutCancellationTokenSource.Token)
+                        // as either of those tokens could have been onward combined with another token by executed code, and so may not be the token expressed on operationCanceledException.CancellationToken.
+                        if (ex is OperationCanceledException && timeoutCancellationTokenSource.IsCancellationRequested)
                         {
                             onTimeout(context, timeout, actionTask, ex);
                             throw new TimeoutRejectedException("The delegate executed through TimeoutPolicy did not complete within the timeout.", ex);


### PR DESCRIPTION
### The issue or feature being addressed

#620 Timeout simultaneous with marshalling a user exception should not mask user exception.

### Confirm the following

- [x]  I started this PR by branching from the head of the latest dev vX.Y branch, or I have rebased on the latest dev vX.Y branch, or I have merged the latest changes from the dev vX.Y branch
- [x]  I have targeted the PR to merge into the latest dev vX.Y branch as the base branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
