### PR TITLE
Add Action<Context> for onHalfOpen

### DIFF
--- a/src/Polly/CircuitBreaker/AdvancedCircuitBreakerSyntax.cs
+++ b/src/Polly/CircuitBreaker/AdvancedCircuitBreakerSyntax.cs
@@ -221,6 +221,46 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         public static CircuitBreakerPolicy AdvancedCircuitBreaker(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
+            => policyBuilder.AdvancedCircuitBreaker(
+                failureThreshold,
+                samplingDuration,
+                minimumThroughput,
+                durationOfBreak,
+                onBreak,
+                onReset,
+                _ => onHalfOpen()
+            );
+
+        /// <summary>
+        /// <para> Builds a <see cref="Policy" /> that will function like a Circuit Breaker.</para>
+        /// <para>The circuit will break if, within any timeslice of duration <paramref name="samplingDuration"/>, the proportion of actions resulting in a handled exception exceeds <paramref name="failureThreshold"/>, provided also that the number of actions through the circuit in the timeslice is at least <paramref name="minimumThroughput" />. </para>
+        /// <para>The circuit will stay broken for the <paramref name="durationOfBreak" />. Any attempt to execute this policy
+        /// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException" /> containing the exception
+        /// that broke the circuit.
+        /// </para>
+        /// <para>If the first action after the break duration period results in a handled exception, the circuit will break
+        /// again for another <paramref name="durationOfBreak" />; if no exception is thrown, the circuit will reset.
+        /// </para>
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="failureThreshold">The failure threshold at which the circuit will break (a number between 0 and 1; eg 0.5 represents breaking if 50% or more of actions result in a handled failure.</param>
+        /// <param name="samplingDuration">The duration of the timeslice over which failure ratios are assessed.</param>
+        /// <param name="minimumThroughput">The minimum throughput: this many actions or more must pass through the circuit in the timeslice, for statistics to be considered significant and the circuit-breaker to come into action.</param>
+        /// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
+        /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open" /> state.</param>
+        /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed" /> state.</param>
+        /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen" /> state, ready to try action executions again.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
+        /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
+        /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
+        /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
+        /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+        /// <exception cref="ArgumentNullException">onBreak</exception>
+        /// <exception cref="ArgumentNullException">onReset</exception>
+        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+        /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+        public static CircuitBreakerPolicy AdvancedCircuitBreaker(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action<Context> onHalfOpen)
         {
             var resolutionOfCircuit = TimeSpan.FromTicks(AdvancedCircuitController<EmptyStruct>.ResolutionOfCircuitTimer);
 

--- a/src/Polly/CircuitBreaker/AdvancedCircuitBreakerTResultSyntax.cs
+++ b/src/Polly/CircuitBreaker/AdvancedCircuitBreakerTResultSyntax.cs
@@ -223,6 +223,47 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
         public static CircuitBreakerPolicy<TResult> AdvancedCircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
+        => policyBuilder.AdvancedCircuitBreaker(
+                failureThreshold,
+                samplingDuration,
+                minimumThroughput,
+                durationOfBreak,
+                onBreak,
+                onReset,
+                _ => onHalfOpen()
+            );
+
+        /// <summary>
+        /// <para> Builds a <see cref="Policy{TResult}" /> that will function like a Circuit Breaker.</para>
+        /// <para>The circuit will break if, within any timeslice of duration <paramref name="samplingDuration" />, the proportion of actions resulting in a handled exception or result exceeds <paramref name="failureThreshold" />, provided also that the number of actions through the circuit in the timeslice is at least <paramref name="minimumThroughput" />. </para>
+        /// <para>The circuit will stay broken for the <paramref name="durationOfBreak" />. Any attempt to execute this policy
+        /// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException" /> containing the exception or result
+        /// that broke the circuit.
+        /// </para>
+        /// <para>If the first action after the break duration period results in a handled exception or result, the circuit will break
+        /// again for another <paramref name="durationOfBreak" />; if no exception or handled result is encountered, the circuit will reset.
+        /// </para>
+        /// </summary>
+        /// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="failureThreshold">The failure threshold at which the circuit will break (a number between 0 and 1; eg 0.5 represents breaking if 50% or more of actions result in a handled failure.</param>
+        /// <param name="samplingDuration">The duration of the timeslice over which failure ratios are assessed.</param>
+        /// <param name="minimumThroughput">The minimum throughput: this many actions or more must pass through the circuit in the timeslice, for statistics to be considered significant and the circuit-breaker to come into action.</param>
+        /// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
+        /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open" /> state.</param>
+        /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed" /> state.</param>
+        /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen" /> state, ready to try action executions again.</param>
+        /// <returns>The policy instance.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
+        /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
+        /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
+        /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
+        /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+        /// <exception cref="ArgumentNullException">onBreak</exception>
+        /// <exception cref="ArgumentNullException">onReset</exception>
+        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+        /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+        public static CircuitBreakerPolicy<TResult> AdvancedCircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action<Context> onHalfOpen)
         {
             var resolutionOfCircuit = TimeSpan.FromTicks(AdvancedCircuitController<EmptyStruct>.ResolutionOfCircuitTimer);
 

--- a/src/Polly/CircuitBreaker/AdvancedCircuitController.cs
+++ b/src/Polly/CircuitBreaker/AdvancedCircuitController.cs
@@ -19,7 +19,7 @@ namespace Polly.CircuitBreaker
             TimeSpan durationOfBreak, 
             Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> onBreak, 
             Action<Context> onReset, 
-            Action onHalfOpen
+            Action<Context> onHalfOpen
             ) : base(durationOfBreak, onBreak, onReset, onHalfOpen)
         {
             _metrics = samplingDuration.Ticks < ResolutionOfCircuitTimer * NumberOfWindows

--- a/src/Polly/CircuitBreaker/AsyncAdvancedCircuitBreakerSyntax.cs
+++ b/src/Polly/CircuitBreaker/AsyncAdvancedCircuitBreakerSyntax.cs
@@ -225,6 +225,46 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onReset</exception>
         /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static AsyncCircuitBreakerPolicy AdvancedCircuitBreakerAsync(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
+            => policyBuilder.AdvancedCircuitBreakerAsync(
+                    failureThreshold,
+                    samplingDuration,
+                    minimumThroughput,
+                    durationOfBreak,
+                    onBreak,
+                    onReset,
+                    _ => onHalfOpen()
+                );
+
+        /// <summary>
+        /// <para> Builds a <see cref="AsyncPolicy"/> that will function like a Circuit Breaker.</para>
+        /// <para>The circuit will break if, within any timeslice of duration <paramref name="samplingDuration"/>, the proportion of actions resulting in a handled exception exceeds <paramref name="failureThreshold"/>, provided also that the number of actions through the circuit in the timeslice is at least <paramref name="minimumThroughput" />. </para>
+        /// <para>The circuit will stay broken for the <paramref name="durationOfBreak" />. Any attempt to execute this policy
+        /// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException" /> containing the exception
+        /// that broke the circuit.
+        /// </para>
+        /// <para>If the first action after the break duration period results in a handled exception, the circuit will break
+        /// again for another <paramref name="durationOfBreak" />; if no exception is thrown, the circuit will reset.
+        /// </para>
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="failureThreshold">The failure threshold at which the circuit will break (a number between 0 and 1; eg 0.5 represents breaking if 50% or more of actions result in a handled failure.</param>
+        /// <param name="samplingDuration">The duration of the timeslice over which failure ratios are assessed.</param>
+        /// <param name="minimumThroughput">The minimum throughput: this many actions or more must pass through the circuit in the timeslice, for statistics to be considered significant and the circuit-breaker to come into action.</param>
+        /// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
+        /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
+        /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
+        /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
+        /// <returns>The policy instance.</returns>
+        /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
+        /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
+        /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
+        /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
+        /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+        /// <exception cref="ArgumentNullException">onBreak</exception>
+        /// <exception cref="ArgumentNullException">onReset</exception>
+        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+        public static AsyncCircuitBreakerPolicy AdvancedCircuitBreakerAsync(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action<Context> onHalfOpen)
         {
             var resolutionOfCircuit = TimeSpan.FromTicks(AdvancedCircuitController<EmptyStruct>.ResolutionOfCircuitTimer);
 

--- a/src/Polly/CircuitBreaker/AsyncAdvancedCircuitBreakerTResultSyntax.cs
+++ b/src/Polly/CircuitBreaker/AsyncAdvancedCircuitBreakerTResultSyntax.cs
@@ -224,6 +224,46 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onReset</exception>
         /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static AsyncCircuitBreakerPolicy<TResult> AdvancedCircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
+            => policyBuilder.AdvancedCircuitBreakerAsync(
+                    failureThreshold,
+                    samplingDuration,
+                    minimumThroughput,
+                    durationOfBreak,
+                    onBreak,
+                    onReset,
+                    _ => onHalfOpen()
+                );
+
+        /// <summary>
+        /// <para> Builds a <see cref="AsyncPolicy{TResult}"/> that will function like a Circuit Breaker.</para>
+        /// <para>The circuit will break if, within any timeslice of duration <paramref name="samplingDuration"/>, the proportion of actions resulting in a handled exception exceeds <paramref name="failureThreshold"/>, provided also that the number of actions through the circuit in the timeslice is at least <paramref name="minimumThroughput" />. </para>
+        /// <para>The circuit will stay broken for the <paramref name="durationOfBreak" />. Any attempt to execute this policy
+        /// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException" /> containing the exception or result
+        /// that broke the circuit.
+        /// </para>
+        /// <para>If the first action after the break duration period results in a handled exception or result, the circuit will break
+        /// again for another <paramref name="durationOfBreak" />; if no exception or handled result is encountered, the circuit will reset.
+        /// </para>
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="failureThreshold">The failure threshold at which the circuit will break (a number between 0 and 1; eg 0.5 represents breaking if 50% or more of actions result in a handled failure.</param>
+        /// <param name="samplingDuration">The duration of the timeslice over which failure ratios are assessed.</param>
+        /// <param name="minimumThroughput">The minimum throughput: this many actions or more must pass through the circuit in the timeslice, for statistics to be considered significant and the circuit-breaker to come into action.</param>
+        /// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
+        /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
+        /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
+        /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
+        /// <returns>The policy instance.</returns>
+        /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
+        /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
+        /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
+        /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
+        /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+        /// <exception cref="ArgumentNullException">onBreak</exception>
+        /// <exception cref="ArgumentNullException">onReset</exception>
+        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+        public static AsyncCircuitBreakerPolicy<TResult> AdvancedCircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action<Context> onHalfOpen)
         {
             var resolutionOfCircuit = TimeSpan.FromTicks(AdvancedCircuitController<EmptyStruct>.ResolutionOfCircuitTimer);
 

--- a/src/Polly/CircuitBreaker/AsyncCircuitBreakerSyntax.cs
+++ b/src/Polly/CircuitBreaker/AsyncCircuitBreakerSyntax.cs
@@ -194,6 +194,39 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onReset</exception>
         /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static AsyncCircuitBreakerPolicy CircuitBreakerAsync(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
+            => policyBuilder.CircuitBreakerAsync(
+                    exceptionsAllowedBeforeBreaking,
+                    durationOfBreak,
+                    onBreak,
+                    onReset,
+                    _ => onHalfOpen()
+                );
+
+        /// <summary>
+        /// <para> Builds a <see cref="AsyncPolicy"/> that will function like a Circuit Breaker.</para>
+        /// <para>The circuit will break if <paramref name="exceptionsAllowedBeforeBreaking"/>
+        /// exceptions that are handled by this policy are raised consecutively. </para>
+        /// <para>The circuit will stay broken for the <paramref name="durationOfBreak"/>. Any attempt to execute this policy
+        /// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException"/> containing the exception 
+        /// that broke the circuit.
+        /// </para>
+        /// <para>If the first action after the break duration period results in a handled exception, the circuit will break
+        /// again for another <paramref name="durationOfBreak"/>; if no exception is thrown, the circuit will reset.
+        /// </para>
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="exceptionsAllowedBeforeBreaking">The number of exceptions that are allowed before opening the circuit.</param>
+        /// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
+        /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
+        /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
+        /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
+        /// <returns>The policy instance.</returns>
+        /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
+        /// <exception cref="ArgumentNullException">onBreak</exception>
+        /// <exception cref="ArgumentNullException">onReset</exception>
+        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+        public static AsyncCircuitBreakerPolicy CircuitBreakerAsync(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action<Context> onHalfOpen)
         {
             if (exceptionsAllowedBeforeBreaking <= 0) throw new ArgumentOutOfRangeException(nameof(exceptionsAllowedBeforeBreaking), "Value must be greater than zero.");
             if (durationOfBreak < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(durationOfBreak), "Value must be greater than zero.");
@@ -215,4 +248,3 @@ namespace Polly
         }
     }
 }
-

--- a/src/Polly/CircuitBreaker/AsyncCircuitBreakerTResultSyntax.cs
+++ b/src/Polly/CircuitBreaker/AsyncCircuitBreakerTResultSyntax.cs
@@ -193,6 +193,39 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onReset</exception>
         /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static AsyncCircuitBreakerPolicy<TResult> CircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
+            => policyBuilder.CircuitBreakerAsync(
+                handledEventsAllowedBeforeBreaking,
+                durationOfBreak,
+                onBreak,
+                onReset,
+                _ => onHalfOpen()
+            );
+
+        /// <summary>
+        /// <para> Builds a <see cref="AsyncPolicy{TResult}"/> that will function like a Circuit Breaker.</para>
+        /// <para>The circuit will break if <paramref name="handledEventsAllowedBeforeBreaking"/>
+        /// exceptions or results that are handled by this policy are encountered consecutively. </para>
+        /// <para>The circuit will stay broken for the <paramref name="durationOfBreak"/>. Any attempt to execute this policy
+        /// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException"/> containing the exception or result 
+        /// that broke the circuit.
+        /// </para>
+        /// <para>If the first action after the break duration period results in a handled exception or result, the circuit will break
+        /// again for another <paramref name="durationOfBreak"/>; if no exception or handled result is encountered, the circuit will reset.
+        /// </para>
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="handledEventsAllowedBeforeBreaking">The number of exceptions or handled results that are allowed before opening the circuit.</param>
+        /// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
+        /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
+        /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
+        /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
+        /// <returns>The policy instance.</returns>
+        /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
+        /// <exception cref="ArgumentNullException">onBreak</exception>
+        /// <exception cref="ArgumentNullException">onReset</exception>
+        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+        public static AsyncCircuitBreakerPolicy<TResult> CircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action<Context> onHalfOpen)
         {
             if (handledEventsAllowedBeforeBreaking <= 0) throw new ArgumentOutOfRangeException(nameof(handledEventsAllowedBeforeBreaking), "Value must be greater than zero.");
             if (durationOfBreak < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(durationOfBreak), "Value must be greater than zero.");
@@ -214,4 +247,3 @@ namespace Polly
         }
     }
 }
-

--- a/src/Polly/CircuitBreaker/CircuitBreakerSyntax.cs
+++ b/src/Polly/CircuitBreaker/CircuitBreakerSyntax.cs
@@ -195,6 +195,39 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onReset</exception>
         /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static CircuitBreakerPolicy CircuitBreaker(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
+            => policyBuilder.CircuitBreaker(
+                exceptionsAllowedBeforeBreaking,
+                durationOfBreak,
+                onBreak,
+                onReset,
+                _ => onHalfOpen()
+            );
+
+        /// <summary>
+        /// <para> Builds a <see cref="Policy"/> that will function like a Circuit Breaker.</para>
+        /// <para>The circuit will break if <paramref name="exceptionsAllowedBeforeBreaking"/>
+        /// exceptions that are handled by this policy are raised consecutively. </para>
+        /// <para>The circuit will stay broken for the <paramref name="durationOfBreak"/>. Any attempt to execute this policy
+        /// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException"/> containing the exception
+        /// that broke the circuit.
+        /// </para>
+        /// <para>If the first action after the break duration period results in a handled exception, the circuit will break
+        /// again for another <paramref name="durationOfBreak"/>; if no exception is thrown, the circuit will reset.
+        /// </para>
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="exceptionsAllowedBeforeBreaking">The number of exceptions that are allowed before opening the circuit.</param>
+        /// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
+        /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
+        /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
+        /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
+        /// <returns>The policy instance.</returns>
+        /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
+        /// <exception cref="ArgumentNullException">onBreak</exception>
+        /// <exception cref="ArgumentNullException">onReset</exception>
+        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+        public static CircuitBreakerPolicy CircuitBreaker(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action<Context> onHalfOpen)
         {
             if (exceptionsAllowedBeforeBreaking <= 0) throw new ArgumentOutOfRangeException(nameof(exceptionsAllowedBeforeBreaking), "Value must be greater than zero.");
             if (durationOfBreak < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(durationOfBreak), "Value must be greater than zero.");

--- a/src/Polly/CircuitBreaker/CircuitBreakerTResultSyntax.cs
+++ b/src/Polly/CircuitBreaker/CircuitBreakerTResultSyntax.cs
@@ -194,6 +194,39 @@ namespace Polly
         /// <exception cref="ArgumentNullException">onReset</exception>
         /// <exception cref="ArgumentNullException">onHalfOpen</exception>
         public static CircuitBreakerPolicy<TResult> CircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
+            => policyBuilder.CircuitBreaker(
+                handledEventsAllowedBeforeBreaking,
+                durationOfBreak,
+                onBreak,
+                onReset,
+                _ => onHalfOpen()
+            );
+
+        /// <summary>
+        /// <para> Builds a <see cref="Policy{TResult}"/> that will function like a Circuit Breaker.</para>
+        /// <para>The circuit will break if <paramref name="handledEventsAllowedBeforeBreaking"/>
+        /// exceptions or results that are handled by this policy are encountered consecutively. </para>
+        /// <para>The circuit will stay broken for the <paramref name="durationOfBreak"/>. Any attempt to execute this policy
+        /// while the circuit is broken, will immediately throw a <see cref="BrokenCircuitException"/> containing the exception or result 
+        /// that broke the circuit.
+        /// </para>
+        /// <para>If the first action after the break duration period results in a handled exception or result, the circuit will break
+        /// again for another <paramref name="durationOfBreak"/>; if no exception or handled result is encountered, the circuit will reset.
+        /// </para>
+        /// </summary>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="handledEventsAllowedBeforeBreaking">The number of exceptions or handled results that are allowed before opening the circuit.</param>
+        /// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
+        /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
+        /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
+        /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
+        /// <returns>The policy instance.</returns>
+        /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
+        /// <exception cref="ArgumentNullException">onBreak</exception>
+        /// <exception cref="ArgumentNullException">onReset</exception>
+        /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+        public static CircuitBreakerPolicy<TResult> CircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action<Context> onHalfOpen)
         {
             if (handledEventsAllowedBeforeBreaking <= 0) throw new ArgumentOutOfRangeException(nameof(handledEventsAllowedBeforeBreaking), "Value must be greater than zero.");
             if (durationOfBreak < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(durationOfBreak), "Value must be greater than zero.");

--- a/src/Polly/CircuitBreaker/CircuitStateController.cs
+++ b/src/Polly/CircuitBreaker/CircuitStateController.cs
@@ -13,7 +13,7 @@ namespace Polly.CircuitBreaker
 
         protected readonly Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> _onBreak;
         protected readonly Action<Context> _onReset;
-        protected readonly Action _onHalfOpen;
+        protected readonly Action<Context> _onHalfOpen;
 
         protected readonly object _lock = new object();
 
@@ -21,7 +21,7 @@ namespace Polly.CircuitBreaker
             TimeSpan durationOfBreak, 
             Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> onBreak, 
             Action<Context> onReset, 
-            Action onHalfOpen)
+            Action<Context> onHalfOpen)
         {
             _durationOfBreak = durationOfBreak;
             _onBreak = onBreak;
@@ -46,7 +46,7 @@ namespace Polly.CircuitBreaker
                     if (_circuitState == CircuitState.Open && !IsInAutomatedBreak_NeedsLock)
                     {
                         _circuitState = CircuitState.HalfOpen;
-                        _onHalfOpen();
+                        _onHalfOpen(Context.None()); // TODO #882 How to thread the user's context through here?
                     }
                     return _circuitState;
                 }

--- a/src/Polly/CircuitBreaker/ConsecutiveCountCircuitController.cs
+++ b/src/Polly/CircuitBreaker/ConsecutiveCountCircuitController.cs
@@ -13,7 +13,7 @@ namespace Polly.CircuitBreaker
             TimeSpan durationOfBreak, 
             Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> onBreak, 
             Action<Context> onReset, 
-            Action onHalfOpen
+            Action<Context> onHalfOpen
             ) : base(durationOfBreak, onBreak, onReset, onHalfOpen)
         {
             _exceptionsAllowedBeforeBreaking = exceptionsAllowedBeforeBreaking;


### PR DESCRIPTION
### The issue or feature being addressed

Add overloads for circuit breakers that accept a `Context`.

Relates to #882.

### Details on the issue fix or feature implementation

The `Context` is always the value of `Context.None()` at present as it seems we would need quite a lot of refactoring to thread it through.
