### PR TITLE
Introduce TimeProvider

### DIFF
--- a/eng/Library.targets
+++ b/eng/Library.targets
@@ -32,6 +32,14 @@
     <PackageReleaseNotes>See https://github.com/App-vNext/Polly/blob/master/CHANGELOG.md for details</PackageReleaseNotes>
   </PropertyGroup>
 
+  <Target Name="AddInternalsVisibleToDynamicProxyGenAssembly2" BeforeTargets="BeforeCompile">
+    <ItemGroup>
+      <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+        <_Parameter1>DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7</_Parameter1>
+      </AssemblyAttribute>
+    </ItemGroup>
+  </Target>
+
   <Target Name="AddInternalsVisibleToTest" BeforeTargets="BeforeCompile">
     <ItemGroup>
       <InternalsVisibleTo Include="%(InternalsVisibleToTest.Identity)$(PollyPublicKeySuffix)" />

--- a/src/Polly.Core.Tests/Builder/ResilienceStrategyBuilderOptionsTests.cs
+++ b/src/Polly.Core.Tests/Builder/ResilienceStrategyBuilderOptionsTests.cs
@@ -1,5 +1,7 @@
 using FluentAssertions;
 using Polly.Builder;
+using Polly.Telemetry;
+using Polly.Utils;
 using Xunit;
 
 namespace Polly.Core.Tests.Builder;
@@ -12,5 +14,8 @@ public class ResilienceStrategyBuilderOptionsTests
         var options = new ResilienceStrategyBuilderOptions();
 
         options.BuilderName.Should().Be("");
+        options.Properties.Should().NotBeNull();
+        options.TimeProvider.Should().Be(TimeProvider.System);
+        options.TelemetryFactory.Should().Be(NullResilienceTelemetryFactory.Instance);
     }
 }

--- a/src/Polly.Core.Tests/Builder/ResilienceStrategyBuilderTests.cs
+++ b/src/Polly.Core.Tests/Builder/ResilienceStrategyBuilderTests.cs
@@ -252,7 +252,8 @@ The StrategyType field is required.
         {
             Options = new ResilienceStrategyBuilderOptions
             {
-                BuilderName = "builder-name"
+                BuilderName = "builder-name",
+                TimeProvider = new FakeTimeProvider().Object
             }
         };
 
@@ -265,6 +266,7 @@ The StrategyType field is required.
                 context.BuilderProperties.Should().BeSameAs(builder.Options.Properties);
                 context.Telemetry.Should().NotBeNull();
                 context.Telemetry.Should().Be(NullResilienceTelemetry.Instance);
+                context.TimeProvider.Should().Be(builder.Options.TimeProvider);
                 verified1 = true;
 
                 return new TestResilienceStrategy();
@@ -280,6 +282,7 @@ The StrategyType field is required.
                 context.BuilderProperties.Should().BeSameAs(builder.Options.Properties);
                 context.Telemetry.Should().NotBeNull();
                 context.Telemetry.Should().Be(NullResilienceTelemetry.Instance);
+                context.TimeProvider.Should().Be(builder.Options.TimeProvider);
                 verified2 = true;
 
                 return new TestResilienceStrategy();

