### PR TITLE
Fix coverage upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
     - uses: codecov/codecov-action@v3
       name: Upload coverage to Codecov
       with:
-        files: ./artifacts/coverage-reports/Polly.Core.Tests/Cobertura.xml,./artifacts/coverage-reports/Polly.Specs/Cobertura.xml
+        files: ./artifacts/coverage-reports/**/Cobertura.xml
         flags: ${{ matrix.os_name }}
 
     - name: Upload Mutation Report

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
     - uses: codecov/codecov-action@v3
       name: Upload coverage to Codecov
       with:
-        directory: ./artifacts/coverage-reports
+        files: ./artifacts/coverage-reports/Polly.Core.Tests/Cobertura.xml,./artifacts/coverage-reports/Polly.Specs/Cobertura.xml
         flags: ${{ matrix.os_name }}
 
     - name: Upload Mutation Report

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
     - uses: codecov/codecov-action@v3
       name: Upload coverage to Codecov
       with:
-        files: ./artifacts/coverage-reports/**/Cobertura.xml
+        files: ./artifacts/coverage-reports/Polly.Core.Tests/Cobertura.xml,./artifacts/coverage-reports/Polly.Specs/Cobertura.xml
         flags: ${{ matrix.os_name }}
 
     - name: Upload Mutation Report

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
     - uses: codecov/codecov-action@v3
       name: Upload coverage to Codecov
       with:
-        files: ./src/Polly.Specs/coverage-reports/Cobertura.xml,./src/Polly.Core.Tests/coverage-reports/Cobertura.xml
+        directory: ./artifacts/coverage-reports
         flags: ${{ matrix.os_name }}
 
     - name: Upload Mutation Report

--- a/build.cake
+++ b/build.cake
@@ -199,7 +199,7 @@ Task("__RunTests")
         loggers = new[] { "GitHubActions;report-warnings=false" };
     }
 
-    var projects = GetFiles("./src/**/*.Specs.csproj").Concat(GetFiles("./src/**/*.Tests.csproj"));
+    var projects = GetFiles("./src/**/*.Tests.csproj").Concat(GetFiles("./src/**/*.Specs.csproj"));
 
     foreach(var proj in projects)
     {
@@ -259,11 +259,11 @@ Task("__CreateSignedNuGetPackages")
         },
     };
 
-    Information("Building Polly.{0}.nupkg", nugetVersion);
-    DotNetPack(System.IO.Path.Combine(srcDir, "Polly", "Polly.csproj"), dotNetPackSettings);
-
     Information("Building Polly.Core.{0}.nupkg", nugetVersion);
     DotNetPack(System.IO.Path.Combine(srcDir, "Polly.Core", "Polly.Core.csproj"), dotNetPackSettings);
+
+    Information("Building Polly.{0}.nupkg", nugetVersion);
+    DotNetPack(System.IO.Path.Combine(srcDir, "Polly", "Polly.csproj"), dotNetPackSettings);
 });
 
 //////////////////////////////////////////////////////////////////////

--- a/build.cake
+++ b/build.cake
@@ -215,8 +215,8 @@ Task("__RunTests")
 Task("__RunMutationTests")
     .Does(() =>
 {
-    TestProject(File("./src/Polly/Polly.csproj"), File("./src/Polly.Specs/Polly.Specs.csproj"), "Polly.csproj");
     TestProject(File("./src/Polly.Core/Polly.Core.csproj"), File("./src/Polly.Core.Tests/Polly.Core.Tests.csproj"), "Polly.Core.csproj");
+    TestProject(File("./src/Polly/Polly.csproj"), File("./src/Polly.Specs/Polly.Specs.csproj"), "Polly.csproj");
 
     void TestProject(FilePath proj, FilePath testProj, string project)
     {

--- a/eng/Test.targets
+++ b/eng/Test.targets
@@ -24,9 +24,9 @@
 
   <PropertyGroup Condition=" '$(CollectCoverage)' == 'true' ">
     <ReportGeneratorOutputMarkdown Condition=" '$(ReportGeneratorOutputMarkdown)' == '' AND '$(GITHUB_SHA)' != '' ">true</ReportGeneratorOutputMarkdown>
-    <ReportGeneratorReportTypes>HTML</ReportGeneratorReportTypes>
+    <ReportGeneratorReportTypes>Cobertura;HTML</ReportGeneratorReportTypes>
     <ReportGeneratorReportTypes Condition=" '$(ReportGeneratorOutputMarkdown)' == 'true' ">$(ReportGeneratorReportTypes);MarkdownSummaryGitHub</ReportGeneratorReportTypes>
-    <ReportGeneratorTargetDirectory>$([System.IO.Path]::Combine($(OutputPath), 'coverage-reports'))</ReportGeneratorTargetDirectory>
+    <ReportGeneratorTargetDirectory>$([System.IO.Path]::Combine('$(MSBuildThisFileDirectory)', '../artifacts/', 'coverage-reports', '$(MSBuildProjectName)'))</ReportGeneratorTargetDirectory>
     <_MarkdownSummaryPrefix>&lt;details&gt;&lt;summary&gt;:chart_with_upwards_trend: &lt;b&gt;$(AssemblyName) Code Coverage report&lt;/b&gt; %28$(TargetFramework)%29&lt;/summary&gt;</_MarkdownSummaryPrefix>
     <_MarkdownSummarySuffix>&lt;/details&gt;</_MarkdownSummarySuffix>
   </PropertyGroup>


### PR DESCRIPTION
- Output a report in Cobertura format for coverlet.
- Write the reports to a stable directory path for coverlet upload.
- Build and test in the order of the dependency tree since #1075.
