### PR TITLE
Fixed possible NRE.

### DIFF
--- a/src/Polly/Retry/AsyncRetryEngine.cs
+++ b/src/Polly/Retry/AsyncRetryEngine.cs
@@ -41,7 +41,7 @@ namespace Polly.Retry
                             return result;
                         }
 
-                        canRetry = tryCount < permittedRetryCount && (sleepDurationsEnumerable == null || sleepDurationsEnumerator.MoveNext());
+                        canRetry = tryCount < permittedRetryCount && (sleepDurationsEnumerator == null || sleepDurationsEnumerator.MoveNext());
 
                         if (!canRetry)
                         {
@@ -58,7 +58,7 @@ namespace Polly.Retry
                             throw;
                         }
 
-                        canRetry = tryCount < permittedRetryCount && (sleepDurationsEnumerable == null || sleepDurationsEnumerator.MoveNext());
+                        canRetry = tryCount < permittedRetryCount && (sleepDurationsEnumerator == null || sleepDurationsEnumerator.MoveNext());
 
                         if (!canRetry)
                         {

--- a/src/Polly/Retry/RetryEngine.cs
+++ b/src/Polly/Retry/RetryEngine.cs
@@ -39,7 +39,7 @@ namespace Polly.Retry
                             return result;
                         }
 
-                        canRetry = tryCount < permittedRetryCount && (sleepDurationsEnumerable == null || sleepDurationsEnumerator.MoveNext());
+                        canRetry = tryCount < permittedRetryCount && (sleepDurationsEnumerator == null || sleepDurationsEnumerator.MoveNext());
                     
                         if (!canRetry)
                         {
@@ -56,7 +56,7 @@ namespace Polly.Retry
                             throw;
                         }
 
-                        canRetry = tryCount < permittedRetryCount && (sleepDurationsEnumerable == null || sleepDurationsEnumerator.MoveNext());
+                        canRetry = tryCount < permittedRetryCount && (sleepDurationsEnumerator == null || sleepDurationsEnumerator.MoveNext());
 
                         if (!canRetry)
                         {


### PR DESCRIPTION
Corrected possible NRE.

Now, when using var `sleepDurationsEnumerator `, it is first checked that it is not null.