--- a/src/Polly.Core.Tests/Utils/FakeTimeProvider.cs
+++ b/src/Polly.Core.Tests/Utils/FakeTimeProvider.cs
@@ -5,8 +5,13 @@ namespace Polly.Core.Tests.Utils;
 
 internal class FakeTimeProvider : Mock<TimeProvider>
 {
+    public FakeTimeProvider(long frequency)
+    : base(MockBehavior.Strict, frequency)
+    {
+    }
+
     public FakeTimeProvider()
-        : base(MockBehavior.Strict, Stopwatch.Frequency)
+        : this(Stopwatch.Frequency)
     {
     }
 

--- a/src/Polly.Core.Tests/Utils/FakeTimeProvider.cs
+++ b/src/Polly.Core.Tests/Utils/FakeTimeProvider.cs
@@ -1,0 +1,24 @@
+using Moq;
+using Polly.Utils;
+
+namespace Polly.Core.Tests.Utils;
+
+internal class FakeTimeProvider : Mock<TimeProvider>
+{
+    public FakeTimeProvider()
+        : base(MockBehavior.Strict, Stopwatch.Frequency)
+    {
+    }
+
+    public FakeTimeProvider SetupDelay(TimeSpan delay, CancellationToken cancellationToken = default)
+    {
+        Setup(x => x.Delay(delay, cancellationToken)).Returns(Task.CompletedTask);
+        return this;
+    }
+
+    public FakeTimeProvider SetupDelayCancelled(TimeSpan delay, CancellationToken cancellationToken = default)
+    {
+        Setup(x => x.Delay(delay, cancellationToken)).ThrowsAsync(new OperationCanceledException());
+        return this;
+    }
+}

--- a/src/Polly.Core.Tests/Utils/SystemTimeProviderTests.cs
+++ b/src/Polly.Core.Tests/Utils/SystemTimeProviderTests.cs
@@ -1,0 +1,75 @@
+using FluentAssertions;
+using Polly.Utils;
+using Xunit;
+
+namespace Polly.Core.Tests.Utils;
+
+public class SystemTimeProviderTests
+{
+    [Fact]
+    public void TimestampFrequency_Ok()
+    {
+        TimeProvider.System.TimestampFrequency.Should().Be(Stopwatch.Frequency);
+    }
+
+    [Fact]
+    public async Task CancelAfter_Ok()
+    {
+        await TestUtils.AssertWithTimeoutAsync(async () =>
+        {
+            using var cts = new CancellationTokenSource();
+            TimeProvider.System.CancelAfter(cts, TimeSpan.FromMilliseconds(10));
+            cts.IsCancellationRequested.Should().BeFalse();
+            await Task.Delay(10);
+            cts.Token.IsCancellationRequested.Should().BeTrue();
+        });
+    }
+
+    [Fact]
+    public async Task Delay_Ok()
+    {
+        using var cts = new CancellationTokenSource();
+
+        await TestUtils.AssertWithTimeoutAsync(() =>
+        {
+            TimeProvider.System.Delay(TimeSpan.FromMilliseconds(10)).IsCompleted.Should().BeFalse();
+        });
+    }
+
+    [Fact]
+    public void Delay_NoDelay_Ok()
+    {
+        using var cts = new CancellationTokenSource();
+
+        TimeProvider.System.Delay(TimeSpan.Zero).IsCompleted.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetElapsedTime_Ok()
+    {
+        var delay = TimeSpan.FromMilliseconds(10);
+        var delayWithTolerance = TimeSpan.FromMilliseconds(30);
+
+        await TestUtils.AssertWithTimeoutAsync(async () =>
+        {
+            var stamp1 = TimeProvider.System.GetTimestamp();
+            await Task.Delay(10);
+            var stamp2 = TimeProvider.System.GetTimestamp();
+
+            var elapsed = TimeProvider.System.GetElapsedTime(stamp1, stamp2);
+
+            elapsed.Should().BeGreaterThanOrEqualTo(delay);
+            elapsed.Should().BeLessThan(delayWithTolerance);
+        });
+    }
+
+    [Fact]
+    public async Task UtcNow_Ok()
+    {
+        await TestUtils.AssertWithTimeoutAsync(() =>
+        {
+            var now = TimeProvider.System.UtcNow;
+            (DateTimeOffset.UtcNow - now).Should().BeLessThanOrEqualTo(TimeSpan.FromMilliseconds(10));
+        });
+    }
+}

--- a/src/Polly.Core.Tests/Utils/SystemTimeProviderTests.cs
+++ b/src/Polly.Core.Tests/Utils/SystemTimeProviderTests.cs
@@ -73,7 +73,11 @@ public class SystemTimeProviderTests
         var stamp2 = provider.Object.GetTimestamp();
 
         var delay = provider.Object.GetElapsedTime(stamp1, stamp2);
-        delay.Should().Be(new TimeSpan(2, 30, 0));
+
+        var tickFrequency = (double)TimeSpan.TicksPerSecond / 40;
+        var expected = new TimeSpan((long)((stamp2 - stamp1) * tickFrequency));
+
+        delay.Should().Be(expected);
     }
 
     [Fact]

--- a/src/Polly.Core.Tests/Utils/SystemTimeProviderTests.cs
+++ b/src/Polly.Core.Tests/Utils/SystemTimeProviderTests.cs
@@ -66,14 +66,14 @@ public class SystemTimeProviderTests
     [Fact]
     public void GetElapsedTime_Mocked_Ok()
     {
-        var provider = new FakeTimeProvider();
+        var provider = new FakeTimeProvider(40);
         provider.SetupSequence(v => v.GetTimestamp()).Returns(120000).Returns(480000);
 
         var stamp1 = provider.Object.GetTimestamp();
         var stamp2 = provider.Object.GetTimestamp();
 
         var delay = provider.Object.GetElapsedTime(stamp1, stamp2);
-        delay.Should().Be(TimeSpan.FromMilliseconds(36));
+        delay.Should().Be(new TimeSpan(2, 30, 0));
     }
 
     [Fact]

--- a/src/Polly.Core.Tests/Utils/SystemTimeProviderTests.cs
+++ b/src/Polly.Core.Tests/Utils/SystemTimeProviderTests.cs
@@ -64,6 +64,19 @@ public class SystemTimeProviderTests
     }
 
     [Fact]
