### PR TITLE
Introduce base class for predicates

### DIFF
--- a/src/Polly.Core.Tests/Polly.Core.Tests.csproj
+++ b/src/Polly.Core.Tests/Polly.Core.Tests.csproj
@@ -16,6 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Using Include="Polly.Core.Tests.Utils"/>
+    <Using Include="Polly.Core.Tests.Utils" />
   </ItemGroup>
 </Project>

--- a/src/Polly.Core.Tests/Retry/RetryStrategyOptionsTests.cs
+++ b/src/Polly.Core.Tests/Retry/RetryStrategyOptionsTests.cs
@@ -1,0 +1,15 @@
+using Polly.Retry;
+
+namespace Polly.Core.Tests.Retry;
+
+public class RetryStrategyOptionsTests
+{
+    [Fact]
+    public void Ctor_Ok()
+    {
+        var options = new RetryStrategyOptions();
+
+        options.ShouldRetry.Should().NotBeNull();
+        options.ShouldRetry.IsEmpty.Should().BeTrue();
+    }
+}

--- a/src/Polly.Core.Tests/Retry/ShouldRetryArgumentsTests.cs
+++ b/src/Polly.Core.Tests/Retry/ShouldRetryArgumentsTests.cs
@@ -1,0 +1,15 @@
+using Polly.Retry;
+
+namespace Polly.Core.Tests.Retry;
+public class ShouldRetryArgumentsTests
+{
+    [Fact]
+    public void Ctor_Ok()
+    {
+        var args = new ShouldRetryArguments(ResilienceContext.Get(), 2, TimeSpan.FromSeconds(2));
+
+        args.Context.Should().NotBeNull();
+        args.AttemptNumber.Should().Be(2);
+        args.TotalExecutionTime.Should().Be(TimeSpan.FromSeconds(2));
+    }
+}

--- a/src/Polly.Core.Tests/Retry/ShouldRetryArgumentsTests.cs
+++ b/src/Polly.Core.Tests/Retry/ShouldRetryArgumentsTests.cs
@@ -1,6 +1,7 @@
 using Polly.Retry;
 
 namespace Polly.Core.Tests.Retry;
+
 public class ShouldRetryArgumentsTests
 {
     [Fact]

--- a/src/Polly.Core.Tests/Retry/ShouldRetryArgumentsTests.cs
+++ b/src/Polly.Core.Tests/Retry/ShouldRetryArgumentsTests.cs
@@ -6,10 +6,9 @@ public class ShouldRetryArgumentsTests
     [Fact]
     public void Ctor_Ok()
     {
-        var args = new ShouldRetryArguments(ResilienceContext.Get(), 2, TimeSpan.FromSeconds(2));
+        var args = new ShouldRetryArguments(ResilienceContext.Get(), 2);
 
         args.Context.Should().NotBeNull();
-        args.AttemptNumber.Should().Be(2);
-        args.TotalExecutionTime.Should().Be(TimeSpan.FromSeconds(2));
+        args.Attempt.Should().Be(2);
     }
 }

