### PR TITLE
937 RateLimiter improvement with sliding window

### DIFF
--- a/src/Polly.Specs/RateLimit/AsyncSlidingWindowRateLimiterTests.cs
+++ b/src/Polly.Specs/RateLimit/AsyncSlidingWindowRateLimiterTests.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Polly.RateLimit;
+using Polly.Utilities;
+using Xunit;
+
+namespace Polly.Specs.RateLimit;
+
+public class AsyncSlidingWindowRateLimiterTests : SlidingWindowRateLimiterTestsBase, IDisposable
+{
+    protected override IRateLimitPolicy GetPolicyViaSyntax(int numberOfExecutions, TimeSpan perTimeSpan)
+    {
+        return Policy.RateLimitAsync(numberOfExecutions, perTimeSpan, spreadUniformly:false);
+    }
+    
+    public void Dispose()
+    {
+        SystemClock.Reset();
+    }
+    
+    [Fact]
+    public void Syntax_should_throw_for_perTimeSpan_zero()
+    {
+        Action invalidSyntax = () => GetPolicyViaSyntax(1, TimeSpan.Zero);
+
+        invalidSyntax.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("perTimeSpan");
+    }
+
+    [Fact]
+    public void Syntax_should_throw_for_perTimeSpan_infinite()
+    {
+        Action invalidSyntax = () => GetPolicyViaSyntax(1, System.Threading.Timeout.InfiniteTimeSpan);
+
+        invalidSyntax.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("perTimeSpan");
+    }
+
+    [Fact]
+    public void Syntax_should_throw_for_numberOfExecutions_negative()
+    {
+        Action invalidSyntax = () => GetPolicyViaSyntax(-1, TimeSpan.FromSeconds(1));
+
+        invalidSyntax.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("numberOfExecutions");
+    }
+
+    [Fact]
+    public void Syntax_should_throw_for_numberOfExecutions_zero()
+    {
+        Action invalidSyntax = () => GetPolicyViaSyntax(0, TimeSpan.FromSeconds(1));
+
+        invalidSyntax.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("numberOfExecutions");
+    }
+
+    [Fact]
+    public void Syntax_should_throw_for_perTimeSpan_negative()
+    {
+        Action invalidSyntax = () => GetPolicyViaSyntax(1, TimeSpan.FromTicks(-1));
+
+        invalidSyntax.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("perTimeSpan");
+    }
+
+    [Fact]
+    public async Task ShouldAllowAllExecutionsWithinThePolicyTimeSpanAndLimit()
+    {
+        FixClock();
+            
+        // 60 executions in 1 minute
+        var rateLimiter = (AsyncRateLimitPolicy) GetPolicyViaSyntax(60, new TimeSpan(0, 1, 0));
+        var tasks = new List<Task<bool>>();
+        for (var i = 0; i < 60; i++)
+        {
+            await Task.Delay(10);
+            tasks.Add(Task.Run(async Task<bool> () =>
+            {
+                try
+                {
+                    await rateLimiter.ExecuteAsync(() => Task.CompletedTask);
+                }
+                catch (RateLimitRejectedException)
+                {
+                    return false;
+                }
+
+                return true;
+            }));
+        }
+        await Task.WhenAll(tasks);
+        tasks.FindAll(task => task.Result).Count.Should().Be(60);
+        tasks.FindAll(task => !task.Result).Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ShouldAllowNumberOfExecutionsPerPolicy_And_RejectTheRestWithinPolicyTimeSpan()
+    {
+        FixClock();
+            
+        // 60 executions in 1 minute
+        var rateLimiter = (AsyncRateLimitPolicy) GetPolicyViaSyntax(60, new TimeSpan(0, 1, 0));
+        var tasks = new List<Task<bool>>();
+        for (var i = 0; i < 70; i++)
+        {
+            await Task.Delay(10);
+            tasks.Add(Task.Run(async Task<bool> () =>
+            {
+                try
+                {
+                    await rateLimiter.ExecuteAsync(() => Task.CompletedTask);
+                }
+                catch (RateLimitRejectedException)
+                {
+                    return false;
+                }
+
+                return true;
+            }));
+        }
+        await Task.WhenAll(tasks);
+        tasks.FindAll(task => task.Result).Count.Should().Be(60);
+        tasks.FindAll(task => !task.Result).Count.Should().Be(10);
+    }
+
+    [Fact]
+    public async Task ShouldAllowAdditionalExecutionsOutsideThePolicyTimeSpanWithinLimit()
+    {
+        FixClock();
+            
+        // 60 executions in 1 minute
+        var rateLimiter = (AsyncRateLimitPolicy) GetPolicyViaSyntax(60, new TimeSpan(0, 1, 0));
+        var tasks = new List<Task<bool>>();
+        for (var i = 0; i < 70; i++)
+        {
+            await Task.Delay(1000);
+            tasks.Add(Task.Run(async Task<bool> () =>
+            {
+                try
+                {
+                    await rateLimiter.ExecuteAsync(() => Task.CompletedTask);
+                }
+                catch (RateLimitRejectedException)
+                {
+                    return false;
+                }
+
+                return true;
+            }));
+        }
+        await Task.WhenAll(tasks);
+        tasks.FindAll(task => task.Result).Count.Should().Be(70);
+        tasks.FindAll(task => !task.Result).Count.Should().Be(0);
+    }
+}

--- a/src/Polly.Specs/RateLimit/SlidingWindowRateLimiterTests.cs
+++ b/src/Polly.Specs/RateLimit/SlidingWindowRateLimiterTests.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Polly.RateLimit;
+using Polly.Utilities;
+using Xunit;
+
+namespace Polly.Specs.RateLimit;
+
+[Collection(Polly.Specs.Helpers.Constants.SystemClockDependentTestCollection)]
+public class SlidingWindowRateLimiterTests : SlidingWindowRateLimiterTestsBase, IDisposable
+{
+    protected override IRateLimitPolicy GetPolicyViaSyntax(int numberOfExecutions, TimeSpan perTimeSpan)
+    {
+        return Policy.RateLimit(numberOfExecutions, perTimeSpan, spreadUniformly:false);
+    }
+    
+    public void Dispose()
+    {
+        SystemClock.Reset();
+    }
+    
+    [Fact]
+    public void Syntax_should_throw_for_perTimeSpan_zero()
+    {
+        Action invalidSyntax = () => GetPolicyViaSyntax(1, TimeSpan.Zero);
+
+        invalidSyntax.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("perTimeSpan");
+    }
+
+    [Fact]
+    public void Syntax_should_throw_for_perTimeSpan_infinite()
+    {
+        Action invalidSyntax = () => GetPolicyViaSyntax(1, System.Threading.Timeout.InfiniteTimeSpan);
+
+        invalidSyntax.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("perTimeSpan");
+    }
+
+    [Fact]
+    public void Syntax_should_throw_for_numberOfExecutions_negative()
+    {
+        Action invalidSyntax = () => GetPolicyViaSyntax(-1, TimeSpan.FromSeconds(1));
+
+        invalidSyntax.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("numberOfExecutions");
+    }
+
+    [Fact]
+    public void Syntax_should_throw_for_numberOfExecutions_zero()
+    {
+        Action invalidSyntax = () => GetPolicyViaSyntax(0, TimeSpan.FromSeconds(1));
+
+        invalidSyntax.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("numberOfExecutions");
+    }
+
+    [Fact]
+    public void Syntax_should_throw_for_perTimeSpan_negative()
+    {
+        Action invalidSyntax = () => GetPolicyViaSyntax(1, TimeSpan.FromTicks(-1));
+
+        invalidSyntax.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("perTimeSpan");
+    }
+
+    [Fact]
+    public async Task ShouldAllowAllExecutionsWithinThePolicyTimeSpanAndLimit()
+    {
+        FixClock();
+            
+        // 60 executions in 1 minute
+        var rateLimiter = (RateLimitPolicy) GetPolicyViaSyntax(60, new TimeSpan(0, 1, 0));
+        var tasks = new List<Task<bool>>();
+        for (var i = 0; i < 60; i++)
+        {
+            await Task.Delay(10);
+            tasks.Add(Task.Run(async Task<bool> () =>
+            {
+                try
+                {
+                    await rateLimiter.Execute(() => Task.CompletedTask);
+                }
+                catch (RateLimitRejectedException)
+                {
+                    return false;
+                }
+
+                return true;
+            }));
+        }
+        await Task.WhenAll(tasks);
+        tasks.FindAll(task => task.Result).Count.Should().Be(60);
+        tasks.FindAll(task => !task.Result).Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ShouldAllowNumberOfExecutionsPerPolicy_And_RejectTheRestWithinPolicyTimeSpan()
+    {
+        FixClock();
+            
+        // 60 executions in 1 minute
+        var rateLimiter = (RateLimitPolicy) GetPolicyViaSyntax(60, new TimeSpan(0, 1, 0));
+        var tasks = new List<Task<bool>>();
+        for (var i = 0; i < 70; i++)
+        {
+            await Task.Delay(10);
+            tasks.Add(Task.Run(async Task<bool> () =>
+            {
+                try
+                {
+                    await rateLimiter.Execute(() => Task.CompletedTask);
+                }
+                catch (RateLimitRejectedException)
+                {
+                    return false;
+                }
+
+                return true;
+            }));
+        }
+        await Task.WhenAll(tasks);
+        tasks.FindAll(task => task.Result).Count.Should().Be(60);
+        tasks.FindAll(task => !task.Result).Count.Should().Be(10);
+    }
+
+    [Fact]
+    public async Task ShouldAllowAdditionalExecutionsOutsideThePolicyTimeSpanWithinLimit()
+    {
+        FixClock();
+            
+        // 60 executions in 1 minute
+        var rateLimiter = (RateLimitPolicy) GetPolicyViaSyntax(60, new TimeSpan(0, 1, 0));
+        var tasks = new List<Task<bool>>();
+        for (var i = 0; i < 70; i++)
+        {
+            await Task.Delay(1000);
+            tasks.Add(Task.Run(async Task<bool> () =>
+            {
+                try
+                {
+                    await rateLimiter.Execute(() => Task.CompletedTask);
+                }
+                catch (RateLimitRejectedException)
+                {
+                    return false;
+                }
+
+                return true;
+            }));
+        }
+        await Task.WhenAll(tasks);
+        tasks.FindAll(task => task.Result).Count.Should().Be(70);
+        tasks.FindAll(task => !task.Result).Count.Should().Be(0);
+    }
+}

--- a/src/Polly.Specs/RateLimit/SlidingWindowRateLimiterTestsBase.cs
+++ b/src/Polly.Specs/RateLimit/SlidingWindowRateLimiterTestsBase.cs
@@ -1,0 +1,9 @@
+using System;
+using Polly.RateLimit;
+
+namespace Polly.Specs.RateLimit;
+
+public abstract class SlidingWindowRateLimiterTestsBase : RateLimitSpecsBase
+{
+    protected abstract IRateLimitPolicy GetPolicyViaSyntax(int numberOfExecutions, TimeSpan perTimeSpan);
+}

--- a/src/Polly/RateLimit/AsyncRateLimitSyntax.cs
+++ b/src/Polly/RateLimit/AsyncRateLimitSyntax.cs
@@ -10,12 +10,14 @@ namespace Polly
         /// </summary>
         /// <param name="numberOfExecutions">The number of executions (call it N) permitted per timespan.</param>
         /// <param name="perTimeSpan">How often N executions are permitted.</param>
+        /// <param name="spreadUniformly">The number of executions allowed are spread equally within the specified time span, default is true.</param>
         /// <returns>The policy instance.</returns>
         public static AsyncRateLimitPolicy RateLimitAsync(
             int numberOfExecutions,
-            TimeSpan perTimeSpan)
+            TimeSpan perTimeSpan,
+            bool spreadUniformly = true)
         {
-            return RateLimitAsync(numberOfExecutions, perTimeSpan, 1);
+            return RateLimitAsync(numberOfExecutions, perTimeSpan, 1, spreadUniformly);
         }
 
         /// <summary>
@@ -25,24 +27,34 @@ namespace Polly
         /// <param name="perTimeSpan">How often N executions are permitted.</param>
         /// <param name="maxBurst">The maximum number of executions that will be permitted in a single burst (for example if none have been executed for a while).
         /// This equates to the bucket-capacity of a token-bucket implementation.</param>
+        /// <param name="spreadUniformly">The number of executions allowed are spread equally within the specified time span, default is true.</param>
         /// <returns>The policy instance.</returns>
         public static AsyncRateLimitPolicy RateLimitAsync(
             int numberOfExecutions,
             TimeSpan perTimeSpan,
-            int maxBurst)
+            int maxBurst,
+            bool spreadUniformly = true)
         {
             if (numberOfExecutions < 1) throw new ArgumentOutOfRangeException(nameof(numberOfExecutions), numberOfExecutions, $"{nameof(numberOfExecutions)} per timespan must be an integer greater than or equal to 1.");
             if (perTimeSpan <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(perTimeSpan), perTimeSpan, $"{nameof(perTimeSpan)} must be a positive timespan.");
             if (maxBurst < 1) throw new ArgumentOutOfRangeException(nameof(maxBurst), maxBurst, $"{nameof(maxBurst)} must be an integer greater than or equal to 1.");
 
-            var onePer = TimeSpan.FromTicks(perTimeSpan.Ticks / numberOfExecutions);
-
-            if (onePer <= TimeSpan.Zero)
+            IRateLimiter rateLimiter;
+            if (spreadUniformly)
             {
-                throw new ArgumentOutOfRangeException(nameof(perTimeSpan), perTimeSpan, "The number of executions per timespan must be positive.");
-            }
+                var onePer = TimeSpan.FromTicks(perTimeSpan.Ticks / numberOfExecutions);
 
-            IRateLimiter rateLimiter = RateLimiterFactory.Create(onePer, maxBurst);
+                if (onePer <= TimeSpan.Zero)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(perTimeSpan), perTimeSpan, "The number of executions per timespan must be positive.");
+                }
+                
+                rateLimiter = RateLimiterFactory.Create(onePer, maxBurst);
+            }
+            else
+            {
+                rateLimiter = RateLimiterFactory.CreateSlidingWindowRateLimiter(perTimeSpan, numberOfExecutions);
+            }
 
             return new AsyncRateLimitPolicy(rateLimiter);
         }