+    public void GetElapsedTime_Mocked_Ok()
+    {
+        var provider = new FakeTimeProvider();
+        provider.SetupSequence(v => v.GetTimestamp()).Returns(120000).Returns(480000);
+
+        var stamp1 = provider.Object.GetTimestamp();
+        var stamp2 = provider.Object.GetTimestamp();
+
+        var delay = provider.Object.GetElapsedTime(stamp1, stamp2);
+        delay.Should().Be(TimeSpan.FromMilliseconds(36));
+    }
+
+    [Fact]
     public async Task UtcNow_Ok()
     {
         await TestUtils.AssertWithTimeoutAsync(() =>
@@ -72,4 +85,5 @@ public class SystemTimeProviderTests
             (DateTimeOffset.UtcNow - now).Should().BeLessThanOrEqualTo(TimeSpan.FromMilliseconds(10));
         });
     }
+
 }

--- a/src/Polly.Core.Tests/Utils/TestUtils.cs
+++ b/src/Polly.Core.Tests/Utils/TestUtils.cs
@@ -1,0 +1,36 @@
+using System;
+
+namespace Polly.Core.Tests.Utils;
+
+#pragma warning disable CA1031 // Do not catch general exception types
+
+public static class TestUtils
+{
+    public static Task AssertWithTimeoutAsync(Func<Task> assertion) => AssertWithTimeoutAsync(assertion, TimeSpan.FromSeconds(60));
+
+    public static Task AssertWithTimeoutAsync(Action assertion) => AssertWithTimeoutAsync(
+        () =>
+        {
+            assertion();
+            return Task.CompletedTask;
+        },
+        TimeSpan.FromSeconds(60));
+
+    public static async Task AssertWithTimeoutAsync(Func<Task> assertion, TimeSpan timeout)
+    {
+        var watch = Stopwatch.StartNew();
+
+        while (true)
+        {
+            try
+            {
+                await assertion();
+                return;
+            }
+            catch (Exception) when (watch.Elapsed < timeout)
+            {
+                await Task.Delay(5);
+            }
+        }
+    }
+}

