### PR TITLE
Use dotnet add instead of Install-Package

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ We are a member of the [.NET Foundation](https://www.dotnetfoundation.org/about)
 
 ![Polly logo](https://raw.github.com/App-vNext/Polly/main/Polly-Logo.png)
 
-## Installing via NuGet
+## Installing via the .NET SDK
 
-```text
-Install-Package Polly
+```sh
+dotnet add package Polly
 ```
 
 ## Resilience policies


### PR DESCRIPTION
Use `dotet add package` for the example for installing Polly as it's more modern and cross-platform than the VS-specific `Install-Package`.
