### PR TITLE
Performance: Use null for unused policy callbacks

### DIFF
--- a/src/Polly.Specs/Bulkhead/BulkheadAsyncSpecs.cs
+++ b/src/Polly.Specs/Bulkhead/BulkheadAsyncSpecs.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Polly.Bulkhead;

--- a/src/Polly.Specs/Bulkhead/BulkheadAsyncSpecs.cs
+++ b/src/Polly.Specs/Bulkhead/BulkheadAsyncSpecs.cs
@@ -40,13 +40,12 @@ namespace Polly.Specs.Bulkhead
         }
 
         [Fact]
-        public void Should_throw_when_onBulkheadRejected_is_null()
+        public void Should_not_throw_when_onBulkheadRejected_is_null()
         {
             Action policy = () => Policy
                 .BulkheadAsync(1, 0, null);
 
-            policy.Should().Throw<ArgumentNullException>().And
-                .ParamName.Should().Be("onBulkheadRejectedAsync");
+            policy.Should().NotThrow();
         }
 
         #endregion

--- a/src/Polly.Specs/Bulkhead/BulkheadSpecs.cs
+++ b/src/Polly.Specs/Bulkhead/BulkheadSpecs.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Polly.Bulkhead;
 using Polly.Specs.Helpers.Bulkhead;

--- a/src/Polly.Specs/Bulkhead/BulkheadSpecs.cs
+++ b/src/Polly.Specs/Bulkhead/BulkheadSpecs.cs
@@ -38,13 +38,12 @@ namespace Polly.Specs.Bulkhead
         }
 
         [Fact]
-        public void Should_throw_when_onBulkheadRejected_is_null()
+        public void Should_not_throw_when_onBulkheadRejected_is_null()
         {
             Action policy = () => Policy
                 .Bulkhead(1, 0, null);
 
-            policy.Should().Throw<ArgumentNullException>().And
-                .ParamName.Should().Be("onBulkheadRejected");
+            policy.Should().NotThrow();
         }
 
         #endregion

--- a/src/Polly.Specs/Bulkhead/BulkheadSpecsBase.cs
+++ b/src/Polly.Specs/Bulkhead/BulkheadSpecsBase.cs
@@ -4,12 +4,10 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
-using FluentAssertions.Execution;
 using Polly.Bulkhead;
 using Polly.Specs.Helpers.Bulkhead;
 using Xunit;
 using Xunit.Abstractions;
-using Xunit.Sdk;
 
 namespace Polly.Specs.Bulkhead
 {

--- a/src/Polly.Specs/Bulkhead/BulkheadTResultAsyncSpecs.cs
+++ b/src/Polly.Specs/Bulkhead/BulkheadTResultAsyncSpecs.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Polly.Bulkhead;

--- a/src/Polly.Specs/Bulkhead/BulkheadTResultAsyncSpecs.cs
+++ b/src/Polly.Specs/Bulkhead/BulkheadTResultAsyncSpecs.cs
@@ -40,13 +40,12 @@ namespace Polly.Specs.Bulkhead
         }
 
         [Fact]
-        public void Should_throw_when_onBulkheadRejected_is_null()
+        public void Should_not_throw_when_onBulkheadRejected_is_null()
         {
             Action policy = () => Policy
                 .BulkheadAsync<int>(1, 0, null);
 
-            policy.Should().Throw<ArgumentNullException>().And
-                .ParamName.Should().Be("onBulkheadRejectedAsync");
+            policy.Should().NotThrow();
         }
 
         #endregion

--- a/src/Polly.Specs/Bulkhead/BulkheadTResultSpecs.cs
+++ b/src/Polly.Specs/Bulkhead/BulkheadTResultSpecs.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Polly.Bulkhead;

--- a/src/Polly.Specs/Bulkhead/BulkheadTResultSpecs.cs
+++ b/src/Polly.Specs/Bulkhead/BulkheadTResultSpecs.cs
@@ -40,13 +40,12 @@ namespace Polly.Specs.Bulkhead
         }
 
         [Fact]
-        public void Should_throw_when_onBulkheadRejected_is_null()
+        public void Should_not_throw_when_onBulkheadRejected_is_null()
         {
             Action policy = () => Policy
                 .Bulkhead<int>(1, 0, null);
 
-            policy.Should().Throw<ArgumentNullException>().And
-                .ParamName.Should().Be("onBulkheadRejected");
+            policy.Should().NotThrow();
         }
 
         #endregion

