### PR TITLE
Add RateLimit benchmarks

### DIFF
--- a/src/Polly.Benchmarks/PollyConfig.cs
+++ b/src/Polly.Benchmarks/PollyConfig.cs
@@ -28,7 +28,7 @@ namespace Polly.Benchmarks
 
             if (useNuGet)
             {
-                result = result.WithNuGet("Polly", "7.2.1");
+                result = result.WithNuGet("Polly", "7.3.0");
             }
 
             return result;

--- a/src/Polly.Benchmarks/PollyConfig.cs
+++ b/src/Polly.Benchmarks/PollyConfig.cs
@@ -28,7 +28,7 @@ namespace Polly.Benchmarks
 
             if (useNuGet)
             {
-                result = result.WithNuGet("Polly", "7.3.0");
+                result = result.WithNuGet("Polly", "7.2.3");
             }
 
             return result;

--- a/src/Polly.Benchmarks/RateLimit.cs
+++ b/src/Polly.Benchmarks/RateLimit.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace Polly.Benchmarks
+{
+    [Config(typeof(PollyConfig))]
+    public class RateLimit
+    {
+        private static readonly Policy SyncPolicy = Policy.RateLimit(20, TimeSpan.FromSeconds(1), int.MaxValue);
+        private static readonly AsyncPolicy AsyncPolicy = Policy.RateLimitAsync(20, TimeSpan.FromSeconds(1), int.MaxValue);
+
+        [Benchmark]
+        public void RateLimit_Synchronous_Succeeds()
+        {
+            SyncPolicy.Execute(() => Workloads.Action());
+        }
+
+        [Benchmark]
+        public async Task RateLimit_Asynchronous_Succeeds()
+        {
+            await AsyncPolicy.ExecuteAsync(() => Workloads.ActionAsync());
+        }
+
+        [Benchmark]
+        public int RateLimit_Synchronous_With_Result_Succeeds()
+        {
+            return SyncPolicy.Execute(() => Workloads.Func<int>());
+        }
+
+        [Benchmark]
+        public async Task<int> RateLimit_Asynchronous_With_Result_Succeeds()
+        {
+            return await AsyncPolicy.ExecuteAsync(() => Workloads.FuncAsync<int>());
+        }
+    }
+}


### PR DESCRIPTION
### Details on the issue fix or feature implementation

Add benchmarks for the rate-limit policy added by #903.

~This won't work until 7.2.3 is actually released to NuGet.org.~

Results from a local run without a baseline are below.

``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19043.1466 (21H1/May2021Update)
Intel Core i9-9980HK CPU 2.40GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK=6.0.101
  [Host]    : .NET 6.0.1 (6.0.121.56705), X64 RyuJIT
  Polly-dev : .NET 6.0.1 (6.0.121.56705), X64 RyuJIT

Job=Polly-dev  Arguments=/p:BenchmarkFromNuGet=False,/p:SignAssembly=false  

```
|                                      Method |      Mean |    Error |   StdDev |  Gen 0 | Allocated |
|-------------------------------------------- |----------:|---------:|---------:|-------:|----------:|
|              RateLimit_Synchronous_Succeeds |  59.66 ns | 0.593 ns | 0.555 ns | 0.0296 |     248 B |
|             RateLimit_Asynchronous_Succeeds | 140.89 ns | 2.772 ns | 2.314 ns | 0.0477 |     400 B |
|  RateLimit_Synchronous_With_Result_Succeeds |  49.59 ns | 0.429 ns | 0.401 ns | 0.0191 |     160 B |
| RateLimit_Asynchronous_With_Result_Succeeds | 107.90 ns | 2.142 ns | 3.072 ns | 0.0191 |     160 B |


### Confirm the following

- [x]  I started this PR by branching from the head of the latest dev vX.Y branch, or I have rebased on the latest dev vX.Y branch, or I have merged the latest changes from the dev vX.Y branch
- [x]  I have targeted the PR to merge into the latest dev vX.Y branch as the base branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
