### PR TITLE
Adopt Central Package Management

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,3 @@
-# Remove the line below if you want to inherit .editorconfig settings from higher directories
 root = true
 
 [*]

--- a/eng/Analyzers.targets
+++ b/eng/Analyzers.targets
@@ -1,11 +1,8 @@
 <Project>
   <ItemGroup Label="Analyzers" Condition="$(UseDefaultAnalyzers) == 'true'">
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1" PrivateAssets="All" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.51.0.59060" PrivateAssets="All" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" PrivateAssets="All" />
+    <PackageReference Include="SonarAnalyzer.CSharp" PrivateAssets="All" />
+    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
     <AdditionalFiles Include="$(MsBuildThisFileDirectory)analyzers\Stylecop.json" Visible="false" />
     <EditorConfigFiles Include="$(MsBuildThisFileDirectory)analyzers\Stylecop.globalconfig" />
     <EditorConfigFiles Include="$(MsBuildThisFileDirectory)analyzers\$(ProjectType).globalconfig" />

--- a/eng/Benchmark.targets
+++ b/eng/Benchmark.targets
@@ -1,9 +1,9 @@
 <Project>
 
   <Import Project="..\Version.props" />
-   
+
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.3" />
-  </ItemGroup> 
+    <PackageReference Include="BenchmarkDotNet" />
+  </ItemGroup>
 
 </Project>

--- a/eng/Library.targets
+++ b/eng/Library.targets
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="SourceLink">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
 
   <PropertyGroup Label="SharedNuspecProperties">

--- a/eng/Test.targets
+++ b/eng/Test.targets
@@ -6,14 +6,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.2.0" PrivateAssets="all" />
-    <PackageReference Include="FluentAssertions" Version="6.10.0" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="ReportGenerator" Version="5.1.19" PrivateAssets="all" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="all" />
+    <PackageReference Include="coverlet.msbuild" PrivateAssets="all" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="ReportGenerator" PrivateAssets="all" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
   </ItemGroup>
 
   <PropertyGroup Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) != '.NETFramework'">

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,16 +1,9 @@
-root = true
-# EditorConfig: http://EditorConfig.org
-
-# top-most EditorConfig file
-
 [*]
 indent_style = space
-
 
 [*.cs]
 indent_size = 4
 charset = utf-8
-
 
 # Microsoft .NET properties
 csharp_preferred_modifier_order = public, private, protected, internal, new, static, abstract, virtual, sealed, readonly, override, extern, unsafe, volatile, async:suggestion

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,4 +1,9 @@
 <Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
   <ItemGroup>
     <Using Include="System.Collections" />
     <Using Include="System.Collections.Concurrent" />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,5 +1,4 @@
 <Project>
   <Import Project="$(MsBuildThisFileDirectory)../eng/Common.targets" />
   <Import Project="$(MsBuildThisFileDirectory)../eng/$(ProjectType).targets" Condition="$(ProjectType) != ''" />
-
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,0 +1,21 @@
+<Project>
+  <ItemGroup>
+    <PackageVersion Include="coverlet.msbuild" Version="3.2.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.13.5" />
+    <PackageVersion Include="FluentAssertions" Version="6.10.0" />
+    <PackageVersion Include="GitHubActionsTestLogger" Version="2.0.1" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <PackageVersion Include="Moq" Version="4.18.4" />
+    <PackageVersion Include="ReportGenerator" Version="5.1.19" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="8.51.0.59060" />
+    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.435" />
+    <PackageVersion Include="System.ComponentModel.Annotations" Version="4.5.0" />
+    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
+    <PackageVersion Include="xunit" Version="2.4.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
+  </ItemGroup>
+</Project>

--- a/src/Polly.Benchmarks/Polly.Benchmarks.csproj
+++ b/src/Polly.Benchmarks/Polly.Benchmarks.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
+    <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
   </ItemGroup>
   <ItemGroup Condition=" '$(BenchmarkFromNuGet)' != 'True' ">
     <ProjectReference Include="..\Polly\Polly.csproj" />

--- a/src/Polly.Core/LegacySupport/CallerArgumentExpressionAttribute.cs
+++ b/src/Polly.Core/LegacySupport/CallerArgumentExpressionAttribute.cs
@@ -9,4 +9,5 @@ internal sealed class CallerArgumentExpressionAttribute : Attribute
 
     public string ParameterName { get; }
 }
+
 #endif

--- a/src/Polly.Core/LegacySupport/MaybeNullWhenAttribute.cs
+++ b/src/Polly.Core/LegacySupport/MaybeNullWhenAttribute.cs
@@ -9,4 +9,5 @@ internal sealed class MaybeNullWhenAttribute : Attribute
 
     public bool ReturnValue { get; }
 }
+
 #endif

--- a/src/Polly.Core/Polly.Core.csproj
+++ b/src/Polly.Core/Polly.Core.csproj
@@ -19,9 +19,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" Condition="!$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'netcoreapp3.1'))" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" Condition="!$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'netcoreapp3.1'))" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Condition="!$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'netcoreapp3.1'))" />
+    <PackageReference Include="System.ValueTuple" Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'" />
+    <PackageReference Include="System.ComponentModel.Annotations" Condition="!$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'netcoreapp3.1'))" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -10,11 +10,11 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
     <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
   </PropertyGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework)'=='net461' or '$(TargetFramework)' == 'netstandard1.1'">
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="System.ValueTuple" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Using Remove="System.Net.Http" />
     <InternalsVisibleToTest Include="Polly.Specs"/>


### PR DESCRIPTION
### The issue or feature being addressed

#1064

### Details on the issue fix or feature implementation

- Adopt Adopt Central Package Management for NuGet packages.
- Fix the child EditorConfig file being marked as the root when it isn't.
- Fix IDE0055 formatting warnings.