--- a/src/Polly.Specs/Fallback/FallbackAsyncSpecs.cs
+++ b/src/Polly.Specs/Fallback/FallbackAsyncSpecs.cs
@@ -57,7 +57,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public void Should_throw_when_onFallback_delegate_is_null()
+        public void Should_not_throw_when_onFallback_delegate_is_null()
         {
             Func<CancellationToken, Task> fallbackActionAsync  = ct => TaskHelper.EmptyTask;
             Func<Exception, Task> onFallbackAsync = null;
@@ -66,12 +66,11 @@ namespace Polly.Specs.Fallback
                                     .Handle<DivideByZeroException>()
                                     .FallbackAsync(fallbackActionAsync, onFallbackAsync);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onFallbackAsync");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onFallback_delegate_is_null_with_context()
+        public void Should_not_throw_when_onFallback_delegate_is_null_with_context()
         {
             Func<Context, CancellationToken, Task> fallbackActionAsync  = (_, __) => TaskHelper.EmptyTask;
             Func<Exception, Context, Task> onFallbackAsync = null;
@@ -80,8 +79,7 @@ namespace Polly.Specs.Fallback
                                     .Handle<DivideByZeroException>()
                                     .FallbackAsync(fallbackActionAsync, onFallbackAsync);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onFallbackAsync");
+            policy.Should().NotThrow();
         }
 
         #endregion

--- a/src/Polly.Specs/Fallback/FallbackSpecs.cs
+++ b/src/Polly.Specs/Fallback/FallbackSpecs.cs
@@ -96,7 +96,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public void Should_throw_when_onFallback_delegate_is_null()
+        public void Should_not_throw_when_onFallback_delegate_is_null()
         {
             Action fallbackAction = () => { };
             Action<Exception> onFallback = null;
@@ -105,12 +105,11 @@ namespace Polly.Specs.Fallback
                                     .Handle<DivideByZeroException>()
                                     .Fallback(fallbackAction, onFallback);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onFallback");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onFallback_delegate_is_null_with_action_with_cancellation()
+        public void Should_not_throw_when_onFallback_delegate_is_null_with_action_with_cancellation()
         {
             Action<CancellationToken> fallbackAction = ct => { };
             Action<Exception> onFallback = null;
@@ -119,12 +118,11 @@ namespace Polly.Specs.Fallback
                 .Handle<DivideByZeroException>()
                 .Fallback(fallbackAction, onFallback);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onFallback");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onFallback_delegate_is_null_with_context()
+        public void Should_not_throw_when_onFallback_delegate_is_null_with_context()
         {
             Action<Context> fallbackAction = _ => { };
             Action<Exception, Context> onFallback = null;
@@ -133,12 +131,11 @@ namespace Polly.Specs.Fallback
                                     .Handle<DivideByZeroException>()
                                     .Fallback(fallbackAction, onFallback);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onFallback");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onFallback_delegate_is_null_with_context_with_action_with_cancellation()
+        public void Should_not_throw_when_onFallback_delegate_is_null_with_context_with_action_with_cancellation()
         {
             Action<Context, CancellationToken> fallbackAction = (_, __) => { };
             Action<Exception, Context> onFallback = null;
@@ -147,8 +144,7 @@ namespace Polly.Specs.Fallback
                                     .Handle<DivideByZeroException>()
                                     .Fallback(fallbackAction, onFallback);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onFallback");
+            policy.Should().NotThrow();
         }
 
         #endregion

--- a/src/Polly.Specs/Fallback/FallbackTResultAsyncSpecs.cs
+++ b/src/Polly.Specs/Fallback/FallbackTResultAsyncSpecs.cs
@@ -57,7 +57,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public void Should_throw_when_onFallback_delegate_is_null()
+        public void Should_not_throw_when_onFallback_delegate_is_null()
         {
             Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = ct => Task.FromResult(ResultPrimitive.Substitute);
             Func<DelegateResult<ResultPrimitive>, Task> onFallbackAsync = null;
@@ -66,12 +66,11 @@ namespace Polly.Specs.Fallback
                                     .HandleResult(ResultPrimitive.Fault)
                                     .FallbackAsync(fallbackAction, onFallbackAsync);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onFallbackAsync");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onFallback_delegate_is_null_with_action_with_cancellation()
+        public void Should_not_throw_when_onFallback_delegate_is_null_with_action_with_cancellation()
         {
             Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = ct => Task.FromResult(ResultPrimitive.Substitute);
             Func<DelegateResult<ResultPrimitive>, Task> onFallbackAsync = null;
@@ -80,12 +79,11 @@ namespace Polly.Specs.Fallback
                 .HandleResult(ResultPrimitive.Fault)
                 .FallbackAsync(fallbackAction, onFallbackAsync);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onFallbackAsync");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onFallback_delegate_is_null_with_context()
+        public void Should_not_throw_when_onFallback_delegate_is_null_with_context()
         {
             Func<Context, CancellationToken, Task<ResultPrimitive>> fallbackAction = (_, __) => Task.FromResult(ResultPrimitive.Substitute);
             Func<DelegateResult<ResultPrimitive>, Context, Task> onFallbackAsync = null;
@@ -94,12 +92,11 @@ namespace Polly.Specs.Fallback
                                     .HandleResult(ResultPrimitive.Fault)
                                     .FallbackAsync(fallbackAction, onFallbackAsync);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onFallbackAsync");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onFallback_delegate_is_null_with_context_with_action_with_cancellation()
+        public void Should_not_throw_when_onFallback_delegate_is_null_with_context_with_action_with_cancellation()
         {
             Func<Context, CancellationToken, Task<ResultPrimitive>> fallbackAction = (_, __) => Task.FromResult(ResultPrimitive.Substitute);
             Func<DelegateResult<ResultPrimitive>, Context, Task> onFallbackAsync = null;
@@ -108,8 +105,7 @@ namespace Polly.Specs.Fallback
                                     .HandleResult(ResultPrimitive.Fault)
                                     .FallbackAsync(fallbackAction, onFallbackAsync);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onFallbackAsync");
+            policy.Should().NotThrow();
         }
 
         #endregion

--- a/src/Polly.Specs/Fallback/FallbackTResultSpecs.cs
+++ b/src/Polly.Specs/Fallback/FallbackTResultSpecs.cs
@@ -97,7 +97,7 @@ namespace Polly.Specs.Fallback
         }
 
         [Fact]
-        public void Should_throw_when_onFallback_delegate_is_null()
+        public void Should_not_throw_when_onFallback_delegate_is_null()
         {
             Func<ResultPrimitive> fallbackAction = () => ResultPrimitive.Substitute;
             Action<DelegateResult<ResultPrimitive>> onFallback = null;
@@ -106,12 +106,11 @@ namespace Polly.Specs.Fallback
                                     .HandleResult(ResultPrimitive.Fault)
                                     .Fallback(fallbackAction, onFallback);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onFallback");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onFallback_delegate_is_null_with_action_with_cancellation()
+        public void Should_not_throw_when_onFallback_delegate_is_null_with_action_with_cancellation()
         {
             Func<CancellationToken, ResultPrimitive> fallbackAction = ct => ResultPrimitive.Substitute;
             Action<DelegateResult<ResultPrimitive>> onFallback = null;
@@ -120,12 +119,11 @@ namespace Polly.Specs.Fallback
                 .HandleResult(ResultPrimitive.Fault)
                 .Fallback(fallbackAction, onFallback);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onFallback");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onFallback_delegate_is_null_with_context()
+        public void Should_not_throw_when_onFallback_delegate_is_null_with_context()
         {
             Func<Context, ResultPrimitive> fallbackAction = _ => ResultPrimitive.Substitute;
             Action<DelegateResult<ResultPrimitive>, Context> onFallback = null;
@@ -134,12 +132,11 @@ namespace Polly.Specs.Fallback
                                     .HandleResult(ResultPrimitive.Fault)
                                     .Fallback(fallbackAction, onFallback);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onFallback");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onFallback_delegate_is_null_with_context_with_action_with_cancellation()
+        public void Should_not_throw_when_onFallback_delegate_is_null_with_context_with_action_with_cancellation()
         {
             Func<Context, CancellationToken, ResultPrimitive> fallbackAction = (_, __) => ResultPrimitive.Substitute;
             Action<DelegateResult<ResultPrimitive>, Context> onFallback = null;
@@ -148,8 +145,7 @@ namespace Polly.Specs.Fallback
                                     .HandleResult(ResultPrimitive.Fault)
                                     .Fallback(fallbackAction, onFallback);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onFallback");
+            policy.Should().NotThrow();
         }
 
         #endregion

--- a/src/Polly.Specs/Fallback/FallbackTResultSpecs.cs
+++ b/src/Polly.Specs/Fallback/FallbackTResultSpecs.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Threading;
 using FluentAssertions;
-using Polly.Fallback;
 using Polly.Specs.Helpers;
 using Xunit;
 

--- a/src/Polly.Specs/Retry/RetryForeverSpecs.cs
+++ b/src/Polly.Specs/Retry/RetryForeverSpecs.cs
@@ -10,7 +10,7 @@ namespace Polly.Specs.Retry
     public class RetryForeverSpecs
     {
         [Fact]
-        public void Should_throw_when_onretry_action_without_context_is_null()
+        public void Should_not_throw_when_onretry_action_without_context_is_null()
         {
             Action<Exception> nullOnRetry = null;
 
@@ -18,12 +18,11 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .RetryForever(nullOnRetry);
 
-            policy.Should().Throw<ArgumentNullException>().And
-                  .ParamName.Should().Be("onRetry");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onretry_action_with_context_is_null()
+        public void Should_not_throw_when_onretry_action_with_context_is_null()
         {
             Action<Exception, Context> nullOnRetry = null;
 
@@ -31,8 +30,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .RetryForever(nullOnRetry);
 
-            policy.Should().Throw<ArgumentNullException>().And
-                  .ParamName.Should().Be("onRetry");
+            policy.Should().NotThrow();
         }
 
         [Fact]

--- a/src/Polly.Specs/Retry/RetrySpecs.cs
+++ b/src/Polly.Specs/Retry/RetrySpecs.cs
@@ -26,7 +26,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public void Should_throw_when_onretry_action_without_context_is_null()
+        public void Should_not_throw_when_onretry_action_without_context_is_null()
         {
             Action<Exception, int> nullOnRetry = null;
 
@@ -34,8 +34,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .Retry(1, nullOnRetry);
 
-            policy.Should().Throw<ArgumentNullException>().And
-                  .ParamName.Should().Be("onRetry");
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -52,7 +51,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public void Should_throw_when_onretry_action_with_context_is_null()
+        public void Should_not_throw_when_onretry_action_with_context_is_null()
         {
             Action<Exception, int, Context> nullOnRetry = null;
 
@@ -60,8 +59,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .Retry(1, nullOnRetry);
 
-            policy.Should().Throw<ArgumentNullException>().And
-                  .ParamName.Should().Be("onRetry");
+            policy.Should().NotThrow();
         }
 
         [Fact]

--- a/src/Polly.Specs/Retry/RetryTResultSpecs.cs
+++ b/src/Polly.Specs/Retry/RetryTResultSpecs.cs
@@ -27,7 +27,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public void Should_throw_when_onretry_action_without_context_is_null()
+        public void Should_not_throw_when_onretry_action_without_context_is_null()
         {
             Action<DelegateResult<ResultPrimitive>, int> nullOnRetry = null;
 
@@ -35,8 +35,7 @@ namespace Polly.Specs.Retry
                                       .HandleResult(ResultPrimitive.Fault)
                                       .Retry(1, nullOnRetry);
 
-            policy.Should().Throw<ArgumentNullException>().And
-                  .ParamName.Should().Be("onRetry");
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -53,7 +52,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public void Should_throw_when_onretry_action_with_context_is_null()
+        public void Should_not_throw_when_onretry_action_with_context_is_null()
         {
             Action<DelegateResult<ResultPrimitive>, int, Context> nullOnRetry = null;
 
@@ -61,8 +60,7 @@ namespace Polly.Specs.Retry
                                       .HandleResult(ResultPrimitive.Fault)
                                       .Retry(1, nullOnRetry);
 
-            policy.Should().Throw<ArgumentNullException>().And
-                  .ParamName.Should().Be("onRetry");
+            policy.Should().NotThrow();
         }
 
         [Fact]

--- a/src/Polly.Specs/Retry/RetryTResultSpecsAsync.cs
+++ b/src/Polly.Specs/Retry/RetryTResultSpecsAsync.cs
@@ -28,7 +28,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public void Should_throw_when_onretry_action_without_context_is_null()
+        public void Should_not_throw_when_onretry_action_without_context_is_null()
         {
             Action<DelegateResult<ResultPrimitive>, int> nullOnRetry = null;
 
@@ -36,8 +36,7 @@ namespace Polly.Specs.Retry
                                       .HandleResult(ResultPrimitive.Fault)
                                       .RetryAsync(1, nullOnRetry);
 
-            policy.Should().Throw<ArgumentNullException>().And
-                  .ParamName.Should().Be("onRetry");
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -54,7 +53,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public void Should_throw_when_onretry_action_with_context_is_null()
+        public void Should_not_throw_when_onretry_action_with_context_is_null()
         {
             Action<DelegateResult<ResultPrimitive>, int, Context> nullOnRetry = null;
 
@@ -62,8 +61,7 @@ namespace Polly.Specs.Retry
                                       .HandleResult(ResultPrimitive.Fault)
                                       .RetryAsync(1, nullOnRetry);
 
-            policy.Should().Throw<ArgumentNullException>().And
-                  .ParamName.Should().Be("onRetry");
+            policy.Should().NotThrow();
         }
 
         [Fact]

--- a/src/Polly.Specs/Retry/WaitAndRetryAsyncSpecs.cs
+++ b/src/Polly.Specs/Retry/WaitAndRetryAsyncSpecs.cs
@@ -37,7 +37,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public void Should_throw_when_onretry_action_is_null_without_context()
+        public void Should_not_throw_when_onretry_action_is_null_without_context()
         {
             Action<Exception, TimeSpan> nullOnRetry = null;
 
@@ -45,10 +45,9 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetryAsync(Enumerable.Empty<TimeSpan>(), nullOnRetry);
 
-            policy.Should().Throw<ArgumentNullException>().And
-                  .ParamName.Should().Be("onRetry");
+            policy.Should().NotThrow();
         }
-        
+
         [Fact]
         public void Should_not_throw_when_specified_exception_thrown_same_number_of_times_as_there_are_sleep_durations()
         {
@@ -522,7 +521,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public void Should_throw_when_onretry_action_is_null_without_context_when_using_provider_overload()
+        public void Should_not_throw_when_onretry_action_is_null_without_context_when_using_provider_overload()
         {
             Action<Exception, TimeSpan> nullOnRetry = null;
 
@@ -530,8 +529,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetryAsync(1, _ => TimeSpan.Zero, nullOnRetry);
 
-            policy.Should().Throw<ArgumentNullException>().And
-                  .ParamName.Should().Be("onRetry");
+            policy.Should().NotThrow();
         }
 
         [Fact]

--- a/src/Polly.Specs/Retry/WaitAndRetryForeverAsyncSpecs.cs
+++ b/src/Polly.Specs/Retry/WaitAndRetryForeverAsyncSpecs.cs
@@ -49,7 +49,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public void Should_throw_when_onretry_action_is_null_without_context()
+        public void Should_not_throw_when_onretry_action_is_null_without_context()
         {
             Action<Exception, TimeSpan> nullOnRetry = null;
             Func<int, TimeSpan> provider = i => TimeSpan.Zero;
@@ -58,12 +58,11 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetryForeverAsync(provider, nullOnRetry);
 
-            policy.Should().Throw<ArgumentNullException>().And
-                  .ParamName.Should().Be("onRetry");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onretry_action_is_null_with_context()
+        public void Should_not_throw_when_onretry_action_is_null_with_context()
         {
             Action<Exception, TimeSpan, Context> nullOnRetry = null;
             Func<int, Context, TimeSpan> provider = (i, ctx) => TimeSpan.Zero;
@@ -72,8 +71,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetryForeverAsync(provider, nullOnRetry);
 
-            policy.Should().Throw<ArgumentNullException>().And
-                  .ParamName.Should().Be("onRetry");
+            policy.Should().NotThrow();
         }
 
         [Fact]

--- a/src/Polly.Specs/Retry/WaitAndRetryForeverSpecs.cs
+++ b/src/Polly.Specs/Retry/WaitAndRetryForeverSpecs.cs
@@ -47,7 +47,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public void Should_throw_when_onretry_action_is_null_without_context()
+        public void Should_not_throw_when_onretry_action_is_null_without_context()
         {
             Action<Exception, TimeSpan> nullOnRetry = null;
             Func<int, TimeSpan> provider = i => TimeSpan.Zero;
@@ -56,12 +56,11 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetryForever(provider, nullOnRetry);
 
-            policy.Should().Throw<ArgumentNullException>().And
-                  .ParamName.Should().Be("onRetry");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onretry_action_is_null_with_context()
+        public void Should_not_throw_when_onretry_action_is_null_with_context()
         {
             Action<Exception, TimeSpan, Context> nullOnRetry = null;
             Func<int, Context, TimeSpan> provider = (i, ctx) => TimeSpan.Zero;
@@ -70,8 +69,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetryForever(provider, nullOnRetry);
 
-            policy.Should().Throw<ArgumentNullException>().And
-                  .ParamName.Should().Be("onRetry");
+            policy.Should().NotThrow();
         }
 
         [Fact]

--- a/src/Polly.Specs/Retry/WaitAndRetrySpecs.cs
+++ b/src/Polly.Specs/Retry/WaitAndRetrySpecs.cs
@@ -63,7 +63,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public void Should_throw_when_onretry_action_is_null_without_context()
+        public void Should_not_throw_when_onretry_action_is_null_without_context()
         {
             Action<Exception, TimeSpan> nullOnRetry = null;
 
@@ -71,12 +71,11 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetry(Enumerable.Empty<TimeSpan>(), nullOnRetry);
 
-            policy.Should().Throw<ArgumentNullException>().And
-                  .ParamName.Should().Be("onRetry");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onretry_action_is_null_with_context()
+        public void Should_not_throw_when_onretry_action_is_null_with_context()
         {
             Action<Exception, TimeSpan, Context> nullOnRetry = null;
 
@@ -84,12 +83,11 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetry(Enumerable.Empty<TimeSpan>(), nullOnRetry);
 
-            policy.Should().Throw<ArgumentNullException>().And
-                  .ParamName.Should().Be("onRetry");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onretry_action_is_null_with_attempts_with_context()
+        public void Should_not_throw_when_onretry_action_is_null_with_attempts_with_context()
         {
             Action<Exception, TimeSpan, int, Context> nullOnRetry = null;
 
@@ -97,8 +95,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetry(Enumerable.Empty<TimeSpan>(), nullOnRetry);
 
-            policy.Should().Throw<ArgumentNullException>().And
-                  .ParamName.Should().Be("onRetry");
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -644,7 +641,7 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
-        public void Should_throw_when_onretry_action_is_null_without_context_when_using_provider_overload()
+        public void Should_not_throw_when_onretry_action_is_null_without_context_when_using_provider_overload()
         {
             Action<Exception, TimeSpan> nullOnRetry = null;
 
@@ -652,12 +649,11 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetry(1, _ => new TimeSpan(), nullOnRetry);
 
-            policy.Should().Throw<ArgumentNullException>().And
-                  .ParamName.Should().Be("onRetry");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onretry_action_is_null_with_context_when_using_provider_overload()
+        public void Should_not_throw_when_onretry_action_is_null_with_context_when_using_provider_overload()
         {
             Action<Exception, TimeSpan, Context> nullOnRetry = null;
 
@@ -665,12 +661,11 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetry(1, _ => new TimeSpan(), nullOnRetry);
 
-            policy.Should().Throw<ArgumentNullException>().And
-                  .ParamName.Should().Be("onRetry");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onretry_action_is_null_with_attempts_with_context_when_using_provider_overload()
+        public void Should_not_throw_when_onretry_action_is_null_with_attempts_with_context_when_using_provider_overload()
         {
             Action<Exception, TimeSpan, int, Context> nullOnRetry = null;
 
@@ -678,8 +673,7 @@ namespace Polly.Specs.Retry
                                       .Handle<DivideByZeroException>()
                                       .WaitAndRetry(1, _ => new TimeSpan(), nullOnRetry);
 
-            policy.Should().Throw<ArgumentNullException>().And
-                  .ParamName.Should().Be("onRetry");
+            policy.Should().NotThrow();
         }
 
         [Fact]

--- a/src/Polly.Specs/Timeout/TimeoutAsyncSpecs.cs
+++ b/src/Polly.Specs/Timeout/TimeoutAsyncSpecs.cs
@@ -118,43 +118,39 @@ namespace Polly.Specs.Timeout
         }
 
         [Fact]
-        public void Should_throw_when_onTimeout_is_null_with_timespan()
+        public void Should_not_throw_when_onTimeout_is_null_with_timespan()
         {
             Func<Context, TimeSpan, Task, Task> onTimeout = null;
             Action policy = () => Policy.TimeoutAsync(TimeSpan.FromMinutes(0.5), onTimeout);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onTimeoutAsync");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onTimeout_is_null_with_timespan_with_full_argument_list_onTimeout()
+        public void Should_not_throw_when_onTimeout_is_null_with_timespan_with_full_argument_list_onTimeout()
         {
             Func<Context, TimeSpan, Task, Exception, Task> onTimeout = null;
             Action policy = () => Policy.TimeoutAsync(TimeSpan.FromMinutes(0.5), onTimeout);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onTimeoutAsync");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onTimeout_is_null_with_seconds()
+        public void Should_not_throw_when_onTimeout_is_null_with_seconds()
         {
             Func<Context, TimeSpan, Task, Task> onTimeout = null;
             Action policy = () => Policy.TimeoutAsync(30, onTimeout);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onTimeoutAsync");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onTimeout_is_null_with_seconds_with_full_argument_list_onTimeout()
+        public void Should_not_throw_when_onTimeout_is_null_with_seconds_with_full_argument_list_onTimeout()
         {
             Func<Context, TimeSpan, Task, Exception, Task> onTimeout = null;
             Action policy = () => Policy.TimeoutAsync(30, onTimeout);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onTimeoutAsync");
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -167,23 +163,21 @@ namespace Polly.Specs.Timeout
         }
 
         [Fact]
-        public void Should_throw_when_onTimeout_is_null_with_timeoutprovider()
+        public void Should_not_throw_when_onTimeout_is_null_with_timeoutprovider()
         {
             Func<Context, TimeSpan, Task, Task> onTimeout = null;
             Action policy = () => Policy.TimeoutAsync(() => TimeSpan.FromSeconds(30), onTimeout);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onTimeoutAsync");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onTimeout_is_null_with_timeoutprovider_with_full_argument_list_onTimeout()
+        public void Should_not_throw_when_onTimeout_is_null_with_timeoutprovider_with_full_argument_list_onTimeout()
         {
             Func<Context, TimeSpan, Task, Exception, Task> onTimeout = null;
             Action policy = () => Policy.TimeoutAsync(() => TimeSpan.FromSeconds(30), onTimeout);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onTimeoutAsync");
+            policy.Should().NotThrow();
         }
 
         [Fact]

--- a/src/Polly.Specs/Timeout/TimeoutSpecs.cs
+++ b/src/Polly.Specs/Timeout/TimeoutSpecs.cs
@@ -136,43 +136,39 @@ namespace Polly.Specs.Timeout
         }
 
         [Fact]
-        public void Should_throw_when_onTimeout_is_null_with_timespan()
+        public void Should_not_throw_when_onTimeout_is_null_with_timespan()
         {
             Action<Context, TimeSpan, Task> onTimeout = null;
             Action policy = () => Policy.Timeout(TimeSpan.FromMinutes(0.5), onTimeout);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onTimeout");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onTimeout_overload_is_null_with_timespan()
+        public void Should_not_throw_when_onTimeout_overload_is_null_with_timespan()
         {
             Action<Context, TimeSpan, Task, Exception> onTimeout = null;
             Action policy = () => Policy.Timeout(TimeSpan.FromMinutes(0.5), onTimeout);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onTimeout");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onTimeout_is_null_with_seconds()
+        public void Should_not_throw_when_onTimeout_is_null_with_seconds()
         {
             Action<Context, TimeSpan, Task> onTimeout = null;
             Action policy = () => Policy.Timeout(30, onTimeout);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onTimeout");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onTimeout_overload_is_null_with_seconds()
+        public void Should_not_throw_when_onTimeout_overload_is_null_with_seconds()
         {
             Action<Context, TimeSpan, Task, Exception> onTimeout = null;
             Action policy = () => Policy.Timeout(30, onTimeout);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onTimeout");
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -185,23 +181,21 @@ namespace Polly.Specs.Timeout
         }
 
         [Fact]
-        public void Should_throw_when_onTimeout_is_null_with_timeoutprovider()
+        public void Should_not_throw_when_onTimeout_is_null_with_timeoutprovider()
         {
             Action<Context, TimeSpan, Task> onTimeout = null;
             Action policy = () => Policy.Timeout(() => TimeSpan.FromSeconds(30), onTimeout);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onTimeout");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onTimeout_overload_is_null_with_timeoutprovider()
+        public void Should_not_throw_when_onTimeout_overload_is_null_with_timeoutprovider()
         {
             Action<Context, TimeSpan, Task, Exception> onTimeout = null;
             Action policy = () => Policy.Timeout(() => TimeSpan.FromSeconds(30), onTimeout);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onTimeout");
+            policy.Should().NotThrow();
         }
 
         [Fact]

--- a/src/Polly.Specs/Timeout/TimeoutTResultAsyncSpecs.cs
+++ b/src/Polly.Specs/Timeout/TimeoutTResultAsyncSpecs.cs
@@ -118,44 +118,40 @@ namespace Polly.Specs.Timeout
         }
 
         [Fact]
-        public void Should_throw_when_onTimeout_is_null_with_timespan()
+        public void Should_not_throw_when_onTimeout_is_null_with_timespan()
         {
             Func<Context, TimeSpan, Task, Task> onTimeout = null;
             Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(TimeSpan.FromMinutes(0.5), onTimeout);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onTimeoutAsync");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onTimeout_is_null_with_timespan_with_full_argument_list_onTimeout()
+        public void Should_not_throw_when_onTimeout_is_null_with_timespan_with_full_argument_list_onTimeout()
         {
             Func<Context, TimeSpan, Task, Exception, Task> onTimeout = null;
             Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(TimeSpan.FromMinutes(0.5), onTimeout);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onTimeoutAsync");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onTimeout_is_null_with_seconds()
+        public void Should_not_throw_when_onTimeout_is_null_with_seconds()
         {
             Func<Context, TimeSpan, Task, Task> onTimeout = null;
             Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(30, onTimeout);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onTimeoutAsync");
+            policy.Should().NotThrow();
         }
 
 
         [Fact]
-        public void Should_throw_when_onTimeout_is_null_with_seconds_with_full_argument_list_onTimeout()
+        public void Should_not_throw_when_onTimeout_is_null_with_seconds_with_full_argument_list_onTimeout()
         {
             Func<Context, TimeSpan, Task, Exception, Task> onTimeout = null;
             Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(30, onTimeout);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onTimeoutAsync");
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -168,23 +164,21 @@ namespace Polly.Specs.Timeout
         }
 
         [Fact]
-        public void Should_throw_when_onTimeout_is_null_with_timeoutprovider()
+        public void Should_not_throw_when_onTimeout_is_null_with_timeoutprovider()
         {
             Func<Context, TimeSpan, Task, Task> onTimeoutAsync = null;
             Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(() => TimeSpan.FromSeconds(30), onTimeoutAsync);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onTimeoutAsync");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onTimeout_is_null_with_timeoutprovider_for_full_argument_list_onTimeout()
+        public void Should_not_throw_when_onTimeout_is_null_with_timeoutprovider_for_full_argument_list_onTimeout()
         {
             Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = null;
             Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(() => TimeSpan.FromSeconds(30), onTimeoutAsync);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onTimeoutAsync");
+            policy.Should().NotThrow();
         }
 
         [Fact]

--- a/src/Polly.Specs/Timeout/TimeoutTResultSpecs.cs
+++ b/src/Polly.Specs/Timeout/TimeoutTResultSpecs.cs
@@ -118,43 +118,39 @@ namespace Polly.Specs.Timeout
         }
 
         [Fact]
-        public void Should_throw_when_onTimeout_is_null_with_timespan()
+        public void Should_not_throw_when_onTimeout_is_null_with_timespan()
         {
             Action<Context, TimeSpan, Task> onTimeout = null;
             Action policy = () => Policy.Timeout<ResultPrimitive>(TimeSpan.FromMinutes(0.5), onTimeout);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onTimeout");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onTimeout_is_null_with_timespan_and_onTimeout_is_full_argument_set()
+        public void Should_not_throw_when_onTimeout_is_null_with_timespan_and_onTimeout_is_full_argument_set()
         {
             Action<Context, TimeSpan, Task, Exception> onTimeout = null;
             Action policy = () => Policy.Timeout<ResultPrimitive>(TimeSpan.FromMinutes(0.5), onTimeout);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onTimeout");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onTimeout_is_null_with_seconds()
+        public void Should_not_throw_when_onTimeout_is_null_with_seconds()
         {
             Action<Context, TimeSpan, Task> onTimeout = null;
             Action policy = () => Policy.Timeout<ResultPrimitive>(30, onTimeout);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onTimeout");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onTimeout_is_null_with_seconds_and_onTimeout_is_full_argument_set()
+        public void Should_not_throw_when_onTimeout_is_null_with_seconds_and_onTimeout_is_full_argument_set()
         {
             Action<Context, TimeSpan, Task, Exception> onTimeout = null;
             Action policy = () => Policy.Timeout<ResultPrimitive>(30, onTimeout);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onTimeout");
+            policy.Should().NotThrow();
         }
 
         [Fact]
@@ -167,23 +163,21 @@ namespace Polly.Specs.Timeout
         }
 
         [Fact]
-        public void Should_throw_when_onTimeout_is_null_with_timeoutprovider()
+        public void Should_not_throw_when_onTimeout_is_null_with_timeoutprovider()
         {
             Action<Context, TimeSpan, Task> onTimeout = null;
             Action policy = () => Policy.Timeout<ResultPrimitive>(() => TimeSpan.FromSeconds(30), onTimeout);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onTimeout");
+            policy.Should().NotThrow();
         }
 
         [Fact]
-        public void Should_throw_when_onTimeout_is_null_with_timeoutprovider_and_onTimeout_is_full_argument_set()
+        public void Should_not_throw_when_onTimeout_is_null_with_timeoutprovider_and_onTimeout_is_full_argument_set()
         {
             Action<Context, TimeSpan, Task, Exception> onTimeout = null;
             Action policy = () => Policy.Timeout<ResultPrimitive>(() => TimeSpan.FromSeconds(30), onTimeout);
 
-            policy.Should().Throw<ArgumentNullException>()
-                .And.ParamName.Should().Be("onTimeout");
+            policy.Should().NotThrow();
         }
 
         [Fact]

--- a/src/Polly/Bulkhead/AsyncBulkheadEngine.cs
+++ b/src/Polly/Bulkhead/AsyncBulkheadEngine.cs
@@ -17,7 +17,7 @@ namespace Polly.Bulkhead
         {
             if (!await maxQueuedActionsSemaphore.WaitAsync(TimeSpan.Zero, cancellationToken).ConfigureAwait(continueOnCapturedContext))
             {
-                await onBulkheadRejectedAsync(context).ConfigureAwait(continueOnCapturedContext);
+                if (onBulkheadRejectedAsync != null) { await onBulkheadRejectedAsync(context).ConfigureAwait(continueOnCapturedContext); }
                 throw new BulkheadRejectedException();
             }
             try

--- a/src/Polly/Bulkhead/AsyncBulkheadPolicy.cs
+++ b/src/Polly/Bulkhead/AsyncBulkheadPolicy.cs
@@ -21,7 +21,7 @@ namespace Polly.Bulkhead
             Func<Context, Task> onBulkheadRejectedAsync)
         {
             _maxQueueingActions = maxQueueingActions;
-            _onBulkheadRejectedAsync = onBulkheadRejectedAsync ?? throw new ArgumentNullException(nameof(onBulkheadRejectedAsync));
+            _onBulkheadRejectedAsync = onBulkheadRejectedAsync;
 
             (_maxParallelizationSemaphore, _maxQueuedActionsSemaphore) = BulkheadSemaphoreFactory.CreateBulkheadSemaphores(maxParallelization, maxQueueingActions);
         }
@@ -69,7 +69,7 @@ namespace Polly.Bulkhead
             Func<Context, Task> onBulkheadRejectedAsync)
         {
             _maxQueueingActions = maxQueueingActions;
-            _onBulkheadRejectedAsync = onBulkheadRejectedAsync ?? throw new ArgumentNullException(nameof(onBulkheadRejectedAsync));
+            _onBulkheadRejectedAsync = onBulkheadRejectedAsync;
 
             (_maxParallelizationSemaphore, _maxQueuedActionsSemaphore) = BulkheadSemaphoreFactory.CreateBulkheadSemaphores(maxParallelization, maxQueueingActions);
         }

--- a/src/Polly/Bulkhead/AsyncBulkheadSyntax.cs
+++ b/src/Polly/Bulkhead/AsyncBulkheadSyntax.cs
@@ -15,8 +15,8 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static IAsyncBulkheadPolicy BulkheadAsync(int maxParallelization)
         {
-            Func<Context, Task> doNothingAsync = _ => TaskHelper.EmptyTask;
-            return BulkheadAsync(maxParallelization, 0, doNothingAsync);
+            
+            return BulkheadAsync(maxParallelization, maxQueuingActions: 0, onBulkheadRejectedAsync: null);
         }
 
         /// <summary>
@@ -27,7 +27,7 @@ namespace Polly
         /// <param name="onBulkheadRejectedAsync">An action to call asynchronously, if the bulkhead rejects execution due to oversubscription.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onBulkheadRejectedAsync</exception>
+        
         /// <returns>The policy instance.</returns>
         public static IAsyncBulkheadPolicy BulkheadAsync(int maxParallelization, Func<Context, Task> onBulkheadRejectedAsync)
             => BulkheadAsync(maxParallelization, 0, onBulkheadRejectedAsync);
@@ -43,8 +43,8 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">maxQueuingActions;Value must be greater than or equal to zero.</exception>
         public static IAsyncBulkheadPolicy BulkheadAsync(int maxParallelization, int maxQueuingActions)
         {
-            Func<Context, Task> doNothingAsync = _ => TaskHelper.EmptyTask;
-            return BulkheadAsync(maxParallelization, maxQueuingActions, doNothingAsync);
+            
+            return BulkheadAsync(maxParallelization, maxQueuingActions, onBulkheadRejectedAsync: null);
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
         /// <exception cref="ArgumentOutOfRangeException">maxQueuingActions;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">onBulkheadRejectedAsync</exception>
+        
         public static IAsyncBulkheadPolicy BulkheadAsync(
             int maxParallelization, 
             int maxQueuingActions, 
@@ -65,7 +65,7 @@ namespace Polly
         {
             if (maxParallelization <= 0) throw new ArgumentOutOfRangeException(nameof(maxParallelization), "Value must be greater than zero.");
             if (maxQueuingActions < 0) throw new ArgumentOutOfRangeException(nameof(maxQueuingActions), "Value must be greater than or equal to zero.");
-            if (onBulkheadRejectedAsync == null) throw new ArgumentNullException(nameof(onBulkheadRejectedAsync));
+            
 
             return new AsyncBulkheadPolicy(
                 maxParallelization,

--- a/src/Polly/Bulkhead/AsyncBulkheadSyntax.cs
+++ b/src/Polly/Bulkhead/AsyncBulkheadSyntax.cs
@@ -57,7 +57,6 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
         /// <exception cref="ArgumentOutOfRangeException">maxQueuingActions;Value must be greater than or equal to zero.</exception>
-        
         public static IAsyncBulkheadPolicy BulkheadAsync(
             int maxParallelization, 
             int maxQueuingActions, 
@@ -65,7 +64,6 @@ namespace Polly
         {
             if (maxParallelization <= 0) throw new ArgumentOutOfRangeException(nameof(maxParallelization), "Value must be greater than zero.");
             if (maxQueuingActions < 0) throw new ArgumentOutOfRangeException(nameof(maxQueuingActions), "Value must be greater than or equal to zero.");
-            
 
             return new AsyncBulkheadPolicy(
                 maxParallelization,

--- a/src/Polly/Bulkhead/AsyncBulkheadSyntax.cs
+++ b/src/Polly/Bulkhead/AsyncBulkheadSyntax.cs
@@ -1,5 +1,4 @@
 using Polly.Bulkhead;
-using Polly.Utilities;
 using System;
 using System.Threading.Tasks;
 

--- a/src/Polly/Bulkhead/AsyncBulkheadTResultSyntax.cs
+++ b/src/Polly/Bulkhead/AsyncBulkheadTResultSyntax.cs
@@ -26,7 +26,7 @@ namespace Polly
         /// <param name="maxParallelization">The maximum number of concurrent actions that may be executing through the policy.</param>
         /// <param name="onBulkheadRejectedAsync">An action to call asynchronously, if the bulkhead rejects execution due to oversubscription.</param>
         /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onBulkheadRejectedAsync</exception>
+        
         /// <returns>The policy instance.</returns>
         public static IAsyncBulkheadPolicy<TResult> BulkheadAsync<TResult>(int maxParallelization, Func<Context, Task> onBulkheadRejectedAsync)
             => BulkheadAsync<TResult>(maxParallelization, 0, onBulkheadRejectedAsync);
@@ -40,7 +40,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
         /// <exception cref="ArgumentOutOfRangeException">maxQueuingActions;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">onBulkheadRejectedAsync</exception>
+        
         public static IAsyncBulkheadPolicy<TResult> BulkheadAsync<TResult>(int maxParallelization, int maxQueuingActions)
         {
             Func<Context, Task> doNothingAsync = _ => TaskHelper.EmptyTask;
@@ -57,12 +57,12 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
         /// <exception cref="ArgumentOutOfRangeException">maxQueuingActions;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">onBulkheadRejectedAsync</exception>
+        
         public static IAsyncBulkheadPolicy<TResult> BulkheadAsync<TResult>(int maxParallelization, int maxQueuingActions, Func<Context, Task> onBulkheadRejectedAsync)
         {
             if (maxParallelization <= 0) throw new ArgumentOutOfRangeException(nameof(maxParallelization), "Value must be greater than zero.");
             if (maxQueuingActions < 0) throw new ArgumentOutOfRangeException(nameof(maxQueuingActions), "Value must be greater than or equal to zero.");
-            if (onBulkheadRejectedAsync == null) throw new ArgumentNullException(nameof(onBulkheadRejectedAsync));
+            
 
             return new AsyncBulkheadPolicy<TResult>(
                 maxParallelization,

--- a/src/Polly/Bulkhead/AsyncBulkheadTResultSyntax.cs
+++ b/src/Polly/Bulkhead/AsyncBulkheadTResultSyntax.cs
@@ -40,7 +40,6 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
         /// <exception cref="ArgumentOutOfRangeException">maxQueuingActions;Value must be greater than or equal to zero.</exception>
-        
         public static IAsyncBulkheadPolicy<TResult> BulkheadAsync<TResult>(int maxParallelization, int maxQueuingActions)
         {
             Func<Context, Task> doNothingAsync = _ => TaskHelper.EmptyTask;
@@ -57,12 +56,10 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
         /// <exception cref="ArgumentOutOfRangeException">maxQueuingActions;Value must be greater than or equal to zero.</exception>
-        
         public static IAsyncBulkheadPolicy<TResult> BulkheadAsync<TResult>(int maxParallelization, int maxQueuingActions, Func<Context, Task> onBulkheadRejectedAsync)
         {
             if (maxParallelization <= 0) throw new ArgumentOutOfRangeException(nameof(maxParallelization), "Value must be greater than zero.");
             if (maxQueuingActions < 0) throw new ArgumentOutOfRangeException(nameof(maxQueuingActions), "Value must be greater than or equal to zero.");
-            
 
             return new AsyncBulkheadPolicy<TResult>(
                 maxParallelization,

--- a/src/Polly/Bulkhead/BulkheadEngine.cs
+++ b/src/Polly/Bulkhead/BulkheadEngine.cs
@@ -15,7 +15,7 @@ namespace Polly.Bulkhead
         {
             if (!maxQueuedActionsSemaphore.Wait(TimeSpan.Zero, cancellationToken))
             {
-                onBulkheadRejected(context);
+                onBulkheadRejected?.Invoke(context);
                 throw new BulkheadRejectedException();
             }
             

--- a/src/Polly/Bulkhead/BulkheadPolicy.cs
+++ b/src/Polly/Bulkhead/BulkheadPolicy.cs
@@ -20,7 +20,7 @@ namespace Polly.Bulkhead
             Action<Context> onBulkheadRejected)
         {
             _maxQueueingActions = maxQueueingActions;
-            _onBulkheadRejected = onBulkheadRejected ?? throw new ArgumentNullException(nameof(onBulkheadRejected));
+            _onBulkheadRejected = onBulkheadRejected;
 
             (_maxParallelizationSemaphore, _maxQueuedActionsSemaphore) = BulkheadSemaphoreFactory.CreateBulkheadSemaphores(maxParallelization, maxQueueingActions);
         }
@@ -69,7 +69,7 @@ namespace Polly.Bulkhead
             Action<Context> onBulkheadRejected)
         {
             _maxQueueingActions = maxQueueingActions;
-            _onBulkheadRejected = onBulkheadRejected ?? throw new ArgumentNullException(nameof(onBulkheadRejected));
+            _onBulkheadRejected = onBulkheadRejected;
 
             (_maxParallelizationSemaphore, _maxQueuedActionsSemaphore) = BulkheadSemaphoreFactory.CreateBulkheadSemaphores(maxParallelization, maxQueueingActions);
         }

--- a/src/Polly/Bulkhead/BulkheadSyntax.cs
+++ b/src/Polly/Bulkhead/BulkheadSyntax.cs
@@ -14,8 +14,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static ISyncBulkheadPolicy Bulkhead(int maxParallelization)
         {
-            Action<Context> doNothing = _ => { };
-            return Bulkhead(maxParallelization, 0, doNothing);
+            return Bulkhead(maxParallelization, maxQueuingActions: 0, onBulkheadRejected: null);
         }
 
         /// <summary>
@@ -25,7 +24,7 @@ namespace Polly
         /// <param name="maxParallelization">The maximum number of concurrent actions that may be executing through the policy.</param>
         /// <param name="onBulkheadRejected">An action to call, if the bulkhead rejects execution due to oversubscription.</param>
         /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onBulkheadRejected</exception>
+        
         /// <returns>The policy instance.</returns>
         public static ISyncBulkheadPolicy Bulkhead(int maxParallelization, Action<Context> onBulkheadRejected)
             => Bulkhead(maxParallelization, 0, onBulkheadRejected);
@@ -41,8 +40,7 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">maxQueuingActions;Value must be greater than or equal to zero.</exception>
         public static ISyncBulkheadPolicy Bulkhead(int maxParallelization, int maxQueuingActions)
         {
-            Action<Context> doNothing = _ => { };
-            return Bulkhead(maxParallelization, maxQueuingActions, doNothing);
+            return Bulkhead(maxParallelization, maxQueuingActions, onBulkheadRejected: null);
         }
 
         /// <summary>
@@ -55,13 +53,12 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
         /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onBulkheadRejected</exception>
+        
         public static ISyncBulkheadPolicy Bulkhead(int maxParallelization, int maxQueuingActions, Action<Context> onBulkheadRejected)
         {
             if (maxParallelization <= 0) throw new ArgumentOutOfRangeException(nameof(maxParallelization), "Value must be greater than zero.");
             if (maxQueuingActions < 0) throw new ArgumentOutOfRangeException(nameof(maxQueuingActions), "Value must be greater than or equal to zero.");
-            if (onBulkheadRejected == null) throw new ArgumentNullException(nameof(onBulkheadRejected));
-
+            
             return new BulkheadPolicy(
                 maxParallelization,
                 maxQueuingActions,

--- a/src/Polly/Bulkhead/BulkheadSyntax.cs
+++ b/src/Polly/Bulkhead/BulkheadSyntax.cs
@@ -53,7 +53,6 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
         /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
-        
         public static ISyncBulkheadPolicy Bulkhead(int maxParallelization, int maxQueuingActions, Action<Context> onBulkheadRejected)
         {
             if (maxParallelization <= 0) throw new ArgumentOutOfRangeException(nameof(maxParallelization), "Value must be greater than zero.");

--- a/src/Polly/Bulkhead/BulkheadTResultSyntax.cs
+++ b/src/Polly/Bulkhead/BulkheadTResultSyntax.cs
@@ -14,8 +14,8 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static ISyncBulkheadPolicy<TResult> Bulkhead<TResult>(int maxParallelization)
         {
-            Action<Context> doNothing = _ => { };
-            return Bulkhead<TResult>(maxParallelization, 0, doNothing);
+            
+            return Bulkhead<TResult>(maxParallelization, maxQueuingActions: 0, onBulkheadRejected: null);
         }
 
         /// <summary>
@@ -25,7 +25,6 @@ namespace Polly
         /// <param name="maxParallelization">The maximum number of concurrent actions that may be executing through the policy.</param>
         /// <param name="onBulkheadRejected">An action to call, if the bulkhead rejects execution due to oversubscription.</param>
         /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onBulkheadRejected</exception>
         /// <returns>The policy instance.</returns>
         public static ISyncBulkheadPolicy<TResult> Bulkhead<TResult>(int maxParallelization, Action<Context> onBulkheadRejected)
             => Bulkhead<TResult>(maxParallelization, 0, onBulkheadRejected);
@@ -41,8 +40,8 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">maxQueuingActions;Value must be greater than or equal to zero.</exception>
         public static ISyncBulkheadPolicy<TResult> Bulkhead<TResult>(int maxParallelization, int maxQueuingActions)
         {
-            Action<Context> doNothing = _ => { };
-            return Bulkhead<TResult>(maxParallelization, maxQueuingActions, doNothing);
+            
+            return Bulkhead<TResult>(maxParallelization, maxQueuingActions, onBulkheadRejected: null);
         }
 
         /// <summary>
@@ -55,13 +54,11 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
         /// <exception cref="ArgumentOutOfRangeException">maxQueuingActions;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">onBulkheadRejected</exception>
         public static ISyncBulkheadPolicy<TResult> Bulkhead<TResult>(int maxParallelization, int maxQueuingActions, Action<Context> onBulkheadRejected)
         {
             if (maxParallelization <= 0) throw new ArgumentOutOfRangeException(nameof(maxParallelization), "Value must be greater than zero.");
             if (maxQueuingActions < 0) throw new ArgumentOutOfRangeException(nameof(maxQueuingActions), "Value must be greater than or equal to zero.");
-            if (onBulkheadRejected == null) throw new ArgumentNullException(nameof(onBulkheadRejected));
-
+            
             return new BulkheadPolicy<TResult>(
                 maxParallelization,
                 maxQueuingActions,

--- a/src/Polly/Caching/AsyncCacheEngine.cs
+++ b/src/Polly/Caching/AsyncCacheEngine.cs
@@ -38,16 +38,16 @@ namespace Polly.Caching
             {
                 cacheHit = false;
                 valueFromCache = default;
-                onCacheGetError(context, cacheKey, ex);
+                onCacheGetError?.Invoke(context, cacheKey, ex);
             }
             if (cacheHit)
             {
-                onCacheGet(context, cacheKey);
+                onCacheGet?.Invoke(context, cacheKey);
                 return valueFromCache;
             }
             else
             {
-                onCacheMiss(context, cacheKey);
+                onCacheMiss?.Invoke(context, cacheKey);
             }
 
             TResult result = await action(context, cancellationToken).ConfigureAwait(continueOnCapturedContext);
@@ -58,11 +58,11 @@ namespace Polly.Caching
                 try
                 {
                     await cacheProvider.PutAsync(cacheKey, result, ttl, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
-                    onCachePut(context, cacheKey);
+                    onCachePut?.Invoke(context, cacheKey);
                 }
                 catch (Exception ex)
                 {
-                    onCachePutError(context, cacheKey, ex);
+                    onCachePutError?.Invoke(context, cacheKey, ex);
                 }
             }
 

--- a/src/Polly/Caching/AsyncCacheSyntax.cs
+++ b/src/Polly/Caching/AsyncCacheSyntax.cs
@@ -70,10 +70,7 @@ namespace Polly
             if (ttlStrategy == null) throw new ArgumentNullException(nameof(ttlStrategy));
             if (cacheKeyStrategy == null) throw new ArgumentNullException(nameof(cacheKeyStrategy));
 
-            onCacheError = onCacheError ?? ((_, __, ___) => { });
-            Action<Context, string> emptyDelegate = (_, __) => { };
-
-            return new AsyncCachePolicy(cacheProvider, ttlStrategy, cacheKeyStrategy.GetCacheKey, emptyDelegate, emptyDelegate, emptyDelegate, onCacheError, onCacheError);
+            return new AsyncCachePolicy(cacheProvider, ttlStrategy, cacheKeyStrategy.GetCacheKey, onCacheGet: null, onCacheMiss: null, onCachePut: null, onCacheGetError: onCacheError, onCachePutError: onCacheError);
         }
 
         /// <summary>
@@ -112,10 +109,7 @@ namespace Polly
             if (ttlStrategy == null) throw new ArgumentNullException(nameof(ttlStrategy));
             if (cacheKeyStrategy == null) throw new ArgumentNullException(nameof(cacheKeyStrategy));
 
-            onCacheError = onCacheError ?? ((_, __, ___) => { });
-            Action<Context, string> emptyDelegate = (_, __) => { };
-
-            return new AsyncCachePolicy(cacheProvider, ttlStrategy, cacheKeyStrategy, emptyDelegate, emptyDelegate, emptyDelegate, onCacheError, onCacheError);
+            return new AsyncCachePolicy(cacheProvider, ttlStrategy, cacheKeyStrategy, onCacheGet: null, onCacheMiss: null, onCachePut: null, onCacheGetError: onCacheError, onCachePutError: onCacheError);
         }
 
         /// <summary>
@@ -133,11 +127,6 @@ namespace Polly
         /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static IAsyncCachePolicy CacheAsync(
             IAsyncCacheProvider cacheProvider,
             TimeSpan ttl,
@@ -164,11 +153,6 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static IAsyncCachePolicy CacheAsync(
             IAsyncCacheProvider cacheProvider,
             ITtlStrategy ttlStrategy,
@@ -196,11 +180,6 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static IAsyncCachePolicy CacheAsync(
             IAsyncCacheProvider cacheProvider, 
             TimeSpan ttl, 
@@ -230,11 +209,6 @@ namespace Polly
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">ttlStrategy</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static IAsyncCachePolicy CacheAsync(
             IAsyncCacheProvider cacheProvider,
             ITtlStrategy ttlStrategy,
@@ -263,11 +237,6 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static IAsyncCachePolicy CacheAsync(
             IAsyncCacheProvider cacheProvider,
             TimeSpan ttl,
@@ -297,11 +266,6 @@ namespace Polly
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">ttlStrategy</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static IAsyncCachePolicy CacheAsync(
             IAsyncCacheProvider cacheProvider,
             ITtlStrategy ttlStrategy,
@@ -315,12 +279,6 @@ namespace Polly
             if (cacheProvider == null) throw new ArgumentNullException(nameof(cacheProvider));
             if (ttlStrategy == null) throw new ArgumentNullException(nameof(ttlStrategy));
             if (cacheKeyStrategy == null) throw new ArgumentNullException(nameof(cacheKeyStrategy));
-
-            if (onCacheGet == null) throw new ArgumentNullException(nameof(onCacheGet));
-            if (onCacheMiss == null) throw new ArgumentNullException(nameof(onCacheMiss));
-            if (onCachePut == null) throw new ArgumentNullException(nameof(onCachePut));
-            if (onCachePutError == null) throw new ArgumentNullException(nameof(onCachePutError));
-            if (onCachePutError == null) throw new ArgumentNullException(nameof(onCachePutError));
 
             return new AsyncCachePolicy(cacheProvider, ttlStrategy, cacheKeyStrategy, onCacheGet, onCacheMiss, onCachePut, onCacheGetError, onCachePutError);
         }

--- a/src/Polly/Caching/AsyncCacheTResultSyntax.cs
+++ b/src/Polly/Caching/AsyncCacheTResultSyntax.cs
@@ -139,11 +139,6 @@ namespace Polly
         /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static IAsyncCachePolicy<TResult> CacheAsync<TResult>(
             IAsyncCacheProvider cacheProvider,
             TimeSpan ttl,
@@ -174,11 +169,6 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static IAsyncCachePolicy<TResult> CacheAsync<TResult>(
             IAsyncCacheProvider cacheProvider,
             ITtlStrategy ttlStrategy,
@@ -210,11 +200,6 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static IAsyncCachePolicy<TResult> CacheAsync<TResult>(
             IAsyncCacheProvider cacheProvider,
             TimeSpan ttl,
@@ -248,11 +233,6 @@ namespace Polly
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">ttlStrategy</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static IAsyncCachePolicy<TResult> CacheAsync<TResult>(
             IAsyncCacheProvider cacheProvider,
             ITtlStrategy ttlStrategy,
@@ -285,11 +265,6 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static IAsyncCachePolicy<TResult> CacheAsync<TResult>(
             IAsyncCacheProvider cacheProvider,
             TimeSpan ttl,
@@ -323,11 +298,6 @@ namespace Polly
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">ttlStrategy</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static IAsyncCachePolicy<TResult> CacheAsync<TResult>(
             IAsyncCacheProvider cacheProvider,
             ITtlStrategy ttlStrategy,
@@ -419,11 +389,7 @@ namespace Polly
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
         public static IAsyncCachePolicy<TResult> CacheAsync<TResult>(IAsyncCacheProvider<TResult> cacheProvider, ITtlStrategy ttlStrategy, ICacheKeyStrategy cacheKeyStrategy, Action<Context, string, Exception> onCacheError = null)
         {
-            onCacheError = onCacheError ?? ((_, __, ___) => { });
-
-            Action<Context, string> emptyDelegate = (_, __) => { };
-
-            return CacheAsync<TResult>(cacheProvider, ttlStrategy, cacheKeyStrategy.GetCacheKey, emptyDelegate, emptyDelegate, emptyDelegate, onCacheError, onCacheError);
+            return CacheAsync<TResult>(cacheProvider, ttlStrategy, cacheKeyStrategy.GetCacheKey, onCacheGet: null, onCacheMiss: null, onCachePut: null, onCacheGetError: onCacheError, onCachePutError: onCacheError);
         }
 
         /// <summary>
@@ -442,11 +408,7 @@ namespace Polly
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
         public static IAsyncCachePolicy<TResult> CacheAsync<TResult>(IAsyncCacheProvider<TResult> cacheProvider, ITtlStrategy<TResult> ttlStrategy, ICacheKeyStrategy cacheKeyStrategy, Action<Context, string, Exception> onCacheError = null)
         {
-            onCacheError = onCacheError ?? ((_, __, ___) => { });
-
-            Action<Context, string> emptyDelegate = (_, __) => { };
-
-            return CacheAsync<TResult>(cacheProvider, ttlStrategy, cacheKeyStrategy.GetCacheKey, emptyDelegate, emptyDelegate, emptyDelegate, onCacheError, onCacheError);
+            return CacheAsync<TResult>(cacheProvider, ttlStrategy, cacheKeyStrategy.GetCacheKey, onCacheGet: null, onCacheMiss: null, onCachePut: null, onCacheGetError: onCacheError, onCachePutError: onCacheError);
         }
 
         /// <summary>
@@ -481,11 +443,7 @@ namespace Polly
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
         public static IAsyncCachePolicy<TResult> CacheAsync<TResult>(IAsyncCacheProvider<TResult> cacheProvider, ITtlStrategy ttlStrategy, Func<Context, string> cacheKeyStrategy, Action<Context, string, Exception> onCacheError = null)
         {
-            onCacheError = onCacheError ?? ((_, __, ___) => { });
-
-            Action<Context, string> emptyDelegate = (_, __) => { };
-
-            return CacheAsync<TResult>(cacheProvider, ttlStrategy, cacheKeyStrategy, emptyDelegate, emptyDelegate, emptyDelegate, onCacheError, onCacheError);
+            return CacheAsync<TResult>(cacheProvider, ttlStrategy, cacheKeyStrategy, onCacheGet: null, onCacheMiss: null, onCachePut: null, onCacheGetError: onCacheError, onCachePutError: onCacheError);
         }
 
         /// <summary>
@@ -504,11 +462,7 @@ namespace Polly
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
         public static IAsyncCachePolicy<TResult> CacheAsync<TResult>(IAsyncCacheProvider<TResult> cacheProvider, ITtlStrategy<TResult> ttlStrategy, Func<Context, string> cacheKeyStrategy, Action<Context, string, Exception> onCacheError = null)
         {
-            onCacheError = onCacheError ?? ((_, __, ___) => { });
-
-            Action<Context, string> emptyDelegate = (_, __) => { };
-
-            return CacheAsync<TResult>(cacheProvider, ttlStrategy, cacheKeyStrategy, emptyDelegate, emptyDelegate, emptyDelegate, onCacheError, onCacheError);
+            return CacheAsync<TResult>(cacheProvider, ttlStrategy, cacheKeyStrategy, onCacheGet: null, onCacheMiss: null, onCachePut: null, onCacheGetError: onCacheError, onCachePutError: onCacheError);
         }
 
         /// <summary>
@@ -526,11 +480,6 @@ namespace Polly
         /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static IAsyncCachePolicy<TResult> CacheAsync<TResult>(
             IAsyncCacheProvider<TResult> cacheProvider,
             TimeSpan ttl,
@@ -558,11 +507,6 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static IAsyncCachePolicy<TResult> CacheAsync<TResult>(
             IAsyncCacheProvider<TResult> cacheProvider,
             ITtlStrategy ttlStrategy,
@@ -589,11 +533,6 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static IAsyncCachePolicy<TResult> CacheAsync<TResult>(
             IAsyncCacheProvider<TResult> cacheProvider,
             ITtlStrategy<TResult> ttlStrategy,
@@ -621,11 +560,6 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static IAsyncCachePolicy<TResult> CacheAsync<TResult>(
             IAsyncCacheProvider<TResult> cacheProvider,
             TimeSpan ttl,
@@ -656,11 +590,6 @@ namespace Polly
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">ttlStrategy</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static IAsyncCachePolicy<TResult> CacheAsync<TResult>(
             IAsyncCacheProvider<TResult> cacheProvider,
             ITtlStrategy ttlStrategy,
@@ -690,11 +619,6 @@ namespace Polly
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">ttlStrategy</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static IAsyncCachePolicy<TResult> CacheAsync<TResult>(
             IAsyncCacheProvider<TResult> cacheProvider,
             ITtlStrategy<TResult> ttlStrategy,
@@ -723,11 +647,6 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static IAsyncCachePolicy<TResult> CacheAsync<TResult>(
             IAsyncCacheProvider<TResult> cacheProvider,
             TimeSpan ttl,
@@ -758,11 +677,6 @@ namespace Polly
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">ttlStrategy</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static IAsyncCachePolicy<TResult> CacheAsync<TResult>(
             IAsyncCacheProvider<TResult> cacheProvider,
             ITtlStrategy ttlStrategy,
@@ -792,11 +706,6 @@ namespace Polly
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">ttlStrategy</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static IAsyncCachePolicy<TResult> CacheAsync<TResult>(
             IAsyncCacheProvider<TResult> cacheProvider,
             ITtlStrategy<TResult> ttlStrategy,
@@ -810,12 +719,6 @@ namespace Polly
             if (cacheProvider == null) throw new ArgumentNullException(nameof(cacheProvider));
             if (ttlStrategy == null) throw new ArgumentNullException(nameof(ttlStrategy));
             if (cacheKeyStrategy == null) throw new ArgumentNullException(nameof(cacheKeyStrategy));
-
-            if (onCacheGet == null) throw new ArgumentNullException(nameof(onCacheGet));
-            if (onCacheMiss == null) throw new ArgumentNullException(nameof(onCacheMiss));
-            if (onCachePut == null) throw new ArgumentNullException(nameof(onCachePut));
-            if (onCachePutError == null) throw new ArgumentNullException(nameof(onCachePutError));
-            if (onCachePutError == null) throw new ArgumentNullException(nameof(onCachePutError));
 
             return new AsyncCachePolicy<TResult>(cacheProvider, ttlStrategy, cacheKeyStrategy, onCacheGet, onCacheMiss, onCachePut, onCacheGetError, onCachePutError);
         }

--- a/src/Polly/Caching/CacheEngine.cs
+++ b/src/Polly/Caching/CacheEngine.cs
@@ -36,16 +36,16 @@ namespace Polly.Caching
             {
                 cacheHit = false;
                 valueFromCache = default;
-                onCacheGetError(context, cacheKey, ex);
+                onCacheGetError?.Invoke(context, cacheKey, ex);
             }
             if (cacheHit)
             {
-                onCacheGet(context, cacheKey);
+                onCacheGet?.Invoke(context, cacheKey);
                 return valueFromCache;
             }
             else
             {
-                onCacheMiss(context, cacheKey);
+                onCacheMiss?.Invoke(context, cacheKey);
             }
 
             TResult result = action(context, cancellationToken);
@@ -56,11 +56,11 @@ namespace Polly.Caching
                 try
                 {
                     cacheProvider.Put(cacheKey, result, ttl);
-                    onCachePut(context, cacheKey);
+                    onCachePut?.Invoke(context, cacheKey);
                 }
                 catch (Exception ex)
                 {
-                    onCachePutError(context, cacheKey, ex);
+                    onCachePutError?.Invoke(context, cacheKey, ex);
                 }
             }
 

--- a/src/Polly/Caching/CacheSyntax.cs
+++ b/src/Polly/Caching/CacheSyntax.cs
@@ -70,10 +70,7 @@ namespace Polly
             if (ttlStrategy == null) throw new ArgumentNullException(nameof(ttlStrategy));
             if (cacheKeyStrategy == null) throw new ArgumentNullException(nameof(cacheKeyStrategy));
 
-            onCacheError = onCacheError ?? ((_, __, ___) => { });
-            Action<Context, string> emptyDelegate = (_, __) => { };
-
-            return Cache(cacheProvider, ttlStrategy, cacheKeyStrategy.GetCacheKey, emptyDelegate, emptyDelegate, emptyDelegate, onCacheError, onCacheError);
+            return Cache(cacheProvider, ttlStrategy, cacheKeyStrategy.GetCacheKey, onCacheGet: null, onCacheMiss: null, onCachePut: null, onCacheGetError: onCacheError, onCachePutError: onCacheError);
         }
 
         /// <summary>
@@ -112,10 +109,7 @@ namespace Polly
             if (ttlStrategy == null) throw new ArgumentNullException(nameof(ttlStrategy));
             if (cacheKeyStrategy == null) throw new ArgumentNullException(nameof(cacheKeyStrategy));
 
-            onCacheError = onCacheError ?? ((_, __, ___) => { });
-            Action<Context, string> emptyDelegate = (_, __) => { };
-
-            return Cache(cacheProvider, ttlStrategy, cacheKeyStrategy, emptyDelegate, emptyDelegate, emptyDelegate, onCacheError, onCacheError);
+            return Cache(cacheProvider, ttlStrategy, cacheKeyStrategy, onCacheGet: null, onCacheMiss: null, onCachePut: null, onCacheGetError: onCacheError, onCachePutError: onCacheError);
         }
 
         /// <summary>
@@ -135,11 +129,6 @@ namespace Polly
         /// <exception cref="ArgumentNullException">
         /// </exception>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static ISyncCachePolicy Cache(
             ISyncCacheProvider cacheProvider,
             TimeSpan ttl,
@@ -168,11 +157,6 @@ namespace Polly
         /// </exception>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static ISyncCachePolicy Cache(
             ISyncCacheProvider cacheProvider,
             ITtlStrategy ttlStrategy,
@@ -202,11 +186,6 @@ namespace Polly
         /// </exception>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static ISyncCachePolicy Cache(
             ISyncCacheProvider cacheProvider, 
             TimeSpan ttl, 
@@ -238,11 +217,6 @@ namespace Polly
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">ttlStrategy</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static ISyncCachePolicy Cache(
             ISyncCacheProvider cacheProvider,
             ITtlStrategy ttlStrategy,
@@ -273,11 +247,6 @@ namespace Polly
         /// </exception>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static ISyncCachePolicy Cache(
             ISyncCacheProvider cacheProvider,
             TimeSpan ttl, 
@@ -309,11 +278,6 @@ namespace Polly
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">ttlStrategy</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static ISyncCachePolicy Cache(
             ISyncCacheProvider cacheProvider, 
             ITtlStrategy ttlStrategy,
@@ -327,12 +291,6 @@ namespace Polly
             if (cacheProvider == null) throw new ArgumentNullException(nameof(cacheProvider));
             if (ttlStrategy == null) throw new ArgumentNullException(nameof(ttlStrategy));
             if (cacheKeyStrategy == null) throw new ArgumentNullException(nameof(cacheKeyStrategy));
-
-            if (onCacheGet == null) throw new ArgumentNullException(nameof(onCacheGet));
-            if (onCacheMiss == null) throw new ArgumentNullException(nameof(onCacheMiss));
-            if (onCachePut == null) throw new ArgumentNullException(nameof(onCachePut));
-            if (onCachePutError == null) throw new ArgumentNullException(nameof(onCachePutError));
-            if (onCachePutError == null) throw new ArgumentNullException(nameof(onCachePutError));
 
             return new CachePolicy(cacheProvider, ttlStrategy, cacheKeyStrategy, onCacheGet, onCacheMiss, onCachePut, onCacheGetError, onCachePutError);
         }

--- a/src/Polly/Caching/CacheTResultSyntax.cs
+++ b/src/Polly/Caching/CacheTResultSyntax.cs
@@ -139,11 +139,6 @@ namespace Polly
         /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static ISyncCachePolicy<TResult> Cache<TResult>(
             ISyncCacheProvider cacheProvider,
             TimeSpan ttl,
@@ -174,11 +169,6 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static ISyncCachePolicy<TResult> Cache<TResult>(
             ISyncCacheProvider cacheProvider,
             ITtlStrategy ttlStrategy,
@@ -210,11 +200,6 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static ISyncCachePolicy<TResult> Cache<TResult>(
             ISyncCacheProvider cacheProvider,
             TimeSpan ttl,
@@ -248,11 +233,6 @@ namespace Polly
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">ttlStrategy</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static ISyncCachePolicy<TResult> Cache<TResult>(
             ISyncCacheProvider cacheProvider,
             ITtlStrategy ttlStrategy,
@@ -285,11 +265,6 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static ISyncCachePolicy<TResult> Cache<TResult>(
             ISyncCacheProvider cacheProvider,
             TimeSpan ttl,
@@ -323,11 +298,6 @@ namespace Polly
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">ttlStrategy</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static ISyncCachePolicy<TResult> Cache<TResult>(
             ISyncCacheProvider cacheProvider,
             ITtlStrategy ttlStrategy, 
@@ -419,12 +389,7 @@ namespace Polly
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
         public static ISyncCachePolicy<TResult> Cache<TResult>(ISyncCacheProvider<TResult> cacheProvider, ITtlStrategy ttlStrategy, ICacheKeyStrategy cacheKeyStrategy, Action<Context, string, Exception> onCacheError = null)
         {
-            onCacheError = onCacheError ?? ((_, __, ___) => { });
-
-            Action<Context, string> emptyDelegate = (_, __) => { };
-
-            return Cache<TResult>(cacheProvider, ttlStrategy.For<TResult>(), cacheKeyStrategy.GetCacheKey,
-                emptyDelegate, emptyDelegate, emptyDelegate, onCacheError, onCacheError);
+            return Cache<TResult>(cacheProvider, ttlStrategy.For<TResult>(), cacheKeyStrategy.GetCacheKey, onCacheGet: null, onCacheMiss: null, onCachePut: null, onCacheGetError: onCacheError, onCachePutError: onCacheError);
         }
 
         /// <summary>
@@ -443,12 +408,7 @@ namespace Polly
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
         public static ISyncCachePolicy<TResult> Cache<TResult>(ISyncCacheProvider<TResult> cacheProvider, ITtlStrategy<TResult> ttlStrategy, ICacheKeyStrategy cacheKeyStrategy, Action<Context, string, Exception> onCacheError = null)
         {
-            onCacheError = onCacheError ?? ((_, __, ___) => { });
-
-            Action<Context, string> emptyDelegate = (_, __) => { };
-
-            return Cache(cacheProvider, ttlStrategy, cacheKeyStrategy, emptyDelegate, emptyDelegate, emptyDelegate,
-                onCacheError, onCacheError);
+            return Cache(cacheProvider, ttlStrategy, cacheKeyStrategy, onCacheGet: null, onCacheMiss: null, onCachePut: null, onCacheGetError: onCacheError, onCachePutError: onCacheError);
         }
 
         /// <summary>
@@ -483,12 +443,7 @@ namespace Polly
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
         public static ISyncCachePolicy<TResult> Cache<TResult>(ISyncCacheProvider<TResult> cacheProvider, ITtlStrategy ttlStrategy, Func<Context, string> cacheKeyStrategy, Action<Context, string, Exception> onCacheError = null)
         {
-            onCacheError = onCacheError ?? ((_, __, ___) => { });
-
-            Action<Context, string> emptyDelegate = (_, __) => { };
-
-            return Cache<TResult>(cacheProvider, ttlStrategy.For<TResult>(), cacheKeyStrategy,
-                emptyDelegate, emptyDelegate, emptyDelegate, onCacheError, onCacheError);
+            return Cache<TResult>(cacheProvider, ttlStrategy.For<TResult>(), cacheKeyStrategy, onCacheGet: null, onCacheMiss: null, onCachePut: null, onCacheGetError: onCacheError, onCachePutError: onCacheError);
         }
 
         /// <summary>
@@ -507,12 +462,7 @@ namespace Polly
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
         public static ISyncCachePolicy<TResult> Cache<TResult>(ISyncCacheProvider<TResult> cacheProvider, ITtlStrategy<TResult> ttlStrategy, Func<Context, string> cacheKeyStrategy, Action<Context, string, Exception> onCacheError = null)
         {
-            onCacheError = onCacheError ?? ((_, __, ___) => { });
-
-            Action<Context, string> emptyDelegate = (_, __) => { };
-
-            return Cache(cacheProvider, ttlStrategy, cacheKeyStrategy, emptyDelegate, emptyDelegate, emptyDelegate,
-                onCacheError, onCacheError);
+            return Cache(cacheProvider, ttlStrategy, cacheKeyStrategy, onCacheGet: null, onCacheMiss: null, onCachePut: null, onCacheGetError: onCacheError, onCachePutError: onCacheError);
         }
 
         /// <summary>
@@ -530,11 +480,6 @@ namespace Polly
         /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static ISyncCachePolicy<TResult> Cache<TResult>(
             ISyncCacheProvider<TResult> cacheProvider,
             TimeSpan ttl,
@@ -562,11 +507,6 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static ISyncCachePolicy<TResult> Cache<TResult>(
             ISyncCacheProvider<TResult> cacheProvider,
             ITtlStrategy ttlStrategy,
@@ -593,11 +533,6 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static ISyncCachePolicy<TResult> Cache<TResult>(
             ISyncCacheProvider<TResult> cacheProvider,
             ITtlStrategy<TResult> ttlStrategy,
@@ -625,11 +560,6 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static ISyncCachePolicy<TResult> Cache<TResult>(
             ISyncCacheProvider<TResult> cacheProvider,
             TimeSpan ttl,
@@ -660,11 +590,6 @@ namespace Polly
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">ttlStrategy</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static ISyncCachePolicy<TResult> Cache<TResult>(
             ISyncCacheProvider<TResult> cacheProvider,
             ITtlStrategy ttlStrategy,
@@ -693,12 +618,6 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-        /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static ISyncCachePolicy<TResult> Cache<TResult>(
             ISyncCacheProvider<TResult> cacheProvider,
             ITtlStrategy<TResult> ttlStrategy,
@@ -727,11 +646,6 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static ISyncCachePolicy<TResult> Cache<TResult>(
             ISyncCacheProvider<TResult> cacheProvider,
             TimeSpan ttl,
@@ -762,11 +676,6 @@ namespace Polly
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">ttlStrategy</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static ISyncCachePolicy<TResult> Cache<TResult>(
             ISyncCacheProvider<TResult> cacheProvider,
             ITtlStrategy ttlStrategy,
@@ -797,11 +706,6 @@ namespace Polly
         /// <exception cref="ArgumentNullException">cacheProvider</exception>
         /// <exception cref="ArgumentNullException">ttlStrategy</exception>
         /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-        /// <exception cref="ArgumentNullException">onCacheGet</exception>
-        /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-        /// <exception cref="ArgumentNullException">onCachePut</exception>
-        /// <exception cref="ArgumentNullException">onCacheGetError</exception>
-        /// <exception cref="ArgumentNullException">onCachePutError</exception>
         public static ISyncCachePolicy<TResult> Cache<TResult>(
             ISyncCacheProvider<TResult> cacheProvider,
             ITtlStrategy<TResult> ttlStrategy,
@@ -815,12 +719,6 @@ namespace Polly
             if (cacheProvider == null) throw new ArgumentNullException(nameof(cacheProvider));
             if (ttlStrategy == null) throw new ArgumentNullException(nameof(ttlStrategy));
             if (cacheKeyStrategy == null) throw new ArgumentNullException(nameof(cacheKeyStrategy));
-
-            if (onCacheGet == null) throw new ArgumentNullException(nameof(onCacheGet));
-            if (onCacheMiss == null) throw new ArgumentNullException(nameof(onCacheMiss));
-            if (onCachePut == null) throw new ArgumentNullException(nameof(onCachePut));
-            if (onCachePutError == null) throw new ArgumentNullException(nameof(onCachePutError));
-            if (onCachePutError == null) throw new ArgumentNullException(nameof(onCachePutError));
 
             return new CachePolicy<TResult>(cacheProvider, ttlStrategy, cacheKeyStrategy, onCacheGet, onCacheMiss, onCachePut, onCacheGetError, onCachePutError);
         }

--- a/src/Polly/CircuitBreaker/AdvancedCircuitBreakerSyntax.cs
+++ b/src/Polly/CircuitBreaker/AdvancedCircuitBreakerSyntax.cs
@@ -34,14 +34,11 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
         public static ISyncCircuitBreakerPolicy AdvancedCircuitBreaker(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak)
         {
-            Action<Exception, TimeSpan> doNothingOnBreak = (_, __) => { };
-            Action doNothingOnReset = () => { };
-
             return policyBuilder.AdvancedCircuitBreaker(
                 failureThreshold, samplingDuration, minimumThroughput, 
                 durationOfBreak, 
-                doNothingOnBreak,
-                doNothingOnReset
+                onBreak: null,
+                onReset: (Action) null
                 );
         }
 
@@ -69,14 +66,12 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
         /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
         /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
         public static ISyncCircuitBreakerPolicy AdvancedCircuitBreaker(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan> onBreak, Action onReset)
             => policyBuilder.AdvancedCircuitBreaker(
                 failureThreshold, samplingDuration, minimumThroughput, 
-                durationOfBreak, 
-                (exception, timespan, context) => onBreak(exception, timespan), 
-                context => onReset()
+                durationOfBreak,
+                onBreak: onBreak == null ? (Action<Exception, TimeSpan, Context>)null : (exception, timespan, context) => onBreak(exception, timespan),
+                onReset: onReset == null ? (Action<Context>)null : context => onReset()
                 );
 
         /// <summary>
@@ -103,16 +98,13 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
         /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
         /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
         public static ISyncCircuitBreakerPolicy AdvancedCircuitBreaker(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset)
         {
-            Action doNothingOnHalfOpen = () => { };
             return policyBuilder.AdvancedCircuitBreaker(failureThreshold, samplingDuration, minimumThroughput, 
                 durationOfBreak, 
                 onBreak, 
                 onReset,
-                doNothingOnHalfOpen
+                onHalfOpen: null
                 );
         }
 
@@ -141,15 +133,12 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
         /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
         /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
-        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static ISyncCircuitBreakerPolicy AdvancedCircuitBreaker(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan> onBreak, Action onReset, Action onHalfOpen)
             => policyBuilder.AdvancedCircuitBreaker(
                 failureThreshold, samplingDuration, minimumThroughput, 
                 durationOfBreak,
-                (exception, timespan, context) => onBreak(exception, timespan),
-                context => onReset(),
+                onBreak: onBreak == null ? (Action<Exception, TimeSpan, Context>)null : (exception, timespan, context) => onBreak(exception, timespan),
+                onReset: onReset == null ? (Action<Context>)null : context => onReset(),
                 onHalfOpen
                 );
 
@@ -178,15 +167,12 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
         /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
         /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
-        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         public static ISyncCircuitBreakerPolicy AdvancedCircuitBreaker(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
             => policyBuilder.AdvancedCircuitBreaker(
                 failureThreshold, samplingDuration, minimumThroughput,
                 durationOfBreak,
-                (exception, state, timespan, context) => onBreak(exception, timespan, context),
+                onBreak: onBreak == null ? (Action<Exception, CircuitState, TimeSpan, Context>)null : (exception, state, timespan, context) => onBreak(exception, timespan, context),
                 onReset,
                 onHalfOpen
             );
@@ -216,9 +202,6 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
         /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
         /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
-        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         public static ISyncCircuitBreakerPolicy AdvancedCircuitBreaker(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
         {
@@ -230,16 +213,12 @@ namespace Polly
             if (minimumThroughput <= 1) throw new ArgumentOutOfRangeException(nameof(minimumThroughput), "Value must be greater than one.");
             if (durationOfBreak < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(durationOfBreak), "Value must be greater than zero.");
 
-            if (onBreak == null) throw new ArgumentNullException(nameof(onBreak));
-            if (onReset == null) throw new ArgumentNullException(nameof(onReset));
-            if (onHalfOpen == null) throw new ArgumentNullException(nameof(onHalfOpen));
-
             var breakerController = new AdvancedCircuitController<EmptyStruct>(
                 failureThreshold,
                 samplingDuration,
                 minimumThroughput,
                 durationOfBreak,
-                (outcome, state, timespan, context) => onBreak(outcome.Exception, state, timespan, context),
+                onBreak: onBreak == null ? (Action<DelegateResult<EmptyStruct>, CircuitState, TimeSpan, Context>)null : (outcome, state, timespan, context) => onBreak(outcome.Exception, state, timespan, context),
                 onReset,
                 onHalfOpen);
             return new CircuitBreakerPolicy(

--- a/src/Polly/CircuitBreaker/AdvancedCircuitBreakerTResultSyntax.cs
+++ b/src/Polly/CircuitBreaker/AdvancedCircuitBreakerTResultSyntax.cs
@@ -34,14 +34,11 @@ namespace Polly
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         public static ISyncCircuitBreakerPolicy<TResult> AdvancedCircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak)
         {
-            Action<DelegateResult<TResult>, TimeSpan> doNothingOnBreak = (_, __) => { };
-            Action doNothingOnReset = () => { };
-
             return policyBuilder.AdvancedCircuitBreaker(
                 failureThreshold, samplingDuration, minimumThroughput,
                 durationOfBreak,
-                doNothingOnBreak,
-                doNothingOnReset
+                onBreak: null,
+                onReset: (Action) null
                 );
         }
 
@@ -69,14 +66,12 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
         /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
         /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
         public static ISyncCircuitBreakerPolicy<TResult> AdvancedCircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan> onBreak, Action onReset)
             => policyBuilder.AdvancedCircuitBreaker(
                 failureThreshold, samplingDuration, minimumThroughput,
                 durationOfBreak,
-                (outcome, timespan, context) => onBreak(outcome, timespan),
-                context => onReset()
+                onBreak: onBreak == null ? (Action<DelegateResult<TResult>, TimeSpan, Context>)null : (outcome, timespan, context) => onBreak(outcome, timespan),
+                onReset: onReset == null ? (Action<Context>)null : context => onReset()
                 );
 
         /// <summary>
@@ -103,16 +98,13 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
         /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
         /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
         public static ISyncCircuitBreakerPolicy<TResult> AdvancedCircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset)
         {
-            Action doNothingOnHalfOpen = () => { };
             return policyBuilder.AdvancedCircuitBreaker(failureThreshold, samplingDuration, minimumThroughput,
                 durationOfBreak,
                 onBreak,
                 onReset,
-                doNothingOnHalfOpen
+                onHalfOpen: null
                 );
         }
 
@@ -141,15 +133,12 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
         /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
         /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
-        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static ISyncCircuitBreakerPolicy<TResult> AdvancedCircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan> onBreak, Action onReset, Action onHalfOpen)
             => policyBuilder.AdvancedCircuitBreaker(
                 failureThreshold, samplingDuration, minimumThroughput,
                 durationOfBreak,
-                (outcome, timespan, context) => onBreak(outcome, timespan),
-                context => onReset(),
+                onBreak: onBreak == null ? (Action<DelegateResult<TResult>, TimeSpan, Context>)null : (outcome, timespan, context) => onBreak(outcome, timespan),
+                onReset: onReset == null ? (Action<Context>)null : context => onReset(),
                 onHalfOpen
                 );
 
@@ -179,15 +168,12 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
         /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
         /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
-        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         public static ISyncCircuitBreakerPolicy<TResult> AdvancedCircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
             => policyBuilder.AdvancedCircuitBreaker(
                 failureThreshold, samplingDuration, minimumThroughput,
                 durationOfBreak,
-                (outcome, state, timespan, context) => onBreak(outcome, timespan, context),
+                onBreak: onBreak == null ? (Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context>)null : (outcome, state, timespan, context) => onBreak(outcome, timespan, context),
                 onReset,
                 onHalfOpen
             );
@@ -218,9 +204,6 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
         /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
         /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
-        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         public static ISyncCircuitBreakerPolicy<TResult> AdvancedCircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
         {
@@ -231,10 +214,6 @@ namespace Polly
             if (samplingDuration < resolutionOfCircuit) throw new ArgumentOutOfRangeException(nameof(samplingDuration), $"Value must be equal to or greater than {resolutionOfCircuit.TotalMilliseconds} milliseconds. This is the minimum resolution of the CircuitBreaker timer.");
             if (minimumThroughput <= 1) throw new ArgumentOutOfRangeException(nameof(minimumThroughput), "Value must be greater than one.");
             if (durationOfBreak < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(durationOfBreak), "Value must be greater than zero.");
-
-            if (onBreak == null) throw new ArgumentNullException(nameof(onBreak));
-            if (onReset == null) throw new ArgumentNullException(nameof(onReset));
-            if (onHalfOpen == null) throw new ArgumentNullException(nameof(onHalfOpen));
 
             var breakerController = new AdvancedCircuitController<TResult>(
                 failureThreshold,

--- a/src/Polly/CircuitBreaker/AsyncAdvancedCircuitBreakerSyntax.cs
+++ b/src/Polly/CircuitBreaker/AsyncAdvancedCircuitBreakerSyntax.cs
@@ -35,14 +35,11 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
         public static IAsyncCircuitBreakerPolicy AdvancedCircuitBreakerAsync(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak)
         {
-            Action<Exception, TimeSpan> doNothingOnBreak = (_, __) => { };
-            Action doNothingOnReset = () => { };
-
             return policyBuilder.AdvancedCircuitBreakerAsync(
                failureThreshold, samplingDuration, minimumThroughput, 
                durationOfBreak,
-               doNothingOnBreak,
-               doNothingOnReset
+               onBreak: null,
+               onReset: (Action)null
                );
         }
 
@@ -71,14 +68,12 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
         /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
         /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
         public static IAsyncCircuitBreakerPolicy AdvancedCircuitBreakerAsync(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan> onBreak, Action onReset)
             => policyBuilder.AdvancedCircuitBreakerAsync(
                 failureThreshold, samplingDuration, minimumThroughput, 
                 durationOfBreak,
-                (exception, timespan, context) => onBreak(exception, timespan),
-                context => onReset()
+                onBreak: onBreak == null ? (Action<Exception, TimeSpan, Context>)null : (exception, timespan, context) => onBreak(exception, timespan),
+                onReset: onReset == null ? (Action<Context>)null : context => onReset()
                 );
 
         /// <summary>
@@ -106,17 +101,14 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
         /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
         /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
         public static IAsyncCircuitBreakerPolicy AdvancedCircuitBreakerAsync(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset)
         {
-            Action doNothingOnHalfOpen = () => { };
             return policyBuilder.AdvancedCircuitBreakerAsync(
                 failureThreshold, samplingDuration, minimumThroughput, 
                 durationOfBreak, 
                 onBreak, 
                 onReset,
-                doNothingOnHalfOpen
+                onHalfOpen: null
                 );
         }
 
@@ -146,14 +138,12 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
         /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
         /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
         public static IAsyncCircuitBreakerPolicy AdvancedCircuitBreakerAsync(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan> onBreak, Action onReset, Action onHalfOpen)
             => policyBuilder.AdvancedCircuitBreakerAsync(
                 failureThreshold, samplingDuration, minimumThroughput, 
                 durationOfBreak,
-                (exception, timespan, context) => onBreak(exception, timespan),
-                context => onReset(),
+                onBreak: onBreak == null ? (Action<Exception, TimeSpan, Context>)null : (exception, timespan, context) => onBreak(exception, timespan),
+                onReset: onReset == null ? (Action<Context>)null : context => onReset(),
                 onHalfOpen
                 );
 
@@ -183,14 +173,11 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
         /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
         /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
-        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static IAsyncCircuitBreakerPolicy AdvancedCircuitBreakerAsync(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
             => policyBuilder.AdvancedCircuitBreakerAsync(
                 failureThreshold, samplingDuration, minimumThroughput,
                 durationOfBreak,
-                (exception, state, timespan, context) => onBreak(exception, timespan, context),
+                onBreak: onBreak == null ? (Action<Exception, CircuitState, TimeSpan, Context>)null : (exception, state, timespan, context) => onBreak(exception, timespan, context),
                 onReset,
                 onHalfOpen
             );
@@ -221,9 +208,6 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
         /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
         /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
-        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static IAsyncCircuitBreakerPolicy AdvancedCircuitBreakerAsync(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
         {
             var resolutionOfCircuit = TimeSpan.FromTicks(AdvancedCircuitController<EmptyStruct>.ResolutionOfCircuitTimer);
@@ -234,16 +218,12 @@ namespace Polly
             if (minimumThroughput <= 1) throw new ArgumentOutOfRangeException(nameof(minimumThroughput), "Value must be greater than one.");
             if (durationOfBreak < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(durationOfBreak), "Value must be greater than zero.");
 
-            if (onBreak == null) throw new ArgumentNullException(nameof(onBreak));
-            if (onReset == null) throw new ArgumentNullException(nameof(onReset));
-            if (onHalfOpen == null) throw new ArgumentNullException(nameof(onHalfOpen));
-
             var breakerController = new AdvancedCircuitController<EmptyStruct>(
                 failureThreshold,
                 samplingDuration,
                 minimumThroughput,
                 durationOfBreak,
-                (outcome, state, timespan, context) => onBreak(outcome.Exception, state, timespan, context),
+                onBreak: onBreak == null ? (Action<DelegateResult<EmptyStruct>, CircuitState, TimeSpan, Context>)null : (outcome, state, timespan, context) => onBreak(outcome.Exception, state, timespan, context),
                 onReset,
                 onHalfOpen);
             return new AsyncCircuitBreakerPolicy(

--- a/src/Polly/CircuitBreaker/AsyncAdvancedCircuitBreakerTResultSyntax.cs
+++ b/src/Polly/CircuitBreaker/AsyncAdvancedCircuitBreakerTResultSyntax.cs
@@ -34,14 +34,11 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
         public static IAsyncCircuitBreakerPolicy<TResult> AdvancedCircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak)
         {
-            Action<DelegateResult<TResult>, TimeSpan> doNothingOnBreak = (_, __) => { };
-            Action doNothingOnReset = () => { };
-
             return policyBuilder.AdvancedCircuitBreakerAsync(
                failureThreshold, samplingDuration, minimumThroughput,
                durationOfBreak,
-               doNothingOnBreak,
-               doNothingOnReset
+               onBreak: null,
+               onReset: (Action)null
                );
         }
 
@@ -70,14 +67,12 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
         /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
         /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
         public static IAsyncCircuitBreakerPolicy<TResult> AdvancedCircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan> onBreak, Action onReset)
             => policyBuilder.AdvancedCircuitBreakerAsync(
                 failureThreshold, samplingDuration, minimumThroughput,
                 durationOfBreak,
-                (outcome, timespan, context) => onBreak(outcome, timespan),
-                context => onReset()
+                onBreak: onBreak == null ? (Action<DelegateResult<TResult>, TimeSpan, Context>)null : (outcome, timespan, context) => onBreak(outcome, timespan),
+                onReset: onReset == null ? (Action<Context>)null : context => onReset()
                 );
 
         /// <summary>
@@ -105,17 +100,14 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
         /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
         /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
         public static IAsyncCircuitBreakerPolicy<TResult> AdvancedCircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset)
         {
-            Action doNothingOnHalfOpen = () => { };
             return policyBuilder.AdvancedCircuitBreakerAsync(
                 failureThreshold, samplingDuration, minimumThroughput,
                 durationOfBreak,
                 onBreak,
                 onReset,
-                doNothingOnHalfOpen
+                onHalfOpen: null
                 );
         }
 
@@ -145,14 +137,12 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
         /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
         /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
         public static IAsyncCircuitBreakerPolicy<TResult> AdvancedCircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan> onBreak, Action onReset, Action onHalfOpen)
             => policyBuilder.AdvancedCircuitBreakerAsync(
                 failureThreshold, samplingDuration, minimumThroughput,
                 durationOfBreak,
-                (outcome, timespan, context) => onBreak(outcome, timespan),
-                context => onReset(),
+                onBreak: onBreak == null ? (Action<DelegateResult<TResult>, TimeSpan, Context>)null : (outcome, timespan, context) => onBreak(outcome, timespan),
+                onReset: onReset == null ? (Action<Context>)null : context => onReset(),
                 onHalfOpen
                 );
 
@@ -182,14 +172,11 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
         /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
         /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
-        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static IAsyncCircuitBreakerPolicy<TResult> AdvancedCircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
             => policyBuilder.AdvancedCircuitBreakerAsync(
                 failureThreshold, samplingDuration, minimumThroughput,
                 durationOfBreak,
-                (outcome, state, timespan, context) => onBreak(outcome, timespan, context),
+                onBreak: onBreak == null ? (Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context>)null : (outcome, state, timespan, context) => onBreak(outcome, timespan, context),
                 onReset,
                 onHalfOpen
             );
@@ -220,9 +207,6 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
         /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
         /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
-        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static IAsyncCircuitBreakerPolicy<TResult> AdvancedCircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
         {
             var resolutionOfCircuit = TimeSpan.FromTicks(AdvancedCircuitController<EmptyStruct>.ResolutionOfCircuitTimer);
@@ -232,10 +216,6 @@ namespace Polly
             if (samplingDuration < resolutionOfCircuit) throw new ArgumentOutOfRangeException(nameof(samplingDuration), $"Value must be equal to or greater than {resolutionOfCircuit.TotalMilliseconds} milliseconds. This is the minimum resolution of the CircuitBreaker timer.");
             if (minimumThroughput <= 1) throw new ArgumentOutOfRangeException(nameof(minimumThroughput), "Value must be greater than one.");
             if (durationOfBreak < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(durationOfBreak), "Value must be greater than zero.");
-
-            if (onBreak == null) throw new ArgumentNullException(nameof(onBreak));
-            if (onReset == null) throw new ArgumentNullException(nameof(onReset));
-            if (onHalfOpen == null) throw new ArgumentNullException(nameof(onHalfOpen));
 
             var breakerController = new AdvancedCircuitController<TResult>(
                 failureThreshold,

--- a/src/Polly/CircuitBreaker/AsyncCircuitBreakerSyntax.cs
+++ b/src/Polly/CircuitBreaker/AsyncCircuitBreakerSyntax.cs
@@ -29,14 +29,11 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
         public static IAsyncCircuitBreakerPolicy CircuitBreakerAsync(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak)
         {
-            Action<Exception, TimeSpan> doNothingOnBreak = (_, __) => { };
-            Action doNothingOnReset = () => { };
-
             return policyBuilder.CircuitBreakerAsync(
                exceptionsAllowedBeforeBreaking,
                durationOfBreak,
-               doNothingOnBreak,
-               doNothingOnReset
+               null,
+               (Action) null
                );
         }
 
@@ -60,14 +57,12 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
         public static IAsyncCircuitBreakerPolicy CircuitBreakerAsync(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, TimeSpan> onBreak, Action onReset)
             => policyBuilder.CircuitBreakerAsync(
                 exceptionsAllowedBeforeBreaking,
                 durationOfBreak,
-                (exception, timespan, context) => onBreak(exception, timespan),
-                context => onReset()
+                onBreak: onBreak == null ? (Action<Exception, TimeSpan, Context>)null : (exception, timespan, context) => onBreak(exception, timespan),
+                onReset: onReset == null ? (Action<Context>)null : context => onReset()
                 );
 
         /// <summary>
@@ -90,17 +85,14 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
         public static IAsyncCircuitBreakerPolicy CircuitBreakerAsync(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset)
         {
-            Action doNothingOnHalfOpen = () => { };
             return policyBuilder.CircuitBreakerAsync(
                 exceptionsAllowedBeforeBreaking, 
                 durationOfBreak, 
                 onBreak, 
                 onReset,
-                doNothingOnHalfOpen
+                onHalfOpen: null
                 );
         }
 
@@ -125,14 +117,12 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
         public static IAsyncCircuitBreakerPolicy CircuitBreakerAsync(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, TimeSpan> onBreak, Action onReset, Action onHalfOpen)
             => policyBuilder.CircuitBreakerAsync(
                 exceptionsAllowedBeforeBreaking,
                 durationOfBreak,
-                (exception, timespan, context) => onBreak(exception, timespan),
-                context => onReset(),
+                onBreak: onBreak == null ? (Action<Exception, TimeSpan, Context>)null : (exception, timespan, context) => onBreak(exception, timespan),
+                onReset: onReset == null ? (Action<Context>)null : context => onReset(),
                 onHalfOpen
                 );
 
@@ -157,14 +147,11 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
-        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static IAsyncCircuitBreakerPolicy CircuitBreakerAsync(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
             => policyBuilder.CircuitBreakerAsync(
                 exceptionsAllowedBeforeBreaking,
                 durationOfBreak,
-                (exception, state, timespan, context) => onBreak(exception, timespan, context),
+                onBreak: onBreak == null ? (Action<Exception, CircuitState, TimeSpan, Context>)null : (exception, state, timespan, context) => onBreak(exception, timespan, context),
                 onReset,
                 onHalfOpen
             );
@@ -190,22 +177,15 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
-        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static IAsyncCircuitBreakerPolicy CircuitBreakerAsync(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
         {
             if (exceptionsAllowedBeforeBreaking <= 0) throw new ArgumentOutOfRangeException(nameof(exceptionsAllowedBeforeBreaking), "Value must be greater than zero.");
             if (durationOfBreak < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(durationOfBreak), "Value must be greater than zero.");
 
-            if (onBreak == null) throw new ArgumentNullException(nameof(onBreak));
-            if (onReset == null) throw new ArgumentNullException(nameof(onReset));
-            if (onHalfOpen == null) throw new ArgumentNullException(nameof(onHalfOpen));
-
             var breakerController = new ConsecutiveCountCircuitController<EmptyStruct>(
                 exceptionsAllowedBeforeBreaking,
                 durationOfBreak,
-                (outcome, state, timespan, context) => onBreak(outcome.Exception, state, timespan, context),
+                onBreak: onBreak == null ? (Action<DelegateResult<EmptyStruct>, CircuitState, TimeSpan, Context>)null : (outcome, state, timespan, context) => onBreak(outcome.Exception, state, timespan, context),
                 onReset,
                 onHalfOpen);
             return new AsyncCircuitBreakerPolicy(

--- a/src/Polly/CircuitBreaker/AsyncCircuitBreakerTResultSyntax.cs
+++ b/src/Polly/CircuitBreaker/AsyncCircuitBreakerTResultSyntax.cs
@@ -28,14 +28,11 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
         public static IAsyncCircuitBreakerPolicy<TResult> CircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak)
         {
-            Action<DelegateResult<TResult>, TimeSpan> doNothingOnBreak = (_, __) => { };
-            Action doNothingOnReset = () => { };
-
             return policyBuilder.CircuitBreakerAsync(
                handledEventsAllowedBeforeBreaking,
                durationOfBreak,
-               doNothingOnBreak,
-               doNothingOnReset
+               null,
+               (Action) null
                );
         }
 
@@ -59,14 +56,12 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
         public static IAsyncCircuitBreakerPolicy<TResult> CircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan> onBreak, Action onReset)
             => policyBuilder.CircuitBreakerAsync(
                 handledEventsAllowedBeforeBreaking,
                 durationOfBreak,
-                (outcome, timespan, context) => onBreak(outcome, timespan),
-                context => onReset()
+                onBreak: onBreak == null ? (Action<DelegateResult<TResult>, TimeSpan, Context>)null : (outcome, timespan, context) => onBreak(outcome, timespan),
+                onReset: onReset == null ? (Action<Context>)null : context => onReset()
                 );
 
         /// <summary>
@@ -89,17 +84,14 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
         public static IAsyncCircuitBreakerPolicy<TResult> CircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset)
         {
-            Action doNothingOnHalfOpen = () => { };
             return policyBuilder.CircuitBreakerAsync(
                 handledEventsAllowedBeforeBreaking, 
                 durationOfBreak, 
                 onBreak, 
                 onReset,
-                doNothingOnHalfOpen
+                onHalfOpen: null
                 );
         }
 
@@ -124,14 +116,12 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
         public static IAsyncCircuitBreakerPolicy<TResult> CircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan> onBreak, Action onReset, Action onHalfOpen)
             => policyBuilder.CircuitBreakerAsync(
                 handledEventsAllowedBeforeBreaking,
                 durationOfBreak,
-                (outcome, timespan, context) => onBreak(outcome, timespan),
-                context => onReset(),
+                onBreak: onBreak == null ? (Action<DelegateResult<TResult>, TimeSpan, Context>)null : (outcome, timespan, context) => onBreak(outcome, timespan),
+                onReset: onReset == null ? (Action<Context>)null : context => onReset(),
                 onHalfOpen
                 );
 
@@ -156,14 +146,11 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
-        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static IAsyncCircuitBreakerPolicy<TResult> CircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
             => policyBuilder.CircuitBreakerAsync(
                 handledEventsAllowedBeforeBreaking,
                 durationOfBreak,
-                (outcome, state, timespan, context) => onBreak(outcome, timespan, context),
+                onBreak: onBreak == null ? (Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context>)null : (outcome, state, timespan, context) => onBreak(outcome, timespan, context),
                 onReset,
                 onHalfOpen
             );
@@ -189,17 +176,10 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
-        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static IAsyncCircuitBreakerPolicy<TResult> CircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
         {
             if (handledEventsAllowedBeforeBreaking <= 0) throw new ArgumentOutOfRangeException(nameof(handledEventsAllowedBeforeBreaking), "Value must be greater than zero.");
             if (durationOfBreak < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(durationOfBreak), "Value must be greater than zero.");
-
-            if (onBreak == null) throw new ArgumentNullException(nameof(onBreak));
-            if (onReset == null) throw new ArgumentNullException(nameof(onReset));
-            if (onHalfOpen == null) throw new ArgumentNullException(nameof(onHalfOpen));
 
             var breakerController = new ConsecutiveCountCircuitController<TResult>(
                 handledEventsAllowedBeforeBreaking,

--- a/src/Polly/CircuitBreaker/CircuitBreakerSyntax.cs
+++ b/src/Polly/CircuitBreaker/CircuitBreakerSyntax.cs
@@ -27,18 +27,13 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
         public static ISyncCircuitBreakerPolicy CircuitBreaker(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak)
         {
-            Action<Exception, TimeSpan> doNothingOnBreak = (_, __) => { };
-            Action doNothingOnReset = () => { };
-
             return policyBuilder.CircuitBreaker
                 (exceptionsAllowedBeforeBreaking, 
                 durationOfBreak, 
-                doNothingOnBreak,
-                doNothingOnReset
+                null,
+                (Action) null
                 );
         }
 
@@ -62,14 +57,12 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
         public static ISyncCircuitBreakerPolicy CircuitBreaker(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, TimeSpan> onBreak, Action onReset)
             => policyBuilder.CircuitBreaker(
                 exceptionsAllowedBeforeBreaking, 
-                durationOfBreak, 
-                (exception, timespan, context) => onBreak(exception, timespan), 
-                context => onReset()
+                durationOfBreak,
+                onBreak: onBreak == null ? (Action<Exception, TimeSpan, Context>)null : (exception, timespan, context) => onBreak(exception, timespan),
+                onReset: onReset == null ? (Action<Context>)null : context => onReset()
                 );
 
         /// <summary>
@@ -92,16 +85,13 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
         public static ISyncCircuitBreakerPolicy CircuitBreaker(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset)
         {
-            Action doNothingOnHalfOpen = () => { };
             return policyBuilder.CircuitBreaker(exceptionsAllowedBeforeBreaking, 
                 durationOfBreak, 
                 onBreak, 
                 onReset,
-                doNothingOnHalfOpen
+                onHalfOpen: null
                 );
         }
 
@@ -126,14 +116,12 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
         public static ISyncCircuitBreakerPolicy CircuitBreaker(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, TimeSpan> onBreak, Action onReset, Action onHalfOpen)
             => policyBuilder.CircuitBreaker(
                 exceptionsAllowedBeforeBreaking,
                 durationOfBreak,
-                (exception, timespan, context) => onBreak(exception, timespan),
-                context => onReset(),
+                onBreak: onBreak == null ? (Action<Exception, TimeSpan, Context>)null : (exception, timespan, context) => onBreak(exception, timespan),
+                onReset: onReset == null ? (Action<Context>)null : context => onReset(),
                 onHalfOpen
                 );
 
@@ -158,14 +146,11 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
-        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static ISyncCircuitBreakerPolicy CircuitBreaker(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
             => policyBuilder.CircuitBreaker(
                 exceptionsAllowedBeforeBreaking,
                 durationOfBreak,
-                (exception, state, timespan, context) => onBreak(exception, timespan, context),
+                onBreak: onBreak == null ? (Action<Exception, CircuitState, TimeSpan, Context>)null : (exception, state, timespan, context) => onBreak(exception, timespan, context),
                 onReset,
                 onHalfOpen
             );
@@ -191,22 +176,15 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
-        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static ISyncCircuitBreakerPolicy CircuitBreaker(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
         {
             if (exceptionsAllowedBeforeBreaking <= 0) throw new ArgumentOutOfRangeException(nameof(exceptionsAllowedBeforeBreaking), "Value must be greater than zero.");
             if (durationOfBreak < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(durationOfBreak), "Value must be greater than zero.");
 
-            if (onBreak == null) throw new ArgumentNullException(nameof(onBreak));
-            if (onReset == null) throw new ArgumentNullException(nameof(onReset));
-            if (onHalfOpen == null) throw new ArgumentNullException(nameof(onHalfOpen));
-
             var breakerController = new ConsecutiveCountCircuitController<EmptyStruct>(
                 exceptionsAllowedBeforeBreaking,
                 durationOfBreak,
-                (outcome, state, timespan, context) => onBreak(outcome.Exception, state, timespan, context),
+                onBreak: onBreak == null ? (Action<DelegateResult<EmptyStruct>, CircuitState, TimeSpan, Context>)null : (outcome, state, timespan, context) => onBreak(outcome.Exception, state, timespan, context),
                 onReset,
                 onHalfOpen);
             return new CircuitBreakerPolicy(

--- a/src/Polly/CircuitBreaker/CircuitBreakerTResultSyntax.cs
+++ b/src/Polly/CircuitBreaker/CircuitBreakerTResultSyntax.cs
@@ -26,18 +26,13 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
         public static ISyncCircuitBreakerPolicy<TResult> CircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak)
         {
-            Action<DelegateResult<TResult>, TimeSpan> doNothingOnBreak = (_, __) => { };
-            Action doNothingOnReset = () => { };
-
             return policyBuilder.CircuitBreaker
                 (handledEventsAllowedBeforeBreaking,
                 durationOfBreak,
-                doNothingOnBreak,
-                doNothingOnReset
+                null,
+                (Action) null
                 );
         }
 
@@ -61,14 +56,12 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
         public static ISyncCircuitBreakerPolicy<TResult> CircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan> onBreak, Action onReset)
             => policyBuilder.CircuitBreaker(
                 handledEventsAllowedBeforeBreaking,
                 durationOfBreak,
-                (outcome, timespan, context) => onBreak(outcome, timespan),
-                context => onReset()
+                onBreak: onBreak == null ? (Action<DelegateResult<TResult>, TimeSpan, Context>)null : (outcome, timespan, context) => onBreak(outcome, timespan),
+                onReset: onReset == null ? (Action<Context>)null : context => onReset()
                 );
 
         /// <summary>
@@ -91,16 +84,13 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
         public static ISyncCircuitBreakerPolicy<TResult> CircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset)
         {
-            Action doNothingOnHalfOpen = () => { };
             return policyBuilder.CircuitBreaker(handledEventsAllowedBeforeBreaking,
                 durationOfBreak,
                 onBreak,
                 onReset,
-                doNothingOnHalfOpen
+                onHalfOpen: null
                 );
         }
 
@@ -125,14 +115,12 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
         public static ISyncCircuitBreakerPolicy<TResult> CircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan> onBreak, Action onReset, Action onHalfOpen)
             => policyBuilder.CircuitBreaker(
                 handledEventsAllowedBeforeBreaking,
                 durationOfBreak,
-                (outcome, timespan, context) => onBreak(outcome, timespan),
-                context => onReset(),
+                onBreak: onBreak == null ? (Action<DelegateResult<TResult>, TimeSpan, Context>)null : (outcome, timespan, context) => onBreak(outcome, timespan),
+                onReset: onReset == null ? (Action<Context>)null : context => onReset(),
                 onHalfOpen
                 );
 
@@ -157,14 +145,11 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
-        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static ISyncCircuitBreakerPolicy<TResult> CircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
             => policyBuilder.CircuitBreaker(
                 handledEventsAllowedBeforeBreaking,
                 durationOfBreak,
-                (outcome, state, timespan, context) => onBreak(outcome, timespan, context),
+                onBreak: onBreak == null ? (Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context>)null : (outcome, state, timespan, context) => onBreak(outcome, timespan, context),
                 onReset,
                 onHalfOpen
             );
@@ -190,17 +175,10 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onBreak</exception>
-        /// <exception cref="ArgumentNullException">onReset</exception>
-        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static ISyncCircuitBreakerPolicy<TResult> CircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
         {
             if (handledEventsAllowedBeforeBreaking <= 0) throw new ArgumentOutOfRangeException(nameof(handledEventsAllowedBeforeBreaking), "Value must be greater than zero.");
             if (durationOfBreak < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(durationOfBreak), "Value must be greater than zero.");
-
-            if (onBreak == null) throw new ArgumentNullException(nameof(onBreak));
-            if (onReset == null) throw new ArgumentNullException(nameof(onReset));
-            if (onHalfOpen == null) throw new ArgumentNullException(nameof(onHalfOpen));
 
             ICircuitController<TResult> breakerController = new ConsecutiveCountCircuitController<TResult>(
                 handledEventsAllowedBeforeBreaking,

--- a/src/Polly/CircuitBreaker/CircuitStateController.cs
+++ b/src/Polly/CircuitBreaker/CircuitStateController.cs
@@ -46,7 +46,7 @@ namespace Polly.CircuitBreaker
                     if (_circuitState == CircuitState.Open && !IsInAutomatedBreak_NeedsLock)
                     {
                         _circuitState = CircuitState.HalfOpen;
-                        _onHalfOpen();
+                        _onHalfOpen?.Invoke();
                     }
                     return _circuitState;
                 }
@@ -106,7 +106,7 @@ namespace Polly.CircuitBreaker
             var transitionedState = _circuitState;
             _circuitState = CircuitState.Open;
 
-            _onBreak(_lastOutcome, transitionedState, durationOfBreak, context);
+            _onBreak?.Invoke(_lastOutcome, transitionedState, durationOfBreak, context);
         }
 
         public void Reset() => OnCircuitReset(Context.None());
@@ -120,7 +120,7 @@ namespace Polly.CircuitBreaker
             _circuitState = CircuitState.Closed;
             if (priorState != CircuitState.Closed)
             {
-                _onReset(context);
+                _onReset?.Invoke(context);
             }
         }
 

--- a/src/Polly/CircuitBreaker/IsolatedCircuitException.cs
+++ b/src/Polly/CircuitBreaker/IsolatedCircuitException.cs
@@ -1,6 +1,5 @@
-﻿using System;
-
-#if NETSTANDARD2_0
+﻿#if NETSTANDARD2_0
+using System;
 using System.Runtime.Serialization;
 #endif
 

--- a/src/Polly/Fallback/AsyncFallbackEngine.cs
+++ b/src/Polly/Fallback/AsyncFallbackEngine.cs
@@ -42,7 +42,7 @@ namespace Polly.Fallback
                 delegateOutcome = new DelegateResult<TResult>(handledException);
             }
 
-            await onFallbackAsync(delegateOutcome, context).ConfigureAwait(continueOnCapturedContext);
+            if (onFallbackAsync != null) { await onFallbackAsync(delegateOutcome, context).ConfigureAwait(continueOnCapturedContext); }
 
             return await fallbackAction(delegateOutcome, context, cancellationToken).ConfigureAwait(continueOnCapturedContext);
         }

--- a/src/Polly/Fallback/AsyncFallbackPolicy.cs
+++ b/src/Polly/Fallback/AsyncFallbackPolicy.cs
@@ -18,7 +18,7 @@ namespace Polly.Fallback
             Func<Exception, Context, CancellationToken, Task> fallbackAction)
            : base(policyBuilder)
         {
-            _onFallbackAsync = onFallbackAsync ?? throw new ArgumentNullException(nameof(onFallbackAsync));
+            _onFallbackAsync = onFallbackAsync;
             _fallbackAction = fallbackAction ?? throw new ArgumentNullException(nameof(fallbackAction));
         }
 
@@ -35,7 +35,7 @@ namespace Polly.Fallback
                 cancellationToken,
                 ExceptionPredicates,
                 ResultPredicates<EmptyStruct>.None,
-                (outcome, ctx) => _onFallbackAsync(outcome.Exception, ctx),
+                _onFallbackAsync == null ? (Func<DelegateResult<EmptyStruct>, Context, Task>)null : (outcome, ctx) => _onFallbackAsync(outcome.Exception, ctx),
                 async (outcome, ctx, ct) =>
                 {
                     await _fallbackAction(outcome.Exception, ctx, ct).ConfigureAwait(continueOnCapturedContext);
@@ -66,7 +66,7 @@ namespace Polly.Fallback
             Func<DelegateResult<TResult>, Context, CancellationToken, Task<TResult>> fallbackAction
             ) : base(policyBuilder)
         {
-            _onFallbackAsync = onFallbackAsync ?? throw new ArgumentNullException(nameof(onFallbackAsync));
+            _onFallbackAsync = onFallbackAsync;
             _fallbackAction = fallbackAction ?? throw new ArgumentNullException(nameof(fallbackAction));
         }
 

--- a/src/Polly/Fallback/AsyncFallbackSyntax.cs
+++ b/src/Polly/Fallback/AsyncFallbackSyntax.cs
@@ -2,7 +2,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Polly.Fallback;
-using Polly.Utilities;
 
 namespace Polly
 {

--- a/src/Polly/Fallback/AsyncFallbackSyntax.cs
+++ b/src/Polly/Fallback/AsyncFallbackSyntax.cs
@@ -22,10 +22,9 @@ namespace Polly
         {
             if (fallbackAction == null) throw new ArgumentNullException(nameof(fallbackAction));
             
-            Func<Exception, Task> doNothing = _ => TaskHelper.EmptyTask;
             return policyBuilder.FallbackAsync(
                 fallbackAction,
-                doNothing
+                onFallbackAsync: null
                 );
         }
 
@@ -36,16 +35,14 @@ namespace Polly
         /// <param name="fallbackAction">The fallback delegate.</param>
         /// <param name="onFallbackAsync">The action to call asynchronously before invoking the fallback delegate.</param>
         /// <exception cref="ArgumentNullException">fallbackAction</exception>
-        /// <exception cref="ArgumentNullException">onFallbackAsync</exception>
         /// <returns>The policy instance.</returns>
         public static IAsyncFallbackPolicy FallbackAsync(this PolicyBuilder policyBuilder, Func<CancellationToken, Task> fallbackAction, Func<Exception, Task> onFallbackAsync)
         {
             if (fallbackAction == null) throw new ArgumentNullException(nameof(fallbackAction));
-            if (onFallbackAsync == null) throw new ArgumentNullException(nameof(onFallbackAsync));
-
+            
             return policyBuilder.FallbackAsync(
                 (outcome, ctx, ct) => fallbackAction(ct),
-                (outcome, context) => onFallbackAsync(outcome)
+                onFallbackAsync == null ? (Func<Exception, Context, Task>)null : (outcome, context) => onFallbackAsync(outcome)
                 );
         }
         
@@ -56,12 +53,10 @@ namespace Polly
         /// <param name="fallbackAction">The fallback delegate.</param>
         /// <param name="onFallbackAsync">The action to call asynchronously before invoking the fallback delegate.</param>
         /// <exception cref="ArgumentNullException">fallbackAction</exception>
-        /// <exception cref="ArgumentNullException">onFallbackAsync</exception>
         /// <returns>The policy instance.</returns>
         public static IAsyncFallbackPolicy FallbackAsync(this PolicyBuilder policyBuilder, Func<Context, CancellationToken, Task> fallbackAction, Func<Exception, Context, Task> onFallbackAsync)
         {
             if (fallbackAction == null) throw new ArgumentNullException(nameof(fallbackAction));
-            if (onFallbackAsync == null) throw new ArgumentNullException(nameof(onFallbackAsync));
 
             return policyBuilder.FallbackAsync((outcome, ctx, ct) => fallbackAction(ctx, ct), onFallbackAsync);
         }
@@ -73,12 +68,10 @@ namespace Polly
         /// <param name="fallbackAction">The fallback delegate.</param>
         /// <param name="onFallbackAsync">The action to call asynchronously before invoking the fallback delegate.</param>
         /// <exception cref="ArgumentNullException">fallbackAction</exception>
-        /// <exception cref="ArgumentNullException">onFallbackAsync</exception>
         /// <returns>The policy instance.</returns>
         public static IAsyncFallbackPolicy FallbackAsync(this PolicyBuilder policyBuilder, Func<Exception, Context, CancellationToken, Task> fallbackAction, Func<Exception, Context, Task> onFallbackAsync)
         {
             if (fallbackAction == null) throw new ArgumentNullException(nameof(fallbackAction));
-            if (onFallbackAsync == null) throw new ArgumentNullException(nameof(onFallbackAsync));
 
             return new AsyncFallbackPolicy(policyBuilder, onFallbackAsync, fallbackAction);
         }
@@ -97,10 +90,9 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static IAsyncFallbackPolicy<TResult> FallbackAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, TResult fallbackValue)
         {
-            Func<DelegateResult<TResult>, Task> doNothing = _ => TaskHelper.EmptyTask;
             return policyBuilder.FallbackAsync(
                 ct => Task.FromResult(fallbackValue),
-                doNothing
+                onFallbackAsync: null
                 );
         }
 
@@ -115,10 +107,9 @@ namespace Polly
         {
             if (fallbackAction == null) throw new ArgumentNullException(nameof(fallbackAction));
 
-            Func<DelegateResult<TResult>, Task> doNothing = _ => TaskHelper.EmptyTask;
             return policyBuilder.FallbackAsync(
                 fallbackAction,
-                doNothing
+                onFallbackAsync: null
                 );
         }
 
@@ -128,15 +119,12 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="fallbackValue">The fallback <typeparamref name="TResult"/> value to provide.</param>
         /// <param name="onFallbackAsync">The action to call asynchronously before invoking the fallback delegate.</param>
-        /// <exception cref="ArgumentNullException">onFallbackAsync</exception>
         /// <returns>The policy instance.</returns>
         public static IAsyncFallbackPolicy<TResult> FallbackAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, TResult fallbackValue, Func<DelegateResult<TResult>, Task> onFallbackAsync)
         {
-            if (onFallbackAsync == null) throw new ArgumentNullException(nameof(onFallbackAsync));
-
             return policyBuilder.FallbackAsync(
                 (outcome, ctx, ct) => Task.FromResult(fallbackValue),
-                (outcome, context) => onFallbackAsync(outcome)
+                onFallbackAsync == null ? (Func<DelegateResult<TResult>, Context, Task>)null : (outcome, context) => onFallbackAsync(outcome)
                 );
         }
 
@@ -147,16 +135,14 @@ namespace Polly
         /// <param name="fallbackAction">The fallback delegate.</param>
         /// <param name="onFallbackAsync">The action to call asynchronously before invoking the fallback delegate.</param>
         /// <exception cref="ArgumentNullException">fallbackAction</exception>
-        /// <exception cref="ArgumentNullException">onFallbackAsync</exception>
         /// <returns>The policy instance.</returns>
         public static IAsyncFallbackPolicy<TResult> FallbackAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<CancellationToken, Task<TResult>> fallbackAction, Func<DelegateResult<TResult>, Task> onFallbackAsync)
         {
             if (fallbackAction == null) throw new ArgumentNullException(nameof(fallbackAction));
-            if (onFallbackAsync == null) throw new ArgumentNullException(nameof(onFallbackAsync));
 
             return policyBuilder.FallbackAsync(
                 (outcome, ctx, ct) => fallbackAction(ct),
-                (outcome, context) => onFallbackAsync(outcome)
+                onFallbackAsync == null ? (Func<DelegateResult<TResult>, Context, Task>)null : (outcome, context) => onFallbackAsync(outcome)
                 );
         }
 
@@ -166,12 +152,9 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="fallbackValue">The fallback <typeparamref name="TResult"/> value to provide.</param>
         /// <param name="onFallbackAsync">The action to call asynchronously before invoking the fallback delegate.</param>
-        /// <exception cref="ArgumentNullException">onFallbackAsync</exception>
         /// <returns>The policy instance.</returns>
         public static IAsyncFallbackPolicy<TResult> FallbackAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, TResult fallbackValue, Func<DelegateResult<TResult>, Context, Task> onFallbackAsync)
         {
-            if (onFallbackAsync == null) throw new ArgumentNullException(nameof(onFallbackAsync));
-
             return policyBuilder.FallbackAsync(
                 (outcome, ctx, ct) => Task.FromResult(fallbackValue),
                 onFallbackAsync
@@ -185,12 +168,10 @@ namespace Polly
         /// <param name="fallbackAction">The fallback delegate.</param>
         /// <param name="onFallbackAsync">The action to call asynchronously before invoking the fallback delegate.</param>
         /// <exception cref="ArgumentNullException">fallbackAction</exception>
-        /// <exception cref="ArgumentNullException">onFallbackAsync</exception>
         /// <returns>The policy instance.</returns>
         public static IAsyncFallbackPolicy<TResult> FallbackAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<Context, CancellationToken, Task<TResult>> fallbackAction, Func<DelegateResult<TResult>, Context, Task> onFallbackAsync)
         {
             if (fallbackAction == null) throw new ArgumentNullException(nameof(fallbackAction));
-            if (onFallbackAsync == null) throw new ArgumentNullException(nameof(onFallbackAsync));
 
             return policyBuilder.FallbackAsync((outcome, ctx, ct) => fallbackAction(ctx, ct), onFallbackAsync);
         }
@@ -202,12 +183,10 @@ namespace Polly
         /// <param name="fallbackAction">The fallback delegate.</param>
         /// <param name="onFallbackAsync">The action to call asynchronously before invoking the fallback delegate.</param>
         /// <exception cref="ArgumentNullException">fallbackAction</exception>
-        /// <exception cref="ArgumentNullException">onFallbackAsync</exception>
         /// <returns>The policy instance.</returns>
         public static IAsyncFallbackPolicy<TResult> FallbackAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<DelegateResult<TResult>, Context, CancellationToken, Task<TResult>> fallbackAction, Func<DelegateResult<TResult>, Context, Task> onFallbackAsync)
         {
             if (fallbackAction == null) throw new ArgumentNullException(nameof(fallbackAction));
-            if (onFallbackAsync == null) throw new ArgumentNullException(nameof(onFallbackAsync));
 
             return new AsyncFallbackPolicy<TResult>(
                     policyBuilder,

--- a/src/Polly/Fallback/FallbackEngine.cs
+++ b/src/Polly/Fallback/FallbackEngine.cs
@@ -40,7 +40,7 @@ namespace Polly.Fallback
                 delegateOutcome = new DelegateResult<TResult>(handledException);
             }
 
-            onFallback(delegateOutcome, context);
+            onFallback?.Invoke(delegateOutcome, context);
 
             return fallbackAction(delegateOutcome, context, cancellationToken);
         }

--- a/src/Polly/Fallback/FallbackPolicy.cs
+++ b/src/Polly/Fallback/FallbackPolicy.cs
@@ -19,7 +19,7 @@ namespace Polly.Fallback
             Action<Exception, Context, CancellationToken> fallbackAction)
             : base(policyBuilder)
         {
-            _onFallback = onFallback ?? throw new ArgumentNullException(nameof(onFallback));
+            _onFallback = onFallback;
             _fallbackAction = fallbackAction ?? throw new ArgumentNullException(nameof(fallbackAction));
         }
 
@@ -32,7 +32,7 @@ namespace Polly.Fallback
                 cancellationToken, 
                 ExceptionPredicates,
                 ResultPredicates<EmptyStruct>.None,
-                (outcome, ctx) => _onFallback(outcome.Exception, ctx),
+                _onFallback == null ? (Action<DelegateResult<EmptyStruct>, Context>)null : (outcome, ctx) => _onFallback(outcome.Exception, ctx),
                 (outcome, ctx, ct) => { _fallbackAction(outcome.Exception, ctx, ct); return EmptyStruct.Instance; });
 
         /// <inheritdoc/>
@@ -55,7 +55,7 @@ namespace Polly.Fallback
             Func<DelegateResult<TResult>, Context, CancellationToken, TResult> fallbackAction
             ) : base(policyBuilder)
         {
-            _onFallback = onFallback ?? throw new ArgumentNullException(nameof(onFallback));
+            _onFallback = onFallback;
             _fallbackAction = fallbackAction ?? throw new ArgumentNullException(nameof(fallbackAction));
         }
 

--- a/src/Polly/Fallback/FallbackSyntax.cs
+++ b/src/Polly/Fallback/FallbackSyntax.cs
@@ -20,8 +20,7 @@ namespace Polly
         {
             if (fallbackAction == null) throw new ArgumentNullException(nameof(fallbackAction));
 
-            Action<Exception> doNothing = _ => { };
-            return policyBuilder.Fallback(fallbackAction, doNothing);
+            return policyBuilder.Fallback(fallbackAction, onFallback: null);
         }
 
         /// <summary>
@@ -35,8 +34,7 @@ namespace Polly
         {
             if (fallbackAction == null) throw new ArgumentNullException(nameof(fallbackAction));
 
-            Action<Exception> doNothing = _ => { };
-            return policyBuilder.Fallback(fallbackAction, doNothing);
+            return policyBuilder.Fallback(fallbackAction, onFallback: null);
         }
 
         /// <summary>
@@ -46,14 +44,12 @@ namespace Polly
         /// <param name="fallbackAction">The fallback action.</param>
         /// <param name="onFallback">The action to call before invoking the fallback delegate.</param>
         /// <exception cref="ArgumentNullException">fallbackAction</exception>
-        /// <exception cref="ArgumentNullException">onFallback</exception>
         /// <returns>The policy instance.</returns>
         public static ISyncFallbackPolicy Fallback(this PolicyBuilder policyBuilder, Action fallbackAction, Action<Exception> onFallback)
         {
             if (fallbackAction == null) throw new ArgumentNullException(nameof(fallbackAction));
-            if (onFallback == null) throw new ArgumentNullException(nameof(onFallback));
 
-            return policyBuilder.Fallback((outcome, ctx, ct) => fallbackAction(), (exception, ctx) => onFallback(exception));
+            return policyBuilder.Fallback((outcome, ctx, ct) => fallbackAction(), onFallback == null ? (Action<Exception, Context>)null : (exception, ctx) => onFallback(exception));
         }
 
 
@@ -64,14 +60,12 @@ namespace Polly
         /// <param name="fallbackAction">The fallback action.</param>
         /// <param name="onFallback">The action to call before invoking the fallback delegate.</param>
         /// <exception cref="ArgumentNullException">fallbackAction</exception>
-        /// <exception cref="ArgumentNullException">onFallback</exception>
         /// <returns>The policy instance.</returns>
         public static ISyncFallbackPolicy Fallback(this PolicyBuilder policyBuilder, Action<CancellationToken> fallbackAction, Action<Exception> onFallback)
         {
             if (fallbackAction == null) throw new ArgumentNullException(nameof(fallbackAction));
-            if (onFallback == null) throw new ArgumentNullException(nameof(onFallback));
 
-            return policyBuilder.Fallback((outcome, ctx, ct) => fallbackAction(ct), (exception, ctx) => onFallback(exception));
+            return policyBuilder.Fallback((outcome, ctx, ct) => fallbackAction(ct), onFallback == null ? (Action<Exception, Context>)null : (exception, ctx) => onFallback(exception));
         }
 
         /// <summary>
@@ -81,12 +75,10 @@ namespace Polly
         /// <param name="fallbackAction">The fallback action.</param>
         /// <param name="onFallback">The action to call before invoking the fallback delegate.</param>
         /// <exception cref="ArgumentNullException">fallbackAction</exception>
-        /// <exception cref="ArgumentNullException">onFallback</exception>
         /// <returns>The policy instance.</returns>
         public static ISyncFallbackPolicy Fallback(this PolicyBuilder policyBuilder, Action<Context> fallbackAction, Action<Exception, Context> onFallback)
         {
             if (fallbackAction == null) throw new ArgumentNullException(nameof(fallbackAction));
-            if (onFallback == null) throw new ArgumentNullException(nameof(onFallback));
 
             return policyBuilder.Fallback((outcome, ctx, ct) => fallbackAction(ctx), onFallback);
         }
@@ -98,12 +90,10 @@ namespace Polly
         /// <param name="fallbackAction">The fallback action.</param>
         /// <param name="onFallback">The action to call before invoking the fallback delegate.</param>
         /// <exception cref="ArgumentNullException">fallbackAction</exception>
-        /// <exception cref="ArgumentNullException">onFallback</exception>
         /// <returns>The policy instance.</returns>
         public static ISyncFallbackPolicy Fallback(this PolicyBuilder policyBuilder, Action<Context, CancellationToken> fallbackAction, Action<Exception, Context> onFallback)
         {
             if (fallbackAction == null) throw new ArgumentNullException(nameof(fallbackAction));
-            if (onFallback == null) throw new ArgumentNullException(nameof(onFallback));
 
             return policyBuilder.Fallback((outcome, ctx, ct) => fallbackAction(ctx, ct), onFallback);
         }
@@ -115,12 +105,10 @@ namespace Polly
         /// <param name="fallbackAction">The fallback action.</param>
         /// <param name="onFallback">The action to call before invoking the fallback delegate.</param>
         /// <exception cref="ArgumentNullException">fallbackAction</exception>
-        /// <exception cref="ArgumentNullException">onFallback</exception>
         /// <returns>The policy instance.</returns>
         public static ISyncFallbackPolicy Fallback(this PolicyBuilder policyBuilder, Action<Exception, Context, CancellationToken> fallbackAction, Action<Exception, Context> onFallback)
         {
             if (fallbackAction == null) throw new ArgumentNullException(nameof(fallbackAction));
-            if (onFallback == null) throw new ArgumentNullException(nameof(onFallback));
 
             return new FallbackPolicy(
                     policyBuilder,
@@ -142,8 +130,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static ISyncFallbackPolicy<TResult> Fallback<TResult>(this PolicyBuilder<TResult> policyBuilder, TResult fallbackValue)
         {
-            Action<DelegateResult<TResult>> doNothing = _ => { };
-            return policyBuilder.Fallback(() => fallbackValue, doNothing);
+            return policyBuilder.Fallback(() => fallbackValue, onFallback: null);
         }
 
         /// <summary>
@@ -157,8 +144,7 @@ namespace Polly
         {
             if (fallbackAction == null) throw new ArgumentNullException(nameof(fallbackAction));
 
-            Action<DelegateResult<TResult>> doNothing = _ => { };
-            return policyBuilder.Fallback(fallbackAction, doNothing);
+            return policyBuilder.Fallback(fallbackAction, onFallback: null);
         }
 
         /// <summary>
@@ -172,8 +158,7 @@ namespace Polly
         {
             if (fallbackAction == null) throw new ArgumentNullException(nameof(fallbackAction));
 
-            Action<DelegateResult<TResult>> doNothing = _ => { };
-            return policyBuilder.Fallback(fallbackAction, doNothing);
+            return policyBuilder.Fallback(fallbackAction, onFallback: null);
         }
 
         /// <summary>
@@ -182,13 +167,10 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="fallbackValue">The fallback <typeparamref name="TResult"/> value to provide.</param>
         /// <param name="onFallback">The action to call before invoking the fallback delegate.</param>
-        /// <exception cref="ArgumentNullException">onFallback</exception>
         /// <returns>The policy instance.</returns>
         public static ISyncFallbackPolicy<TResult> Fallback<TResult>(this PolicyBuilder<TResult> policyBuilder, TResult fallbackValue, Action<DelegateResult<TResult>> onFallback)
         {
-            if (onFallback == null) throw new ArgumentNullException(nameof(onFallback));
-
-            return policyBuilder.Fallback((outcome, ctx, ct) => fallbackValue, (outcome, ctx) => onFallback(outcome));
+            return policyBuilder.Fallback((outcome, ctx, ct) => fallbackValue, onFallback == null ? (Action<DelegateResult<TResult>, Context>)null : (outcome, ctx) => onFallback(outcome));
         }
 
         /// <summary>
@@ -198,14 +180,12 @@ namespace Polly
         /// <param name="fallbackAction">The fallback action.</param>
         /// <param name="onFallback">The action to call before invoking the fallback delegate.</param>
         /// <exception cref="ArgumentNullException">fallbackAction</exception>
-        /// <exception cref="ArgumentNullException">onFallback</exception>
         /// <returns>The policy instance.</returns>
         public static ISyncFallbackPolicy<TResult> Fallback<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<TResult> fallbackAction, Action<DelegateResult<TResult>> onFallback)
         {
             if (fallbackAction == null) throw new ArgumentNullException(nameof(fallbackAction));
-            if (onFallback == null) throw new ArgumentNullException(nameof(onFallback));
 
-            return policyBuilder.Fallback((outcome, ctx, ct) => fallbackAction(), (outcome, ctx) => onFallback(outcome));
+            return policyBuilder.Fallback((outcome, ctx, ct) => fallbackAction(), onFallback == null ? (Action<DelegateResult<TResult>, Context>)null : (outcome, ctx) => onFallback(outcome));
         }
 
         /// <summary>
@@ -215,14 +195,12 @@ namespace Polly
         /// <param name="fallbackAction">The fallback action.</param>
         /// <param name="onFallback">The action to call before invoking the fallback delegate.</param>
         /// <exception cref="ArgumentNullException">fallbackAction</exception>
-        /// <exception cref="ArgumentNullException">onFallback</exception>
         /// <returns>The policy instance.</returns>
         public static ISyncFallbackPolicy<TResult> Fallback<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<CancellationToken, TResult> fallbackAction, Action<DelegateResult<TResult>> onFallback)
         {
             if (fallbackAction == null) throw new ArgumentNullException(nameof(fallbackAction));
-            if (onFallback == null) throw new ArgumentNullException(nameof(onFallback));
 
-            return policyBuilder.Fallback((outcome, ctx, ct) => fallbackAction(ct), (outcome, ctx) => onFallback(outcome));
+            return policyBuilder.Fallback((outcome, ctx, ct) => fallbackAction(ct), onFallback == null ? (Action<DelegateResult<TResult>, Context>)null : (outcome, ctx) => onFallback(outcome));
         }
 
         /// <summary>
@@ -231,12 +209,10 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="fallbackValue">The fallback <typeparamref name="TResult"/> value to provide.</param>
         /// <param name="onFallback">The action to call before invoking the fallback delegate.</param>
-        /// <exception cref="ArgumentNullException">onFallback</exception>
+        
         /// <returns>The policy instance.</returns>
         public static ISyncFallbackPolicy<TResult> Fallback<TResult>(this PolicyBuilder<TResult> policyBuilder, TResult fallbackValue, Action<DelegateResult<TResult>, Context> onFallback)
         {
-            if (onFallback == null) throw new ArgumentNullException(nameof(onFallback));
-
             return policyBuilder.Fallback((outcome, ctx, ct) => fallbackValue, onFallback);
         }
 
@@ -247,12 +223,10 @@ namespace Polly
         /// <param name="fallbackAction">The fallback action.</param>
         /// <param name="onFallback">The action to call before invoking the fallback delegate.</param>
         /// <exception cref="ArgumentNullException">fallbackAction</exception>
-        /// <exception cref="ArgumentNullException">onFallback</exception>
         /// <returns>The policy instance.</returns>
         public static ISyncFallbackPolicy<TResult> Fallback<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<Context, TResult> fallbackAction, Action<DelegateResult<TResult>, Context> onFallback)
         {
             if (fallbackAction == null) throw new ArgumentNullException(nameof(fallbackAction));
-            if (onFallback == null) throw new ArgumentNullException(nameof(onFallback));
 
             return policyBuilder.Fallback((outcome, ctx, ct) => fallbackAction(ctx), onFallback);
         }
@@ -264,12 +238,10 @@ namespace Polly
         /// <param name="fallbackAction">The fallback action.</param>
         /// <param name="onFallback">The action to call before invoking the fallback delegate.</param>
         /// <exception cref="ArgumentNullException">fallbackAction</exception>
-        /// <exception cref="ArgumentNullException">onFallback</exception>
         /// <returns>The policy instance.</returns>
         public static ISyncFallbackPolicy<TResult> Fallback<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<Context, CancellationToken, TResult> fallbackAction, Action<DelegateResult<TResult>, Context> onFallback)
         {
             if (fallbackAction == null) throw new ArgumentNullException(nameof(fallbackAction));
-            if (onFallback == null) throw new ArgumentNullException(nameof(onFallback));
 
             return policyBuilder.Fallback((outcome, ctx, ct) => fallbackAction(ctx, ct), onFallback);
         }
@@ -281,12 +253,10 @@ namespace Polly
         /// <param name="fallbackAction">The fallback action.</param>
         /// <param name="onFallback">The action to call before invoking the fallback delegate.</param>
         /// <exception cref="ArgumentNullException">fallbackAction</exception>
-        /// <exception cref="ArgumentNullException">onFallback</exception>
         /// <returns>The policy instance.</returns>
         public static ISyncFallbackPolicy<TResult> Fallback<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<DelegateResult<TResult>, Context, CancellationToken, TResult> fallbackAction, Action<DelegateResult<TResult>, Context> onFallback)
         {
             if (fallbackAction == null) throw new ArgumentNullException(nameof(fallbackAction));
-            if (onFallback == null) throw new ArgumentNullException(nameof(onFallback));
 
             return new FallbackPolicy<TResult>(
                 policyBuilder,

--- a/src/Polly/Retry/AsyncRetryEngine.cs
+++ b/src/Polly/Retry/AsyncRetryEngine.cs
@@ -73,7 +73,7 @@ namespace Polly.Retry
 
                     TimeSpan waitDuration = sleepDurationsEnumerator?.Current ?? (sleepDurationProvider?.Invoke(tryCount, outcome, context) ?? TimeSpan.Zero);
 
-                    await onRetryAsync(outcome, waitDuration, tryCount, context).ConfigureAwait(continueOnCapturedContext);
+                    if (onRetryAsync != null) { await onRetryAsync(outcome, waitDuration, tryCount, context).ConfigureAwait(continueOnCapturedContext); }
 
                     if (waitDuration > TimeSpan.Zero)
                     {

--- a/src/Polly/Retry/AsyncRetryPolicy.cs
+++ b/src/Polly/Retry/AsyncRetryPolicy.cs
@@ -28,7 +28,7 @@ namespace Polly.Retry
             _permittedRetryCount = permittedRetryCount;
             _sleepDurationsEnumerable = sleepDurationsEnumerable;
             _sleepDurationProvider = sleepDurationProvider;
-            _onRetryAsync = onRetryAsync ?? throw new ArgumentNullException(nameof(onRetryAsync));
+            _onRetryAsync = onRetryAsync;
         }
 
         /// <inheritdoc/>
@@ -42,7 +42,7 @@ namespace Polly.Retry
                 cancellationToken,
                 ExceptionPredicates,
                 ResultPredicates<TResult>.None,
-                (outcome, timespan, retryCount, ctx) => _onRetryAsync(outcome.Exception, timespan, retryCount, ctx),
+                _onRetryAsync == null ? (Func<DelegateResult<TResult>, TimeSpan, int, Context, Task>)null : (outcome, timespan, retryCount, ctx) => _onRetryAsync(outcome.Exception, timespan, retryCount, ctx),
                 _permittedRetryCount,
                 _sleepDurationsEnumerable,
                 _sleepDurationProvider != null 
@@ -76,7 +76,7 @@ namespace Polly.Retry
             _permittedRetryCount = permittedRetryCount;
             _sleepDurationsEnumerable = sleepDurationsEnumerable;
             _sleepDurationProvider = sleepDurationProvider;
-            _onRetryAsync = onRetryAsync ?? throw new ArgumentNullException(nameof(onRetryAsync));
+            _onRetryAsync = onRetryAsync;
         }
 
         /// <inheritdoc/>

--- a/src/Polly/Retry/AsyncRetrySyntax.cs
+++ b/src/Polly/Retry/AsyncRetrySyntax.cs
@@ -27,9 +27,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static IAsyncRetryPolicy RetryAsync(this PolicyBuilder policyBuilder, int retryCount)
         {
-            Action<Exception, int, Context> doNothing = (_, __, ___) => { };
-
-            return policyBuilder.RetryAsync(retryCount, onRetry: doNothing);
+            return policyBuilder.RetryAsync(retryCount, onRetry: (Action<Exception, int, Context>) null);
         }
 
         /// <summary>
@@ -39,11 +37,10 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static IAsyncRetryPolicy RetryAsync(this PolicyBuilder policyBuilder, Action<Exception, int> onRetry)
             => policyBuilder.RetryAsync(1,
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, i, ctx) => onRetry(outcome, i)
+                onRetryAsync: onRetry == null ? (Func<Exception, int, Context, Task>)null : async (outcome, i, ctx) => onRetry(outcome, i)
 #pragma warning restore 1998
             );
 
@@ -54,9 +51,8 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static IAsyncRetryPolicy RetryAsync(this PolicyBuilder policyBuilder, Func<Exception, int, Task> onRetryAsync)
-            => policyBuilder.RetryAsync(1, onRetryAsync: (outcome, i, ctx) => onRetryAsync(outcome, i));
+            => policyBuilder.RetryAsync(1, onRetryAsync: onRetryAsync == null ? (Func<Exception, int, Context, Task>)null : (outcome, i, ctx) => onRetryAsync(outcome, i));
 
         /// <summary>
         ///     Builds an <see cref="AsyncRetryPolicy" /> that will retry <paramref name="retryCount" /> times
@@ -67,14 +63,11 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static IAsyncRetryPolicy RetryAsync(this PolicyBuilder policyBuilder, int retryCount, Action<Exception, int> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.RetryAsync(retryCount,
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, i, ctx) => onRetry(outcome, i)
+                onRetryAsync: onRetry == null ? (Func<Exception, int, Context, Task>)null : async(outcome, i, ctx) => onRetry(outcome, i)
 #pragma warning restore 1998
             );
         }
@@ -88,12 +81,9 @@ namespace Polly
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">onRetryAsync</exception>
         public static IAsyncRetryPolicy RetryAsync(this PolicyBuilder policyBuilder, int retryCount, Func<Exception, int, Task> onRetryAsync)
         {
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
-
-            return policyBuilder.RetryAsync(retryCount, onRetryAsync: (outcome, i, ctx) => onRetryAsync(outcome, i));
+            return policyBuilder.RetryAsync(retryCount, onRetryAsync: onRetryAsync == null ? (Func<Exception, int, Context, Task>)null : (outcome, i, ctx) => onRetryAsync(outcome, i));
         }
 
         /// <summary>
@@ -103,7 +93,6 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static IAsyncRetryPolicy RetryAsync(this PolicyBuilder policyBuilder, Action<Exception, int, Context> onRetry)
             => policyBuilder.RetryAsync(1, onRetry);
 
@@ -114,7 +103,6 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static IAsyncRetryPolicy RetryAsync(this PolicyBuilder policyBuilder, Func<Exception, int, Context, Task> onRetryAsync)
             => policyBuilder.RetryAsync(1, onRetryAsync);
 
@@ -127,14 +115,11 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static IAsyncRetryPolicy RetryAsync(this PolicyBuilder policyBuilder, int retryCount, Action<Exception, int, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.RetryAsync(retryCount,
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, i, ctx) => onRetry(outcome, i, ctx)
+                onRetryAsync: onRetry == null ? (Func<Exception, int, Context, Task>)null : async (outcome, i, ctx) => onRetry(outcome, i, ctx)
 #pragma warning restore 1998
                 );
         }
@@ -148,15 +133,13 @@ namespace Polly
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onRetryAsync</exception>
         public static IAsyncRetryPolicy RetryAsync(this PolicyBuilder policyBuilder, int retryCount, Func<Exception, int, Context, Task> onRetryAsync)
         {
             if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             return new AsyncRetryPolicy(
                 policyBuilder,
-                (outcome, timespan, i, ctx) => onRetryAsync(outcome, i, ctx),
+                onRetryAsync: onRetryAsync == null ? (Func<Exception, TimeSpan, int, Context, Task>)null : (outcome, timespan, i, ctx) => onRetryAsync(outcome, i, ctx),
                 retryCount
             );
         }
@@ -168,9 +151,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static IAsyncRetryPolicy RetryForeverAsync(this PolicyBuilder policyBuilder)
         {
-            Action<Exception> doNothing = _ => { };
-
-            return policyBuilder.RetryForeverAsync(doNothing);
+            return policyBuilder.RetryForeverAsync(onRetry: (Action<Exception>) null);
         }
 
         /// <summary>
@@ -180,14 +161,11 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static IAsyncRetryPolicy RetryForeverAsync(this PolicyBuilder policyBuilder, Action<Exception> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.RetryForeverAsync(
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (Exception outcome, Context ctx) => onRetry(outcome)
+                onRetryAsync: onRetry == null ? (Func<Exception, Context, Task>)null : async (Exception outcome, Context ctx) => onRetry(outcome)
 #pragma warning restore 1998
             );
         }
@@ -199,14 +177,11 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static IAsyncRetryPolicy RetryForeverAsync(this PolicyBuilder policyBuilder, Action<Exception, int> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.RetryForeverAsync(
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, i, context) => onRetry(outcome, i)
+                onRetryAsync: onRetry == null ? (Func<Exception, int, Context, Task>)null : async (outcome, i, context) => onRetry(outcome, i)
 #pragma warning restore 1998
             );
         }
@@ -218,12 +193,9 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetryAsync</exception>
         public static IAsyncRetryPolicy RetryForeverAsync(this PolicyBuilder policyBuilder, Func<Exception, Task> onRetryAsync)
         {
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
-
-            return policyBuilder.RetryForeverAsync(onRetryAsync: (Exception outcome, Context ctx) => onRetryAsync(outcome));
+            return policyBuilder.RetryForeverAsync(onRetryAsync: onRetryAsync == null ? (Func<Exception, Context, Task>)null : (Exception outcome, Context ctx) => onRetryAsync(outcome));
         }
 
         /// <summary>
@@ -233,12 +205,9 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetryAsync</exception>
         public static IAsyncRetryPolicy RetryForeverAsync(this PolicyBuilder policyBuilder, Func<Exception, int, Task> onRetryAsync)
         {
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
-
-            return policyBuilder.RetryForeverAsync(onRetryAsync: (outcome, i, context) => onRetryAsync(outcome, i));
+            return policyBuilder.RetryForeverAsync(onRetryAsync: onRetryAsync == null ? (Func<Exception, int, Context, Task>)null : (outcome, i, context) => onRetryAsync(outcome, i));
         }
 
         /// <summary>
@@ -248,14 +217,11 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static IAsyncRetryPolicy RetryForeverAsync(this PolicyBuilder policyBuilder, Action<Exception, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.RetryForeverAsync(
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, ctx) => onRetry(outcome, ctx)
+                onRetryAsync: onRetry == null ? (Func<Exception, Context, Task>)null : async (outcome, ctx) => onRetry(outcome, ctx)
 #pragma warning restore 1998
             );
         }
@@ -267,14 +233,11 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static IAsyncRetryPolicy RetryForeverAsync(this PolicyBuilder policyBuilder, Action<Exception, int, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.RetryForeverAsync(
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, i, ctx) => onRetry(outcome, i, ctx)
+                onRetryAsync: onRetry == null ? (Func<Exception, int, Context, Task>)null : async (outcome, i, ctx) => onRetry(outcome, i, ctx)
 #pragma warning restore 1998
             );
         }
@@ -286,14 +249,11 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetryAsync</exception>
         public static IAsyncRetryPolicy RetryForeverAsync(this PolicyBuilder policyBuilder, Func<Exception, Context, Task> onRetryAsync)
         {
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
-
             return new AsyncRetryPolicy(
                 policyBuilder,
-                (outcome, timespan, i, ctx) => onRetryAsync(outcome, ctx)
+                onRetryAsync: onRetryAsync == null ? (Func<Exception, TimeSpan, int, Context, Task>)null : (outcome, timespan, i, ctx) => onRetryAsync(outcome, ctx)
             );
         }
 
@@ -304,14 +264,11 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetryAsync</exception>
         public static IAsyncRetryPolicy RetryForeverAsync(this PolicyBuilder policyBuilder, Func<Exception, int, Context, Task> onRetryAsync)
         {
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
-
             return new AsyncRetryPolicy(
                 policyBuilder,
-                (outcome, timespan, i, ctx) => onRetryAsync(outcome, i, ctx)
+                onRetryAsync: onRetryAsync == null ? (Func<Exception, TimeSpan, int, Context, Task>)null : (outcome, timespan, i, ctx) => onRetryAsync(outcome, i, ctx)
             );
         }
 
@@ -326,9 +283,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static IAsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider)
         {
-            Action<Exception, TimeSpan> doNothing = (_, __) => { };
-
-            return policyBuilder.WaitAndRetryAsync(retryCount, sleepDurationProvider, doNothing);
+            return policyBuilder.WaitAndRetryAsync(retryCount, sleepDurationProvider, onRetry: (Action<Exception, TimeSpan>) null);
         }
 
         /// <summary>
@@ -343,20 +298,14 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurationProvider
-        ///     or
-        ///     onRetry
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static IAsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.WaitAndRetryAsync(
                 retryCount,
                 sleepDurationProvider,
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, span, i, ctx) => onRetry(outcome, span)
+                onRetryAsync: onRetry == null ? (Func<Exception, TimeSpan, int, Context, Task>)null : async (outcome, span, i, ctx) => onRetry(outcome, span)
 #pragma warning restore 1998
             );
         }
@@ -373,20 +322,14 @@ namespace Polly
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurationProvider
-        ///     or
-        ///     onRetryAsync
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static IAsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, Task> onRetryAsync)
         {
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
-
             return policyBuilder.WaitAndRetryAsync(
                 retryCount,
                 sleepDurationProvider,
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: (outcome, span, i, ctx) => onRetryAsync(outcome, span)
+                onRetryAsync: onRetryAsync == null ? (Func<Exception, TimeSpan, int, Context, Task>)null : (outcome, span, i, ctx) => onRetryAsync(outcome, span)
 #pragma warning restore 1998
             );
         }
@@ -403,21 +346,15 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurationProvider
-        ///     or
-        ///     onRetry
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static IAsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
             Func<int, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.WaitAndRetryAsync(
                 retryCount,
                 sleepDurationProvider,
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, span, i, ctx) => onRetry(outcome, span, ctx)
+                onRetryAsync: onRetry == null ? (Func<Exception, TimeSpan, int, Context, Task>)null : async (outcome, span, i, ctx) => onRetry(outcome, span, ctx)
 #pragma warning restore 1998
                 );
         }
@@ -434,20 +371,14 @@ namespace Polly
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurationProvider
-        ///     or
-        ///     onRetryAsync
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static IAsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
             Func<int, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, Context, Task> onRetryAsync)
         {
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
-
             return policyBuilder.WaitAndRetryAsync(
                 retryCount,
                 sleepDurationProvider,
-                onRetryAsync: (outcome, timespan, i, ctx) => onRetryAsync(outcome, timespan, ctx)
+                onRetryAsync: onRetryAsync == null ? (Func<Exception, TimeSpan, int, Context, Task>)null : (outcome, timespan, i, ctx) => onRetryAsync(outcome, timespan, ctx)
             );
         }
 
@@ -463,20 +394,14 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurationProvider
-        ///     or
-        ///     onRetry
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static IAsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, int, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.WaitAndRetryAsync(
                 retryCount,
                 sleepDurationProvider,
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, timespan, i, ctx) => onRetry(outcome, timespan, i, ctx)
+                onRetryAsync: onRetry == null ? (Func<Exception, TimeSpan, int, Context, Task>)null : async (outcome, timespan, i, ctx) => onRetry(outcome, timespan, i, ctx)
 #pragma warning restore 1998
             );
         }
@@ -493,17 +418,12 @@ namespace Polly
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurationProvider
-        ///     or
-        ///     onRetryAsync
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static IAsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
             Func<int, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, int, Context, Task> onRetryAsync)
         {
             if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             IEnumerable<TimeSpan> sleepDurations = Enumerable.Range(1, retryCount)
                 .Select(sleepDurationProvider);
@@ -528,21 +448,15 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurationProvider
-        ///     or
-        ///     onRetry
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static IAsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
             Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.WaitAndRetryAsync(
                 retryCount,
                 sleepDurationProvider,
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, span, i, ctx) => onRetry(outcome, span, ctx)
+                onRetryAsync: onRetry == null ? (Func<Exception, TimeSpan, int, Context, Task>)null : async (outcome, span, i, ctx) => onRetry(outcome, span, ctx)
 #pragma warning restore 1998
                 );
         }
@@ -559,20 +473,14 @@ namespace Polly
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurationProvider
-        ///     or
-        ///     onRetryAsync
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static IAsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
             Func<int, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, Context, Task> onRetryAsync)
         {
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
-
             return policyBuilder.WaitAndRetryAsync(
                 retryCount,
                 sleepDurationProvider,
-                onRetryAsync: (outcome, timespan, i, ctx) => onRetryAsync(outcome, timespan, ctx)
+                onRetryAsync: onRetryAsync == null ? (Func<Exception, TimeSpan, int, Context, Task>)null : (outcome, timespan, i, ctx) => onRetryAsync(outcome, timespan, ctx)
             );
         }
 
@@ -588,20 +496,14 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurationProvider
-        ///     or
-        ///     onRetry
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static IAsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, int, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.WaitAndRetryAsync(
                 retryCount,
                 sleepDurationProvider,
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, timespan, i, ctx) => onRetry(outcome, timespan, i, ctx)
+                onRetryAsync: onRetry == null ? (Func<Exception, TimeSpan, int, Context, Task>)null : async (outcome, timespan, i, ctx) => onRetry(outcome, timespan, i, ctx)
 #pragma warning restore 1998
             );
         }
@@ -618,18 +520,14 @@ namespace Polly
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurationProvider
-        ///     or
-        ///     onRetryAsync
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static IAsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
             Func<int, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, int, Context, Task> onRetryAsync)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             return policyBuilder.WaitAndRetryAsync(
                 retryCount,
-                (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+                sleepDurationProvider: (i, outcome, ctx) => sleepDurationProvider(i, ctx),
                 onRetryAsync);
         }
 
@@ -645,17 +543,12 @@ namespace Polly
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurationProvider
-        ///     or
-        ///     onRetryAsync
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static IAsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
             Func<int, Exception, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, int, Context, Task> onRetryAsync)
         {
             if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
             
             return new AsyncRetryPolicy(
                 policyBuilder,
@@ -675,9 +568,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static IAsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, IEnumerable<TimeSpan> sleepDurations)
         {
-            Action<Exception, TimeSpan, int, Context> doNothing = (_, __, ___, ____) => { };
-
-            return policyBuilder.WaitAndRetryAsync(sleepDurations, doNothing);
+            return policyBuilder.WaitAndRetryAsync(sleepDurations, onRetry: (Action<Exception, TimeSpan, int, Context>)null);
         }
 
         /// <summary>
@@ -692,17 +583,13 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">
         ///     sleepDurations
-        ///     or
-        ///     onRetry
         /// </exception>
         public static IAsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, IEnumerable<TimeSpan> sleepDurations, Action<Exception, TimeSpan> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.WaitAndRetryAsync(
                 sleepDurations,
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, timespan, i, ctx) => onRetry(outcome, timespan)
+                onRetryAsync: onRetry == null ? (Func<Exception, TimeSpan, int, Context, Task>)null : async (outcome, timespan, i, ctx) => onRetry(outcome, timespan)
 #pragma warning restore 1998
             );
         }
@@ -719,16 +606,12 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">
         ///     sleepDurations
-        ///     or
-        ///     onRetryAsync
         /// </exception>
         public static IAsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, IEnumerable<TimeSpan> sleepDurations, Func<Exception, TimeSpan, Task> onRetryAsync)
         {
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
-
             return policyBuilder.WaitAndRetryAsync(
                 sleepDurations,
-                onRetryAsync: (outcome, timespan, i, ctx) => onRetryAsync(outcome, timespan)
+                onRetryAsync: onRetryAsync == null ? (Func<Exception, TimeSpan, int, Context, Task>)null : (outcome, timespan, i, ctx) => onRetryAsync(outcome, timespan)
             );
         }
 
@@ -744,17 +627,13 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">
         ///     sleepDurations
-        ///     or
-        ///     onRetry
         /// </exception>
         public static IAsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, IEnumerable<TimeSpan> sleepDurations, Action<Exception, TimeSpan, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.WaitAndRetryAsync(
                 sleepDurations,
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, timespan, i, ctx) => onRetry(outcome, timespan, ctx)
+                onRetryAsync: onRetry == null ? (Func<Exception, TimeSpan, int, Context, Task>)null : async (outcome, timespan, i, ctx) => onRetry(outcome, timespan, ctx)
 #pragma warning restore 1998
             );
 
@@ -770,18 +649,12 @@ namespace Polly
         /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurations
-        ///     or
-        ///     onRetryAsync
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurations</exception>
         public static IAsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, IEnumerable<TimeSpan> sleepDurations, Func<Exception, TimeSpan, Context, Task> onRetryAsync)
         {
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
-
             return policyBuilder.WaitAndRetryAsync(
                 sleepDurations,
-                onRetryAsync: (outcome, timespan, i, ctx) => onRetryAsync(outcome, timespan, ctx)
+                onRetryAsync: onRetryAsync == null ? (Func<Exception, TimeSpan, int, Context, Task>)null : (outcome, timespan, i, ctx) => onRetryAsync(outcome, timespan, ctx)
             );
         }
 
@@ -797,17 +670,13 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">
         ///     sleepDurations
-        ///     or
-        ///     onRetry
         /// </exception>
         public static IAsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, IEnumerable<TimeSpan> sleepDurations, Action<Exception, TimeSpan, int, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.WaitAndRetryAsync(
                 sleepDurations,
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, timespan, i, ctx) => onRetry(outcome, timespan, i, ctx)
+                onRetryAsync: onRetry == null ? (Func<Exception, TimeSpan, int, Context, Task>)null : async (outcome, timespan, i, ctx) => onRetry(outcome, timespan, i, ctx)
 #pragma warning restore 1998
             );
         }
@@ -822,15 +691,10 @@ namespace Polly
         /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurations
-        ///     or
-        ///     onRetryAsync
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurations</exception>
         public static IAsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, IEnumerable<TimeSpan> sleepDurations, Func<Exception, TimeSpan, int, Context, Task> onRetryAsync)
         {
             if (sleepDurations == null) throw new ArgumentNullException(nameof(sleepDurations));
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             return new AsyncRetryPolicy(
                 policyBuilder,
@@ -852,9 +716,7 @@ namespace Polly
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
 
-            Action<Exception, TimeSpan> doNothing = (_, __) => { };
-
-            return policyBuilder.WaitAndRetryForeverAsync(sleepDurationProvider, doNothing);
+            return policyBuilder.WaitAndRetryForeverAsync(sleepDurationProvider, onRetry: (Action<Exception, TimeSpan>) null);
         }
 
         /// <summary>
@@ -870,9 +732,7 @@ namespace Polly
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
 
-            Action<Exception, TimeSpan, Context> doNothing = (_, __, ___) => { };
-
-            return policyBuilder.WaitAndRetryForeverAsync(sleepDurationProvider, doNothing);
+            return policyBuilder.WaitAndRetryForeverAsync(sleepDurationProvider, onRetry: (Action<Exception, TimeSpan, Context>) null);
         }
 
         /// <summary>
@@ -886,15 +746,13 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static IAsyncRetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan> onRetry)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return policyBuilder.WaitAndRetryForeverAsync(
-                (retryCount, context) => sleepDurationProvider(retryCount),
-                (exception, timespan, context) => onRetry(exception, timespan)
+                sleepDurationProvider: (retryCount, context) => sleepDurationProvider(retryCount),
+                onRetry: onRetry == null ? (Action<Exception, TimeSpan, Context>)null : (exception, timespan, context) => onRetry(exception, timespan)
             );
         }
 
@@ -909,15 +767,13 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static IAsyncRetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, int, TimeSpan> onRetry)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return policyBuilder.WaitAndRetryForeverAsync(
-                (retryCount, context) => sleepDurationProvider(retryCount),
-                (exception, i, timespan, context) => onRetry(exception, i, timespan)
+                sleepDurationProvider: (retryCount, context) => sleepDurationProvider(retryCount),
+                onRetry: onRetry == null ? (Action<Exception, int, TimeSpan, Context>)null : (exception, i, timespan, context) => onRetry(exception, i, timespan)
             );
         }
 
@@ -932,15 +788,13 @@ namespace Polly
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetryAsync</exception>
         public static IAsyncRetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, Task> onRetryAsync)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             return policyBuilder.WaitAndRetryForeverAsync(
-             (retryCount, context) => sleepDurationProvider(retryCount),
-             (exception, timespan, context) => onRetryAsync(exception, timespan)
+               sleepDurationProvider: (retryCount, context) => sleepDurationProvider(retryCount),
+               onRetryAsync: onRetryAsync == null ? (Func<Exception, TimeSpan, Context, Task>)null : (exception, timespan, context) => onRetryAsync(exception, timespan)
          );
         }
 
@@ -955,15 +809,13 @@ namespace Polly
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetryAsync</exception>
         public static IAsyncRetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Func<Exception, int, TimeSpan, Task> onRetryAsync)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             return policyBuilder.WaitAndRetryForeverAsync(
-             (retryCount, context) => sleepDurationProvider(retryCount),
-             (exception, i, timespan, context) => onRetryAsync(exception, i, timespan)
+             sleepDurationProvider: (retryCount, context) => sleepDurationProvider(retryCount),
+             onRetryAsync: onRetryAsync == null ? (Func<Exception, int, TimeSpan, Context, Task>)null : (exception, i, timespan, context) => onRetryAsync(exception, i, timespan)
          );
         }
 
@@ -978,16 +830,14 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetry</exception>        
         public static IAsyncRetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, Context> onRetry)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return policyBuilder.WaitAndRetryForeverAsync(
                 sleepDurationProvider,
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                async (exception, timespan, ctx) => onRetry(exception, timespan, ctx)
+                onRetryAsync: onRetry == null ? (Func<Exception, TimeSpan, Context, Task>)null : async (exception, timespan, ctx) => onRetry(exception, timespan, ctx)
 #pragma warning restore 1998
             );
         }
@@ -1003,16 +853,14 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetry</exception>        
         public static IAsyncRetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, int, TimeSpan, Context> onRetry)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return policyBuilder.WaitAndRetryForeverAsync(
                 sleepDurationProvider,
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                async (exception, i, timespan, ctx) => onRetry(exception, i, timespan, ctx)
+                onRetryAsync: onRetry == null ? (Func<Exception, int, TimeSpan, Context, Task>)null : async (exception, i, timespan, ctx) => onRetry(exception, i, timespan, ctx)
 #pragma warning restore 1998
             );
         }
@@ -1028,12 +876,11 @@ namespace Polly
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetryAsync</exception>        
         public static IAsyncRetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, Context, Task> onRetryAsync)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             return policyBuilder.WaitAndRetryForeverAsync(
-                (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+                sleepDurationProvider: (i, outcome, ctx) => sleepDurationProvider(i, ctx),
                 onRetryAsync
             );
         }
@@ -1049,12 +896,11 @@ namespace Polly
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetryAsync</exception>        
         public static IAsyncRetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Func<Exception, int, TimeSpan, Context, Task> onRetryAsync)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             return policyBuilder.WaitAndRetryForeverAsync(
-                (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+                sleepDurationProvider: (i, outcome, ctx) => sleepDurationProvider(i, ctx),
                 onRetryAsync
             );
         }
@@ -1070,15 +916,13 @@ namespace Polly
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetryAsync</exception>        
         public static IAsyncRetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, Exception, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, Context, Task> onRetryAsync)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             return new AsyncRetryPolicy(
                 policyBuilder,
-                (outcome, timespan, i, ctx) => onRetryAsync(outcome, timespan, ctx),
+                onRetryAsync: onRetryAsync == null ? (Func<Exception, TimeSpan, int, Context, Task>)null : (outcome, timespan, i, ctx) => onRetryAsync(outcome, timespan, ctx),
                 sleepDurationProvider: sleepDurationProvider);
         }
 
@@ -1093,15 +937,13 @@ namespace Polly
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetryAsync</exception>        
         public static IAsyncRetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, Exception, Context, TimeSpan> sleepDurationProvider, Func<Exception, int, TimeSpan, Context, Task> onRetryAsync)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             return new AsyncRetryPolicy(
                 policyBuilder,
-                (exception, timespan, i, ctx) => onRetryAsync(exception, i, timespan, ctx),
+                onRetryAsync: onRetryAsync == null ? (Func<Exception, TimeSpan, int, Context, Task>)null : (exception, timespan, i, ctx) => onRetryAsync(exception, i, timespan, ctx),
                 sleepDurationProvider: sleepDurationProvider
             );
         }

--- a/src/Polly/Retry/AsyncRetryTResultSyntax.cs
+++ b/src/Polly/Retry/AsyncRetryTResultSyntax.cs
@@ -27,9 +27,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static IAsyncRetryPolicy<TResult> RetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount)
         {
-            Action<DelegateResult<TResult>, int> doNothing = (_, __) => { };
-
-            return policyBuilder.RetryAsync(retryCount, doNothing);
+            return policyBuilder.RetryAsync(retryCount, onRetry: (Action<DelegateResult<TResult>, int>) null);
         }
 
         /// <summary>
@@ -39,11 +37,10 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static IAsyncRetryPolicy<TResult> RetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>, int> onRetry)
             => policyBuilder.RetryAsync(1,
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, i, ctx) => onRetry(outcome, i)
+                onRetryAsync: onRetry == null ? (Func<DelegateResult<TResult>, int, Context, Task>)null : async(outcome, i, ctx) => onRetry(outcome, i)
 #pragma warning restore 1998
             );
 
@@ -54,9 +51,8 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static IAsyncRetryPolicy<TResult> RetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<DelegateResult<TResult>, int, Task> onRetryAsync)
-            => policyBuilder.RetryAsync(1, onRetryAsync: (outcome, i, ctx) => onRetryAsync(outcome, i));
+            => policyBuilder.RetryAsync(1, onRetryAsync: onRetryAsync == null ? (Func<DelegateResult<TResult>, int, Context, Task>)null : (outcome, i, ctx) => onRetryAsync(outcome, i));
 
         /// <summary>
         ///     Builds an <see cref="AsyncRetryPolicy{TResult}" /> that will retry <paramref name="retryCount" /> times
@@ -67,14 +63,11 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static IAsyncRetryPolicy<TResult> RetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Action<DelegateResult<TResult>, int> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.RetryAsync(retryCount,
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, i, ctx) => onRetry(outcome, i)
+                onRetryAsync: onRetry == null ? (Func<DelegateResult<TResult>, int, Context, Task>)null : async (outcome, i, ctx) => onRetry(outcome, i)
 #pragma warning restore 1998
             );
         }
@@ -88,12 +81,9 @@ namespace Polly
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">onRetryAsync</exception>
         public static IAsyncRetryPolicy<TResult> RetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<DelegateResult<TResult>, int, Task> onRetryAsync)
         {
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
-
-            return policyBuilder.RetryAsync(retryCount, onRetryAsync: (outcome, i, ctx) => onRetryAsync(outcome, i));
+            return policyBuilder.RetryAsync(retryCount, onRetryAsync: onRetryAsync == null ? (Func<DelegateResult<TResult>, int, Context, Task>)null : (outcome, i, ctx) => onRetryAsync(outcome, i));
         }
 
         /// <summary>
@@ -103,7 +93,6 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static IAsyncRetryPolicy<TResult> RetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>, int, Context> onRetry)
             => policyBuilder.RetryAsync(1, onRetry);
 
@@ -114,7 +103,6 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static IAsyncRetryPolicy<TResult> RetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<DelegateResult<TResult>, int, Context, Task> onRetryAsync)
             => policyBuilder.RetryAsync(1, onRetryAsync);
 
