### PR TITLE
remove Serializable

### DIFF
--- a/src/Polly/Bulkhead/BulkheadRejectedException.cs
+++ b/src/Polly/Bulkhead/BulkheadRejectedException.cs
@@ -1,16 +1,10 @@
 ﻿#nullable enable
-#if NETSTANDARD2_0
-using System.Runtime.Serialization;
-#endif
 
 namespace Polly.Bulkhead;
 
 /// <summary>
 /// Exception thrown when a bulkhead's semaphore and queue are full.
 /// </summary>
-#if NETSTANDARD2_0
-[Serializable]
-#endif
 public class BulkheadRejectedException : ExecutionRejectedException
 {
     /// <summary>
@@ -36,15 +30,4 @@ public class BulkheadRejectedException : ExecutionRejectedException
     public BulkheadRejectedException(string message, Exception innerException) : base(message, innerException)
     {
     }
-
-#if NETSTANDARD2_0
-    /// <summary>
-    /// Initializes a new instance of the <see cref="BulkheadRejectedException"/> class.
-    /// </summary>
-    /// <param name="info">The information.</param>
-    /// <param name="context">The context.</param>
-    protected BulkheadRejectedException(SerializationInfo info, StreamingContext context) : base(info, context)
-    {
-    }
-#endif
 }

--- a/src/Polly/CircuitBreaker/BrokenCircuitException.cs
+++ b/src/Polly/CircuitBreaker/BrokenCircuitException.cs
@@ -1,15 +1,8 @@
-﻿#if NETSTANDARD2_0
-using System.Runtime.Serialization;
-#endif
-
-namespace Polly.CircuitBreaker;
+﻿namespace Polly.CircuitBreaker;
 
 /// <summary>
 /// Exception thrown when a circuit is broken.
 /// </summary>
-#if NETSTANDARD2_0
-[Serializable]
-#endif
 public class BrokenCircuitException : ExecutionRejectedException
 {
     /// <summary>
@@ -35,28 +28,12 @@ public class BrokenCircuitException : ExecutionRejectedException
     public BrokenCircuitException(string message, Exception inner) : base(message, inner)
     {
     }
-
-#if NETSTANDARD2_0
-    /// <summary>
-    /// Initializes a new instance of the <see cref="BrokenCircuitException"/> class.
-    /// </summary>
-    /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
-    /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual information about the source or destination.</param>
-    protected BrokenCircuitException(
-        SerializationInfo info,
-        StreamingContext context) : base(info, context)
-    {
-    }
-#endif
 }
 
 /// <summary>
 /// Exception thrown when a circuit is broken.
 /// </summary>
 /// <typeparam name="TResult">The type of returned results being handled by the policy.</typeparam>
-#if NETSTANDARD2_0
-[Serializable]
-#endif
 public class BrokenCircuitException<TResult> : BrokenCircuitException
 {
     private readonly TResult result;
@@ -80,17 +57,4 @@ public class BrokenCircuitException<TResult> : BrokenCircuitException
     /// The result value which was considered a handled fault, by the policy.
     /// </summary>
     public TResult Result => result;
-
-#if NETSTANDARD2_0
-    /// <summary>
-    /// Initializes a new instance of the <see cref="BrokenCircuitException"/> class.
-    /// </summary>
-    /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
-    /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual information about the source or destination.</param>
-    protected BrokenCircuitException(
-        SerializationInfo info,
-        StreamingContext context) : base(info, context)
-    {
-    }
-#endif
 }

--- a/src/Polly/CircuitBreaker/IsolatedCircuitException.cs
+++ b/src/Polly/CircuitBreaker/IsolatedCircuitException.cs
@@ -1,15 +1,8 @@
-﻿#if NETSTANDARD2_0
-using System.Runtime.Serialization;
-#endif
-
-namespace Polly.CircuitBreaker;
+﻿namespace Polly.CircuitBreaker;
 
 /// <summary>
 /// Exception thrown when a circuit is isolated (held open) by manual override.
 /// </summary>
