### PR TITLE
Polly now references Polly.Core

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -10,7 +10,7 @@ var configuration = Argument<string>("configuration", "Release");
 //////////////////////////////////////////////////////////////////////
 
 #Tool "xunit.runner.console&version=2.4.2"
-#Tool "dotnet-stryker&version=3.6.1"
+#Tool "dotnet-stryker&version=3.7.0"
 
 //////////////////////////////////////////////////////////////////////
 // EXTERNAL NUGET LIBRARIES
@@ -215,11 +215,20 @@ Task("__RunTests")
 Task("__RunMutationTests")
     .Does(() =>
 {
-    TestProject(File("./src/Polly/Polly.csproj"), File("./src/Polly.Specs/Polly.Specs.csproj"), "Polly");
-    TestProject(File("./src/Polly.Core/Polly.Core.csproj"), File("./src/Polly.Core.Tests/Polly.Core.Tests.csproj"), "Polly.Core");
+    TestProject(File("./src/Polly/Polly.csproj"), File("./src/Polly.Specs/Polly.Specs.csproj"), "Polly.csproj");
+    TestProject(File("./src/Polly.Core/Polly.Core.csproj"), File("./src/Polly.Core.Tests/Polly.Core.Tests.csproj"), "Polly.Core.csproj");
 
     void TestProject(FilePath proj, FilePath testProj, string project)
     {
+        var dotNetBuildSettings = new DotNetBuildSettings
+        {
+            Configuration = "Debug",
+            Verbosity = DotNetVerbosity.Minimal,
+            NoRestore = true
+        };
+
+        DotNetBuild(proj.ToString(), dotNetBuildSettings);
+
         var strykerPath = Context.Tools.Resolve("Stryker.CLI.dll");
         var mutationScore = XmlPeek(proj, "/Project/PropertyGroup/MutationScore/text()", new XmlPeekSettings { SuppressWarning = true });
         var score = int.Parse(mutationScore);

--- a/eng/Test.targets
+++ b/eng/Test.targets
@@ -19,7 +19,6 @@
   <PropertyGroup Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) != '.NETFramework'">
     <CollectCoverage>true</CollectCoverage>
     <CoverletOutputFormat>cobertura</CoverletOutputFormat>
-    <Exclude>[xunit.*]*</Exclude>
     <ExcludeByAttribute>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
   </PropertyGroup>
 

--- a/src/Polly.Core.Tests/Polly.Core.Tests.csproj
+++ b/src/Polly.Core.Tests/Polly.Core.Tests.csproj
@@ -8,6 +8,7 @@
     <SkipPollyUsings>true</SkipPollyUsings>
     <Threshold>100</Threshold>
     <NoWarn>$(NoWarn);SA1600</NoWarn>
+    <Include>[Polly.Core]*</Include>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Polly.Core/Polly.Core.csproj
+++ b/src/Polly.Core/Polly.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netstandard2.0;net472;net461</TargetFrameworks>
     <AssemblyTitle>Polly.Core</AssemblyTitle>
     <RootNamespace>Polly</RootNamespace>
     <Nullable>enable</Nullable>

--- a/src/Polly.Specs/Polly.Specs.csproj
+++ b/src/Polly.Specs/Polly.Specs.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <ProjectType>Test</ProjectType>
     <Threshold>75,60,70</Threshold>
+    <Exclude>[Polly.Core]*</Exclude>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Polly.Specs/Polly.Specs.csproj
+++ b/src/Polly.Specs/Polly.Specs.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <ProjectType>Test</ProjectType>
     <Threshold>75,60,70</Threshold>
-    <Exclude>[Polly.Core]*</Exclude>
+    <Include>[Polly]*</Include>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461;</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;net461;</TargetFrameworks>
     <AssemblyTitle>Polly</AssemblyTitle>
     <ProjectType>Library</ProjectType>
     <MutationScore>70</MutationScore>

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -1,22 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;netstandard2.0;net461;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;</TargetFrameworks>
     <AssemblyTitle>Polly</AssemblyTitle>
     <ProjectType>Library</ProjectType>
     <MutationScore>70</MutationScore>
   </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
-    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
-  </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'=='net461' or '$(TargetFramework)' == 'netstandard1.1'">
-    <PackageReference Include="System.ValueTuple" />
+  
+  <ItemGroup>
+    <Using Remove="System.Net.Http" />
+    <InternalsVisibleToTest Include="Polly.Specs" />
   </ItemGroup>
 
   <ItemGroup>
-    <Using Remove="System.Net.Http" />
-    <InternalsVisibleToTest Include="Polly.Specs"/>
+    <ProjectReference Include="..\Polly.Core\Polly.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Polly/Properties/AssemblyInfo.cs
+++ b/src/Polly/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+using Polly;
+
+// [assembly: TypeForwardedTo(typeof(ExecutionRejectedException))]

--- a/src/Polly/Utilities/TaskHelper.cs
+++ b/src/Polly/Utilities/TaskHelper.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 namespace Polly.Utilities;
 
 /// <summary>
@@ -9,11 +9,5 @@ public static class TaskHelper
     /// <summary>
     /// Defines a completed Task for use as a completed, empty asynchronous delegate.
     /// </summary>
-    public static Task EmptyTask =
-#if NETSTANDARD1_1
-        Task.FromResult(true)
-#else
-        Task.CompletedTask
-#endif
-        ;
+    public static Task EmptyTask = Task.CompletedTask;
 }


### PR DESCRIPTION
### The issue or feature being addressed

We will be moving some types `from Polly` to `Polly.Core` so Polly needs reference the core project. As a part of this we are also dropping support for legacy `netstandard1.1` target.

### Details on the issue fix or feature implementation

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
