### PR TITLE
Suppress NETSDK1138

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "sdk": {
+    "allowPrerelease": false
+  }
+}

--- a/src/Polly.Specs/Polly.Specs.csproj
+++ b/src/Polly.Specs/Polly.Specs.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netcoreapp1.1;netcoreapp2.0;netcoreapp3.0;net461;net472</TargetFrameworks>
     <!-- Disable warning about End-of-Life .NET versions -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Polly.Specs/Polly.Specs.csproj
+++ b/src/Polly.Specs/Polly.Specs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;netcoreapp2.0;netcoreapp3.0;net461;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net461;net472</TargetFrameworks>
     <!-- Disable warning about End-of-Life .NET versions -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>

--- a/src/Polly.Specs/Polly.Specs.csproj
+++ b/src/Polly.Specs/Polly.Specs.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp1.1;netcoreapp2.0;netcoreapp3.0;net461;net472</TargetFrameworks>
-    <!-- Disable warning about End-of-Line .NET versions -->
+    <!-- Disable warning about End-of-Life .NET versions -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 

--- a/src/Polly.Specs/Polly.Specs.csproj
+++ b/src/Polly.Specs/Polly.Specs.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp1.1;netcoreapp2.0;netcoreapp3.0;net461;net472</TargetFrameworks>
+    <!-- Disable warning about End-of-Line .NET versions -->
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### The issue or feature being addressed

Relates to #815.

### Details on the issue fix or feature implementation

Suppress the `NETSDK1138` warning which otherwise causes the build to fail with .NET 5.0 SDK.

Wasn't sure on exactly which branch to deal with as there's 3 other than the default, which are all months old and all have failing CI anyway.

### Confirm the following

- [ ]  I started this PR by branching from the head of the latest dev vX.Y branch, or I have rebased on the latest dev vX.Y branch, or I have merged the latest changes from the dev vX.Y branch
- [ ]  I have targeted the PR to merge into the latest dev vX.Y branch as the base branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build
