### PR TITLE
Introduce OutcomeGenerator

### DIFF
--- a/src/Polly.Core.Tests/Polly.Core.Tests.csproj
+++ b/src/Polly.Core.Tests/Polly.Core.Tests.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <SkipPollyUsings>true</SkipPollyUsings>
     <Threshold>100</Threshold>
-    <NoWarn>$(NoWarn);SA1600;SA1204</NoWarn>
+    <NoWarn>$(NoWarn);SA1600;SA1204;SA1602</NoWarn>
     <Include>[Polly.Core]*</Include>
   </PropertyGroup>
 

--- a/src/Polly.Core.Tests/Retry/RetryDelayArgumentsTests.cs
+++ b/src/Polly.Core.Tests/Retry/RetryDelayArgumentsTests.cs
@@ -1,0 +1,15 @@
+using Polly.Retry;
+
+namespace Polly.Core.Tests.Retry;
+
+public class RetryDelayArgumentsTests
+{
+    [Fact]
+    public void Ctor_Ok()
+    {
+        var args = new RetryDelayArguments(ResilienceContext.Get(), 2);
+
+        args.Context.Should().NotBeNull();
+        args.Attempt.Should().Be(2);
+    }
+}

--- a/src/Polly.Core.Tests/Retry/RetryDelayGeneratorTests.cs
+++ b/src/Polly.Core.Tests/Retry/RetryDelayGeneratorTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Polly.Retry;
 using Polly.Strategy;
+using Xunit;
 
 namespace Polly.Core.Tests.Retry;
 
@@ -18,14 +19,17 @@ public class RetryDelayGeneratorTests
         result.Should().Be(TimeSpan.MinValue);
     }
 
-    [Fact]
-    public async Task GeneratorRegistered_EnsureValueNotIgnored()
+    public static readonly TheoryData<TimeSpan> ValidDelays = new() { TimeSpan.Zero, TimeSpan.FromMilliseconds(123) };
+
+    [MemberData(nameof(ValidDelays))]
+    [Theory]
+    public async Task GeneratorRegistered_EnsureValueNotIgnored(TimeSpan delay)
     {
         var result = await new RetryDelayGenerator()
-            .SetGenerator<int>((_, _) => TimeSpan.FromMilliseconds(123))
+            .SetGenerator<int>((_, _) => delay)
             .CreateHandler()!
             .Generate(new Outcome<int>(0), new RetryDelayArguments(ResilienceContext.Get(), 0));
 
-        result.Should().Be(TimeSpan.FromMilliseconds(123));
+        result.Should().Be(delay);
     }
 }

--- a/src/Polly.Core.Tests/Retry/RetryDelayGeneratorTests.cs
+++ b/src/Polly.Core.Tests/Retry/RetryDelayGeneratorTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Threading.Tasks;
+using Polly.Retry;
+using Polly.Strategy;
+
+namespace Polly.Core.Tests.Retry;
+
+public class RetryDelayGeneratorTests
+{
+    [Fact]
+    public async Task NoGeneratorRegisteredForType_EnsureDefaultValue()
+    {
+        var result = await new RetryDelayGenerator()
+            .SetGenerator<int>((_, _) => TimeSpan.Zero)
+            .CreateHandler()!
+            .Generate(new Outcome<bool>(true), new RetryDelayArguments(ResilienceContext.Get(), 0));
+
+        result.Should().Be(TimeSpan.MinValue);
+    }
+
+    [Fact]
+    public async Task GeneratorRegistered_EnsureValueNotIgnored()
+    {
+        var result = await new RetryDelayGenerator()
+            .SetGenerator<int>((_, _) => TimeSpan.FromMilliseconds(123))
+            .CreateHandler()!
+            .Generate(new Outcome<int>(0), new RetryDelayArguments(ResilienceContext.Get(), 0));
+
+        result.Should().Be(TimeSpan.FromMilliseconds(123));
+    }
+}

--- a/src/Polly.Core.Tests/Retry/RetryStrategyOptionsTests.cs
+++ b/src/Polly.Core.Tests/Retry/RetryStrategyOptionsTests.cs
@@ -11,5 +11,8 @@ public class RetryStrategyOptionsTests
 
         options.ShouldRetry.Should().NotBeNull();
         options.ShouldRetry.IsEmpty.Should().BeTrue();
