### PR TITLE
Ignore some dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,8 @@ updates:
     day: thursday
     time: "12:00"
     timezone: "America/New_York"
+  ignore:
+    # Ignore the libraries which are pinned
+    - dependency-name: "System.ComponentModel.Annotations"
+    - dependency-name: "System.Threading.Tasks.Extensions"
+    - dependency-name: "System.ValueTuplens"


### PR DESCRIPTION
Ignore packages we want to pin to a specific version - well, that's what I assume we want to do for these .NET Framework dependencies.
