### PR TITLE
Fix unstable tests

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -10,7 +10,7 @@ var configuration = Argument<string>("configuration", "Release");
 //////////////////////////////////////////////////////////////////////
 
 #Tool "xunit.runner.console&version=2.4.2"
-#Tool "dotnet-stryker&version=3.7.0"
+#Tool "dotnet-stryker&version=3.7.1"
 
 //////////////////////////////////////////////////////////////////////
 // EXTERNAL NUGET LIBRARIES

--- a/src/Polly.Core.Tests/ResilienceStrategyTests.Async.Task.cs
+++ b/src/Polly.Core.Tests/ResilienceStrategyTests.Async.Task.cs
@@ -15,14 +15,12 @@ public partial class ResilienceStrategyTests
         {
             Caption = "ExecuteAsTaskAsync_NoCancellation",
             AssertContext = AssertResilienceContext,
-            AssertContextAfter = AssertContextNotInitialized,
         };
 
         yield return new ExecuteParameters(r => r.ExecuteTaskAsync(async t => { t.Should().Be(CancellationToken); }, CancellationToken))
         {
             Caption = "ExecuteAsTaskAsync_Cancellation",
             AssertContext = AssertResilienceContextAndToken,
-            AssertContextAfter = AssertContextNotInitialized,
         };
 
         yield return new ExecuteParameters(r => r.ExecuteTaskAsync(async (_, s) => { s.Should().Be("dummy-state"); }, ResilienceContext.Get(), "dummy-state"))
@@ -44,8 +42,6 @@ public partial class ResilienceStrategyTests
             AssertResilienceContext(context);
             context.CancellationToken.Should().Be(CancellationToken);
         }
-
-        static void AssertContextNotInitialized(ResilienceContext context) => context.IsInitialized.Should().BeFalse();
 
         static void AssertContextInitialized(ResilienceContext context) => context.IsInitialized.Should().BeTrue();
     }

--- a/src/Polly.Core.Tests/ResilienceStrategyTests.Async.TaskT.cs
+++ b/src/Polly.Core.Tests/ResilienceStrategyTests.Async.TaskT.cs
@@ -17,14 +17,12 @@ public partial class ResilienceStrategyTests
         {
             Caption = "ExecuteAsTaskAsyncT_NoCancellation",
             AssertContext = AssertResilienceContext,
-            AssertContextAfter = AssertContextNotInitialized,
         };
 
         yield return new ExecuteParameters<long>(r => r.ExecuteTaskAsync(async t => { t.Should().Be(CancellationToken); return result; }, CancellationToken), result)
         {
             Caption = "ExecuteAsTaskAsyncT_Cancellation",
             AssertContext = AssertResilienceContextAndToken,
-            AssertContextAfter = AssertContextNotInitialized,
         };
 
         yield return new ExecuteParameters<long>(r => r.ExecuteTaskAsync(async (_, s) => { s.Should().Be("dummy-state"); return result; }, ResilienceContext.Get(), "dummy-state"), result)
@@ -47,8 +45,6 @@ public partial class ResilienceStrategyTests
             AssertResilienceContext(context);
             context.CancellationToken.Should().Be(CancellationToken);
         }
-
-        static void AssertContextNotInitialized(ResilienceContext context) => context.IsInitialized.Should().BeFalse();
 
         static void AssertContextInitialized(ResilienceContext context) => context.IsInitialized.Should().BeTrue();
     }

--- a/src/Polly.Core.Tests/ResilienceStrategyTests.Async.ValueTask.cs
+++ b/src/Polly.Core.Tests/ResilienceStrategyTests.Async.ValueTask.cs
@@ -15,14 +15,12 @@ public partial class ResilienceStrategyTests
         {
             Caption = "ExecuteAsync_NoCancellation",
             AssertContext = AssertResilienceContext,
-            AssertContextAfter = AssertContextNotInitialized,
         };
 
         yield return new ExecuteParameters(r => r.ExecuteValueTaskAsync(async t => { t.Should().Be(CancellationToken); }, CancellationToken))
         {
             Caption = "ExecuteAsync_Cancellation",
             AssertContext = AssertResilienceContextAndToken,
-            AssertContextAfter = AssertContextNotInitialized,
         };
 
         yield return new ExecuteParameters(r => r.ExecuteValueTaskAsync(async (_, s) => { s.Should().Be("dummy-state"); }, ResilienceContext.Get(), "dummy-state"))
