### PR TITLE
Introduce ResilienceStrategyRegistry

### DIFF
--- a/src/Polly.Core.Tests/Registry/ResilienceStrategyProviderTests.cs
+++ b/src/Polly.Core.Tests/Registry/ResilienceStrategyProviderTests.cs
@@ -1,10 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
-using FluentAssertions;
-using Polly.Core.Tests.Utils;
 using Polly.Registry;
-using Xunit;
 
 namespace Polly.Core.Tests.Registry;
+
 public class ResilienceStrategyProviderTests
 {
     [Fact]
@@ -14,7 +12,7 @@ public class ResilienceStrategyProviderTests
             .Invoking(o => o.Get("not-exists"))
             .Should()
             .Throw<KeyNotFoundException>()
-            .WithMessage("Unable to find a resilience strategy associated with the key 'not-exists'. Please ensure the either resilience strategy or builder is registered.");
+            .WithMessage("Unable to find a resilience strategy associated with the key 'not-exists'. Please ensure that either the resilience strategy or the builder is registered.");
     }
 
     [Fact]

--- a/src/Polly.Core.Tests/Registry/ResilienceStrategyProviderTests.cs
+++ b/src/Polly.Core.Tests/Registry/ResilienceStrategyProviderTests.cs
@@ -1,0 +1,38 @@
+using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
+using Polly.Core.Tests.Utils;
+using Polly.Registry;
+using Xunit;
+
+namespace Polly.Core.Tests.Registry;
+public class ResilienceStrategyProviderTests
+{
+    [Fact]
+    public void Get_DoesNotExist_Throws()
+    {
+        new Provider()
+            .Invoking(o => o.Get("not-exists"))
+            .Should()
+            .Throw<KeyNotFoundException>()
+            .WithMessage("Unable to find a resilience strategy associated with the key 'not-exists'. Please ensure the either resilience strategy or builder is registered.");
+    }
+
+    [Fact]
+    public void Get_Exist_Ok()
+    {
+        var provider = new Provider { Strategy = new TestResilienceStrategy() };
+
+        provider.Get("exists").Should().Be(provider.Strategy);
+    }
+
+    private class Provider : ResilienceStrategyProvider<string>
+    {
+        public ResilienceStrategy? Strategy { get; set; }
+
+        public override bool TryGet(string key, [NotNullWhen(true)] out ResilienceStrategy? strategy)
+        {
+            strategy = Strategy;
+            return Strategy != null;
+        }
+    }
+}

--- a/src/Polly.Core.Tests/Registry/ResilienceStrategyRegistryTests.cs
+++ b/src/Polly.Core.Tests/Registry/ResilienceStrategyRegistryTests.cs
@@ -1,13 +1,10 @@
-using System;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
-using FluentAssertions;
 using Polly.Builder;
-using Polly.Core.Tests.Utils;
 using Polly.Registry;
-using Xunit;
 
 namespace Polly.Core.Tests.Registry;
