### PR TITLE
Introduce ResilienceTelemetryFactory

### DIFF
--- a/src/Polly.Core.Tests/Builder/ResilienceStrategyBuilderContextTests.cs
+++ b/src/Polly.Core.Tests/Builder/ResilienceStrategyBuilderContextTests.cs
@@ -1,0 +1,21 @@
+using FluentAssertions;
+using Polly.Builder;
+using Polly.Telemetry;
+using Xunit;
+
+namespace Polly.Core.Tests.Builder;
+
+public class ResilienceStrategyBuilderContextTests
+{
+    [Fact]
+    public void Ctor_EnsureDefaults()
+    {
+        var context = new ResilienceStrategyBuilderContext();
+
+        context.BuilderName.Should().Be("");
+        context.BuilderProperties.Should().NotBeNull();
+        context.StrategyName.Should().Be("");
+        context.StrategyType.Should().Be("");
+        context.Telemetry.Should().Be(NullResilienceTelemetry.Instance);
+    }
+}

--- a/src/Polly.Core.Tests/Telemetry/NullResilienceTelemetryFactoryTests.cs
+++ b/src/Polly.Core.Tests/Telemetry/NullResilienceTelemetryFactoryTests.cs
@@ -1,0 +1,25 @@
+using FluentAssertions;
+using Polly.Telemetry;
+using Xunit;
+
+namespace Polly.Core.Tests.Telemetry;
+
+public class NullResilienceTelemetryFactoryTests
+{
+    [Fact]
+    public void Instance_NotNull()
+    {
+        NullResilienceTelemetry.Instance.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Default_Ok()
+    {
+        var context = new ResilienceTelemetryFactoryContext();
+
+        context.BuilderName.Should().BeEmpty();
+        context.StrategyType.Should().BeEmpty();
+        context.StrategyName.Should().BeEmpty();
+        context.BuilderProperties.Should().NotBeNull();
+    }
+}

--- a/src/Polly.Core.Tests/Telemetry/NullResilienceTelemetryTests.cs
+++ b/src/Polly.Core.Tests/Telemetry/NullResilienceTelemetryTests.cs
@@ -1,0 +1,29 @@
+using System;
+using FluentAssertions;
+using Polly.Telemetry;
+using Xunit;
+
+namespace Polly.Core.Tests.Telemetry;
+
+public class NullResilienceTelemetryTests
+{
+    [Fact]
+    public void Instance_NotNull()
+    {
+        NullResilienceTelemetry.Instance.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Report_ShouldNotThrow()
+    {
+        NullResilienceTelemetry.Instance
+            .Invoking(v =>
+            {
+                NullResilienceTelemetry.Instance.Report("dummy", ResilienceContext.Get());
+                NullResilienceTelemetry.Instance.Report("dummy", 10, ResilienceContext.Get());
+                NullResilienceTelemetry.Instance.ReportException("dummy", new InvalidOperationException(), ResilienceContext.Get());
+            })
+            .Should()
+            .NotThrow();
+    }
+}

--- a/src/Polly.Core/Builder/ResilienceStrategyBuilder.cs
+++ b/src/Polly.Core/Builder/ResilienceStrategyBuilder.cs
@@ -1,3 +1,5 @@
+using Polly.Telemetry;
+
 namespace Polly.Builder;
 
 /// <summary>
@@ -88,11 +90,22 @@ public class ResilienceStrategyBuilder
 
     private ResilienceStrategy CreateResilienceStrategy(Entry entry)
     {
-        var context = new ResilienceStrategyBuilderContext(
-            builderName: Options.BuilderName,
-            builderProperties: Options.Properties,
-            strategyName: entry.Properties.StrategyName,
-            strategyType: entry.Properties.StrategyType);
+        var telemetryContext = new ResilienceTelemetryFactoryContext
+        {
+            BuilderName = Options.BuilderName,
+            BuilderProperties = Options.Properties,
+            StrategyName = entry.Properties.StrategyName,
+            StrategyType = entry.Properties.StrategyType
+        };
+
+        var context = new ResilienceStrategyBuilderContext
+        {
+            BuilderName = Options.BuilderName,
+            BuilderProperties = Options.Properties,
+            StrategyName = entry.Properties.StrategyName,
+            StrategyType = entry.Properties.StrategyType,
+            Telemetry = Options.TelemetryFactory.Create(telemetryContext)
+        };
 
         return entry.Factory(context);
     }

--- a/src/Polly.Core/Builder/ResilienceStrategyBuilderContext.cs
+++ b/src/Polly.Core/Builder/ResilienceStrategyBuilderContext.cs
@@ -1,3 +1,5 @@
+using Polly.Telemetry;
+
 namespace Polly.Builder;
 
 /// <summary>
@@ -5,35 +7,28 @@ namespace Polly.Builder;
 /// </summary>
 public class ResilienceStrategyBuilderContext
 {
-    internal ResilienceStrategyBuilderContext(
-        string builderName,
-        ResilienceProperties builderProperties,
-        string strategyName,
-        string strategyType)
-    {
-        BuilderName = Guard.NotNull(builderName);
-        BuilderProperties = Guard.NotNull(builderProperties);
-        StrategyName = Guard.NotNull(strategyName);
-        StrategyType = Guard.NotNull(strategyType);
-    }
-
     /// <summary>
     /// Gets the name of the builder.
     /// </summary>
-    public string BuilderName { get; }
+    public string BuilderName { get; internal set; } = string.Empty;
 
     /// <summary>
     /// Gets the custom properties attached to the builder.
     /// </summary>
-    public ResilienceProperties BuilderProperties { get; }
+    public ResilienceProperties BuilderProperties { get; internal set; } = new();
 
     /// <summary>
     /// Gets the name of the strategy.
     /// </summary>
-    public string StrategyName { get; }
+    public string StrategyName { get; internal set; } = string.Empty;
 
     /// <summary>
     /// Gets the type of the strategy.
     /// </summary>
-    public string StrategyType { get; }
+    public string StrategyType { get; internal set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the resilience telemetry used to report important events.
+    /// </summary>
+    public ResilienceTelemetry Telemetry { get; internal set; } = NullResilienceTelemetry.Instance;
 }

--- a/src/Polly.Core/Builder/ResilienceStrategyBuilderOptions.cs
+++ b/src/Polly.Core/Builder/ResilienceStrategyBuilderOptions.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Polly.Telemetry;
 
 namespace Polly.Builder;
 
@@ -18,4 +19,10 @@ public class ResilienceStrategyBuilderOptions
     /// Gets the custom properties attached to builder options.
     /// </summary>
     public ResilienceProperties Properties { get; } = new();
+
+    /// <summary>
+    /// Gets or sets an instance of <see cref="TelemetryFactory"/>.
+    /// </summary>
+    [Required]
+    public ResilienceTelemetryFactory TelemetryFactory { get; set; } = NullResilienceTelemetryFactory.Instance;
 }

--- a/src/Polly.Core/Telemetry/NullResilienceTelemetry.cs
+++ b/src/Polly.Core/Telemetry/NullResilienceTelemetry.cs
@@ -20,7 +20,7 @@ public sealed class NullResilienceTelemetry : ResilienceTelemetry
     }
 
     /// <inheritdoc/>
-    public override void Report<T>(string eventName, T result, ResilienceContext context)
+    public override void Report<TResult>(string eventName, TResult result, ResilienceContext context)
     {
     }
 

--- a/src/Polly.Core/Telemetry/NullResilienceTelemetry.cs
+++ b/src/Polly.Core/Telemetry/NullResilienceTelemetry.cs
@@ -1,0 +1,31 @@
+namespace Polly.Telemetry;
+
+/// <summary>
+/// A implementation of <see cref="ResilienceTelemetryFactory"/> that does nothing.
+/// </summary>
+public sealed class NullResilienceTelemetry : ResilienceTelemetry
+{
+    private NullResilienceTelemetry()
+    {
+    }
+
+    /// <summary>
+    /// Gets an instance of <see cref="NullResilienceTelemetry"/>.
+    /// </summary>
+    public static readonly NullResilienceTelemetry Instance = new();
+
+    /// <inheritdoc/>
+    public override void Report(string eventName, ResilienceContext context)
+    {
+    }
+
+    /// <inheritdoc/>
+    public override void Report<T>(string eventName, T result, ResilienceContext context)
+    {
+    }
+
+    /// <inheritdoc/>
+    public override void ReportException(string eventName, Exception exception, ResilienceContext context)
+    {
+    }
+}

--- a/src/Polly.Core/Telemetry/NullResilienceTelemetryFactory.cs
+++ b/src/Polly.Core/Telemetry/NullResilienceTelemetryFactory.cs
@@ -1,0 +1,19 @@
+namespace Polly.Telemetry;
+
+/// <summary>
+/// Factory that returns <see cref="NullResilienceTelemetry"/> instances.
+/// </summary>
+public sealed class NullResilienceTelemetryFactory : ResilienceTelemetryFactory
+{
+    /// <summary>
+    /// Gets the singleton instance of the factory.
+    /// </summary>
+    public static readonly NullResilienceTelemetryFactory Instance = new();
+
+    private NullResilienceTelemetryFactory()
+    {
+    }
+
+    /// <inheritdoc/>
+    public override ResilienceTelemetry Create(ResilienceTelemetryFactoryContext context) => NullResilienceTelemetry.Instance;
+}

--- a/src/Polly.Core/Telemetry/ResilienceTelemetry.cs
+++ b/src/Polly.Core/Telemetry/ResilienceTelemetry.cs
@@ -1,0 +1,36 @@
+namespace Polly.Telemetry;
+
+#pragma warning disable S1694 // An abstract class should have both abstract and concrete methods
+
+/// <summary>
+/// Resilience telemetry is used by individual resilience strategies to report some important events.
+/// </summary>
+/// <remarks>
+/// For example, the timeout strategy reports "OnTimeout" event when the timeout is reached or "OnRetry" for retry strategy.
+/// </remarks>
+public abstract class ResilienceTelemetry
+{
+    /// <summary>
+    /// Reports an event that occurred in the resilience strategy.
+    /// </summary>
+    /// <param name="eventName">The event name.</param>
+    /// <param name="context">The context associated with the event.</param>
+    public abstract void Report(string eventName, ResilienceContext context);
+
+    /// <summary>
+    /// Reports an event that occurred in the resilience strategy.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
+    /// <param name="eventName">The event name.</param>
+    /// <param name="result">The result associated with the event.</param>
+    /// <param name="context">The context associated with the event.</param>
+    public abstract void Report<TResult>(string eventName, TResult result, ResilienceContext context);
+
+    /// <summary>
+    /// Reports an event that occurred in the resilience strategy.
+    /// </summary>
+    /// <param name="eventName">The event name.</param>
+    /// <param name="exception">The exception associated with the event.</param>
+    /// <param name="context">The context associated with the event.</param>
+    public abstract void ReportException(string eventName, Exception exception, ResilienceContext context);
+}

--- a/src/Polly.Core/Telemetry/ResilienceTelemetryFactory.cs
+++ b/src/Polly.Core/Telemetry/ResilienceTelemetryFactory.cs
@@ -1,0 +1,16 @@
+namespace Polly.Telemetry;
+
+#pragma warning disable S1694 // An abstract class should have both abstract and concrete methods
+
+/// <summary>
+/// Factory used to created instances of <see cref="ResilienceTelemetry"/>.
+/// </summary>
+public abstract class ResilienceTelemetryFactory
+{
+    /// <summary>
+    /// Creates a new instance of <see cref="ResilienceTelemetry"/>.
+    /// </summary>
+    /// <param name="context">The context associated with the creation of <see cref="ResilienceTelemetry"/>.</param>
+    /// <returns>An instance of <see cref="ResilienceTelemetry"/>.</returns>
+    public abstract ResilienceTelemetry Create(ResilienceTelemetryFactoryContext context);
+}

--- a/src/Polly.Core/Telemetry/ResilienceTelemetryFactoryContext.cs
+++ b/src/Polly.Core/Telemetry/ResilienceTelemetryFactoryContext.cs
@@ -1,0 +1,27 @@
+namespace Polly.Telemetry;
+
+/// <summary>
+/// The context used for building an instance of <see cref="ResilienceTelemetry"/>.
+/// </summary>
+public class ResilienceTelemetryFactoryContext
+{
+    /// <summary>
+    /// Gets the name of the builder.
+    /// </summary>
+    public string BuilderName { get; internal set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the name of the strategy.
+    /// </summary>
+    public string StrategyName { get; internal set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the type of the strategy.
+    /// </summary>
+    public string StrategyType { get; internal set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the custom properties attached to the builder.
+    /// </summary>
+    public ResilienceProperties BuilderProperties { get; internal set; } = new();
+}


### PR DESCRIPTION
### The issue or feature being addressed

#1066 

### Details on the issue fix or feature implementation

This API exposes simple `ResilienceTelemetry` API that the `ResilienceStrategy` authors can use to report important events in a unified way. For example:

``` csharp
ResilienceTelemetry telemetry = ...;

telemetry.Report("OnTimeout", resilienceContext);
 
telemetry.Report("OnRetry", failedResult, resilienceContext);
 
telemetry.ReportException("OnRetry", failedException, resilienceContext);
```

The consumers of `ResilienceStrategy` can provide their own implementation of `ResilienceTelemetryFactory` to provide additional telemetry with each event (extracted from `ResilienceContext` or from reported result or exception).

By default, we use `NullResilienceTelemetryFactory` that does nothing. At later stages we might consider introducing `Polly.Telemetry` package that implements `ResilienceTelemetryFactory` and does logging using `ILoggerFactory` and metering with the new `Meter` API.

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