@@ -127,14 +115,11 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static IAsyncRetryPolicy<TResult> RetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Action<DelegateResult<TResult>, int, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.RetryAsync(retryCount,
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, i, ctx) => onRetry(outcome, i, ctx)
+                onRetryAsync: onRetry == null ? (Func<DelegateResult<TResult>, int, Context, Task>)null : async(outcome, i, ctx) => onRetry(outcome, i, ctx)
 #pragma warning restore 1998
                 );
         }
@@ -148,15 +133,13 @@ namespace Polly
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onRetryAsync</exception>
         public static IAsyncRetryPolicy<TResult> RetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<DelegateResult<TResult>, int, Context, Task> onRetryAsync)
         {
             if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             return new AsyncRetryPolicy<TResult>(
                 policyBuilder,
-                (outcome, timespan, i, ctx) => onRetryAsync(outcome, i, ctx),
+                onRetryAsync: onRetryAsync == null ? (Func<DelegateResult<TResult>, TimeSpan, int, Context, Task>)null : (outcome, timespan, i, ctx) => onRetryAsync(outcome, i, ctx),
                 retryCount
             );
         }
@@ -168,9 +151,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static IAsyncRetryPolicy<TResult> RetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder)
         {
-            Action<DelegateResult<TResult>> doNothing = _ => { };
-
-            return policyBuilder.RetryForeverAsync(doNothing);
+            return policyBuilder.RetryForeverAsync(onRetry: (Action<DelegateResult<TResult>>) null);
         }
 
         /// <summary>
