### PR TITLE
v7.2.2: Bug fixes, issue 818

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 7.2.2
+
+- Recursively search all `AggregateException` inner exceptions for predicate matches when using `HandleInner()` ([#818](https://github.com/App-vNext/Polly/issues/818)) - Thanks to [@sideproject](https://github.com/sideproject)
+- Polly now builds deterministically - Thanks to [@304NotModified](https://github.com/304NotModified)
+- Bug fix: the `timeoutStrategy` parameter was not being used by the `TimeoutAsync(Func<TimeSpan>, TimeoutStrategy, Func<Context, TimeSpan, Task, Task>)` method - Thanks to [@martincostello](https://github.com/martincostello)
+- Bug fix: the solution can now be built with the .NET 5.0 SDK - Thanks to [@martincostello](https://github.com/martincostello)
+
 ## 7.2.1
 - Upgrade SourceLink to RTM v1 (fixes building from source for latest .NET Core 3.1.x)
 - Bug fix: rare circuit-breaker race condition causing NullReferenceException when circuit throws BrokenCircuitException.
@@ -56,7 +63,7 @@
 - Remove methods marked as deprecated in v5.9.0
 
 ## 5.9.0
-- Allow Timeout.InfiniteTimeSpan (no timeout) for TimeoutPolicy. 
+- Allow Timeout.InfiniteTimeSpan (no timeout) for TimeoutPolicy.
 - Add .AsPolicy&lt;TResult&gt; and .AsAsyncPolicy&lt;TResult&gt; methods for converting non-generic policies to generic policies.
 - Per Semver, indicates deprecation of overloads and properties intended to be removed or renamed in Polly v6.
 
@@ -67,7 +74,7 @@
 ## 5.7.0
 - Minor cache fixes
 - Add ability to calculate cache Ttl based on item to cache
-- Allow user-created custom policies 
+- Allow user-created custom policies
 
 ## 5.6.1
 - Extend PolicyWrap syntax with interfaces
@@ -105,7 +112,7 @@
 - Add PolicyRegistry for storing and retrieving policies.
 - Add interfaces by policy type and execution type.
 - Change .NetStandard minimum support to NetStandard1.1.
-     
+
 ## 5.1.0
 - Allow different parts of a policy execution to exchange data via a mutable Context travelling with each execution.
 
@@ -120,22 +127,22 @@
 - Add NoOpPolicy: NoOpPolicy executes delegates without intervention; for eg stubbing out Polly in unit testing.
 
 ## 5.0.4 pre
-- Fix Microsoft.Bcl and Nito.AsyncEx dependencies for Polly.Net40Async. 
-     
+- Fix Microsoft.Bcl and Nito.AsyncEx dependencies for Polly.Net40Async.
+
 ## 5.0.3 RTM
 - Refine implementation of cancellable synchronous WaitAndRetry
 - Minor breaking change: Where a user delegate does not observe cancellation, Polly will now honour the delegate's outcome rather than throw for the unobserved cancellation (issue 188).
 
 ## 5.0.2 alpha
 
-- .NETStandard1.0 target: Correctly state dependencies. 
+- .NETStandard1.0 target: Correctly state dependencies.
 - .NETStandard1.0 target: Fix SemVer stamping of Polly.dll.
 - PCL259 project and target: Remove, in favour of .NETStandard1.0 target.  PCL259 is supported via .NETStandard1.0 target, going forward.
 - Mark Polly.dll as CLSCompliant.
 - Tidy build around GitVersionTask and ReferenceGenerator.
 - Update FluentAssertions dependency.
 - Added Polly.Net40Async specs project.
-- Fix issue 179: Make Net4.0 async implementation for Bulkhead truly async. 
+- Fix issue 179: Make Net4.0 async implementation for Bulkhead truly async.
 
 ## 5.0.1 alpha
 
@@ -159,15 +166,15 @@ Other changes include:
 - Provide .NET4.0 support uniquely through Polly.NET40Async package
 - Retire ContextualPolicy (not part of documented API; support now in Policy base class)
 - Discontinue .NET3.5 support
- 
+
 ## 4.3.0
 
 - Added ability for policies to handle returned results.  Optimised circuit-breaker hot path.  Fixed circuit-breaker threshold bug.  Thanks to [@reisenberger](https://github.com/reisenberger), [@christopherbahr](https://github.com/christopherbahr) and [@Finity](https://github.com/Finity) respectively.
 
 ## 4.2.4
 
-- Added overloads to WaitAndRetry and WaitAndRetryAsync methods that accept an onRetry delegate which includes the attempt count.  Thanks to [@SteveCote](https://github.com/steveCote) 
-     
+- Added overloads to WaitAndRetry and WaitAndRetryAsync methods that accept an onRetry delegate which includes the attempt count.  Thanks to [@SteveCote](https://github.com/steveCote)
+
 ## 4.2.3
 
 - Updated the Polly.Net40Async NuGet package to enable async via the SUPPORTSASYNC constant. Cleaned up the build scripts in order to ensure unnecessary DLL references are not included within each of the framework targets.  Thanks to [@reisenberger](https://github.com/reisenberger) and [@joelhulen](https://github.com/joelhulen)
@@ -246,7 +253,7 @@ Other changes include:
 ## 2.2.1
 
 - Replaced non-blocking sleep implementation with a blocking one for PCL
-       
+
 ## 2.2.0
 
 - Added Async Support (PCL)
@@ -260,9 +267,9 @@ Other changes include:
 ## 2.0.0
 
 - Added Portable Class Library ([Issue #4](https://github.com/michael-wolfenden/Polly/issues/4)) - Thanks to  [@ghuntley](https://github.com/ghuntley) for the implementation
-- The `Polly` NuGet package is now no longer strongly named. The strongly named NuGet package is now `Polly-Signed` ([Issue #5](https://github.com/michael-wolfenden/Polly/issues/5)) 
+- The `Polly` NuGet package is now no longer strongly named. The strongly named NuGet package is now `Polly-Signed` ([Issue #5](https://github.com/michael-wolfenden/Polly/issues/5))
 
 ## 1.1.0
 
 - Added additional overloads to Retry
-- Allow arbitrary data to be passed to policy execution ([Issue #1](https://github.com/michael-wolfenden/Polly/issues/1)) 
+- Allow arbitrary data to be passed to policy execution ([Issue #1](https://github.com/michael-wolfenden/Polly/issues/1))

--- a/GitVersionConfig.yaml
+++ b/GitVersionConfig.yaml
@@ -1,1 +1,1 @@
-next-version: 7.2.1
+next-version: 7.2.2

--- a/build.cake
+++ b/build.cake
@@ -169,6 +169,7 @@ Task("__UpdateDotNetStandardAssemblyVersionNumber")
         { "InformationalVersion", assemblySemver },
         { "Version", nugetVersion },
         { "PackageVersion", nugetVersion },
+        { "ContinuousIntegrationBuild", "true" },
     };
 
     var csproj = File("./src/" + projectName + "/" + projectName + ".csproj");

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "sdk": {
+    "allowPrerelease": false
+  }
+}

--- a/src/Polly.Specs/Polly.Specs.csproj
+++ b/src/Polly.Specs/Polly.Specs.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netcoreapp1.1;netcoreapp2.0;netcoreapp3.0;net461;net472</TargetFrameworks>
     <!-- Disable warning about End-of-Life .NET versions -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Polly.Specs/Polly.Specs.csproj
+++ b/src/Polly.Specs/Polly.Specs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;netcoreapp2.0;netcoreapp3.0;net461;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net461;net472</TargetFrameworks>
     <!-- Disable warning about End-of-Life .NET versions -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>

--- a/src/Polly.Specs/Polly.Specs.csproj
+++ b/src/Polly.Specs/Polly.Specs.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp1.1;netcoreapp2.0;netcoreapp3.0;net461;net472</TargetFrameworks>
-    <!-- Disable warning about End-of-Line .NET versions -->
+    <!-- Disable warning about End-of-Life .NET versions -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 

--- a/src/Polly.Specs/Polly.Specs.csproj
+++ b/src/Polly.Specs/Polly.Specs.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp1.1;netcoreapp2.0;netcoreapp3.0;net461;net472</TargetFrameworks>
+    <!-- Disable warning about End-of-Line .NET versions -->
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Polly.Specs/Retry/RetrySpecs.cs
+++ b/src/Polly.Specs/Retry/RetrySpecs.cs
@@ -252,6 +252,94 @@ namespace Polly.Specs.Retry
         }
 
         [Fact]
+        public void Should_call_onretry_with_handled_exception_nested_in_aggregate_as_first_exception()
+        {
+            Exception passedToOnRetry = null;
+
+            var policy = Policy
+                .HandleInner<DivideByZeroException>()
+                .Retry(3, (exception, _) => passedToOnRetry = exception);
+
+            Exception toRaiseAsInner = new DivideByZeroException();
+
+            Exception aggregateException = new AggregateException(
+                new Exception("First: With Inner Exception",
+                    toRaiseAsInner),
+                new Exception("Second: Without Inner Exception"));
+
+            policy.RaiseException(aggregateException);
+
+            passedToOnRetry.Should().BeSameAs(toRaiseAsInner);
+        }
+
+        [Fact]
+        public void Should_call_onretry_with_handled_exception_nested_in_aggregate_as_second_exception()
+        {
+            Exception passedToOnRetry = null;
+
+            var policy = Policy
+                .HandleInner<DivideByZeroException>()
+                .Retry(3, (exception, _) => passedToOnRetry = exception);
+
+            Exception toRaiseAsInner = new DivideByZeroException();
+
+            Exception aggregateException = new AggregateException(
+                new Exception("First: Without Inner Exception"),
+                new Exception("Second: With Inner Exception",
+                    toRaiseAsInner));
+
+            policy.RaiseException(aggregateException);
+
+            passedToOnRetry.Should().BeSameAs(toRaiseAsInner);
+        }
+
+        [Fact]
+        public void Should_call_onretry_with_handled_exception_nested_in_aggregate_inside_another_aggregate_as_first_exception()
+        {
+            Exception passedToOnRetry = null;
+
+            var policy = Policy
+                .HandleInner<DivideByZeroException>()
+                .Retry(3, (exception, _) => passedToOnRetry = exception);
+
+            Exception toRaiseAsInner = new DivideByZeroException();
+
+            Exception aggregateException = new AggregateException(
+                new AggregateException(
+                    new Exception("First: With Inner Exception",
+                        toRaiseAsInner),
+                    new Exception("Second: Without Inner Exception")),
+                new Exception("Exception"));
+
+            policy.RaiseException(aggregateException);
+
+            passedToOnRetry.Should().BeSameAs(toRaiseAsInner);
+        }
+
+        [Fact]
+        public void Should_call_onretry_with_handled_exception_nested_in_aggregate_inside_another_aggregate_as_second_exception()
+        {
+            Exception passedToOnRetry = null;
+
+            var policy = Policy
+                .HandleInner<DivideByZeroException>()
+                .Retry(3, (exception, _) => passedToOnRetry = exception);
+
+            Exception toRaiseAsInner = new DivideByZeroException();
+
+            Exception aggregateException = new AggregateException(
+                new Exception("Exception"),
+                new AggregateException(
+                    new Exception("First: Without Inner Exception"),
+                    new Exception("Second: With Inner Exception",
+                        toRaiseAsInner)));
+
+            policy.RaiseException(aggregateException);
+
+            passedToOnRetry.Should().BeSameAs(toRaiseAsInner);
+        }
+
+        [Fact]
         public void Should_not_call_onretry_when_no_retries_are_performed()
         {
             var retryCounts = new List<int>();

--- a/src/Polly/PolicyBuilder.OrSyntax.cs
+++ b/src/Polly/PolicyBuilder.OrSyntax.cs
@@ -58,8 +58,13 @@ namespace Polly
             {
                 if (exception is AggregateException aggregateException)
                 {
-                    Exception matchedInAggregate = aggregateException.Flatten().InnerExceptions.FirstOrDefault(predicate);
-                    if (matchedInAggregate != null) return matchedInAggregate;
+                    //search all inner exceptions wrapped inside the AggregateException recursively
+                    foreach (var innerException in aggregateException.Flatten().InnerExceptions)
+                    {
+                        var matchedInAggregate = HandleInnerNested(predicate, innerException);
+                        if (matchedInAggregate != null)
+                            return matchedInAggregate;
+                    }
                 }
 
                 return HandleInnerNested(predicate, exception);

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -4,13 +4,13 @@
     <TargetFrameworks>netstandard1.1;netstandard2.0;net461;net472</TargetFrameworks>
     <AssemblyName>Polly</AssemblyName>
     <RootNamespace>Polly</RootNamespace>
-    <Version>7.2.1</Version>
+    <Version>7.2.2</Version>
     <AssemblyVersion>7.0.0.0</AssemblyVersion>
-    <FileVersion>7.2.1.0</FileVersion>
-    <InformationalVersion>7.2.1.0</InformationalVersion>
-    <PackageVersion>7.2.1</PackageVersion>
+    <FileVersion>7.2.2.0</FileVersion>
+    <InformationalVersion>7.2.2.0</InformationalVersion>
+    <PackageVersion>7.2.2</PackageVersion>
     <Company>App vNext</Company>
-    <Copyright>Copyright (c) 2020, App vNext</Copyright>
+    <Copyright>Copyright (c) $([System.DateTime]::Now.ToString(yyyy)), App vNext</Copyright>
     <Description>Polly is a library that allows developers to express resilience and transient fault handling policies such as Retry, Circuit Breaker, Timeout, Bulkhead Isolation, and Fallback in a fluent and thread-safe manner.</Description>
     <DefaultLanguage>en-US</DefaultLanguage>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -18,6 +18,8 @@
     <Authors>Michael Wolfenden, App vNext</Authors>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <LangVersion>latest</LangVersion>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources> <!-- EmbedUntrackedSources for deterministic build -->
+    <ContinuousIntegrationBuild>false</ContinuousIntegrationBuild>
   </PropertyGroup>
   <PropertyGroup Label="SourceLink">
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/Polly/Timeout/AsyncTimeoutTResultSyntax.cs
+++ b/src/Polly/Timeout/AsyncTimeoutTResultSyntax.cs
@@ -273,7 +273,7 @@ namespace Polly
         {
             if (timeoutProvider == null) throw new ArgumentNullException(nameof(timeoutProvider));
 
-            return TimeoutAsync<TResult>(ctx => timeoutProvider(), onTimeoutAsync);
+            return TimeoutAsync<TResult>(ctx => timeoutProvider(), timeoutStrategy, onTimeoutAsync);
         }
 
         /// <summary>


### PR DESCRIPTION
### The issue or feature being addressed

#818 - When using `HandleInner()` not all `AggregateException`s are being checked

### Details on the issue fix or feature implementation

#816 - The solution can now be built with the .NET 5.0 SDK
#823 - The `timeoutStrategy` parameter was not being used by the [`TimeoutAsync(Func<TimeSpan>, TimeoutStrategy, Func<Context, TimeSpan, Task, Task>)`](https://github.com/App-vNext/Polly/blob/52968c25f2e13e2708898174c15aafc9cb915020/src/Polly/Timeout/AsyncTimeoutTResultSyntax.cs#L272) method
#824 - Recursively search all `AggregateException` inner exceptions for predicate matches when using `HandleInner()`
#839 - Polly now builds deterministically

### Confirm the following

- [x]  I started this PR by branching from the head of the latest dev vX.Y branch, or I have rebased on the latest dev vX.Y branch, or I have merged the latest changes from the dev vX.Y branch
- [x]  I have targeted the PR to merge into the latest dev vX.Y branch as the base branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
