### PR TITLE
Cleanup rate limiter extensions

### DIFF
--- a/src/Polly.RateLimiting.Tests/RateLimiterResilienceStrategyBuilderExtensionsTests.cs
+++ b/src/Polly.RateLimiting.Tests/RateLimiterResilienceStrategyBuilderExtensionsTests.cs
@@ -12,18 +12,8 @@ public class RateLimiterResilienceStrategyBuilderExtensionsTests
     {
         builder =>
         {
-            var called = false;
-
-            builder.AddConcurrencyLimiter(
-                new ConcurrencyLimiterOptions
-                {
-                    PermitLimit = 2,
-                    QueueLimit = 2
-                },
-                () => called = true);
-            AssertConcurrencyLimiter(builder, hasEvents: true);
-
-            called.Should().BeTrue();
+            builder.AddConcurrencyLimiter(2, 2);
+            AssertConcurrencyLimiter(builder, hasEvents: false);
         },
         builder =>
         {
@@ -46,7 +36,7 @@ public class RateLimiterResilienceStrategyBuilderExtensionsTests
                     PermitLimit = 2,
                     QueueLimit = 2
                 },
-                configure => configure.Add(() => called = true));
+                args => called = true);
 
             AssertConcurrencyLimiter(builder, hasEvents: true);
             called.Should().BeTrue();
@@ -59,14 +49,7 @@ public class RateLimiterResilienceStrategyBuilderExtensionsTests
         builder =>
         {
             var called = false;
-            builder.AddRateLimiter(Mock.Of<RateLimiter>(), () => called =true);
-            AssertRateLimiter(builder, hasEvents: true);
-            called.Should().BeTrue();
-        },
-        builder =>
-        {
-            var called = false;
-            builder.AddRateLimiter(Mock.Of<RateLimiter>(), ev => ev.Add(() => called = true));
+            builder.AddRateLimiter(Mock.Of<RateLimiter>(), args => called = true);
             AssertRateLimiter(builder, hasEvents: true);
             called.Should().BeTrue();
         }

--- a/src/Polly.RateLimiting/README.md
+++ b/src/Polly.RateLimiting/README.md
@@ -10,13 +10,11 @@ Example:
 
 ``` csharp
 // Convenience extension method for ConcurrencyLimiter
-builder.AddConcurrencyLimiter(
-    new ConcurrencyLimiterOptions
-    {
-        PermitLimit = 10,
-        QueueLimit = 10
-    },
-    () => Console.WriteLine("Rate limiter rejected!"));
+builder.AddConcurrencyLimiter(new ConcurrencyLimiterOptions
+{
+    PermitLimit = 10,
+    QueueLimit = 10
+});
 
 // Convenience extension method
 builder.AddRateLimiter(
@@ -25,7 +23,7 @@ builder.AddRateLimiter(
         PermitLimit = 10,
         QueueLimit = 10
     }),
-    onRejected => onRejected.Add(() => Console.WriteLine("Rate limiter rejected!")));
+    args => Console.WriteLine("Rate limiter rejected!"));
 
 // Add rate limiter using the RateLimiterStrategyOptions
 builder.AddRateLimiter(new RateLimiterStrategyOptions

--- a/src/Polly.RateLimiting/README.md
+++ b/src/Polly.RateLimiting/README.md
@@ -1,4 +1,4 @@
-# About Polly.Hosting
+# About Polly.RateLimiting
 
 The `Polly.RateLimiting` package adopts the [.NET Rate Limiting](https://devblogs.microsoft.com/dotnet/announcing-rate-limiting-for-dotnet/) APIs for Polly scenarios.
 
@@ -10,6 +10,9 @@ Example:
 
 ``` csharp
 // Convenience extension method for ConcurrencyLimiter