--- a/src/Polly/RateLimit/AsyncRateLimitTResultSyntax.cs
+++ b/src/Polly/RateLimit/AsyncRateLimitTResultSyntax.cs
@@ -11,12 +11,14 @@ namespace Polly
         /// <typeparam name="TResult">The type of return values this policy will handle.</typeparam>
         /// <param name="numberOfExecutions">The number of executions (call it N) permitted per timespan.</param>
         /// <param name="perTimeSpan">How often N executions are permitted.</param>
+        /// <param name="spreadUniformly">The number of executions allowed are spread equally within the specified time span, default is true.</param>
         /// <returns>The policy instance.</returns>
         public static AsyncRateLimitPolicy<TResult> RateLimitAsync<TResult>(
             int numberOfExecutions,
-            TimeSpan perTimeSpan)
+            TimeSpan perTimeSpan,
+            bool spreadUniformly = true)
         {
-            return RateLimitAsync<TResult>(numberOfExecutions, perTimeSpan, null);
+            return RateLimitAsync<TResult>(numberOfExecutions, perTimeSpan, null, spreadUniformly);
         }
 
         /// <summary>
@@ -27,13 +29,15 @@ namespace Polly
         /// <param name="perTimeSpan">How often N executions are permitted.</param>
         /// <param name="retryAfterFactory">An (optional) factory to express the recommended retry-after time back to the caller, when an operation is rate-limited.
         /// <remarks>If null, a <see cref="RateLimitRejectedException"/> with property <see cref="RateLimitRejectedException.RetryAfter"/> will be thrown to indicate rate-limiting.</remarks></param>