+
+        options.RetryDelayGenerator.Should().NotBeNull();
+        options.RetryDelayGenerator.IsEmpty.Should().BeTrue();
     }
 }

--- a/src/Polly.Core.Tests/Strategy/OutcomeGeneratorTests.cs
+++ b/src/Polly.Core.Tests/Strategy/OutcomeGeneratorTests.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Threading.Tasks;
+using Polly.Strategy;
+
+namespace Polly.Core.Tests.Strategy;
+
+public class OutcomeGeneratorTests
+{
+    private readonly DummyGenerator _sut = new();
+
+    [Fact]
+    public void Empty_Ok()
+    {
+        _sut.IsEmpty.Should().BeTrue();
+
+        _sut.SetGenerator<int>((_, _) => GeneratedValue.Invalid);
+
+        _sut.IsEmpty.Should().BeFalse();
+    }
+
+    [Fact]
+    public void CreateHandler_Empty_ReturnsNull()
+    {
+        _sut.CreateHandler().Should().BeNull();
+    }
+
+    public static readonly TheoryData<Action<DummyGenerator>> Data = new()
+    {
+        sut =>
+        {
+            sut.SetGenerator<int>((_, _) => GeneratedValue.Valid1);
+            InvokeHandler(sut, new Outcome<int>(0), GeneratedValue.Valid1);
+        },
+        sut =>
+        {
+            sut.SetGenerator<int>((_, _) => new ValueTask<GeneratedValue>(GeneratedValue.Valid1));
+            InvokeHandler(sut, new Outcome<int>(0), GeneratedValue.Valid1);
+        },
+        sut =>
+        {
+            sut.SetGenerator<int>((_, _) => GeneratedValue.Valid1);
+            InvokeHandler(sut, new Outcome<bool>(true), GeneratedValue.Default);
+        },
+        sut =>
+        {
+            sut.SetGenerator<int>((_, _) => new ValueTask<GeneratedValue>(GeneratedValue.Valid1));
+            InvokeHandler(sut, new Outcome<bool>(true), GeneratedValue.Default);
+        },
+        sut =>
+        {
+            sut.SetGenerator<int>((_, _) => GeneratedValue.Invalid);
+            InvokeHandler(sut, new Outcome<int>(0), GeneratedValue.Default);
+        },
+        sut =>
+        {
+            sut.SetGenerator<int>((_, _) => new ValueTask<GeneratedValue>(GeneratedValue.Invalid));
+            InvokeHandler(sut, new Outcome<int>(0), GeneratedValue.Default);
+        },
+        sut =>
+        {
+            sut.SetGenerator<int>((_, _) => GeneratedValue.Valid1);
+            sut.SetGenerator<int>((_, _) => GeneratedValue.Valid2);
+            InvokeHandler(sut, new Outcome<int>(0), GeneratedValue.Valid2);
+        },
+        sut =>
+        {
+            sut.SetGenerator<int>((_, _) => new ValueTask<GeneratedValue>(GeneratedValue.Valid1));
+            sut.SetGenerator<int>((_, _) => new ValueTask<GeneratedValue>(GeneratedValue.Valid2));
+            InvokeHandler(sut, new Outcome<int>(0), GeneratedValue.Valid2);
+        },
+        sut =>
+        {
+            sut.SetGenerator<int>((_, _) => GeneratedValue.Valid1);
+            sut.SetGenerator<bool>((_, _) => GeneratedValue.Valid2);
+            InvokeHandler(sut, new Outcome<int>(0), GeneratedValue.Valid1);
+            InvokeHandler(sut, new Outcome<bool>(true), GeneratedValue.Valid2);
+        },
+        sut =>
+        {
+            sut.SetGenerator<int>((_, _) => GeneratedValue.Valid1);
+            sut.SetGenerator<double>((_, _) => GeneratedValue.Valid1);
+            InvokeHandler(sut, new Outcome<bool>(true), GeneratedValue.Default);
+        },
+    };
+
+    [MemberData(nameof(Data))]
+    [Theory]
+    public void ResultHandler_SinglePredicate_Ok(Action<DummyGenerator> callback)
+    {
+        _sut.Invoking(s => callback(s)).Should().NotThrow();
+        callback(_sut);
+    }
+
+    [Fact]
+    public void AddResultHandlers_DifferentResultType_NotInvoked()
+    {
+        var callbacks = new List<int>();
+
+        for (var i = 0; i < 10; i++)
+        {
+            var index = i;
+
+            _sut.SetGenerator<int>((_, _) =>
+            {
+                callbacks.Add(index);
+                return GeneratedValue.Valid1;
+            });
+
+            _sut.SetGenerator<bool>((_, _) =>
+            {
+                callbacks.Add(index);
+                return GeneratedValue.Valid1;
+            });
+        }
+
+        InvokeHandler(_sut, new Outcome<int>(1), GeneratedValue.Valid1);
+
+        callbacks.Distinct().Should().HaveCount(1);
+    }
+
+    private static void InvokeHandler<T>(DummyGenerator sut, Outcome<T> outcome, GeneratedValue expectedResult)
+    {
+        var args = new Args();
+        sut.CreateHandler()!.Generate(outcome, args).AsTask().Result.Should().Be(expectedResult);
+    }
+
+    public sealed class DummyGenerator : OutcomeGenerator<GeneratedValue, Args, DummyGenerator>
+    {
+        protected override GeneratedValue DefaultValue => GeneratedValue.Default;
+
+        protected override bool IsValid(GeneratedValue value) => value == GeneratedValue.Valid1 || value == GeneratedValue.Valid2;
+    }
+
+    public enum GeneratedValue
+    {
+        Default,
+        Valid1,
+        Valid2,
+        Invalid
+    }
+
+    public class Args : IResilienceArguments
+    {
+        public Args() => Context = ResilienceContext.Get();
+
+        public ResilienceContext Context { get; private set; }
+    }
+}

