### PR TITLE
Always attempt to upload mutation report

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,12 +51,15 @@ jobs:
       with:
         files: ./artifacts/coverage-reports/Polly.Core.Tests/Cobertura.xml,./artifacts/coverage-reports/Polly.Specs/Cobertura.xml
         flags: ${{ matrix.os_name }}
+        if-no-files-found: warn
 
     - name: Upload Mutation Report
+      if: always()
       uses: actions/upload-artifact@v3
       with:
         name: mutation-report-${{ matrix.os_name }}
         path: StrykerOutput
+        if-no-files-found: warn
 
     - name: Publish NuGet packages
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,6 @@ jobs:
       with:
         files: ./artifacts/coverage-reports/Polly.Core.Tests/Cobertura.xml,./artifacts/coverage-reports/Polly.Specs/Cobertura.xml
         flags: ${{ matrix.os_name }}
-        if-no-files-found: warn
 
     - name: Upload Mutation Report
       if: always()
@@ -59,7 +58,6 @@ jobs:
       with:
         name: mutation-report-${{ matrix.os_name }}
         path: StrykerOutput
-        if-no-files-found: warn
 
     - name: Publish NuGet packages
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
### The issue or feature being addressed

We have seen mutants that were not killed in some builds. Because the mutation report was not uploaded, we couldn't determine the cause. With this change, we always try to upload the mutation reports.

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