@@ -180,14 +161,11 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static IAsyncRetryPolicy<TResult> RetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.RetryForeverAsync(
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (DelegateResult<TResult> outcome, Context ctx) => onRetry(outcome)
+                onRetryAsync: onRetry == null ? (Func<DelegateResult<TResult>, Context, Task>)null : async(DelegateResult<TResult> outcome, Context ctx) => onRetry(outcome)
 #pragma warning restore 1998
                 );
         }
@@ -199,14 +177,11 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static IAsyncRetryPolicy<TResult> RetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>, int> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.RetryForeverAsync(
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, i, context) => onRetry(outcome, i)
+                onRetryAsync: onRetry == null ? (Func<DelegateResult<TResult>, int, Context, Task>)null : async(outcome, i, context) => onRetry(outcome, i)
 #pragma warning restore 1998
                 );
         }
@@ -218,12 +193,9 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetryAsync</exception>
         public static IAsyncRetryPolicy<TResult> RetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<DelegateResult<TResult>, Task> onRetryAsync)
         {
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
-
-            return policyBuilder.RetryForeverAsync(onRetryAsync: (DelegateResult<TResult> outcome, Context ctx) => onRetryAsync(outcome));
+            return policyBuilder.RetryForeverAsync(onRetryAsync: onRetryAsync == null ? (Func<DelegateResult<TResult>, Context, Task>)null : (DelegateResult<TResult> outcome, Context ctx) => onRetryAsync(outcome));
         }
 
         /// <summary>
