### PR TITLE
Fix unused TimeoutStrategy parameter

### DIFF
--- a/src/Polly/Timeout/AsyncTimeoutTResultSyntax.cs
+++ b/src/Polly/Timeout/AsyncTimeoutTResultSyntax.cs
@@ -273,7 +273,7 @@ namespace Polly
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
-            return TimeoutAsync<TResult>(ctx => timeoutProvider(), onTimeoutAsync);
+            return TimeoutAsync<TResult>(ctx => timeoutProvider(), timeoutStrategy, onTimeoutAsync);
         }
 
         /// <summary>


### PR DESCRIPTION
### The issue or feature being addressed

Fix the `timeoutStrategy` parameter not being used by `Policy.TimeoutAsync<TResult>(Func<TimeSpan>, TimeoutStrategy, Func<Context, TimeSpan, Task, Task>)` which meant that `TimeoutStrategy.Optimistic` was always being used.

I found this issue when experimenting with whether it was worth adding a `net5.0` TFM to Polly (TL;DR - I don't think it is) and enabling the new .NET analyzers built into the .NET 5.0 SDK. Doing that flagged up the unused parameter as a [CA1801](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1801) warning.

### Details on the issue fix or feature implementation

Pass the parameter value to `Policy.TimeoutAsync<TResult>(Func<Context, TimeSpan>, TimeoutStrategy, Func<Context, TimeSpan, Task, Task>)`.

I did try to come up with a unit test that verified the wrong strategy was being used pre-fix, but I got stuck with the custom clock implementation in the tests and couldn't get a test using a never-completing callback to not hang forever.

### Confirm the following

- [x]  I started this PR by branching from the head of the latest dev vX.Y branch, or I have rebased on the latest dev vX.Y branch, or I have merged the latest changes from the dev vX.Y branch
- [x]  I have targeted the PR to merge into the latest dev vX.Y branch as the base branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