--- a/src/Polly.Core.Tests/Strategy/OutcomePredicateTests.cs
+++ b/src/Polly.Core.Tests/Strategy/OutcomePredicateTests.cs
@@ -1,0 +1,334 @@
+using System;
+using System.Threading.Tasks;
+using Polly.Strategy;
+
+namespace Polly.Core.Tests.Strategy;
+
+public class OutcomePredicateTests
+{
+    private readonly DummyPredicate _sut = new();
+
+    [Fact]
+    public void Empty_Ok()
+    {
+        _sut.IsEmpty.Should().BeTrue();
+
+        _sut.Exception<Exception>();
+
+        _sut.IsEmpty.Should().BeFalse();
+    }
+
+    [Fact]
+    public void CreateHandler_Empty_ReturnsNull()
+    {
+        _sut.CreateHandler().Should().BeNull();
+    }
+
+    public static readonly TheoryData<Action<DummyPredicate>> ExceptionPredicates = new()
+    {
+        sut =>
+        {
+            sut.Exception<InvalidOperationException>();
+            InvokeHandler(sut, new InvalidOperationException("dummy"), true);
+        },
+        sut =>
+        {
+            sut.Exception<InvalidOperationException>(_=> true);
+            InvokeHandler(sut, new ArgumentNullException("dummy"), false);
+        },
+        sut =>
+        {
+            sut.Exception<InvalidOperationException>((_, _)=> true);
+            InvokeHandler(sut, new ArgumentNullException("dummy"), false);
+        },
+        sut =>
+        {
+            sut.Exception<InvalidOperationException>((_, _)=> new ValueTask<bool>(true));
+            InvokeHandler(sut, new ArgumentNullException("dummy"), false);
+        },
+        sut =>
+        {
+            sut.Exception<InvalidOperationException>();
+            InvokeHandler(sut, new ArgumentNullException("dummy"), false);
+        },
+        sut =>
+        {
+            sut.Exception<InvalidOperationException>();
+            InvokeHandler(sut, new InvalidOperationException("dummy"), true);
+        },
+        sut =>
+        {
+            sut.Exception<InvalidOperationException>(e => e.Message.Contains("dummy"));
+            InvokeHandler(sut, new InvalidOperationException("other message"), false);
+        },
+        sut =>
+        {
+            sut.Exception<InvalidOperationException>((e, _) => e.Message.Contains("dummy"));
+            InvokeHandler(sut, new InvalidOperationException("other message"), false);
+        },
+        sut =>
+        {
+            sut.Exception<InvalidOperationException>((e, _) => e.Message.Contains("dummy"));
+            InvokeHandler(sut, new InvalidOperationException("dummy"), true);
+        },
+        sut =>
+        {
+            sut.Exception<InvalidOperationException>((e, _) => new ValueTask<bool>(e.Message.Contains("dummy")));
+            InvokeHandler(sut, new InvalidOperationException("other message"), false);
+        },
+        sut =>
+        {
+            sut.Exception<InvalidOperationException>((e, _) => new ValueTask<bool>(e.Message.Contains("dummy")));
+            InvokeHandler(sut, new InvalidOperationException("dummy"), true);
+        },
+    };
+
+    [MemberData(nameof(ExceptionPredicates))]
+    [Theory]
+    public void ExceptionHandler_SinglePredicate_Ok(Action<DummyPredicate> execute)
+    {
+        _sut.Invoking(s => execute(s)).Should().NotThrow();
+        execute(_sut);
+    }
+
+    [MemberData(nameof(ExceptionPredicates))]
+    [Theory]
+    public void ExceptionHandler_MultiplePredicates_Ok(Action<DummyPredicate> execute)
+    {
+        _sut.Exception<Exception>(e => false);
+        _sut.Invoking(s => execute(s)).Should().NotThrow();
+    }
+
+    public static readonly TheoryData<Action<DummyPredicate>> ResultPredicates = new()
+    {
+        sut =>
+        {
+            sut.Result(10);
+            InvokeResultHandler(sut, 10, true);
+        },
+        sut =>
+        {
+            sut.Result(11);
+            InvokeResultHandler(sut, 10, false);
+        },
+        sut =>
+        {
+            sut.Result(10);
+            InvokeResultHandler(sut, 10.0, false);
+        },
+        sut =>
+        {
+            sut.Result<int>(result => result == 5);
+            InvokeResultHandler(sut, 5, true);
+        },
+        sut =>
+        {
+            sut.Result<int>(result => result == 5);
+            InvokeResultHandler(sut, 6, false);
+        },
+        sut =>
+        {
+            sut.Result<int>((result, _) => result == 5);
+            InvokeResultHandler(sut, 5, true);
+        },
+        sut =>
+        {
+            sut.Result<int>((result, _) => result == 5);
+            InvokeResultHandler(sut, 6, false);
+        },
+        sut =>
+        {
+            sut.Result<int>((result, _) => new ValueTask<bool>(result == 5));
+            InvokeResultHandler(sut, 5, true);
+        },
+        sut =>
+        {
+            sut.Result<int>((result, _) => new ValueTask<bool>(result == 5));
+            InvokeResultHandler(sut, 6, false);
+        },
+        sut =>
+        {
+            sut.Result(10);
+            sut.Result(11);
+            sut.Result("dummy-1");
+            sut.Result("dummy-2");
+
+            InvokeResultHandler(sut, "dummy", false);
+            InvokeResultHandler(sut, "dummy-1", true);
+            InvokeResultHandler(sut, "dummy-2", true);
+
+            InvokeResultHandler(sut, 10, true);
+            InvokeResultHandler(sut, 11, true);
+            InvokeResultHandler(sut, 12, false);
+
+            InvokeResultHandler(sut, new object(), false);
+        },
+        sut =>
+        {
+            sut.Outcome<int>((outcome, _) => new ValueTask<bool>(outcome.Result == 5));
+            InvokeResultHandler(sut, 6, false);
+        },
+        sut =>
+        {
+            sut.Outcome<int>((outcome, _) => new ValueTask<bool>(outcome.Result == 6));
+            InvokeResultHandler(sut, 6, true);
+        },
+        sut =>
+        {
+            sut.Outcome<int>((outcome, _) => outcome.Result == 5);
+            InvokeResultHandler(sut, 6, false);
+        },
+        sut =>
+        {
+            sut.Outcome<int>((outcome, _) => outcome.Result == 6);
+            InvokeResultHandler(sut, 6, true);
+        },
+        sut =>
+        {
+            sut.Result<int>((result, _) => result == 6);
+            InvokeHandler(sut, new InvalidOperationException(), false);
+            InvokeHandler<int>(sut, new InvalidOperationException(), false);
+        },
+        sut =>
+        {
+            sut.Result<int>((result, _) => new ValueTask<bool>(result == 6));
+            InvokeHandler(sut, new InvalidOperationException(), false);
+            InvokeHandler<int>(sut, new InvalidOperationException(), false);
+        },
+        sut =>
+        {
+            sut.Outcome<int>((outcome, _) => outcome.Exception is InvalidOperationException);
+            InvokeHandler<int>(sut, new InvalidOperationException(), true);
+        },
+        sut =>
+        {
+            sut.Outcome<int>((outcome, _) => new ValueTask<bool>(outcome.Exception is InvalidOperationException));
+            InvokeHandler<int>(sut, new InvalidOperationException(), true);
+        }
+    };
+
+    [MemberData(nameof(ResultPredicates))]
+    [Theory]
+    public void ResultHandler_SinglePredicate_Ok(Action<DummyPredicate> executeResult)
+    {
+        _sut.Invoking(s => executeResult(s)).Should().NotThrow();
+        executeResult(_sut);
+    }
+
+    [MemberData(nameof(ResultPredicates))]
+    [Theory]
+    public void ResultHandler_MultiplePredicates_Ok(Action<DummyPredicate> executeResult)
+    {
+        _sut.Exception<Exception>(e => false);
+        _sut.Invoking(s => executeResult(s)).Should().NotThrow();
+    }
+
+    [InlineData(true)]
+    [InlineData(false)]
+    [Theory]
+    public void AddResultHandlers_Multiple(bool differentTypes)
+    {
+        var callbacks = new List<int>();
+
+        for (var i = 0; i < 10; i++)
+        {
+            var index = i;
+
+            _sut.Result<int>(result =>
+            {
+                callbacks.Add(index);
+                return false;
+            });
+
+            if (differentTypes)
+            {
+                _sut.Result<string>(result =>
+                {
+                    callbacks.Add(index);
+                    return false;
+                });
+            }
+        }
+
+        InvokeResultHandler(_sut, 10, false);
+        callbacks.Distinct().Should().HaveCount(10);
+    }
+
+    [Fact]
+    public void AddResultHandlers_DifferentResultType_NotInvoked()
+    {
+        var callbacks = new List<int>();
+
+        for (var i = 0; i < 10; i++)
+        {
+            var index = i;
+
+            _sut.Result<int>(result =>
+            {
+                callbacks.Add(index);
+                return false;
+            });
+        }
+
+        InvokeResultHandler(_sut, new object(), false);
+
+        callbacks.Distinct().Should().HaveCount(0);
+    }
+
+    [Fact]
+    public void AddResultHandlers_StopOnTrue()
+    {
+        var callbacks = new List<int>();
+
+        for (var i = 0; i < 10; i++)
+        {
+            var index = i;
+
+            _sut.Result<int>(result =>
+            {
+                callbacks.Add(index);
+                return index > 5;
+            });
+        }
+
+        InvokeResultHandler(_sut, 1, true);
+        callbacks.Distinct().Should().HaveCount(7);
+    }
+
+    private static void InvokeHandler<TResult>(DummyPredicate sut, Exception exception, bool expectedResult)
+    {
+        var args = new Args();
+        sut.CreateHandler()!.ShouldHandle(new Outcome<TResult>(exception), args).AsTask().Result.Should().Be(expectedResult);
+    }
+
+    private static void InvokeHandler(DummyPredicate sut, Exception exception, bool expectedResult)
+    {
+        var args = new Args();
+
+        sut.CreateHandler()!.ShouldHandle(new Outcome<object>(exception), args).AsTask().Result.Should().Be(expectedResult);
+
+        // again with void result
+        sut.CreateHandler()!.ShouldHandle(new Outcome<VoidResult>(exception), args).AsTask().Result.Should().Be(expectedResult);
+
+        // again with result
+        sut.Result(12345);
+        sut.CreateHandler()!.ShouldHandle(new Outcome<int>(10), args).AsTask().Result.Should().Be(false);
+    }
+
+    private static void InvokeResultHandler<T>(DummyPredicate sut, T result, bool expectedResult)
+    {
+        var args = new Args();
+        sut.CreateHandler()!.ShouldHandle<T>(new Outcome<T>(result), args).AsTask().Result.Should().Be(expectedResult);
+    }
+
+    public sealed class DummyPredicate : OutcomePredicate<Args, DummyPredicate>
+    {
+    }
+
+    public class Args : IResilienceArguments
+    {
+        public Args() => Context = ResilienceContext.Get();
+
+        public ResilienceContext Context { get; private set; }
+    }
+}

