### PR TITLE
Fix sample code for `Timeout` overload

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,7 +619,7 @@ Policy
 
 // Configure variable timeout via a func provider.
 Policy
-  .Timeout(() => myTimeoutProvider)) // Func<TimeSpan> myTimeoutProvider
+  .Timeout(myTimeoutProvider)) // Func<TimeSpan> myTimeoutProvider
 
 // Timeout, calling an action if the action times out
 Policy


### PR DESCRIPTION
The overload takes a `Func<TimeSpan>`, and it is assumed that we already have a lambda variable called `myTimeoutProvider, but the variable is incorrectly passed to the overload.

<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors.  All non-trivial contributions get a public credit in the readme! -->


### Confirm the following

- [X]  I started this PR by branching from the head of the default branch
- [X]  I have targeted the PR to merge into the default branch