+        /// <param name="spreadUniformly">The number of executions allowed are spread equally within the specified time span, default is true.</param>
         /// <returns>The policy instance.</returns>
         public static AsyncRateLimitPolicy<TResult> RateLimitAsync<TResult>(
             int numberOfExecutions,
             TimeSpan perTimeSpan,
-            Func<TimeSpan, Context, TResult> retryAfterFactory)
+            Func<TimeSpan, Context, TResult> retryAfterFactory,
+            bool spreadUniformly = true)
         {
-            return RateLimitAsync(numberOfExecutions, perTimeSpan, 1, retryAfterFactory);
+            return RateLimitAsync(numberOfExecutions, perTimeSpan, 1, retryAfterFactory, spreadUniformly);
         }
 
         /// <summary>
@@ -44,13 +48,15 @@ namespace Polly
         /// <param name="perTimeSpan">How often N executions are permitted.</param>
         /// <param name="maxBurst">The maximum number of executions that will be permitted in a single burst (for example if none have been executed for a while).
         /// This equates to the bucket-capacity of a token-bucket implementation.</param>
+        /// <param name="spreadUniformly">The number of executions allowed are spread equally within the specified time span, default is true.</param>
         /// <returns>The policy instance.</returns>
         public static AsyncRateLimitPolicy<TResult> RateLimitAsync<TResult>(
             int numberOfExecutions,
             TimeSpan perTimeSpan,
-            int maxBurst)
+            int maxBurst,
+            bool spreadUniformly = true)
         {
-            return RateLimitAsync<TResult>(numberOfExecutions, perTimeSpan, maxBurst, null);
+            return RateLimitAsync<TResult>(numberOfExecutions, perTimeSpan, maxBurst, null, spreadUniformly);
         }
 
         /// <summary>