@@ -44,8 +42,6 @@ public partial class ResilienceStrategyTests
             AssertResilienceContext(context);
             context.CancellationToken.Should().Be(CancellationToken);
         }
-
-        static void AssertContextNotInitialized(ResilienceContext context) => context.IsInitialized.Should().BeFalse();
 
         static void AssertContextInitialized(ResilienceContext context) => context.IsInitialized.Should().BeTrue();
     }

--- a/src/Polly.Core.Tests/ResilienceStrategyTests.Async.ValueTaskT.cs
+++ b/src/Polly.Core.Tests/ResilienceStrategyTests.Async.ValueTaskT.cs
@@ -17,14 +17,12 @@ public partial class ResilienceStrategyTests
         {
             Caption = "ExecuteAsyncT_NoCancellation",
             AssertContext = AssertResilienceContext,
-            AssertContextAfter = AssertContextNotInitialized,
         };
 
         yield return new ExecuteParameters<long>(r => r.ExecuteValueTaskAsync(async t => { t.Should().Be(CancellationToken); return result; }, CancellationToken), result)
         {
             Caption = "ExecuteAsyncT_Cancellation",
             AssertContext = AssertResilienceContextAndToken,
-            AssertContextAfter = AssertContextNotInitialized,
         };
 
         yield return new ExecuteParameters<long>(r => r.ExecuteValueTaskAsync(async (_, s) => { s.Should().Be("dummy-state"); return result; }, ResilienceContext.Get(), "dummy-state"), result)
@@ -47,8 +45,6 @@ public partial class ResilienceStrategyTests
             AssertResilienceContext(context);
             context.CancellationToken.Should().Be(CancellationToken);
         }
-
-        static void AssertContextNotInitialized(ResilienceContext context) => context.IsInitialized.Should().BeFalse();
 
         static void AssertContextInitialized(ResilienceContext context) => context.IsInitialized.Should().BeTrue();
     }

--- a/src/Polly.Core.Tests/ResilienceStrategyTests.Sync.cs
+++ b/src/Polly.Core.Tests/ResilienceStrategyTests.Sync.cs
@@ -13,14 +13,12 @@ public partial class ResilienceStrategyTests
         {
             Caption = "Execute_NoCancellation",
             AssertContext = AssertResilienceContext,
-            AssertContextAfter = AssertContextNotInitialized,
         };
 
         yield return new ExecuteParameters(r => r.Execute(t => { t.Should().Be(CancellationToken); }, CancellationToken))
         {
             Caption = "Execute_Cancellation",
             AssertContext = AssertResilienceContextAndToken,
-            AssertContextAfter = AssertContextNotInitialized,
         };
 
         yield return new ExecuteParameters(r => r.Execute((_, s) => { s.Should().Be("dummy-state"); }, ResilienceContext.Get(), "dummy-state"))
@@ -42,8 +40,6 @@ public partial class ResilienceStrategyTests
             AssertResilienceContext(context);
             context.CancellationToken.Should().Be(CancellationToken);
         }
-
-        static void AssertContextNotInitialized(ResilienceContext context) => context.IsInitialized.Should().BeFalse();
 
         static void AssertContextInitialized(ResilienceContext context) => context.IsInitialized.Should().BeTrue();
     }