--- a/src/Polly.Core.Tests/Strategy/OutcomeTests.cs
+++ b/src/Polly.Core.Tests/Strategy/OutcomeTests.cs
@@ -1,0 +1,38 @@
+using System;
+using Polly.Strategy;
+
+namespace Polly.Core.Tests.Strategy;
+public class OutcomeTests
+{
+    [Fact]
+    public void Ctor_Result_Ok()
+    {
+        var outcome = new Outcome<int>(10);
+        outcome.HasResult.Should().BeTrue();
+        outcome.Exception.Should().BeNull();
+        outcome.IsVoidResult.Should().BeFalse();
+        outcome.TryGetResult(out var result).Should().BeTrue();
+        result.Should().Be(10);
+    }
+
+    [Fact]
+    public void Ctor_VoidResult_Ok()
+    {
+        var outcome = new Outcome<VoidResult>(VoidResult.Instance);
+        outcome.HasResult.Should().BeTrue();
+        outcome.Exception.Should().BeNull();
+        outcome.IsVoidResult.Should().BeTrue();
+        outcome.TryGetResult(out var result).Should().BeFalse();
+        outcome.Result.Should().Be(VoidResult.Instance);
+    }
+
+    [Fact]
+    public void Ctor_Exception_Ok()
+    {
+        var outcome = new Outcome<VoidResult>(new InvalidOperationException());
+        outcome.HasResult.Should().BeFalse();
+        outcome.Exception.Should().NotBeNull();
+        outcome.IsVoidResult.Should().BeFalse();
+        outcome.TryGetResult(out var result).Should().BeFalse();
+    }
+}

