### PR TITLE
Introduce RateLimiterResilienceStrategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,4 @@ updates:
     - dependency-name: "Microsoft.Extensions.Options"
     - dependency-name: "Microsoft.Extensions.Logging.Abstractions"
     - dependency-name: "System.Diagnostics.DiagnosticSource"
+    - dependency-name: "System.Threading.RateLimiting"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
     - uses: codecov/codecov-action@v3
       name: Upload coverage to Codecov
       with:
-        files: ./artifacts/coverage-reports/Polly.Core.Tests/Cobertura.xml,./artifacts/coverage-reports/Polly.Specs/Cobertura.xml
+        files: ./artifacts/coverage-reports/Polly.Core.Tests/Cobertura.xml,./artifacts/coverage-reports/Polly.Specs/Cobertura.xml,./artifacts/coverage-reports/Polly.RateLimiting.Tests/Cobertura.xml,./artifacts/coverage-reports/Polly.Extensions.Tests/Cobertura.xml,
         flags: ${{ matrix.os_name }}
 
     - name: Upload Mutation Report

--- a/build.cake
+++ b/build.cake
@@ -216,7 +216,9 @@ Task("__RunMutationTests")
     .Does(() =>
 {
     TestProject(File("./src/Polly.Core/Polly.Core.csproj"), File("./src/Polly.Core.Tests/Polly.Core.Tests.csproj"), "Polly.Core.csproj");
+    TestProject(File("./src/Polly.RateLimiting/Polly.RateLimiting.csproj"), File("./src/Polly.RateLimiting.Tests/Polly.RateLimiting.Tests.csproj"), "Polly.RateLimiting.csproj");
     TestProject(File("./src/Polly.Extensions/Polly.Extensions.csproj"), File("./src/Polly.Extensions.Tests/Polly.Extensions.Tests.csproj"), "Polly.Extensions.csproj");
+
     TestProject(File("./src/Polly/Polly.csproj"), File("./src/Polly.Specs/Polly.Specs.csproj"), "Polly.csproj");
 
     void TestProject(FilePath proj, FilePath testProj, string project)
@@ -265,6 +267,9 @@ Task("__CreateSignedNuGetPackages")
 
     Information("Building Polly.{0}.nupkg", nugetVersion);
     DotNetPack(System.IO.Path.Combine(srcDir, "Polly", "Polly.csproj"), dotNetPackSettings);
+
+    Information("Building Polly.RateLimiting.{0}.nupkg", nugetVersion);
+    DotNetPack(System.IO.Path.Combine(srcDir, "Polly.RateLimiting", "Polly.RateLimiting.csproj"), dotNetPackSettings);
 
     Information("Building Polly.Extensions.{0}.nupkg", nugetVersion);
     DotNetPack(System.IO.Path.Combine(srcDir, "Polly.Extensions", "Polly.Extensions.csproj"), dotNetPackSettings);

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.435" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="4.5.0" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
+    <PackageVersion Include="System.Threading.RateLimiting" Version="7.0.0" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="xunit" Version="2.4.2" />

--- a/src/Polly.Core/Retry/RetryResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/Retry/RetryResilienceStrategyBuilderExtensions.cs
@@ -1,7 +1,8 @@
 using System;
 using Polly.Builder;
+using Polly.Retry;
 
-namespace Polly.Retry;
+namespace Polly;
 
 /// <summary>
 /// Retry extension methods for the <see cref="ResilienceStrategyBuilder"/>.

--- a/src/Polly.Core/Strategy/SimpleEvent.cs
+++ b/src/Polly.Core/Strategy/SimpleEvent.cs
@@ -63,7 +63,11 @@ public abstract class SimpleEvent<TArgs, TSelf>
         return (TSelf)this;
     }
 
-    internal Func<TArgs, ValueTask>? CreateHandler()
+    /// <summary>
+    /// Creates a callback handler for all registered event callbacks.
+    /// </summary>
+    /// <returns>A callback handler.</returns>
+    protected internal Func<TArgs, ValueTask>? CreateHandler()
     {
         return _callbacks.Count switch
         {

--- a/src/Polly.Core/Timeout/TimeoutResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/Timeout/TimeoutResilienceStrategyBuilderExtensions.cs
@@ -1,7 +1,8 @@
 using System;
 using Polly.Builder;
+using Polly.Timeout;
 
-namespace Polly.Timeout;
+namespace Polly;
 
 /// <summary>
 /// Extension methods for adding timeouts to a <see cref="ResilienceStrategyBuilder"/>.

--- a/src/Polly.Core/Utils/Guard.cs
+++ b/src/Polly.Core/Utils/Guard.cs
@@ -1,7 +1,9 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace Polly.Utils;
 
+[ExcludeFromCodeCoverage]
 internal static class Guard
 {
     public static T NotNull<T>(T value, [CallerArgumentExpression("value")] string argumentName = "")

--- a/src/Polly.Core/Utils/SynchronousExecutionHelper.cs
+++ b/src/Polly.Core/Utils/SynchronousExecutionHelper.cs
@@ -15,10 +15,13 @@ internal static class SynchronousExecutionHelper
             "The value task should be already completed at this point. If not, it's an indication that the strategy does not respect the ResilienceContext.IsSynchronous value.");
 
         // Stryker disable once boolean : no means to test this
-        if (!task.IsCompleted)
+        if (task.IsCompleted)
         {
-            task.Preserve().GetAwaiter().GetResult();
+            _ = task.Result;
+            return;
         }
+
+        task.Preserve().GetAwaiter().GetResult();
     }
 
     public static TResult GetResult<TResult>(this ValueTask<TResult> task)

--- a/src/Polly.Core/Utils/ValidationHelper.cs
+++ b/src/Polly.Core/Utils/ValidationHelper.cs
@@ -1,9 +1,11 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
 namespace Polly.Utils;
 
+[ExcludeFromCodeCoverage]
 internal static class ValidationHelper
 {
     public static void ValidateObject(object instance, string mainMessage)

--- a/src/Polly.RateLimiting.Tests/OnRateLimiterRejectedArgumentsTests.cs
+++ b/src/Polly.RateLimiting.Tests/OnRateLimiterRejectedArgumentsTests.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.RateLimiting;
+using Moq;
+
+namespace Polly.RateLimiting.Tests;
+
+public class OnRateLimiterRejectedArgumentsTests
+{
+    [Fact]
+    public void Ctor_Ok()
+    {
+        var args = new OnRateLimiterRejectedArguments(ResilienceContext.Get(), Mock.Of<RateLimitLease>(), TimeSpan.FromSeconds(1));
+
+        args.Context.Should().NotBeNull();
+        args.Lease.Should().NotBeNull();
+        args.RetryAfter.Should().Be(TimeSpan.FromSeconds(1));
+    }
+}

--- a/src/Polly.RateLimiting.Tests/OnRateLimiterRejectedEventTests.cs
+++ b/src/Polly.RateLimiting.Tests/OnRateLimiterRejectedEventTests.cs
@@ -1,0 +1,12 @@
+namespace Polly.RateLimiting.Tests;
+
+public class OnRateLimiterRejectedEventTests
+{
+    [Fact]
+    public void Ctor_Ok()
+    {
+        var ev = new OnRateLimiterRejectedEvent();
+
+        ev.Should().NotBeNull();
+    }
+}

--- a/src/Polly.RateLimiting.Tests/Polly.RateLimiting.Tests.csproj
+++ b/src/Polly.RateLimiting.Tests/Polly.RateLimiting.Tests.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net481</TargetFrameworks>
+    <ProjectType>Test</ProjectType>
+    <UseDefaultAnalyzers>true</UseDefaultAnalyzers>
+    <Nullable>enable</Nullable>
+    <SkipPollyUsings>true</SkipPollyUsings>
+    <Threshold>100</Threshold>
+    <NoWarn>$(NoWarn);SA1600;SA1204</NoWarn>
+    <Include>[Polly.RateLimiting]*</Include>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Polly.RateLimiting\Polly.RateLimiting.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Polly.RateLimiting.Tests/RateLimiterConstantsTests.cs
+++ b/src/Polly.RateLimiting.Tests/RateLimiterConstantsTests.cs
@@ -1,0 +1,11 @@
+namespace Polly.RateLimiting.Tests;
+
+public class RateLimiterConstantsTests
+{
+    [Fact]
+    public void Ctor_EnsureDefaults()
+    {
+        RateLimiterConstants.OnRateLimiterRejectedEvent.Should().Be("OnRateLimiterRejected");
+        RateLimiterConstants.StrategyType.Should().Be("RateLimiter");
+    }
+}

--- a/src/Polly.RateLimiting.Tests/RateLimiterRejectedExceptionTests.cs
+++ b/src/Polly.RateLimiting.Tests/RateLimiterRejectedExceptionTests.cs
@@ -9,12 +9,12 @@ public class RateLimiterRejectedExceptionTests
     {
         var retryAfter = TimeSpan.FromSeconds(4);
 
-        new RateLimiterRejectedException().Message.Should().Be("The operation couldn't be executed because it was rejected by the rate limiter.");
+        new RateLimiterRejectedException().Message.Should().Be("The operation could not be executed because it was rejected by the rate limiter.");
         new RateLimiterRejectedException().RetryAfter.Should().BeNull();
         new RateLimiterRejectedException("dummy").Message.Should().Be("dummy");
         new RateLimiterRejectedException("dummy", new InvalidOperationException()).Message.Should().Be("dummy");
         new RateLimiterRejectedException(retryAfter).RetryAfter.Should().Be(retryAfter);
-        new RateLimiterRejectedException(retryAfter).Message.Should().Be($"The operation couldn't be executed because it was rejected by the rate limiter. It can be retried after '{retryAfter}'.");
+        new RateLimiterRejectedException(retryAfter).Message.Should().Be($"The operation could not be executed because it was rejected by the rate limiter. It can be retried after '{retryAfter}'.");
         new RateLimiterRejectedException("dummy", retryAfter).RetryAfter.Should().Be(retryAfter);
         new RateLimiterRejectedException("dummy", retryAfter, new InvalidOperationException()).RetryAfter.Should().Be(retryAfter);
     }

--- a/src/Polly.RateLimiting.Tests/RateLimiterRejectedExceptionTests.cs
+++ b/src/Polly.RateLimiting.Tests/RateLimiterRejectedExceptionTests.cs
@@ -1,0 +1,44 @@
+using Polly.RateLimiting;
+
+namespace Polly.Core.Tests.Timeout;
+
+public class RateLimiterRejectedExceptionTests
+{
+    [Fact]
+    public void Ctor_Ok()
+    {
+        var retryAfter = TimeSpan.FromSeconds(4);
+
+        new RateLimiterRejectedException().Message.Should().Be("The operation couldn't be executed because it was rejected by the rate limiter.");
+        new RateLimiterRejectedException().RetryAfter.Should().BeNull();
+        new RateLimiterRejectedException("dummy").Message.Should().Be("dummy");
+        new RateLimiterRejectedException("dummy", new InvalidOperationException()).Message.Should().Be("dummy");
+        new RateLimiterRejectedException(retryAfter).RetryAfter.Should().Be(retryAfter);
+        new RateLimiterRejectedException(retryAfter).Message.Should().Be($"The operation couldn't be executed because it was rejected by the rate limiter. It can be retried after '{retryAfter}'.");
+        new RateLimiterRejectedException("dummy", retryAfter).RetryAfter.Should().Be(retryAfter);
+        new RateLimiterRejectedException("dummy", retryAfter, new InvalidOperationException()).RetryAfter.Should().Be(retryAfter);
+    }
+
+#if !NETCOREAPP
+    [Fact]
+    public void BinaryDeserialization_Ok()
+    {
+        var timeout = TimeSpan.FromSeconds(4);
+        var result = SerializeAndDeserializeException(new RateLimiterRejectedException(timeout));
+        result.RetryAfter.Should().Be(timeout);
+
+        result = SerializeAndDeserializeException(new RateLimiterRejectedException());
+        result.RetryAfter.Should().BeNull();
+    }
+
+    public static T SerializeAndDeserializeException<T>(T exception)
+        where T : Exception
+    {
+        using var stream = new MemoryStream();
+        var formatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
+        formatter.Serialize(stream, exception);
+        stream.Position = 0;
+        return (T)formatter.Deserialize(stream);
+    }
+#endif
+}

--- a/src/Polly.RateLimiting.Tests/RateLimiterResilienceStrategyBuilderExtensionsTests.cs
+++ b/src/Polly.RateLimiting.Tests/RateLimiterResilienceStrategyBuilderExtensionsTests.cs
@@ -1,0 +1,148 @@
+using System.ComponentModel.DataAnnotations;
+using System.Threading.RateLimiting;
+using Moq;
+using Polly.Builder;
+using Xunit;
+
+namespace Polly.RateLimiting.Tests;
+
+public class RateLimiterResilienceStrategyBuilderExtensionsTests
+{
+    public static readonly TheoryData<Action<ResilienceStrategyBuilder>> Data = new()
+    {
+        builder =>
+        {
+            var called = false;
+
+            builder.AddConcurrencyLimiter(
+                new ConcurrencyLimiterOptions
+                {
+                    PermitLimit = 2,
+                    QueueLimit = 2
+                },
+                () => called = true);
+            AssertConcurrencyLimiter(builder, hasEvents: true);
+
+            called.Should().BeTrue();
+        },
+        builder =>
+        {
+            builder.AddConcurrencyLimiter(
+                new ConcurrencyLimiterOptions
+                {
+                    PermitLimit = 2,
+                    QueueLimit = 2
+                });
+
+            AssertConcurrencyLimiter(builder, hasEvents: false);
+        },
+        builder =>
+        {
+            var called = false;
+
+            builder.AddConcurrencyLimiter(
+                new ConcurrencyLimiterOptions
+                {
+                    PermitLimit = 2,
+                    QueueLimit = 2
+                },
+                configure => configure.Add(() => called = true));
+
+            AssertConcurrencyLimiter(builder, hasEvents: true);
+            called.Should().BeTrue();
+        },
+        builder =>
+        {
+            builder.AddRateLimiter(Mock.Of<RateLimiter>());
+            AssertRateLimiter(builder, hasEvents: false);
+        },
+        builder =>
+        {
+            var called = false;
+            builder.AddRateLimiter(Mock.Of<RateLimiter>(), () => called =true);
+            AssertRateLimiter(builder, hasEvents: true);
+            called.Should().BeTrue();
+        },
+        builder =>
+        {
+            var called = false;
+            builder.AddRateLimiter(Mock.Of<RateLimiter>(), ev => ev.Add(() => called = true));
+            AssertRateLimiter(builder, hasEvents: true);
+            called.Should().BeTrue();
+        }
+    };
+
+    [MemberData(nameof(Data))]
+    [Theory]
+    public void AddRateLimiter_Extensions_Ok(Action<ResilienceStrategyBuilder> configure)
+    {
+        var builder = new ResilienceStrategyBuilder();
+
+        configure(builder);
+
+        builder.Build().Should().BeOfType<RateLimiterResilienceStrategy>();
+    }
+
+    [Fact]
+    public void AddRateLimiter_InvalidOptions_Throws()
+    {
+        new ResilienceStrategyBuilder().Invoking(b => b.AddRateLimiter(new RateLimiterStrategyOptions()))
+            .Should()
+            .Throw<ValidationException>()
+            .WithMessage("""
+            The rate limiter strategy options are invalid.
+
+            Validation Errors:
+            The RateLimiter field is required.
+            """);
+    }
+
+    [Fact]
+    public void AddRateLimiter_Options_Ok()
+    {
+        var strategy = new ResilienceStrategyBuilder()
+            .AddRateLimiter(new RateLimiterStrategyOptions
+            {
+                RateLimiter = Mock.Of<RateLimiter>()
+            })
+            .Build();
+
+        strategy.Should().BeOfType<RateLimiterResilienceStrategy>();
+    }
+
+    private static void AssertRateLimiter(ResilienceStrategyBuilder builder, bool hasEvents)
+    {
+        var strategy = (RateLimiterResilienceStrategy)builder.Build();
+        strategy.Limiter.Should().NotBeNull();
+
+        if (hasEvents)
+        {
+            strategy.OnLeaseRejected.Should().NotBeNull();
+            strategy
+                .OnLeaseRejected!(new OnRateLimiterRejectedArguments(ResilienceContext.Get(), Mock.Of<RateLimitLease>(), null))
+                .Preserve().GetAwaiter().GetResult();
+        }
+        else
+        {
+            strategy.OnLeaseRejected.Should().BeNull();
+        }
+    }
+
+    private static void AssertConcurrencyLimiter(ResilienceStrategyBuilder builder, bool hasEvents)
+    {
+        var strategy = (RateLimiterResilienceStrategy)builder.Build();
+        strategy.Limiter.Should().BeOfType<ConcurrencyLimiter>();
+
+        if (hasEvents)
+        {
+            strategy.OnLeaseRejected.Should().NotBeNull();
+            strategy
+                .OnLeaseRejected!(new OnRateLimiterRejectedArguments(ResilienceContext.Get(), Mock.Of<RateLimitLease>(), null))
+                .Preserve().GetAwaiter().GetResult();
+        }
+        else
+        {
+            strategy.OnLeaseRejected.Should().BeNull();
+        }
+    }
+}

--- a/src/Polly.RateLimiting.Tests/RateLimiterResilienceStrategyTests.cs
+++ b/src/Polly.RateLimiting.Tests/RateLimiterResilienceStrategyTests.cs
@@ -1,0 +1,92 @@
+using System.Threading.RateLimiting;
+using Moq;
+using Moq.Protected;
+using Polly.Telemetry;
+
+namespace Polly.RateLimiting.Tests;
+
+public class RateLimiterResilienceStrategyTests
+{
+    private readonly Mock<RateLimiter> _limiter = new(MockBehavior.Strict);
+    private readonly Mock<RateLimitLease> _lease = new(MockBehavior.Strict);
+    private readonly OnRateLimiterRejectedEvent _event = new();
+    private readonly Mock<ResilienceTelemetry> _telemetry = new(MockBehavior.Strict);
+
+    [Fact]
+    public void Ctor_Ok()
+    {
+        Create().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Execute_HappyPath()
+    {
+        using var cts = new CancellationTokenSource();
+
+        SetupLimiter(cts.Token);
+
+        _lease.Setup(v => v.IsAcquired).Returns(true);
+        _lease.Protected().Setup("Dispose", exactParameterMatch: true, new object[] { true });
+
+        Create().Should().NotBeNull();
+
+        var strategy = Create();
+
+        strategy.Execute(_ => { }, cts.Token);
+
+        _limiter.VerifyAll();
+        _lease.VerifyAll();
+    }
+
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [Theory]
+    public void Execute_LeaseRejected(bool hasEvents, bool hasRetryAfter)
+    {
+        object? metadata = hasRetryAfter ? TimeSpan.FromSeconds(123) : null;
+
+        using var cts = new CancellationTokenSource();
+        var eventCalled = false;
+        SetupLimiter(cts.Token);
+
+        _lease.Setup(v => v.IsAcquired).Returns(false);
+        _lease.Protected().Setup("Dispose", exactParameterMatch: true, new object[] { true });
+        _lease.Setup(v => v.TryGetMetadata("RETRY_AFTER", out metadata)).Returns(hasRetryAfter);
+        _telemetry.Setup(v => v.Report(RateLimiterConstants.OnRateLimiterRejectedEvent, It.IsAny<ResilienceContext>()));
+
+        if (hasEvents)
+        {
+            _event.Add(args =>
+            {
+                args.Context.Should().NotBeNull();
+                args.Lease.Should().Be(_lease.Object);
+                args.RetryAfter.Should().Be((TimeSpan?)metadata);
+                eventCalled = true;
+            });
+        }
+
+        var strategy = Create();
+
+        var assertion = strategy
+            .Invoking(s => s.Execute(_ => { }, cts.Token))
+            .Should()
+            .Throw<RateLimiterRejectedException>()
+            .And
+            .RetryAfter.Should().Be((TimeSpan?)metadata);
+
+        _limiter.VerifyAll();
+        _lease.VerifyAll();
+        _telemetry.VerifyAll();
+        eventCalled.Should().Be(hasEvents);
+    }
+
+    private void SetupLimiter(CancellationToken token) => _limiter
+                .Protected()
+                .Setup<ValueTask<RateLimitLease>>("AcquireAsyncCore", 1, token)
+                .Returns(new ValueTask<RateLimitLease>(_lease.Object));
+
+    private RateLimiterResilienceStrategy Create() => new(_limiter.Object, _event, _telemetry.Object);
+
+}

--- a/src/Polly.RateLimiting.Tests/RateLimiterStrategyOptionsTests.cs
+++ b/src/Polly.RateLimiting.Tests/RateLimiterStrategyOptionsTests.cs
@@ -1,0 +1,14 @@
+namespace Polly.RateLimiting.Tests;
+
+public class RateLimiterStrategyOptionsTests
+{
+    [Fact]
+    public void Ctor_EnsureDefaults()
+    {
+        var options = new RateLimiterStrategyOptions();
+
+        options.StrategyType.Should().Be(RateLimiterConstants.StrategyType);
+        options.RateLimiter.Should().BeNull();
+        options.OnRejected.Should().NotBeNull();
+    }
+}

--- a/src/Polly.RateLimiting/OnRateLimiterRejectedArguments.cs
+++ b/src/Polly.RateLimiting/OnRateLimiterRejectedArguments.cs
@@ -1,0 +1,35 @@
+using System.Threading.RateLimiting;
+using Polly.Strategy;
+
+namespace Polly.RateLimiting;
+
+#pragma warning disable CA1815 // Override equals and operator equals on value types
+
+/// <summary>
+/// The arguments used by the <see cref="OnRateLimiterRejectedEvent"/>.
+/// </summary>
+public readonly struct OnRateLimiterRejectedArguments : IResilienceArguments
+{
+    internal OnRateLimiterRejectedArguments(ResilienceContext context, RateLimitLease lease, TimeSpan? retryAfter)
+    {
+        Context = context;
+        Lease = lease;
+        RetryAfter = retryAfter;
+    }
+
+    /// <inheritdoc/>
+    public ResilienceContext Context { get; }
+
+    /// <summary>
+    /// Gets the lease that has no permits and was rejected by the rate limiter.
+    /// </summary>
+    public RateLimitLease Lease { get; }
+
+    /// <summary>
+    /// Gets the amount of time to wait before retrying again.
+    /// </summary>
+    /// <remarks>
+    /// This value is retrieved from the <see cref="Lease"/> by reading the <see cref="MetadataName.RetryAfter"/>.
+    /// </remarks>
+    public TimeSpan? RetryAfter { get; }
+}

--- a/src/Polly.RateLimiting/OnRateLimiterRejectedEvent.cs
+++ b/src/Polly.RateLimiting/OnRateLimiterRejectedEvent.cs
@@ -1,0 +1,11 @@
+using Polly.Strategy;
+
+namespace Polly.RateLimiting;
+
+/// <summary>
+/// Event raised when a rate limiter rejects the execution.
+/// </summary>
+public sealed class OnRateLimiterRejectedEvent : SimpleEvent<OnRateLimiterRejectedArguments, OnRateLimiterRejectedEvent>
+{
+    internal Func<OnRateLimiterRejectedArguments, ValueTask>? CreateHandlerInternal() => CreateHandler();
+}

--- a/src/Polly.RateLimiting/Polly.RateLimiting.csproj
+++ b/src/Polly.RateLimiting/Polly.RateLimiting.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net7.0;net6.0;netstandard2.0;net472;net462</TargetFrameworks>
+    <AssemblyTitle>Polly.RateLimiting</AssemblyTitle>
+    <RootNamespace>Polly.RateLimiting</RootNamespace>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <ProjectType>Library</ProjectType>
+    <UseDefaultAnalyzers>true</UseDefaultAnalyzers>
+    <SkipPollyUsings>true</SkipPollyUsings>
+    <MutationScore>100</MutationScore>
+    <LegacySupport>true</LegacySupport>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <Using Include="Polly.Utils" />
+    <Using Remove="System.Net.Http" />
+    <Compile Include="..\Polly.Core\Utils\Guard.cs" Link="Utils\Guard.cs" />
+    <Compile Include="..\Polly.Core\Utils\ValidationHelper.cs" Link="Utils\ValidationHelper.cs" />
+    <InternalsVisibleToTest Include="Polly.RateLimiting.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Polly.Core\Polly.Core.csproj" />
+    <PackageReference Include="System.Threading.RateLimiting" />
+  </ItemGroup>
+</Project>

--- a/src/Polly.RateLimiting/README.md
+++ b/src/Polly.RateLimiting/README.md
@@ -1,0 +1,41 @@
+# About Polly.Hosting
+
+The `Polly.RateLimiting` adopts the [.NET Rate Limiting](https://devblogs.microsoft.com/dotnet/announcing-rate-limiting-for-dotnet/) APIs for Polly scenarios.
+
+- It exposes the `AddRateLimiter` extension methods for `ResiliencePipelineBuilder`.
+- It exposes the `AddConcurrencyLimiter` convenience extension methods for `ResiliencePipelineBuilder`.
+- It exposes the `RateLimiterRejectedException` to notify the caller that the operation was rate limited.
+
+Example:
+
+``` csharp
+// Convenience extension method for ConcurrencyLimiter
+builder.AddConcurrencyLimiter(
+    new ConcurrencyLimiterOptions
+    {
+        PermitLimit = 10,
+        QueueLimit = 10
+    },
+    () => Console.WriteLine("Rate limiter rejected!"));
+
+// Convenience extension method
+builder.AddRateLimiter(
+    new ConcurrencyLimiter(new ConcurrencyLimiterOptions
+    {
+        PermitLimit = 10,
+        QueueLimit = 10
+    }),
+    onRejected => onRejected.Add(() => Console.WriteLine("Rate limiter rejected!")));
+
+// Add rate limiter using the RateLimiterStrategyOptions
+builder.AddRateLimiter(new RateLimiterStrategyOptions
+{
+    RateLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
+    {
+        PermitLimit = 10,
+        QueueLimit = 10
+    }),
+    OnRejected = new OnRateLimiterRejectedEvent().Add(() => Console.WriteLine("Rate limiter rejected!"))
+});
+```
+

--- a/src/Polly.RateLimiting/README.md
+++ b/src/Polly.RateLimiting/README.md
@@ -1,10 +1,10 @@
 # About Polly.Hosting
 
-The `Polly.RateLimiting` adopts the [.NET Rate Limiting](https://devblogs.microsoft.com/dotnet/announcing-rate-limiting-for-dotnet/) APIs for Polly scenarios.
+The `Polly.RateLimiting` package adopts the [.NET Rate Limiting](https://devblogs.microsoft.com/dotnet/announcing-rate-limiting-for-dotnet/) APIs for Polly scenarios.
 
 - It exposes the `AddRateLimiter` extension methods for `ResiliencePipelineBuilder`.
 - It exposes the `AddConcurrencyLimiter` convenience extension methods for `ResiliencePipelineBuilder`.
-- It exposes the `RateLimiterRejectedException` to notify the caller that the operation was rate limited.
+- It exposes the `RateLimiterRejectedException` class to notify the caller that the operation was rate limited.
 
 Example:
 

--- a/src/Polly.RateLimiting/RateLimiterConstants.cs
+++ b/src/Polly.RateLimiting/RateLimiterConstants.cs
@@ -1,6 +1,6 @@
 namespace Polly.RateLimiting;
 
-internal class RateLimiterConstants
+internal static class RateLimiterConstants
 {
     public const string StrategyType = "RateLimiter";
 

--- a/src/Polly.RateLimiting/RateLimiterConstants.cs
+++ b/src/Polly.RateLimiting/RateLimiterConstants.cs
@@ -1,0 +1,8 @@
+namespace Polly.RateLimiting;
+
+internal class RateLimiterConstants
+{
+    public const string StrategyType = "RateLimiter";
+
+    public const string OnRateLimiterRejectedEvent = "OnRateLimiterRejected";
+}

--- a/src/Polly.RateLimiting/RateLimiterRejectedException.cs
+++ b/src/Polly.RateLimiting/RateLimiterRejectedException.cs
@@ -71,7 +71,7 @@ public sealed class RateLimiterRejectedException : ExecutionRejectedException
     /// </summary>
     /// <param name="info">The information.</param>
     /// <param name="context">The context.</param>
-    protected RateLimiterRejectedException(SerializationInfo info, StreamingContext context)
+    private RateLimiterRejectedException(SerializationInfo info, StreamingContext context)
         : base(info, context)
     {
         var value = info.GetDouble("RetryAfter");

--- a/src/Polly.RateLimiting/RateLimiterRejectedException.cs
+++ b/src/Polly.RateLimiting/RateLimiterRejectedException.cs
@@ -1,0 +1,112 @@
+#if !NETCOREAPP
+using System.Runtime.Serialization;
+#endif
+using System.Threading.RateLimiting;
+
+namespace Polly.RateLimiting;
+
+/// <summary>
+/// Exception thrown when a rate limiter rejects an execution.
+/// </summary>
+#if !NETCOREAPP
+[Serializable]
+#endif
+public class RateLimiterRejectedException : ExecutionRejectedException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RateLimiterRejectedException"/> class.
+    /// </summary>
+    public RateLimiterRejectedException()
+        : base("The operation couldn't be executed because it was rejected by the rate limiter.")
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RateLimiterRejectedException"/> class.
+    /// </summary>
+    /// <param name="retryAfter">The retry after value.</param>
+    public RateLimiterRejectedException(TimeSpan retryAfter)
+        : base($"The operation couldn't be executed because it was rejected by the rate limiter. It can be retried after '{retryAfter}'.")
+        => RetryAfter = retryAfter;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RateLimiterRejectedException"/> class.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public RateLimiterRejectedException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RateLimiterRejectedException"/> class.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="retryAfter">The retry after value.</param>
+    public RateLimiterRejectedException(string message, TimeSpan retryAfter)
+        : base(message) => RetryAfter = retryAfter;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RateLimiterRejectedException"/> class.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="inner">The inner exception.</param>
+    public RateLimiterRejectedException(string message, Exception inner)
+        : base(message, inner)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RateLimiterRejectedException"/> class.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="retryAfter">The retry after value.</param>
+    /// <param name="inner">The inner exception.</param>
+    public RateLimiterRejectedException(string message, TimeSpan retryAfter, Exception inner)
+        : base(message, inner) => RetryAfter = retryAfter;
+
+#if !NETCOREAPP
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RateLimiterRejectedException"/> class.
+    /// </summary>
+    /// <param name="info">The information.</param>
+    /// <param name="context">The context.</param>
+    protected RateLimiterRejectedException(SerializationInfo info, StreamingContext context)
+        : base(info, context)
+    {
+        var value = info.GetDouble("RetryAfter");
+        if (value >= 0.0)
+        {
+            RetryAfter = TimeSpan.FromSeconds(value);
+        }
+    }
+#endif
+
+    /// <summary>
+    /// Gets the amount of time to wait before retrying again.
+    /// </summary>
+    /// <remarks>
+    /// This value was retrieved from the <see cref="RateLimitLease"/> by reading the <see cref="MetadataName.RetryAfter"/>.
+    /// Defaults to <c>null</c>.
+    /// </remarks>
+    public TimeSpan? RetryAfter { get; }
+
+#if !NETCOREAPP
+    /// <inheritdoc/>
+    public override void GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+        Guard.NotNull(info);
+
+        if (RetryAfter.HasValue)
+        {
+            info.AddValue("RetryAfter", RetryAfter.Value.TotalSeconds);
+        }
+        else
+        {
+            info.AddValue("RetryAfter", -1.0);
+        }
+
+        base.GetObjectData(info, context);
+    }
+#endif
+}

--- a/src/Polly.RateLimiting/RateLimiterRejectedException.cs
+++ b/src/Polly.RateLimiting/RateLimiterRejectedException.cs
@@ -11,13 +11,13 @@ namespace Polly.RateLimiting;
 #if !NETCOREAPP
 [Serializable]
 #endif
-public class RateLimiterRejectedException : ExecutionRejectedException
+public sealed class RateLimiterRejectedException : ExecutionRejectedException
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="RateLimiterRejectedException"/> class.
     /// </summary>
     public RateLimiterRejectedException()
-        : base("The operation couldn't be executed because it was rejected by the rate limiter.")
+        : base("The operation could not be executed because it was rejected by the rate limiter.")
     {
     }
 
@@ -26,7 +26,7 @@ public class RateLimiterRejectedException : ExecutionRejectedException
     /// </summary>
     /// <param name="retryAfter">The retry after value.</param>
     public RateLimiterRejectedException(TimeSpan retryAfter)
-        : base($"The operation couldn't be executed because it was rejected by the rate limiter. It can be retried after '{retryAfter}'.")
+        : base($"The operation could not be executed because it was rejected by the rate limiter. It can be retried after '{retryAfter}'.")
         => RetryAfter = retryAfter;
 
     /// <summary>

--- a/src/Polly.RateLimiting/RateLimiterResilienceStrategy.cs
+++ b/src/Polly.RateLimiting/RateLimiterResilienceStrategy.cs
@@ -1,0 +1,49 @@
+using System.Threading.RateLimiting;
+using Polly.Telemetry;
+
+namespace Polly.RateLimiting;
+
+internal class RateLimiterResilienceStrategy : ResilienceStrategy
+{
+    private readonly ResilienceTelemetry _telemetry;
+
+    public RateLimiterResilienceStrategy(RateLimiter limiter, OnRateLimiterRejectedEvent @event, ResilienceTelemetry telemetry)
+    {
+        Limiter = limiter;
+        OnLeaseRejected = @event.CreateHandlerInternal();
+
+        _telemetry = telemetry;
+    }
+
+    public RateLimiter Limiter { get; }
+
+    public Func<OnRateLimiterRejectedArguments, ValueTask>? OnLeaseRejected { get; }
+
+    protected override async ValueTask<TResult> ExecuteCoreAsync<TResult, TState>(Func<ResilienceContext, TState, ValueTask<TResult>> callback, ResilienceContext context, TState state)
+    {
+        using var lease = await Limiter.AcquireAsync(
+            permitCount: 1,
+            context.CancellationToken).ConfigureAwait(context.ContinueOnCapturedContext);
+
+        if (lease.IsAcquired)
+        {
+            return await callback(context, state).ConfigureAwait(context.ContinueOnCapturedContext);
+        }
+
+        TimeSpan? retryAfter = null;
+
+        if (lease.TryGetMetadata(MetadataName.RetryAfter, out TimeSpan retryAfterValue))
+        {
+            retryAfter = retryAfterValue;
+        }
+
+        _telemetry.Report(RateLimiterConstants.OnRateLimiterRejectedEvent, context);
+
+        if (OnLeaseRejected != null)
+        {
+            await OnLeaseRejected(new OnRateLimiterRejectedArguments(context, lease, retryAfter)).ConfigureAwait(context.ContinueOnCapturedContext);
+        }
+
+        throw retryAfter.HasValue ? new RateLimiterRejectedException(retryAfter.Value) : new RateLimiterRejectedException();
+    }
+}

--- a/src/Polly.RateLimiting/RateLimiterResilienceStrategy.cs
+++ b/src/Polly.RateLimiting/RateLimiterResilienceStrategy.cs
@@ -3,7 +3,7 @@ using Polly.Telemetry;
 
 namespace Polly.RateLimiting;
 
-internal class RateLimiterResilienceStrategy : ResilienceStrategy
+internal sealed class RateLimiterResilienceStrategy : ResilienceStrategy
 {
     private readonly ResilienceTelemetry _telemetry;
 

--- a/src/Polly.RateLimiting/RateLimiterResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.RateLimiting/RateLimiterResilienceStrategyBuilderExtensions.cs
@@ -1,0 +1,156 @@
+using System.Threading.RateLimiting;
+using Polly.Builder;
+using Polly.Utils;
+
+namespace Polly.RateLimiting;
+
+/// <summary>
+/// The rate limiter extensions for <see cref="ResilienceStrategyBuilder"/>.
+/// </summary>
+public static class RateLimiterResilienceStrategyBuilderExtensions
+{
+    /// <summary>
+    /// Adds the concurrency limiter strategy.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="options">The concurrency limiter options.</param>
+    /// <returns>The builder instance with the concurrency limiter strategy added.</returns>
+    public static ResilienceStrategyBuilder AddConcurrencyLimiter(
+        this ResilienceStrategyBuilder builder,
+        ConcurrencyLimiterOptions options)
+    {
+        Guard.NotNull(builder);
+        Guard.NotNull(options);
+
+        return builder.AddRateLimiter(new RateLimiterStrategyOptions
+        {
+            RateLimiter = new ConcurrencyLimiter(options),
+        });
+    }
+
+    /// <summary>
+    /// Adds the concurrency limiter strategy.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="options">The concurrency limiter options.</param>
+    /// <param name="onRejected">The action that is invoked when the execution is rejected by the rate limiter.</param>
+    /// <returns>The builder instance with the concurrency limiter strategy added.</returns>
+    public static ResilienceStrategyBuilder AddConcurrencyLimiter(
+        this ResilienceStrategyBuilder builder,
+        ConcurrencyLimiterOptions options,
+        Action onRejected)
+    {
+        Guard.NotNull(builder);
+        Guard.NotNull(options);
+        Guard.NotNull(onRejected);
+
+        return builder.AddConcurrencyLimiter(options, rejected => rejected.Add(onRejected));
+    }
+
+    /// <summary>
+    /// Adds the concurrency limiter strategy.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="options">The concurrency limiter options.</param>
+    /// <param name="onRejected">The callbacks that configures the <see cref="OnRateLimiterRejectedEvent"/>.</param>
+    /// <returns>The builder instance with the concurrency limiter strategy added.</returns>
+    public static ResilienceStrategyBuilder AddConcurrencyLimiter(
+        this ResilienceStrategyBuilder builder,
+        ConcurrencyLimiterOptions options,
+        Action<OnRateLimiterRejectedEvent> onRejected)
+    {
+        Guard.NotNull(builder);
+        Guard.NotNull(options);
+        Guard.NotNull(onRejected);
+
+        var strategyOptions = new RateLimiterStrategyOptions
+        {
+            RateLimiter = new ConcurrencyLimiter(options)
+        };
+        onRejected(strategyOptions.OnRejected);
+
+        return builder.AddRateLimiter(strategyOptions);
+    }
+
+    /// <summary>
+    /// Adds the rate limiter strategy.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="limiter">The rate limiter to use.</param>
+    /// <returns>The builder instance with the rate limiter strategy added.</returns>
+    public static ResilienceStrategyBuilder AddRateLimiter(
+        this ResilienceStrategyBuilder builder,
+        RateLimiter limiter)
+    {
+        Guard.NotNull(builder);
+        Guard.NotNull(limiter);
+
+        return builder.AddRateLimiter(new RateLimiterStrategyOptions
+        {
+            RateLimiter = limiter,
+        });
+    }
+
+    /// <summary>
+    /// Adds the rate limiter strategy.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="limiter">The rate limiter to use.</param>
+    /// <param name="onRejected">The action that is invoked when the execution is rejected by the rate limiter.</param>
+    /// <returns>The builder instance with the rate limiter strategy added.</returns>
+    public static ResilienceStrategyBuilder AddRateLimiter(
+        this ResilienceStrategyBuilder builder,
+        RateLimiter limiter,
+        Action onRejected)
+    {
+        Guard.NotNull(builder);
+        Guard.NotNull(limiter);
+        Guard.NotNull(onRejected);
+
+        return builder.AddRateLimiter(limiter, rejected => rejected.Add(onRejected));
+    }
+
+    /// <summary>
+    /// Adds the rate limiter strategy.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="limiter">The rate limiter to use.</param>
+    /// <param name="onRejected">The callbacks that configures the <see cref="OnRateLimiterRejectedEvent"/>.</param>
+    /// <returns>The builder instance with the rate limiter strategy added.</returns>
+    public static ResilienceStrategyBuilder AddRateLimiter(
+        this ResilienceStrategyBuilder builder,
+        RateLimiter limiter,
+        Action<OnRateLimiterRejectedEvent> onRejected)
+    {
+        Guard.NotNull(builder);
+        Guard.NotNull(limiter);
+        Guard.NotNull(onRejected);
+
+        var options = new RateLimiterStrategyOptions
+        {
+            RateLimiter = limiter,
+        };
+
+        onRejected(options.OnRejected);
+
+        return builder.AddRateLimiter(options);
+    }
+
+    /// <summary>
+    /// Adds the rate limiter strategy.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="options">The rate limiter strategy options.</param>
+    /// <returns>The builder instance with the rate limiter strategy added.</returns>
+    public static ResilienceStrategyBuilder AddRateLimiter(
+        this ResilienceStrategyBuilder builder,
+        RateLimiterStrategyOptions options)
+    {
+        Guard.NotNull(builder);
+        Guard.NotNull(options);
+
+        ValidationHelper.ValidateObject(options, "The rate limiter strategy options are invalid.");
+
+        return builder.AddStrategy(context => new RateLimiterResilienceStrategy(options.RateLimiter!, options.OnRejected, context.Telemetry), options);
+    }
+}

--- a/src/Polly.RateLimiting/RateLimiterResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.RateLimiting/RateLimiterResilienceStrategyBuilderExtensions.cs
@@ -1,8 +1,9 @@
 using System.Threading.RateLimiting;
 using Polly.Builder;
+using Polly.RateLimiting;
 using Polly.Utils;
 
-namespace Polly.RateLimiting;
+namespace Polly;
 
 /// <summary>
 /// The rate limiter extensions for <see cref="ResilienceStrategyBuilder"/>.

--- a/src/Polly.RateLimiting/RateLimiterStrategyOptions.cs
+++ b/src/Polly.RateLimiting/RateLimiterStrategyOptions.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel.DataAnnotations;
+using System.Threading.RateLimiting;
+using Polly.Builder;
+
+namespace Polly.RateLimiting;
+
+/// <summary>
+/// Options for the rate limiter strategy.
+/// </summary>
+public class RateLimiterStrategyOptions : ResilienceStrategyOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RateLimiterStrategyOptions"/> class.
+    /// </summary>
+    public RateLimiterStrategyOptions() => StrategyType = RateLimiterConstants.StrategyType;
+
+    /// <summary>
+    /// Gets or sets an event that is raised when the execution of user-provided callback is rejected by the rate limiter.
+    /// </summary>
+    [Required]
+    public OnRateLimiterRejectedEvent OnRejected { get; set; } = new();
+
+    /// <summary>
+    ///  Gets or sets the rate limiter that the strategy uses.
+    /// </summary>
+    /// <remarks>
+    /// This property is required and defaults to <c>null</c>.
+    /// </remarks>
+    [Required]
+    public RateLimiter? RateLimiter { get; set; }
+}

--- a/src/Polly.sln
+++ b/src/Polly.sln
@@ -43,6 +43,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Polly.Extensions", "Polly.E
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Polly.Extensions.Tests", "Polly.Extensions.Tests\Polly.Extensions.Tests.csproj", "{BB2843CA-B518-48A1-BAD9-B63238F21608}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Polly.RateLimiting", "Polly.RateLimiting\Polly.RateLimiting.csproj", "{BCA09595-A4D3-4D74-AC80-3E7017E51B24}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Polly.RateLimiting.Tests", "Polly.RateLimiting.Tests\Polly.RateLimiting.Tests.csproj", "{06070F42-6738-4D0B-8D7E-9400B4030193}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -81,6 +85,14 @@ Global
 		{BB2843CA-B518-48A1-BAD9-B63238F21608}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BB2843CA-B518-48A1-BAD9-B63238F21608}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BB2843CA-B518-48A1-BAD9-B63238F21608}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BCA09595-A4D3-4D74-AC80-3E7017E51B24}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BCA09595-A4D3-4D74-AC80-3E7017E51B24}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BCA09595-A4D3-4D74-AC80-3E7017E51B24}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BCA09595-A4D3-4D74-AC80-3E7017E51B24}.Release|Any CPU.Build.0 = Release|Any CPU
+		{06070F42-6738-4D0B-8D7E-9400B4030193}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{06070F42-6738-4D0B-8D7E-9400B4030193}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{06070F42-6738-4D0B-8D7E-9400B4030193}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{06070F42-6738-4D0B-8D7E-9400B4030193}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors.  All non-trivial contributions get a public credit in the readme! -->

### The issue or feature being addressed

Closes #1086 

### Details on the issue fix or feature implementation

The `Polly.RateLimiting` adopts the [.NET Rate Limiting](https://devblogs.microsoft.com/dotnet/announcing-rate-limiting-for-dotnet/) APIs for Polly scenarios.

- It exposes the `AddRateLimiter` extension methods for `ResiliencePipelineBuilder`.
- It exposes the `AddConcurrencyLimiter` convenience extension methods for `ResiliencePipelineBuilder`.
- It exposes the `RateLimiterRejectedException` to notify the caller that the operation was rate limited.

Example:

``` csharp
// Convenience extension method for ConcurrencyLimiter
builder.AddConcurrencyLimiter(
    new ConcurrencyLimiterOptions
    {
        PermitLimit = 10,
        QueueLimit = 10
    },
    () => Console.WriteLine("Rate limiter rejected!"));

// Convenience extension method
builder.AddRateLimiter(
    new ConcurrencyLimiter(new ConcurrencyLimiterOptions
    {
        PermitLimit = 10,
        QueueLimit = 10
    }),
    onRejected => onRejected.Add(() => Console.WriteLine("Rate limiter rejected!")));

// Add rate limiter using the RateLimiterStrategyOptions
builder.AddRateLimiter(new RateLimiterStrategyOptions
{
    RateLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
    {
        PermitLimit = 10,
        QueueLimit = 10
    }),
    OnRejected = new OnRateLimiterRejectedEvent().Add(() => Console.WriteLine("Rate limiter rejected!"))
});
```

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build