@@ -64,25 +70,35 @@ namespace Polly
         /// This equates to the bucket-capacity of a token-bucket implementation.</param>
         /// <param name="retryAfterFactory">An (optional) factory to use to express retry-after back to the caller, when an operation is rate-limited.
         /// <remarks>If null, a <see cref="RateLimitRejectedException"/> with property <see cref="RateLimitRejectedException.RetryAfter"/> will be thrown to indicate rate-limiting.</remarks></param>
+        /// <param name="spreadUniformly">The number of executions allowed are spread equally within the specified time span, default is true.</param>
         /// <returns>The policy instance.</returns>
         public static AsyncRateLimitPolicy<TResult> RateLimitAsync<TResult>(
             int numberOfExecutions,
             TimeSpan perTimeSpan,
             int maxBurst,
-            Func<TimeSpan, Context, TResult> retryAfterFactory)
+            Func<TimeSpan, Context, TResult> retryAfterFactory,
+            bool spreadUniformly = true)
         {
             if (numberOfExecutions < 1) throw new ArgumentOutOfRangeException(nameof(numberOfExecutions), numberOfExecutions, $"{nameof(numberOfExecutions)} per timespan must be an integer greater than or equal to 1.");
             if (perTimeSpan <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(perTimeSpan), perTimeSpan, $"{nameof(perTimeSpan)} must be a positive timespan.");
             if (maxBurst < 1) throw new ArgumentOutOfRangeException(nameof(maxBurst), maxBurst, $"{nameof(maxBurst)} must be an integer greater than or equal to 1.");
 
-            var onePer = TimeSpan.FromTicks(perTimeSpan.Ticks / numberOfExecutions);
-
-            if (onePer <= TimeSpan.Zero)
+            IRateLimiter rateLimiter;
+            if (spreadUniformly)
             {
-                throw new ArgumentOutOfRangeException(nameof(perTimeSpan), perTimeSpan, "The number of executions per timespan must be positive.");
-            }
+                var onePer = TimeSpan.FromTicks(perTimeSpan.Ticks / numberOfExecutions);
 
-            IRateLimiter rateLimiter = RateLimiterFactory.Create(onePer, maxBurst);
+                if (onePer <= TimeSpan.Zero)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(perTimeSpan), perTimeSpan, "The number of executions per timespan must be positive.");
+                }
+                
+                rateLimiter = RateLimiterFactory.Create(onePer, maxBurst);
+            }
+            else
+            {
+                rateLimiter = RateLimiterFactory.CreateSlidingWindowRateLimiter(perTimeSpan, numberOfExecutions);
+            }
 
             return new AsyncRateLimitPolicy<TResult>(rateLimiter, retryAfterFactory);
         }

