### PR TITLE
Tweak AppVeyor build numbering to avoid failed builds

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -144,7 +144,9 @@ Task("__UpdateAssemblyVersionInformation")
     Information("FullSemVer -> {0}", gitVersionOutput["FullSemVer"]);
     Information("AssemblySemVer -> {0}", gitVersionOutput["AssemblySemVer"]);
 
-    appveyorBuildNumber = gitVersionOutput["FullSemVer"].ToString();
+    appveyorBuildNumber = gitVersionOutput["BranchName"].ToString().Equals("master")
+        ? gitVersionOutput["FullSemVer"].ToString() 
+        : gitVersionOutput["InformationalVersion"].ToString();
     nugetVersion = gitVersionOutput["NuGetVersion"].ToString();
     assemblyVersion = gitVersionOutput["Major"].ToString() + ".0.0.0";
     assemblySemver = gitVersionOutput["AssemblySemVer"].ToString();

--- a/build.cake
+++ b/build.cake
@@ -144,7 +144,7 @@ Task("__UpdateAssemblyVersionInformation")
     Information("FullSemVer -> {0}", gitVersionOutput["FullSemVer"]);
     Information("AssemblySemVer -> {0}", gitVersionOutput["AssemblySemVer"]);
 
-    appveyorBuildNumber = gitVersionOutput["BranchName"].ToString().Equals("master")
+    appveyorBuildNumber = gitVersionOutput["BranchName"].ToString().Equals("master", StringComparison.OrdinalIgnoreCase)
         ? gitVersionOutput["FullSemVer"].ToString() 
         : gitVersionOutput["InformationalVersion"].ToString();
     nugetVersion = gitVersionOutput["NuGetVersion"].ToString();


### PR DESCRIPTION
### The issue or feature being addressed

#737 PR builds fails on second Appveyor build, for merge-commit

### Details on the issue fix or feature implementation

Amend cake script to use an AppVeyor build number based on the commit sha, when not on the `master` branch; this will be different for the HEAD of branch and merge-commit.

When on the `master` branch, continue to use AppVeyor build numbers following the current `FullSemVer` label, as this is the label used when [auto-tagging releases](https://github.com/App-vNext/Polly/releases)

### Confirm the following

- [x]  I started this PR by branching from the head of the latest dev vX.Y branch, or I have rebased on the latest dev vX.Y branch, or I have merged the latest changes from the dev vX.Y branch
- [x]  I have targeted the PR to merge into the latest dev vX.Y branch as the base branch
- [n/a]  ~I have included unit tests for the issue/feature~
- [x]  I have successfully run a local build
