### PR TITLE
try get nullable

### DIFF
--- a/src/Polly.Benchmarks/Cache.cs
+++ b/src/Polly.Benchmarks/Cache.cs
@@ -67,7 +67,7 @@ public class Cache
             return (cacheHit, value);
         }
 
-        public void Put(string key, object value, Ttl ttl)
+        public void Put(string key, object? value, Ttl ttl)
         {
             TimeSpan remaining = DateTimeOffset.MaxValue - DateTimeOffset.UtcNow;
             var options = new MemoryCacheEntryOptions();
@@ -96,7 +96,7 @@ public class Cache
             return Task.FromResult(TryGet(key));
         }
 
-        public Task PutAsync(string key, object value, Ttl ttl, CancellationToken cancellationToken, bool continueOnCapturedContext)
+        public Task PutAsync(string key, object? value, Ttl ttl, CancellationToken cancellationToken, bool continueOnCapturedContext)
         {
             Put(key, value, ttl);
             return Task.CompletedTask;

--- a/src/Polly.Specs/Bulkhead/BulkheadAsyncSpecs.cs
+++ b/src/Polly.Specs/Bulkhead/BulkheadAsyncSpecs.cs
@@ -79,7 +79,7 @@ public class BulkheadAsyncSpecs : BulkheadSpecsBase
         Policy.BulkheadAsync(maxParallelization, maxQueuingActions);
 
     protected override Task ExecuteOnBulkhead(IBulkheadPolicy bulkhead, TraceableAction action) =>
-        action.ExecuteOnBulkheadAsync((AsyncBulkheadPolicy)bulkhead);
+        action.ExecuteOnBulkheadAsync((AsyncBulkheadPolicy) bulkhead);
 
     #endregion
 }

--- a/src/Polly.Specs/Bulkhead/BulkheadScenario.cs
+++ b/src/Polly.Specs/Bulkhead/BulkheadScenario.cs
@@ -20,5 +20,13 @@ internal struct BulkheadScenario
     }
 
     public object[] ToTheoryData() =>
-        new object[] {_maxParallelization, _maxQueuingActions, _totalTestLoad, _cancelQueuing, _cancelExecuting, _scenario };
+        new object[]
+        {
+            _maxParallelization,
+            _maxQueuingActions,
+            _totalTestLoad,
+            _cancelQueuing,
+            _cancelExecuting,
+            _scenario
+        };
 }

--- a/src/Polly.Specs/Bulkhead/BulkheadTResultAsyncSpecs.cs
+++ b/src/Polly.Specs/Bulkhead/BulkheadTResultAsyncSpecs.cs
@@ -86,7 +86,7 @@ public class BulkheadTResultAsyncSpecs : BulkheadSpecsBase
         Policy.BulkheadAsync<ResultPrimitive>(maxParallelization, maxQueuingActions);
 
     protected override Task ExecuteOnBulkhead(IBulkheadPolicy bulkhead, TraceableAction action) =>
-        action.ExecuteOnBulkheadAsync<ResultPrimitive>((AsyncBulkheadPolicy<ResultPrimitive>)bulkhead);
+        action.ExecuteOnBulkheadAsync<ResultPrimitive>((AsyncBulkheadPolicy<ResultPrimitive>) bulkhead);
 
     #endregion
 }

