### PR TITLE
Enable deterministic build

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -169,6 +169,7 @@ Task("__UpdateDotNetStandardAssemblyVersionNumber")
         { "InformationalVersion", assemblySemver },
         { "Version", nugetVersion },
         { "PackageVersion", nugetVersion },
+        { "ContinuousIntegrationBuild", "true" },
     };
 
     var csproj = File("./src/" + projectName + "/" + projectName + ".csproj");

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -18,6 +18,8 @@
     <Authors>Michael Wolfenden, App vNext</Authors>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <LangVersion>latest</LangVersion>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources> <!-- EmbedUntrackedSources for deterministic build -->
+    <ContinuousIntegrationBuild>false</ContinuousIntegrationBuild>
   </PropertyGroup>
   <PropertyGroup Label="SourceLink">
     <PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors.  All non-trivial contributions get a public credit in the readme! -->

### The issue or feature being addressed
Enable deterministic build

<!-- Please include the existing github issue number where relevant -->

### Details on the issue fix or feature implementation

Enabled deterministic build. See https://github.com/clairernovotny/DeterministicBuilds

Goals is to have all checks green. Current result: 

![image](https://user-images.githubusercontent.com/5808377/113214336-9d23cf80-9279-11eb-8c44-df51f691e464.png)


local result:

![image](https://user-images.githubusercontent.com/5808377/113215242-d90b6480-927a-11eb-9fd7-d348bc2bb577.png)

> ContinuousIntegrationBuild. These should not be enabled during local dev or the debugger won't be able to find the local source files.

So ContinuousIntegrationBuild is set in the .cake file

### Confirm the following

- [x]  I started this PR by branching from the head of the latest dev vX.Y branch, or I have rebased on the latest dev vX.Y branch, or I have merged the latest changes from the dev vX.Y branch -> Yes , v722-or-v730
- [x]  I have targeted the PR to merge into the latest dev vX.Y branch as the base branch -> Yes , v722-or-v730
- [x]  I have included unit tests for the issue/feature -> not possible
- [x]  I have successfully run a local build -> ran build.ps1
