### PR TITLE
Recursively search all AggregateException InnerExceptions for predicate matches when using HandleInner()

### DIFF
--- a/src/Polly.Specs/Retry/RetrySpecs.cs
+++ b/src/Polly.Specs/Retry/RetrySpecs.cs
@@ -252,6 +252,48 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
+        public void Should_call_onretry_with_handled_exception_nested_in_aggregate_as_first_exception()
+        {
+            Exception passedToOnRetry = null;
+
+            var policy = Policy
+                .HandleInner<DivideByZeroException>()
+                .Retry(3, (exception, _) => passedToOnRetry = exception);
+
+            Exception toRaiseAsInner = new DivideByZeroException();
+
+            Exception aggregateException = new AggregateException(
+                new Exception("First: With Inner Exception",
+                    toRaiseAsInner),
+                new Exception("Second: Without Inner Exception"));
+
+            policy.RaiseException(aggregateException);
+
+            passedToOnRetry.Should().BeSameAs(toRaiseAsInner);
+        }
+
+        [Fact]
+        public void Should_call_onretry_with_handled_exception_nested_in_aggregate_as_second_exception()
+        {
+            Exception passedToOnRetry = null;
+
+            var policy = Policy
+                .HandleInner<DivideByZeroException>()
+                .Retry(3, (exception, _) => passedToOnRetry = exception);
+
+            Exception toRaiseAsInner = new DivideByZeroException();
+
+            Exception aggregateException = new AggregateException(
+                new Exception("First: Without Inner Exception"),
+                new Exception("Second: With Inner Exception",
+                    toRaiseAsInner));
+
+            policy.RaiseException(aggregateException);
+
+            passedToOnRetry.Should().BeSameAs(toRaiseAsInner);
+        }
+
+        [Fact]
         public void Should_not_call_onretry_when_no_retries_are_performed()
         {
             var retryCounts = new List<int>();

--- a/src/Polly/PolicyBuilder.OrSyntax.cs
+++ b/src/Polly/PolicyBuilder.OrSyntax.cs
@@ -58,8 +58,13 @@ namespace Polly
             {
                 if (exception is AggregateException aggregateException)
                 {
-                    Exception matchedInAggregate = aggregateException.Flatten().InnerExceptions.FirstOrDefault(predicate);
-                    if (matchedInAggregate != null) return matchedInAggregate;
+                    //search all inner exceptions wrapped inside the AggregateException recursively
+                    foreach (var innerException in aggregateException.Flatten().InnerExceptions)
+                    {
+                        var matchedInAggregate = HandleInnerNested(predicate, innerException);
+                        if (matchedInAggregate != null)
+                            return matchedInAggregate;
+                    }
                 }
 
                 return HandleInnerNested(predicate, exception);


### PR DESCRIPTION
Recursively search all AggregateException InnerExceptions for predicate matches when using HandleInner()

Related Issue: #818

(Apologies for the second PR, I had some trouble with the first one so I started over)