### PR TITLE
Run mutations tests on linux only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,7 @@ jobs:
         DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
         NUGET_XMLDOC_MODE: skip
         TERM: xterm
+        RUN_MUTATION_TESTS: ${{ matrix.os_name == 'linux' && 'true' || 'false' }}
 
     - uses: codecov/codecov-action@40a12dcee2df644d47232dde008099a3e9e4f865 # v3.1.2
       name: Upload coverage to Codecov
@@ -63,10 +64,10 @@ jobs:
         flags: ${{ matrix.os_name }}
 
     - name: Upload Mutation Report
-      if: always()
+      if: always() && matrix.os_name == 'linux'
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
-        name: mutation-report-${{ matrix.os_name }}
+        name: mutation-report
         path: StrykerOutput
 
     - name: Publish NuGet packages

--- a/build.cake
+++ b/build.cake
@@ -218,6 +218,17 @@ Task("__RunTests")
 Task("__RunMutationTests")
     .Does(() =>
 {
+    var runMutationTests = EnvironmentVariable("RUN_MUTATION_TESTS") switch
+    {
+        "false" => false,
+        _ => true
+    };
+
+    if (!runMutationTests)
+    {
+        return;
+    }
+        
     TestProject(File("./src/Polly.Core/Polly.Core.csproj"), File("./src/Polly.Core.Tests/Polly.Core.Tests.csproj"), "Polly.Core.csproj");
     TestProject(File("./src/Polly.RateLimiting/Polly.RateLimiting.csproj"), File("./src/Polly.RateLimiting.Tests/Polly.RateLimiting.Tests.csproj"), "Polly.RateLimiting.csproj");
     TestProject(File("./src/Polly.Extensions/Polly.Extensions.csproj"), File("./src/Polly.Extensions.Tests/Polly.Extensions.Tests.csproj"), "Polly.Extensions.csproj");


### PR DESCRIPTION
### The issue or feature being addressed

Contributes to #1092 

### Details on the issue fix or feature implementation

Running mutation testing only on Linux as is the fastest and on other systems it produces identical results anyway.

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
