### PR TITLE
Handle rate-limit edge case

### DIFF
--- a/src/Polly.Specs/RateLimit/RateLimitPolicySpecsBase.cs
+++ b/src/Polly.Specs/RateLimit/RateLimitPolicySpecsBase.cs
@@ -61,6 +61,23 @@ namespace Polly.Specs.RateLimit
         }
 
         [Fact]
+        public void Syntax_should_throw_for_perTimeSpan_infinite()
+        {
+            Action invalidSyntax = () => GetPolicyViaSyntax(1, System.Threading.Timeout.InfiniteTimeSpan);
+
+            invalidSyntax.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("perTimeSpan");
+        }
+
+        [Fact]
+        public void Syntax_should_throw_for_perTimeSpan_too_small()
+        {
+            Action invalidSyntax = () => GetPolicyViaSyntax(int.MaxValue, TimeSpan.FromSeconds(1));
+
+            invalidSyntax.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("perTimeSpan");
+            invalidSyntax.Should().Throw<ArgumentOutOfRangeException>().And.Message.Should().StartWith("The number of executions per timespan must be positive.");
+        }
+
+        [Fact]
         public void Syntax_should_throw_for_numberOfExecutions_negative()
         {
             Action invalidSyntax = () => GetPolicyViaSyntax(-1, TimeSpan.FromSeconds(1));

--- a/src/Polly/RateLimit/AsyncRateLimitSyntax.cs
+++ b/src/Polly/RateLimit/AsyncRateLimitSyntax.cs
@@ -35,7 +35,14 @@ namespace Polly
             if (perTimeSpan <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(perTimeSpan), perTimeSpan, $"{nameof(perTimeSpan)} must be a positive timespan.");
             if (maxBurst < 1) throw new ArgumentOutOfRangeException(nameof(maxBurst), maxBurst, $"{nameof(maxBurst)} must be an integer greater than or equal to 1.");
 
-            IRateLimiter rateLimiter = RateLimiterFactory.Create(TimeSpan.FromTicks(perTimeSpan.Ticks / numberOfExecutions), maxBurst);
+            var onePer = TimeSpan.FromTicks(perTimeSpan.Ticks / numberOfExecutions);
+
+            if (onePer <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(perTimeSpan), perTimeSpan, "The number of executions per timespan must be positive.");
+            }
+
+            IRateLimiter rateLimiter = RateLimiterFactory.Create(onePer, maxBurst);
 
             return new AsyncRateLimitPolicy(rateLimiter);
         }

--- a/src/Polly/RateLimit/AsyncRateLimitTResultSyntax.cs
+++ b/src/Polly/RateLimit/AsyncRateLimitTResultSyntax.cs
@@ -75,7 +75,14 @@ namespace Polly
             if (perTimeSpan <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(perTimeSpan), perTimeSpan, $"{nameof(perTimeSpan)} must be a positive timespan.");
             if (maxBurst < 1) throw new ArgumentOutOfRangeException(nameof(maxBurst), maxBurst, $"{nameof(maxBurst)} must be an integer greater than or equal to 1.");
 
-            IRateLimiter rateLimiter = RateLimiterFactory.Create(TimeSpan.FromTicks(perTimeSpan.Ticks / numberOfExecutions), maxBurst);
+            var onePer = TimeSpan.FromTicks(perTimeSpan.Ticks / numberOfExecutions);
+
+            if (onePer <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(perTimeSpan), perTimeSpan, "The number of executions per timespan must be positive.");
+            }
+
+            IRateLimiter rateLimiter = RateLimiterFactory.Create(onePer, maxBurst);
 
             return new AsyncRateLimitPolicy<TResult>(rateLimiter, retryAfterFactory);
         }

--- a/src/Polly/RateLimit/RateLimitSyntax.cs
+++ b/src/Polly/RateLimit/RateLimitSyntax.cs
@@ -35,7 +35,14 @@ namespace Polly
             if (perTimeSpan <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(perTimeSpan), perTimeSpan, $"{nameof(perTimeSpan)} must be a positive timespan.");
             if (maxBurst < 1) throw new ArgumentOutOfRangeException(nameof(maxBurst), maxBurst, $"{nameof(maxBurst)} must be an integer greater than or equal to 1.");
 
-            IRateLimiter rateLimiter = RateLimiterFactory.Create(TimeSpan.FromTicks(perTimeSpan.Ticks / numberOfExecutions), maxBurst);
+            var onePer = TimeSpan.FromTicks(perTimeSpan.Ticks / numberOfExecutions);
+
+            if (onePer <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(perTimeSpan), perTimeSpan, "The number of executions per timespan must be positive.");
+            }
+
+            IRateLimiter rateLimiter = RateLimiterFactory.Create(onePer, maxBurst);
 
             return new RateLimitPolicy(rateLimiter);
         }

--- a/src/Polly/RateLimit/RateLimitTResultSyntax.cs
+++ b/src/Polly/RateLimit/RateLimitTResultSyntax.cs
@@ -75,7 +75,14 @@ namespace Polly
             if (perTimeSpan <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(perTimeSpan), perTimeSpan, $"{nameof(perTimeSpan)} must be a positive timespan.");
             if (maxBurst < 1) throw new ArgumentOutOfRangeException(nameof(maxBurst), maxBurst, $"{nameof(maxBurst)} must be an integer greater than or equal to 1.");
 
-            IRateLimiter rateLimiter = RateLimiterFactory.Create(TimeSpan.FromTicks(perTimeSpan.Ticks / numberOfExecutions), maxBurst);
+            var onePer = TimeSpan.FromTicks(perTimeSpan.Ticks / numberOfExecutions);
+
+            if (onePer <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(perTimeSpan), perTimeSpan, "The number of executions per timespan must be positive.");
+            }
+
+            IRateLimiter rateLimiter = RateLimiterFactory.Create(onePer, maxBurst);
 
             return new RateLimitPolicy<TResult>(rateLimiter, retryAfterFactory);
         }


### PR DESCRIPTION
### The issue or feature being addressed

If a large `numberOfExecutions` value (e.g. `int.MaxValue`) is used with a small `perTimeSpan` value, the division between the two will create a number too small to be represented by a tick, ending up with a `TimeSpan.Zero` value.

This then created a confusing exception message saying that the user had specified `TimeSpan.Zero`, when they hadn't.

Found while creating a "big enough" rate limit to use for the benchmarks in #910.

### Details on the issue fix or feature implementation

Improved the exception message by throwing a specific exception if `onePer` ends up with a zero or negative value once computed.

### Confirm the following

- [x]  I started this PR by branching from the head of the latest dev vX.Y branch, or I have rebased on the latest dev vX.Y branch, or I have merged the latest changes from the dev vX.Y branch
- [x]  I have targeted the PR to merge into the latest dev vX.Y branch as the base branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
