### PR TITLE
Update .csproj to enforce use of required Language version.

### DIFF
--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -17,6 +17,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Michael Wolfenden, App vNext</Authors>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Label="SourceLink">
     <PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
Needed for use of 'default' keyword.

### The issue or feature being addressed

Can't compile this locally. Possibly due to using VS 2017?
There's a piece of syntax around `default` that is new to 7.1, but by default this repo tries to compile against 7.0

### Details on the issue fix or feature implementation
default is to use the latest major version ... 7.0 in VS2017
"latest" forces it to use latest minor version.
Hence needs gets it to use 7.3, not 7.0, allowing compilation

### Confirm the following
Branch state on your repo currently looks weird?
The only thing that looks like a "dev vX.Y" branch is `v712-or-v720`, but that work is already on master?
It suggests to me that there ought to be a `v721-or-v730` branch, currently in sync with `master`?
I've currently worked on top of `master`, and targetted my PR there. Happy to re-raise a new PR after the review is complete, to re-target it if necessary.

- [N*]  I started this PR by branching from the head of the latest dev vX.Y branch, or I have rebased on the latest dev vX.Y branch, or I have merged the latest changes from the dev vX.Y branch
- [N*]  I have targeted the PR to merge into the latest dev vX.Y branch as the base branch
- [N/A]  I have included unit tests for the issue/feature
- [Y]  I have successfully run a local build
