### PR TITLE
Add GitHub Actions workflow to update the .NET SDK

### DIFF
--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -1,0 +1,27 @@
+name: update-dotnet-sdk
+
+on:
+  schedule:
+    - cron:  '0 12 * * WED'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-dotnet-sdk:
+    name: Update .NET SDK
+    runs-on: ubuntu-latest
+    if: ${{ github.event.repository.fork == false }}
+
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Update .NET SDK
+      uses: martincostello/update-dotnet-sdk@v2
+      with:
+        labels: "dependencies,.NET"
+        repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add a GitHub Actions workflow with [an action](https://github.com/martincostello/update-dotnet-sdk) that checks for updates to the .NET SDK at 1200 UTC on Wednesdays (i.e. the day after when Update Tuesday would be).

This allows for automated PRs like this one https://github.com/martincostello/update-dotnet-sdk/pull/320. As they're raised by `github-actions[bot]`, CI builds won't be automatically triggered so you have to close and open the PR again to get the builds to run [due to this restriction](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow).

We could always set up a bot account at some point and use its PAT to raise the PRs instead to improve that (example: https://github.com/martincostello/sqllocaldb/pull/568, [config](https://github.com/martincostello/sqllocaldb/blob/3fdace267ebcdd946cb7ded65cbe5302226a3b7d/.github/workflows/update-dotnet-sdk.yml#L24-L26)).