+builder.AddConcurrencyLimiter(permitLimit: 10, queueLimit: 10);
+
+// Convenience extension method for ConcurrencyLimiter that uses ConcurrencyLimiterOptions
 builder.AddConcurrencyLimiter(new ConcurrencyLimiterOptions
 {
     PermitLimit = 10,

--- a/src/Polly.RateLimiting/README.md
+++ b/src/Polly.RateLimiting/README.md
@@ -12,15 +12,8 @@ Example:
 // Convenience extension method for ConcurrencyLimiter
 builder.AddConcurrencyLimiter(permitLimit: 10, queueLimit: 10);
 
-// Convenience extension method for ConcurrencyLimiter that uses ConcurrencyLimiterOptions
-builder.AddConcurrencyLimiter(new ConcurrencyLimiterOptions
-{
-    PermitLimit = 10,
-    QueueLimit = 10
-});
-
-// Convenience extension method
-builder.AddRateLimiter(
+// Convenience extension method for ConcurrencyLimiter with callback
+builder.AddConcurrencyLimiter(
     new ConcurrencyLimiter(new ConcurrencyLimiterOptions
     {
         PermitLimit = 10,
@@ -28,6 +21,15 @@ builder.AddRateLimiter(
     }),
     args => Console.WriteLine("Rate limiter rejected!"));
 
+// Convenience extension method with custom limiter creation
+builder.AddRateLimiter(
+    new ConcurrencyLimiter(new ConcurrencyLimiterOptions
+    {
+        PermitLimit = 10,
+        QueueLimit = 10
+    }),
+    args => Console.WriteLine("Rate limiter rejected!"));
+    
 // Add rate limiter using the RateLimiterStrategyOptions
 builder.AddRateLimiter(new RateLimiterStrategyOptions
 {

--- a/src/Polly.RateLimiting/RateLimiterResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.RateLimiting/RateLimiterResilienceStrategyBuilderExtensions.cs
@@ -14,6 +14,27 @@ public static class RateLimiterResilienceStrategyBuilderExtensions
     /// Adds the concurrency limiter strategy.
     /// </summary>
     /// <param name="builder">The builder instance.</param>
+    /// <param name="permitLimit">Maximum number of permits that can be leased concurrently.</param>
+    /// <param name="queueLimit">Maximum number of permits that can be queued concurrently.</param>
+    /// <returns>The builder instance with the concurrency limiter strategy added.</returns>
+    public static ResilienceStrategyBuilder AddConcurrencyLimiter(
+        this ResilienceStrategyBuilder builder,
+        int permitLimit,
+        int queueLimit = 0)
+    {
+        Guard.NotNull(builder);
+
+        return builder.AddConcurrencyLimiter(new ConcurrencyLimiterOptions
+        {
+            PermitLimit = permitLimit,
+            QueueLimit = queueLimit
+        });
+    }
+
+    /// <summary>
+    /// Adds the concurrency limiter strategy.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
     /// <param name="options">The concurrency limiter options.</param>
     /// <returns>The builder instance with the concurrency limiter strategy added.</returns>
     public static ResilienceStrategyBuilder AddConcurrencyLimiter(
@@ -34,43 +55,22 @@ public static class RateLimiterResilienceStrategyBuilderExtensions
     /// </summary>
     /// <param name="builder">The builder instance.</param>
     /// <param name="options">The concurrency limiter options.</param>
-    /// <param name="onRejected">The action that is invoked when the execution is rejected by the rate limiter.</param>
-    /// <returns>The builder instance with the concurrency limiter strategy added.</returns>
-    public static ResilienceStrategyBuilder AddConcurrencyLimiter(
-        this ResilienceStrategyBuilder builder,
-        ConcurrencyLimiterOptions options,
-        Action onRejected)
-    {
-        Guard.NotNull(builder);
-        Guard.NotNull(options);
-        Guard.NotNull(onRejected);
-
-        return builder.AddConcurrencyLimiter(options, rejected => rejected.Add(onRejected));
-    }
-
-    /// <summary>
-    /// Adds the concurrency limiter strategy.
-    /// </summary>
-    /// <param name="builder">The builder instance.</param>
-    /// <param name="options">The concurrency limiter options.</param>
     /// <param name="onRejected">The callbacks that configures the <see cref="OnRateLimiterRejectedEvent"/>.</param>
     /// <returns>The builder instance with the concurrency limiter strategy added.</returns>
     public static ResilienceStrategyBuilder AddConcurrencyLimiter(
         this ResilienceStrategyBuilder builder,
         ConcurrencyLimiterOptions options,
-        Action<OnRateLimiterRejectedEvent> onRejected)
+        Action<OnRateLimiterRejectedArguments> onRejected)
     {
         Guard.NotNull(builder);
         Guard.NotNull(options);
         Guard.NotNull(onRejected);
 
-        var strategyOptions = new RateLimiterStrategyOptions
+        return builder.AddRateLimiter(new RateLimiterStrategyOptions
         {
-            RateLimiter = new ConcurrencyLimiter(options)
-        };
-        onRejected(strategyOptions.OnRejected);
-
-        return builder.AddRateLimiter(strategyOptions);
+            RateLimiter = new ConcurrencyLimiter(options),
+            OnRejected = new OnRateLimiterRejectedEvent().Add(onRejected)
+        });
     }
 
     /// <summary>
@@ -97,44 +97,22 @@ public static class RateLimiterResilienceStrategyBuilderExtensions
     /// </summary>
     /// <param name="builder">The builder instance.</param>
     /// <param name="limiter">The rate limiter to use.</param>
-    /// <param name="onRejected">The action that is invoked when the execution is rejected by the rate limiter.</param>
-    /// <returns>The builder instance with the rate limiter strategy added.</returns>
-    public static ResilienceStrategyBuilder AddRateLimiter(
-        this ResilienceStrategyBuilder builder,
-        RateLimiter limiter,
-        Action onRejected)
-    {
-        Guard.NotNull(builder);
-        Guard.NotNull(limiter);
-        Guard.NotNull(onRejected);
-
-        return builder.AddRateLimiter(limiter, rejected => rejected.Add(onRejected));
-    }
-
-    /// <summary>
-    /// Adds the rate limiter strategy.
-    /// </summary>
-    /// <param name="builder">The builder instance.</param>
-    /// <param name="limiter">The rate limiter to use.</param>
     /// <param name="onRejected">The callbacks that configures the <see cref="OnRateLimiterRejectedEvent"/>.</param>
     /// <returns>The builder instance with the rate limiter strategy added.</returns>
     public static ResilienceStrategyBuilder AddRateLimiter(
         this ResilienceStrategyBuilder builder,
         RateLimiter limiter,
-        Action<OnRateLimiterRejectedEvent> onRejected)
+        Action<OnRateLimiterRejectedArguments> onRejected)
     {
         Guard.NotNull(builder);
         Guard.NotNull(limiter);
         Guard.NotNull(onRejected);
 
-        var options = new RateLimiterStrategyOptions
+        return builder.AddRateLimiter(new RateLimiterStrategyOptions
         {
             RateLimiter = limiter,
-        };
-
-        onRejected(options.OnRejected);
-
-        return builder.AddRateLimiter(options);
+            OnRejected = new OnRateLimiterRejectedEvent().Add(onRejected)
+        });
     }
 
     /// <summary>


### PR DESCRIPTION
### The issue or feature being addressed

Follow-up of #1103 

### Details on the issue fix or feature implementation

Cleaning up the new rate limiter extensions

- Dropping the `Action` overload. The same can be done with simple discard argument.
- Using `Action<OnRateLimiterRejectedArguments>` instead of `Action<OnRateLimiterRejectedEvent>`. Configuring the event directly is more advanced scenario that can be done by using the options directly.
- Adding new `AddConcurrencyLimiter` extension that accepts the `permitLimit` and `queueLimit` directly.


### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