--- a/src/Polly.Core.Tests/ResilienceStrategyTests.SyncT.cs
+++ b/src/Polly.Core.Tests/ResilienceStrategyTests.SyncT.cs
@@ -15,14 +15,12 @@ public partial class ResilienceStrategyTests
         {
             Caption = "ExecuteT_NoCancellation",
             AssertContext = AssertResilienceContext,
-            AssertContextAfter = AssertContextNotInitialized,
         };
 
         yield return new ExecuteParameters<long>(r => r.Execute(t => { t.Should().Be(CancellationToken); return result; }, CancellationToken), result)
         {
             Caption = "ExecuteT_Cancellation",
             AssertContext = AssertResilienceContextAndToken,
-            AssertContextAfter = AssertContextNotInitialized,
         };
 
         yield return new ExecuteParameters<long>(r => r.Execute((_, s) => { s.Should().Be("dummy-state"); return result; }, ResilienceContext.Get(), "dummy-state"), result)
@@ -45,8 +43,6 @@ public partial class ResilienceStrategyTests
             AssertResilienceContext(context);
             context.CancellationToken.Should().Be(CancellationToken);
         }
-
-        static void AssertContextNotInitialized(ResilienceContext context) => context.IsInitialized.Should().BeFalse();
 
         static void AssertContextInitialized(ResilienceContext context) => context.IsInitialized.Should().BeTrue();
     }

--- a/src/Polly.Core.Tests/Utils/TimeProviderExtensionsTests.cs
+++ b/src/Polly.Core.Tests/Utils/TimeProviderExtensionsTests.cs
@@ -54,6 +54,24 @@ public class TimeProviderExtensionsTests
         });
     }
 
+    [Fact]
+    public async Task DelayAsync_SystemSynchronousWhenCancelled_Ok()
+    {
+        using var cts = new CancellationTokenSource(5);
+        var delay = TimeSpan.FromMilliseconds(10);
+        var context = ResilienceContext.Get();
+        context.Initialize<VoidResult>(isSynchronous: true);
+        context.CancellationToken = cts.Token;
+
+        await TestUtils.AssertWithTimeoutAsync(async () =>
+        {
+            await TimeProvider.System
+                .Invoking(p => p.DelayAsync(delay, context))
+                .Should()
+                .ThrowAsync<OperationCanceledException>();
+        });
+    }
+
     [InlineData(false, false)]
     [InlineData(false, true)]
     [InlineData(true, false)]

--- a/src/Polly.RateLimiting.Tests/RateLimiterResilienceStrategyBuilderExtensionsTests.cs
+++ b/src/Polly.RateLimiting.Tests/RateLimiterResilienceStrategyBuilderExtensionsTests.cs
@@ -56,7 +56,7 @@ public class RateLimiterResilienceStrategyBuilderExtensionsTests
     };
 
     [MemberData(nameof(Data))]
-    [Theory]
+    [Theory(Skip = "https://github.com/stryker-mutator/stryker-net/issues/2144")]
     public void AddRateLimiter_Extensions_Ok(Action<ResilienceStrategyBuilder> configure)
     {
         var builder = new ResilienceStrategyBuilder();
@@ -64,6 +64,19 @@ public class RateLimiterResilienceStrategyBuilderExtensionsTests
         configure(builder);
 
         builder.Build().Should().BeOfType<RateLimiterResilienceStrategy>();
+    }
+
+    [Fact]
+    public void AddRateLimiter_AllExtensions_Ok()
+    {
+        foreach (var configure in Data.Select(v => v[0]).Cast<Action<ResilienceStrategyBuilder>>())
+        {
+            var builder = new ResilienceStrategyBuilder();
+
+            configure(builder);
+
+            builder.Build().Should().BeOfType<RateLimiterResilienceStrategy>();
+        }
     }
 
     [Fact]


### PR DESCRIPTION
### Details on the issue fix or feature implementation

With the introduction of `ResilienceContext` pooling (#1111) the "NotInitialized" assertion in `ResilienceStrategyTests` is no longer reliable because other tests might get the context from the pool and initialize it. This causes test instability.


### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
