### PR TITLE
Add publish workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: build
 on:
   push:
     branches: [ main ]
+    tags: [ '*' ]
   pull_request:
     branches: [ main ]
   workflow_dispatch:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,4 +95,5 @@ jobs:
       shell: pwsh
       run: |
         Write-Host "This is where the packages would be published to NuGet.org"
-        <# dotnet nuget push "artifacts\nuget-packages\*.nupkg" --api-key ${{ secrets.NUGET_TOKEN }} --skip-duplicate --source https://api.nuget.org/v3/index.json #>
+        ls
+        <# dotnet nuget push "*.nupkg" --api-key ${{ secrets.NUGET_TOKEN }} --skip-duplicate --source https://api.nuget.org/v3/index.json #>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,15 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_GENERATE_ASPNET_CERTIFICATE: false
+  DOTNET_NOLOGO: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
+  NUGET_XMLDOC_MODE: skip
+  TERM: xterm
+
 permissions:
   contents: read
 
@@ -48,13 +57,6 @@ jobs:
       shell: pwsh
       run: ./build.ps1
       env:
-        DOTNET_CLI_TELEMETRY_OPTOUT: true
-        DOTNET_GENERATE_ASPNET_CERTIFICATE: false
-        DOTNET_NOLOGO: true
-        DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-        DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
-        NUGET_XMLDOC_MODE: skip
-        TERM: xterm
         RUN_MUTATION_TESTS: ${{ matrix.os_name == 'linux' && 'true' || 'false' }}
 
     - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
@@ -76,11 +78,41 @@ jobs:
         name: packages-${{ matrix.os_name }}
         path: ./artifacts/nuget-packages
 
-  publish:
-    name: publish
+  validate-packages:
     needs: build
     runs-on: ubuntu-latest
-    #if: ${{ github.event.repository.fork == false && startsWith(github.ref, 'refs/tags/') }}
+    steps:
+
+    - name: Download packages
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      with:
+        name: packages-windows
+
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
+
+    - name: Validate NuGet packages
+      shell: pwsh
+      run: |
+        dotnet tool install --global dotnet-validate --version 0.0.1-preview.304
+        $packages = Get-ChildItem -Filter "*.nupkg" | ForEach-Object { $_.FullName }
+        $invalidPackages = 0
+        foreach ($package in $packages) {
+          dotnet validate package local $package
+          if ($LASTEXITCODE -ne 0) {
+            $invalidPackages++
+          }
+        }
+        if ($invalidPackages -gt 0) {
+          Write-Output "::error::$invalidPackages NuGet package(s) failed validation."
+        }
+
+  publish-nuget:
+    needs: validate-packages
+    runs-on: ubuntu-latest
+    if: |
+      github.event.repository.fork == false &&
+      startsWith(github.ref, 'refs/tags/')
     steps:
 
     - name: Download packages
@@ -92,8 +124,4 @@ jobs:
       uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
 
     - name: Push NuGet packages to NuGet.org
-      shell: pwsh
-      run: |
-        Write-Host "This is where the packages would be published to NuGet.org"
-        ls
-        <# dotnet nuget push "*.nupkg" --api-key ${{ secrets.NUGET_TOKEN }} --skip-duplicate --source https://api.nuget.org/v3/index.json #>
+      run: dotnet nuget push "*.nupkg" --api-key ${{ secrets.NUGET_TOKEN }} --skip-duplicate --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,4 +74,25 @@ jobs:
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: packages-${{ matrix.os_name }}
-        path: ./artifacts/nuget-package
+        path: ./artifacts/nuget-packages
+
+  publish:
+    name: publish
+    needs: build
+    runs-on: ubuntu-latest
+    #if: ${{ github.event.repository.fork == false && startsWith(github.ref, 'refs/tags/') }}
+    steps:
+
+    - name: Download packages
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      with:
+        name: packages-windows
+
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
+
+    - name: Push NuGet packages to NuGet.org
+      shell: pwsh
+      run: |
+        Write-Host "This is where the packages would be published to NuGet.org"
+        <# dotnet nuget push "artifacts\nuget-packages\*.nupkg" --api-key ${{ secrets.NUGET_TOKEN }} --skip-duplicate --source https://api.nuget.org/v3/index.json #>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
         name: packages-windows
 
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
+      uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
 
     - name: Validate NuGet packages
       shell: pwsh
@@ -108,9 +108,38 @@ jobs:
           Write-Output "::error::$invalidPackages NuGet package(s) failed validation."
         }
 
-  publish-nuget:
+  publish-github:
     needs: validate-packages
+    permissions:
+      packages: write
     runs-on: ubuntu-latest
+    if: |
+      github.event.repository.fork == false &&
+      (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) ||
+       startsWith(github.ref, 'refs/tags/v'))
+    steps:
+
+    - name: Download packages
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      with:
+        name: packages-windows
+
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
+
+    - name: Publish NuGet packages to GitHub Packages
+      run: dotnet nuget push "*.nupkg" --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate --no-symbols --source https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+
+  # TODO Add Authenticode signing step before publish-nuget.
+  # See https://github.com/dotnet/sign/blob/main/docs/gh-build-and-sign.yml.
+
+  publish-nuget:
+    needs: publish-github
+    runs-on: ubuntu-latest
+    # TODO Optionally use an environment to protect access to the token
+    #environment:
+    #  name: NuGet
+    #  url: https://www.nuget.org/packages/Polly
     if: |
       github.event.repository.fork == false &&
       startsWith(github.ref, 'refs/tags/')
@@ -122,7 +151,7 @@ jobs:
         name: packages-windows
 
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
+      uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
 
     - name: Push NuGet packages to NuGet.org
       run: dotnet nuget push "*.nupkg" --api-key ${{ secrets.NUGET_TOKEN }} --skip-duplicate --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,7 @@ jobs:
       with:
         name: packages-${{ matrix.os_name }}
         path: ./artifacts/nuget-packages
+        if-no-files-found: error
 
   validate-packages:
     needs: build

--- a/build.cake
+++ b/build.cake
@@ -35,7 +35,7 @@ var artifactsDir = Directory("./artifacts");
 var testResultsDir = System.IO.Path.Combine(artifactsDir, Directory("test-results"));
 
 // NuGet
-var nupkgDestDir = System.IO.Path.Combine(artifactsDir, Directory("nuget-package"));
+var nupkgDestDir = System.IO.Path.Combine(artifactsDir, Directory("nuget-packages"));
 
 // GitVersion
 var gitVersionPath = ToolsExePath("GitVersion.exe");


### PR DESCRIPTION
Add a workflow to publish NuGet packages to NuGet.org - the packages are pushed only when a tag is created in this repository.

As currently configured, anyone with write access to the repository would be able to publish a package as they would be able to use the secret.

If this isn't desirable for some reason, we could have the NuGet publish token as an _environment secret_, and have that require approval by specific GitHub accounts by tying the NuGet publish step to that environment.
