### PR TITLE
Resilience telemetry API

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,3 +18,4 @@ tab_width = 2
 [*.cs]
 
 # Put any C# specific settings here
+dotnet_code_quality.CA1062.null_check_validation_methods = NotNull

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,5 +21,6 @@ updates:
     - dependency-name: "System.ValueTuple"
     - dependency-name: "Microsoft.Extensions.Options"
     - dependency-name: "Microsoft.Extensions.Logging.Abstractions"
+    - dependency-name: "Microsoft.Extensions.Logging"
     - dependency-name: "System.Diagnostics.DiagnosticSource"
     - dependency-name: "System.Threading.RateLimiting"

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -7,6 +7,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Moq" Version="4.18.4" />

--- a/src/Polly.Core.Tests/Registry/ResilienceStrategyRegistryOptionsTests.cs
+++ b/src/Polly.Core.Tests/Registry/ResilienceStrategyRegistryOptionsTests.cs
@@ -1,0 +1,15 @@
+using Polly.Registry;
+
+namespace Polly.Core.Tests.Registry;
+public class ResilienceStrategyRegistryOptionsTests
+{
+    [Fact]
+    public void Ctor_EnsureDefaults()
+    {
+        ResilienceStrategyRegistryOptions<object> options = new();
+
+        options.KeyFormatter.Should().NotBeNull();
+        options.KeyFormatter(null!).Should().Be("");
+        options.KeyFormatter("ABC").Should().Be("ABC");
+    }
+}

--- a/src/Polly.Core.Tests/Registry/ResilienceStrategyRegistryTests.cs
+++ b/src/Polly.Core.Tests/Registry/ResilienceStrategyRegistryTests.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using Polly.Registry;
+using Polly.Telemetry;
 
 namespace Polly.Core.Tests.Registry;
 
@@ -115,6 +116,24 @@ public class ResilienceStrategyRegistryTests
         called.Should().Be(3);
         activatorCalls.Should().Be(3);
         strategies.Keys.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void AddBuilder_EnsureStrategyKey()
+    {
+        var called = false;
+        var registry = CreateRegistry();
+        registry.TryAddBuilder(StrategyId.Create("A"), (key, builder) =>
+        {
+            builder.AddStrategy(new TestResilienceStrategy());
+            builder.Properties.TryGetValue(TelemetryUtil.StrategyKey, out var val).Should().BeTrue();
+            val.Should().Be(key.ToString());
+            called = true;
+        });
+
+        registry.Get(StrategyId.Create("A", "Instance1"));
+
+        called.Should().BeTrue();
     }
 
     [Fact]

--- a/src/Polly.Core.Tests/ResilienceContextTests.cs
+++ b/src/Polly.Core.Tests/ResilienceContextTests.cs
@@ -17,13 +17,16 @@ public class ResilienceContextTests
     }
 
     [Fact]
-    public void Get_EnsurePooled()
+    public async Task Get_EnsurePooled()
     {
-        var context = ResilienceContext.Get();
+        await TestUtils.AssertWithTimeoutAsync(() =>
+        {
+            var context = ResilienceContext.Get();
 
-        ResilienceContext.Return(context);
+            ResilienceContext.Return(context);
 
-        ResilienceContext.Get().Should().BeSameAs(context);
+            ResilienceContext.Get().Should().BeSameAs(context);
+        });
     }
 
     [Fact]
@@ -33,17 +36,20 @@ public class ResilienceContextTests
     }
 
     [Fact]
-    public void Return_EnsureDefaults()
+    public async Task Return_EnsureDefaults()
     {
-        using var cts = new CancellationTokenSource();
-        var context = ResilienceContext.Get();
-        context.CancellationToken = cts.Token;
-        context.Initialize<bool>(true);
-        context.CancellationToken.Should().Be(cts.Token);
-        context.Properties.Set(new ResiliencePropertyKey<int>("abc"), 10);
-        ResilienceContext.Return(context);
+        await TestUtils.AssertWithTimeoutAsync(() =>
+        {
+            using var cts = new CancellationTokenSource();
+            var context = ResilienceContext.Get();
+            context.CancellationToken = cts.Token;
+            context.Initialize<bool>(true);
+            context.CancellationToken.Should().Be(cts.Token);
+            context.Properties.Set(new ResiliencePropertyKey<int>("abc"), 10);
+            ResilienceContext.Return(context);
 
-        AssertDefaults(context);
+            AssertDefaults(context);
+        });
     }
 
     [InlineData(true)]

--- a/src/Polly.Core.Tests/Strategy/ResilienceStrategyTelemetryTests.cs
+++ b/src/Polly.Core.Tests/Strategy/ResilienceStrategyTelemetryTests.cs
@@ -51,6 +51,16 @@ public class ResilienceStrategyTelemetryTests
     }
 
     [Fact]
