### PR TITLE
#944- Added to readme explaining waitand/retryforever is not actually…

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ Policy
   });
 ```
 
+`RetryForever` does not actually retry forever; it will retry up to `int.MaxValue` (2147483647) times. Depending on what is done in the policy delegate this may take an exceedingly long time, but the policy will eventually hit `int.MaxValue` retries, get the last exception and stop retrying.
+
 #### Wait and retry
 
 ```csharp
@@ -322,6 +324,8 @@ Policy
         // Add logic to be executed before each retry, such as logging       
     });
 ```
+
+Similarly to `RetryForever`, `WaitAndRetryForever` only actually retries `int.MaxValue` times.
 
 If all retries fail, a retry policy rethrows the final exception back to the calling code.
 


### PR DESCRIPTION
… forever

<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors.  All non-trivial contributions get a public credit in the readme! -->

### The issue or feature being addressed

<!-- Please include the existing GitHub issue number where relevant -->

#944 

### Details on the issue fix or feature implementation

Added to README for both `RetryForever` and `WaitAndRetryForever`

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build