--- a/src/Polly/RateLimit/RateLimitSyntax.cs
+++ b/src/Polly/RateLimit/RateLimitSyntax.cs
@@ -10,12 +10,14 @@ namespace Polly
         /// </summary>
         /// <param name="numberOfExecutions">The number of executions (call it N) permitted per timespan.</param>
         /// <param name="perTimeSpan">How often N executions are permitted.</param>
+        /// <param name="spreadUniformly">The number of executions allowed are spread equally within the specified time span, default is true.</param>
         /// <returns>The policy instance.</returns>
         public static RateLimitPolicy RateLimit(
             int numberOfExecutions,
-            TimeSpan perTimeSpan)
+            TimeSpan perTimeSpan,
+            bool spreadUniformly = true)
         {
-            return RateLimit(numberOfExecutions, perTimeSpan, 1);
+            return RateLimit(numberOfExecutions, perTimeSpan, 1, spreadUniformly);
         }
 
         /// <summary>
@@ -25,24 +27,34 @@ namespace Polly
         /// <param name="perTimeSpan">How often N executions are permitted.</param>
         /// <param name="maxBurst">The maximum number of executions that will be permitted in a single burst (for example if none have been executed for a while).
         /// This equates to the bucket-capacity of a token-bucket implementation.</param>
+        /// <param name="spreadUniformly">The number of executions allowed are spread equally within the specified time span, default is true.</param>
         /// <returns>The policy instance.</returns>
         public static RateLimitPolicy RateLimit(
             int numberOfExecutions,
             TimeSpan perTimeSpan,
-            int maxBurst)
+            int maxBurst,
+            bool spreadUniformly = true)
         {
             if (numberOfExecutions < 1) throw new ArgumentOutOfRangeException(nameof(numberOfExecutions), numberOfExecutions, $"{nameof(numberOfExecutions)} per timespan must be an integer greater than or equal to 1.");
             if (perTimeSpan <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(perTimeSpan), perTimeSpan, $"{nameof(perTimeSpan)} must be a positive timespan.");
             if (maxBurst < 1) throw new ArgumentOutOfRangeException(nameof(maxBurst), maxBurst, $"{nameof(maxBurst)} must be an integer greater than or equal to 1.");
 
-            var onePer = TimeSpan.FromTicks(perTimeSpan.Ticks / numberOfExecutions);
-
-            if (onePer <= TimeSpan.Zero)
+            IRateLimiter rateLimiter;
+            if (spreadUniformly)
             {
-                throw new ArgumentOutOfRangeException(nameof(perTimeSpan), perTimeSpan, "The number of executions per timespan must be positive.");
-            }
+                var onePer = TimeSpan.FromTicks(perTimeSpan.Ticks / numberOfExecutions);
 
-            IRateLimiter rateLimiter = RateLimiterFactory.Create(onePer, maxBurst);
+                if (onePer <= TimeSpan.Zero)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(perTimeSpan), perTimeSpan, "The number of executions per timespan must be positive.");
+                }
+
+                rateLimiter = RateLimiterFactory.Create(onePer, maxBurst);
+            }
+            else
+            {
+                rateLimiter = RateLimiterFactory.CreateSlidingWindowRateLimiter(perTimeSpan, numberOfExecutions);
+            }
 
             return new RateLimitPolicy(rateLimiter);
         }

