### PR TITLE
Add Benchmarks project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,7 @@ UpgradeLog*.XML
 
 artifacts
 build
+BenchmarkDotNet.Artifacts
 tools
 
 *.lock.json

--- a/src/Polly.Benchmarks/Bulkhead.cs
+++ b/src/Polly.Benchmarks/Bulkhead.cs
@@ -1,0 +1,49 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace Polly.Benchmarks
+{
+    [Config(typeof(PollyConfig))]
+    public class Bulkhead
+    {
+        private static readonly Policy SyncPolicy = Policy.Bulkhead(2);
+        private static readonly AsyncPolicy AsyncPolicy = Policy.BulkheadAsync(2);
+
+        [Benchmark]
+        public void Bulkhead_Synchronous()
+        {
+            SyncPolicy.Execute(() => Workloads.Action());
+        }
+
+        [Benchmark]
+        public async Task Bulkhead_Asynchronous()
+        {
+            await AsyncPolicy.ExecuteAsync(() => Workloads.ActionAsync());
+        }
+
+        [Benchmark]
+        public async Task Bulkhead_Asynchronous_With_CancellationToken()
+        {
+            await AsyncPolicy.ExecuteAsync((token) => Workloads.ActionAsync(token), CancellationToken.None);
+        }
+
+        [Benchmark]
+        public int Bulkhead_Synchronous_With_Result()
+        {
+            return SyncPolicy.Execute(() => Workloads.Func<int>());
+        }
+
+        [Benchmark]
+        public async Task<int> Bulkhead_Asynchronous_With_Result()
+        {
+            return await AsyncPolicy.ExecuteAsync(() => Workloads.FuncAsync<int>());
+        }
+
+        [Benchmark]
+        public async Task<int> Bulkhead_Asynchronous_With_Result_With_CancellationToken()
+        {
+            return await AsyncPolicy.ExecuteAsync((token) => Workloads.FuncAsync<int>(token), CancellationToken.None);
+        }
+    }
+}