-#if NETSTANDARD2_0
-[Serializable]
-#endif
 public class IsolatedCircuitException : BrokenCircuitException
 {
     /// <summary>
@@ -17,17 +10,4 @@ public class IsolatedCircuitException : BrokenCircuitException
     /// </summary>
     /// <param name="message">The message that describes the error.</param>
     public IsolatedCircuitException(string message) : base(message) { }
-
-#if NETSTANDARD2_0
-    /// <summary>
-    /// Initializes a new instance of the <see cref="IsolatedCircuitException"/> class.
-    /// </summary>
-    /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
-    /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual information about the source or destination.</param>
-    protected IsolatedCircuitException(
-        SerializationInfo info,
-        StreamingContext context) : base(info, context)
-    {
-    }
-#endif
 }

--- a/src/Polly/ExecutionRejectedException.cs
+++ b/src/Polly/ExecutionRejectedException.cs
@@ -1,8 +1,4 @@
-﻿#if NETSTANDARD2_0
-using System.Runtime.Serialization;
-#endif
-
-namespace Polly;
+﻿namespace Polly;
 
 /// <summary>
 /// Exception thrown when a policy rejects execution of a delegate.
@@ -33,17 +29,4 @@ public abstract class ExecutionRejectedException : Exception
     protected ExecutionRejectedException(string message, Exception inner) : base(message, inner)
     {
     }
-
-#if NETSTANDARD2_0
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ExecutionRejectedException"/> class.
-    /// </summary>
-    /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
-    /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual information about the source or destination.</param>
-    protected ExecutionRejectedException(
-        SerializationInfo info,
-        StreamingContext context) : base(info, context)
-    {
-    }
-#endif
 }

--- a/src/Polly/RateLimit/RateLimitRejectedException.cs
+++ b/src/Polly/RateLimit/RateLimitRejectedException.cs
@@ -1,17 +1,10 @@
 ﻿#nullable enable
 
-#if NETSTANDARD2_0
-using System.Runtime.Serialization;
-#endif
-
 namespace Polly.RateLimit;
 
 /// <summary>
 /// Exception thrown when a delegate executed through a <see cref="IRateLimitPolicy"/> is rate-limited.
 /// </summary>
-#if NETSTANDARD2_0
-[Serializable]
-#endif
 public class RateLimitRejectedException : ExecutionRejectedException
 {
     /// <summary>
@@ -60,15 +53,4 @@ public class RateLimitRejectedException : ExecutionRejectedException
 
     private static string DefaultMessage(TimeSpan retryAfter) =>
         $"The operation has been rate-limited and should be retried after {retryAfter}";
-
-#if NETSTANDARD2_0
-    /// <summary>
-    /// Initializes a new instance of the <see cref="RateLimitRejectedException"/> class.
-    /// </summary>
-    /// <param name="info">The information.</param>
-    /// <param name="context">The context.</param>
-    protected RateLimitRejectedException(SerializationInfo info, StreamingContext context) : base(info, context)
-    {
-    }
-#endif
 }

--- a/src/Polly/Timeout/TimeoutRejectedException.cs
+++ b/src/Polly/Timeout/TimeoutRejectedException.cs
@@ -1,15 +1,8 @@
-﻿#if NETSTANDARD2_0
-using System.Runtime.Serialization;
-#endif
-
-namespace Polly.Timeout;
+﻿namespace Polly.Timeout;
 
 /// <summary>
 /// Exception thrown when a delegate executed through a <see cref="TimeoutPolicy"/> does not complete, before the configured timeout.
 /// </summary>
-#if NETSTANDARD2_0
-[Serializable]
-#endif
 public class TimeoutRejectedException : ExecutionRejectedException
 {
     /// <summary>
@@ -35,15 +28,4 @@ public class TimeoutRejectedException : ExecutionRejectedException
     public TimeoutRejectedException(string message, Exception innerException) : base(message, innerException)
     {
     }
-
-#if NETSTANDARD2_0
-    /// <summary>
-    /// Initializes a new instance of the <see cref="TimeoutRejectedException"/> class.
-    /// </summary>
-    /// <param name="info">The information.</param>
-    /// <param name="context">The context.</param>
-    protected TimeoutRejectedException(SerializationInfo info, StreamingContext context) : base(info, context)
-    {
-    }
-#endif
 }


### PR DESCRIPTION
given binary serializer is no longer supported.

and it was never implementd properly in Polly. take `RateLimitRejectedException` for example. the `RetryAfter` property is not added in GetObjectData and not read back in the deserialize constructor