--- a/src/Polly/RateLimit/RateLimiterFactory.cs
+++ b/src/Polly/RateLimit/RateLimiterFactory.cs
@@ -6,5 +6,8 @@ namespace Polly.RateLimit
     {
         public static IRateLimiter Create(TimeSpan onePer, int bucketCapacity)
             => new LockFreeTokenBucketRateLimiter(onePer, bucketCapacity);
+
+        public static IRateLimiter CreateSlidingWindowRateLimiter(TimeSpan perTimeSpan, int numberOfExecutions)
+            => new SlidingWindowRateLimiter(perTimeSpan, numberOfExecutions);
     }
 }

--- a/src/Polly/RateLimit/SlidingWindowRateLimiter.cs
+++ b/src/Polly/RateLimit/SlidingWindowRateLimiter.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Concurrent;
+
+namespace Polly.RateLimit;
+
+/// <summary>
+/// An IRateLimiter implementation for a Polly <see cref="IRateLimitPolicy"/> that uses sliding window that limits
+/// the number of executions for a specified window of time.
+/// </summary>
+internal sealed class SlidingWindowRateLimiter : IRateLimiter
+{
+    private readonly TimeSpan _window;
+    private readonly int _maxExecution;
+    private readonly ConcurrentQueue<DateTime> _windowQueue;
+
+    /// <summary>
+    /// Creates an instance of <see cref="SlidingWindowRateLimiter"/>
+    /// </summary>
+    /// <param name="window">The window time frame for limiting the number of executions</param>
+    /// <param name="maxExecution">The maximum number of execution allowed per time frame window specified</param>
+    public SlidingWindowRateLimiter(TimeSpan window, int maxExecution)
+    {
+        if (window <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(window), window, $"The {nameof(LockFreeTokenBucketRateLimiter)} must specify a positive TimeSpan for a window of time.");
+        
+        _window = window;
+        _maxExecution = maxExecution;
+        _windowQueue = new ConcurrentQueue<DateTime>();
+    }
+
+    /// <summary>
+    /// Returns whether the execution is permitted.
+    /// If not, returns the amount of time <see cref="TimeSpan"/> should be waited before retrying.
+    /// </summary>
+    /// <returns>Tuple of permit execution boolean, and the amount of time to wait before retrying</returns>
+    public (bool permitExecution, TimeSpan retryAfter) PermitExecution()
+    {
+        var utcNow = DateTime.UtcNow;
+        if (_windowQueue.Count == 0)
+        {
+            _windowQueue.Enqueue(utcNow);
+            return (true, TimeSpan.Zero);
+        }
+
+        if (_windowQueue.Count == _maxExecution)
+        {
+            _windowQueue.TryDequeue(out var earliestExecution);
+            if (utcNow - earliestExecution <= _window)
+            {
+                _windowQueue.TryPeek(out var nextExecution);
+                var retryAfter = nextExecution - earliestExecution;
+                _windowQueue.Enqueue(earliestExecution);
+                return (false, retryAfter);
+            }
+        }
+
+        _windowQueue.Enqueue(utcNow);
+        return (true, TimeSpan.Zero);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors.  All non-trivial contributions get a public credit in the readme! -->

### The issue or feature being addressed

#937 Implement sliding window for rate limiting, that addresses the interpreted 1/sec issue when specifying 60/min.

### Details on the issue fix or feature implementation

Using a ConcurrentQueue object to keep track of execution timestamp and using the earliest timestamp and the number of queued execution timestamp to determine if next execution should be blocked. Dequeue when max specified number of execution is reached.

### Confirm the following

- [x]  I started this PR by branching from the head of the latest dev vX.Y branch, or I have rebased on the latest dev vX.Y branch, or I have merged the latest changes from the dev vX.Y branch
- [x]  I have targeted the PR to merge into the latest dev vX.Y branch as the base branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