--- a/src/Polly.Benchmarks/Cache.cs
+++ b/src/Polly.Benchmarks/Cache.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.Caching.Memory;
+using Polly.Caching;
+
+namespace Polly.Benchmarks
+{
+    [Config(typeof(PollyConfig))]
+    public class Cache
+    {
+        private static readonly MemoryCache MemoryCache = new MemoryCache(new MemoryCacheOptions());
+        private static readonly MemoryCacheProvider CacheProvider = new MemoryCacheProvider(MemoryCache);
+
+        private static readonly Policy SyncPolicyMiss = Policy.Cache(CacheProvider, TimeSpan.Zero);
+        private static readonly AsyncPolicy AsyncPolicyMiss = Policy.CacheAsync(CacheProvider, TimeSpan.Zero);
+
+        private static readonly Policy SyncPolicyHit = Policy.Cache(CacheProvider, TimeSpan.MaxValue);
+        private static readonly AsyncPolicy AsyncPolicyHit = Policy.CacheAsync(CacheProvider, TimeSpan.MaxValue);
+
+        private static readonly Context HitContext = new Context(nameof(HitContext));
+        private static readonly Context MissContext = new Context(nameof(MissContext));
+
+        [GlobalSetup]
+        public async Task GlobalSetup()
+        {
+            SyncPolicyHit.Execute((context) => GetObject(), HitContext);
+            await AsyncPolicyHit.ExecuteAsync((context, token) => GetObjectAsync(token), HitContext, CancellationToken.None);
+        }
+
+        [Benchmark]
+        public object Cache_Synchronous_Hit()
+        {
+            return SyncPolicyHit.Execute((context) => GetObject(), HitContext);
+        }
+
+        [Benchmark]
+        public async Task<object> Cache_Asynchronous_Hit()
+        {
+            return await AsyncPolicyHit.ExecuteAsync((context, token) => GetObjectAsync(token), HitContext, CancellationToken.None);
+        }
+
+        [Benchmark]
+        public object Cache_Synchronous_Miss()
+        {
+            return SyncPolicyMiss.Execute((context) => GetObject(), MissContext);
+        }
+
+        [Benchmark]
+        public async Task<object> Cache_Asynchronous_Miss()
+        {
+            return await AsyncPolicyMiss.ExecuteAsync((context, token) => GetObjectAsync(token), MissContext, CancellationToken.None);
+        }
+
+        private static object GetObject() => new object();
+
+        private static Task<object> GetObjectAsync(CancellationToken cancellationToken) => Task.FromResult(new object());
+
+        private sealed class MemoryCacheProvider : ISyncCacheProvider, IAsyncCacheProvider
+        {
+            private readonly IMemoryCache _cache;
+
+            public MemoryCacheProvider(IMemoryCache memoryCache)
+            {
+                _cache = memoryCache;
+            }
+
+            public (bool, object) TryGet(string key)
+            {
+                bool cacheHit = _cache.TryGetValue(key, out var value);
+                return (cacheHit, value);
+            }
+
+            public void Put(string key, object value, Ttl ttl)
+            {
+                TimeSpan remaining = DateTimeOffset.MaxValue - DateTimeOffset.UtcNow;
+                var options = new MemoryCacheEntryOptions();
+
+                if (ttl.SlidingExpiration)
+                {
+                    options.SlidingExpiration = ttl.Timespan < remaining ? ttl.Timespan : remaining;
+                }
+                else
+                {
+                    if (ttl.Timespan == TimeSpan.MaxValue)
+                    {
+                        options.AbsoluteExpiration = DateTimeOffset.MaxValue;
+                    }
+                    else
+                    {
+                        options.AbsoluteExpirationRelativeToNow = ttl.Timespan < remaining ? ttl.Timespan : remaining;
+                    }
+                }
+
+                _cache.Set(key, value, options);
+            }
+
+            public Task<(bool, object)> TryGetAsync(string key, CancellationToken cancellationToken, bool continueOnCapturedContext)
+            {
+                return Task.FromResult(TryGet(key));
+            }
+
+            public Task PutAsync(string key, object value, Ttl ttl, CancellationToken cancellationToken, bool continueOnCapturedContext)
+            {
+                Put(key, value, ttl);
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/src/Polly.Benchmarks/CircuitBreaker.cs
+++ b/src/Polly.Benchmarks/CircuitBreaker.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace Polly.Benchmarks
+{
+    [Config(typeof(PollyConfig))]
+    public class CircuitBreaker
+    {
+        private static readonly Policy SyncPolicy = Policy.Handle<InvalidOperationException>().CircuitBreaker(2, TimeSpan.FromMinutes(1));
+        private static readonly AsyncPolicy AsyncPolicy = Policy.Handle<InvalidOperationException>().CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
+
+        [Benchmark]
+        public void CircuitBreaker_Synchronous_Succeeds()
+        {
+            SyncPolicy.Execute(() => Workloads.Action());
+        }
+
+        [Benchmark]
+        public async Task CircuitBreaker_Asynchronous_Succeeds()
+        {
+            await AsyncPolicy.ExecuteAsync((token) => Workloads.ActionAsync(token), CancellationToken.None);
+        }
+
+        [Benchmark]
+        public int CircuitBreaker_Synchronous_With_Result_Succeeds()
+        {
+            return SyncPolicy.Execute(() => Workloads.Func<int>());
+        }
+
+        [Benchmark]
+        public async Task<int> CircuitBreaker_Asynchronous_With_Result_Succeeds()
+        {
+            return await AsyncPolicy.ExecuteAsync((token) => Workloads.FuncAsync<int>(token), CancellationToken.None);
+        }
+    }
+}

--- a/src/Polly.Benchmarks/Fallback.cs
+++ b/src/Polly.Benchmarks/Fallback.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace Polly.Benchmarks
+{
+    [Config(typeof(PollyConfig))]
+    public class Fallback
+    {
+        private static readonly Policy<int> SyncPolicy = Policy<int>.Handle<InvalidOperationException>().Fallback(0);
+        private static readonly AsyncPolicy<int> AsyncPolicy = Policy<int>.Handle<InvalidOperationException>().FallbackAsync(0);
+
+        [Benchmark]
+        public int Fallback_Synchronous_Succeeds()
+        {
+            return SyncPolicy.Execute(() => Workloads.Func<int>());
+        }
+
+        [Benchmark]
+        public async Task<int> Fallback_Asynchronous_Succeeds()
+        {
+            return await AsyncPolicy.ExecuteAsync(() => Workloads.FuncAsync<int>());
+        }
+
+        [Benchmark]
+        public int Fallback_Synchronous_Throws()
+        {
+            return SyncPolicy.Execute(() => Workloads.FuncThrows<int, InvalidOperationException>());
+        }
+
+        [Benchmark]
+        public async Task<int> Fallback_Asynchronous_Throws()
+        {
+            return await AsyncPolicy.ExecuteAsync(() => Workloads.FuncThrowsAsync<int, InvalidOperationException>());
+        }
+    }
+}

--- a/src/Polly.Benchmarks/NoOp.cs
+++ b/src/Polly.Benchmarks/NoOp.cs
@@ -1,0 +1,37 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace Polly.Benchmarks
+{
+    [Config(typeof(PollyConfig))]
+    public class NoOp
+    {
+        private static readonly Policy SyncPolicy = Policy.NoOp();
+        private static readonly AsyncPolicy AsyncPolicy = Policy.NoOpAsync();
+
+        [Benchmark]
+        public void NoOp_Synchronous()
+        {
+            SyncPolicy.Execute(() => Workloads.Action());
+        }
+
+        [Benchmark]
+        public async Task NoOp_Asynchronous()
+        {
+            await AsyncPolicy.ExecuteAsync((token) => Workloads.ActionAsync(token), CancellationToken.None);
+        }
+
+        [Benchmark]
+        public int NoOp_Synchronous_With_Result()
+        {
+            return SyncPolicy.Execute(() => Workloads.Func<int>());
+        }
+
+        [Benchmark]
+        public async Task<int> NoOp_Asynchronous_With_Result()
+        {
+            return await AsyncPolicy.ExecuteAsync((token) => Workloads.FuncAsync<int>(token), CancellationToken.None);
+        }
+    }
+}

--- a/src/Polly.Benchmarks/PolicyWrap.cs
+++ b/src/Polly.Benchmarks/PolicyWrap.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace Polly.Benchmarks
+{
+    [Config(typeof(PollyConfig))]
+    public class PolicyWrap
+    {
+        private static readonly Policy SyncPolicy = Policy.Wrap(
+            Policy.Handle<InvalidOperationException>().Retry(),
+            Policy.Handle<InvalidOperationException>().CircuitBreaker(2, TimeSpan.FromMinutes(1)),
+            Policy.Timeout(TimeSpan.FromMilliseconds(10)));
+
+        private static readonly AsyncPolicy AsyncPolicy = Policy.WrapAsync(
+            Policy.Handle<InvalidOperationException>().RetryAsync(),
+            Policy.Handle<InvalidOperationException>().CircuitBreakerAsync(2, TimeSpan.FromMinutes(1)),
+            Policy.TimeoutAsync(TimeSpan.FromMilliseconds(10)));
+
+        [Benchmark]
+        public void PolicyWrap_Synchronous()
+        {
+            SyncPolicy.Execute(() => Workloads.Action());
+        }
+
+        [Benchmark]
+        public async Task PolicyWrap_Asynchronous()
+        {
+            await AsyncPolicy.ExecuteAsync((token) => Workloads.ActionAsync(token), CancellationToken.None);
+        }
+
+        [Benchmark]
+        public int PolicyWrap_Synchronous_With_Result()
+        {
+            return SyncPolicy.Execute(() => Workloads.Func<int>());
+        }
+
+        [Benchmark]
+        public async Task<int> PolicyWrap_Asynchronous_With_Result()
+        {
+            return await AsyncPolicy.ExecuteAsync((token) => Workloads.FuncAsync<int>(token), CancellationToken.None);
+        }
+    }
+}

--- a/src/Polly.Benchmarks/PolicyWrap.cs
+++ b/src/Polly.Benchmarks/PolicyWrap.cs
@@ -11,12 +11,14 @@ namespace Polly.Benchmarks
         private static readonly Policy SyncPolicy = Policy.Wrap(
             Policy.Handle<InvalidOperationException>().Retry(),
             Policy.Handle<InvalidOperationException>().CircuitBreaker(2, TimeSpan.FromMinutes(1)),
-            Policy.Timeout(TimeSpan.FromMilliseconds(10)));
+            Policy.Timeout(TimeSpan.FromMilliseconds(10)),
+            Policy.Bulkhead(2));
 
         private static readonly AsyncPolicy AsyncPolicy = Policy.WrapAsync(
             Policy.Handle<InvalidOperationException>().RetryAsync(),
             Policy.Handle<InvalidOperationException>().CircuitBreakerAsync(2, TimeSpan.FromMinutes(1)),
-            Policy.TimeoutAsync(TimeSpan.FromMilliseconds(10)));
+            Policy.TimeoutAsync(TimeSpan.FromMilliseconds(10)),
+            Policy.BulkheadAsync(2));
 
         [Benchmark]
         public void PolicyWrap_Synchronous()

--- a/src/Polly.Benchmarks/Polly.Benchmarks.csproj
+++ b/src/Polly.Benchmarks/Polly.Benchmarks.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(BenchmarkFromNuGet)' != 'True' ">
     <ProjectReference Include="..\Polly\Polly.csproj" />

--- a/src/Polly.Benchmarks/Polly.Benchmarks.csproj
+++ b/src/Polly.Benchmarks/Polly.Benchmarks.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(BenchmarkFromNuGet)' != 'True' ">
+    <ProjectReference Include="..\Polly\Polly.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Polly.Benchmarks/Polly.Benchmarks.csproj
+++ b/src/Polly.Benchmarks/Polly.Benchmarks.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <LangVersion>latest</LangVersion>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>

--- a/src/Polly.Benchmarks/Polly.Benchmarks.csproj
+++ b/src/Polly.Benchmarks/Polly.Benchmarks.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(BenchmarkFromNuGet)' != 'True' ">

--- a/src/Polly.Benchmarks/PollyConfig.cs
+++ b/src/Polly.Benchmarks/PollyConfig.cs
@@ -23,7 +23,6 @@ namespace Polly.Benchmarks
                 new[]
                 {
                     new MsBuildArgument("/p:BenchmarkFromNuGet=" + useNuGet),
-                    new MsBuildArgument("/p:LangVersion=9.0"),
                     new MsBuildArgument("/p:SignAssembly=false"),
                 });
 

--- a/src/Polly.Benchmarks/PollyConfig.cs
+++ b/src/Polly.Benchmarks/PollyConfig.cs
@@ -1,0 +1,39 @@
+﻿using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+
+namespace Polly.Benchmarks
+{
+    internal class PollyConfig : ManualConfig
+    {
+        public PollyConfig()
+        {
+            var job = Job.Default;
+
+            AddDiagnoser(BenchmarkDotNet.Diagnosers.EventPipeProfiler.Default);
+            AddDiagnoser(BenchmarkDotNet.Diagnosers.MemoryDiagnoser.Default);
+
+            AddJob(PollyJob(job, useNuGet: true).AsBaseline());
+            AddJob(PollyJob(job, useNuGet: false));
+        }
+
+        private static Job PollyJob(Job job, bool useNuGet)
+        {
+            var result = job
+                .WithId("Polly" + (useNuGet ? string.Empty : "-dev"))
+                .WithArguments(
+                new[]
+                {
+                    new MsBuildArgument("/p:BenchmarkFromNuGet=" + useNuGet),
+                    new MsBuildArgument("/p:LangVersion=9.0"),
+                    new MsBuildArgument("/p:SignAssembly=false"),
+                });
+
+            if (useNuGet)
+            {
+                result = result.WithNuGet("Polly", "7.2.1");
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Polly.Benchmarks/PollyConfig.cs
+++ b/src/Polly.Benchmarks/PollyConfig.cs
@@ -9,7 +9,6 @@ namespace Polly.Benchmarks
         {
             var job = Job.Default;
 
-            AddDiagnoser(BenchmarkDotNet.Diagnosers.EventPipeProfiler.Default);
             AddDiagnoser(BenchmarkDotNet.Diagnosers.MemoryDiagnoser.Default);
 
             AddJob(PollyJob(job, useNuGet: true).AsBaseline());

--- a/src/Polly.Benchmarks/Program.cs
+++ b/src/Polly.Benchmarks/Program.cs
@@ -1,4 +1,4 @@
 ﻿using System.Reflection;
 using BenchmarkDotNet.Running;
 
-BenchmarkSwitcher.FromAssembly(Assembly.GetCallingAssembly()).RunAll();
+BenchmarkRunner.Run(Assembly.GetCallingAssembly(), args: args); 

--- a/src/Polly.Benchmarks/Program.cs
+++ b/src/Polly.Benchmarks/Program.cs
@@ -1,0 +1,4 @@
+﻿using System.Reflection;
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher.FromAssembly(Assembly.GetCallingAssembly()).RunAll();

--- a/src/Polly.Benchmarks/Retry.cs
+++ b/src/Polly.Benchmarks/Retry.cs
@@ -6,7 +6,7 @@ using BenchmarkDotNet.Attributes;
 namespace Polly.Benchmarks
 {
     [Config(typeof(PollyConfig))]
-    public class RetryBenchmarks
+    public class Retry
     {
         [Benchmark]
         public void Retry_Synchronous_Succeeds()

--- a/src/Polly.Benchmarks/Retry.cs
+++ b/src/Polly.Benchmarks/Retry.cs
@@ -8,58 +8,51 @@ namespace Polly.Benchmarks
     [Config(typeof(PollyConfig))]
     public class Retry
     {
+        private static readonly Policy SyncPolicy = Policy.Handle<InvalidOperationException>().Retry();
+        private static readonly AsyncPolicy AsyncPolicy = Policy.Handle<InvalidOperationException>().RetryAsync();
+
         [Benchmark]
         public void Retry_Synchronous_Succeeds()
         {
-            var policy = Policy.Handle<InvalidOperationException>().Retry();
-            policy.Execute(() => Workloads.Action());
+            SyncPolicy.Execute(() => Workloads.Action());
         }
 
         [Benchmark]
         public async Task Retry_Asynchronous_Succeeds()
         {
-            var policy = Policy.Handle<InvalidOperationException>().RetryAsync();
-            await policy.ExecuteAsync(() => Workloads.ActionAsync());
+            await AsyncPolicy.ExecuteAsync(() => Workloads.ActionAsync());
         }
 
         [Benchmark]
         public async Task Retry_Asynchronous_Succeeds_With_CancellationToken()
         {
-            var cancellationToken = CancellationToken.None;
-            var policy = Policy.Handle<InvalidOperationException>().RetryAsync();
-            await policy.ExecuteAsync((token) => Workloads.ActionAsync(token), cancellationToken);
+            await AsyncPolicy.ExecuteAsync((token) => Workloads.ActionAsync(token), CancellationToken.None);
         }
 
         [Benchmark]
         public int Retry_Synchronous_With_Result_Succeeds()
         {
-            var policy = Policy.Handle<InvalidOperationException>().Retry();
-            return policy.Execute(() => Workloads.Func<int>());
+            return SyncPolicy.Execute(() => Workloads.Func<int>());
         }
 
         [Benchmark]
         public async Task<int> Retry_Asynchronous_With_Result_Succeeds()
         {
-            var policy = Policy.Handle<InvalidOperationException>().RetryAsync();
-            return await policy.ExecuteAsync(() => Workloads.FuncAsync<int>());
+            return await AsyncPolicy.ExecuteAsync(() => Workloads.FuncAsync<int>());
         }
 
         [Benchmark]
         public async Task<int> Retry_Asynchronous_With_Result_Succeeds_With_CancellationToken()
         {
-            var cancellationToken = CancellationToken.None;
-            var policy = Policy.Handle<InvalidOperationException>().RetryAsync();
-            return await policy.ExecuteAsync((token) => Workloads.FuncAsync<int>(token), cancellationToken);
+            return await AsyncPolicy.ExecuteAsync((token) => Workloads.FuncAsync<int>(token), CancellationToken.None);
         }
 
         [Benchmark]
         public void Retry_Synchronous_Throws_Then_Succeeds()
         {
-            var policy = Policy.Handle<InvalidOperationException>().Retry();
-
             int count = 0;
 
-            policy.Execute(() =>
+            SyncPolicy.Execute(() =>
             {
                 if (count++ % 2 == 0)
                 {
@@ -71,11 +64,9 @@ namespace Polly.Benchmarks
         [Benchmark]
         public async Task Retry_Asynchronous_Throws_Then_Succeeds()
         {
-            var policy = Policy.Handle<InvalidOperationException>().RetryAsync();
-
             int count = 0;
 
-            await policy.ExecuteAsync(() =>
+            await AsyncPolicy.ExecuteAsync(() =>
             {
                 if (count++ % 2 == 0)
                 {

--- a/src/Polly.Benchmarks/RetryBenchmarks.cs
+++ b/src/Polly.Benchmarks/RetryBenchmarks.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 
@@ -8,7 +9,51 @@ namespace Polly.Benchmarks
     public class RetryBenchmarks
     {
         [Benchmark]
-        public void Retry_Synchronous()
+        public void Retry_Synchronous_Succeeds()
+        {
+            var policy = Policy.Handle<InvalidOperationException>().Retry();
+            policy.Execute(() => Workloads.Action());
+        }
+
+        [Benchmark]
+        public async Task Retry_Asynchronous_Succeeds()
+        {
+            var policy = Policy.Handle<InvalidOperationException>().RetryAsync();
+            await policy.ExecuteAsync(() => Workloads.ActionAsync());
+        }
+
+        [Benchmark]
+        public async Task Retry_Asynchronous_Succeeds_With_CancellationToken()
+        {
+            var cancellationToken = CancellationToken.None;
+            var policy = Policy.Handle<InvalidOperationException>().RetryAsync();
+            await policy.ExecuteAsync((token) => Workloads.ActionAsync(token), cancellationToken);
+        }
+
+        [Benchmark]
+        public int Retry_Synchronous_With_Result_Succeeds()
+        {
+            var policy = Policy.Handle<InvalidOperationException>().Retry();
+            return policy.Execute(() => Workloads.Func<int>());
+        }
+
+        [Benchmark]
+        public async Task<int> Retry_Asynchronous_With_Result_Succeeds()
+        {
+            var policy = Policy.Handle<InvalidOperationException>().RetryAsync();
+            return await policy.ExecuteAsync(() => Workloads.FuncAsync<int>());
+        }
+
+        [Benchmark]
+        public async Task<int> Retry_Asynchronous_With_Result_Succeeds_With_CancellationToken()
+        {
+            var cancellationToken = CancellationToken.None;
+            var policy = Policy.Handle<InvalidOperationException>().RetryAsync();
+            return await policy.ExecuteAsync((token) => Workloads.FuncAsync<int>(token), cancellationToken);
+        }
+
+        [Benchmark]
+        public void Retry_Synchronous_Throws_Then_Succeeds()
         {
             var policy = Policy.Handle<InvalidOperationException>().Retry();
 
@@ -24,7 +69,7 @@ namespace Polly.Benchmarks
         }
 
         [Benchmark]
-        public async Task Retry_Aynchronous()
+        public async Task Retry_Asynchronous_Throws_Then_Succeeds()
         {
             var policy = Policy.Handle<InvalidOperationException>().RetryAsync();
 

--- a/src/Polly.Benchmarks/RetryBenchmarks.cs
+++ b/src/Polly.Benchmarks/RetryBenchmarks.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace Polly.Benchmarks
+{
+    [Config(typeof(PollyConfig))]
+    public class RetryBenchmarks
+    {
+        [Benchmark]
+        public void Retry_Synchronous()
+        {
+            var policy = Policy.Handle<InvalidOperationException>().Retry();
+
+            int count = 0;
+
+            policy.Execute(() =>
+            {
+                if (count++ % 2 == 0)
+                {
+                    throw new InvalidOperationException();
+                }
+            });
+        }
+
+        [Benchmark]
+        public async Task Retry_Aynchronous()
+        {
+            var policy = Policy.Handle<InvalidOperationException>().RetryAsync();
+
+            int count = 0;
+
+            await policy.ExecuteAsync(() =>
+            {
+                if (count++ % 2 == 0)
+                {
+                    throw new InvalidOperationException();
+                }
+
+                return Task.CompletedTask;
+            });
+        }
+    }
+}

--- a/src/Polly.Benchmarks/Timeout.cs
+++ b/src/Polly.Benchmarks/Timeout.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace Polly.Benchmarks
+{
+    [Config(typeof(PollyConfig))]
+    public class Timeout
+    {
+        private static readonly Policy SyncPolicy = Policy.Timeout(TimeSpan.FromMilliseconds(1));
+        private static readonly AsyncPolicy AsyncPolicy = Policy.TimeoutAsync(TimeSpan.FromMilliseconds(1));
+
+        [Benchmark]
+        public void Timeout_Synchronous_Succeeds()
+        {
+            SyncPolicy.Execute(() => Workloads.Action());
+        }
+
+        [Benchmark]
+        public async Task Timeout_Asynchronous_Succeeds()
+        {
+            await AsyncPolicy.ExecuteAsync(() => Workloads.ActionAsync());
+        }
+
+        [Benchmark]
+        public async Task Timeout_Asynchronous_Succeeds_With_CancellationToken()
+        {
+            await AsyncPolicy.ExecuteAsync((token) => Workloads.ActionAsync(token), CancellationToken.None);
+        }
+
+        [Benchmark]
+        public int Timeout_Synchronous_With_Result_Succeeds()
+        {
+            return SyncPolicy.Execute(() => Workloads.Func<int>());
+        }
+
+        [Benchmark]
+        public async Task<int> Timeout_Asynchronous_With_Result_Succeeds()
+        {
+            return await AsyncPolicy.ExecuteAsync(() => Workloads.FuncAsync<int>());
+        }
+
+        [Benchmark]
+        public async Task<int> Timeout_Asynchronous_With_Result_Succeeds_With_CancellationToken()
+        {
+            return await AsyncPolicy.ExecuteAsync((token) => Workloads.FuncAsync<int>(token), CancellationToken.None);
+        }
+
+        [Benchmark]
+        public void Timeout_Synchronous_Times_Out()
+        {
+            SyncPolicy.Execute(() => Workloads.ActionInfinite());
+        }
+
+        [Benchmark]
+        public async Task Timeout_Asynchronous_Times_Out_Optimistic()
+        {
+            await AsyncPolicy.ExecuteAsync((token) => Workloads.ActionInfiniteAsync(token), CancellationToken.None);
+        }
+
+        [Benchmark]
+        public async Task Timeout_Asynchronous_Times_Out_Pessimistic()
+        {
+            await AsyncPolicy.ExecuteAsync(() => Workloads.ActionInfiniteAsync());
+        }
+    }
+}

--- a/src/Polly.Benchmarks/Timeout.cs
+++ b/src/Polly.Benchmarks/Timeout.cs
@@ -52,11 +52,5 @@ namespace Polly.Benchmarks
         {
             await AsyncPolicy.ExecuteAsync((token) => Workloads.ActionInfiniteAsync(token), CancellationToken.None);
         }
-
-        [Benchmark]
-        public async Task Timeout_Asynchronous_Times_Out_Pessimistic()
-        {
-            await AsyncPolicy.ExecuteAsync(() => Workloads.ActionInfiniteAsync());
-        }
     }
 }

--- a/src/Polly.Benchmarks/Timeout.cs
+++ b/src/Polly.Benchmarks/Timeout.cs
@@ -48,12 +48,6 @@ namespace Polly.Benchmarks
         }
 
         [Benchmark]
-        public void Timeout_Synchronous_Times_Out()
-        {
-            SyncPolicy.Execute(() => Workloads.ActionInfinite());
-        }
-
-        [Benchmark]
         public async Task Timeout_Asynchronous_Times_Out_Optimistic()
         {
             await AsyncPolicy.ExecuteAsync((token) => Workloads.ActionInfiniteAsync(token), CancellationToken.None);

--- a/src/Polly.Benchmarks/Workloads.cs
+++ b/src/Polly.Benchmarks/Workloads.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Polly.Benchmarks
@@ -13,10 +14,46 @@ namespace Polly.Benchmarks
 
         internal static Task ActionAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
+        internal static void ActionInfinite()
+        {
+            while (true)
+            {
+                Thread.Sleep(1);
+            }
+        }
+
+        internal static async Task ActionInfiniteAsync()
+        {
+            while (true)
+            {
+                await Task.Yield();
+            }
+        }
+
+        internal static async Task ActionInfiniteAsync(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                await Task.Yield();
+            }
+        }
+
         internal static T Func<T>() => default;
 
         internal static Task<T> FuncAsync<T>() => Task.FromResult<T>(default);
 
         internal static Task<T> FuncAsync<T>(CancellationToken cancellationToken) => Task.FromResult<T>(default);
+
+        internal static TResult FuncThrows<TResult, TException>()
+            where TException : Exception, new()
+        {
+            throw new TException();
+        }
+
+        internal static Task<TResult> FuncThrowsAsync<TResult, TException>()
+            where TException : Exception, new()
+        {
+            throw new TException();
+        }
     }
 }

--- a/src/Polly.Benchmarks/Workloads.cs
+++ b/src/Polly.Benchmarks/Workloads.cs
@@ -14,14 +14,6 @@ namespace Polly.Benchmarks
 
         internal static Task ActionAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
-        internal static void ActionInfinite()
-        {
-            while (true)
-            {
-                Thread.Sleep(1);
-            }
-        }
-
         internal static async Task ActionInfiniteAsync()
         {
             while (true)

--- a/src/Polly.Benchmarks/Workloads.cs
+++ b/src/Polly.Benchmarks/Workloads.cs
@@ -1,0 +1,22 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace Polly.Benchmarks
+{
+    internal static class Workloads
+    {
+        internal static void Action()
+        {
+        }
+
+        internal static Task ActionAsync() => Task.CompletedTask;
+
+        internal static Task ActionAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        internal static T Func<T>() => default;
+
+        internal static Task<T> FuncAsync<T>() => Task.FromResult<T>(default);
+
+        internal static Task<T> FuncAsync<T>(CancellationToken cancellationToken) => Task.FromResult<T>(default);
+    }
+}

--- a/src/Polly.sln
+++ b/src/Polly.sln
@@ -12,6 +12,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Polly", "Polly\Polly.csproj
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Polly.Specs", "Polly.Specs\Polly.Specs.csproj", "{F771DF22-5684-43DF-B574-D76C35202AF4}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Polly.Benchmarks", "Polly.Benchmarks\Polly.Benchmarks.csproj", "{BED2624C-E418-4177-8696-0242363FFD43}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,6 +28,10 @@ Global
 		{F771DF22-5684-43DF-B574-D76C35202AF4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F771DF22-5684-43DF-B574-D76C35202AF4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F771DF22-5684-43DF-B574-D76C35202AF4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BED2624C-E418-4177-8696-0242363FFD43}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BED2624C-E418-4177-8696-0242363FFD43}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BED2624C-E418-4177-8696-0242363FFD43}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BED2624C-E418-4177-8696-0242363FFD43}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Polly/Caching/ContextualTtl.cs
+++ b/src/Polly/Caching/ContextualTtl.cs
@@ -29,7 +29,14 @@ namespace Polly.Caching
         public Ttl GetTtl(Context context, object result)
         {
             if (!context.ContainsKey(TimeSpanKey)) return _noTtl;
-            bool sliding = context.ContainsKey(SlidingExpirationKey) ? context[SlidingExpirationKey] as bool? ?? false : false;
+
+            bool sliding = false;
+
+            if (context.TryGetValue(SlidingExpirationKey, out object objValue))
+            {
+                sliding = objValue as bool? ?? false;
+            }
+
             return new Ttl(context[TimeSpanKey] as TimeSpan? ?? TimeSpan.Zero, sliding);
         }
 

--- a/src/Polly/Utilities/TaskHelper.cs
+++ b/src/Polly/Utilities/TaskHelper.cs
@@ -10,6 +10,12 @@ namespace Polly.Utilities
         /// <summary>
         /// Defines a completed Task for use as a completed, empty asynchronous delegate.
         /// </summary>
-        public static Task EmptyTask = Task.FromResult(true);
+        public static Task EmptyTask =
+#if NETSTANDARD1_1
+            Task.FromResult(true)
+#else
+            Task.CompletedTask
+#endif
+            ;
     }
 }


### PR DESCRIPTION
A few months ago I was playing around with benchmarking Polly to see if there were any allocation-related quick wins anywhere. I didn't really get anywhere with finding any, but I figured it might be worth pushing up the benchmarks project I used for it so it can be re-used in the future.