--- a/src/Polly.Core.Tests/Utils/TimeProviderExtensionsTests.cs
+++ b/src/Polly.Core.Tests/Utils/TimeProviderExtensionsTests.cs
@@ -1,0 +1,89 @@
+using FluentAssertions;
+using Polly.Utils;
+using Xunit;
+
+namespace Polly.Core.Tests.Utils;
+
+public class TimeProviderExtensionsTests
+{
+    [InlineData(false, false, false)]
+    [InlineData(false, false, true)]
+    [InlineData(false, true, true)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    [InlineData(true, false, true)]
+    [InlineData(true, true, true)]
+    [InlineData(true, true, false)]
+    [Theory]
+    public async Task DelayAsync_System_Ok(bool synchronous, bool mocked, bool hasCancellation)
+    {
+        using var tcs = new CancellationTokenSource();
+        var token = hasCancellation ? tcs.Token : default;
+        var delay = TimeSpan.FromMilliseconds(10);
+        var mock = new FakeTimeProvider();
+        var timeProvider = mocked ? mock.Object : TimeProvider.System;
+        var context = ResilienceContext.Get();
+        context.Initialize<VoidResult>(isSynchronous: synchronous);
+        context.CancellationToken = token;
+        mock.SetupDelay(delay, token);
+
+        await TestUtils.AssertWithTimeoutAsync(async () =>
+        {
+            var task = timeProvider.DelayAsync(delay, context);
+            task.IsCompleted.Should().Be(synchronous || mocked);
+            await task;
+        });
+
+        if (mocked)
+        {
+            mock.VerifyAll();
+        }
+    }
+
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    [Theory]
+    public async Task DelayAsync_CancellationRequestedbefore_Throws(bool synchronous, bool mocked)
+    {
+        using var tcs = new CancellationTokenSource();
+        tcs.Cancel();
+        var token = tcs.Token;
+        var delay = TimeSpan.FromMilliseconds(10);
+        var mock = new FakeTimeProvider();
+        var timeProvider = mocked ? mock.Object : TimeProvider.System;
+        var context = ResilienceContext.Get();
+        context.Initialize<VoidResult>(isSynchronous: synchronous);
+        context.CancellationToken = token;
+        mock.SetupDelayCancelled(delay, token);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => timeProvider.DelayAsync(delay, context));
+    }
+
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    [Theory]
+    public async Task DelayAsync_CancellationAfter_Throws(bool synchronous, bool mocked)
+    {
+        var delay = TimeSpan.FromMilliseconds(20);
+
+        await TestUtils.AssertWithTimeoutAsync(async () =>
+        {
+            var mock = new FakeTimeProvider();
+            using var tcs = new CancellationTokenSource();
+            var token = tcs.Token;
+            var timeProvider = mocked ? mock.Object : TimeProvider.System;
+            var context = ResilienceContext.Get();
+            context.Initialize<VoidResult>(isSynchronous: synchronous);
+            context.CancellationToken = token;
+            mock.SetupDelayCancelled(delay, token);
+
+            tcs.CancelAfter(TimeSpan.FromMilliseconds(5));
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => timeProvider.DelayAsync(delay, context));
+        });
+    }
+}

--- a/src/Polly.Core/Builder/ResilienceStrategyBuilder.cs
+++ b/src/Polly.Core/Builder/ResilienceStrategyBuilder.cs
@@ -104,7 +104,8 @@ public class ResilienceStrategyBuilder
             BuilderProperties = Options.Properties,
             StrategyName = entry.Properties.StrategyName,
             StrategyType = entry.Properties.StrategyType,
-            Telemetry = Options.TelemetryFactory.Create(telemetryContext)
+            Telemetry = Options.TelemetryFactory.Create(telemetryContext),
+            TimeProvider = Options.TimeProvider
         };
 
         return entry.Factory(context);

--- a/src/Polly.Core/Builder/ResilienceStrategyBuilderContext.cs
+++ b/src/Polly.Core/Builder/ResilienceStrategyBuilderContext.cs
@@ -31,4 +31,9 @@ public class ResilienceStrategyBuilderContext
     /// Gets the resilience telemetry used to report important events.
     /// </summary>
     public ResilienceTelemetry Telemetry { get; internal set; } = NullResilienceTelemetry.Instance;
+
+    /// <summary>
+    /// Gets or sets the <see cref="TimeProvider"/> used by this strategy.
+    /// </summary>
+    internal TimeProvider TimeProvider { get; set; } = TimeProvider.System;
 }

--- a/src/Polly.Core/Builder/ResilienceStrategyBuilderOptions.cs
+++ b/src/Polly.Core/Builder/ResilienceStrategyBuilderOptions.cs
@@ -25,4 +25,13 @@ public class ResilienceStrategyBuilderOptions
     /// </summary>
     [Required]
     public ResilienceTelemetryFactory TelemetryFactory { get; set; } = NullResilienceTelemetryFactory.Instance;
+
+    /// <summary>
+    /// Gets or sets a <see cref="TimeProvider"/> that is used by strategies that work with time.
+    /// </summary>
+    /// <remarks>
+    /// This property is internal until we switch to official System.TimeProvider.
+    /// </remarks>
+    [Required]
+    internal TimeProvider TimeProvider { get; set; } = TimeProvider.System;
 }