@@ -233,12 +205,9 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetryAsync</exception>
         public static IAsyncRetryPolicy<TResult> RetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<DelegateResult<TResult>, int, Task> onRetryAsync)
         {
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
-
-            return policyBuilder.RetryForeverAsync(onRetryAsync: (outcome, i, context) => onRetryAsync(outcome, i));
+            return policyBuilder.RetryForeverAsync(onRetryAsync: onRetryAsync == null ? (Func<DelegateResult<TResult>, int, Context, Task>)null : (outcome, i, context) => onRetryAsync(outcome, i));
         }
 
         /// <summary>
@@ -248,14 +217,11 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static IAsyncRetryPolicy<TResult> RetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.RetryForeverAsync(
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, ctx) => onRetry(outcome, ctx)
+                onRetryAsync: onRetry == null ? (Func<DelegateResult<TResult>, Context, Task>)null : async(outcome, ctx) => onRetry(outcome, ctx)
 #pragma warning restore 1998
             );
         }
@@ -267,14 +233,11 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static IAsyncRetryPolicy<TResult> RetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>, int, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.RetryForeverAsync(
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, i, ctx) => onRetry(outcome, i, ctx)
+                onRetryAsync: onRetry == null ? (Func<DelegateResult<TResult>, int, Context, Task>)null : async(outcome, i, ctx) => onRetry(outcome, i, ctx)
 #pragma warning restore 1998
             );
         }