+    public void ResilienceStrategyTelemetry_NoDiagnosticSource_Ok()
+    {
+        var source = new ResilienceTelemetrySource("builder", new ResilienceProperties(), "strategy-name", "strategy-type");
+        var sut = new ResilienceStrategyTelemetry(source, null);
+
+        sut.Invoking(s => s.Report("dummy", new TestArguments())).Should().NotThrow();
+        sut.Invoking(s => s.Report("dummy", new Outcome<int>(1), new TestArguments())).Should().NotThrow();
+    }
+
+    [Fact]
     public void Report_Outcome_OK()
     {
         _diagnosticSource.Setup(o => o.IsEnabled("dummy-event")).Returns(true);

--- a/src/Polly.Core.Tests/Telemetry/TelemetryUtilTests.cs
+++ b/src/Polly.Core.Tests/Telemetry/TelemetryUtilTests.cs
@@ -7,6 +7,13 @@ namespace Polly.Core.Tests.Telemetry;
 public class TelemetryUtilTests
 {
     [Fact]
+    public void Ctor_Ok()
+    {
+        TelemetryUtil.DiagnosticSourceKey.Key.Should().Be("DiagnosticSource");
+        TelemetryUtil.StrategyKey.Key.Should().Be("StrategyKey");
+    }
+
+    [Fact]
     public void CreateResilienceTelemetry_Ok()
     {
         var telemetry = TelemetryUtil.CreateTelemetry("builder", new ResilienceProperties(), "strategy-name", "strategy-type");
@@ -14,9 +21,7 @@ public class TelemetryUtilTests
         telemetry.TelemetrySource.BuilderName.Should().Be("builder");
         telemetry.TelemetrySource.StrategyName.Should().Be("strategy-name");
         telemetry.TelemetrySource.StrategyType.Should().Be("strategy-type");
-        telemetry.DiagnosticSource.Should().NotBeNull();
-
-        telemetry.DiagnosticSource.Should().BeOfType<DiagnosticListener>().Subject.Name.Should().Be("Polly");
+        telemetry.DiagnosticSource.Should().BeNull();
     }
 
     [Fact]

--- a/src/Polly.Core/Polly.Core.csproj
+++ b/src/Polly.Core/Polly.Core.csproj
@@ -18,6 +18,7 @@
     <Using Include="Polly.Utils" />
     <Using Remove="System.Net.Http" />
     <InternalsVisibleToTest Include="Polly.Core.Tests" />
+    <InternalsVisibleToTest Include="Polly.Extensions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Polly.Core/Registry/ResilienceStrategyRegistryOptions.cs
+++ b/src/Polly.Core/Registry/ResilienceStrategyRegistryOptions.cs
@@ -34,4 +34,10 @@ public class ResilienceStrategyRegistryOptions<TKey>
     /// </remarks>
     [Required]
     public IEqualityComparer<TKey> BuilderComparer { get; set; } = EqualityComparer<TKey>.Default;
+
+    /// <summary>
+    /// Gets or sets the formatter that is used by the registry to format the keys as a string.
+    /// </summary>
+    [Required]
+    public Func<TKey, string> KeyFormatter { get; set; } = (key) => key?.ToString() ?? string.Empty;
 }

--- a/src/Polly.Core/Strategy/ResilienceStrategyTelemetry.cs
+++ b/src/Polly.Core/Strategy/ResilienceStrategyTelemetry.cs
@@ -10,13 +10,13 @@ namespace Polly.Strategy;
 /// </remarks>
 public sealed class ResilienceStrategyTelemetry
 {
-    internal ResilienceStrategyTelemetry(ResilienceTelemetrySource source, DiagnosticSource diagnosticSource)
+    internal ResilienceStrategyTelemetry(ResilienceTelemetrySource source, DiagnosticSource? diagnosticSource)
     {
         TelemetrySource = source;
         DiagnosticSource = diagnosticSource;
     }
 
-    internal DiagnosticSource DiagnosticSource { get; }
+    internal DiagnosticSource? DiagnosticSource { get; }
 
     internal ResilienceTelemetrySource TelemetrySource { get; }
 
@@ -29,7 +29,7 @@ public sealed class ResilienceStrategyTelemetry
     public void Report<TArgs>(string eventName, TArgs args)
         where TArgs : IResilienceArguments
     {
-        if (!DiagnosticSource.IsEnabled(eventName))
+        if (DiagnosticSource is null || !DiagnosticSource.IsEnabled(eventName))
         {
             return;
         }
@@ -48,7 +48,7 @@ public sealed class ResilienceStrategyTelemetry
     public void Report<TArgs, TResult>(string eventName, Outcome<TResult> outcome, TArgs args)
         where TArgs : IResilienceArguments
     {
-        if (!DiagnosticSource.IsEnabled(eventName))
+        if (DiagnosticSource is null || !DiagnosticSource.IsEnabled(eventName))
         {
             return;
         }

--- a/src/Polly.Core/Telemetry/TelemetryUtil.cs
+++ b/src/Polly.Core/Telemetry/TelemetryUtil.cs
@@ -4,19 +4,15 @@ namespace Polly.Telemetry;
 
 internal static class TelemetryUtil
 {
-    private const string PollyDiagnosticSource = "Polly";
+    internal const string PollyDiagnosticSource = "Polly";
 
-    private static readonly DiagnosticSource DefaultDiagnosticSource = new DiagnosticListener(PollyDiagnosticSource);
+    internal static readonly ResiliencePropertyKey<DiagnosticSource> DiagnosticSourceKey = new("DiagnosticSource");
 
-    private static readonly ResiliencePropertyKey<DiagnosticSource> DiagnosticSourceKey = new("DiagnosticSource");
+    internal static readonly ResiliencePropertyKey<string> StrategyKey = new("StrategyKey");
 
     public static ResilienceStrategyTelemetry CreateTelemetry(string builderName, ResilienceProperties builderProperties, string strategyName, string strategyType)
     {
-        // Allows the user to override the default diagnostic source.
-        if (!builderProperties.TryGetValue(DiagnosticSourceKey, out var diagnosticSource))
-        {
-            diagnosticSource = DefaultDiagnosticSource;
-        }
+        builderProperties.TryGetValue(DiagnosticSourceKey, out var diagnosticSource);
 
         var telemetrySource = new ResilienceTelemetrySource(builderName, builderProperties, strategyName, strategyType);
 

--- a/src/Polly.Extensions.Tests/Helpers/FakeLogger.cs
+++ b/src/Polly.Extensions.Tests/Helpers/FakeLogger.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.Logging;
+
+namespace Polly.Extensions.Tests.Helpers;
+
+#pragma warning disable CS8633 // Nullability in constraints for type parameter doesn't match the constraints for type parameter in implicitly implemented interface method'.
+
+public class FakeLogger : ILogger
+{
+    public List<string> Messages { get; } = new();
+
+    public List<Exception?> Exceptions { get; } = new();
+
+    public List<EventId> Events { get; } = new();
+
+    public IDisposable BeginScope<TState>(TState state)
+        where TState : notnull => throw new NotSupportedException();
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+         where TState : notnull
+    {
+        Exceptions.Add(exception);
+        Messages.Add(formatter(state, exception));
+        Events.Add(eventId);
+    }
+}

--- a/src/Polly.Extensions.Tests/Helpers/TestArguments.cs
+++ b/src/Polly.Extensions.Tests/Helpers/TestArguments.cs
@@ -1,0 +1,5 @@
+using Polly.Strategy;
+
+namespace Polly.Extensions.Tests.Helpers;
+
+public record class TestArguments(ResilienceContext Context) : IResilienceArguments;

--- a/src/Polly.Extensions.Tests/Helpers/TestStrategy.cs
+++ b/src/Polly.Extensions.Tests/Helpers/TestStrategy.cs
@@ -1,0 +1,43 @@
+using Polly.Strategy;
+
+namespace Polly.Extensions.Tests.Helpers;
+
+public class TestStrategy : ResilienceStrategy
+{
+    private readonly ResilienceStrategyTelemetry _telemetry;
+    private readonly bool _noOutcome;
+
+    public TestStrategy(ResilienceStrategyTelemetry telemetry, bool noOutcome)
+    {
+        _telemetry = telemetry;
+        _noOutcome = noOutcome;
+    }
+
+    protected override async ValueTask<TResult> ExecuteCoreAsync<TResult, TState>(Func<ResilienceContext, TState, ValueTask<TResult>> callback, ResilienceContext context, TState state)
+    {
+        if (_noOutcome)
+        {
+            _telemetry.Report("no-outcome", new TestArguments(context));
+        }
+
+        try
+        {
+            var result = await callback(context, state);
+            if (!_noOutcome)
+            {
+                _telemetry.Report("outcome", new Outcome<TResult>(result), new TestArguments(context));
+            }
+
+            return result;
+        }
+        catch (Exception e)
+        {
+            if (!_noOutcome)
+            {
+                _telemetry.Report("outcome", new Outcome<TResult>(e), new TestArguments(context));
+            }
+
+            throw;
+        }
+    }
+}

--- a/src/Polly.Extensions.Tests/Helpers/TestUtils.cs
+++ b/src/Polly.Extensions.Tests/Helpers/TestUtils.cs
@@ -1,0 +1,58 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Polly.Extensions.Telemetry;
+using Polly.Strategy;
+
+namespace Polly.Extensions.Tests.Helpers;
+
+#pragma warning disable CA1031 // Do not catch general exception types
+
+public static class TestUtils
+{
+    public static Task AssertWithTimeoutAsync(Func<Task> assertion) => AssertWithTimeoutAsync(assertion, TimeSpan.FromSeconds(60));
+
+    public static Task AssertWithTimeoutAsync(Action assertion) => AssertWithTimeoutAsync(
+        () =>
+        {
+            assertion();
+            return Task.CompletedTask;
+        },
+        TimeSpan.FromSeconds(60));
+
+    public static async Task AssertWithTimeoutAsync(Func<Task> assertion, TimeSpan timeout)
+    {
+        var watch = Stopwatch.StartNew();
+
+        while (true)
+        {
+            try
+            {
+                await assertion();
+                return;
+            }
+            catch (Exception) when (watch.Elapsed < timeout)
+            {
+                await Task.Delay(5);
+            }
+        }
+    }
+
+    public static ILoggerFactory CreateLoggerFactory(out FakeLogger logger)
+    {
+        logger = new FakeLogger();
+        var loggerFactory = new Mock<ILoggerFactory>(MockBehavior.Strict);
+        loggerFactory.Setup(v => v.CreateLogger("Polly")).Returns(logger);
+        loggerFactory.Setup(v => v.Dispose());
+
+        return loggerFactory.Object;
+    }
+
+    public static TestStrategy AddStrategyAndEnableTelemetry(this ResilienceStrategyBuilder builder, bool noOutcome, Action<ResilienceStrategyTelemetryOptions> configure)
+    {
+        var options = new ResilienceStrategyTelemetryOptions();
+        configure.Invoke(options);
+        builder.EnableTelemetry(options);
+        builder.AddStrategy(c => new TestStrategy(c.Telemetry, noOutcome), new ResilienceStrategyOptions { StrategyName = "strategy-name", StrategyType = "strategy-type" });
+        return (TestStrategy)builder.Build();
+    }
+}

--- a/src/Polly.Extensions.Tests/Polly.Extensions.Tests.csproj
+++ b/src/Polly.Extensions.Tests/Polly.Extensions.Tests.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Polly.Extensions.Tests/Telemetry/EnrichmentContextTests.cs
+++ b/src/Polly.Extensions.Tests/Telemetry/EnrichmentContextTests.cs
@@ -1,0 +1,21 @@
+using System.Threading.Tasks;
+using Polly.Extensions.Telemetry;
+using Polly.Extensions.Tests.Helpers;
+
+namespace Polly.Extensions.Tests.Telemetry;
+
+public class EnrichmentContextTests
+{
+    [Fact]
+    public async Task Pooling_OK()
+    {
+        await TestUtils.AssertWithTimeoutAsync(() =>
+        {
+            var context = EnrichmentContext.Get(new TestArguments(ResilienceContext.Get()), null);
+
+            EnrichmentContext.Return(context);
+
+            EnrichmentContext.Get(new TestArguments(ResilienceContext.Get()), null).Should().BeSameAs(context);
+        });
+    }
+}

--- a/src/Polly.Extensions.Tests/Telemetry/ResilienceStrategyTelemetryOptionsTests.cs
+++ b/src/Polly.Extensions.Tests/Telemetry/ResilienceStrategyTelemetryOptionsTests.cs
@@ -1,0 +1,16 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Polly.Extensions.Telemetry;
+
+namespace Polly.Extensions.Tests.Telemetry;
+public class ResilienceStrategyTelemetryOptionsTests
+{
+    [Fact]
+    public void Ctor_EnsureDefaults()
+    {
+        var options = new ResilienceStrategyTelemetryOptions();
+
+        options.Enrichers.Should().BeEmpty();
+        options.LoggerFactory.Should().Be(NullLoggerFactory.Instance);
+        options.OutcomeFormatter(new Strategy.Outcome(typeof(string), "A")).Should().Be("A");
+    }
+}

--- a/src/Polly.Extensions.Tests/Telemetry/ResilienceTelemetryDiagnosticSourceTests.cs
+++ b/src/Polly.Extensions.Tests/Telemetry/ResilienceTelemetryDiagnosticSourceTests.cs
@@ -1,0 +1,36 @@
+using Polly.Extensions.Telemetry;
+using Polly.Extensions.Tests.Helpers;
+
+namespace Polly.Extensions.Tests.Telemetry;
+
+public class ResilienceTelemetryDiagnosticSourceTests
+{
+    [Fact]
+    public void Meter_Ok()
+    {
+        ResilienceTelemetryDiagnosticSource.Meter.Name.Should().Be("Polly");
+        ResilienceTelemetryDiagnosticSource.Meter.Version.Should().Be("1.0");
+        new ResilienceTelemetryDiagnosticSource(new ResilienceStrategyTelemetryOptions())
+            .Counter.Description.Should().Be("Tracks the number of resilience events that occurred in resilience strategies.");
+    }
+
+    [Fact]
+    public void LoggerFactory_Ok()
+    {
+        var source = new ResilienceTelemetryDiagnosticSource(new ResilienceStrategyTelemetryOptions());
+        source.LoggerFactory.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Write_InvalidType_Nothing()
+    {
+        var source = new ResilienceTelemetryDiagnosticSource(new ResilienceStrategyTelemetryOptions
+        {
+            LoggerFactory = TestUtils.CreateLoggerFactory(out var logger)
+        });
+
+        source.Write("dummy", new object());
+
+        logger.Messages.Should().BeEmpty();
+    }
+}

--- a/src/Polly.Extensions.Tests/Telemetry/TelemetryResilienceStrategyBuilderExtensionsTests.cs
+++ b/src/Polly.Extensions.Tests/Telemetry/TelemetryResilienceStrategyBuilderExtensionsTests.cs
@@ -1,0 +1,265 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.Logging;
+using Polly.Extensions.Telemetry;
+using Polly.Extensions.Tests.Helpers;
+using Polly.Strategy;
+
+namespace Polly.Extensions.Tests.Telemetry;
+
+#pragma warning disable S103 // Lines should not be too long
+
+public class TelemetryResilienceStrategyBuilderExtensionsTests : IDisposable
+{
+    private readonly ResilienceStrategyBuilder _builder = new();
+    private readonly FakeLogger _logger;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly MeterListener _meterListener;
+    private readonly List<Dictionary<string, object?>> _events = new();
+
+    public TelemetryResilienceStrategyBuilderExtensionsTests()
+    {
+        _builder.BuilderName = "dummy-builder";
+        _builder.Properties.Set(new ResiliencePropertyKey<string>("StrategyKey"), "strategy-key");
+        _loggerFactory = TestUtils.CreateLoggerFactory(out _logger);
+        _meterListener = new MeterListener
+        {
+            InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == "Polly")
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+        _meterListener.SetMeasurementEventCallback<int>(OnMeasurementRecorded);
+        _meterListener.Start();
+
+        void OnMeasurementRecorded<T>(Instrument instrument, T measurement, ReadOnlySpan<KeyValuePair<string, object?>> tags, object? state)
+        {
+            instrument.Name.Should().Be("resilience-events");
+            _events.Add(tags.ToArray().ToDictionary(v => v.Key, v => v.Value));
+        }
+    }
+
+    public void Dispose()
+    {
+        _loggerFactory.Dispose();
+        _meterListener.Dispose();
+    }
+
+    [InlineData(true)]
+    [InlineData(false)]
+    [Theory]
+    public void EnableTelemetry_LoggingWithOutcome_Ok(bool noOutcome)
+    {
+        var strategy = CreateStrategyWithTelemetry(noOutcome);
+
+        strategy.Execute(_ => true);
+
+        _logger.Messages.Should().HaveCount(1);
+        _logger.Events.Should().HaveCount(1);
+
+        _logger.Events[0].Name.Should().Be("ResilienceEvent");
+        _logger.Events[0].Id.Should().Be(1);
+
+        if (noOutcome)
+        {
+            _logger.Messages[0].Should().Be("Resilience event occurred. EventName: 'no-outcome', Builder Name: 'dummy-builder', Strategy Name: 'strategy-name', Strategy Type: 'strategy-type', Strategy Key: 'strategy-key', Outcome: 'null'");
+        }
+        else
+        {
+            _logger.Messages[0].Should().Be("Resilience event occurred. EventName: 'outcome', Builder Name: 'dummy-builder', Strategy Name: 'strategy-name', Strategy Type: 'strategy-type', Strategy Key: 'strategy-key', Outcome: 'True'");
+        }
+    }
+
+    [InlineData(true)]
+    [InlineData(false)]
+    [Theory]
+    public void EnableTelemetry_LoggingWithException_Ok(bool noOutcome)
+    {
+        var strategy = CreateStrategyWithTelemetry(noOutcome);
+
+        try
+        {
+            strategy.Execute(_ => throw new InvalidOperationException("Dummy message."));
+        }
+        catch (InvalidOperationException)
+        {
+            // ok
+        }
+
+        _logger.Messages.Should().HaveCount(1);
+        _logger.Exceptions.Should().HaveCount(1);
+
+        if (noOutcome)
+        {
+            _logger.Messages[0].Should().Be("Resilience event occurred. EventName: 'no-outcome', Builder Name: 'dummy-builder', Strategy Name: 'strategy-name', Strategy Type: 'strategy-type', Strategy Key: 'strategy-key', Outcome: 'null'");
+        }
+        else
+        {
+            _logger.Messages[0].Should().Be("Resilience event occurred. EventName: 'outcome', Builder Name: 'dummy-builder', Strategy Name: 'strategy-name', Strategy Type: 'strategy-type', Strategy Key: 'strategy-key', Outcome: 'Dummy message.'");
+        }
+    }
+
+    [Fact]
+    public void EnableTelemetry_LoggingWithoutStrategyKey_Ok()
+    {
+        ((IDictionary<string, object?>)_builder.Properties).Remove("StrategyKey");
+        var strategy = CreateStrategyWithTelemetry(true);
+
+        try
+        {
+            strategy.Execute(_ => throw new InvalidOperationException("Dummy message."));
+        }
+        catch (InvalidOperationException)
+        {
+            // ok
+        }
+
+        _logger.Messages[0].Should().Be("Resilience event occurred. EventName: 'no-outcome', Builder Name: 'dummy-builder', Strategy Name: 'strategy-name', Strategy Type: 'strategy-type', Strategy Key: 'null', Outcome: 'null'");
+    }
+
+    [InlineData(true, false)]
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    [InlineData(false, true)]
+    [Theory]
+    public void EnableTelemetry_MeteringWithoutEnrichers_Ok(bool noOutcome, bool exception)
+    {
+        var strategy = CreateStrategyWithTelemetry(noOutcome);
+        var exceptionReported = exception && !noOutcome;
+
+        try
+        {
+            if (noOutcome)
+            {
+                strategy.Execute(_ => true);
+            }
+            else
+            {
+                strategy.Execute(_ =>
+                {
+                    if (exception)
+                    {
+                        throw new InvalidOperationException();
+                    }
+                });
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            // ok
+        }
+
+        _events.Should().HaveCount(1);
+
+        var ev = _events[0];
+
+        ev.Count.Should().Be(7);
+        ev["event-name"].Should().Be(noOutcome ? "no-outcome" : "outcome");
+        ev["strategy-type"].Should().Be("strategy-type");
+        ev["strategy-name"].Should().Be("strategy-name");
+        ev["strategy-type"].Should().Be("strategy-type");
+        ev["strategy-key"].Should().Be("strategy-key");
+        ev["builder-name"].Should().Be("dummy-builder");
+        ev["result-type"].Should().Be(noOutcome ? "Boolean" : "void");
+
+        if (exceptionReported)
+        {
+            ev["exception-name"].Should().Be("System.InvalidOperationException");
+        }
+        else
+        {
+            ev["exception-name"].Should().Be(null);
+        }
+    }
+
+    [InlineData(true)]
+    [InlineData(false)]
+    [Theory]
+    public void EnableTelemetry_MeteringWithEnrichers_Ok(bool noOutcome)
+    {
+        var strategy = CreateStrategyWithTelemetry(noOutcome, options =>
+        {
+            options.Enrichers.Add(context =>
+            {
+                if (noOutcome)
+                {
+                    context.Outcome.Should().BeNull();
+                }
+                else
+                {
+                    context.Outcome!.Value.Result.Should().Be(true);
+                }
+
+                context.ResilienceContext.Should().NotBeNull();
+                context.ResilienceArguments.Should().BeOfType<TestArguments>();
+                context.Tags.Add(new KeyValuePair<string, object?>("custom-1", "custom-1-value"));
+            });
+
+            options.Enrichers.Add(context =>
+            {
+                context.Tags.Add(new KeyValuePair<string, object?>("custom-2", "custom-2-value"));
+            });
+        });
+
+        strategy.Execute(_ => true);
+        strategy.Execute(_ => true);
+
+        var ev = _events[0];
+        ev.Count.Should().Be(9);
+
+        ev["custom-1"].Should().Be("custom-1-value");
+        ev["custom-2"].Should().Be("custom-2-value");
+
+        ev = _events[1];
+        ev.Count.Should().Be(9);
+
+        ev["custom-1"].Should().Be("custom-1-value");
+        ev["custom-2"].Should().Be("custom-2-value");
+    }
+
+    [InlineData(true)]
+    [InlineData(false)]
+    [Theory]
+    public void EnableTelemetry_MeteringWithoutStrategyKey_Ok(bool noOutcome)
+    {
+        ((IDictionary<string, object?>)_builder.Properties).Remove("StrategyKey");
+        var strategy = CreateStrategyWithTelemetry(noOutcome);
+
+        strategy.Execute(_ => true);
+
+        _events[0]["strategy-key"].Should().BeNull();
+    }
+
+    [Fact]
+    public void EnableTelemetry_InvalidOptions_Throws()
+    {
+        _builder
+            .Invoking(b => b.EnableTelemetry(new ResilienceStrategyTelemetryOptions
+            {
+                LoggerFactory = null!,
+                OutcomeFormatter = null!
+            })).Should()
+            .Throw<ValidationException>()
+            .WithMessage("""
+            The resilience telemetry options are invalid.
+
+            Validation Errors:
+            The LoggerFactory field is required.
+            The OutcomeFormatter field is required.
+            """);
+    }
+
+    private ResilienceStrategy CreateStrategyWithTelemetry(bool noOutcome, Action<ResilienceStrategyTelemetryOptions>? configure = null)
+    {
+        return _builder.AddStrategyAndEnableTelemetry(noOutcome, options =>
+        {
+            options.LoggerFactory = _loggerFactory;
+            configure?.Invoke(options);
+
+        });
+    }
+}

--- a/src/Polly.Extensions/Polly.Extensions.csproj
+++ b/src/Polly.Extensions/Polly.Extensions.csproj
@@ -11,9 +11,6 @@
     <MutationScore>100</MutationScore>
     <LegacySupport>true</LegacySupport>
   </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="..\Polly.Core\Utils\Guard.cs" Link="Utils\Guard.cs" />
-  </ItemGroup>
 
   <ItemGroup>
     <InternalsVisibleToTest Include="Polly.Extensions.Tests" />

--- a/src/Polly.Extensions/Telemetry/EnrichmentContext.Pool.cs
+++ b/src/Polly.Extensions/Telemetry/EnrichmentContext.Pool.cs
@@ -1,0 +1,33 @@
+using Polly.Strategy;
+using Polly.Utils;
+
+namespace Polly.Extensions.Telemetry;
+
+public partial class EnrichmentContext
+{
+    private static readonly ObjectPool<EnrichmentContext> ContextPool = new(
+        static () => new EnrichmentContext(),
+        static context =>
+        {
+            context.Outcome = null;
+            context.ResilienceContext = null!;
+            context.Tags.Clear();
+            return true;
+        });
+
+    internal static EnrichmentContext Get(IResilienceArguments arguments, Outcome? outcome)
+    {
+        var context = ContextPool.Get();
+        context.ResilienceContext = arguments.Context;
+        context.ResilienceArguments = arguments;
+        context.Outcome = outcome;
+
+        return context;
+    }
+
+    internal static void Return(EnrichmentContext context)
+    {
+        context.Tags.Clear();
+        ContextPool.Return(context);
+    }
+}

--- a/src/Polly.Extensions/Telemetry/EnrichmentContext.cs
+++ b/src/Polly.Extensions/Telemetry/EnrichmentContext.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using Polly.Strategy;
+
+namespace Polly.Extensions.Telemetry;
+
+/// <summary>
+/// Enrichment context used when reporting resilience telemetry. This context is passed to the registered enrichers in <see cref="ResilienceStrategyTelemetryOptions.Enrichers"/>.
+/// </summary>
+public partial class EnrichmentContext
+{
+    private EnrichmentContext()
+    {
+    }
+
+    /// <summary>
+    /// Gets the outcome of the operation if any.
+    /// </summary>
+    public Outcome? Outcome { get; internal set; }
+
+    /// <summary>
+    /// Gets the resilience arguments associated with the resilience event.
+    /// </summary>
+    public IResilienceArguments ResilienceArguments { get; internal set; } = null!;
+
+    /// <summary>
+    /// Gets the resilience context associated with the operation that produced the resilience event.
+    /// </summary>
+    public ResilienceContext ResilienceContext { get; internal set; } = null!;
+
+    /// <summary>
+    /// Gets the tags associated with the resilience event.
+    /// </summary>
+    public ICollection<KeyValuePair<string, object?>> Tags { get; } = new List<KeyValuePair<string, object?>>();
+}

--- a/src/Polly.Extensions/Telemetry/ResilienceStrategyTelemetryOptions.cs
+++ b/src/Polly.Extensions/Telemetry/ResilienceStrategyTelemetryOptions.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Polly.Strategy;
+
+namespace Polly.Extensions.Telemetry;
+
+/// <summary>
+/// The options that are used to configure the telemetry that is produced by the resilience strategies.
+/// </summary>
+public class ResilienceStrategyTelemetryOptions
+{
+    /// <summary>
+    /// Gets or sets the logger factory.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="NullLoggerFactory.Instance"/>.
+    /// </remarks>
+    [Required]
+    public ILoggerFactory LoggerFactory { get; set; } = NullLoggerFactory.Instance;
+
+    /// <summary>
+    /// Gets the registered resilience telemetry enrichers.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to an empty collection.
+    /// </remarks>
+    public ICollection<Action<EnrichmentContext>> Enrichers { get; } = new List<Action<EnrichmentContext>>();
+
+    /// <summary>
+    /// Gets or sets the formatter that converts the outcome to a string.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to formatter that calls <see cref="Outcome.ToString"/> when formatting the outcome.
+    /// </remarks>
+    [Required]
+    public Func<Outcome, string> OutcomeFormatter { get; set; } = outcome => outcome.ToString();
+}

--- a/src/Polly.Extensions/Telemetry/ResilienceTelemetryDiagnosticSource.cs
+++ b/src/Polly.Extensions/Telemetry/ResilienceTelemetryDiagnosticSource.cs
@@ -1,0 +1,134 @@
+using System.Diagnostics.Metrics;
+using System.Globalization;
+using Microsoft.Extensions.Logging;
+using Polly.Strategy;
+using Polly.Telemetry;
+
+namespace Polly.Extensions.Telemetry;
+
+internal class ResilienceTelemetryDiagnosticSource : DiagnosticSource
+{
+    private const string ResilienceEventFormatString =
+        "Resilience event occurred. " +
+        "EventName: '{EventName}', " +
+        "Builder Name: '{BuilderName}', " +
+        "Strategy Name: '{StrategyName}', " +
+        "Strategy Type: '{StrategyType}', " +
+        "Strategy Key: '{StrategyKey}', " +
+        "Outcome: '{Outcome}'";
+
+    internal static readonly Meter Meter = new(TelemetryUtil.PollyDiagnosticSource, "1.0");
+
+    private static readonly Action<ILogger, string, string, string, string, string, string, Exception?> ResilienceEventLog = LoggerMessage.Define<string, string, string, string, string, string>(
+            LogLevel.Warning,
+            new EventId(1, "ResilienceEvent"),
+            ResilienceEventFormatString);
+
+    private readonly ILogger _logger;
+
+    public ResilienceTelemetryDiagnosticSource(ResilienceStrategyTelemetryOptions options)
+    {
+        LoggerFactory = options.LoggerFactory;
+        Enrichers = options.Enrichers.ToList();
+        OutcomeFormatter = options.OutcomeFormatter;
+
+        _logger = options.LoggerFactory.CreateLogger(TelemetryUtil.PollyDiagnosticSource);
+        Counter = Meter.CreateCounter<int>(
+            "resilience-events",
+            description: "Tracks the number of resilience events that occurred in resilience strategies.");
+    }
+
+    public ILoggerFactory LoggerFactory { get; }
+
+    public Func<Outcome, string> OutcomeFormatter { get; }
+
+    public List<Action<EnrichmentContext>> Enrichers { get; }
+
+    public Counter<int> Counter { get; }
+
+    public override bool IsEnabled(string name) => true;
+
+    public override void Write(string name, object? value)
+    {
+        if (value is not TelemetryEventArguments args)
+        {
+            return;
+        }
+
+        LogEvent(args);
+        MeterEvent(args);
+    }
+
+    private void MeterEvent(TelemetryEventArguments args)
+    {
+        var tags = new TagList
+        {
+            { "event-name", args.EventName },
+            { "builder-name", args.Source.BuilderName },
+            { "strategy-name", args.Source.StrategyName },
+            { "strategy-type", args.Source.StrategyType },
+            { "result-type", args.Context.IsVoid ? "void" : args.Context.ResultType.Name.ToString(CultureInfo.InvariantCulture) }
+        };
+
+        if (args.Source.BuilderProperties.TryGetValue(TelemetryUtil.StrategyKey, out var key))
+        {
+            tags.Add("strategy-key", key);
+        }
+        else
+        {
+            tags.Add("strategy-key", null);
+        }
+
+        tags.Add("exception-name", args.Outcome?.Exception?.GetType().FullName);
+
+        Enrich(args, ref tags);
+
+        Counter.Add(1, tags);
+    }
+
+    private void Enrich(TelemetryEventArguments args, ref TagList tags)
+    {
+        if (Enrichers.Count == 0)
+        {
+            return;
+        }
+
+        var context = EnrichmentContext.Get(args.Arguments, args.Outcome);
+
+        foreach (var enricher in Enrichers)
+        {
+            enricher(context);
+        }
+
+        foreach (var pair in context.Tags)
+        {
+            tags.Add(pair.Key, pair.Value);
+        }
+
+        EnrichmentContext.Return(context);
+    }
+
+    private void LogEvent(TelemetryEventArguments args)
+    {
+        string outcomeString = "null";
+
+        if (args.Outcome is Outcome outcome)
+        {
+            outcomeString = OutcomeFormatter(outcome);
+        }
+
+        if (!args.Source.BuilderProperties.TryGetValue(TelemetryUtil.StrategyKey, out var strategyKey))
+        {
+            strategyKey = "null";
+        }
+
+        if (args.Outcome?.Exception is Exception exception)
+        {
+            ResilienceEventLog(_logger, args.EventName, args.Source.BuilderName, args.Source.StrategyName, args.Source.StrategyType, strategyKey, outcomeString, exception);
+        }
+        else
+        {
+            ResilienceEventLog(_logger, args.EventName, args.Source.BuilderName, args.Source.StrategyName, args.Source.StrategyType, strategyKey, outcomeString, null);
+        }
+    }
+}

--- a/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategyBuilderExtensions.cs
@@ -1,0 +1,30 @@
+using Polly.Extensions.Telemetry;
+using Polly.Utils;
+
+namespace Polly;
+
+/// <summary>
+/// The telemetry extensions for the <see cref="ResilienceStrategyBuilder"/>.
+/// </summary>
+public static class TelemetryResilienceStrategyBuilderExtensions
+{
+    /// <summary>
+    /// Enables telemetry for this builder.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="options">The resilience telemetry options.</param>
+    /// <returns>The builder instance with the telemetry enabled.</returns>
+    public static ResilienceStrategyBuilder EnableTelemetry(this ResilienceStrategyBuilder builder, ResilienceStrategyTelemetryOptions options)
+    {
+        Guard.NotNull(builder);
+        Guard.NotNull(options);
+
+        ValidationHelper.ValidateObject(options, "The resilience telemetry options are invalid.");
+
+        builder.Properties.Set(
+            Telemetry.TelemetryUtil.DiagnosticSourceKey,
+            new ResilienceTelemetryDiagnosticSource(options));
+
+        return builder;
+    }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors.  All non-trivial contributions get a public credit in the readme! -->

### The issue or feature being addressed

Closes #1112 

### Details on the issue fix or feature implementation

This PR enables the real telemetry for `Polly.Core` by calling the `EnableTelemetry` extension. 

API Usage:

``` csharp
var options = new ResilienceStrategyTelemetryOptions
{
    LoggerFactory = NullLoggerFactory.Instance
};

// configure custom enrichers
options.Enrichers.Add(context =>
{
    context.Tags.Add(new KeyValuePair<string, object?>("my-custom-dimension", "some-value"));
});
        
// enable telemetry
var builder = new ResilienceStrategyBuilder().EnableTelemetry(options);
```

The telemetry is automatically enabled for resilience strategies added using `IServiceCollection`.

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
