### PR TITLE
Exception classes should be publicly accessible.

### DIFF
--- a/src/Polly/Utilities/TimedLock.cs
+++ b/src/Polly/Utilities/TimedLock.cs
@@ -86,9 +86,12 @@ namespace Polly.Utilities
 
     }
 
-    internal class LockTimeoutException : Exception
+    /// <summary>
+    /// Exception caused by if a lock cannot be obtained within the Lock Timeout.
+    /// </summary>
+    public class LockTimeoutException : Exception
     {
-        public LockTimeoutException() : base("Timeout waiting for lock")
+        internal LockTimeoutException() : base("Timeout waiting for lock")
         {
         }
     }


### PR DESCRIPTION
Fixed exception class inaccessible to other builds. If such an exception is thrown, the external code will have to catch instances of the nearest accessible parent class such as the base class of all exceptions, 'Exception'. This hinders exception handling since the code of other builds cannot identify the problem precisely.