--- a/src/Polly.Core/Utils/TimeProvider.cs
+++ b/src/Polly.Core/Utils/TimeProvider.cs
@@ -1,0 +1,50 @@
+using System.Threading;
+
+namespace Polly.Utils;
+
+#pragma warning disable S3872 // Parameter names should not duplicate the names of their methods
+
+/// <summary>
+/// TEMPORARY ONLY, to be replaced with System.TimeProvider - https://github.com/dotnet/runtime/issues/36617 later.
+/// </summary>
+/// <remarks>We trimmed some of the API that's not relevant for us to.</remarks>
+internal abstract class TimeProvider
+{
+    private readonly double _tickFrequency;
+
+    public static TimeProvider System { get; } = new SystemTimeProvider();
+
+    protected TimeProvider(long timestampFrequency)
+    {
+        TimestampFrequency = timestampFrequency;
+        _tickFrequency = (double)TimeSpan.TicksPerSecond / TimestampFrequency;
+    }
+
+    public abstract DateTimeOffset UtcNow { get; }
+
+    public long TimestampFrequency { get; }
+
+    public abstract long GetTimestamp();
+
+    public TimeSpan GetElapsedTime(long startingTimestamp, long endingTimestamp) => new((long)((endingTimestamp - startingTimestamp) * _tickFrequency));
+
+    public abstract Task Delay(TimeSpan delay, CancellationToken cancellationToken = default);
+
+    public abstract void CancelAfter(CancellationTokenSource source, TimeSpan delay);
+
+    private sealed class SystemTimeProvider : TimeProvider
+    {
+        public SystemTimeProvider()
+            : base(Stopwatch.Frequency)
+        {
+        }
+
+        public override long GetTimestamp() => Stopwatch.GetTimestamp();
+
+        public override Task Delay(TimeSpan delay, CancellationToken cancellationToken = default) => Task.Delay(delay, cancellationToken);
+
+        public override void CancelAfter(CancellationTokenSource source, TimeSpan delay) => source.CancelAfter(delay);
+
+        public override DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
+    }
+}

--- a/src/Polly.Core/Utils/TimeProvider.cs
+++ b/src/Polly.Core/Utils/TimeProvider.cs
@@ -7,7 +7,7 @@ namespace Polly.Utils;
 /// <summary>
 /// TEMPORARY ONLY, to be replaced with System.TimeProvider - https://github.com/dotnet/runtime/issues/36617 later.
 /// </summary>
-/// <remarks>We trimmed some of the API that's not relevant for us to.</remarks>
+/// <remarks>We trimmed some of the API that's not relevant for us too.</remarks>
 internal abstract class TimeProvider
 {
     private readonly double _tickFrequency;

--- a/src/Polly.Core/Utils/TimeProviderExtensions.cs
+++ b/src/Polly.Core/Utils/TimeProviderExtensions.cs
@@ -1,0 +1,54 @@
+namespace Polly.Utils;
+
+/// <summary>
+/// Extensions for <see cref="TimeProvider"/> used by resilience strategies.
+/// </summary>
+internal static class TimeProviderExtensions
+{
+    /// <summary>
+    /// Delays the execution for the specified time span.
+    /// </summary>
+    /// <param name="timeProvider">The instance of <see cref="TimeProvider"/>.</param>
+    /// <param name="delay">For how long we should delay.</param>
+    /// <param name="context">The resilience context.</param>
+    /// <returns>The task.</returns>
+    /// <remarks>
+    /// The delay is performed synchronously if the <see cref="ResilienceContext.IsSynchronous"/> property is true, otherwise the delay is performed asynchronously.
+    /// This method will be public later.
+    /// </remarks>
+    public static Task DelayAsync(this TimeProvider timeProvider, TimeSpan delay, ResilienceContext context)
+    {
+        Guard.NotNull(timeProvider);
+        Guard.NotNull(context);
+
+        context.CancellationToken.ThrowIfCancellationRequested();
+
+        if (context.IsSynchronous && timeProvider == TimeProvider.System)
+        {
+            if (context.CancellationToken.CanBeCanceled)
+            {
+                context.CancellationToken.WaitHandle.WaitOne(delay);
+                context.CancellationToken.ThrowIfCancellationRequested();
+            }
+            else
+            {
+                Thread.Sleep(delay);
+            }
+
+            return Task.CompletedTask;
+        }
+        else
+        {
+            if (context.IsSynchronous)
+            {
+#pragma warning disable CA1849 // For synchronous scenarios we want to return completed task
+                timeProvider.Delay(delay, context.CancellationToken).GetAwaiter().GetResult();
+#pragma warning restore CA1849
+
+                return Task.CompletedTask;
+            }
+
+            return timeProvider.Delay(delay, context.CancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
### The issue or feature being addressed

#1070 

### Details on the issue fix or feature implementation

This adds a `TimeProvider` API copied from .NET and made internal. We will use it internally in strategies until the official  API and package is ready.

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