--- a/src/Polly.Core/Retry/RetryDelayArguments.cs
+++ b/src/Polly.Core/Retry/RetryDelayArguments.cs
@@ -5,7 +5,7 @@ namespace Polly.Retry;
 #pragma warning disable CA1815 // Override equals and operator equals on value types
 
 /// <summary>
-/// Represents the arguments used in <see cref="ShouldRetryPredicate"/> for determining whether a retry should be performed.
+/// Represents the arguments used in <see cref="RetryDelayGenerator"/> for generating the next retry delay.
 /// </summary>
 public readonly struct RetryDelayArguments : IResilienceArguments
 {

--- a/src/Polly.Core/Retry/RetryDelayArguments.cs
+++ b/src/Polly.Core/Retry/RetryDelayArguments.cs
@@ -1,0 +1,28 @@
+using Polly.Strategy;
+
+namespace Polly.Retry;
+
+#pragma warning disable CA1815 // Override equals and operator equals on value types
+
+/// <summary>
+/// Represents the arguments used in <see cref="ShouldRetryPredicate"/> for determining whether a retry should be performed.
+/// </summary>
+public readonly struct RetryDelayArguments : IResilienceArguments
+{
+    internal RetryDelayArguments(ResilienceContext context, int attempt)
+    {
+        Attempt = attempt;
+        Context = context;
+    }
+
+    /// <summary>
+    /// Gets the zero-based attempt number.
+    /// </summary>
+    /// <remarks>
+    /// The first attempt is 0, the second attempt is 1, and so on.
+    /// </remarks>
+    public int Attempt { get; }
+
+    /// <inheritdoc/>
+    public ResilienceContext Context { get; }
+}

--- a/src/Polly.Core/Retry/RetryDelayGenerator.cs
+++ b/src/Polly.Core/Retry/RetryDelayGenerator.cs
@@ -1,0 +1,18 @@
+using Polly.Strategy;
+
+namespace Polly.Retry;
+
+/// <summary>
+/// This class generates the customized retries used in retry strategy.
+/// </summary>
+/// <remarks>
+/// If the generator returns a negative value, it's value is ignored.
+/// </remarks>
+public sealed class RetryDelayGenerator : OutcomeGenerator<TimeSpan, RetryDelayArguments, RetryDelayGenerator>
+{
+    /// <inheritdoc/>
+    protected override TimeSpan DefaultValue => TimeSpan.MinValue;
+
+    /// <inheritdoc/>
+    protected override bool IsValid(TimeSpan value) => value >= TimeSpan.Zero;
+}

--- a/src/Polly.Core/Retry/RetryStrategyOptions.cs
+++ b/src/Polly.Core/Retry/RetryStrategyOptions.cs
@@ -10,6 +10,18 @@ public class RetryStrategyOptions
     /// <summary>
     /// Gets or sets the <see cref="ShouldRetryPredicate"/> instance used to determine if a retry should be performed.
     /// </summary>
+    /// <remarks>
+    /// By default, the predicate is empty and no results or exceptions are retried.
+    /// </remarks>
     [Required]
     public ShouldRetryPredicate ShouldRetry { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the <see cref="RetryDelayGenerator"/> instance that is used to generated the delay between retries.
+    /// </summary>
+    /// <remarks>
+    /// By default, the generator is empty and it does not affect the delay between retries.
+    /// </remarks>
+    [Required]
+    public RetryDelayGenerator RetryDelayGenerator { get; set; } = new();
 }

--- a/src/Polly.Core/Strategy/OutcomeGenerator.Handler.cs
+++ b/src/Polly.Core/Strategy/OutcomeGenerator.Handler.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+
+namespace Polly.Strategy;
+
+#pragma warning disable CA1034 // Nested types should not be visible
+#pragma warning disable CA1005 // Avoid excessive parameters on generic types
+#pragma warning disable S2436 // Types and methods should not have too many generic parameters
+
+public abstract partial class OutcomeGenerator<TGeneratedValue, TArgs, TSelf>
+{
+    /// <summary>
+    /// The resulting handler for the outcome.
+    /// </summary>
+    public abstract class Handler
+    {
+        private protected Handler(TGeneratedValue defaultValue, Predicate<TGeneratedValue> isValid)
+        {
+            DefaultValue = defaultValue;
+            IsValid = isValid;
+        }
+
+        internal TGeneratedValue DefaultValue { get; }
+
+        internal Predicate<TGeneratedValue> IsValid { get; }
+
+        /// <summary>
+        /// Determines if the handler should handle the outcome.
+        /// </summary>
+        /// <typeparam name="TResult">The result type to add a predicate for.</typeparam>
+        /// <param name="outcome">The operation outcome.</param>
+        /// <param name="args">The arguments.</param>
+        /// <returns>The result of the handle operation.</returns>
+        public abstract ValueTask<TGeneratedValue> Generate<TResult>(Outcome<TResult> outcome, TArgs args);
+    }
+
+    private sealed class TypeHandler : Handler
+    {
+        private readonly Type _type;
+        private readonly object _generator;
+
+        public TypeHandler(
+            Type type,
+            object generator,
+            TGeneratedValue defaultValue,
+            Predicate<TGeneratedValue> isValid)
+            : base(defaultValue, isValid)
+        {
+            _type = type;
+            _generator = generator;
+        }
+
+        public override async ValueTask<TGeneratedValue> Generate<TResult>(Outcome<TResult> outcome, TArgs args)
+        {
+            if (typeof(TResult) == _type)
+            {
+                var value = await ((Func<Outcome<TResult>, TArgs, ValueTask<TGeneratedValue>>)_generator)(outcome, args).ConfigureAwait(args.Context.ContinueOnCapturedContext);
+
+                if (IsValid(value))
+                {
+                    return value;
+                }
+
+                return DefaultValue;
+            }
+
+            return DefaultValue;
+        }
+    }
+
+    private sealed class TypesHandler : Handler
+    {
+        private readonly Dictionary<Type, TypeHandler> _generators;
+
+        public TypesHandler(
+            IEnumerable<KeyValuePair<Type, object>> generators,
+            TGeneratedValue defaultValue,
+            Predicate<TGeneratedValue> isValid)
+            : base(defaultValue, isValid)
+            => _generators = generators.ToDictionary(v => v.Key, v => new TypeHandler(v.Key, v.Value, defaultValue, isValid));
+
+        public override ValueTask<TGeneratedValue> Generate<TResult>(Outcome<TResult> outcome, TArgs args)
+        {
+            if (_generators.TryGetValue(typeof(TResult), out var handler))
+            {
+                return handler.Generate(outcome, args);
+            }
+
+            return new ValueTask<TGeneratedValue>(DefaultValue);
+        }
+    }
+}

--- a/src/Polly.Core/Strategy/OutcomeGenerator.cs
+++ b/src/Polly.Core/Strategy/OutcomeGenerator.cs
@@ -1,0 +1,81 @@
+using System;
+using Polly.Strategy;
+
+namespace Polly.Strategy;
+
+#pragma warning disable S2436 // Types and methods should not have too many generic parameters
+#pragma warning disable CA1005 // Too many generic arguments, but this is the only way to make the API work without unnecessary extensions
+
+/// <summary>
+/// The base class for all generators that generate a value based on the <see cref="Outcome{TResult}"/>.
+/// </summary>
+/// <typeparam name="TGeneratedValue">The type of generated value.</typeparam>
+/// <typeparam name="TArgs">The arguments the generator uses.</typeparam>
+/// <typeparam name="TSelf">The class that implements <see cref="OutcomeGenerator{TGeneratedValue, TArgs, TSelf}"/>.</typeparam>
+public abstract partial class OutcomeGenerator<TGeneratedValue, TArgs, TSelf>
+    where TArgs : IResilienceArguments
+    where TSelf : OutcomeGenerator<TGeneratedValue, TArgs, TSelf>
+{
+    private readonly Dictionary<Type, object> _generators = new();
+
+    /// <summary>
+    /// Gets the default value returned by the generator.
+    /// </summary>
+    protected abstract TGeneratedValue DefaultValue { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the generator is empty.
+    /// </summary>
+    public bool IsEmpty => _generators.Count == 0;
+
+    /// <summary>
+    /// Adds a result generator for the specified result type.
+    /// </summary>
+    /// <typeparam name="TResult">The result type to add a generator for.</typeparam>
+    /// <param name="generator">The generator to determine if the result should be retried.</param>
+    /// <returns>The current updated instance.</returns>
+    public TSelf SetGenerator<TResult>(Func<Outcome<TResult>, TArgs, TGeneratedValue> generator)
+    {
+        Guard.NotNull(generator);
+
+        return SetGenerator<TResult>((outcome, args) => new ValueTask<TGeneratedValue>(generator(outcome, args)));
+    }
+
+    /// <summary>
+    /// Adds a result generator for the specified result type.
+    /// </summary>
+    /// <typeparam name="TResult">The result type to add a generator for.</typeparam>
+    /// <param name="generator">The generator to determine if the result should be retried.</param>
+    /// <returns>The current updated instance.</returns>
+    public TSelf SetGenerator<TResult>(Func<Outcome<TResult>, TArgs, ValueTask<TGeneratedValue>> generator)
+    {
+        Guard.NotNull(generator);
+
+        _generators[typeof(TResult)] = generator;
+
+        return (TSelf)this;
+    }
+
+    /// <summary>
+    /// Determines if the generated value is valid.
+    /// </summary>
+    /// <param name="value">The value returned by the user-provided generator.</param>
+    /// <returns>True if generated value is valid, false otherwise.</returns>
+    protected abstract bool IsValid(TGeneratedValue value);
+
+    /// <summary>
+    /// Creates a handler for the specified generators.
+    /// </summary>
+    /// <returns>Handler instance or null if no generators are registered.</returns>
+    protected internal Handler? CreateHandler()
+    {
+        var pairs = _generators.ToArray();
+
+        return pairs.Length switch
+        {
+            0 => null,
+            1 => new TypeHandler(pairs[0].Key, pairs[0].Value, DefaultValue, IsValid),
+            _ => new TypesHandler(pairs, DefaultValue, IsValid)
+        };
+    }
+}


### PR DESCRIPTION
### The issue or feature being addressed

Contributes to #1093 and #1094 

### Details on the issue fix or feature implementation

This PR introduces the base class for all generator events that generate the output value from the outcome. It also introduces the `RetryDelayGenerator` that is able to generate delays based on user-provided callbacks.

Usage:

``` csharp
new RetryStrategyOptions()
{
    RetryDelayGenerator =
        new RetryDelayGenerator()
            // generates the delay for all int-based results
            .SetGenerator<int>((outcome, args) => TimeSpan.FromSeconds(args.Attempt))
};
```

In the next PR I'll introduce the `OutcomeEvent` and the core infra for callbacks should be done.

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
