### PR TITLE
v7.2.1: Bug fixes, issues 758 and 762

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.2.1
+- Upgrade SourceLink to RTM v1 (fixes building from source for latest .NET Core 3.1.x)
+- Bug fix: rare circuit-breaker race condition causing NullReferenceException when circuit throws BrokenCircuitException.
+
 ## 7.2.0
 - Add test target for netcoreapp3.0.
 - Extend PolicyRegistry with concurrent method support, TryAdd, TryRemove, TryUpdate, GetOrAdd, AddOrUpdate; new interface IConcurrentPolicyRegistry

--- a/GitVersionConfig.yaml
+++ b/GitVersionConfig.yaml
@@ -1,1 +1,1 @@
-next-version: 7.2.0
+next-version: 7.2.1

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 New BSD License
 =
-Copyright (c) 2015-2019, App vNext
+Copyright (c) 2015-2020, App vNext
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/Polly/CircuitBreaker/CircuitStateController.cs
+++ b/src/Polly/CircuitBreaker/CircuitStateController.cs
@@ -137,9 +137,22 @@ namespace Polly.CircuitBreaker
         }
 
         private BrokenCircuitException GetBreakingException()
-            => _lastOutcome.Exception != null
-                ? new BrokenCircuitException("The circuit is now open and is not allowing calls.", _lastOutcome.Exception)
-                : new BrokenCircuitException<TResult>("The circuit is now open and is not allowing calls.", _lastOutcome.Result);
+        {
+            const string BrokenCircuitMessage = "The circuit is now open and is not allowing calls.";
+
+            var lastOutcome = _lastOutcome;
+            if (lastOutcome == null)
+            {
+                return new BrokenCircuitException(BrokenCircuitMessage);
+            }
+
+            if (lastOutcome.Exception != null)
+            {
+                return new BrokenCircuitException(BrokenCircuitMessage, lastOutcome.Exception);
+            }
+
+            return new BrokenCircuitException<TResult>(BrokenCircuitMessage, lastOutcome.Result);
+        }
 
         public void OnActionPreExecute()
         {

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -4,11 +4,11 @@
     <TargetFrameworks>netstandard1.1;netstandard2.0;net461;net472</TargetFrameworks>
     <AssemblyName>Polly</AssemblyName>
     <RootNamespace>Polly</RootNamespace>
-    <Version>7.1.1</Version>
+    <Version>7.2.1</Version>
     <AssemblyVersion>7.0.0.0</AssemblyVersion>
-    <FileVersion>7.1.1.0</FileVersion>
-    <InformationalVersion>7.1.1.0</InformationalVersion>
-    <PackageVersion>7.1.1</PackageVersion>
+    <FileVersion>7.2.1.0</FileVersion>
+    <InformationalVersion>7.2.1.0</InformationalVersion>
+    <PackageVersion>7.2.1</PackageVersion>
     <Company>App vNext</Company>
     <Copyright>Copyright (c) 2020, App vNext</Copyright>
     <Description>Polly is a library that allows developers to express resilience and transient fault handling policies such as Retry, Circuit Breaker, Timeout, Bulkhead Isolation, and Fallback in a fluent and thread-safe manner.</Description>

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -24,7 +24,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup Label="SourceLink">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <Optimize>true</Optimize>

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -10,7 +10,7 @@
     <InformationalVersion>7.1.1.0</InformationalVersion>
     <PackageVersion>7.1.1</PackageVersion>
     <Company>App vNext</Company>
-    <Copyright>Copyright (c) 2019, App vNext</Copyright>
+    <Copyright>Copyright (c) 2020, App vNext</Copyright>
     <Description>Polly is a library that allows developers to express resilience and transient fault handling policies such as Retry, Circuit Breaker, Timeout, Bulkhead Isolation, and Fallback in a fluent and thread-safe manner.</Description>
     <DefaultLanguage>en-US</DefaultLanguage>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>


### PR DESCRIPTION
### The issue or feature being addressed

#758 : Rare race condition causing `NullReferenceException` when circuit-breaker should throw `BrokenCircuitException`
#762 : Use SourceLink v1 RTM.  Fixes build with latest .NET Core v3.1.x

### Confirm the following

- [x]  I started this PR by branching from the head of the latest dev vX.Y branch, or I have rebased on the latest dev vX.Y branch, or I have merged the latest changes from the dev vX.Y branch
- [x]  I have targeted the PR to merge into the latest dev vX.Y branch as the base branch
- [n/a]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