@@ -286,14 +249,11 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetryAsync</exception>
         public static IAsyncRetryPolicy<TResult> RetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<DelegateResult<TResult>, Context, Task> onRetryAsync)
         {
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
-
             return new AsyncRetryPolicy<TResult>(
                 policyBuilder,
-                (outcome, timespan, i, ctx) => onRetryAsync(outcome, ctx)
+                onRetryAsync: onRetryAsync == null ? (Func<DelegateResult<TResult>, TimeSpan, int, Context, Task>)null : (outcome, timespan, i, ctx) => onRetryAsync(outcome, ctx)
             );
         }
 
@@ -304,14 +264,11 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetryAsync</exception>
         public static IAsyncRetryPolicy<TResult> RetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<DelegateResult<TResult>, int, Context, Task> onRetryAsync)
         {
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
-
             return new AsyncRetryPolicy<TResult>(
                 policyBuilder,
-                (outcome, timespan, i, ctx) => onRetryAsync(outcome, i, ctx)
+                onRetryAsync: onRetryAsync == null ? (Func<DelegateResult<TResult>, TimeSpan, int, Context, Task>)null : (outcome, timespan, i, ctx) => onRetryAsync(outcome, i, ctx)
             );
         }
 
@@ -326,9 +283,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static IAsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider)
         {
-            Action<DelegateResult<TResult>, TimeSpan> doNothing = (_, __) => { };
-
-            return policyBuilder.WaitAndRetryAsync(retryCount, sleepDurationProvider, doNothing);
+            return policyBuilder.WaitAndRetryAsync(retryCount, sleepDurationProvider, onRetry: (Action<DelegateResult<TResult>, TimeSpan>) null);
         }
 
         /// <summary>
@@ -343,21 +298,15 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurationProvider
-        ///     or
-        ///     onRetry
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static IAsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
             Func<int, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.WaitAndRetryAsync(
                 retryCount,
                 sleepDurationProvider,
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, span, i, ctx) => onRetry(outcome, span)
+                onRetryAsync: onRetry == null ? (Func<DelegateResult<TResult>, TimeSpan, int, Context, Task>)null : async(outcome, span, i, ctx) => onRetry(outcome, span)
 #pragma warning restore 1998
             );
         }
@@ -374,20 +323,14 @@ namespace Polly
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurationProvider
-        ///     or
-        ///     onRetryAsync
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static IAsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, Task> onRetryAsync)
         {
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
-
             return policyBuilder.WaitAndRetryAsync(
                 retryCount,
                 sleepDurationProvider,
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: (outcome, span, i, ctx) => onRetryAsync(outcome, span)
+                onRetryAsync: onRetryAsync == null ? (Func<DelegateResult<TResult>, TimeSpan, int, Context, Task>)null : (outcome, span, i, ctx) => onRetryAsync(outcome, span)
 #pragma warning restore 1998
             );
         }
@@ -404,21 +347,15 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurationProvider
-        ///     or
-        ///     onRetry
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static IAsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
             Func<int, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.WaitAndRetryAsync(
                 retryCount,
                 sleepDurationProvider,
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, span, i, ctx) => onRetry(outcome, span, ctx)
+                onRetryAsync: onRetry == null ? (Func<DelegateResult<TResult>, TimeSpan, int, Context, Task>)null : async(outcome, span, i, ctx) => onRetry(outcome, span, ctx)
 #pragma warning restore 1998
             );
         }
@@ -435,19 +372,13 @@ namespace Polly
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurationProvider
-        ///     or
-        ///     onRetryAsync
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static IAsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, Context, Task> onRetryAsync)
         {
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
-
             return policyBuilder.WaitAndRetryAsync(
                 retryCount,
                 sleepDurationProvider,
-                onRetryAsync: (outcome, timespan, i, ctx) => onRetryAsync(outcome, timespan, ctx)
+                onRetryAsync: onRetryAsync == null ? (Func<DelegateResult<TResult>, TimeSpan, int, Context, Task>)null : (outcome, timespan, i, ctx) => onRetryAsync(outcome, timespan, ctx)
             );
         }
 
@@ -463,20 +394,14 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurationProvider
-        ///     or
-        ///     onRetry
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static IAsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.WaitAndRetryAsync(
                 retryCount,
                 sleepDurationProvider,
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, timespan, i, ctx) => onRetry(outcome, timespan, i, ctx)
+                onRetryAsync: onRetry == null ? (Func<DelegateResult<TResult>, TimeSpan, int, Context, Task>)null : async(outcome, timespan, i, ctx) => onRetry(outcome, timespan, i, ctx)
 #pragma warning restore 1998
             );
         }
@@ -493,17 +418,12 @@ namespace Polly
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurationProvider
-        ///     or
-        ///     onRetryAsync
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static IAsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
             Func<int, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync)
         {
             if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             IEnumerable<TimeSpan> sleepDurations = Enumerable.Range(1, retryCount)
                 .Select(sleepDurationProvider);
@@ -528,21 +448,15 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurationProvider
-        ///     or
-        ///     onRetry
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static IAsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
             Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.WaitAndRetryAsync(
                 retryCount,
                 sleepDurationProvider,
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, span, i, ctx) => onRetry(outcome, span, ctx)
+                onRetryAsync: onRetry == null ? (Func<DelegateResult<TResult>, TimeSpan, int, Context, Task>)null : async(outcome, span, i, ctx) => onRetry(outcome, span, ctx)
 #pragma warning restore 1998
             );
         }
@@ -559,19 +473,13 @@ namespace Polly
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurationProvider
-        ///     or
-        ///     onRetryAsync
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static IAsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, Context, Task> onRetryAsync)
         {
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
-
             return policyBuilder.WaitAndRetryAsync(
                 retryCount,
                 sleepDurationProvider,
-                onRetryAsync: (outcome, timespan, i, ctx) => onRetryAsync(outcome, timespan, ctx)
+                onRetryAsync: onRetryAsync == null ? (Func<DelegateResult<TResult>, TimeSpan, int, Context, Task>)null : (outcome, timespan, i, ctx) => onRetryAsync(outcome, timespan, ctx)
             );
         }
 
@@ -587,20 +495,14 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurationProvider
-        ///     or
-        ///     onRetry
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static IAsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.WaitAndRetryAsync(
                 retryCount,
                 sleepDurationProvider,
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, timespan, i, ctx) => onRetry(outcome, timespan, i, ctx)
+                onRetryAsync: onRetry == null ? (Func<DelegateResult<TResult>, TimeSpan, int, Context, Task>)null : async (outcome, timespan, i, ctx) => onRetry(outcome, timespan, i, ctx)
 #pragma warning restore 1998
             );
         }
@@ -617,11 +519,7 @@ namespace Polly
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurationProvider
-        ///     or
-        ///     onRetryAsync
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static IAsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
             Func<int, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync)
         {
@@ -644,17 +542,12 @@ namespace Polly
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurationProvider
-        ///     or
-        ///     onRetryAsync
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static IAsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
             Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync)
         {
             if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             return new AsyncRetryPolicy<TResult>(
                 policyBuilder,
@@ -674,9 +567,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static IAsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, IEnumerable<TimeSpan> sleepDurations)
         {
-            Action<DelegateResult<TResult>, TimeSpan> doNothing = (_, __) => { };
-
-            return policyBuilder.WaitAndRetryAsync(sleepDurations, doNothing);
+            return policyBuilder.WaitAndRetryAsync(sleepDurations, onRetry: (Action<DelegateResult<TResult>, TimeSpan>)null);
         }
 
         /// <summary>
@@ -689,19 +580,13 @@ namespace Polly
         /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurations
-        ///     or
-        ///     onRetry
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurations</exception>
         public static IAsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, IEnumerable<TimeSpan> sleepDurations, Action<DelegateResult<TResult>, TimeSpan> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.WaitAndRetryAsync(
                 sleepDurations,
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, timespan, i, ctx) => onRetry(outcome, timespan)
+                onRetryAsync: onRetry == null ? (Func<DelegateResult<TResult>, TimeSpan, int, Context, Task>)null : async (outcome, timespan, i, ctx) => onRetry(outcome, timespan)
 #pragma warning restore 1998
             );
         }
@@ -716,18 +601,12 @@ namespace Polly
         /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurations
-        ///     or
-        ///     onRetryAsync
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurations</exception>
         public static IAsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, IEnumerable<TimeSpan> sleepDurations, Func<DelegateResult<TResult>, TimeSpan, Task> onRetryAsync)
         {
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
-
             return policyBuilder.WaitAndRetryAsync(
                 sleepDurations,
-                onRetryAsync: (outcome, timespan, i, ctx) => onRetryAsync(outcome, timespan)
+                onRetryAsync: onRetryAsync == null ? (Func<DelegateResult<TResult>, TimeSpan, int, Context, Task>)null : (outcome, timespan, i, ctx) => onRetryAsync(outcome, timespan)
             );
         }
 
@@ -741,22 +620,15 @@ namespace Polly
         /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurations
-        ///     or
-        ///     onRetry
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurations</exception>
         public static IAsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, IEnumerable<TimeSpan> sleepDurations, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.WaitAndRetryAsync(
                 sleepDurations,
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, timespan, i, ctx) => onRetry(outcome, timespan, ctx)
+                onRetryAsync: onRetry == null ? (Func<DelegateResult<TResult>, TimeSpan, int, Context, Task>)null : async(outcome, timespan, i, ctx) => onRetry(outcome, timespan, ctx)
 #pragma warning restore 1998
             );
-
         }
 
         /// <summary>
@@ -769,18 +641,12 @@ namespace Polly
         /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurations
-        ///     or
-        ///     onRetryAsync
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurations</exception>
         public static IAsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, IEnumerable<TimeSpan> sleepDurations, Func<DelegateResult<TResult>, TimeSpan, Context, Task> onRetryAsync)
         {
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
-
             return policyBuilder.WaitAndRetryAsync(
                 sleepDurations,
-                onRetryAsync: (outcome, timespan, i, ctx) => onRetryAsync(outcome, timespan, ctx)
+                onRetryAsync: onRetryAsync == null ? (Func<DelegateResult<TResult>, TimeSpan, int, Context, Task>)null : (outcome, timespan, i, ctx) => onRetryAsync(outcome, timespan, ctx)
             );
         }
 
@@ -794,19 +660,13 @@ namespace Polly
         /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurations
-        ///     or
-        ///     onRetry
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurations</exception>
         public static IAsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, IEnumerable<TimeSpan> sleepDurations, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.WaitAndRetryAsync(
                 sleepDurations,
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                onRetryAsync: async (outcome, timespan, i, ctx) => onRetry(outcome, timespan, i, ctx)
+                onRetryAsync: onRetry == null ? (Func<DelegateResult<TResult>, TimeSpan, int, Context, Task>)null : async(outcome, timespan, i, ctx) => onRetry(outcome, timespan, i, ctx)
 #pragma warning restore 1998
             );
         }
@@ -821,15 +681,10 @@ namespace Polly
         /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">
-        ///     sleepDurations
-        ///     or
-        ///     onRetryAsync
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurations</exception>
         public static IAsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, IEnumerable<TimeSpan> sleepDurations, Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync)
         {
             if (sleepDurations == null) throw new ArgumentNullException(nameof(sleepDurations));
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             return new AsyncRetryPolicy<TResult>(
                 policyBuilder,
@@ -851,9 +706,7 @@ namespace Polly
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
 
-            Action<DelegateResult<TResult>, TimeSpan> doNothing = (_, __) => { };
-
-            return policyBuilder.WaitAndRetryForeverAsync(sleepDurationProvider, doNothing);
+            return policyBuilder.WaitAndRetryForeverAsync(sleepDurationProvider, onRetry: (Action<DelegateResult<TResult>, TimeSpan>) null);
         }
 
         /// <summary>
@@ -869,9 +722,7 @@ namespace Polly
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
 
-            Action<DelegateResult<TResult>, TimeSpan, Context> doNothing = (_, __, ___) => { };
-
-            return policyBuilder.WaitAndRetryForeverAsync(sleepDurationProvider, doNothing);
+            return policyBuilder.WaitAndRetryForeverAsync(sleepDurationProvider, onRetry: (Action<DelegateResult<TResult>, TimeSpan, Context>)null);
         }
 
         /// <summary>
@@ -885,15 +736,13 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static IAsyncRetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan> onRetry)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return policyBuilder.WaitAndRetryForeverAsync(
-                (retryCount, context) => sleepDurationProvider(retryCount),
-                (outcome, timespan, context) => onRetry(outcome, timespan)
+                sleepDurationProvider: (retryCount, context) => sleepDurationProvider(retryCount),
+                onRetry: onRetry == null ? (Action<DelegateResult<TResult>, TimeSpan, Context>)null : (outcome, timespan, context) => onRetry(outcome, timespan)
             );
         }
 
@@ -908,15 +757,13 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static IAsyncRetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, int, TimeSpan> onRetry)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return policyBuilder.WaitAndRetryForeverAsync(
-                (retryCount, context) => sleepDurationProvider(retryCount),
-                (outcome, i, timespan, context) => onRetry(outcome, i, timespan)
+                sleepDurationProvider: (retryCount, context) => sleepDurationProvider(retryCount),
+                onRetry: onRetry == null ? (Action<DelegateResult<TResult>, int, TimeSpan, Context>)null : (outcome, i, timespan, context) => onRetry(outcome, i, timespan)
             );
         }
 
@@ -931,15 +778,13 @@ namespace Polly
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetryAsync</exception>
         public static IAsyncRetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, Task> onRetryAsync)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             return policyBuilder.WaitAndRetryForeverAsync(
-                (retryCount, context) => sleepDurationProvider(retryCount),
-                (outcome, timespan, context) => onRetryAsync(outcome, timespan)
+                sleepDurationProvider: (retryCount, context) => sleepDurationProvider(retryCount),
+                onRetryAsync: onRetryAsync == null ? (Func<DelegateResult<TResult>, TimeSpan, Context, Task>)null : (outcome, timespan, context) => onRetryAsync(outcome, timespan)
             );
         }
 
@@ -954,15 +799,13 @@ namespace Polly
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetryAsync</exception>
         public static IAsyncRetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, int, TimeSpan, Task> onRetryAsync)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             return policyBuilder.WaitAndRetryForeverAsync(
-                (retryCount, context) => sleepDurationProvider(retryCount),
-                (outcome, i, timespan, context) => onRetryAsync(outcome, i, timespan)
+                sleepDurationProvider: (retryCount, context) => sleepDurationProvider(retryCount),
+                onRetryAsync: onRetryAsync == null ? (Func<DelegateResult<TResult>, int, TimeSpan, Context, Task>)null : (outcome, i, timespan, context) => onRetryAsync(outcome, i, timespan)
             );
         }
 
@@ -977,15 +820,12 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetry</exception>        
         public static IAsyncRetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.WaitAndRetryForeverAsync(
                 sleepDurationProvider,
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                async (outcome, timespan, ctx) => onRetry(outcome, timespan, ctx)
+                onRetryAsync: onRetry == null ? (Func<DelegateResult<TResult>, TimeSpan, Context, Task>)null : async (outcome, timespan, ctx) => onRetry(outcome, timespan, ctx)
 #pragma warning restore 1998
             );
         }
@@ -1001,15 +841,12 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetry</exception>        
         public static IAsyncRetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, int, TimeSpan, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.WaitAndRetryForeverAsync(
                 sleepDurationProvider,
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
-                async (outcome, i, timespan, ctx) => onRetry(outcome, i, timespan, ctx)
+                onRetryAsync: onRetry == null ? (Func<DelegateResult<TResult>, int, TimeSpan, Context, Task>)null : async(outcome, i, timespan, ctx) => onRetry(outcome, i, timespan, ctx)
 #pragma warning restore 1998
             );
         }
@@ -1025,12 +862,11 @@ namespace Polly
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetryAsync</exception>        
         public static IAsyncRetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, Context, Task> onRetryAsync)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             return policyBuilder.WaitAndRetryForeverAsync(
-                (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+                sleepDurationProvider: (i, outcome, ctx) => sleepDurationProvider(i, ctx),
                 onRetryAsync
             );
         }
@@ -1046,12 +882,11 @@ namespace Polly
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetryAsync</exception>        
         public static IAsyncRetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, int, TimeSpan, Context, Task> onRetryAsync)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             return policyBuilder.WaitAndRetryForeverAsync(
-                (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+                sleepDurationProvider: (i, outcome, ctx) => sleepDurationProvider(i, ctx),
                 onRetryAsync
             );
         }
@@ -1067,15 +902,13 @@ namespace Polly
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetryAsync</exception>        
         public static IAsyncRetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, Context, Task> onRetryAsync)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
-
+            
             return new AsyncRetryPolicy<TResult>(
                 policyBuilder,
-                (outcome, timespan, i, ctx) => onRetryAsync(outcome, timespan, ctx),
+                onRetryAsync: onRetryAsync == null ? (Func<DelegateResult<TResult>, TimeSpan, int, Context, Task>)null : (outcome, timespan, i, ctx) => onRetryAsync(outcome, timespan, ctx),
                 sleepDurationProvider: sleepDurationProvider);
         }
 
@@ -1090,15 +923,13 @@ namespace Polly
         /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetryAsync</exception>        
         public static IAsyncRetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, int, TimeSpan, Context, Task> onRetryAsync)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetryAsync == null) throw new ArgumentNullException(nameof(onRetryAsync));
 
             return new AsyncRetryPolicy<TResult>(
                 policyBuilder,
-                (exception, timespan, i, ctx) => onRetryAsync(exception, i, timespan, ctx),
+                onRetryAsync: onRetryAsync == null ? (Func<DelegateResult<TResult>, TimeSpan, int, Context, Task>)null : (exception, timespan, i, ctx) => onRetryAsync(exception, i, timespan, ctx),
                 sleepDurationProvider: sleepDurationProvider
             );
         }

--- a/src/Polly/Retry/RetryEngine.cs
+++ b/src/Polly/Retry/RetryEngine.cs
@@ -71,7 +71,7 @@ namespace Polly.Retry
 
                     TimeSpan waitDuration = sleepDurationsEnumerator?.Current ?? (sleepDurationProvider?.Invoke(tryCount, outcome, context) ?? TimeSpan.Zero);
                 
-                    onRetry(outcome, waitDuration, tryCount, context);
+                    onRetry?.Invoke(outcome, waitDuration, tryCount, context);
 
                     if (waitDuration > TimeSpan.Zero)
                     {

--- a/src/Polly/Retry/RetryPolicy.cs
+++ b/src/Polly/Retry/RetryPolicy.cs
@@ -27,23 +27,24 @@ namespace Polly.Retry
             _permittedRetryCount = permittedRetryCount;
             _sleepDurationsEnumerable = sleepDurationsEnumerable;
             _sleepDurationProvider = sleepDurationProvider;
-            _onRetry = onRetry ?? throw new ArgumentNullException(nameof(onRetry));
+            _onRetry = onRetry;
         }
 
         /// <inheritdoc/>
-        protected override TResult Implementation<TResult>(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken)
+        protected override TResult Implementation<TResult>(Func<Context, CancellationToken, TResult> action,
+            Context context, CancellationToken cancellationToken)
             => RetryEngine.Implementation(
-                    action, 
-                    context, 
-                    cancellationToken,
-                    ExceptionPredicates,
-                    ResultPredicates<TResult>.None, 
-                    (outcome, timespan, retryCount, ctx) => _onRetry(outcome.Exception, timespan, retryCount, ctx),
-                    _permittedRetryCount,
-                    _sleepDurationsEnumerable,
-                    _sleepDurationProvider != null
-                        ? (retryCount, outcome, ctx) => _sleepDurationProvider(retryCount, outcome.Exception, ctx)
-                        : (Func<int, DelegateResult<TResult>, Context, TimeSpan>)null
+                action,
+                context,
+                cancellationToken,
+                ExceptionPredicates,
+                ResultPredicates<TResult>.None,
+                _onRetry == null ? (Action<DelegateResult<TResult>, TimeSpan, int, Context>)null : (outcome, timespan, retryCount, ctx) => _onRetry(outcome.Exception, timespan, retryCount, ctx),
+                _permittedRetryCount,
+                _sleepDurationsEnumerable,
+                _sleepDurationProvider != null
+                    ? (retryCount, outcome, ctx) => _sleepDurationProvider(retryCount, outcome.Exception, ctx)
+                    : (Func<int, DelegateResult<TResult>, Context, TimeSpan>)null
                 );
     }
 
@@ -70,7 +71,7 @@ namespace Polly.Retry
             _permittedRetryCount = permittedRetryCount;
             _sleepDurationsEnumerable = sleepDurationsEnumerable;
             _sleepDurationProvider = sleepDurationProvider;
-            _onRetry = onRetry ?? throw new ArgumentNullException(nameof(onRetry));
+            _onRetry = onRetry;
         }
 
         /// <inheritdoc/>

--- a/src/Polly/Retry/RetrySyntax.cs
+++ b/src/Polly/Retry/RetrySyntax.cs
@@ -26,9 +26,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static ISyncRetryPolicy Retry(this PolicyBuilder policyBuilder, int retryCount)
         {
-            Action<Exception, int> doNothing = (_, __) => { };
-
-            return policyBuilder.Retry(retryCount, doNothing);
+            return policyBuilder.Retry(retryCount, onRetry: (Action<Exception, int>) null);
         }
 
         /// <summary>
@@ -38,7 +36,6 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static ISyncRetryPolicy Retry(this PolicyBuilder policyBuilder, Action<Exception, int> onRetry)
             => policyBuilder.Retry(1, onRetry);
 
@@ -51,13 +48,11 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static ISyncRetryPolicy Retry(this PolicyBuilder policyBuilder, int retryCount, Action<Exception, int> onRetry)
         {
             if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
-            return policyBuilder.Retry(retryCount, (outcome, i, ctx) => onRetry(outcome, i));
+            return policyBuilder.Retry(retryCount, onRetry: onRetry == null ? (Action<Exception, int, Context>)null : (outcome, i, ctx) => onRetry(outcome, i));
         }
 
         /// <summary>
@@ -67,7 +62,6 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static ISyncRetryPolicy Retry(this PolicyBuilder policyBuilder, Action<Exception, int, Context> onRetry)
             => policyBuilder.Retry(1, onRetry);
 
@@ -80,15 +74,13 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static ISyncRetryPolicy Retry(this PolicyBuilder policyBuilder, int retryCount, Action<Exception, int, Context> onRetry)
         {
             if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return new RetryPolicy(
                 policyBuilder,
-                (outcome, timespan, i, ctx) => onRetry(outcome, i, ctx),
+                onRetry: onRetry == null ? (Action<Exception, TimeSpan, int, Context>)null : (outcome, timespan, i, ctx) => onRetry(outcome, i, ctx),
                 retryCount);
         }
 
@@ -99,9 +91,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static ISyncRetryPolicy RetryForever(this PolicyBuilder policyBuilder)
         {
-            Action<Exception> doNothing = _ => { };
-
-            return policyBuilder.RetryForever(doNothing);
+            return policyBuilder.RetryForever(onRetry: (Action<Exception>) null);
         }
 
         /// <summary>
@@ -111,12 +101,9 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static ISyncRetryPolicy RetryForever(this PolicyBuilder policyBuilder, Action<Exception> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
-            return policyBuilder.RetryForever((Exception outcome, Context ctx) => onRetry(outcome));
+            return policyBuilder.RetryForever(onRetry: onRetry == null ? (Action<Exception, Context>)null : (Exception outcome, Context ctx) => onRetry(outcome));
         }
 
         /// <summary>
@@ -126,12 +113,9 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static ISyncRetryPolicy RetryForever(this PolicyBuilder policyBuilder, Action<Exception, int> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
-            return policyBuilder.RetryForever((outcome, i, ctx) => onRetry(outcome, i));
+            return policyBuilder.RetryForever(onRetry: onRetry == null ? (Action<Exception, int, Context>)null : (outcome, i, ctx) => onRetry(outcome, i));
         }
 
         /// <summary>
@@ -141,14 +125,11 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static ISyncRetryPolicy RetryForever(this PolicyBuilder policyBuilder, Action<Exception, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
                 return new RetryPolicy(
                     policyBuilder,
-                    (outcome, timespan, i, ctx) => onRetry(outcome, ctx)
+                    onRetry: onRetry == null ? (Action<Exception, TimeSpan, int, Context>)null : (outcome, timespan, i, ctx) => onRetry(outcome, ctx)
                     );
         }
 
@@ -159,14 +140,11 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static ISyncRetryPolicy RetryForever(this PolicyBuilder policyBuilder, Action<Exception, int, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return new RetryPolicy(
                 policyBuilder,
-                (outcome, timespan, i, ctx) => onRetry(outcome, i, ctx)
+                onRetry: onRetry == null ? (Action<Exception, TimeSpan, int, Context>)null : (outcome, timespan, i, ctx) => onRetry(outcome, i, ctx)
             );
         }
 