--- a/src/Polly.Core/Retry/RetryStrategyOptions.cs
+++ b/src/Polly.Core/Retry/RetryStrategyOptions.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Polly.Retry;
+
+/// <summary>
+/// Represents the options used to configure a retry strategy.
+/// </summary>
+public class RetryStrategyOptions
+{
+    /// <summary>
+    /// Gets or sets the <see cref="ShouldRetryPredicate"/> instance used to determine if a retry should be performed.
+    /// </summary>
+    [Required]
+    public ShouldRetryPredicate ShouldRetry { get; set; } = new();
+}

--- a/src/Polly.Core/Retry/ShouldRetryArguments.cs
+++ b/src/Polly.Core/Retry/ShouldRetryArguments.cs
@@ -1,0 +1,37 @@
+using Polly.Strategy;
+
+namespace Polly.Retry;
+
+#pragma warning disable CA1815 // Override equals and operator equals on value types
+
+/// <summary>
+/// Represents the arguments used in <see cref="ShouldRetryPredicate"/> for determining whether a retry should be performed.
+/// </summary>
+public readonly struct ShouldRetryArguments : IResilienceArguments
+{
+    internal ShouldRetryArguments(ResilienceContext context, int attemptNumber, TimeSpan totalExecutionTime)
+    {
+        AttemptNumber = attemptNumber;
+        TotalExecutionTime = totalExecutionTime;
+        Context = context;
+    }
+
+    /// <summary>
+    /// Gets the zero-based attempt number.
+    /// </summary>
+    /// <remarks>
+    /// The first attempt is 0, the second attempt is 1, and so on.
+    /// </remarks>
+    public int AttemptNumber { get; }
+
+    /// <summary>
+    /// Gets the total execution time.
+    /// </summary>
+    /// <remarks>
+    /// The total execution time from the very first attempt and up to this point.
+    /// </remarks>
+    public TimeSpan TotalExecutionTime { get; }
+
+    /// <inheritdoc/>
+    public ResilienceContext Context { get; }
+}

