### PR TITLE
Introduce ObjectPool and use it for ResilienceContext pooling

### DIFF
--- a/src/Polly.Core.Tests/ExecutionRejectedExceptionTests.cs
+++ b/src/Polly.Core.Tests/ExecutionRejectedExceptionTests.cs
@@ -1,4 +1,4 @@
-namespace Polly.Core.Tests.Timeout;
+namespace Polly.Core.Tests;
 
 public class ExecutionRejectedExceptionTests
 {

--- a/src/Polly.Core.Tests/Helpers/BinarySerializationUtil.cs
+++ b/src/Polly.Core.Tests/Helpers/BinarySerializationUtil.cs
@@ -2,7 +2,7 @@
 
 using System;
 
-namespace Polly.Core.Tests.Utils;
+namespace Polly.Core.Tests.Helpers;
 
 /// <summary>
 /// Utility that serializes and deserializes the exceptions using the binary formatter.

--- a/src/Polly.Core.Tests/Helpers/FakeTimeProvider.cs
+++ b/src/Polly.Core.Tests/Helpers/FakeTimeProvider.cs
@@ -1,7 +1,7 @@
 using Moq;
 using Polly.Utils;
 
-namespace Polly.Core.Tests.Utils;
+namespace Polly.Core.Tests.Helpers;
 
 internal class FakeTimeProvider : Mock<TimeProvider>
 {

--- a/src/Polly.Core.Tests/Helpers/TestArguments.cs
+++ b/src/Polly.Core.Tests/Helpers/TestArguments.cs
@@ -1,6 +1,6 @@
 using Polly.Strategy;
 
-namespace Polly.Core.Tests.Utils;
+namespace Polly.Core.Tests.Helpers;
 
 public class TestArguments : IResilienceArguments
 {

--- a/src/Polly.Core.Tests/Helpers/TestResilienceStrategy.cs
+++ b/src/Polly.Core.Tests/Helpers/TestResilienceStrategy.cs
@@ -1,4 +1,4 @@
-namespace Polly.Core.Tests.Utils;
+namespace Polly.Core.Tests.Helpers;
 
 public class TestResilienceStrategy : ResilienceStrategy
 {

--- a/src/Polly.Core.Tests/Helpers/TestUtils.cs
+++ b/src/Polly.Core.Tests/Helpers/TestUtils.cs
@@ -1,4 +1,4 @@
-namespace Polly.Core.Tests.Utils;
+namespace Polly.Core.Tests.Helpers;
 
 #pragma warning disable CA1031 // Do not catch general exception types
 

--- a/src/Polly.Core.Tests/Polly.Core.Tests.csproj
+++ b/src/Polly.Core.Tests/Polly.Core.Tests.csproj
@@ -16,6 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Using Include="Polly.Core.Tests.Utils" />
+    <Using Include="Polly.Core.Tests.Helpers" />
   </ItemGroup>
 </Project>

--- a/src/Polly.Core.Tests/Registry/StrategyId.cs
+++ b/src/Polly.Core.Tests/Registry/StrategyId.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-
 namespace Polly.Core.Tests.Registry;
 
 public record StrategyId(Type Type, string BuilderName, string InstanceName = "")

--- a/src/Polly.Core.Tests/ResilienceContextTests.cs
+++ b/src/Polly.Core.Tests/ResilienceContextTests.cs
@@ -17,6 +17,16 @@ public class ResilienceContextTests
     }
 
     [Fact]
+    public void Get_EnsurePooled()
+    {
+        var context = ResilienceContext.Get();
+
+        ResilienceContext.Return(context);
+
+        ResilienceContext.Get().Should().BeSameAs(context);
+    }
+
+    [Fact]
     public void Return_Null_Throws()
     {
         Assert.Throws<ArgumentNullException>(() => ResilienceContext.Return(null!));

--- a/src/Polly.Core.Tests/Retry/RetryDelayGeneratorTests.cs
+++ b/src/Polly.Core.Tests/Retry/RetryDelayGeneratorTests.cs
@@ -1,8 +1,5 @@
-using System;
-using System.Threading.Tasks;
 using Polly.Retry;
 using Polly.Strategy;
-using Xunit;
 
 namespace Polly.Core.Tests.Retry;
 

--- a/src/Polly.Core.Tests/Retry/RetryHelperTests.cs
+++ b/src/Polly.Core.Tests/Retry/RetryHelperTests.cs
@@ -1,4 +1,3 @@
-using System;
 using Polly.Retry;
 
 namespace Polly.Core.Tests.Retry;

--- a/src/Polly.Core.Tests/Retry/RetryResilienceStrategyBuilderExtensionsTests.cs
+++ b/src/Polly.Core.Tests/Retry/RetryResilienceStrategyBuilderExtensionsTests.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Polly.Builder;
 using Polly.Retry;
-using Xunit;
 
 namespace Polly.Core.Tests.Retry;
 

--- a/src/Polly.Core.Tests/Strategy/OutcomeEventTests.cs
+++ b/src/Polly.Core.Tests/Strategy/OutcomeEventTests.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Threading.Tasks;
 using Polly.Strategy;
 
 namespace Polly.Core.Tests.Strategy;

--- a/src/Polly.Core.Tests/Strategy/OutcomeGeneratorTests.cs
+++ b/src/Polly.Core.Tests/Strategy/OutcomeGeneratorTests.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Threading.Tasks;
 using Polly.Strategy;
 
 namespace Polly.Core.Tests.Strategy;

--- a/src/Polly.Core.Tests/Strategy/OutcomePredicateTests.cs
+++ b/src/Polly.Core.Tests/Strategy/OutcomePredicateTests.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Threading.Tasks;
 using Polly.Strategy;
 
 namespace Polly.Core.Tests.Strategy;

--- a/src/Polly.Core.Tests/Strategy/OutcomeTests.cs
+++ b/src/Polly.Core.Tests/Strategy/OutcomeTests.cs
@@ -1,4 +1,3 @@
-using System;
 using Polly.Strategy;
 
 namespace Polly.Core.Tests.Strategy;

--- a/src/Polly.Core.Tests/Strategy/SimpleEventTests.cs
+++ b/src/Polly.Core.Tests/Strategy/SimpleEventTests.cs
@@ -1,6 +1,6 @@
 using Polly.Strategy;
 
-namespace Polly.Core.Tests.Timeout;
+namespace Polly.Core.Tests.Strategy;
 
 public class SimpleEventTests
 {
@@ -8,7 +8,7 @@ public class SimpleEventTests
     public async Task Add_EnsureOrdering()
     {
         var ev = new DummyEvent();
-        List<int> raisedEvents = new List<int>();
+        var raisedEvents = new List<int>();
 
         ev.Add(() => raisedEvents.Add(1));
         ev.Add(args => raisedEvents.Add(2));
@@ -41,7 +41,7 @@ public class SimpleEventTests
         var ev = new DummyEvent();
         var events = new List<int>();
 
-        for (int i = 0; i < count; i++)
+        for (var i = 0; i < count; i++)
         {
             ev.Add(() => events.Add(i));
         }

--- a/src/Polly.Core.Tests/Timeout/TimeoutAttributeTests.cs
+++ b/src/Polly.Core.Tests/Timeout/TimeoutAttributeTests.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel.DataAnnotations;
 using Polly.Timeout;
 
 namespace Polly.Core.Tests.Timeout;

--- a/src/Polly.Core.Tests/Timeout/TimeoutStrategyOptionsTests.cs
+++ b/src/Polly.Core.Tests/Timeout/TimeoutStrategyOptionsTests.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Polly.Timeout;
 using Polly.Utils;
-using Xunit;
 
 namespace Polly.Core.Tests.Timeout;
 

--- a/src/Polly.Core.Tests/Timeout/TimeoutUtilTests.cs
+++ b/src/Polly.Core.Tests/Timeout/TimeoutUtilTests.cs
@@ -1,6 +1,4 @@
-using System;
 using Polly.Timeout;
-using Xunit;
 
 namespace Polly.Core.Tests.Timeout;
 public class TimeoutUtilTests

--- a/src/Polly.Core.Tests/Utils/ObjectPoolTests.cs
+++ b/src/Polly.Core.Tests/Utils/ObjectPoolTests.cs
@@ -1,6 +1,4 @@
-using System.Collections.Generic;
 using Polly.Utils;
-using Xunit;
 
 namespace Polly.Core.Tests.Utils;
 

--- a/src/Polly.Core.Tests/Utils/ObjectPoolTests.cs
+++ b/src/Polly.Core.Tests/Utils/ObjectPoolTests.cs
@@ -1,0 +1,113 @@
+using System.Collections.Generic;
+using Polly.Utils;
+using Xunit;
+
+namespace Polly.Core.Tests.Utils;
+
+public class ObjectPoolTests
+{
+    [Fact]
+    public void GetAnd_ReturnObject_SameInstance()
+    {
+        // Arrange
+        var pool = new ObjectPool<object>(() => new object(), _ => true);
+
+        var obj1 = pool.Get();
+        pool.Return(obj1);
+
+        // Act
+        var obj2 = pool.Get();
+
+        // Assert
+        Assert.Same(obj1, obj2);
+    }
+
+    [Fact]
+    public void MaxCapacity_Ok()
+    {
+        ObjectPool<object>.MaxCapacity.Should().Be((Environment.ProcessorCount * 2) - 1);
+    }
+
+    [Fact]
+    public void MaxCapacity_Respected()
+    {
+        // Arrange
+        var pool = new ObjectPool<object>(() => new object(), _ => true);
+        var items1 = GetStoreReturn(pool);
+
+        // Act
+        var items2 = GetStoreReturn(pool);
+
+        // Assert
+        items1.Should().BeEquivalentTo(items2);
+    }
+
+    [Fact]
+    public void MaxCapacityOverflow_Respected()
+    {
+        // Arrange
+        var count = ObjectPool<object>.MaxCapacity + 10;
+        var pool = new ObjectPool<object>(() => new object(), _ => true);
+        var items1 = GetStoreReturn(pool, count);
+
+        // Act
+        var items2 = GetStoreReturn(pool, count);
+
+        // Assert
+        items1.Last().Should().NotBeSameAs(items2.Last());
+    }
+
+    [Fact]
+    public void CreatedByPolicy()
+    {
+        // Arrange
+        var policy = new ListPolicy();
+        var pool = new ObjectPool<List<int>>(ListPolicy.Create, ListPolicy.Return);
+
+        // Act
+        var list = pool.Get();
+
+        // Assert
+        Assert.Equal(17, list.Capacity);
+    }
+
+    [Fact]
+    public void Return_RejectedByPolicy()
+    {
+        // Arrange
+        var policy = new ListPolicy();
+        var pool = new ObjectPool<List<int>>(ListPolicy.Create, ListPolicy.Return);
+        var list1 = pool.Get();
+        list1.Capacity = 20;
+
+        // Act
+        pool.Return(list1);
+        var list2 = pool.Get();
+
+        // Assert
+        Assert.NotSame(list1, list2);
+    }
+
+    private static List<object> GetStoreReturn(ObjectPool<object> pool, int? count = null)
+    {
+        var items = new List<object>();
+        for (int i = 0; i < (count ?? ObjectPool<object>.MaxCapacity); i++)
+        {
+            items.Add(pool.Get());
+        }
+
+        foreach (var item in items)
+        {
+            pool.Return(item);
+        }
+
+        return items;
+    }
+
+    private class ListPolicy
+    {
+        public static List<int> Create() => new(17);
+
+        public static bool Return(List<int> obj) => obj.Capacity == 17;
+    }
+}

--- a/src/Polly.Core.Tests/Utils/TimeSpanAttributeTests.cs
+++ b/src/Polly.Core.Tests/Utils/TimeSpanAttributeTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace Polly.Core.Tests.Utils;

--- a/src/Polly.Core.Tests/Utils/ValidationContextExtensionsTests.cs
+++ b/src/Polly.Core.Tests/Utils/ValidationContextExtensionsTests.cs
@@ -2,7 +2,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Polly.Core.Tests.Utils;
 
-public class ValidationContextExtensions
+public class ValidationContextExtensionsTests
 {
     [Fact]
     public void GetMemberName_Ok()

--- a/src/Polly.Core/Utils/ObjectPool.cs
+++ b/src/Polly.Core/Utils/ObjectPool.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace Polly.Utils;
+
+// copied from https://raw.githubusercontent.com/dotnet/aspnetcore/main/src/ObjectPool/src/DefaultObjectPool.cs
+internal sealed class ObjectPool<T>
+    where T : class
+{
+    internal static readonly int MaxCapacity = (Environment.ProcessorCount * 2) - 1; // the - 1 is to account for _fastItem
+
+    private readonly Func<T> _createFunc;
+    private readonly Func<T, bool> _returnFunc;
+
+    private readonly ConcurrentQueue<T> _items = new();
+
+    private T? _fastItem;
+    private int _numItems;
+
+    public ObjectPool(Func<T> createFunc, Func<T, bool> returnFunc)
+    {
+        _createFunc = createFunc;
+        _returnFunc = returnFunc;
+    }
+
+    public T Get()
+    {
+        var item = _fastItem;
+        if (item == null || Interlocked.CompareExchange(ref _fastItem, null, item) != item)
+        {
+            if (_items.TryDequeue(out item))
+            {
+                Interlocked.Decrement(ref _numItems);
+                return item;
+            }
+
+            // no object available, so go get a brand new one
+            return _createFunc();
+        }
+
+        return item;
+    }
+
+    public void Return(T obj)
+    {
+        if (!_returnFunc(obj))
+        {
+            // policy says to drop this object
+            return;
+        }
+
+        // Stryker disable once equality : no means to test this
+        if (_fastItem != null || Interlocked.CompareExchange(ref _fastItem, obj, null) != null)
+        {
+            // Stryker disable once equality : no means to test this
+            if (Interlocked.Increment(ref _numItems) <= MaxCapacity)
+            {
+                _items.Enqueue(obj);
+                return;
+            }
+
+            // no room, clean up the count and drop the object on the floor
+            Interlocked.Decrement(ref _numItems);
+        }
+    }
+}


### PR DESCRIPTION
### The issue or feature being addressed

Closes #955 

### Details on the issue fix or feature implementation

The `ObjectPool` is just trimmed down version of [`DefaultObjectPool`](https://github.com/dotnet/aspnetcore/blob/main/src/ObjectPool/src/DefaultObjectPool.cs). 

I had to add more tests so the code passes our gates. I will re-run the benchmarks later once we add polling for `CancellationTokenSource` instances.

### Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build