@@ -179,11 +157,9 @@ namespace Polly
         /// <param name="retryCount">The retry count.</param>
         /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
         /// <returns>The policy instance.</returns>
-        public static ISyncRetryPolicy  WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider)
+        public static ISyncRetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider)
         {
-            Action<Exception, TimeSpan, int, Context> doNothing = (_, __, ___, ____) => { };
-
-            return policyBuilder.WaitAndRetry(retryCount, sleepDurationProvider, doNothing);
+            return policyBuilder.WaitAndRetry(retryCount, sleepDurationProvider, onRetry: (Action<Exception, TimeSpan, int, Context>) null);
         }
 
         /// <summary>
@@ -198,19 +174,13 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        /// sleepDurationProvider
-        /// or
-        /// onRetry
-        /// </exception>
-        public static ISyncRetryPolicy  WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan> onRetry)
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
+        public static ISyncRetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.WaitAndRetry(
                 retryCount,
                 sleepDurationProvider,
-                (outcome, span, i, ctx) => onRetry(outcome, span)
+                onRetry: onRetry == null ? (Action<Exception, TimeSpan, int, Context>)null : (outcome, span, i, ctx) => onRetry(outcome, span)
                 );
         }
 
@@ -226,19 +196,13 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        /// sleepDurationProvider
-        /// or
-        /// onRetry
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static ISyncRetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.WaitAndRetry(
                 retryCount, 
-                sleepDurationProvider, 
-                (outcome, span, i, ctx) => onRetry(outcome, span, ctx)
+                sleepDurationProvider,
+                onRetry: onRetry == null ? (Action<Exception, TimeSpan, int, Context>)null : (outcome, span, i, ctx) => onRetry(outcome, span, ctx)
                 );
         }
 
@@ -256,14 +220,11 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="ArgumentNullException">
         /// timeSpanProvider
-        /// or
-        /// onRetry
         /// </exception>
         public static ISyncRetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, int, Context> onRetry)
         {
             if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             var sleepDurations = Enumerable.Range(1, retryCount)
                                            .Select(sleepDurationProvider);
@@ -287,9 +248,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static ISyncRetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider)
         {
-            Action<Exception, TimeSpan, int, Context> doNothing = (_, __, ___, ____) => { };
-
-            return policyBuilder.WaitAndRetry(retryCount, sleepDurationProvider, doNothing);
+            return policyBuilder.WaitAndRetry(retryCount, sleepDurationProvider, onRetry: (Action<Exception, TimeSpan, int, Context>) null);
         }
 
         /// <summary>
@@ -304,19 +263,13 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        /// sleepDurationProvider
-        /// or
-        /// onRetry
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static ISyncRetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.WaitAndRetry(
                 retryCount,
                 sleepDurationProvider,
-                (outcome, span, i, ctx) => onRetry(outcome, span, ctx)
+                onRetry: onRetry == null ? (Action<Exception, TimeSpan, int, Context>)null : (outcome, span, i, ctx) => onRetry(outcome, span, ctx)
                 );
         }
 
@@ -335,15 +288,13 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="ArgumentNullException">
         /// timeSpanProvider
-        /// or
-        /// onRetry
         /// </exception>
         public static ISyncRetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, int, Context> onRetry)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             return policyBuilder.WaitAndRetry(
                 retryCount,
-                (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+                sleepDurationProvider: (i, outcome, ctx) => sleepDurationProvider(i, ctx),
                 onRetry);
         }
 
@@ -361,14 +312,11 @@ namespace Polly
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
         /// <exception cref="ArgumentNullException">
         /// timeSpanProvider
-        /// or
-        /// onRetry
         /// </exception>
         public static ISyncRetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, Exception, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, int, Context> onRetry)
         {
             if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
                 return new RetryPolicy(
                     policyBuilder,
@@ -387,9 +335,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static ISyncRetryPolicy  WaitAndRetry(this PolicyBuilder policyBuilder, IEnumerable<TimeSpan> sleepDurations)
         {
-            Action<Exception, TimeSpan> doNothing = (_, __) => { };
-
-            return policyBuilder.WaitAndRetry(sleepDurations, doNothing);
+            return policyBuilder.WaitAndRetry(sleepDurations, onRetry: (Action<Exception, TimeSpan>) null);
         }
 
         /// <summary>
@@ -401,16 +347,10 @@ namespace Polly
         /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// sleepDurations
-        /// or
-        /// onRetry
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurations</exception>
         public static ISyncRetryPolicy  WaitAndRetry(this PolicyBuilder policyBuilder, IEnumerable<TimeSpan> sleepDurations, Action<Exception, TimeSpan> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
-            return policyBuilder.WaitAndRetry(sleepDurations, (outcome, span, i, ctx) => onRetry(outcome, span));
+            return policyBuilder.WaitAndRetry(sleepDurations,  onRetry: onRetry == null ? (Action<Exception, TimeSpan, int, Context>)null : (outcome, span, i, ctx) => onRetry(outcome, span));
         }
 
         /// <summary>
@@ -422,17 +362,12 @@ namespace Polly
         /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// sleepDurations
-        /// or
-        /// onRetry
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurations</exception>
         public static ISyncRetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, IEnumerable<TimeSpan> sleepDurations, Action<Exception, TimeSpan, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
-            return policyBuilder.WaitAndRetry(sleepDurations, (outcome, span, i, ctx) => onRetry(outcome, span, ctx));
+            return policyBuilder.WaitAndRetry(sleepDurations, onRetry: onRetry == null ? (Action<Exception, TimeSpan, int, Context>)null : (outcome, span, i, ctx) => onRetry(outcome, span, ctx));
         }
+
 
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait and retry as many times as there are provided <paramref name="sleepDurations"/>
@@ -443,15 +378,10 @@ namespace Polly
         /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// sleepDurations
-        /// or
-        /// onRetry
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurations</exception>
         public static ISyncRetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, IEnumerable<TimeSpan> sleepDurations, Action<Exception, TimeSpan, int, Context> onRetry)
         {
             if (sleepDurations == null) throw new ArgumentNullException(nameof(sleepDurations));
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return new RetryPolicy(
                 policyBuilder,
@@ -473,9 +403,7 @@ namespace Polly
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
 
-            Action<Exception, TimeSpan> doNothing = (_, __) => { };
-
-            return policyBuilder.WaitAndRetryForever(sleepDurationProvider, doNothing);
+            return policyBuilder.WaitAndRetryForever(sleepDurationProvider, onRetry: (Action<Exception, TimeSpan>) null);
         }
 
         /// <summary>
@@ -491,9 +419,7 @@ namespace Polly
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
 
-            Action<Exception, TimeSpan, Context> doNothing = (_, __, ___) => { };
-
-            return policyBuilder.WaitAndRetryForever(sleepDurationProvider, doNothing);
+            return policyBuilder.WaitAndRetryForever(sleepDurationProvider, onRetry: (Action<Exception, TimeSpan, Context>) null);
         }
 
         /// <summary>
@@ -507,15 +433,13 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static ISyncRetryPolicy WaitAndRetryForever(this PolicyBuilder policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan> onRetry)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return policyBuilder.WaitAndRetryForever(
                 (retryCount, context) => sleepDurationProvider(retryCount),
-                (exception, timespan, context) => onRetry(exception, timespan)
+                onRetry: onRetry == null ? (Action<Exception, TimeSpan, Context>)null : (exception, timespan, context) => onRetry(exception, timespan)
             );
         }
 
@@ -530,15 +454,13 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static ISyncRetryPolicy WaitAndRetryForever(this PolicyBuilder policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, int, TimeSpan> onRetry)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return policyBuilder.WaitAndRetryForever(
                 (retryCount, exception, context) => sleepDurationProvider(retryCount),
-                (exception, i, timespan, context) => onRetry(exception, i, timespan)
+                onRetry: onRetry == null ? (Action<Exception, int, TimeSpan, Context>)null : (exception, i, timespan, context) => onRetry(exception, i, timespan)
             );
         }
 
@@ -553,7 +475,6 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static ISyncRetryPolicy WaitAndRetryForever(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, Context> onRetry)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
@@ -574,7 +495,6 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static ISyncRetryPolicy WaitAndRetryForever(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, int, TimeSpan, Context> onRetry)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
@@ -595,15 +515,13 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static ISyncRetryPolicy WaitAndRetryForever(this PolicyBuilder policyBuilder, Func<int, Exception, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, Context> onRetry)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return new RetryPolicy(
                 policyBuilder,
-                (outcome, timespan, i, ctx) => onRetry(outcome, timespan, ctx),
+                onRetry: onRetry == null ? (Action<Exception, TimeSpan, int, Context>)null : (outcome, timespan, i, ctx) => onRetry(outcome, timespan, ctx),
                 sleepDurationProvider: sleepDurationProvider);
         }
 
@@ -618,15 +536,13 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static ISyncRetryPolicy WaitAndRetryForever(this PolicyBuilder policyBuilder, Func<int, Exception, Context, TimeSpan> sleepDurationProvider, Action<Exception, int, TimeSpan, Context> onRetry)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return new RetryPolicy(
                 policyBuilder, 
-                (exception, timespan, i, ctx) => onRetry(exception, i, timespan, ctx),
+                onRetry: onRetry == null ? (Action<Exception, TimeSpan, int, Context>) null : (exception, timespan, i, ctx) => onRetry(exception, i, timespan, ctx),
                 sleepDurationProvider: sleepDurationProvider
                 );
         }

--- a/src/Polly/Retry/RetryTResultSyntax.cs
+++ b/src/Polly/Retry/RetryTResultSyntax.cs
@@ -26,9 +26,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static ISyncRetryPolicy<TResult> Retry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount)
         {
-            Action<DelegateResult<TResult>, int> doNothing = (_, __) => { };
-
-            return policyBuilder.Retry(retryCount, doNothing);
+            return policyBuilder.Retry(retryCount, onRetry: (Action<DelegateResult<TResult>, int>) null);
         }
 
         /// <summary>
@@ -38,7 +36,6 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static ISyncRetryPolicy<TResult> Retry<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>, int> onRetry)
             => policyBuilder.Retry(1, onRetry);
 
@@ -51,13 +48,11 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static ISyncRetryPolicy<TResult> Retry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Action<DelegateResult<TResult>, int> onRetry)
         {
             if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
-            return policyBuilder.Retry(retryCount, (outcome, i, ctx) => onRetry(outcome, i));
+            return policyBuilder.Retry(retryCount, onRetry: onRetry == null ? (Action<DelegateResult<TResult>, int, Context>)null : (outcome, i, ctx) => onRetry(outcome, i));
         }
 
         /// <summary>
@@ -67,7 +62,6 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static ISyncRetryPolicy<TResult> Retry<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>, int, Context> onRetry)
             => policyBuilder.Retry(1, onRetry);
 
@@ -80,15 +74,13 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static ISyncRetryPolicy<TResult> Retry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Action<DelegateResult<TResult>, int, Context> onRetry)
         {
             if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return new RetryPolicy<TResult>(
                 policyBuilder,
-                (outcome, timespan, i, ctx) => onRetry(outcome, i, ctx),
+                onRetry: onRetry == null ? (Action<DelegateResult<TResult>, TimeSpan, int, Context>)null : (outcome, timespan, i, ctx) => onRetry(outcome, i, ctx),
                 retryCount);
         }
 
@@ -99,9 +91,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static ISyncRetryPolicy<TResult> RetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder)
         {
-            Action<DelegateResult<TResult>> doNothing = _ => { };
-
-            return policyBuilder.RetryForever(doNothing);
+            return policyBuilder.RetryForever(onRetry: (Action<DelegateResult<TResult>>) null);
         }
 
         /// <summary>
@@ -111,12 +101,9 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static ISyncRetryPolicy<TResult> RetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
-            return policyBuilder.RetryForever((DelegateResult<TResult> outcome, Context ctx) => onRetry(outcome));
+            return policyBuilder.RetryForever(onRetry: onRetry == null ? (Action<DelegateResult<TResult>, Context>)null : (DelegateResult<TResult> outcome, Context ctx) => onRetry(outcome));
         }
 
         /// <summary>
@@ -126,12 +113,9 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static ISyncRetryPolicy<TResult> RetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>, int> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
-            return policyBuilder.RetryForever((outcome, i, context) => onRetry(outcome, i));
+            return policyBuilder.RetryForever(onRetry: onRetry == null ? (Action<DelegateResult<TResult>, int, Context>)null : (outcome, i, context) => onRetry(outcome, i));
         }
 
         /// <summary>
@@ -141,14 +125,11 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static ISyncRetryPolicy<TResult> RetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return new RetryPolicy<TResult>(
                 policyBuilder,
-                (outcome, timespan, i, ctx) => onRetry(outcome, ctx)
+                onRetry: onRetry == null ? (Action<DelegateResult<TResult>, TimeSpan, int, Context>)null : (outcome, timespan, i, ctx) => onRetry(outcome, ctx)
                 );
         }
 
@@ -159,14 +140,11 @@ namespace Polly
         /// <param name="policyBuilder">The policy builder.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static ISyncRetryPolicy<TResult> RetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>, int, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return new RetryPolicy<TResult>(
                 policyBuilder,
-                (outcome, timespan, i, ctx) => onRetry(outcome, i, ctx)
+                onRetry: onRetry == null ? (Action<DelegateResult<TResult>, TimeSpan, int, Context>)null : (outcome, timespan, i, ctx) => onRetry(outcome, i, ctx)
             );
         }
 
@@ -181,9 +159,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static ISyncRetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider)
         {
-            Action<DelegateResult<TResult>, TimeSpan, int, Context> doNothing = (_, __, ___, ____) => { };
-
-            return policyBuilder.WaitAndRetry(retryCount, sleepDurationProvider, doNothing);
+            return policyBuilder.WaitAndRetry(retryCount, sleepDurationProvider, onRetry: (Action<DelegateResult<TResult>, TimeSpan, int, Context>) null);
         }
 
         /// <summary>
@@ -198,19 +174,13 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        /// sleepDurationProvider
-        /// or
-        /// onRetry
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static ISyncRetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.WaitAndRetry(
                 retryCount,
                 sleepDurationProvider,
-                (outcome, span, i, ctx) => onRetry(outcome, span)
+                onRetry: onRetry == null ? (Action<DelegateResult<TResult>, TimeSpan, int, Context>)null : (outcome, span, i, ctx) => onRetry(outcome, span)
             );
         }
 
@@ -226,19 +196,13 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        /// sleepDurationProvider
-        /// or
-        /// onRetry
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static ISyncRetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.WaitAndRetry(
                 retryCount, 
-                sleepDurationProvider, 
-                (outcome, span, i, ctx) => onRetry(outcome, span, ctx)
+                sleepDurationProvider,
+                onRetry: onRetry == null ? (Action<DelegateResult<TResult>, TimeSpan, int, Context>)null : (outcome, span, i, ctx) => onRetry(outcome, span, ctx)
                 );
         }
 
@@ -254,16 +218,11 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        /// timeSpanProvider
-        /// or
-        /// onRetry
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static ISyncRetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
         {
             if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             var sleepDurations = Enumerable.Range(1, retryCount)
                                            .Select(sleepDurationProvider);
@@ -287,9 +246,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static ISyncRetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider)
         {
-            Action<DelegateResult<TResult>, TimeSpan, int, Context> doNothing = (_, __, ___, ____) => { };
-
-            return policyBuilder.WaitAndRetry(retryCount, sleepDurationProvider, doNothing);
+            return policyBuilder.WaitAndRetry(retryCount, sleepDurationProvider, onRetry: (Action<DelegateResult<TResult>, TimeSpan, int, Context>) null);
         }
 
         /// <summary>
@@ -304,19 +261,13 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        /// sleepDurationProvider
-        /// or
-        /// onRetry
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static ISyncRetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.WaitAndRetry(
                 retryCount,
                 sleepDurationProvider,
-                (outcome, span, i, ctx) => onRetry(outcome, span, ctx)
+                onRetry: onRetry == null ? (Action<DelegateResult<TResult>, TimeSpan, int, Context>)null : (outcome, span, i, ctx) => onRetry(outcome, span, ctx)
                 );
         }
 
@@ -332,15 +283,11 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        /// timeSpanProvider
-        /// or
-        /// onRetry
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static ISyncRetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
             => policyBuilder.WaitAndRetry(
                 retryCount,
-                (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+                sleepDurationProvider: (i, outcome, ctx) => sleepDurationProvider(i, ctx),
                 onRetry
             );
 
@@ -355,9 +302,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static ISyncRetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider)
         {
-            Action<DelegateResult<TResult>, TimeSpan, int, Context> doNothing = (_, __, ___, ____) => { };
-
-            return policyBuilder.WaitAndRetry(retryCount, sleepDurationProvider, doNothing);
+            return policyBuilder.WaitAndRetry(retryCount, sleepDurationProvider, onRetry: (Action<DelegateResult<TResult>, TimeSpan, int, Context>) null);
         }
 
         /// <summary>
@@ -372,19 +317,13 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        /// sleepDurationProvider
-        /// or
-        /// onRetry
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static ISyncRetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
             return policyBuilder.WaitAndRetry(
                 retryCount,
                 sleepDurationProvider,
-                (outcome, span, i, ctx) => onRetry(outcome, span, ctx)
+                onRetry: onRetry == null ? (Action<DelegateResult<TResult>, TimeSpan, int, Context>)null : (outcome, span, i, ctx) => onRetry(outcome, span, ctx)
                 );
         }
 
@@ -400,16 +339,11 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-        /// <exception cref="ArgumentNullException">
-        /// timeSpanProvider
-        /// or
-        /// onRetry
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
         public static ISyncRetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
         {
             if (retryCount < 0) throw new ArgumentOutOfRangeException(nameof(retryCount), "Value must be greater than or equal to zero.");
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return new RetryPolicy<TResult>(
                 policyBuilder,
@@ -428,9 +362,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static ISyncRetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, IEnumerable<TimeSpan> sleepDurations)
         {
-            Action<DelegateResult<TResult>, TimeSpan> doNothing = (_, __) => { };
-
-            return policyBuilder.WaitAndRetry(sleepDurations, doNothing);
+            return policyBuilder.WaitAndRetry(sleepDurations, onRetry: (Action<DelegateResult<TResult>, TimeSpan>) null);
         }
 
         /// <summary>
@@ -442,16 +374,10 @@ namespace Polly
         /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// sleepDurations
-        /// or
-        /// onRetry
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurations</exception>
         public static ISyncRetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, IEnumerable<TimeSpan> sleepDurations, Action<DelegateResult<TResult>, TimeSpan> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
-            return policyBuilder.WaitAndRetry(sleepDurations, (outcome, span, i, ctx) => onRetry(outcome, span));
+            return policyBuilder.WaitAndRetry(sleepDurations, onRetry: onRetry == null ? (Action<DelegateResult<TResult>, TimeSpan, int, Context>)null : (outcome, span, i, ctx) => onRetry(outcome, span));
         }
 
         /// <summary>
@@ -463,16 +389,10 @@ namespace Polly
         /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// sleepDurations
-        /// or
-        /// onRetry
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurations</exception>
         public static ISyncRetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, IEnumerable<TimeSpan> sleepDurations, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
         {
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
-
-            return policyBuilder.WaitAndRetry(sleepDurations, (outcome, span, i, ctx) => onRetry(outcome, span, ctx));
+            return policyBuilder.WaitAndRetry(sleepDurations, onRetry: onRetry == null ? (Action<DelegateResult<TResult>, TimeSpan, int, Context>)null : (outcome, span, i, ctx) => onRetry(outcome, span, ctx));
         }
 
         /// <summary>
@@ -484,15 +404,10 @@ namespace Polly
         /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// sleepDurations
-        /// or
-        /// onRetry
-        /// </exception>
+        /// <exception cref="ArgumentNullException">sleepDurations</exception>
         public static ISyncRetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, IEnumerable<TimeSpan> sleepDurations, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
         {
             if (sleepDurations == null) throw new ArgumentNullException(nameof(sleepDurations));
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return new RetryPolicy<TResult>(
                 policyBuilder,
@@ -514,9 +429,7 @@ namespace Polly
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
 
-            Action<DelegateResult<TResult>, TimeSpan> doNothing = (_, __) => { };
-
-            return policyBuilder.WaitAndRetryForever(sleepDurationProvider, doNothing);
+            return policyBuilder.WaitAndRetryForever(sleepDurationProvider, onRetry: (Action<DelegateResult<TResult>, TimeSpan>) null);
         }
 
         /// <summary>
@@ -532,9 +445,7 @@ namespace Polly
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
 
-            Action<DelegateResult<TResult>, TimeSpan, Context> doNothing = (_, __, ___) => { };
-
-            return policyBuilder.WaitAndRetryForever(sleepDurationProvider, doNothing);
+            return policyBuilder.WaitAndRetryForever(sleepDurationProvider, onRetry: (Action<DelegateResult<TResult>, TimeSpan, Context>) null);
         }
 
         /// <summary>
@@ -548,15 +459,13 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static ISyncRetryPolicy<TResult> WaitAndRetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan> onRetry)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return policyBuilder.WaitAndRetryForever(
-                (retryCount, context) => sleepDurationProvider(retryCount),
-                (exception, timespan, context) => onRetry(exception, timespan)
+                sleepDurationProvider: (retryCount, context) => sleepDurationProvider(retryCount),
+                onRetry: onRetry == null ? (Action<DelegateResult<TResult>, TimeSpan, Context>)null : (exception, timespan, context) => onRetry(exception, timespan)
             );
         }
 
@@ -571,15 +480,13 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static ISyncRetryPolicy<TResult> WaitAndRetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, int, TimeSpan> onRetry)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return policyBuilder.WaitAndRetryForever(
-                (retryCount, outcome, context) => sleepDurationProvider(retryCount),
-                (outcome, i, timespan, context) => onRetry(outcome, i, timespan)
+                sleepDurationProvider: (retryCount, outcome, context) => sleepDurationProvider(retryCount),
+                onRetry: onRetry == null ? (Action<DelegateResult<TResult>, int, TimeSpan, Context>)null : (outcome, i, timespan, context) => onRetry(outcome, i, timespan)
             );
         }
 
@@ -594,12 +501,11 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static ISyncRetryPolicy<TResult> WaitAndRetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             return policyBuilder.WaitAndRetryForever(
-                (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+                sleepDurationProvider: (i, outcome, ctx) => sleepDurationProvider(i, ctx),
                 onRetry
             );
         }
@@ -615,12 +521,11 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static ISyncRetryPolicy<TResult> WaitAndRetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, int, TimeSpan, Context> onRetry)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
             return policyBuilder.WaitAndRetryForever(
-                (i, outcome, ctx) => sleepDurationProvider(i, ctx),
+                sleepDurationProvider: (i, outcome, ctx) => sleepDurationProvider(i, ctx),
                 onRetry
             );
         }
@@ -636,15 +541,13 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static ISyncRetryPolicy<TResult> WaitAndRetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return new RetryPolicy<TResult>(
                 policyBuilder,
-                (outcome, timespan, i, ctx) => onRetry(outcome, timespan, ctx),
+                onRetry: onRetry == null ? (Action<DelegateResult<TResult>, TimeSpan, int, Context>)null : (outcome, timespan, i, ctx) => onRetry(outcome, timespan, ctx),
                 sleepDurationProvider: sleepDurationProvider);
         }
 
@@ -659,15 +562,13 @@ namespace Polly
         /// <param name="onRetry">The action to call on each retry.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-        /// <exception cref="ArgumentNullException">onRetry</exception>
         public static ISyncRetryPolicy<TResult> WaitAndRetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, int, TimeSpan, Context> onRetry)
         {
             if (sleepDurationProvider == null) throw new ArgumentNullException(nameof(sleepDurationProvider));
-            if (onRetry == null) throw new ArgumentNullException(nameof(onRetry));
 
             return new RetryPolicy<TResult>(
                 policyBuilder,
-                (exception, timespan, i, ctx) => onRetry(exception, i, timespan, ctx),
+                onRetry: onRetry == null ? (Action<DelegateResult<TResult>, TimeSpan, int, Context>)null : (exception, timespan, i, ctx) => onRetry(exception, i, timespan, ctx),
                 sleepDurationProvider: sleepDurationProvider
                 );
         }

--- a/src/Polly/Timeout/AsyncTimeoutEngine.cs
+++ b/src/Polly/Timeout/AsyncTimeoutEngine.cs
@@ -51,7 +51,7 @@ namespace Polly.Timeout
                         // as either of those tokens could have been onward combined with another token by executed code, and so may not be the token expressed on operationCanceledException.CancellationToken.
                         if (ex is OperationCanceledException && timeoutCancellationTokenSource.IsCancellationRequested)
                         {
-                            await onTimeoutAsync(context, timeout, actionTask, ex).ConfigureAwait(continueOnCapturedContext);
+                            if (onTimeoutAsync != null) { await onTimeoutAsync(context, timeout, actionTask, ex).ConfigureAwait(continueOnCapturedContext);}
                             throw new TimeoutRejectedException("The delegate executed asynchronously through TimeoutPolicy did not complete within the timeout.", ex);
                         }
 

--- a/src/Polly/Timeout/AsyncTimeoutPolicy.cs
+++ b/src/Polly/Timeout/AsyncTimeoutPolicy.cs
@@ -22,7 +22,7 @@ namespace Polly.Timeout
         {
             _timeoutProvider = timeoutProvider ?? throw new ArgumentNullException(nameof(timeoutProvider));
             _timeoutStrategy = timeoutStrategy;
-            _onTimeoutAsync = onTimeoutAsync ?? throw new ArgumentNullException(nameof(onTimeoutAsync));
+            _onTimeoutAsync = onTimeoutAsync;
         }
 
         /// <inheritdoc/>
@@ -61,7 +61,7 @@ namespace Polly.Timeout
         {
             _timeoutProvider = timeoutProvider ?? throw new ArgumentNullException(nameof(timeoutProvider));
             _timeoutStrategy = timeoutStrategy;
-            _onTimeoutAsync = onTimeoutAsync ?? throw new ArgumentNullException(nameof(onTimeoutAsync));
+            _onTimeoutAsync = onTimeoutAsync;
         }
 
         /// <inheritdoc/>

