### PR TITLE
Minor API cleanup

### DIFF
--- a/src/Polly.Core.Tests/Builder/ResilienceStrategyBuilderTests.cs
+++ b/src/Polly.Core.Tests/Builder/ResilienceStrategyBuilderTests.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using Moq;
 using Polly.Builder;
+using Polly.Strategy;
 using Polly.Telemetry;
 using Polly.Utils;
 

--- a/src/Polly.Core.Tests/ResilienceStrategyTests.Async.Task.cs
+++ b/src/Polly.Core.Tests/ResilienceStrategyTests.Async.Task.cs
@@ -11,19 +11,19 @@ public partial class ResilienceStrategyTests
 
     private static IEnumerable<ExecuteParameters> ExecuteAsTaskAsync_EnsureCorrectBehavior_ExecuteParameters()
     {
-        yield return new ExecuteParameters(r => r.ExecuteTaskAsync(async _ => { }))
+        yield return new ExecuteParameters(r => r.ExecuteAsync(async _ => { }))
         {
             Caption = "ExecuteAsTaskAsync_NoCancellation",
             AssertContext = AssertResilienceContext,
         };
 
-        yield return new ExecuteParameters(r => r.ExecuteTaskAsync(async t => { t.Should().Be(CancellationToken); }, CancellationToken))
+        yield return new ExecuteParameters(r => r.ExecuteAsync(async t => { t.Should().Be(CancellationToken); }, CancellationToken))
         {
             Caption = "ExecuteAsTaskAsync_Cancellation",
             AssertContext = AssertResilienceContextAndToken,
         };
 
-        yield return new ExecuteParameters(r => r.ExecuteTaskAsync(async (_, s) => { s.Should().Be("dummy-state"); }, ResilienceContext.Get(), "dummy-state"))
+        yield return new ExecuteParameters(r => r.ExecuteAsync(async (_, s) => { s.Should().Be("dummy-state"); }, ResilienceContext.Get(), "dummy-state"))
         {
             Caption = "ExecuteAsTaskAsync_ResilienceContextAndState",
             AssertContext = AssertResilienceContext,

--- a/src/Polly.Core.Tests/ResilienceStrategyTests.Async.TaskT.cs
+++ b/src/Polly.Core.Tests/ResilienceStrategyTests.Async.TaskT.cs
@@ -13,19 +13,19 @@ public partial class ResilienceStrategyTests
     {
         long result = 12345;
 
-        yield return new ExecuteParameters<long>(r => r.ExecuteTaskAsync(async t => result), result)
+        yield return new ExecuteParameters<long>(r => r.ExecuteAsync(async t => result), result)
         {
             Caption = "ExecuteAsTaskAsyncT_NoCancellation",
             AssertContext = AssertResilienceContext,
         };
 
-        yield return new ExecuteParameters<long>(r => r.ExecuteTaskAsync(async t => { t.Should().Be(CancellationToken); return result; }, CancellationToken), result)
+        yield return new ExecuteParameters<long>(r => r.ExecuteAsync(async t => { t.Should().Be(CancellationToken); return result; }, CancellationToken), result)
         {
             Caption = "ExecuteAsTaskAsyncT_Cancellation",
             AssertContext = AssertResilienceContextAndToken,
         };
 
-        yield return new ExecuteParameters<long>(r => r.ExecuteTaskAsync(async (_, s) => { s.Should().Be("dummy-state"); return result; }, ResilienceContext.Get(), "dummy-state"), result)
+        yield return new ExecuteParameters<long>(r => r.ExecuteAsync(async (_, s) => { s.Should().Be("dummy-state"); return result; }, ResilienceContext.Get(), "dummy-state"), result)
         {
             Caption = "ExecuteAsTaskAsyncT_ResilienceContextAndState",
             AssertContext = AssertResilienceContext,

--- a/src/Polly.Core.Tests/Strategy/ResilienceStrategyOptionsTests.cs
+++ b/src/Polly.Core.Tests/Strategy/ResilienceStrategyOptionsTests.cs
@@ -1,6 +1,6 @@
-using Polly.Builder;
+using Polly.Strategy;
 
-namespace Polly.Core.Tests.Builder;
+namespace Polly.Core.Tests.Strategy;
 
 public class ResilienceStrategyOptionsTests
 {

--- a/src/Polly.Core.Tests/Timeout/TimeoutResilienceStrategyTests.cs
+++ b/src/Polly.Core.Tests/Timeout/TimeoutResilienceStrategyTests.cs
@@ -70,7 +70,7 @@ public class TimeoutResilienceStrategyTests : IDisposable
         _timeProvider.SetupCancelAfterNow(_delay);
 
         var sut = CreateSut();
-        await sut.Invoking(s => sut.ExecuteTaskAsync(token => Task.Delay(_delay, token))).Should().ThrowAsync<TimeoutRejectedException>();
+        await sut.Invoking(s => sut.ExecuteAsync(token => Task.Delay(_delay, token))).Should().ThrowAsync<TimeoutRejectedException>();
 
         called.Should().BeTrue();
     }
@@ -103,7 +103,7 @@ public class TimeoutResilienceStrategyTests : IDisposable
         var sut = CreateSut();
 
         await sut
-            .Invoking(s => s.ExecuteTaskAsync(token => Delay(token), token))
+            .Invoking(s => s.ExecuteAsync(token => Delay(token), token))
             .Should().ThrowAsync<TimeoutRejectedException>()
             .WithMessage("The operation didn't complete within the allowed timeout of '00:00:02'.");
 
@@ -123,7 +123,7 @@ public class TimeoutResilienceStrategyTests : IDisposable
 
         var sut = CreateSut();
 
-        await sut.Invoking(s => s.ExecuteTaskAsync(token => Delay(token, () => cts.Cancel()), cts.Token))
+        await sut.Invoking(s => s.ExecuteAsync(token => Delay(token, () => cts.Cancel()), cts.Token))
                  .Should()
                  .ThrowAsync<OperationCanceledException>();
 
@@ -146,7 +146,7 @@ public class TimeoutResilienceStrategyTests : IDisposable
         var context = ResilienceContext.Get();
         context.CancellationToken = cts.Token;
 
-        await sut.ExecuteTaskAsync(
+        await sut.ExecuteAsync(
             (r, _) =>
             {
                 r.CancellationToken.Should().NotBe(cts.Token);
@@ -182,7 +182,7 @@ public class TimeoutResilienceStrategyTests : IDisposable
         // Act
         try
         {
-            await sut.ExecuteTaskAsync(token => Delay(token, () => cts.Cancel()), cts.Token);
+            await sut.ExecuteAsync(token => Delay(token, () => cts.Cancel()), cts.Token);
         }
         catch (OperationCanceledException)
         {

--- a/src/Polly.Core/Builder/ResilienceStrategyBuilder.cs
+++ b/src/Polly.Core/Builder/ResilienceStrategyBuilder.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Polly.Strategy;
 using Polly.Telemetry;
 
 namespace Polly.Builder;

--- a/src/Polly.Core/ResilienceStrategy.Async.Task.cs
+++ b/src/Polly.Core/ResilienceStrategy.Async.Task.cs
@@ -13,7 +13,7 @@ public abstract partial class ResilienceStrategy
     /// <param name="context">The context associated with the callback.</param>
     /// <param name="state">The state associated with the callback.</param>
     /// <returns>The instance of <see cref="Task"/> that represents the asynchronous execution.</returns>
-    public async Task ExecuteTaskAsync<TState>(
+    public async Task ExecuteAsync<TState>(
         Func<ResilienceContext, TState, Task> callback,
         ResilienceContext context,
         TState state)
@@ -39,7 +39,7 @@ public abstract partial class ResilienceStrategy
     /// <param name="callback">The user-provided callback.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> associated with the callback.</param>
     /// <returns>The instance of <see cref="Task"/> that represents an asynchronous callback.</returns>
-    public async Task ExecuteTaskAsync(
+    public async Task ExecuteAsync(
         Func<CancellationToken, Task> callback,
         CancellationToken cancellationToken = default)
     {

--- a/src/Polly.Core/ResilienceStrategy.Async.TaskT.cs
+++ b/src/Polly.Core/ResilienceStrategy.Async.TaskT.cs
@@ -11,7 +11,7 @@ public abstract partial class ResilienceStrategy
     /// <param name="context">The context associated with the callback.</param>
     /// <param name="state">The state associated with the callback.</param>
     /// <returns>The instance of <see cref="Task"/> that represents the asynchronous execution.</returns>
-    public async Task<TResult> ExecuteTaskAsync<TResult, TState>(
+    public async Task<TResult> ExecuteAsync<TResult, TState>(
         Func<ResilienceContext, TState, Task<TResult>> callback,
         ResilienceContext context,
         TState state)
@@ -37,7 +37,7 @@ public abstract partial class ResilienceStrategy
     /// <param name="callback">The user-provided callback.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> associated with the callback.</param>
     /// <returns>The instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
-    public async Task<TResult> ExecuteTaskAsync<TResult>(
+    public async Task<TResult> ExecuteAsync<TResult>(
         Func<CancellationToken, Task<TResult>> callback,
         CancellationToken cancellationToken = default)
     {

--- a/src/Polly.Core/Retry/RetryStrategyOptions.cs
+++ b/src/Polly.Core/Retry/RetryStrategyOptions.cs
@@ -1,5 +1,5 @@
 using System.ComponentModel.DataAnnotations;
-using Polly.Builder;
+using Polly.Strategy;
 
 namespace Polly.Retry;
 

--- a/src/Polly.Core/Strategy/ResilienceStrategyOptions.cs
+++ b/src/Polly.Core/Strategy/ResilienceStrategyOptions.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 
-namespace Polly.Builder;
+namespace Polly.Strategy;
 
 /// <summary>
 /// The options associated with the <see cref="ResilienceStrategy"/>.

--- a/src/Polly.Core/Timeout/TimeoutStrategyOptions.cs
+++ b/src/Polly.Core/Timeout/TimeoutStrategyOptions.cs
@@ -1,6 +1,6 @@
 using System;
 using System.ComponentModel.DataAnnotations;
-using Polly.Builder;
+using Polly.Strategy;
 
 namespace Polly.Timeout;
 

--- a/src/Polly.RateLimiting/RateLimiterStrategyOptions.cs
+++ b/src/Polly.RateLimiting/RateLimiterStrategyOptions.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Threading.RateLimiting;
-using Polly.Builder;
+using Polly.Strategy;
 
 namespace Polly.RateLimiting;
 


### PR DESCRIPTION
### Details on the issue fix or feature implementation

- Renaming `ExecuteTaskAsync` to `ExecuteAsync`
- Moving `ResilienceStrategyOptions` to `Polly.Strategy` namespace

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