--- a/src/Polly.Core/Retry/ShouldRetryArguments.cs
+++ b/src/Polly.Core/Retry/ShouldRetryArguments.cs
@@ -9,10 +9,9 @@ namespace Polly.Retry;
 /// </summary>
 public readonly struct ShouldRetryArguments : IResilienceArguments
 {
-    internal ShouldRetryArguments(ResilienceContext context, int attemptNumber, TimeSpan totalExecutionTime)
+    internal ShouldRetryArguments(ResilienceContext context, int attemptNumber)
     {
-        AttemptNumber = attemptNumber;
-        TotalExecutionTime = totalExecutionTime;
+        Attempt = attemptNumber;
         Context = context;
     }
 
@@ -22,15 +21,7 @@ public readonly struct ShouldRetryArguments : IResilienceArguments
     /// <remarks>
     /// The first attempt is 0, the second attempt is 1, and so on.
     /// </remarks>
-    public int AttemptNumber { get; }
-
-    /// <summary>
-    /// Gets the total execution time.
-    /// </summary>
-    /// <remarks>
-    /// The total execution time from the very first attempt and up to this point.
-    /// </remarks>
-    public TimeSpan TotalExecutionTime { get; }
+    public int Attempt { get; }
 
     /// <inheritdoc/>
     public ResilienceContext Context { get; }

--- a/src/Polly.Core/Retry/ShouldRetryPredicate.cs
+++ b/src/Polly.Core/Retry/ShouldRetryPredicate.cs
@@ -1,0 +1,10 @@
+using Polly.Strategy;
+
+namespace Polly.Retry;
+
+/// <summary>
+/// This class configures the predicates used by the retry strategy to determine if a retry should be performed.
+/// </summary>
+public sealed class ShouldRetryPredicate : OutcomePredicate<ShouldRetryArguments, ShouldRetryPredicate>
+{
+}

--- a/src/Polly.Core/Strategy/Outcome.cs
+++ b/src/Polly.Core/Strategy/Outcome.cs
@@ -1,0 +1,67 @@
+using System.Diagnostics.CodeAnalysis;
+
+#pragma warning disable CA1815 // Override equals and operator equals on value types
+
+namespace Polly.Strategy;
+
+/// <summary>
+/// Represents the outcome of an operation that returns a result of type TResult or an exception.
+/// </summary>
+/// <typeparam name="TResult">The type of the result produced by the operation.</typeparam>
+public readonly struct Outcome<TResult>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Outcome{TResult}"/> struct with the specified exception.
+    /// </summary>
+    /// <param name="exception">The exception that occurred during the operation.</param>
+    public Outcome(Exception exception)
+    : this() => Exception = Guard.NotNull(exception);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Outcome{TResult}"/> struct with the specified result.
+    /// </summary>
+    /// <param name="result">The result produced by the operation.</param>
+    public Outcome(TResult result)
+    : this() => Result = result;
+
+    /// <summary>
+    /// Gets the exception that occurred during the operation, if any.
+    /// </summary>
+    public Exception? Exception { get; }
+
+    /// <summary>
+    /// Gets the result produced by the operation, if any.
+    /// </summary>
+    public TResult? Result { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the operation produced a result.
+    /// </summary>
+    /// <remarks>
+    /// If the operation returned a void result the value will be <c>true</c>.
+    /// You can use <see cref="IsVoidResult"/> to determine if the result is a void result.
+    /// </remarks>
+    public bool HasResult => Exception == null;
+
+    /// <summary>
+    /// Gets a value indicating whether the operation produced a void result.
+    /// </summary>
+    public bool IsVoidResult => Result is VoidResult;
+
+    /// <summary>
+    /// Tries to get a result if available.
+    /// </summary>
+    /// <param name="result">The result instance.</param>
+    /// <returns>True if result is available, false otherwise.</returns>
+    public bool TryGetResult([NotNullWhen(true)] out TResult? result)
+    {
+        if (HasResult && !IsVoidResult)
+        {
+            result = Result!;
+            return true;
+        }
+
+        result = default;
+        return false;
+    }
+}

--- a/src/Polly.Core/Strategy/OutcomePredicate.Handler.cs
+++ b/src/Polly.Core/Strategy/OutcomePredicate.Handler.cs
@@ -1,0 +1,105 @@
+using System.Collections.Generic;
+
+namespace Polly.Strategy;
+
+#pragma warning disable CA1034 // Nested types should not be visible
+
+public abstract partial class OutcomePredicate<TArgs, TSelf>
+{
+    /// <summary>
+    /// The resulting predicate handler.
+    /// </summary>
+    public abstract class Handler
+    {
+        private protected Handler()
+        {
+        }
+
+        /// <summary>
+        /// Determines if the handler should handle the outcome.
+        /// </summary>
+        /// <typeparam name="TResult">The result type to add a predicate for.</typeparam>
+        /// <param name="outcome">The operation outcome.</param>
+        /// <param name="args">The arguments.</param>
+        /// <returns>The result of the handle operation.</returns>
+        public abstract ValueTask<bool> ShouldHandle<TResult>(Outcome<TResult> outcome, TArgs args);
+    }
+
+    private sealed class TypeHandler : Handler
+    {
+        private readonly Type _type;
+        private readonly object[] _predicates;
+
+        public TypeHandler(Type type, List<object> predicates)
+        {
+            _type = type;
+            _predicates = predicates.ToArray();
+        }
+
+        public override ValueTask<bool> ShouldHandle<TResult>(Outcome<TResult> outcome, TArgs args)
+        {
+            // special case for exception-based callbacks
+            if (!outcome.HasResult && _type == typeof(ExceptionOutcome))
+            {
+                return ShouldHandlerCoreAsync(new Outcome<ExceptionOutcome>(outcome.Exception!), args);
+            }
+
+            if (typeof(TResult) != _type)
+            {
+                return new ValueTask<bool>(false);
+            }
+
+            return ShouldHandlerCoreAsync(outcome, args);
+        }
+
+        private ValueTask<bool> ShouldHandlerCoreAsync<TResult>(Outcome<TResult> outcome, TArgs args)
+        {
+            if (_predicates.Length == 1)
+            {
+                var predicate = (Func<Outcome<TResult>, TArgs, ValueTask<bool>>)_predicates[0];
+
+                return predicate(outcome, args);
+            }
+
+            return ExecutePredicatesAsync(outcome, args);
+        }
+
+        private async ValueTask<bool> ExecutePredicatesAsync<TResult>(Outcome<TResult> outcome, TArgs args)
+        {
+            foreach (var obj in _predicates)
+            {
+                var predicate = (Func<Outcome<TResult>, TArgs, ValueTask<bool>>)obj;
+
+                if (await predicate(outcome, args).ConfigureAwait(args.Context.ContinueOnCapturedContext))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
+    private sealed class TypesHandler : Handler
+    {
+        private readonly Dictionary<Type, TypeHandler> _predicates;
+
+        public TypesHandler(IEnumerable<KeyValuePair<Type, List<object>>> predicates)
+            => _predicates = predicates.ToDictionary(v => v.Key, v => new TypeHandler(v.Key, v.Value));
+
+        public override async ValueTask<bool> ShouldHandle<TResult>(Outcome<TResult> outcome, TArgs args)
+        {
+            if (_predicates.TryGetValue(typeof(TResult), out var handler) && await handler.ShouldHandle(outcome, args).ConfigureAwait(args.Context.ContinueOnCapturedContext))
+            {
+                return true;
+            }
+
+            if (!outcome.HasResult && _predicates.TryGetValue(typeof(ExceptionOutcome), out var exceptionHandler))
+            {
+                return await exceptionHandler.ShouldHandle(outcome, args).ConfigureAwait(args.Context.ContinueOnCapturedContext);
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Polly.Core/Strategy/OutcomePredicate.cs
+++ b/src/Polly.Core/Strategy/OutcomePredicate.cs
@@ -1,0 +1,229 @@
+using System;
+using Polly.Strategy;
+
+namespace Polly.Strategy;
+
+/// <summary>
+/// The base class for predicates that use <see cref="Strategy.Outcome{TResult}"/> as an input.
+/// </summary>
+/// <typeparam name="TArgs">The type of arguments the predicate uses.</typeparam>
+/// <typeparam name="TSelf">The class that implements <see cref="OutcomePredicate{TArgs, TSelf}"/>.</typeparam>
+public abstract partial class OutcomePredicate<TArgs, TSelf>
+    where TArgs : IResilienceArguments
+    where TSelf : OutcomePredicate<TArgs, TSelf>
+{
+    private readonly Dictionary<Type, List<object>> _predicates = new();
+
+    /// <summary>
+    /// Gets a value indicating whether the predicate is empty.
+    /// </summary>
+    public bool IsEmpty => _predicates.Count == 0;
+
+    /// <summary>
+    /// Adds an exception predicate for the specified exception type.
+    /// </summary>
+    /// <typeparam name="TException">The exception type to add a predicate for.</typeparam>
+    /// <returns>The current updated instance.</returns>
+    public TSelf Exception<TException>()
+        where TException : Exception
+    {
+        return Outcome<ExceptionOutcome>((outcome, _) =>
+        {
+            if (outcome.Exception is TException typedException)
+            {
+                return new ValueTask<bool>(true);
+            }
+
+            return new ValueTask<bool>(false);
+        });
+    }
+
+    /// <summary>
+    /// Adds an exception predicate for the specified exception type.
+    /// </summary>
+    /// <typeparam name="TException">The exception type to add a predicate for.</typeparam>
+    /// <param name="predicate">The predicate to determine if the exception should be retried.</param>
+    /// <returns>The current updated instance.</returns>
+    public TSelf Exception<TException>(Func<TException, bool> predicate)
+        where TException : Exception
+    {
+        Guard.NotNull(predicate);
+
+        return Outcome<ExceptionOutcome>((outcome, _) =>
+        {
+            if (outcome.Exception is TException typedException)
+            {
+                return new ValueTask<bool>(predicate(typedException));
+            }
+
+            return new ValueTask<bool>(false);
+        });
+    }
+
+    /// <summary>
+    /// Adds an exception predicate for the specified exception type.
+    /// </summary>
+    /// <typeparam name="TException">The exception type to add a predicate for.</typeparam>
+    /// <param name="predicate">The predicate to determine if the exception should be retried.</param>
+    /// <returns>The current updated instance.</returns>
+    public TSelf Exception<TException>(Func<TException, TArgs, bool> predicate)
+        where TException : Exception
+    {
+        Guard.NotNull(predicate);
+
+        return Outcome<ExceptionOutcome>((outcome, args) =>
+        {
+            if (outcome.Exception is TException typedException)
+            {
+                return new ValueTask<bool>(predicate(typedException, args));
+            }
+
+            return new ValueTask<bool>(false);
+        });
+    }
+
+    /// <summary>
+    /// Adds an exception predicate for the specified exception type.
+    /// </summary>
+    /// <typeparam name="TException">The exception type to add a predicate for.</typeparam>
+    /// <param name="predicate">The predicate to determine if the exception should be retried.</param>
+    /// <returns>The current updated instance.</returns>
+    public TSelf Exception<TException>(Func<TException, TArgs, ValueTask<bool>> predicate)
+        where TException : Exception
+    {
+        Guard.NotNull(predicate);
+
+        return Outcome<ExceptionOutcome>((outcome, args) =>
+        {
+            if (outcome.Exception is TException typedException)
+            {
+                return predicate(typedException, args);
+            }
+
+            return new ValueTask<bool>(false);
+        });
+    }
+
+    /// <summary>
+    /// Adds a result predicate for the specified result value.
+    /// </summary>
+    /// <typeparam name="TResult">The result type to add a predicate for.</typeparam>
+    /// <param name="value">The result value to be retried.</param>
+    /// <returns>The current updated instance.</returns>
+    /// <remarks>
+    /// By default, the default equality comparer is used to compare the result value with the value specified in this method.
+    /// </remarks>
+    public TSelf Result<TResult>(TResult value)
+    {
+        return Result<TResult>((result, _) => new ValueTask<bool>(EqualityComparer<TResult>.Default.Equals(result, value)));
+    }
+
+    /// <summary>
+    /// Adds a result predicate for the specified result type.
+    /// </summary>
+    /// <typeparam name="TResult">The result type to add a predicate for.</typeparam>
+    /// <param name="predicate">The predicate to determine if the result should be retried.</param>
+    /// <returns>The current updated instance.</returns>
+    public TSelf Result<TResult>(Func<TResult, bool> predicate)
+    {
+        Guard.NotNull(predicate);
+
+        return Result<TResult>((result, _) => new ValueTask<bool>(predicate(result)));
+    }
+
+    /// <summary>
+    /// Adds a result predicate for the specified result type.
+    /// </summary>
+    /// <typeparam name="TResult">The result type to add a predicate for.</typeparam>
+    /// <param name="predicate">The predicate to determine if the result should be retried.</param>
+    /// <returns>The current updated instance.</returns>
+    public TSelf Result<TResult>(Func<TResult, TArgs, bool> predicate)
+    {
+        Guard.NotNull(predicate);
+
+        return Outcome<TResult>((outcome, args) =>
+        {
+            return new ValueTask<bool>(outcome.TryGetResult(out var result) && predicate(result, args));
+        });
+    }
+
+    /// <summary>
+    /// Adds a result predicate for the specified result type.
+    /// </summary>
+    /// <typeparam name="TResult">The result type to add a predicate for.</typeparam>
+    /// <param name="predicate">The predicate to determine if the result should be retried.</param>
+    /// <returns>The current updated instance.</returns>
+    public TSelf Result<TResult>(Func<TResult, TArgs, ValueTask<bool>> predicate)
+    {
+        Guard.NotNull(predicate);
+
+        return Outcome<TResult>((outcome, args) =>
+        {
+            if (outcome.TryGetResult(out var result))
+            {
+                return predicate(result, args);
+            }
+
+            return new ValueTask<bool>(false);
+        });
+    }
+
+    /// <summary>
+    /// Adds a result predicate for the specified result type.
+    /// </summary>
+    /// <typeparam name="TResult">The result type to add a predicate for.</typeparam>
+    /// <param name="predicate">The predicate to determine if the result should be retried.</param>
+    /// <returns>The current updated instance.</returns>
+    public TSelf Outcome<TResult>(Func<Outcome<TResult>, TArgs, bool> predicate)
+    {
+        Guard.NotNull(predicate);
+
+        return Outcome<TResult>((outcome, args) => new ValueTask<bool>(predicate(outcome, args)));
+    }
+
+    /// <summary>
+    /// Adds a result predicate for the specified result type.
+    /// </summary>
+    /// <typeparam name="TResult">The result type to add a predicate for.</typeparam>
+    /// <param name="predicate">The predicate to determine if the result should be retried.</param>
+    /// <returns>The current updated instance.</returns>
+    public TSelf Outcome<TResult>(Func<Outcome<TResult>, TArgs, ValueTask<bool>> predicate)
+    {
+        Guard.NotNull(predicate);
+
+        if (!_predicates.TryGetValue(typeof(TResult), out var predicates))
+        {
+            predicates = new List<object> { predicate };
+            _predicates.Add(typeof(TResult), predicates);
+        }
+        else
+        {
+            predicates.Add(predicate);
+        }
+
+        return (TSelf)this;
+    }
+
+    /// <summary>
+    /// Creates a handler for the specified predicates.
+    /// </summary>
+    /// <returns>Handler instance or null if no predicates are registered.</returns>
+    protected internal Handler? CreateHandler()
+    {
+        var pairs = _predicates.ToArray();
+
+        return pairs.Length switch
+        {
+            0 => null,
+            1 => new TypeHandler(pairs[0].Key, pairs[0].Value),
+            _ => new TypesHandler(pairs)
+        };
+    }
+
+    /// <summary>
+    /// A special type for predicates that only care about exceptions.
+    /// </summary>
+    private sealed class ExceptionOutcome
+    {
+    }
+}


### PR DESCRIPTION
### The issue or feature being addressed

#1067 

### Details on the issue fix or feature implementation

Contributes to #1093 

Usage:

Derive from the base class:

``` csharp
public sealed class ShouldRetryPredicate : Predicate<ShouldRetryArguments, ShouldRetryPredicate>
{
}
```
And call the methods on `ShouldRetryPredicate`:

``` csharp
predicate
   .AddException<InvalidOperationException>()
   .AddResult(1))
   .AddResult(result => IsValid(result));
```

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
