### PR TITLE
Add OSSF Scorecard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: ${{ matrix.os }}
@@ -27,12 +30,19 @@ jobs:
     steps:
 
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       with:
         fetch-depth: 0
 
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
+
+    - name: Setup NuGet cache
+      uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props') }}
+        restore-keys: ${{ runner.os }}-nuget-
 
     - name: Build, Test and Package
       shell: pwsh
@@ -46,7 +56,7 @@ jobs:
         NUGET_XMLDOC_MODE: skip
         TERM: xterm
 
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
       name: Upload coverage to Codecov
       with:
         files: ./artifacts/coverage-reports/Polly.Core.Tests/Cobertura.xml,./artifacts/coverage-reports/Polly.Specs/Cobertura.xml,./artifacts/coverage-reports/Polly.RateLimiting.Tests/Cobertura.xml,./artifacts/coverage-reports/Polly.Extensions.Tests/Cobertura.xml,
@@ -54,13 +64,13 @@ jobs:
 
     - name: Upload Mutation Report
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: mutation-report-${{ matrix.os_name }}
         path: StrykerOutput
 
     - name: Publish NuGet packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: packages-${{ matrix.os_name }}
         path: ./artifacts/nuget-package

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,52 @@
+name: code-scan
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '0 8 * * MON'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  code-ql:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'csharp' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
+
+    - name: Setup NuGet cache
+      uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props') }}
+        restore-keys: ${{ runner.os }}-nuget-
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@d186a2a36cc67bfa1b860e6170d37fb9634742c7 # v2.2.11
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@d186a2a36cc67bfa1b860e6170d37fb9634742c7 # v2.2.11
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@d186a2a36cc67bfa1b860e6170d37fb9634742c7 # v2.2.11
+      with:
+        category: "/language:${{ matrix.language }}"

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -1,0 +1,45 @@
+name: ossf-scorecard
+
+on:
+  branch_protection_rule:
+  push:
+    branches: [ main ]
+  schedule:
+    - cron: '0 8 * * MON'
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: analysis
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      security-events: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@80e868c13c90f172d68d1f4501dee99e2479f7af # v2.1.3
+        with:
+          publish_results: true
+          results_file: results.sarif
+          results_format: sarif
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: SARIF
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@d186a2a36cc67bfa1b860e6170d37fb9634742c7 # v2.2.11
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -1,7 +1,6 @@
 name: ossf-scorecard
 
 on:
-  branch_protection_rule:
   push:
     branches: [ main ]
   schedule:

--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
 
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
 
     - name: Update .NET SDK
-      uses: martincostello/update-dotnet-sdk@v2
+      uses: martincostello/update-dotnet-sdk@8d99db1db36692f0d5c5bf3ef91fb654c2d4e298 # v2.1.0
       with:
         labels: "dependencies,.NET"
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+To privately report a security vulnerability, please create a security advisory in the [repository's Security tab](https://github.com/App-vNext/Polly/security/advisories).
+
+Further details can be found in the [GitHub documentation](https://docs.github.com/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability).


### PR DESCRIPTION
- Add GitHub Actions workflow to compute OSSF Scorecard.
- Add CodeQL.
- Pin GitHub Actions workflow versions.
- Add explicit permissions to GitHub Actions workflows.
- Add security policy.
- Add NuGet package caching.

I've also created an entry for the project in [OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/en/projects/7211) based on changes made in this PR or in #1105.