+
 public class ResilienceStrategyRegistryTests
 {
     private Action<ResilienceStrategyBuilder> _callback = _ => { };

--- a/src/Polly.Core.Tests/Registry/ResilienceStrategyRegistryTests.cs
+++ b/src/Polly.Core.Tests/Registry/ResilienceStrategyRegistryTests.cs
@@ -1,0 +1,175 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using FluentAssertions;
+using Polly.Builder;
+using Polly.Core.Tests.Utils;
+using Polly.Registry;
+using Xunit;
+
+namespace Polly.Core.Tests.Registry;
+public class ResilienceStrategyRegistryTests
+{
+    private Action<ResilienceStrategyBuilder> _callback = _ => { };
+
+    [Fact]
+    public void Ctor_Default_Ok()
+    {
+        this.Invoking(_ => new ResilienceStrategyRegistry<string>()).Should().NotThrow();
+    }
+
+    [Fact]
+    public void Ctor_InvalidOptions_Throws()
+    {
+        this.Invoking(_ => new ResilienceStrategyRegistry<string>(new ResilienceStrategyRegistryOptions<string> { BuilderFactory = null! }))
+            .Should()
+            .Throw<ValidationException>();
+    }
+
+    [Fact]
+    public void Clear_Ok()
+    {
+        var registry = new ResilienceStrategyRegistry<string>();
+
+        registry.TryAddBuilder("C", (_, b) => b.AddStrategy(new TestResilienceStrategy()));
+
+        registry.TryAdd("A", new TestResilienceStrategy());
+        registry.TryAdd("B", new TestResilienceStrategy());
+        registry.TryAdd("C", new TestResilienceStrategy());
+
+        registry.Clear();
+
+        registry.TryGet("A", out _).Should().BeFalse();
+        registry.TryGet("B", out _).Should().BeFalse();
+        registry.TryGet("C", out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Remove_Ok()
+    {
+        var registry = new ResilienceStrategyRegistry<string>();
+
+        registry.TryAdd("A", new TestResilienceStrategy());
+        registry.TryAdd("B", new TestResilienceStrategy());
+
+        registry.Remove("A").Should().BeTrue();
+        registry.Remove("A").Should().BeFalse();
+
+        registry.TryGet("A", out _).Should().BeFalse();
+        registry.TryGet("B", out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public void RemoveBuilder_Ok()
+    {
+        var registry = new ResilienceStrategyRegistry<string>();
+        registry.TryAddBuilder("A", (_, b) => b.AddStrategy(new TestResilienceStrategy()));
+
+        registry.RemoveBuilder("A").Should().BeTrue();
+        registry.RemoveBuilder("A").Should().BeFalse();
+
+        registry.TryGet("A", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetStrategy_BuilderMultiInstance_EnsureMultipleInstances()
+    {
+        var builderName = "A";
+        var registry = CreateRegistry();
+        var strategies = new HashSet<ResilienceStrategy>();
+        registry.TryAddBuilder(StrategyId.Create(builderName), (_, builder) => builder.AddStrategy(new TestResilienceStrategy()));
+
+        for (int i = 0; i < 100; i++)
+        {
+            var key = StrategyId.Create(builderName, i.ToString(CultureInfo.InvariantCulture));
+
+            strategies.Add(registry.Get(key));
+
+            // call again, the strategy should be already cached
+            strategies.Add(registry.Get(key));
+        }
+
+        strategies.Should().HaveCount(100);
+    }
+
+    [Fact]
+    public void AddBuilder_GetStrategy_EnsureCalled()
+    {
+        var activatorCalls = 0;
+        _callback = _ => activatorCalls++;
+        var registry = CreateRegistry();
+        var called = 0;
+        registry.TryAddBuilder(StrategyId.Create("A"), (key, builder) =>
+        {
+            builder.AddStrategy(new TestResilienceStrategy());
+            builder.Options.Properties.Set(StrategyId.ResilienceKey, key);
+            called++;
+        });
+
+        var key1 = StrategyId.Create("A");
+        var key2 = StrategyId.Create("A", "Instance1");
+        var key3 = StrategyId.Create("A", "Instance2");
+        var keys = new[] { key1, key2, key3 };
+        var strategies = keys.ToDictionary(k => k, registry.Get);
+        foreach (var key in keys)
+        {
+            registry.Get(key);
+        }
+
+        called.Should().Be(3);
+        activatorCalls.Should().Be(3);
+        strategies.Keys.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void TryGet_NoBuilder_Null()
+    {
+        var registry = CreateRegistry();
+        var key = StrategyId.Create("A");
+
+        registry.TryGet(key, out var strategy).Should().BeFalse();
+        strategy.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryGet_ExplicitStrategyAdded_Ok()
+    {
+        var expectedStrategy = new TestResilienceStrategy();
+        var registry = CreateRegistry();
+        var key = StrategyId.Create("A", "Instance");
+        registry.TryAdd(key, expectedStrategy).Should().BeTrue();
+
+        registry.TryGet(key, out var strategy).Should().BeTrue();
+
+        strategy.Should().BeSameAs(expectedStrategy);
+    }
+
+    [Fact]
+    public void TryAdd_Twice_SecondNotAdded()
+    {
+        var expectedStrategy = new TestResilienceStrategy();
+        var registry = CreateRegistry();
+        var key = StrategyId.Create("A", "Instance");
+        registry.TryAdd(key, expectedStrategy);
+
+        registry.TryAdd(key, new TestResilienceStrategy()).Should().BeFalse();
+
+        registry.TryGet(key, out var strategy).Should().BeTrue();
+        strategy.Should().BeSameAs(expectedStrategy);
+    }
+
+    private ResilienceStrategyRegistry<StrategyId> CreateRegistry()
+    {
+        return new ResilienceStrategyRegistry<StrategyId>(new ResilienceStrategyRegistryOptions<StrategyId>
+        {
+            BuilderFactory = () =>
+            {
+                var builder = new ResilienceStrategyBuilder();
+                _callback(builder);
+                return builder;
+            },
+            StrategyComparer = StrategyId.Comparer,
+            BuilderComparer = StrategyId.BuilderComparer
+        });
+    }
+}

--- a/src/Polly.Core.Tests/Registry/ResilienceStrategyRegistryTests.cs
+++ b/src/Polly.Core.Tests/Registry/ResilienceStrategyRegistryTests.cs
@@ -23,7 +23,7 @@ public class ResilienceStrategyRegistryTests
     {
         this.Invoking(_ => new ResilienceStrategyRegistry<string>(new ResilienceStrategyRegistryOptions<string> { BuilderFactory = null! }))
             .Should()
-            .Throw<ValidationException>();
+            .Throw<ValidationException>().WithMessage("The resilience strategy registry options are invalid.*");
     }
 
     [Fact]

--- a/src/Polly.Core.Tests/Registry/StrategyId.cs
+++ b/src/Polly.Core.Tests/Registry/StrategyId.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+
+namespace Polly.Core.Tests.Registry;
+
+public record StrategyId(Type Type, string BuilderName, string InstanceName = "")
+{
+    public static readonly ResiliencePropertyKey<StrategyId> ResilienceKey = new("Polly.StrategyId");
+
+    public static StrategyId Create<T>(string builderName, string instanceName = "")
+        => new(typeof(T), builderName, instanceName);
+    public static StrategyId Create(string builderName, string instanceName = "")
+        => new(typeof(StrategyId), builderName, instanceName);
+
+    public static readonly IEqualityComparer<StrategyId> Comparer = EqualityComparer<StrategyId>.Default;
+
+    public static readonly IEqualityComparer<StrategyId> BuilderComparer = new BuilderResilienceKeyComparer();
+
+    private class BuilderResilienceKeyComparer : IEqualityComparer<StrategyId>
+    {
+        public bool Equals(StrategyId? x, StrategyId? y) => x?.Type == y?.Type && x?.BuilderName == y?.BuilderName;
+
+        public int GetHashCode(StrategyId obj) => (obj.Type, obj.BuilderName).GetHashCode();
+    }
+}

--- a/src/Polly.Core.Tests/Registry/StrategyId.cs
+++ b/src/Polly.Core.Tests/Registry/StrategyId.cs
@@ -16,7 +16,7 @@ public record StrategyId(Type Type, string BuilderName, string InstanceName = ""
 
     public static readonly IEqualityComparer<StrategyId> BuilderComparer = new BuilderResilienceKeyComparer();
 
-    private class BuilderResilienceKeyComparer : IEqualityComparer<StrategyId>
+    private sealed class BuilderResilienceKeyComparer : IEqualityComparer<StrategyId>
     {
         public bool Equals(StrategyId? x, StrategyId? y) => x?.Type == y?.Type && x?.BuilderName == y?.BuilderName;
 

--- a/src/Polly.Core/Registry/ResilienceStrategyProvider.cs
+++ b/src/Polly.Core/Registry/ResilienceStrategyProvider.cs
@@ -1,0 +1,37 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Polly.Registry;
+
+#pragma warning disable CA1716 // Identifiers should not match keywords
+
+/// <summary>
+/// Represents a provider for resilience strategies that are accessible by <typeparamref name="TKey"/>.
+/// </summary>
+/// <typeparam name="TKey">The type of the key.</typeparam>
+public abstract class ResilienceStrategyProvider<TKey>
+    where TKey : notnull
+{
+    /// <summary>
+    /// Retrieves a resilience strategy from the provider using the specified key.
+    /// </summary>
+    /// <param name="key">The key used to identify the resilience strategy.</param>
+    /// <returns>The resilience strategy associated with the specified key.</returns>
+    /// <exception cref="KeyNotFoundException">Thrown when no resilience strategy is found for the specified key.</exception>
+    public virtual ResilienceStrategy Get(TKey key)
+    {
+        if (TryGet(key, out var strategy))
+        {
+            return strategy;
+        }
+
+        throw new KeyNotFoundException($"Unable to find a resilience strategy associated with the key '{key}'. Please ensure the either resilience strategy or builder is registered.");
+    }
+
+    /// <summary>
+    /// Tries to get a resilience strategy from the provider using the specified key.
+    /// </summary>
+    /// <param name="key">The key used to identify the resilience strategy.</param>
+    /// <param name="strategy">The output resilience strategy if found, null otherwise.</param>
+    /// <returns>true if the strategy was found, false otherwise.</returns>
+    public abstract bool TryGet(TKey key, [NotNullWhen(true)] out ResilienceStrategy? strategy);
+}

--- a/src/Polly.Core/Registry/ResilienceStrategyProvider.cs
+++ b/src/Polly.Core/Registry/ResilienceStrategyProvider.cs
@@ -24,7 +24,8 @@ public abstract class ResilienceStrategyProvider<TKey>
             return strategy;
         }
 
-        throw new KeyNotFoundException($"Unable to find a resilience strategy associated with the key '{key}'. Please ensure the either resilience strategy or builder is registered.");
+        throw new KeyNotFoundException($"Unable to find a resilience strategy associated with the key '{key}'. " +
+            $"Please ensure that either the resilience strategy or the builder is registered.");
     }
 
     /// <summary>

--- a/src/Polly.Core/Registry/ResilienceStrategyRegistry.cs
+++ b/src/Polly.Core/Registry/ResilienceStrategyRegistry.cs
@@ -1,0 +1,131 @@
+using System.Diagnostics.CodeAnalysis;
+using Polly.Builder;
+
+namespace Polly.Registry;
+
+/// <summary>
+/// Represents a registry of resilience strategies and builders that are accessible by <typeparamref name="TKey"/>.
+/// </summary>
+/// <typeparam name="TKey">The type of the key.</typeparam>
+/// <remarks>
+/// The ResilienceStrategyRegistry class provides a way to organize and manage multiple resilience strategies
+/// using keys of type <typeparamref name="TKey"/>.
+/// <para>
+/// Additionally, it allows registration of callbacks that configure the strategy using <see cref="ResilienceStrategyBuilder"/>.
+/// These callbacks are called when the resilience strategy is not yet cached and it's retrieved for the first time.
+/// </para>
+/// </remarks>
+public sealed class ResilienceStrategyRegistry<TKey> : ResilienceStrategyProvider<TKey>
+    where TKey : notnull
+{
+    private readonly Func<ResilienceStrategyBuilder> _activator;
+    private readonly ConcurrentDictionary<TKey, Action<TKey, ResilienceStrategyBuilder>> _builders;
+    private readonly ConcurrentDictionary<TKey, ResilienceStrategy> _strategies;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ResilienceStrategyRegistry{TKey}"/> class with the default comparer.
+    /// </summary>
+    public ResilienceStrategyRegistry()
+        : this(new ResilienceStrategyRegistryOptions<TKey>())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ResilienceStrategyRegistry{TKey}"/> class with a custom builder factory and comparer.
+    /// </summary>
+    /// <param name="options">The registry options.</param>
+    public ResilienceStrategyRegistry(ResilienceStrategyRegistryOptions<TKey> options)
+    {
+        Guard.NotNull(options);
+
+        ValidationHelper.ValidateObject(options, "The resilience strategy registry options are invalid.");
+
+        _activator = options.BuilderFactory;
+        _builders = new ConcurrentDictionary<TKey, Action<TKey, ResilienceStrategyBuilder>>(options.BuilderComparer);
+        _strategies = new ConcurrentDictionary<TKey, ResilienceStrategy>(options.StrategyComparer);
+    }
+
+    /// <summary>
+    /// Tries to add an existing resilience strategy to the registry.
+    /// </summary>
+    /// <param name="key">The key used to identify the resilience strategy.</param>
+    /// <param name="strategy">The resilience strategy instance.</param>
+    /// <returns>true if the strategy was added successfully, false otherwise.</returns>
+    public bool TryAdd(TKey key, ResilienceStrategy strategy)
+    {
+        Guard.NotNull(strategy);
+
+        return _strategies.TryAdd(key, strategy);
+    }
+
+    /// <summary>
+    /// Removes a resilience strategy from the registry.
+    /// </summary>
+    /// <param name="key">The key used to identify the resilience strategy.</param>
+    /// <returns>true if the strategy was removed successfully, false otherwise.</returns>
+    public bool Remove(TKey key) => _strategies.TryRemove(key, out _);
+
+    /// <summary>
+    /// Tries to get a resilience strategy from the registry.
+    /// </summary>
+    /// <param name="key">The key used to identify the resilience strategy.</param>
+    /// <param name="strategy">The output resilience strategy if found, null otherwise.</param>
+    /// <returns>true if the strategy was found, false otherwise.</returns>
+    /// <remarks>
+    /// Tries to get a strategy using the given key. If not found, it looks for a builder with the key, builds the strategy,
+    /// adds it to the registry, and returns true. If neither the strategy nor the builder is found, the method returns false.
+    /// </remarks>
+    public override bool TryGet(TKey key, [NotNullWhen(true)] out ResilienceStrategy? strategy)
+    {
+        if (_strategies.TryGetValue(key, out strategy))
+        {
+            return true;
+        }
+
+        if (_builders.TryGetValue(key, out var configure))
+        {
+            strategy = _strategies.GetOrAdd(key, key =>
+            {
+                var builder = _activator();
+                configure(key, builder);
+                return builder.Build();
+            });
+
+            return true;
+        }
+
+        strategy = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Tries to add a resilience strategy builder to the registry.
+    /// </summary>
+    /// <param name="key">The key used to identify the strategy builder.</param>
+    /// <param name="configure">The action that configures the resilience strategy builder.</param>
+    /// <returns>True if the builder was added successfully, false otherwise.</returns>
+    /// <remarks>
+    /// Use this method when you want to create the strategy on-demand when it's first accessed.
+    /// </remarks>
+    public bool TryAddBuilder(TKey key, Action<TKey, ResilienceStrategyBuilder> configure)
+    {
+        Guard.NotNull(configure);
+
+        return _builders.TryAdd(key, configure);
+    }
+
+    /// <summary>
+    /// Removes a resilience strategy builder  from the registry.
+    /// </summary>
+    /// <param name="key">The key used to identify the resilience strategy builder.</param>
+    /// <returns>true if the builder was removed successfully, false otherwise.</returns>
+    public bool RemoveBuilder(TKey key) => _builders.TryRemove(key, out _);
+
+    /// <summary>
+    /// Clears all cached strategies.
+    /// </summary>
+    /// <remarks>
+    /// This method only clears the cached strategies, the registered builders are kept unchanged.
+    /// </remarks>
+    public void Clear() => _strategies.Clear();
+}

--- a/src/Polly.Core/Registry/ResilienceStrategyRegistry.cs
+++ b/src/Polly.Core/Registry/ResilienceStrategyRegistry.cs
@@ -8,7 +8,7 @@ namespace Polly.Registry;
 /// </summary>
 /// <typeparam name="TKey">The type of the key.</typeparam>
 /// <remarks>
-/// The ResilienceStrategyRegistry class provides a way to organize and manage multiple resilience strategies
+/// This class provides a way to organize and manage multiple resilience strategies
 /// using keys of type <typeparamref name="TKey"/>.
 /// <para>
 /// Additionally, it allows registration of callbacks that configure the strategy using <see cref="ResilienceStrategyBuilder"/>.

--- a/src/Polly.Core/Registry/ResilienceStrategyRegistry.cs
+++ b/src/Polly.Core/Registry/ResilienceStrategyRegistry.cs
@@ -115,7 +115,7 @@ public sealed class ResilienceStrategyRegistry<TKey> : ResilienceStrategyProvide
     }
 
     /// <summary>
-    /// Removes a resilience strategy builder  from the registry.
+    /// Removes a resilience strategy builder from the registry.
     /// </summary>
     /// <param name="key">The key used to identify the resilience strategy builder.</param>
     /// <returns>true if the builder was removed successfully, false otherwise.</returns>

--- a/src/Polly.Core/Registry/ResilienceStrategyRegistryOptions.cs
+++ b/src/Polly.Core/Registry/ResilienceStrategyRegistryOptions.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using Polly.Builder;
 
 namespace Polly.Registry;
@@ -12,18 +12,27 @@ public class ResilienceStrategyRegistryOptions<TKey>
     /// <summary>
     /// Gets or sets the factory method that creates instances of <see cref="ResilienceStrategyBuilder"/>.
     /// </summary>
+    /// <remarks>
+    /// By default, the factory method creates a new instance of <see cref="ResilienceStrategyBuilder"/> using the default constructor.
+    /// </remarks>
     [Required]
     public Func<ResilienceStrategyBuilder> BuilderFactory { get; set; } = static () => new ResilienceStrategyBuilder();
 
     /// <summary>
     /// Gets or sets the comparer that is used by the registry to retrieve the resilience strategies.
     /// </summary>
+    /// <remarks>
+    /// By default, the comparer uses the default equality comparer for <typeparamref name="TKey"/>.
+    /// </remarks>
     [Required]
     public IEqualityComparer<TKey> StrategyComparer { get; set; } = EqualityComparer<TKey>.Default;
 
     /// <summary>
     /// Gets or sets the comparer that is used by the registry to retrieve the resilience strategy builders.
     /// </summary>
+    /// <remarks>
+    /// By default, the comparer uses the default equality comparer for <typeparamref name="TKey"/>.
+    /// </remarks>
     [Required]
     public IEqualityComparer<TKey> BuilderComparer { get; set; } = EqualityComparer<TKey>.Default;
 }

--- a/src/Polly.Core/Registry/ResilienceStrategyRegistryOptions.cs
+++ b/src/Polly.Core/Registry/ResilienceStrategyRegistryOptions.cs
@@ -1,0 +1,29 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Polly.Builder;
+
+namespace Polly.Registry;
+
+/// <summary>
+/// An options class used by <see cref="ResilienceStrategyRegistry{TKey}"/>.
+/// </summary>
+/// <typeparam name="TKey">The type of the key used by the registry.</typeparam>
+public class ResilienceStrategyRegistryOptions<TKey>
+{
+    /// <summary>
+    /// Gets or sets the factory method that creates instances of <see cref="ResilienceStrategyBuilder"/>.
+    /// </summary>
+    [Required]
+    public Func<ResilienceStrategyBuilder> BuilderFactory { get; set; } = () => new ResilienceStrategyBuilder();
+
+    /// <summary>
+    /// Gets or sets the comparer that is used by the registry to retrieve the resilience strategies.
+    /// </summary>
+    [Required]
+    public IEqualityComparer<TKey> StrategyComparer { get; set; } = EqualityComparer<TKey>.Default;
+
+    /// <summary>
+    /// Gets or sets the comparer that is used by the registry to retrieve the resilience strategy builders.
+    /// </summary>
+    [Required]
+    public IEqualityComparer<TKey> BuilderComparer { get; set; } = EqualityComparer<TKey>.Default;
+}

--- a/src/Polly.Core/Registry/ResilienceStrategyRegistryOptions.cs
+++ b/src/Polly.Core/Registry/ResilienceStrategyRegistryOptions.cs
@@ -13,7 +13,7 @@ public class ResilienceStrategyRegistryOptions<TKey>
     /// Gets or sets the factory method that creates instances of <see cref="ResilienceStrategyBuilder"/>.
     /// </summary>
     [Required]
-    public Func<ResilienceStrategyBuilder> BuilderFactory { get; set; } = () => new ResilienceStrategyBuilder();
+    public Func<ResilienceStrategyBuilder> BuilderFactory { get; set; } = static () => new ResilienceStrategyBuilder();
 
     /// <summary>
     /// Gets or sets the comparer that is used by the registry to retrieve the resilience strategies.


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors.  All non-trivial contributions get a public credit in the readme! -->

### The issue or feature being addressed

#1084 

### Details on the issue fix or feature implementation

Registry allows registration and retrieval of strategies:

``` csharp
var registry = new ResilienceStrategyRegistry<string>();
var strategy = new ResilienceStrategyBuilder().AddTimeout(TimeSpan.FromSeconds(10));

registry.TryAdd("timeout-strategy", strategy);
registry.Get("timeout-strategy");
```

Or builders:
``` csharp
var registry = new ResilienceStrategyRegistry<string>();
registry.AddBuilder("timeout-strategy", (key, builder) => builder.AddTimeout(TimeSpan.FromSeconds(10));
registry.Get("timeout-strategy"); // strategy is dynamically created on-demand
```

The more advanced scenarios allow multi-instance support where one builder is repeatedly used to create multiple strategies. Registry then caches each of these strategies individually. We need this functionality to allow having distinct circuit breaker instances that are cached by composite keys.

Typical scenario for this is having HttpClient that sends requests to a different server across multiple geo-locations. We want to have a different circuit breaker instances assigned.

``` csharp
var registry = new ResilienceStrategyRegistry<StrategyId>(new ResilienceStrategyRegistryOptions<StrategyId>
{
    StrategyComparer = StrategyId.Comparer,
    BuilderComparer = StrategyId.BuilderComparer
});

registry.TryAddBuilder(StrategyId.Create("my-pipeline"), (id, builder) => builder.AddCircuitBreaker());

// access the strategy
registry.Get(StrategyId.Create("my-pipeline", "instance-A"));
registry.Get(StrategyId.Create("my-pipeline", "instance-B"));
```

In the follow-up (#1087) I would like to introduce `Polly.Hosting` or `Polly.DependencyInjection` project that integrates the `ResilienceStrategyRegistry` into the DI and allows defining the strategies at startup using `IServiceCollection`. That way, the core infra will be done and we can focus fully on strategies.

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