--- a/src/Polly/Timeout/AsyncTimeoutSyntax.cs
+++ b/src/Polly/Timeout/AsyncTimeoutSyntax.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Polly.Timeout;
-using Polly.Utilities;
 
 namespace Polly
 {

--- a/src/Polly/Timeout/AsyncTimeoutSyntax.cs
+++ b/src/Polly/Timeout/AsyncTimeoutSyntax.cs
@@ -16,9 +16,8 @@ namespace Polly
         public static IAsyncTimeoutPolicy TimeoutAsync(int seconds)
         {
             TimeoutValidator.ValidateSecondsTimeout(seconds);
-            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => TaskHelper.EmptyTask;
 
-            return TimeoutAsync(ctx => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, doNothingAsync);
+            return TimeoutAsync(ctx => TimeSpan.FromSeconds(seconds), DefaultTimeoutStrategy, onTimeoutAsync: (Func<Context, TimeSpan, Task, Exception, Task>)null);
         }
 
         /// <summary>
@@ -31,9 +30,8 @@ namespace Polly
         public static IAsyncTimeoutPolicy TimeoutAsync(int seconds, TimeoutStrategy timeoutStrategy)
         {
             TimeoutValidator.ValidateSecondsTimeout(seconds);
-            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => TaskHelper.EmptyTask;
 
-            return TimeoutAsync(ctx => TimeSpan.FromSeconds(seconds), timeoutStrategy, doNothingAsync);
+            return TimeoutAsync(ctx => TimeSpan.FromSeconds(seconds), timeoutStrategy, onTimeoutAsync: (Func<Context, TimeSpan, Task, Exception, Task>)null);
         }
 
         /// <summary>
@@ -44,14 +42,12 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy TimeoutAsync(int seconds, Func<Context
             , TimeSpan, Task, Task> onTimeoutAsync)
         {
             TimeoutValidator.ValidateSecondsTimeout(seconds);
-            if (onTimeoutAsync == null) throw new ArgumentNullException(nameof(onTimeoutAsync));
 
-            return TimeoutAsync(ctx => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, onTimeoutAsync);
+            return TimeoutAsync(ctx => TimeSpan.FromSeconds(seconds), DefaultTimeoutStrategy, onTimeoutAsync);
         }
 
         /// <summary>
@@ -62,13 +58,11 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy TimeoutAsync(int seconds, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
         {
-            if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
-            if (onTimeoutAsync == null) throw new ArgumentNullException(nameof(onTimeoutAsync));
+            TimeoutValidator.ValidateSecondsTimeout(seconds);
 
-            return TimeoutAsync(ctx => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, onTimeoutAsync);
+            return TimeoutAsync(ctx => TimeSpan.FromSeconds(seconds), DefaultTimeoutStrategy, onTimeoutAsync);
         }
 
         /// <summary>
@@ -100,7 +94,7 @@ namespace Polly
         /// <exception cref="ArgumentNullException">seconds;Value must be greater than zero.</exception>
         public static IAsyncTimeoutPolicy TimeoutAsync(int seconds, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
         {
-            if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
+            TimeoutValidator.ValidateSecondsTimeout(seconds);
 
             return TimeoutAsync(ctx => TimeSpan.FromSeconds(seconds), timeoutStrategy, onTimeoutAsync);
         }
@@ -114,9 +108,8 @@ namespace Polly
         public static IAsyncTimeoutPolicy TimeoutAsync(TimeSpan timeout)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
-            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => TaskHelper.EmptyTask;
 
-            return TimeoutAsync(ctx => timeout, TimeoutStrategy.Optimistic, doNothingAsync);
+            return TimeoutAsync(ctx => timeout, DefaultTimeoutStrategy, onTimeoutAsync: (Func<Context, TimeSpan, Task, Exception, Task>)null);
         }
 
         /// <summary>
@@ -129,9 +122,8 @@ namespace Polly
         public static IAsyncTimeoutPolicy TimeoutAsync(TimeSpan timeout, TimeoutStrategy timeoutStrategy)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
-            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => TaskHelper.EmptyTask;
 
-            return TimeoutAsync(ctx => timeout, timeoutStrategy, doNothingAsync);
+            return TimeoutAsync(ctx => timeout, timeoutStrategy, onTimeoutAsync: (Func<Context, TimeSpan, Task, Exception, Task>)null);
         }
 
         /// <summary>
@@ -142,12 +134,11 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy TimeoutAsync(TimeSpan timeout, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
 
-            return TimeoutAsync(ctx => timeout, TimeoutStrategy.Optimistic, onTimeoutAsync);
+            return TimeoutAsync(ctx => timeout, DefaultTimeoutStrategy, onTimeoutAsync);
         }
 
         /// <summary>
@@ -158,12 +149,11 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy TimeoutAsync(TimeSpan timeout, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
 
-            return TimeoutAsync(ctx => timeout, TimeoutStrategy.Optimistic, onTimeoutAsync);
+            return TimeoutAsync(ctx => timeout, DefaultTimeoutStrategy, onTimeoutAsync);
         }
 
         /// <summary>
@@ -175,7 +165,6 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy TimeoutAsync(TimeSpan timeout, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
@@ -192,7 +181,6 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy TimeoutAsync(TimeSpan timeout, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
@@ -210,8 +198,7 @@ namespace Polly
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
-            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => TaskHelper.EmptyTask;
-            return TimeoutAsync(ctx => timeoutProvider(), TimeoutStrategy.Optimistic, doNothingAsync);
+            return TimeoutAsync(ctx => timeoutProvider(), DefaultTimeoutStrategy, onTimeoutAsync: (Func<Context, TimeSpan, Task, Exception, Task>)null);
         }
 
         /// <summary>
@@ -225,8 +212,7 @@ namespace Polly
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
-            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => TaskHelper.EmptyTask;
-            return TimeoutAsync(ctx => timeoutProvider(), timeoutStrategy, doNothingAsync);
+            return TimeoutAsync(ctx => timeoutProvider(), timeoutStrategy, onTimeoutAsync: (Func<Context, TimeSpan, Task, Exception, Task>)null);
         }
 
         /// <summary>
@@ -237,12 +223,11 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy TimeoutAsync(Func<TimeSpan> timeoutProvider, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
-            return TimeoutAsync(ctx => timeoutProvider(), TimeoutStrategy.Optimistic, onTimeoutAsync);
+            return TimeoutAsync(ctx => timeoutProvider(), DefaultTimeoutStrategy, onTimeoutAsync);
         }
 
         /// <summary>
@@ -253,12 +238,11 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy TimeoutAsync(Func<TimeSpan> timeoutProvider, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
-            return TimeoutAsync(ctx => timeoutProvider(), TimeoutStrategy.Optimistic, onTimeoutAsync);
+            return TimeoutAsync(ctx => timeoutProvider(), DefaultTimeoutStrategy, onTimeoutAsync);
         }
 
         /// <summary>
@@ -270,7 +254,6 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy TimeoutAsync(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
@@ -287,7 +270,6 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy TimeoutAsync(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
@@ -303,9 +285,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static IAsyncTimeoutPolicy TimeoutAsync(Func<Context, TimeSpan> timeoutProvider)
         {
-            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => TaskHelper.EmptyTask;
-
-            return TimeoutAsync(timeoutProvider, TimeoutStrategy.Optimistic, doNothingAsync);
+            return TimeoutAsync(timeoutProvider, DefaultTimeoutStrategy, onTimeoutAsync: (Func<Context, TimeSpan, Task, Exception, Task>)null);
         }
 
         /// <summary>
@@ -317,9 +297,7 @@ namespace Polly
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
         public static IAsyncTimeoutPolicy TimeoutAsync(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy)
         {
-            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => TaskHelper.EmptyTask;
-
-            return TimeoutAsync(timeoutProvider, timeoutStrategy, doNothingAsync);
+            return TimeoutAsync(timeoutProvider, timeoutStrategy, onTimeoutAsync: (Func<Context, TimeSpan, Task, Exception, Task>)null);
         }
 
         /// <summary>
@@ -330,9 +308,8 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy TimeoutAsync(Func<Context, TimeSpan> timeoutProvider, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
-            => TimeoutAsync(timeoutProvider, TimeoutStrategy.Optimistic, onTimeoutAsync);
+            => TimeoutAsync(timeoutProvider, DefaultTimeoutStrategy, onTimeoutAsync);
 
         /// <summary>
         /// Builds an <see cref="AsyncPolicy"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
@@ -342,9 +319,8 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy TimeoutAsync(Func<Context, TimeSpan> timeoutProvider, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
-            => TimeoutAsync(timeoutProvider, TimeoutStrategy.Optimistic, onTimeoutAsync);
+            => TimeoutAsync(timeoutProvider, DefaultTimeoutStrategy, onTimeoutAsync);
 
         /// <summary>
         /// Builds an <see cref="AsyncPolicy" /> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
@@ -355,12 +331,9 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy TimeoutAsync(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
         {
-            if (onTimeoutAsync == null) throw new ArgumentNullException(nameof(onTimeoutAsync));
-
-            return TimeoutAsync(timeoutProvider, timeoutStrategy, (ctx, timeout, task, ex) => onTimeoutAsync(ctx, timeout, task));
+            return TimeoutAsync(timeoutProvider, timeoutStrategy, onTimeoutAsync == null ? (Func<Context, TimeSpan, Task, Exception, Task>)null : (ctx, timeout, task, ex) => onTimeoutAsync(ctx, timeout, task));
         }
 
         /// <summary>
@@ -372,14 +345,12 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy TimeoutAsync(
             Func<Context, TimeSpan> timeoutProvider, 
             TimeoutStrategy timeoutStrategy, 
             Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
-            if (onTimeoutAsync == null) throw new ArgumentNullException(nameof(onTimeoutAsync));
 
             return new AsyncTimeoutPolicy(
                     timeoutProvider,

--- a/src/Polly/Timeout/AsyncTimeoutTResultSyntax.cs
+++ b/src/Polly/Timeout/AsyncTimeoutTResultSyntax.cs
@@ -16,8 +16,7 @@ namespace Polly
         {
             TimeoutValidator.ValidateSecondsTimeout(seconds);
 
-            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => Task.FromResult(default(TResult));
-            return TimeoutAsync<TResult>(ctx => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, doNothingAsync);
+            return TimeoutAsync<TResult>(ctx => TimeSpan.FromSeconds(seconds), DefaultTimeoutStrategy, onTimeoutAsync: (Func<Context, TimeSpan, Task, Exception, Task>)null);
         }
 
         /// <summary>
@@ -31,8 +30,7 @@ namespace Polly
         {
             TimeoutValidator.ValidateSecondsTimeout(seconds);
 
-            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => Task.FromResult(default(TResult));
-            return TimeoutAsync<TResult>(ctx => TimeSpan.FromSeconds(seconds), timeoutStrategy, doNothingAsync);
+            return TimeoutAsync<TResult>(ctx => TimeSpan.FromSeconds(seconds), timeoutStrategy, onTimeoutAsync: (Func<Context, TimeSpan, Task, Exception, Task>)null);
         }
 
         /// <summary>
@@ -43,12 +41,11 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(int seconds, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
         {
             TimeoutValidator.ValidateSecondsTimeout(seconds);
 
-            return TimeoutAsync<TResult>(ctx => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, onTimeoutAsync);
+            return TimeoutAsync<TResult>(ctx => TimeSpan.FromSeconds(seconds), DefaultTimeoutStrategy, onTimeoutAsync);
         }
 
         /// <summary>
@@ -59,12 +56,11 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(int seconds, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
         {
-            if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
+            TimeoutValidator.ValidateSecondsTimeout(seconds);
 
-            return TimeoutAsync<TResult>(ctx => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, onTimeoutAsync);
+            return TimeoutAsync<TResult>(ctx => TimeSpan.FromSeconds(seconds), DefaultTimeoutStrategy, onTimeoutAsync);
         }
 
         /// <summary>
@@ -76,7 +72,6 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(int seconds, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
         {
             TimeoutValidator.ValidateSecondsTimeout(seconds);
@@ -93,10 +88,9 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(int seconds, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
         {
-            if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
+            TimeoutValidator.ValidateSecondsTimeout(seconds);
 
             return TimeoutAsync<TResult>(ctx => TimeSpan.FromSeconds(seconds), timeoutStrategy, onTimeoutAsync);
         }
@@ -111,8 +105,7 @@ namespace Polly
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
 
-            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => Task.FromResult(default(TResult));
-            return TimeoutAsync<TResult>(ctx => timeout, TimeoutStrategy.Optimistic, doNothingAsync);
+            return TimeoutAsync<TResult>(ctx => timeout, DefaultTimeoutStrategy, onTimeoutAsync: (Func<Context, TimeSpan, Task, Exception, Task>)null);
         }
 
         /// <summary>
@@ -126,8 +119,7 @@ namespace Polly
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
 
-            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => Task.FromResult(default(TResult));
-            return TimeoutAsync<TResult>(ctx => timeout, timeoutStrategy, doNothingAsync);
+            return TimeoutAsync<TResult>(ctx => timeout, timeoutStrategy, onTimeoutAsync: (Func<Context, TimeSpan, Task, Exception, Task>)null);
         }
 
         /// <summary>
@@ -138,13 +130,11 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(TimeSpan timeout, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
-            if (onTimeoutAsync == null) throw new ArgumentNullException(nameof(onTimeoutAsync));
 
-            return TimeoutAsync<TResult>(ctx => timeout, TimeoutStrategy.Optimistic, onTimeoutAsync);
+            return TimeoutAsync<TResult>(ctx => timeout, DefaultTimeoutStrategy, onTimeoutAsync);
         }
 
         /// <summary>
@@ -155,13 +145,11 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(TimeSpan timeout, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
         {
             if (timeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
-            if (onTimeoutAsync == null) throw new ArgumentNullException(nameof(onTimeoutAsync));
-
-            return TimeoutAsync<TResult>(ctx => timeout, TimeoutStrategy.Optimistic, onTimeoutAsync);
+            
+            return TimeoutAsync<TResult>(ctx => timeout, DefaultTimeoutStrategy, onTimeoutAsync);
         }
 
         /// <summary>
@@ -173,7 +161,6 @@ namespace Polly
         /// <param name="timeoutStrategy">The timeout strategy.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(TimeSpan timeout, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
@@ -190,7 +177,6 @@ namespace Polly
         /// <param name="timeoutStrategy">The timeout strategy.</param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(TimeSpan timeout, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
         {
             if (timeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
@@ -208,8 +194,7 @@ namespace Polly
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
-            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => Task.FromResult(default(TResult));
-            return TimeoutAsync<TResult>(ctx => timeoutProvider(), TimeoutStrategy.Optimistic, doNothingAsync);
+            return TimeoutAsync<TResult>(ctx => timeoutProvider(), DefaultTimeoutStrategy, onTimeoutAsync: (Func<Context, TimeSpan, Task, Exception, Task>)null);
         }
 
         /// <summary>
@@ -223,8 +208,7 @@ namespace Polly
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
-            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => Task.FromResult(default(TResult));
-            return TimeoutAsync<TResult>(ctx => timeoutProvider(), timeoutStrategy, doNothingAsync);
+            return TimeoutAsync<TResult>(ctx => timeoutProvider(), timeoutStrategy, onTimeoutAsync: (Func<Context, TimeSpan, Task, Exception, Task>)null);
         }
 
         /// <summary>
@@ -235,12 +219,11 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<TimeSpan> timeoutProvider, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
-            return TimeoutAsync<TResult>(ctx => timeoutProvider(), TimeoutStrategy.Optimistic, onTimeoutAsync);
+            return TimeoutAsync<TResult>(ctx => timeoutProvider(), DefaultTimeoutStrategy, onTimeoutAsync);
         }
 
         /// <summary>
@@ -251,12 +234,11 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<TimeSpan> timeoutProvider, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
-            return TimeoutAsync<TResult>(ctx => timeoutProvider(), TimeoutStrategy.Optimistic, onTimeoutAsync);
+            return TimeoutAsync<TResult>(ctx => timeoutProvider(), DefaultTimeoutStrategy, onTimeoutAsync);
         }
 
         /// <summary>
@@ -268,7 +250,6 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
@@ -285,7 +266,6 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
@@ -302,7 +282,7 @@ namespace Polly
         public static IAsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<Context, TimeSpan> timeoutProvider)
         {
             Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => Task.FromResult(default(TResult));
-            return TimeoutAsync<TResult>(timeoutProvider, TimeoutStrategy.Optimistic, doNothingAsync);
+            return TimeoutAsync<TResult>(timeoutProvider, DefaultTimeoutStrategy, doNothingAsync);
         }
 
         /// <summary>
@@ -314,8 +294,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static IAsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy)
         {
-            Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, __, ___, ____) => Task.FromResult(default(TResult));
-            return TimeoutAsync<TResult>(timeoutProvider, timeoutStrategy, doNothingAsync);
+            return TimeoutAsync<TResult>(timeoutProvider, timeoutStrategy, onTimeoutAsync: (Func<Context, TimeSpan, Task, Exception, Task>)null);
         }
 
         /// <summary>
@@ -326,9 +305,8 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<Context, TimeSpan> timeoutProvider, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
-            => TimeoutAsync<TResult>(timeoutProvider, TimeoutStrategy.Optimistic, onTimeoutAsync);
+            => TimeoutAsync<TResult>(timeoutProvider, DefaultTimeoutStrategy, onTimeoutAsync);
 
         /// <summary>
         /// Builds an <see cref="AsyncPolicy{TResult}"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
@@ -338,9 +316,8 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<Context, TimeSpan> timeoutProvider, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
-            => TimeoutAsync<TResult>(timeoutProvider, TimeoutStrategy.Optimistic, onTimeoutAsync);
+            => TimeoutAsync<TResult>(timeoutProvider, DefaultTimeoutStrategy, onTimeoutAsync);
 
         /// <summary>
         /// Builds an <see cref="AsyncPolicy{TResult}"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
@@ -351,12 +328,9 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
         {
-            if (onTimeoutAsync == null) throw new ArgumentNullException(nameof(onTimeoutAsync));
-
-            return TimeoutAsync<TResult>(timeoutProvider, timeoutStrategy, (ctx, timeout, task, ex) => onTimeoutAsync(ctx, timeout, task));
+            return TimeoutAsync<TResult>(timeoutProvider, timeoutStrategy, onTimeoutAsync == null ? (Func<Context, TimeSpan, Task, Exception, Task>)null : (ctx, timeout, task, ex) => onTimeoutAsync(ctx, timeout, task));
         }
 
         /// <summary>
@@ -368,11 +342,9 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
         public static IAsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
-            if (onTimeoutAsync == null) throw new ArgumentNullException(nameof(onTimeoutAsync));
 
             return new AsyncTimeoutPolicy<TResult>(
                     timeoutProvider,

--- a/src/Polly/Timeout/TimeoutEngine.cs
+++ b/src/Polly/Timeout/TimeoutEngine.cs
@@ -58,7 +58,7 @@ namespace Polly.Timeout
                         // as either of those tokens could have been onward combined with another token by executed code, and so may not be the token expressed on operationCanceledException.CancellationToken.
                         if (ex is OperationCanceledException && timeoutCancellationTokenSource.IsCancellationRequested)
                         {
-                            onTimeout(context, timeout, actionTask, ex);
+                            onTimeout?.Invoke(context, timeout, actionTask, ex);
                             throw new TimeoutRejectedException("The delegate executed through TimeoutPolicy did not complete within the timeout.", ex);
                         }
 

--- a/src/Polly/Timeout/TimeoutPolicy.cs
+++ b/src/Polly/Timeout/TimeoutPolicy.cs
@@ -21,7 +21,7 @@ namespace Polly.Timeout
         {
             _timeoutProvider = timeoutProvider ?? throw new ArgumentNullException(nameof(timeoutProvider));
             _timeoutStrategy = timeoutStrategy;
-            _onTimeout = onTimeout ?? throw new ArgumentNullException(nameof(onTimeout));
+            _onTimeout = onTimeout;
         }
 
         /// <inheritdoc/>
@@ -53,7 +53,7 @@ namespace Polly.Timeout
         {
             _timeoutProvider = timeoutProvider ?? throw new ArgumentNullException(nameof(timeoutProvider));
             _timeoutStrategy = timeoutStrategy;
-            _onTimeout = onTimeout ?? throw new ArgumentNullException(nameof(onTimeout));
+            _onTimeout = onTimeout;
         }
 
         /// <inheritdoc/>

--- a/src/Polly/Timeout/TimeoutSyntax.cs
+++ b/src/Polly/Timeout/TimeoutSyntax.cs
@@ -6,6 +6,8 @@ namespace Polly
 {
     public partial class Policy
     {
+        private const TimeoutStrategy DefaultTimeoutStrategy = TimeoutStrategy.Optimistic;
+
         /// <summary>
         /// Builds a <see cref="Policy"/> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
         /// </summary>
@@ -15,9 +17,8 @@ namespace Polly
         public static ISyncTimeoutPolicy Timeout(int seconds)
         {
             TimeoutValidator.ValidateSecondsTimeout(seconds);
-            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
 
-            return Timeout(ctx => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, doNothing);
+            return Timeout(ctx => TimeSpan.FromSeconds(seconds), DefaultTimeoutStrategy, onTimeout: (Action<Context, TimeSpan, Task, Exception>)null);
         }
 
         /// <summary>
@@ -30,9 +31,8 @@ namespace Polly
         public static ISyncTimeoutPolicy Timeout(int seconds, TimeoutStrategy timeoutStrategy)
         {
             TimeoutValidator.ValidateSecondsTimeout(seconds);
-            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
 
-            return Timeout(ctx => TimeSpan.FromSeconds(seconds), timeoutStrategy, doNothing);
+            return Timeout(ctx => TimeSpan.FromSeconds(seconds), timeoutStrategy, onTimeout: (Action<Context, TimeSpan, Task, Exception>)null);
         }
 
         /// <summary>
@@ -43,12 +43,12 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
+        
         public static ISyncTimeoutPolicy Timeout(int seconds, Action<Context, TimeSpan, Task> onTimeout)
         {
             TimeoutValidator.ValidateSecondsTimeout(seconds);
 
-            return Timeout(ctx => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, onTimeout);
+            return Timeout(ctx => TimeSpan.FromSeconds(seconds), DefaultTimeoutStrategy, onTimeout);
         }
 
         /// <summary>
@@ -59,12 +59,11 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy Timeout(int seconds, Action<Context, TimeSpan, Task, Exception> onTimeout)
         {
-            if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
+            TimeoutValidator.ValidateSecondsTimeout(seconds);
 
-            return Timeout(ctx => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, onTimeout);
+            return Timeout(ctx => TimeSpan.FromSeconds(seconds), DefaultTimeoutStrategy, onTimeout);
         }
 
         /// <summary>
@@ -76,7 +75,6 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy Timeout(int seconds, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task> onTimeout)
         {
             TimeoutValidator.ValidateSecondsTimeout(seconds);
@@ -93,10 +91,9 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy Timeout(int seconds, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task, Exception> onTimeout)
         {
-            if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
+            TimeoutValidator.ValidateSecondsTimeout(seconds);
 
             return Timeout(ctx => TimeSpan.FromSeconds(seconds), timeoutStrategy, onTimeout);
         }
@@ -110,9 +107,8 @@ namespace Polly
         public static ISyncTimeoutPolicy Timeout(TimeSpan timeout)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
-            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
 
-            return Timeout(ctx => timeout, TimeoutStrategy.Optimistic, doNothing);
+            return Timeout(ctx => timeout, DefaultTimeoutStrategy, onTimeout: (Action<Context, TimeSpan, Task, Exception>)null);
         }
 
         /// <summary>
@@ -125,9 +121,8 @@ namespace Polly
         public static ISyncTimeoutPolicy Timeout(TimeSpan timeout, TimeoutStrategy timeoutStrategy)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
-            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
 
-            return Timeout(ctx => timeout, timeoutStrategy, doNothing);
+            return Timeout(ctx => timeout, timeoutStrategy, onTimeout: (Action<Context, TimeSpan, Task, Exception>)null);
         }
 
         /// <summary>
@@ -138,12 +133,11 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy Timeout(TimeSpan timeout, Action<Context, TimeSpan, Task> onTimeout)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
 
-            return Timeout(ctx => timeout, TimeoutStrategy.Optimistic, onTimeout);
+            return Timeout(ctx => timeout, DefaultTimeoutStrategy, onTimeout);
         }
 
         /// <summary>
@@ -154,12 +148,11 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy Timeout(TimeSpan timeout, Action<Context, TimeSpan, Task, Exception> onTimeout)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
 
-            return Timeout(ctx => timeout, TimeoutStrategy.Optimistic, onTimeout);
+            return Timeout(ctx => timeout, DefaultTimeoutStrategy, onTimeout);
         }
 
         /// <summary>
@@ -171,7 +164,6 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy Timeout(TimeSpan timeout, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task> onTimeout)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
@@ -188,7 +180,6 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy Timeout(TimeSpan timeout, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task, Exception> onTimeout)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
@@ -206,8 +197,7 @@ namespace Polly
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
-            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
-            return Timeout(ctx => timeoutProvider(), TimeoutStrategy.Optimistic, doNothing);
+            return Timeout(ctx => timeoutProvider(), DefaultTimeoutStrategy, onTimeout: (Action<Context, TimeSpan, Task, Exception>)null);
         }
 
         /// <summary>
@@ -221,8 +211,7 @@ namespace Polly
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
-            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
-            return Timeout(ctx => timeoutProvider(), timeoutStrategy, doNothing);
+            return Timeout(ctx => timeoutProvider(), timeoutStrategy, onTimeout: (Action<Context, TimeSpan, Task, Exception>)null);
         }
 
         /// <summary>
@@ -233,12 +222,11 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy Timeout(Func<TimeSpan> timeoutProvider, Action<Context, TimeSpan, Task> onTimeout)
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
-            return Timeout(ctx => timeoutProvider(), TimeoutStrategy.Optimistic, onTimeout);
+            return Timeout(ctx => timeoutProvider(), DefaultTimeoutStrategy, onTimeout);
         }
 
         /// <summary>
@@ -249,12 +237,11 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy Timeout(Func<TimeSpan> timeoutProvider, Action<Context, TimeSpan, Task, Exception> onTimeout)
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
-            return Timeout(ctx => timeoutProvider(), TimeoutStrategy.Optimistic, onTimeout);
+            return Timeout(ctx => timeoutProvider(), DefaultTimeoutStrategy, onTimeout);
         }
 
         /// <summary>
@@ -266,7 +253,6 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy Timeout(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task> onTimeout)
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
@@ -283,7 +269,6 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy Timeout(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task, Exception> onTimeout)
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
@@ -299,8 +284,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static ISyncTimeoutPolicy Timeout(Func<Context, TimeSpan> timeoutProvider)
         {
-            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
-            return Timeout(timeoutProvider, TimeoutStrategy.Optimistic, doNothing);
+            return Timeout(timeoutProvider, DefaultTimeoutStrategy, onTimeout: (Action<Context, TimeSpan, Task, Exception>)null);
         }
 
         /// <summary>
@@ -312,8 +296,7 @@ namespace Polly
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
         public static ISyncTimeoutPolicy Timeout(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy)
         {
-            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
-            return Timeout(timeoutProvider, timeoutStrategy, doNothing);
+            return Timeout(timeoutProvider, timeoutStrategy, onTimeout: (Action<Context, TimeSpan, Task, Exception>)null);
         }
 
         /// <summary>
@@ -324,9 +307,8 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy Timeout(Func<Context, TimeSpan> timeoutProvider, Action<Context, TimeSpan, Task> onTimeout)
-            => Timeout(timeoutProvider, TimeoutStrategy.Optimistic, onTimeout);
+            => Timeout(timeoutProvider, DefaultTimeoutStrategy, onTimeout);
 
         /// <summary>
         /// Builds a <see cref="Policy" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
@@ -336,9 +318,8 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy Timeout(Func<Context, TimeSpan> timeoutProvider, Action<Context, TimeSpan, Task, Exception> onTimeout)
-            => Timeout(timeoutProvider, TimeoutStrategy.Optimistic, onTimeout);
+            => Timeout(timeoutProvider, DefaultTimeoutStrategy, onTimeout);
 
         /// <summary>
         /// Builds a <see cref="Policy" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
@@ -349,12 +330,9 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy Timeout(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task> onTimeout)
         {
-            if (onTimeout == null) throw new ArgumentNullException(nameof(onTimeout));
-
-            return Timeout(timeoutProvider, timeoutStrategy, (ctx, timeout, task, ex) => onTimeout(ctx, timeout, task));
+            return Timeout(timeoutProvider, timeoutStrategy, onTimeout == null ? (Action<Context, TimeSpan, Task, Exception>)null : (ctx, timeout, task, ex) => onTimeout(ctx, timeout, task));
         }
 
         /// <summary>
@@ -366,14 +344,12 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy Timeout(
             Func<Context, TimeSpan> timeoutProvider, 
             TimeoutStrategy timeoutStrategy, 
             Action<Context, TimeSpan, Task, Exception> onTimeout)
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
-            if (onTimeout == null) throw new ArgumentNullException(nameof(onTimeout));
 
             return new TimeoutPolicy(
                     timeoutProvider,

--- a/src/Polly/Timeout/TimeoutSyntax.cs
+++ b/src/Polly/Timeout/TimeoutSyntax.cs
@@ -43,7 +43,6 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-        
         public static ISyncTimeoutPolicy Timeout(int seconds, Action<Context, TimeSpan, Task> onTimeout)
         {
             TimeoutValidator.ValidateSecondsTimeout(seconds);

--- a/src/Polly/Timeout/TimeoutTResultSyntax.cs
+++ b/src/Polly/Timeout/TimeoutTResultSyntax.cs
@@ -16,9 +16,8 @@ namespace Polly
         public static ISyncTimeoutPolicy<TResult> Timeout<TResult>(int seconds)
         {
             TimeoutValidator.ValidateSecondsTimeout(seconds);
-            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
 
-            return Timeout<TResult>(ctx => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, doNothing);
+            return Timeout<TResult>(ctx => TimeSpan.FromSeconds(seconds), DefaultTimeoutStrategy, onTimeout: (Action<Context, TimeSpan, Task, Exception>)null);
         }
 
         /// <summary>
@@ -32,9 +31,8 @@ namespace Polly
         public static ISyncTimeoutPolicy<TResult> Timeout<TResult>(int seconds, TimeoutStrategy timeoutStrategy)
         {
             TimeoutValidator.ValidateSecondsTimeout(seconds);
-            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
 
-            return Timeout<TResult>(ctx => TimeSpan.FromSeconds(seconds), timeoutStrategy, doNothing);
+            return Timeout<TResult>(ctx => TimeSpan.FromSeconds(seconds), timeoutStrategy, onTimeout: (Action<Context, TimeSpan, Task, Exception>)null);
         }
 
         /// <summary>
@@ -45,11 +43,11 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
+        
         public static ISyncTimeoutPolicy<TResult> Timeout<TResult>(int seconds, Action<Context, TimeSpan, Task> onTimeout)
         {
             TimeoutValidator.ValidateSecondsTimeout(seconds);
-            return Timeout<TResult>(ctx => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, onTimeout);
+            return Timeout<TResult>(ctx => TimeSpan.FromSeconds(seconds), DefaultTimeoutStrategy, onTimeout);
         }
 
         /// <summary>
@@ -60,11 +58,11 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy<TResult> Timeout<TResult>(int seconds, Action<Context, TimeSpan, Task, Exception> onTimeout)
         {
-            if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
-            return Timeout<TResult>(ctx => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, onTimeout);
+            TimeoutValidator.ValidateSecondsTimeout(seconds);
+
+            return Timeout<TResult>(ctx => TimeSpan.FromSeconds(seconds), DefaultTimeoutStrategy, onTimeout);
         }
 
         /// <summary>
@@ -77,7 +75,6 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy<TResult> Timeout<TResult>(int seconds, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task> onTimeout)
         {
             TimeoutValidator.ValidateSecondsTimeout(seconds);
@@ -95,10 +92,9 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy<TResult> Timeout<TResult>(int seconds, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task, Exception> onTimeout)
         {
-            if (seconds <= 0) throw new ArgumentOutOfRangeException(nameof(seconds));
+            TimeoutValidator.ValidateSecondsTimeout(seconds);
 
             return Timeout<TResult>(ctx => TimeSpan.FromSeconds(seconds), timeoutStrategy, onTimeout);
         }
@@ -112,9 +108,8 @@ namespace Polly
         public static ISyncTimeoutPolicy<TResult> Timeout<TResult>(TimeSpan timeout)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
-            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
 
-            return Timeout<TResult>(ctx => timeout, TimeoutStrategy.Optimistic, doNothing);
+            return Timeout<TResult>(ctx => timeout, DefaultTimeoutStrategy, onTimeout: (Action<Context, TimeSpan, Task, Exception>)null);
         }
 
         /// <summary>
@@ -128,9 +123,8 @@ namespace Polly
         public static ISyncTimeoutPolicy<TResult> Timeout<TResult>(TimeSpan timeout, TimeoutStrategy timeoutStrategy)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
-            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
 
-            return Timeout<TResult>(ctx => timeout, timeoutStrategy, doNothing);
+            return Timeout<TResult>(ctx => timeout, timeoutStrategy, onTimeout: (Action<Context, TimeSpan, Task, Exception>)null);
         }
 
         /// <summary>
@@ -141,11 +135,10 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy<TResult> Timeout<TResult>(TimeSpan timeout, Action<Context, TimeSpan, Task> onTimeout)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
-            return Timeout<TResult>(ctx => timeout, TimeoutStrategy.Optimistic, onTimeout);
+            return Timeout<TResult>(ctx => timeout, DefaultTimeoutStrategy, onTimeout);
         }
 
         /// <summary>
@@ -156,11 +149,10 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy<TResult> Timeout<TResult>(TimeSpan timeout, Action<Context, TimeSpan, Task, Exception> onTimeout)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
-            return Timeout<TResult>(ctx => timeout, TimeoutStrategy.Optimistic, onTimeout);
+            return Timeout<TResult>(ctx => timeout, DefaultTimeoutStrategy, onTimeout);
         }
 
         /// <summary>
@@ -173,7 +165,6 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy<TResult> Timeout<TResult>(TimeSpan timeout, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task> onTimeout)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
@@ -190,7 +181,6 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be greater than zero.</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy<TResult> Timeout<TResult>(TimeSpan timeout, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task, Exception> onTimeout)
         {
             TimeoutValidator.ValidateTimeSpanTimeout(timeout);
@@ -207,8 +197,7 @@ namespace Polly
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
-            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
-            return Timeout<TResult>(ctx => timeoutProvider(), TimeoutStrategy.Optimistic, doNothing);
+            return Timeout<TResult>(ctx => timeoutProvider(), DefaultTimeoutStrategy, onTimeout: (Action<Context, TimeSpan, Task, Exception>)null);
         }
 
         /// <summary>
@@ -223,8 +212,7 @@ namespace Polly
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
-            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
-            return Timeout<TResult>(ctx => timeoutProvider(), timeoutStrategy, doNothing);
+            return Timeout<TResult>(ctx => timeoutProvider(), timeoutStrategy, onTimeout: (Action<Context, TimeSpan, Task, Exception>)null);
         }
 
         /// <summary>
@@ -235,12 +223,11 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy<TResult> Timeout<TResult>(Func<TimeSpan> timeoutProvider, Action<Context, TimeSpan, Task> onTimeout)
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
-            return Timeout<TResult>(ctx => timeoutProvider(), TimeoutStrategy.Optimistic, onTimeout);
+            return Timeout<TResult>(ctx => timeoutProvider(), DefaultTimeoutStrategy, onTimeout);
         }
 
         /// <summary>
@@ -251,12 +238,11 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy<TResult> Timeout<TResult>(Func<TimeSpan> timeoutProvider, Action<Context, TimeSpan, Task, Exception> onTimeout)
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
-            return Timeout<TResult>(ctx => timeoutProvider(), TimeoutStrategy.Optimistic, onTimeout);
+            return Timeout<TResult>(ctx => timeoutProvider(), DefaultTimeoutStrategy, onTimeout);
         }
 
         /// <summary>
@@ -269,7 +255,6 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy<TResult> Timeout<TResult>(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task> onTimeout)
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
@@ -287,7 +272,6 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy<TResult> Timeout<TResult>(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task, Exception> onTimeout)
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
@@ -303,8 +287,7 @@ namespace Polly
         /// <returns>The policy instance.</returns>
         public static ISyncTimeoutPolicy<TResult> Timeout<TResult>(Func<Context, TimeSpan> timeoutProvider)
         {
-            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
-            return Timeout<TResult>(timeoutProvider, TimeoutStrategy.Optimistic, doNothing);
+            return Timeout<TResult>(timeoutProvider, DefaultTimeoutStrategy, onTimeout: (Action<Context, TimeSpan, Task, Exception>)null);
         }
 
         /// <summary>
@@ -317,8 +300,7 @@ namespace Polly
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
         public static ISyncTimeoutPolicy<TResult> Timeout<TResult>(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy)
         {
-            Action<Context, TimeSpan, Task, Exception> doNothing = (_, __, ___, ____) => { };
-            return Timeout<TResult>(timeoutProvider, timeoutStrategy, doNothing);
+            return Timeout<TResult>(timeoutProvider, timeoutStrategy, onTimeout: (Action<Context, TimeSpan, Task, Exception>)null);
         }
 
         /// <summary>
@@ -329,9 +311,8 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy<TResult> Timeout<TResult>(Func<Context, TimeSpan> timeoutProvider, Action<Context, TimeSpan, Task> onTimeout)
-            => Timeout<TResult>(timeoutProvider, TimeoutStrategy.Optimistic, onTimeout);
+            => Timeout<TResult>(timeoutProvider, DefaultTimeoutStrategy, onTimeout);
 
         /// <summary>
         /// Builds a <see cref="Policy{TResult}"/> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
@@ -341,9 +322,8 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy<TResult> Timeout<TResult>(Func<Context, TimeSpan> timeoutProvider, Action<Context, TimeSpan, Task, Exception> onTimeout)
-            => Timeout<TResult>(timeoutProvider, TimeoutStrategy.Optimistic, onTimeout);
+            => Timeout<TResult>(timeoutProvider, DefaultTimeoutStrategy, onTimeout);
 
         /// <summary>
         /// Builds a <see cref="Policy{TResult}" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
@@ -355,12 +335,9 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy<TResult> Timeout<TResult>(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task> onTimeout)
         {
-            if (onTimeout == null) throw new ArgumentNullException(nameof(onTimeout));
-
-            return Timeout<TResult>(timeoutProvider, timeoutStrategy, (ctx, timeout, task, ex) => onTimeout(ctx, timeout, task));
+            return Timeout<TResult>(timeoutProvider, timeoutStrategy, onTimeout == null ? (Action<Context, TimeSpan, Task, Exception>)null : (ctx, timeout, task, ex) => onTimeout(ctx, timeout, task));
         }
 
         /// <summary>
@@ -373,14 +350,12 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-        /// <exception cref="ArgumentNullException">onTimeout</exception>
         public static ISyncTimeoutPolicy<TResult> Timeout<TResult>(
             Func<Context, TimeSpan> timeoutProvider, 
             TimeoutStrategy timeoutStrategy, 
             Action<Context, TimeSpan, Task, Exception> onTimeout)
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
-            if (onTimeout == null) throw new ArgumentNullException(nameof(onTimeout));
 
             return new TimeoutPolicy<TResult>(
                     timeoutProvider,

--- a/src/Polly/Timeout/TimeoutTResultSyntax.cs
+++ b/src/Polly/Timeout/TimeoutTResultSyntax.cs
@@ -43,7 +43,6 @@ namespace Polly
         /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
         /// <returns>The policy instance.</returns>
         /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-        
         public static ISyncTimeoutPolicy<TResult> Timeout<TResult>(int seconds, Action<Context, TimeSpan, Task> onTimeout)
         {
             TimeoutValidator.ValidateSecondsTimeout(seconds);


### PR DESCRIPTION
### The issue or feature being addressed

Implements #741 Handle non-configured policy callbacks as null (reduce allocations)

### Details on the issue fix or feature implementation

+ Amends all policy configuration syntax to handle non-configured policy callbacks as `null`
+ Amends policy implementations to handle this

### Confirm the following

- [x]  I started this PR by branching from the head of the relevant vX.Y branch, or I have rebased on the relevant vX.Y branch, or I have merged the latest changes from the vX.Y branch
- [x]  I have targeted the PR to merge into the latest dev vX.Y branch as the base branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