--- a/src/Polly.Specs/Caching/SerializingCacheProviderAsyncSpecs.cs
+++ b/src/Polly.Specs/Caching/SerializingCacheProviderAsyncSpecs.cs
@@ -9,7 +9,7 @@ public class AsyncSerializingCacheProviderSpecs
     {
         StubSerializer<object, StubSerialized> stubObjectSerializer = new StubSerializer<object, StubSerialized>(
             serialize: o => new StubSerialized(o),
-            deserialize: s => s.Original
+            deserialize: s => s?.Original ?? default
         );
 
         Action configure = () => new AsyncSerializingCacheProvider<StubSerialized>(null!, stubObjectSerializer);
@@ -42,7 +42,7 @@ public class AsyncSerializingCacheProviderSpecs
         bool serializeInvoked = false;
         StubSerializer<object, StubSerialized> stubSerializer = new StubSerializer<object, StubSerialized>(
             serialize: o => { serializeInvoked = true; return new StubSerialized(o); },
-            deserialize: s => s.Original
+            deserialize: s => s?.Original ?? default
         );
         StubCacheProvider stubCacheProvider = new StubCacheProvider();
         object objectToCache = new object();
@@ -66,7 +66,7 @@ public class AsyncSerializingCacheProviderSpecs
         bool serializeInvoked = false;
         StubSerializer<object, StubSerialized> stubSerializer = new StubSerializer<object, StubSerialized>(
             serialize: o => { serializeInvoked = true; return new StubSerialized(o); },
-            deserialize: s => s.Original
+            deserialize: s => s?.Original ?? default
         );
         StubCacheProvider stubCacheProvider = new StubCacheProvider();
         object? objectToCache = null;
@@ -90,7 +90,7 @@ public class AsyncSerializingCacheProviderSpecs
         bool deserializeInvoked = false;
         StubSerializer<object, StubSerialized> stubSerializer = new StubSerializer<object, StubSerialized>(
             serialize: o => new StubSerialized(o),
-            deserialize: s => { deserializeInvoked = true; return s.Original; }
+            deserialize: s => { deserializeInvoked = true; return s?.Original ?? default; }
         );
 
         var stubCacheProvider = new StubCacheProvider();
@@ -113,7 +113,7 @@ public class AsyncSerializingCacheProviderSpecs
         bool deserializeInvoked = false;
         StubSerializer<object, StubSerialized> stubSerializer = new StubSerializer<object, StubSerialized>(
             serialize: o => new StubSerialized(o),
-            deserialize: s => { deserializeInvoked = true; return s.Original; }
+            deserialize: s => { deserializeInvoked = true; return s?.Original ?? default; }
         );
         var stubCacheProvider = new StubCacheProvider();
         string key = "some key";
@@ -134,7 +134,7 @@ public class AsyncSerializingCacheProviderSpecs
         bool serializeInvoked = false;
         StubSerializer<object, StubSerialized> stubSerializer = new StubSerializer<object, StubSerialized>(
             serialize: o => { serializeInvoked = true; return new StubSerialized(o); },
-            deserialize: s => s.Original
+            deserialize: s => s?.Original ?? default
         );
         StubCacheProvider stubCacheProvider = new StubCacheProvider();
         object objectToCache = new object();
@@ -158,7 +158,7 @@ public class AsyncSerializingCacheProviderSpecs
         bool serializeInvoked = false;
         StubSerializer<object, StubSerialized> stubSerializer = new StubSerializer<object, StubSerialized>(
             serialize: o => { serializeInvoked = true; return new StubSerialized(o); },
-            deserialize: s => s.Original
+            deserialize: s => s?.Original ?? default
         );
         StubCacheProvider stubCacheProvider = new StubCacheProvider();
         object? objectToCache = null;
@@ -182,7 +182,7 @@ public class AsyncSerializingCacheProviderSpecs
         bool deserializeInvoked = false;
         StubSerializer<object, StubSerialized> stubSerializer = new StubSerializer<object, StubSerialized>(
             serialize: o => new StubSerialized(o),
-            deserialize: s => { deserializeInvoked = true; return s.Original; }
+            deserialize: s => { deserializeInvoked = true; return s?.Original ?? default; }
         );
         var stubCacheProvider = new StubCacheProvider();
         object objectToCache = new object();
@@ -204,7 +204,7 @@ public class AsyncSerializingCacheProviderSpecs
         bool deserializeInvoked = false;
         StubSerializer<object, StubSerialized> stubSerializer = new StubSerializer<object, StubSerialized>(
             serialize: o => new StubSerialized(o),
-            deserialize: s => { deserializeInvoked = true; return s.Original; }
+            deserialize: s => { deserializeInvoked = true; return s?.Original ?? default; }
         );
         var stubCacheProvider = new StubCacheProvider();
         string key = "some key";
@@ -228,7 +228,7 @@ public class AsyncSerializingCacheProviderSpecs
     {
         StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>> stubTResultSerializer = new StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>>(
             serialize: o => new StubSerialized<ResultPrimitive>(o),
-            deserialize: s => s.Original
+            deserialize: s => s?.Original ?? default
         );
 
         Action configure = () => new AsyncSerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>>(null!, stubTResultSerializer);
@@ -261,7 +261,7 @@ public class AsyncSerializingCacheProviderSpecs
         bool serializeInvoked = false;
         StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>> stubTResultSerializer = new StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>>(
             serialize: o => { serializeInvoked = true; return new StubSerialized<ResultPrimitive>(o); },
-            deserialize: s => s.Original
+            deserialize: s => s?.Original ?? default
         );
         var stubCacheProvider = new StubCacheProvider();
         ResultPrimitive objectToCache = ResultPrimitive.Good;
@@ -285,7 +285,7 @@ public class AsyncSerializingCacheProviderSpecs
         bool serializeInvoked = false;
         StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>> stubTResultSerializer = new StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>>(
             serialize: o => { serializeInvoked = true; return new StubSerialized<ResultPrimitive>(o); },
-            deserialize: s => s.Original
+            deserialize: s => s?.Original ?? default
         );
         StubCacheProvider stubCacheProvider = new StubCacheProvider();
         ResultPrimitive objectToCache = default;
@@ -309,7 +309,7 @@ public class AsyncSerializingCacheProviderSpecs
         bool deserializeInvoked = false;
         StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>> stubTResultSerializer = new StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>>(
             serialize: o => new StubSerialized<ResultPrimitive>(o),
-            deserialize: s => { deserializeInvoked = true; return s.Original; }
+            deserialize: s => { deserializeInvoked = true; return s?.Original ?? default; }
         );
         var stubCacheProvider = new StubCacheProvider();
         ResultPrimitive objectToCache = ResultPrimitive.Good;
@@ -318,7 +318,7 @@ public class AsyncSerializingCacheProviderSpecs
         AsyncSerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>> serializingCacheProvider = new AsyncSerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>>(stubCacheProvider.AsyncFor<StubSerialized<ResultPrimitive>>(), stubTResultSerializer);
 
         await stubCacheProvider.PutAsync(key, new StubSerialized<ResultPrimitive>(objectToCache), new Ttl(TimeSpan.FromMinutes(1)), CancellationToken.None, false);
-        (bool cacheHit, object fromCache) = await serializingCacheProvider.TryGetAsync(key, CancellationToken.None, false);
+        (bool cacheHit, object? fromCache) = await serializingCacheProvider.TryGetAsync(key, CancellationToken.None, false);
 
         cacheHit.Should().BeTrue();
         deserializeInvoked.Should().BeTrue();
@@ -331,7 +331,7 @@ public class AsyncSerializingCacheProviderSpecs
         bool deserializeInvoked = false;
         StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>> stubTResultSerializer = new StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>>(
             serialize: o => new StubSerialized<ResultPrimitive>(o),
-            deserialize: s => { deserializeInvoked = true; return s.Original; }
+            deserialize: s => { deserializeInvoked = true; return s?.Original ?? default; }
         );
         var stubCacheProvider = new StubCacheProvider();
         string key = "some key";
@@ -339,7 +339,7 @@ public class AsyncSerializingCacheProviderSpecs
         stubCacheProvider.TryGet(key).Item1.Should().BeFalse();
 
         AsyncSerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>> serializingCacheProvider = new AsyncSerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>>(stubCacheProvider.AsyncFor<StubSerialized<ResultPrimitive>>(), stubTResultSerializer);
-        (bool cacheHit, ResultPrimitive fromCache) = await serializingCacheProvider.TryGetAsync(key, CancellationToken.None, false);
+        (bool cacheHit, ResultPrimitive? fromCache) = await serializingCacheProvider.TryGetAsync(key, CancellationToken.None, false);
 
         cacheHit.Should().BeFalse();
         deserializeInvoked.Should().BeFalse();
@@ -352,7 +352,7 @@ public class AsyncSerializingCacheProviderSpecs
         bool serializeInvoked = false;
         StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>> stubTResultSerializer = new StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>>(
             serialize: o => { serializeInvoked = true; return new StubSerialized<ResultPrimitive>(o); },
-            deserialize: s => s.Original
+            deserialize: s => s?.Original ?? default
         );
         var stubCacheProvider = new StubCacheProvider();
         ResultPrimitive objectToCache = ResultPrimitive.Good;
@@ -376,7 +376,7 @@ public class AsyncSerializingCacheProviderSpecs
         bool serializeInvoked = false;
         StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>> stubTResultSerializer = new StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>>(
             serialize: o => { serializeInvoked = true; return new StubSerialized<ResultPrimitive>(o); },
-            deserialize: s => s.Original
+            deserialize: s => s?.Original ?? default
         );
         StubCacheProvider stubCacheProvider = new StubCacheProvider();
         ResultPrimitive objectToCache = default;
@@ -401,7 +401,7 @@ public class AsyncSerializingCacheProviderSpecs
         bool deserializeInvoked = false;
         StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>> stubTResultSerializer = new StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>>(
             serialize: o => new StubSerialized<ResultPrimitive>(o),
-            deserialize: s => { deserializeInvoked = true; return s.Original; }
+            deserialize: s => { deserializeInvoked = true; return s?.Original ?? default; }
         );
         var stubCacheProvider = new StubCacheProvider();
         ResultPrimitive objectToCache = ResultPrimitive.Good;
@@ -411,7 +411,7 @@ public class AsyncSerializingCacheProviderSpecs
             stubCacheProvider.AsyncFor<StubSerialized<ResultPrimitive>>().WithSerializer(stubTResultSerializer);
 
         await stubCacheProvider.PutAsync(key, new StubSerialized<ResultPrimitive>(objectToCache), new Ttl(TimeSpan.FromMinutes(1)), CancellationToken.None, false);
-        (bool cacheHit, ResultPrimitive fromCache) = await serializingCacheProvider.TryGetAsync(key, CancellationToken.None, false);
+        (bool cacheHit, ResultPrimitive? fromCache) = await serializingCacheProvider.TryGetAsync(key, CancellationToken.None, false);
 
         cacheHit.Should().BeTrue();
         deserializeInvoked.Should().BeTrue();
@@ -424,7 +424,7 @@ public class AsyncSerializingCacheProviderSpecs
         bool deserializeInvoked = false;
         StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>> stubTResultSerializer = new StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>>(
             serialize: o => new StubSerialized<ResultPrimitive>(o),
-            deserialize: s => { deserializeInvoked = true; return s.Original; }
+            deserialize: s => { deserializeInvoked = true; return s?.Original ?? default; }
         );
         var stubCacheProvider = new StubCacheProvider();
         string key = "some key";
@@ -433,7 +433,7 @@ public class AsyncSerializingCacheProviderSpecs
 
         AsyncSerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>> serializingCacheProvider =
             stubCacheProvider.AsyncFor<StubSerialized<ResultPrimitive>>().WithSerializer(stubTResultSerializer);
-        (bool cacheHit, ResultPrimitive fromCache) = await serializingCacheProvider.TryGetAsync(key, CancellationToken.None, false);
+        (bool cacheHit, ResultPrimitive? fromCache) = await serializingCacheProvider.TryGetAsync(key, CancellationToken.None, false);
 
         cacheHit.Should().BeFalse();
         deserializeInvoked.Should().BeFalse();

--- a/src/Polly.Specs/Caching/SerializingCacheProviderSpecs.cs
+++ b/src/Polly.Specs/Caching/SerializingCacheProviderSpecs.cs
@@ -9,7 +9,7 @@ public class SerializingCacheProviderSpecs
     {
         StubSerializer<object, StubSerialized> stubObjectSerializer = new StubSerializer<object, StubSerialized>(
             serialize: o => new StubSerialized(o),
-            deserialize: s => s.Original
+            deserialize: s => s?.Original ?? default
         );
 
     Action configure = () => new SerializingCacheProvider<StubSerialized>(null!, stubObjectSerializer);
@@ -42,7 +42,7 @@ public class SerializingCacheProviderSpecs
         bool serializeInvoked = false;
         StubSerializer<object, StubSerialized> stubSerializer = new StubSerializer<object, StubSerialized>(
             serialize: o => { serializeInvoked = true; return new StubSerialized(o);},
-            deserialize: s => s.Original
+            deserialize: s => s?.Original ?? default
         );
         StubCacheProvider stubCacheProvider = new StubCacheProvider();
         object objectToCache = new object();
@@ -66,7 +66,7 @@ public class SerializingCacheProviderSpecs
         bool serializeInvoked = false;
         StubSerializer<object, StubSerialized> stubSerializer = new StubSerializer<object, StubSerialized>(
             serialize: o => { serializeInvoked = true; return new StubSerialized(o); },
-            deserialize: s => s.Original
+            deserialize: s => s?.Original ?? default
         );
         StubCacheProvider stubCacheProvider = new StubCacheProvider();
         object? objectToCache = null;
@@ -90,7 +90,7 @@ public class SerializingCacheProviderSpecs
         bool deserializeInvoked = false;
         StubSerializer<object, StubSerialized> stubSerializer = new StubSerializer<object, StubSerialized>(
             serialize: o => new StubSerialized(o),
-            deserialize: s => { deserializeInvoked = true; return s.Original; }
+            deserialize: s => { deserializeInvoked = true; return s?.Original ?? default; }
         );
 
         var stubCacheProvider = new StubCacheProvider();
@@ -113,7 +113,7 @@ public class SerializingCacheProviderSpecs
         bool deserializeInvoked = false;
         StubSerializer<object, StubSerialized> stubSerializer = new StubSerializer<object, StubSerialized>(
             serialize: o => new StubSerialized(o),
-            deserialize: s => { deserializeInvoked = true; return s.Original; }
+            deserialize: s => { deserializeInvoked = true; return s?.Original ?? default; }
         );
         var stubCacheProvider = new StubCacheProvider();
         string key = "some key";
@@ -134,7 +134,7 @@ public class SerializingCacheProviderSpecs
         bool serializeInvoked = false;
         StubSerializer<object, StubSerialized> stubSerializer = new StubSerializer<object, StubSerialized>(
             serialize: o => { serializeInvoked = true; return new StubSerialized(o); },
-            deserialize: s => s.Original
+            deserialize: s => s?.Original
         );
         StubCacheProvider stubCacheProvider = new StubCacheProvider();
         object objectToCache = new object();
@@ -158,7 +158,7 @@ public class SerializingCacheProviderSpecs
         bool serializeInvoked = false;
         StubSerializer<object, StubSerialized> stubSerializer = new StubSerializer<object, StubSerialized>(
             serialize: o => { serializeInvoked = true; return new StubSerialized(o); },
-            deserialize: s => s.Original
+            deserialize: s => s?.Original ?? default
         );
         StubCacheProvider stubCacheProvider = new StubCacheProvider();
         object? objectToCache = null;
@@ -182,7 +182,7 @@ public class SerializingCacheProviderSpecs
         bool deserializeInvoked = false;
         StubSerializer<object, StubSerialized> stubSerializer = new StubSerializer<object, StubSerialized>(
             serialize: o => new StubSerialized(o),
-            deserialize: s => { deserializeInvoked = true; return s.Original; }
+            deserialize: s => { deserializeInvoked = true; return s?.Original ?? default; }
         );
         var stubCacheProvider = new StubCacheProvider();
         object objectToCache = new object();
@@ -204,7 +204,7 @@ public class SerializingCacheProviderSpecs
         bool deserializeInvoked = false;
         StubSerializer<object, StubSerialized> stubSerializer = new StubSerializer<object, StubSerialized>(
             serialize: o => new StubSerialized(o),
-            deserialize: s => { deserializeInvoked = true; return s.Original; }
+            deserialize: s => { deserializeInvoked = true; return s?.Original ?? default; }
         );
         var stubCacheProvider = new StubCacheProvider();
         string key = "some key";
@@ -228,7 +228,7 @@ public class SerializingCacheProviderSpecs
     {
         StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>> stubTResultSerializer = new StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>>(
         serialize: o => new StubSerialized<ResultPrimitive>(o),
-        deserialize: s => s.Original
+        deserialize: s => s?.Original ?? default
         );
 
     Action configure = () => new SerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>>(null!, stubTResultSerializer);
@@ -261,7 +261,7 @@ public class SerializingCacheProviderSpecs
         bool serializeInvoked = false;
         StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>> stubTResultSerializer = new StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>>(
             serialize: o => { serializeInvoked = true; return new StubSerialized<ResultPrimitive>(o); },
-            deserialize: s => s.Original
+            deserialize: s => s?.Original ?? default
         );
         var stubCacheProvider = new StubCacheProvider();
         ResultPrimitive objectToCache = ResultPrimitive.Good;
@@ -285,7 +285,7 @@ public class SerializingCacheProviderSpecs
         bool serializeInvoked = false;
         StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>> stubTResultSerializer = new StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>>(
             serialize: o => { serializeInvoked = true; return new StubSerialized<ResultPrimitive>(o); },
-            deserialize: s => s.Original
+            deserialize: s => s?.Original ?? default
         );
         StubCacheProvider stubCacheProvider = new StubCacheProvider();
         ResultPrimitive objectToCache = default;
@@ -309,7 +309,7 @@ public class SerializingCacheProviderSpecs
         bool deserializeInvoked = false;
         StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>> stubTResultSerializer = new StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>>(
             serialize: o => new StubSerialized<ResultPrimitive>(o),
-            deserialize: s => { deserializeInvoked = true; return s.Original; }
+            deserialize: s => { deserializeInvoked = true; return s?.Original ?? default; }
         );
         var stubCacheProvider = new StubCacheProvider();
         ResultPrimitive objectToCache = ResultPrimitive.Good;
@@ -331,7 +331,7 @@ public class SerializingCacheProviderSpecs
         bool deserializeInvoked = false;
         StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>> stubTResultSerializer = new StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>>(
             serialize: o => new StubSerialized<ResultPrimitive>(o),
-            deserialize: s => { deserializeInvoked = true; return s.Original; }
+            deserialize: s => { deserializeInvoked = true; return s?.Original ?? default; }
         );
         var stubCacheProvider = new StubCacheProvider();
         string key = "some key";
@@ -350,10 +350,9 @@ public class SerializingCacheProviderSpecs
     public void Double_generic_SerializingCacheProvider_from_extension_syntax_should_serialize_on_put()
     {
         bool serializeInvoked = false;
-        StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>> stubTResultSerializer = new StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>>(
+        var stubTResultSerializer = new StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>>(
             serialize: o => { serializeInvoked = true; return new StubSerialized<ResultPrimitive>(o); },
-            deserialize: s => s.Original
-        );
+            deserialize: s => s?.Original ?? default);
         var stubCacheProvider = new StubCacheProvider();
         ResultPrimitive objectToCache = ResultPrimitive.Good;
         string key = "some key";
@@ -377,7 +376,7 @@ public class SerializingCacheProviderSpecs
         bool serializeInvoked = false;
         StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>> stubTResultSerializer = new StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>>(
             serialize: o => { serializeInvoked = true; return new StubSerialized<ResultPrimitive>(o); },
-            deserialize: s => s.Original
+            deserialize: s => s?.Original ?? default
         );
         StubCacheProvider stubCacheProvider = new StubCacheProvider();
         ResultPrimitive objectToCache = default;
@@ -403,7 +402,7 @@ public class SerializingCacheProviderSpecs
         bool deserializeInvoked = false;
         StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>> stubTResultSerializer = new StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>>(
             serialize: o => new StubSerialized<ResultPrimitive>(o),
-            deserialize: s => { deserializeInvoked = true; return s.Original; }
+            deserialize: s => { deserializeInvoked = true; return s?.Original ?? default; }
         );
         var stubCacheProvider = new StubCacheProvider();
         ResultPrimitive objectToCache = ResultPrimitive.Good;
@@ -413,7 +412,7 @@ public class SerializingCacheProviderSpecs
             stubCacheProvider.For<StubSerialized<ResultPrimitive>>().WithSerializer(stubTResultSerializer);
 
         stubCacheProvider.Put(key, new StubSerialized<ResultPrimitive>(objectToCache), new Ttl(TimeSpan.FromMinutes(1)));
-        (bool cacheHit, ResultPrimitive fromCache) = serializingCacheProvider.TryGet(key);
+        (bool cacheHit, ResultPrimitive? fromCache) = serializingCacheProvider.TryGet(key);
 
         cacheHit.Should().BeTrue();
         deserializeInvoked.Should().BeTrue();
@@ -426,7 +425,7 @@ public class SerializingCacheProviderSpecs
         bool deserializeInvoked = false;
         StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>> stubTResultSerializer = new StubSerializer<ResultPrimitive, StubSerialized<ResultPrimitive>>(
             serialize: o => new StubSerialized<ResultPrimitive>(o),
-            deserialize: s => { deserializeInvoked = true; return s.Original; }
+            deserialize: s => { deserializeInvoked = true; return s?.Original ?? default; }
         );
         var stubCacheProvider = new StubCacheProvider();
         string key = "some key";
@@ -435,7 +434,7 @@ public class SerializingCacheProviderSpecs
 
         SerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>> serializingCacheProvider =
             stubCacheProvider.For<StubSerialized<ResultPrimitive>>().WithSerializer(stubTResultSerializer);
-        (bool cacheHit, ResultPrimitive fromCache) = serializingCacheProvider.TryGet(key);
+        (bool cacheHit, ResultPrimitive? fromCache) = serializingCacheProvider.TryGet(key);
 
         cacheHit.Should().BeFalse();
         deserializeInvoked.Should().BeFalse();

--- a/src/Polly.Specs/Helpers/Bulkhead/TraceableAction.cs
+++ b/src/Polly.Specs/Helpers/Bulkhead/TraceableAction.cs
@@ -46,7 +46,11 @@ public class TraceableAction : IDisposable
 
     public Task ExecuteOnBulkhead<TResult>(BulkheadPolicy<TResult?> bulkhead) =>
         ExecuteThroughSyncBulkheadOuter(
-            () => bulkhead.Execute(_ => { ExecuteThroughSyncBulkheadInner(); return default; }, CancellationSource.Token)
+            () => bulkhead.Execute(_ =>
+            {
+                ExecuteThroughSyncBulkheadInner();
+                return default;
+            }, CancellationSource.Token)
         );
 
     // Note re TaskCreationOptions.LongRunning: Testing the parallelization of the bulkhead policy efficiently requires the ability to start large numbers of parallel tasks in a short space of time.  The ThreadPool's algorithm of only injecting extra threads (when necessary) at a rate of two-per-second however makes high-volume tests using the ThreadPool both slow and flaky.  For PCL tests further, ThreadPool.SetMinThreads(...) is not available, to mitigate this.  Using TaskCreationOptions.LongRunning allows us to force tasks to be started near-instantly on non-ThreadPool threads.
@@ -122,7 +126,11 @@ public class TraceableAction : IDisposable
 
     public Task ExecuteOnBulkheadAsync<TResult>(AsyncBulkheadPolicy<TResult?> bulkhead) =>
         ExecuteThroughAsyncBulkheadOuter(
-            () => bulkhead.ExecuteAsync(async _ => { await ExecuteThroughAsyncBulkheadInner(); return default; }, CancellationSource.Token)
+            () => bulkhead.ExecuteAsync(async _ =>
+            {
+                await ExecuteThroughAsyncBulkheadInner();
+                return default;
+            }, CancellationSource.Token)
         );
 
     public Task ExecuteThroughAsyncBulkheadOuter(Func<Task> executeThroughBulkheadInner)

--- a/src/Polly.Specs/Helpers/Caching/StubCacheProvider.cs
+++ b/src/Polly.Specs/Helpers/Caching/StubCacheProvider.cs
@@ -35,18 +35,14 @@ internal class StubCacheProvider : ISyncCacheProvider, IAsyncCacheProvider
         return (false, null);
     }
 
-    public void Put(string key, object? value, Ttl ttl)
-    {
+    public void Put(string key, object? value, Ttl ttl) =>
         cachedValues[key] = new CacheItem(value, ttl);
-    }
 
     #region Naive async-over-sync implementation
 
     // Intentionally naive async-over-sync implementation.  Its purpose is to be the simplest thing to support tests of the CachePolicyAsync and CacheEngineAsync, not to be a usable implementation of IAsyncCacheProvider.
-    public Task<(bool, object?)> TryGetAsync(string key, CancellationToken cancellationToken, bool continueOnCapturedContext)
-    {
-        return Task.FromResult(TryGet(key));
-    }
+    public Task<(bool, object?)> TryGetAsync(string key, CancellationToken cancellationToken, bool continueOnCapturedContext) =>
+        Task.FromResult(TryGet(key));
 
     public Task PutAsync(string key, object? value, Ttl ttl, CancellationToken cancellationToken, bool continueOnCapturedContext)
     {

--- a/src/Polly.Specs/Helpers/Caching/StubCacheProvider.cs
+++ b/src/Polly.Specs/Helpers/Caching/StubCacheProvider.cs
@@ -7,14 +7,14 @@ internal class StubCacheProvider : ISyncCacheProvider, IAsyncCacheProvider
 {
     class CacheItem
     {
-        public CacheItem(object value, Ttl ttl)
+        public CacheItem(object? value, Ttl ttl)
         {
             Expiry = DateTimeOffset.MaxValue - SystemClock.DateTimeOffsetUtcNow() > ttl.Timespan ? SystemClock.DateTimeOffsetUtcNow().Add(ttl.Timespan) : DateTimeOffset.MaxValue;
             Value = value;
         }
 
         public readonly DateTimeOffset Expiry;
-        public readonly object Value;
+        public readonly object? Value;
     }
 
     private readonly Dictionary<string, CacheItem> cachedValues = new Dictionary<string, CacheItem>();
@@ -35,7 +35,7 @@ internal class StubCacheProvider : ISyncCacheProvider, IAsyncCacheProvider
         return (false, null);
     }
 
-    public void Put(string key, object value, Ttl ttl)
+    public void Put(string key, object? value, Ttl ttl)
     {
         cachedValues[key] = new CacheItem(value, ttl);
     }
@@ -48,7 +48,7 @@ internal class StubCacheProvider : ISyncCacheProvider, IAsyncCacheProvider
         return Task.FromResult(TryGet(key));
     }
 
-    public Task PutAsync(string key, object value, Ttl ttl, CancellationToken cancellationToken, bool continueOnCapturedContext)
+    public Task PutAsync(string key, object? value, Ttl ttl, CancellationToken cancellationToken, bool continueOnCapturedContext)
     {
         Put(key, value, ttl);
         return TaskHelper.EmptyTask;

--- a/src/Polly.Specs/Helpers/Caching/StubErroringCacheProvider.cs
+++ b/src/Polly.Specs/Helpers/Caching/StubErroringCacheProvider.cs
@@ -19,7 +19,7 @@ internal class StubErroringCacheProvider : ISyncCacheProvider, IAsyncCacheProvid
         return innerProvider.TryGet(key);
     }
 
-    public void Put(string key, object value, Ttl ttl)
+    public void Put(string key, object? value, Ttl ttl)
     {
         if (_putException != null) throw _putException;
         innerProvider.Put(key, value, ttl);
@@ -33,7 +33,7 @@ internal class StubErroringCacheProvider : ISyncCacheProvider, IAsyncCacheProvid
         return Task.FromResult(TryGet(key));
     }
 
-    public Task PutAsync(string key, object value, Ttl ttl, CancellationToken cancellationToken, bool continueOnCapturedContext)
+    public Task PutAsync(string key, object? value, Ttl ttl, CancellationToken cancellationToken, bool continueOnCapturedContext)
     {
         Put(key, value, ttl);
         return TaskHelper.EmptyTask;

--- a/src/Polly.Specs/Helpers/Caching/StubSerialized.cs
+++ b/src/Polly.Specs/Helpers/Caching/StubSerialized.cs
@@ -8,10 +8,8 @@ internal class StubSerialized<TOriginal>
 {
     public TOriginal? Original;
 
-    public StubSerialized(TOriginal? original)
-    {
+    public StubSerialized(TOriginal? original) =>
         Original = original;
-    }
 }
 
 /// <summary>

--- a/src/Polly.Specs/Helpers/Caching/StubSerialized.cs
+++ b/src/Polly.Specs/Helpers/Caching/StubSerialized.cs
@@ -6,9 +6,9 @@ namespace Polly.Specs.Helpers.Caching;
 /// <typeparam name="TOriginal">The type of the item being 'serialized'.</typeparam>
 internal class StubSerialized<TOriginal>
 {
-    public TOriginal Original;
+    public TOriginal? Original;
 
-    public StubSerialized(TOriginal original)
+    public StubSerialized(TOriginal? original)
     {
         Original = original;
     }
@@ -19,5 +19,5 @@ internal class StubSerialized<TOriginal>
 /// </summary>
 internal class StubSerialized : StubSerialized<object>
 {
-    public StubSerialized(object obj) : base(obj) { }
+    public StubSerialized(object? obj) : base(obj) { }
 }

--- a/src/Polly.Specs/Helpers/Caching/StubSerializer.cs
+++ b/src/Polly.Specs/Helpers/Caching/StubSerializer.cs
@@ -7,15 +7,15 @@
 /// <typeparam name="TSerialized">The type of the serialized values.</typeparam>
 internal class StubSerializer<TResult, TSerialized> : ICacheItemSerializer<TResult, TSerialized>
 {
-    private readonly Func<TResult, TSerialized> _serialize;
-    private readonly Func<TSerialized, TResult> _deserialize;
+    private readonly Func<TResult?, TSerialized?> _serialize;
+    private readonly Func<TSerialized?, TResult?> _deserialize;
 
-    public StubSerializer(Func<TResult, TSerialized> serialize, Func<TSerialized, TResult> deserialize)
+    public StubSerializer(Func<TResult?, TSerialized?> serialize, Func<TSerialized?, TResult?> deserialize)
     {
         _serialize = serialize;
         _deserialize = deserialize;
     }
-    public TSerialized Serialize(TResult objectToSerialize) => _serialize(objectToSerialize);
+    public TSerialized? Serialize(TResult? objectToSerialize) => _serialize(objectToSerialize);
 
-    public TResult Deserialize(TSerialized objectToDeserialize) => _deserialize(objectToDeserialize);
+    public TResult? Deserialize(TSerialized? objectToDeserialize) => _deserialize(objectToDeserialize);
 }

--- a/src/Polly.Specs/Helpers/Caching/StubSerializer.cs
+++ b/src/Polly.Specs/Helpers/Caching/StubSerializer.cs
@@ -15,7 +15,9 @@ internal class StubSerializer<TResult, TSerialized> : ICacheItemSerializer<TResu
         _serialize = serialize;
         _deserialize = deserialize;
     }
-    public TSerialized? Serialize(TResult? objectToSerialize) => _serialize(objectToSerialize);
+    public TSerialized? Serialize(TResult? objectToSerialize) =>
+        _serialize(objectToSerialize);
 
-    public TResult? Deserialize(TSerialized? objectToDeserialize) => _deserialize(objectToDeserialize);
+    public TResult? Deserialize(TSerialized? objectToDeserialize) =>
+        _deserialize(objectToDeserialize);
 }

--- a/src/Polly/Caching/AsyncCacheEngine.cs
+++ b/src/Polly/Caching/AsyncCacheEngine.cs
@@ -1,4 +1,5 @@
-﻿namespace Polly.Caching;
+﻿#nullable enable
+namespace Polly.Caching;
 
 internal static class AsyncCacheEngine
 {
@@ -25,7 +26,7 @@ internal static class AsyncCacheEngine
         }
 
         bool cacheHit;
-        TResult valueFromCache;
+        TResult? valueFromCache;
         try
         {
             (cacheHit, valueFromCache) = await cacheProvider.TryGetAsync(cacheKey, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
@@ -39,7 +40,7 @@ internal static class AsyncCacheEngine
         if (cacheHit)
         {
             onCacheGet(context, cacheKey);
-            return valueFromCache;
+            return valueFromCache!;
         }
         else
         {

--- a/src/Polly/Caching/AsyncGenericCacheProvider.cs
+++ b/src/Polly/Caching/AsyncGenericCacheProvider.cs
@@ -18,6 +18,6 @@ internal class AsyncGenericCacheProvider<TCacheFormat> : IAsyncCacheProvider<TCa
         return (cacheHit, (TCacheFormat?)(result ?? default(TCacheFormat)));
     }
 
-    Task IAsyncCacheProvider<TCacheFormat>.PutAsync(string key, TCacheFormat value, Ttl ttl, CancellationToken cancellationToken, bool continueOnCapturedContext)
+    Task IAsyncCacheProvider<TCacheFormat>.PutAsync(string key, TCacheFormat? value, Ttl ttl, CancellationToken cancellationToken, bool continueOnCapturedContext)
         => _wrappedCacheProvider.PutAsync(key, value, ttl, cancellationToken, continueOnCapturedContext);
 }

--- a/src/Polly/Caching/AsyncGenericCacheProvider.cs
+++ b/src/Polly/Caching/AsyncGenericCacheProvider.cs
@@ -1,4 +1,5 @@
-﻿namespace Polly.Caching;
+﻿#nullable enable
+namespace Polly.Caching;
 
 /// <summary>
 /// Provides a strongly-typed wrapper over a non-generic CacheProviderAsync.
@@ -11,10 +12,10 @@ internal class AsyncGenericCacheProvider<TCacheFormat> : IAsyncCacheProvider<TCa
     internal AsyncGenericCacheProvider(IAsyncCacheProvider nonGenericCacheProvider)
         => _wrappedCacheProvider = nonGenericCacheProvider ?? throw new ArgumentNullException(nameof(nonGenericCacheProvider));
 
-    async Task<(bool, TCacheFormat)> IAsyncCacheProvider<TCacheFormat>.TryGetAsync(string key, CancellationToken cancellationToken, bool continueOnCapturedContext)
+    async Task<(bool, TCacheFormat?)> IAsyncCacheProvider<TCacheFormat>.TryGetAsync(string key, CancellationToken cancellationToken, bool continueOnCapturedContext)
     {
-        (bool cacheHit, object result) = await _wrappedCacheProvider.TryGetAsync(key, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
-        return (cacheHit, (TCacheFormat)(result ?? default(TCacheFormat)));
+        (bool cacheHit, object? result) = await _wrappedCacheProvider.TryGetAsync(key, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
+        return (cacheHit, (TCacheFormat?)(result ?? default(TCacheFormat)));
     }
 
     Task IAsyncCacheProvider<TCacheFormat>.PutAsync(string key, TCacheFormat value, Ttl ttl, CancellationToken cancellationToken, bool continueOnCapturedContext)

--- a/src/Polly/Caching/AsyncGenericCacheProvider.cs
+++ b/src/Polly/Caching/AsyncGenericCacheProvider.cs
@@ -9,8 +9,8 @@ internal class AsyncGenericCacheProvider<TCacheFormat> : IAsyncCacheProvider<TCa
 {
     private readonly IAsyncCacheProvider _wrappedCacheProvider;
 
-    internal AsyncGenericCacheProvider(IAsyncCacheProvider nonGenericCacheProvider)
-        => _wrappedCacheProvider = nonGenericCacheProvider ?? throw new ArgumentNullException(nameof(nonGenericCacheProvider));
+    internal AsyncGenericCacheProvider(IAsyncCacheProvider nonGenericCacheProvider) =>
+        _wrappedCacheProvider = nonGenericCacheProvider ?? throw new ArgumentNullException(nameof(nonGenericCacheProvider));
 
     async Task<(bool, TCacheFormat?)> IAsyncCacheProvider<TCacheFormat>.TryGetAsync(string key, CancellationToken cancellationToken, bool continueOnCapturedContext)
     {
@@ -18,6 +18,6 @@ internal class AsyncGenericCacheProvider<TCacheFormat> : IAsyncCacheProvider<TCa
         return (cacheHit, (TCacheFormat?)(result ?? default(TCacheFormat)));
     }
 
-    Task IAsyncCacheProvider<TCacheFormat>.PutAsync(string key, TCacheFormat? value, Ttl ttl, CancellationToken cancellationToken, bool continueOnCapturedContext)
-        => _wrappedCacheProvider.PutAsync(key, value, ttl, cancellationToken, continueOnCapturedContext);
+    Task IAsyncCacheProvider<TCacheFormat>.PutAsync(string key, TCacheFormat? value, Ttl ttl, CancellationToken cancellationToken, bool continueOnCapturedContext) =>
+        _wrappedCacheProvider.PutAsync(key, value, ttl, cancellationToken, continueOnCapturedContext);
 }

--- a/src/Polly/Caching/AsyncSerializingCacheProvider.cs
+++ b/src/Polly/Caching/AsyncSerializingCacheProvider.cs
@@ -49,16 +49,14 @@ public class AsyncSerializingCacheProvider<TSerialized> : IAsyncCacheProvider
     /// <param name="continueOnCapturedContext">Whether async calls should continue on a captured synchronization context.</param>
     /// <returns>A <see cref="Task" /> which completes when the value has been cached.</returns>
     public Task PutAsync(string key, object? value, Ttl ttl, CancellationToken cancellationToken,
-        bool continueOnCapturedContext)
-    {
-        return _wrappedCacheProvider.PutAsync(
-                    key,
-                    _serializer.Serialize(value),
-                    ttl,
-                    cancellationToken,
-                    continueOnCapturedContext
-                );
-    }
+        bool continueOnCapturedContext) =>
+        _wrappedCacheProvider.PutAsync(
+            key,
+            _serializer.Serialize(value),
+            ttl,
+            cancellationToken,
+            continueOnCapturedContext
+        );
 }
 
 /// <summary>
@@ -110,14 +108,12 @@ public class AsyncSerializingCacheProvider<TResult, TSerialized> : IAsyncCachePr
     /// <param name="continueOnCapturedContext">Whether async calls should continue on a captured synchronization context.</param>
     /// <returns>A <see cref="Task" /> which completes when the value has been cached.</returns>
     public Task PutAsync(string key, TResult? value, Ttl ttl, CancellationToken cancellationToken,
-        bool continueOnCapturedContext)
-    {
-        return _wrappedCacheProvider.PutAsync(
-                    key,
-                    _serializer.Serialize(value),
-                    ttl,
-                    cancellationToken,
-                    continueOnCapturedContext
-                );
-    }
+        bool continueOnCapturedContext) =>
+        _wrappedCacheProvider.PutAsync(
+            key,
+            _serializer.Serialize(value),
+            ttl,
+            cancellationToken,
+            continueOnCapturedContext
+        );
 }

--- a/src/Polly/Caching/AsyncSerializingCacheProvider.cs
+++ b/src/Polly/Caching/AsyncSerializingCacheProvider.cs
@@ -1,4 +1,5 @@
-﻿namespace Polly.Caching;
+﻿#nullable enable
+namespace Polly.Caching;
 
 /// <summary>
 /// Defines an <see cref="IAsyncCacheProvider"/> which serializes objects of any type in and out of an underlying cache which caches as type <typeparamref name="TSerialized"/>.  For use with asynchronous <see cref="CachePolicy" />.
@@ -32,9 +33,9 @@ public class AsyncSerializingCacheProvider<TSerialized> : IAsyncCacheProvider
     /// A <see cref="Task{TResult}" /> promising as Result a tuple whose first element is a value indicating whether
     /// the key was found in the cache, and whose second element is the value from the cache (null if not found).
     /// </returns>
-    public async Task<(bool, object)> TryGetAsync(string key, CancellationToken cancellationToken, bool continueOnCapturedContext)
+    public async Task<(bool, object?)> TryGetAsync(string key, CancellationToken cancellationToken, bool continueOnCapturedContext)
     {
-        (bool cacheHit, TSerialized objectToDeserialize) = await _wrappedCacheProvider.TryGetAsync(key, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
+        (bool cacheHit, TSerialized? objectToDeserialize) = await _wrappedCacheProvider.TryGetAsync(key, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
         return (cacheHit, cacheHit ? _serializer.Deserialize(objectToDeserialize) : null);
     }
 
@@ -47,7 +48,7 @@ public class AsyncSerializingCacheProvider<TSerialized> : IAsyncCacheProvider
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <param name="continueOnCapturedContext">Whether async calls should continue on a captured synchronization context.</param>
     /// <returns>A <see cref="Task" /> which completes when the value has been cached.</returns>
-    public Task PutAsync(string key, object value, Ttl ttl, CancellationToken cancellationToken,
+    public Task PutAsync(string key, object? value, Ttl ttl, CancellationToken cancellationToken,
         bool continueOnCapturedContext)
     {
         return _wrappedCacheProvider.PutAsync(
@@ -93,9 +94,9 @@ public class AsyncSerializingCacheProvider<TResult, TSerialized> : IAsyncCachePr
     /// A <see cref="Task{TResult}" /> promising as Result a tuple whose first element is a value indicating whether
     /// the key was found in the cache, and whose second element is the value from the cache (default(TResult) if not found).
     /// </returns>
-    public async Task<(bool, TResult)> TryGetAsync(string key, CancellationToken cancellationToken, bool continueOnCapturedContext)
+    public async Task<(bool, TResult?)> TryGetAsync(string key, CancellationToken cancellationToken, bool continueOnCapturedContext)
     {
-        (bool cacheHit, TSerialized objectToDeserialize) = await _wrappedCacheProvider.TryGetAsync(key, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
+        (bool cacheHit, TSerialized? objectToDeserialize) = await _wrappedCacheProvider.TryGetAsync(key, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
         return (cacheHit, cacheHit ? _serializer.Deserialize(objectToDeserialize) : default);
     }
 
@@ -108,7 +109,7 @@ public class AsyncSerializingCacheProvider<TResult, TSerialized> : IAsyncCachePr
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <param name="continueOnCapturedContext">Whether async calls should continue on a captured synchronization context.</param>
     /// <returns>A <see cref="Task" /> which completes when the value has been cached.</returns>
-    public Task PutAsync(string key, TResult value, Ttl ttl, CancellationToken cancellationToken,
+    public Task PutAsync(string key, TResult? value, Ttl ttl, CancellationToken cancellationToken,
         bool continueOnCapturedContext)
     {
         return _wrappedCacheProvider.PutAsync(

--- a/src/Polly/Caching/CacheEngine.cs
+++ b/src/Polly/Caching/CacheEngine.cs
@@ -1,4 +1,5 @@
-﻿namespace Polly.Caching;
+﻿#nullable enable
+namespace Polly.Caching;
 
 internal static class CacheEngine
 {
@@ -24,7 +25,7 @@ internal static class CacheEngine
         }
 
         bool cacheHit;
-        TResult valueFromCache;
+        TResult? valueFromCache;
         try
         {
             (cacheHit, valueFromCache) = cacheProvider.TryGet(cacheKey);
@@ -38,7 +39,7 @@ internal static class CacheEngine
         if (cacheHit)
         {
             onCacheGet(context, cacheKey);
-            return valueFromCache;
+            return valueFromCache!;
         }
         else
         {

--- a/src/Polly/Caching/GenericCacheProvider.cs
+++ b/src/Polly/Caching/GenericCacheProvider.cs
@@ -9,8 +9,8 @@ internal class GenericCacheProvider<TCacheFormat> : ISyncCacheProvider<TCacheFor
 {
     private readonly ISyncCacheProvider _wrappedCacheProvider;
 
-    internal GenericCacheProvider(ISyncCacheProvider nonGenericCacheProvider)
-        => _wrappedCacheProvider = nonGenericCacheProvider ?? throw new ArgumentNullException(nameof(nonGenericCacheProvider));
+    internal GenericCacheProvider(ISyncCacheProvider nonGenericCacheProvider) =>
+        _wrappedCacheProvider = nonGenericCacheProvider ?? throw new ArgumentNullException(nameof(nonGenericCacheProvider));
 
     (bool, TCacheFormat?) ISyncCacheProvider<TCacheFormat>.TryGet(string key)
     {
@@ -18,6 +18,6 @@ internal class GenericCacheProvider<TCacheFormat> : ISyncCacheProvider<TCacheFor
         return (cacheHit, (TCacheFormat?) (result ?? default(TCacheFormat)));
     }
 
-    void ISyncCacheProvider<TCacheFormat>.Put(string key, TCacheFormat? value, Ttl ttl)
-        => _wrappedCacheProvider.Put(key, value, ttl);
+    void ISyncCacheProvider<TCacheFormat>.Put(string key, TCacheFormat? value, Ttl ttl) =>
+        _wrappedCacheProvider.Put(key, value, ttl);
 }

--- a/src/Polly/Caching/GenericCacheProvider.cs
+++ b/src/Polly/Caching/GenericCacheProvider.cs
@@ -1,4 +1,5 @@
-﻿namespace Polly.Caching;
+﻿#nullable enable
+namespace Polly.Caching;
 
 /// <summary>
 /// Provides a strongly-typed wrapper over a non-generic CacheProvider.
@@ -11,12 +12,12 @@ internal class GenericCacheProvider<TCacheFormat> : ISyncCacheProvider<TCacheFor
     internal GenericCacheProvider(ISyncCacheProvider nonGenericCacheProvider)
         => _wrappedCacheProvider = nonGenericCacheProvider ?? throw new ArgumentNullException(nameof(nonGenericCacheProvider));
 
-    (bool, TCacheFormat) ISyncCacheProvider<TCacheFormat>.TryGet(string key)
+    (bool, TCacheFormat?) ISyncCacheProvider<TCacheFormat>.TryGet(string key)
     {
-        (bool cacheHit, object result) = _wrappedCacheProvider.TryGet(key);
-        return (cacheHit, (TCacheFormat) (result ?? default(TCacheFormat)));
+        (bool cacheHit, object? result) = _wrappedCacheProvider.TryGet(key);
+        return (cacheHit, (TCacheFormat?) (result ?? default(TCacheFormat)));
     }
 
-    void ISyncCacheProvider<TCacheFormat>.Put(string key, TCacheFormat value, Ttl ttl)
+    void ISyncCacheProvider<TCacheFormat>.Put(string key, TCacheFormat? value, Ttl ttl)
         => _wrappedCacheProvider.Put(key, value, ttl);
 }

--- a/src/Polly/Caching/IAsyncCacheProvider.cs
+++ b/src/Polly/Caching/IAsyncCacheProvider.cs
@@ -1,4 +1,5 @@
-﻿namespace Polly.Caching;
+﻿#nullable enable
+namespace Polly.Caching;
 
 /// <summary>
 /// Defines methods for classes providing asynchronous cache functionality for Polly <see cref="CachePolicy" />s.
@@ -44,7 +45,7 @@ public interface IAsyncCacheProvider<TResult>
     /// A <see cref="Task{TResult}" /> promising as Result a tuple whose first element is a value indicating whether
     /// the key was found in the cache, and whose second element is the value from the cache (default(TResult) if not found).
     /// </returns>
-    Task<(bool, TResult)> TryGetAsync(string key, CancellationToken cancellationToken, bool continueOnCapturedContext);
+    Task<(bool, TResult?)> TryGetAsync(string key, CancellationToken cancellationToken, bool continueOnCapturedContext);
 
     /// <summary>
     /// Puts the specified value in the cache asynchronously.

--- a/src/Polly/Caching/IAsyncCacheProvider.cs
+++ b/src/Polly/Caching/IAsyncCacheProvider.cs
@@ -16,7 +16,7 @@ public interface IAsyncCacheProvider
     /// A <see cref="Task{TResult}" /> promising as Result a tuple whose first element is a value indicating whether
     /// the key was found in the cache, and whose second element is the value from the cache (null if not found).
     /// </returns>
-    Task<(bool, object)> TryGetAsync(string key, CancellationToken cancellationToken, bool continueOnCapturedContext);
+    Task<(bool, object?)> TryGetAsync(string key, CancellationToken cancellationToken, bool continueOnCapturedContext);
 
     /// <summary>
     /// Puts the specified value in the cache asynchronously.
@@ -27,7 +27,7 @@ public interface IAsyncCacheProvider
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <param name="continueOnCapturedContext">Whether async calls should continue on a captured synchronization context.<para><remarks>Note: if the underlying cache's async API does not support controlling whether to continue on a captured context, async Policy executions with continueOnCapturedContext == true cannot be guaranteed to remain on the captured context.</remarks></para></param>
     /// <returns>A <see cref="Task" /> which completes when the value has been cached.</returns>
-    Task PutAsync(string key, object value, Ttl ttl, CancellationToken cancellationToken, bool continueOnCapturedContext);
+    Task PutAsync(string key, object? value, Ttl ttl, CancellationToken cancellationToken, bool continueOnCapturedContext);
 }
 
 /// <summary>
@@ -56,5 +56,5 @@ public interface IAsyncCacheProvider<TResult>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <param name="continueOnCapturedContext">Whether async calls should continue on a captured synchronization context.<para><remarks>Note: if the underlying cache's async API does not support controlling whether to continue on a captured context, async Policy executions with continueOnCapturedContext == true cannot be guaranteed to remain on the captured context.</remarks></para></param>
     /// <returns>A <see cref="Task" /> which completes when the value has been cached.</returns>
-    Task PutAsync(string key, TResult value, Ttl ttl, CancellationToken cancellationToken, bool continueOnCapturedContext);
+    Task PutAsync(string key, TResult? value, Ttl ttl, CancellationToken cancellationToken, bool continueOnCapturedContext);
 }

--- a/src/Polly/Caching/ICacheItemSerializer.cs
+++ b/src/Polly/Caching/ICacheItemSerializer.cs
@@ -1,4 +1,5 @@
-﻿namespace Polly.Caching;
+﻿#nullable enable
+namespace Polly.Caching;
 
 /// <summary>
 /// Defines operations for serializing and deserializing values being placed in caches by <see cref="CachePolicy" /> instances.
@@ -12,12 +13,12 @@ public interface ICacheItemSerializer<TResult, TSerialized>
     /// </summary>
     /// <param name="objectToSerialize">The object to serialize.</param>
     /// <returns>The serialized object</returns>
-    TSerialized Serialize(TResult objectToSerialize);
+    TSerialized? Serialize(TResult? objectToSerialize);
 
     /// <summary>
     /// Deserializes the specified object.
     /// </summary>
     /// <param name="objectToDeserialize">The object to deserialize.</param>
     /// <returns>The deserialized object</returns>
-    TResult Deserialize(TSerialized objectToDeserialize);
+    TResult? Deserialize(TSerialized? objectToDeserialize);
 }

--- a/src/Polly/Caching/ISyncCacheProvider.cs
+++ b/src/Polly/Caching/ISyncCacheProvider.cs
@@ -1,4 +1,5 @@
-﻿namespace Polly.Caching;
+﻿#nullable enable
+namespace Polly.Caching;
 
 /// <summary>
 /// Defines methods for classes providing synchronous cache functionality for Polly <see cref="CachePolicy"/>s.
@@ -13,7 +14,7 @@ public interface ISyncCacheProvider
     /// A tuple whose first element is a value indicating whether the key was found in the cache,
     /// and whose second element is the value from the cache (null if not found).
     /// </returns>
-    (bool, object) TryGet(string key);
+    (bool, object?) TryGet(string key);
 
     /// <summary>
     /// Puts the specified value in the cache.
@@ -21,7 +22,7 @@ public interface ISyncCacheProvider
     /// <param name="key">The cache key.</param>
     /// <param name="value">The value to put into the cache.</param>
     /// <param name="ttl">The time-to-live for the cache entry.</param>
-    void Put(string key, object value, Ttl ttl);
+    void Put(string key, object? value, Ttl ttl);
 }
 
 /// <summary>
@@ -37,7 +38,7 @@ public interface ISyncCacheProvider<TResult>
     /// A tuple whose first element is a value indicating whether the key was found in the cache,
     /// and whose second element is the value from the cache (default(TResult) if not found).
     /// </returns>
-    (bool, TResult) TryGet(string key);
+    (bool, TResult?) TryGet(string key);
 
     /// <summary>
     /// Puts the specified value in the cache.
@@ -45,5 +46,5 @@ public interface ISyncCacheProvider<TResult>
     /// <param name="key">The cache key.</param>
     /// <param name="value">The value to put into the cache.</param>
     /// <param name="ttl">The time-to-live for the cache entry.</param>
-    void Put(string key, TResult value, Ttl ttl);
+    void Put(string key, TResult? value, Ttl ttl);
 }

--- a/src/Polly/Caching/SerializingCacheProvider.cs
+++ b/src/Polly/Caching/SerializingCacheProvider.cs
@@ -43,10 +43,8 @@ public class SerializingCacheProvider<TSerialized> : ISyncCacheProvider
     /// <param name="key">The cache key.</param>
     /// <param name="value">The value to put into the cache.</param>
     /// <param name="ttl">The time-to-live for the cache entry.</param>
-    public void Put(string key, object? value, Ttl ttl)
-    {
+    public void Put(string key, object? value, Ttl ttl) =>
         _wrappedCacheProvider.Put(key, _serializer.Serialize(value), ttl);
-    }
 }
 
 /// <summary>
@@ -92,8 +90,6 @@ public class SerializingCacheProvider<TResult, TSerialized> : ISyncCacheProvider
     /// <param name="key">The cache key.</param>
     /// <param name="value">The value to put into the cache.</param>
     /// <param name="ttl">The time-to-live for the cache entry.</param>
-    public void Put(string key, TResult? value, Ttl ttl)
-    {
+    public void Put(string key, TResult? value, Ttl ttl) =>
         _wrappedCacheProvider.Put(key, _serializer.Serialize(value), ttl);
-    }
 }

--- a/src/Polly/Caching/SerializingCacheProvider.cs
+++ b/src/Polly/Caching/SerializingCacheProvider.cs
@@ -1,4 +1,5 @@
-﻿namespace Polly.Caching;
+﻿#nullable enable
+namespace Polly.Caching;
 
 /// <summary>
 /// Defines an <see cref="ISyncCacheProvider"/> which serializes objects of any type in and out of an underlying cache which caches as type <typeparamref name="TSerialized"/>.  For use with synchronous <see cref="CachePolicy" />.
@@ -30,9 +31,9 @@ public class SerializingCacheProvider<TSerialized> : ISyncCacheProvider
     /// A tuple whose first element is a value indicating whether the key was found in the cache,
     /// and whose second element is the value from the cache (null if not found).
     /// </returns>
-    public (bool, object) TryGet(string key)
+    public (bool, object?) TryGet(string key)
     {
-        (bool cacheHit, TSerialized objectToDeserialize) = _wrappedCacheProvider.TryGet(key);
+        (bool cacheHit, TSerialized? objectToDeserialize) = _wrappedCacheProvider.TryGet(key);
         return (cacheHit, cacheHit ? _serializer.Deserialize(objectToDeserialize) : null);
     }
 
@@ -42,7 +43,7 @@ public class SerializingCacheProvider<TSerialized> : ISyncCacheProvider
     /// <param name="key">The cache key.</param>
     /// <param name="value">The value to put into the cache.</param>
     /// <param name="ttl">The time-to-live for the cache entry.</param>
-    public void Put(string key, object value, Ttl ttl)
+    public void Put(string key, object? value, Ttl ttl)
     {
         _wrappedCacheProvider.Put(key, _serializer.Serialize(value), ttl);
     }
@@ -79,9 +80,9 @@ public class SerializingCacheProvider<TResult, TSerialized> : ISyncCacheProvider
     /// A tuple whose first element is a value indicating whether the key was found in the cache,
     /// and whose second element is the value from the cache (default(TResult) if not found).
     /// </returns>
-    public (bool, TResult) TryGet(string key)
+    public (bool, TResult?) TryGet(string key)
     {
-        (bool cacheHit, TSerialized objectToDeserialize) = _wrappedCacheProvider.TryGet(key);
+        (bool cacheHit, TSerialized? objectToDeserialize) = _wrappedCacheProvider.TryGet(key);
         return (cacheHit, cacheHit ? _serializer.Deserialize(objectToDeserialize) : default);
     }
 
@@ -91,7 +92,7 @@ public class SerializingCacheProvider<TResult, TSerialized> : ISyncCacheProvider
     /// <param name="key">The cache key.</param>
     /// <param name="value">The value to put into the cache.</param>
     /// <param name="ttl">The time-to-live for the cache entry.</param>
-    public void Put(string key, TResult value, Ttl ttl)
+    public void Put(string key, TResult? value, Ttl ttl)
     {
         _wrappedCacheProvider.Put(key, _serializer.Serialize(value), ttl);
     }

--- a/src/Polly/Fallback/AsyncFallbackPolicy.cs
+++ b/src/Polly/Fallback/AsyncFallbackPolicy.cs
@@ -23,7 +23,11 @@ public class AsyncFallbackPolicy : AsyncPolicy, IFallbackPolicy
         CancellationToken cancellationToken,
         bool continueOnCapturedContext) =>
         AsyncFallbackEngine.ImplementationAsync<EmptyStruct>(
-            async (ctx, ct) => { await action(ctx, ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
+            async (ctx, ct) =>
+            {
+                await action(ctx, ct).ConfigureAwait(continueOnCapturedContext);
+                return EmptyStruct.Instance;
+            },
             context,
             cancellationToken,
             ExceptionPredicates,

--- a/src/Polly/Retry/AsyncRetryPolicy.cs
+++ b/src/Polly/Retry/AsyncRetryPolicy.cs
@@ -39,8 +39,8 @@ public class AsyncRetryPolicy : AsyncPolicy, IRetryPolicy
             _permittedRetryCount,
             _sleepDurationsEnumerable,
             _sleepDurationProvider != null
-                ? (retryCount, outcome, ctx) =>  _sleepDurationProvider(retryCount, outcome.Exception, ctx)
-                : (Func<int, DelegateResult<TResult>, Context, TimeSpan>)null,
+                ? (retryCount, outcome, ctx) => _sleepDurationProvider(retryCount, outcome.Exception, ctx)
+                : (Func<int, DelegateResult<TResult>, Context, TimeSpan>) null,
             continueOnCapturedContext
         );
 }


### PR DESCRIPTION
@martincostello 

i put together a minimal example to show how i came to use the NotNull for `TResult` in  `IAsyncCacheProvider<TResult>`

this PR enables nullable for `AsyncGenericCacheProvider.cs` and `IAsyncCacheProvider`

you will notice we get the warning

```
  AsyncGenericCacheProvider.cs(22, 48): [CS8604] Possible null reference argument for parameter 'value' in 'Task IAsyncCacheProvider.PutAsync(string key, object value, Ttl ttl, CancellationToken cancellationToken, bool continueOnCapturedContext)'.
```

so in 
```
internal class AsyncGenericCacheProvider<TCacheFormat> : IAsyncCacheProvider<TCacheFormat>
{
    private readonly IAsyncCacheProvider _wrappedCacheProvider;

    internal AsyncGenericCacheProvider(IAsyncCacheProvider nonGenericCacheProvider)
        => _wrappedCacheProvider = nonGenericCacheProvider ?? throw new ArgumentNullException(nameof(nonGenericCacheProvider));

    async Task<(bool, TCacheFormat?)> IAsyncCacheProvider<TCacheFormat>.TryGetAsync(string key, CancellationToken cancellationToken, bool continueOnCapturedContext)
    {
        (bool cacheHit, object? result) = await _wrappedCacheProvider.TryGetAsync(key, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
        return (cacheHit, (TCacheFormat?)(result ?? default(TCacheFormat)));
    }

    Task IAsyncCacheProvider<TCacheFormat>.PutAsync(string key, TCacheFormat value, Ttl ttl, CancellationToken cancellationToken, bool continueOnCapturedContext)
        => _wrappedCacheProvider.PutAsync(key, value, ttl, cancellationToken, continueOnCapturedContext);
}
```

since someone could define `AsyncGenericCacheProvider<MyType?>` it means `value` could be null in 

```
_wrappedCacheProvider.PutAsync(key, value, ttl, cancellationToken, continueOnCapturedContext);
```

so we could allow null for value through the stack. so `IAsyncCacheProvider` would need to accept null for `PutAsync`. Do we want that?

if we `notnull` on `TCacheFormat` it means people cant pass a null `value` to `PutAsync`.

TBH i think the fix here is to add a `Clear` method that takes a key??

thoughts?