### PR TITLE
Migrate `CircuitStateController`  and implement `CircutBreakerResilienceStrategy `

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -211,7 +211,7 @@ Task("__RunTests")
             Configuration = configuration,
             Loggers = loggers,
             NoBuild = true,
-            ArgumentCustomization = args => args.Append($"--blame-hang-timeout 5s")
+            ArgumentCustomization = args => args.Append($"--blame-hang-timeout 10s")
         });
     }
 });

--- a/build.cake
+++ b/build.cake
@@ -211,6 +211,7 @@ Task("__RunTests")
             Configuration = configuration,
             Loggers = loggers,
             NoBuild = true,
+            ArgumentCustomization = args => args.Append($"--blame-hang-timeout 5s")
         });
     }
 });

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.0-preview-20230223-05" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="ReportGenerator" Version="5.1.19" />

--- a/src/Polly.Core.Tests/CircuitBreaker/AdvancedCircuitBreakerOptionsTests.cs
+++ b/src/Polly.Core.Tests/CircuitBreaker/AdvancedCircuitBreakerOptionsTests.cs
@@ -97,10 +97,10 @@ public class AdvancedCircuitBreakerOptionsTests
 
         (await converted.ShouldHandle.CreateHandler()!.ShouldHandleAsync(new Outcome<int>(new InvalidOperationException()), new CircuitBreakerPredicateArguments(context))).Should().BeTrue();
 
-        await converted.OnClosed.CreateHandler()!.HandleAsync(new Outcome<int>(new InvalidOperationException()), new OnCircuitClosedArguments(context));
+        await converted.OnClosed.CreateHandler()!.HandleAsync(new Outcome<int>(new InvalidOperationException()), new OnCircuitClosedArguments(context, true));
         onResetCalled.Should().BeTrue();
 
-        await converted.OnOpened.CreateHandler()!.HandleAsync(new Outcome<int>(new InvalidOperationException()), new OnCircuitOpenedArguments(context, TimeSpan.Zero));
+        await converted.OnOpened.CreateHandler()!.HandleAsync(new Outcome<int>(new InvalidOperationException()), new OnCircuitOpenedArguments(context, TimeSpan.Zero, true));
         onBreakCalled.Should().BeTrue();
 
         await converted.OnHalfOpened.CreateHandler()!(new OnCircuitHalfOpenedArguments(context));

--- a/src/Polly.Core.Tests/CircuitBreaker/CircuitBreakerOptionsTests.cs
+++ b/src/Polly.Core.Tests/CircuitBreaker/CircuitBreakerOptionsTests.cs
@@ -85,10 +85,10 @@ public class CircuitBreakerOptionsTests
 
         (await converted.ShouldHandle.CreateHandler()!.ShouldHandleAsync(new Outcome<int>(new InvalidOperationException()), new CircuitBreakerPredicateArguments(context))).Should().BeTrue();
 
-        await converted.OnClosed.CreateHandler()!.HandleAsync(new Outcome<int>(new InvalidOperationException()), new OnCircuitClosedArguments(context));
+        await converted.OnClosed.CreateHandler()!.HandleAsync(new Outcome<int>(new InvalidOperationException()), new OnCircuitClosedArguments(context, true));
         onResetCalled.Should().BeTrue();
 
-        await converted.OnOpened.CreateHandler()!.HandleAsync(new Outcome<int>(new InvalidOperationException()), new OnCircuitOpenedArguments(context, TimeSpan.Zero));
+        await converted.OnOpened.CreateHandler()!.HandleAsync(new Outcome<int>(new InvalidOperationException()), new OnCircuitOpenedArguments(context, TimeSpan.Zero, true));
         onBreakCalled.Should().BeTrue();
 
         await converted.OnHalfOpened.CreateHandler()!(new OnCircuitHalfOpenedArguments(context));

--- a/src/Polly.Core.Tests/CircuitBreaker/CircuitBreakerResilienceStrategyBuilderTests.cs
+++ b/src/Polly.Core.Tests/CircuitBreaker/CircuitBreakerResilienceStrategyBuilderTests.cs
@@ -74,4 +74,87 @@ public class CircuitBreakerResilienceStrategyBuilderTests
             .Throw<ValidationException>()
             .WithMessage("The advanced circuit breaker strategy options are invalid.*");
     }
+
+    [Fact]
+    public void AddCircuitBreaker_IntegrationTest()
+    {
+        int opened = 0;
+        int closed = 0;
+        int halfOpened = 0;
+
+        var options = new CircuitBreakerStrategyOptions
+        {
+            FailureThreshold = 5,
+            BreakDuration = TimeSpan.FromMilliseconds(500),
+        };
+
+        options.ShouldHandle.HandleResult(-1);
+        options.OnOpened.Register<int>(() => opened++);
+        options.OnClosed.Register<int>(() => closed++);
+        options.OnHalfOpened.Register(() => halfOpened++);
+
+        var timeProvider = new FakeTimeProvider();
+        var strategy = new ResilienceStrategyBuilder { TimeProvider = timeProvider.Object }.AddCircuitBreaker(options).Build();
+        var time = DateTime.UtcNow;
+        timeProvider.Setup(v => v.UtcNow).Returns(() => time);
+
+        for (int i = 0; i < options.FailureThreshold; i++)
+        {
+            strategy.Execute(_ => -1);
+        }
+
+        // Circuit opened
+        opened.Should().Be(1);
+        halfOpened.Should().Be(0);
+        closed.Should().Be(0);
+        Assert.Throws<BrokenCircuitException<int>>(() => strategy.Execute(_ => 0));
+
+        // Circuit Half Opened
+        time += options.BreakDuration;
+        strategy.Execute(_ => -1);
+        Assert.Throws<BrokenCircuitException<int>>(() => strategy.Execute(_ => 0));
+        opened.Should().Be(2);
+        halfOpened.Should().Be(1);
+        closed.Should().Be(0);
+
+        // Now close it
+        time += options.BreakDuration;
+        strategy.Execute(_ => 0);
+        opened.Should().Be(2);
+        halfOpened.Should().Be(2);
+        closed.Should().Be(1);
+    }
+
+    [Fact]
+    public void AddAdvancedCircuitBreaker_IntegrationTest()
+    {
+        var options = new AdvancedCircuitBreakerStrategyOptions
+        {
+            BreakDuration = TimeSpan.FromMilliseconds(500),
+        };
+
+        options.ShouldHandle.HandleResult(-1);
+        options.OnOpened.Register<int>(() => { });
+        options.OnClosed.Register<int>(() => { });
+        options.OnHalfOpened.Register(() => { });
+
+        var timeProvider = new FakeTimeProvider();
+        var strategy = new ResilienceStrategyBuilder { TimeProvider = timeProvider.Object }.AddAdvancedCircuitBreaker(options).Build();
+        var time = DateTime.UtcNow;
+        timeProvider.Setup(v => v.UtcNow).Returns(() => time);
+
+        strategy.Should().BeOfType<CircuitBreakerResilienceStrategy>();
+    }
+
+    [Fact]
+    public void AddCircuitBreaker_UnrecognizedOptions_Throws()
+    {
+        var builder = new ResilienceStrategyBuilder();
+
+        builder.Invoking(b => b.AddCircuitBreakerCore(new DummyOptions()).Build()).Should().Throw<NotSupportedException>();
+    }
+
+    private class DummyOptions : BaseCircuitBreakerStrategyOptions
+    {
+    }
 }

--- a/src/Polly.Core.Tests/CircuitBreaker/CircuitBreakerResilienceStrategyTests.cs
+++ b/src/Polly.Core.Tests/CircuitBreaker/CircuitBreakerResilienceStrategyTests.cs
@@ -4,22 +4,121 @@ using Polly.Strategy;
 
 namespace Polly.Core.Tests.CircuitBreaker;
 
-public class CircuitBreakerResilienceStrategyTests
+public class CircuitBreakerResilienceStrategyTests : IDisposable
 {
     private readonly FakeTimeProvider _timeProvider;
+    private readonly Mock<CircuitBehavior> _behavior;
     private readonly ResilienceStrategyTelemetry _telemetry;
+    private readonly CircuitBreakerStrategyOptions _options;
+    private readonly CircuitStateController _controller;
 
     public CircuitBreakerResilienceStrategyTests()
     {
         _timeProvider = new FakeTimeProvider();
+        _timeProvider.Setup(v => v.UtcNow).Returns(DateTime.UtcNow);
+        _behavior = new Mock<CircuitBehavior>(MockBehavior.Strict);
         _telemetry = TestUtilities.CreateResilienceTelemetry(Mock.Of<DiagnosticSource>());
+        _options = new CircuitBreakerStrategyOptions();
+        _controller = new CircuitStateController(
+            new CircuitBreakerStrategyOptions(),
+            _behavior.Object,
+            _timeProvider.Object,
+            _telemetry);
     }
 
     [Fact]
     public void Ctor_Ok()
     {
-        Create().Should().NotBeNull();
+        this.Invoking(_ => Create()).Should().NotThrow();
     }
+
+    [Fact]
+    public void Ctor_StateProvider_EnsureAttached()
+    {
+        _options.StateProvider = new CircuitBreakerStateProvider();
+        Create();
+
+        _options.StateProvider.IsInitialized.Should().BeTrue();
+
+        _options.StateProvider.CircuitState.Should().Be(CircuitState.Closed);
+        _options.StateProvider.LastHandledOutcome.Should().Be(null);
+    }
+
+    [Fact]
+    public async Task Ctor_ManualControl_EnsureAttached()
+    {
+        _options.ShouldHandle.HandleException<InvalidOperationException>();
+        _options.ManualControl = new CircuitBreakerManualControl();
+        var strategy = Create();
+
+        _options.ManualControl.IsInitialized.Should().BeTrue();
+
+        await _options.ManualControl.IsolateAsync(CancellationToken.None);
+        strategy.Invoking(s => s.Execute(_ => { })).Should().Throw<IsolatedCircuitException>();
+
+        _behavior.Setup(v => v.OnCircuitClosed());
+        await _options.ManualControl.CloseAsync(CancellationToken.None);
+
+        _behavior.Setup(v => v.OnActionSuccess(CircuitState.Closed));
+        strategy.Invoking(s => s.Execute(_ => { })).Should().NotThrow();
+
+        _options.ManualControl.Dispose();
+        strategy.Invoking(s => s.Execute(_ => { })).Should().Throw<ObjectDisposedException>();
+
+        _behavior.VerifyAll();
+    }
+
+    [Fact]
+    public void Execute_HandledResult_OnFailureCalled()
+    {
+        _options.ShouldHandle.HandleResult(-1);
+        var strategy = Create();
+        var shouldBreak = false;
+
+        _behavior.Setup(v => v.OnActionFailure(CircuitState.Closed, out shouldBreak));
+        strategy.Execute(_ => -1).Should().Be(-1);
+
+        _behavior.VerifyAll();
+    }
+
+    [Fact]
+    public void Execute_UnhandledResult_OnActionSuccess()
+    {
+        _options.ShouldHandle.HandleResult(-1);
+        var strategy = Create();
+
+        _behavior.Setup(v => v.OnActionSuccess(CircuitState.Closed));
+        strategy.Execute(_ => 0).Should().Be(0);
+
+        _behavior.VerifyAll();
+    }
+
+    [Fact]
+    public void Execute_HandledException_OnFailureCalled()
+    {
+        _options.ShouldHandle.HandleException<InvalidOperationException>();
+        var strategy = Create();
+        var shouldBreak = false;
+
+        _behavior.Setup(v => v.OnActionFailure(CircuitState.Closed, out shouldBreak));
+
+        strategy.Invoking(s => s.Execute(_ => throw new InvalidOperationException())).Should().Throw<InvalidOperationException>();
+
+        _behavior.VerifyAll();
+    }
+
+    [Fact]
+    public void Execute_UnhandledException_NoCalls()
+    {
+        _options.ShouldHandle.HandleException<InvalidOperationException>();
+        var strategy = Create();
+
+        strategy.Invoking(s => s.Execute(_ => throw new ArgumentException())).Should().Throw<ArgumentException>();
+
+        _behavior.VerifyNoOtherCalls();
+    }
+
+    public void Dispose() => _controller.Dispose();
 
     [Fact]
     public void Execute_Ok()
@@ -27,5 +126,5 @@ public class CircuitBreakerResilienceStrategyTests
         Create().Invoking(s => s.Execute(_ => { })).Should().NotThrow();
     }
 
-    private CircuitBreakerResilienceStrategy Create() => new(_timeProvider.Object, _telemetry, new CircuitBreakerStrategyOptions());
+    private CircuitBreakerResilienceStrategy Create() => new(_options, _controller);
 }

--- a/src/Polly.Core.Tests/CircuitBreaker/Controller/AdvancedCircuitBehaviorTests.cs
+++ b/src/Polly.Core.Tests/CircuitBreaker/Controller/AdvancedCircuitBehaviorTests.cs
@@ -1,0 +1,22 @@
+using Polly.CircuitBreaker;
+
+namespace Polly.Core.Tests.CircuitBreaker.Controller;
+public class AdvancedCircuitBehaviorTests
+{
+    [Fact]
+    public void HappyPath()
+    {
+        var behavior = new AdvancedCircuitBehavior();
+
+        behavior
+            .Invoking(b =>
+            {
+                behavior.OnActionFailure(CircuitState.Closed, out var shouldBreak);
+                shouldBreak.Should().BeFalse();
+                behavior.OnCircuitClosed();
+                behavior.OnActionSuccess(CircuitState.Closed);
+            })
+            .Should()
+            .NotThrow();
+    }
+}

--- a/src/Polly.Core.Tests/CircuitBreaker/Controller/CircuitStateControllerTests.cs
+++ b/src/Polly.Core.Tests/CircuitBreaker/Controller/CircuitStateControllerTests.cs
@@ -1,0 +1,418 @@
+using System;
+using System.Threading.Tasks;
+using Moq;
+using Polly.CircuitBreaker;
+using Polly.Strategy;
+
+namespace Polly.Core.Tests.CircuitBreaker.Controller;
+public class CircuitStateControllerTests
+{
+    private readonly FakeTimeProvider _timeProvider = new();
+    private readonly BaseCircuitBreakerStrategyOptions _options = new CircuitBreakerStrategyOptions();
+    private readonly Mock<CircuitBehavior> _circuitBehavior = new(MockBehavior.Strict);
+    private readonly Action<IResilienceArguments> _onTelemetry = _ => { };
+    private DateTimeOffset _utcNow = DateTimeOffset.UtcNow;
+
+    public CircuitStateControllerTests() => _timeProvider.Setup(v => v.UtcNow).Returns(() => _utcNow);
+
+    [Fact]
+    public void Ctor_EnsureDefaults()
+    {
+        using var controller = CreateController();
+
+        controller.CircuitState.Should().Be(CircuitState.Closed);
+        controller.LastException.Should().BeNull();
+        controller.LastHandledOutcome.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task IsolateAsync_Ok()
+    {
+        // arrange
+        bool called = false;
+        _options.OnOpened.Register<VoidResult>((outcome, args) =>
+        {
+            args.BreakDuration.Should().Be(TimeSpan.MaxValue);
+            args.Context.IsSynchronous.Should().BeFalse();
+            args.Context.IsVoid.Should().BeTrue();
+            args.IsManual.Should().BeTrue();
+            outcome.IsVoidResult.Should().BeTrue();
+            called = true;
+        });
+
+        _timeProvider.Setup(v => v.UtcNow).Returns(DateTime.UtcNow);
+        using var controller = CreateController();
+        var context = ResilienceContext.Get();
+
+        // act
+        await controller.IsolateCircuitAsync(context);
+
+        // assert
+        controller.CircuitState.Should().Be(CircuitState.Isolated);
+        called.Should().BeTrue();
+
+        await Assert.ThrowsAsync<IsolatedCircuitException>(async () => await controller.OnActionPreExecuteAsync(ResilienceContext.Get()));
+
+        // now close it
+        _circuitBehavior.Setup(v => v.OnCircuitClosed());
+        await controller.CloseCircuitAsync(ResilienceContext.Get());
+        await controller.OnActionPreExecuteAsync(ResilienceContext.Get());
+        context.ResilienceEvents.Should().Contain(new ReportedResilienceEvent("OnCircuitOpened"));
+    }
+
+    [Fact]
+    public async Task BreakAsync_Ok()
+    {
+        // arrange
+        bool called = false;
+        _options.OnClosed.Register<VoidResult>((outcome, args) =>
+        {
+            args.Context.IsSynchronous.Should().BeFalse();
+            args.Context.IsVoid.Should().BeTrue();
+            args.IsManual.Should().BeTrue();
+            outcome.IsVoidResult.Should().BeTrue();
+            called = true;
+        });
+
+        _timeProvider.Setup(v => v.UtcNow).Returns(DateTime.UtcNow);
+        using var controller = CreateController();
+        await controller.IsolateCircuitAsync(ResilienceContext.Get());
+        _circuitBehavior.Setup(v => v.OnCircuitClosed());
+        var context = ResilienceContext.Get();
+
+        // act
+        await controller.CloseCircuitAsync(context);
+
+        // assert
+        called.Should().BeTrue();
+
+        await controller.OnActionPreExecuteAsync(ResilienceContext.Get());
+        _circuitBehavior.VerifyAll();
+        context.ResilienceEvents.Should().Contain(new ReportedResilienceEvent("OnCircuitClosed"));
+    }
+
+    [Fact]
+    public async Task Disposed_EnsureThrows()
+    {
+        var controller = CreateController();
+        controller.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => controller.CircuitState);
+        Assert.Throws<ObjectDisposedException>(() => controller.LastException);
+        Assert.Throws<ObjectDisposedException>(() => controller.LastHandledOutcome);
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(async () => await controller.CloseCircuitAsync(ResilienceContext.Get()));
+        await Assert.ThrowsAsync<ObjectDisposedException>(async () => await controller.IsolateCircuitAsync(ResilienceContext.Get()));
+        await Assert.ThrowsAsync<ObjectDisposedException>(async () => await controller.OnActionPreExecuteAsync(ResilienceContext.Get()));
+        await Assert.ThrowsAsync<ObjectDisposedException>(async () => await controller.OnActionSuccessAsync(new Outcome<int>(10), ResilienceContext.Get()));
+        await Assert.ThrowsAsync<ObjectDisposedException>(async () => await controller.OnActionFailureAsync(new Outcome<int>(10), ResilienceContext.Get()));
+    }
+
+    [Fact]
+    public async Task OnActionPreExecute_CircuitOpenedByValue()
+    {
+        using var controller = CreateController();
+
+        await OpenCircuit(controller, new Outcome<int>(99));
+        var error = await Assert.ThrowsAsync<BrokenCircuitException<int>>(async () => await controller.OnActionPreExecuteAsync(ResilienceContext.Get()));
+        error.Result.Should().Be(99);
+
+        GetBlockedTill(controller).Should().Be(_utcNow + _options.BreakDuration);
+    }
+
+    [Fact]
+    public async Task HalfOpen_EnsureBreakDuration()
+    {
+        using var controller = CreateController();
+
+        await TransitionToState(controller, CircuitState.HalfOpen);
+        GetBlockedTill(controller).Should().Be(_utcNow + _options.BreakDuration);
+    }
+
+    [InlineData(true)]
+    [InlineData(false)]
+    [Theory]
+    public async Task HalfOpen_EnsureCorrectStateTransitionAfterExecution(bool success)
+    {
+        using var controller = CreateController();
+
+        await TransitionToState(controller, CircuitState.HalfOpen);
+
+        if (success)
+        {
+            _circuitBehavior.Setup(v => v.OnActionSuccess(CircuitState.HalfOpen));
+            _circuitBehavior.Setup(v => v.OnCircuitClosed());
+
+            await controller.OnActionSuccessAsync(new Outcome<int>(0), ResilienceContext.Get());
+            controller.CircuitState.Should().Be(CircuitState.Closed);
+        }
+        else
+        {
+            var shouldBreak = true;
+            _circuitBehavior.Setup(v => v.OnActionFailure(CircuitState.HalfOpen, out shouldBreak));
+            await controller.OnActionFailureAsync(new Outcome<int>(0), ResilienceContext.Get());
+            controller.CircuitState.Should().Be(CircuitState.Open);
+        }
+    }
+
+    [Fact]
+    public async Task OnActionPreExecute_CircuitOpenedByException()
+    {
+        using var controller = CreateController();
+
+        await OpenCircuit(controller, new Outcome<int>(new InvalidOperationException()));
+        var error = await Assert.ThrowsAsync<BrokenCircuitException>(async () => await controller.OnActionPreExecuteAsync(ResilienceContext.Get()));
+        error.InnerException.Should().BeOfType<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task OnActionFailure_EnsureLock()
+    {
+        // arrange
+        using var executing = new ManualResetEvent(false);
+        using var verified = new ManualResetEvent(false);
+
+        AdvanceTime(_options.BreakDuration);
+        bool shouldBreak = false;
+        _circuitBehavior.Setup(v => v.OnActionFailure(CircuitState.Closed, out shouldBreak)).Callback(() =>
+        {
+            executing.Set();
+            verified.WaitOne();
+        });
+
+        using var controller = CreateController();
+
+        // act
+        var executeAction = Task.Run(() => controller.OnActionFailureAsync(new Outcome<int>(0), ResilienceContext.Get()));
+        executing.WaitOne();
+        var executeAction2 = Task.Run(() => controller.OnActionFailureAsync(new Outcome<int>(0), ResilienceContext.Get()));
+
+        // assert
+        executeAction.Wait(50).Should().BeFalse();
+        verified.Set();
+        await executeAction;
+        await executeAction2;
+    }
+
+    [Fact]
+    public async Task OnActionPreExecute_HalfOpen()
+    {
+        // arrange
+        var called = false;
+        _options.OnHalfOpened.Register(_ => called = true);
+        using var controller = CreateController();
+
+        await OpenCircuit(controller, new Outcome<int>(10));
+        AdvanceTime(_options.BreakDuration);
+
+        // act
+        await controller.OnActionPreExecuteAsync(ResilienceContext.Get());
+        var error = await Assert.ThrowsAsync<BrokenCircuitException<int>>(async () => await controller.OnActionPreExecuteAsync(ResilienceContext.Get()));
+
+        // assert
+        controller.CircuitState.Should().Be(CircuitState.HalfOpen);
+        called.Should().BeTrue();
+    }
+
+    [InlineData(CircuitState.HalfOpen, CircuitState.Closed)]
+    [InlineData(CircuitState.Isolated, CircuitState.Isolated)]
+    [InlineData(CircuitState.Closed, CircuitState.Closed)]
+    [Theory]
+    public async Task OnActionSuccess_EnsureCorrectBehavior(CircuitState state, CircuitState expectedState)
+    {
+        // arrange
+        var called = false;
+        _options.OnClosed.Register<int>((_, args) =>
+        {
+            args.IsManual.Should().BeFalse();
+            called = true;
+        });
+        using var controller = CreateController();
+
+        await TransitionToState(controller, state);
+
+        _circuitBehavior.Setup(v => v.OnActionSuccess(state));
+        if (expectedState == CircuitState.Closed && state != CircuitState.Closed)
+        {
+            _circuitBehavior.Setup(v => v.OnCircuitClosed());
+        }
+
+        // act
+        await controller.OnActionSuccessAsync(new Outcome<int>(10), ResilienceContext.Get());
+
+        // assert
+        controller.CircuitState.Should().Be(expectedState);
+        _circuitBehavior.VerifyAll();
+
+        if (expectedState == CircuitState.Closed && state != CircuitState.Closed)
+        {
+            called.Should().BeTrue();
+        }
+    }
+
+    [InlineData(CircuitState.HalfOpen, CircuitState.Open, true)]
+    [InlineData(CircuitState.Closed, CircuitState.Open, true)]
+    [InlineData(CircuitState.Closed, CircuitState.Closed, false)]
+    [InlineData(CircuitState.Open, CircuitState.Open, false)]
+    [InlineData(CircuitState.Isolated, CircuitState.Isolated, false)]
+    [Theory]
+    public async Task OnActionFailureAsync_EnsureCorrectBehavior(CircuitState state, CircuitState expectedState, bool shouldBreak)
+    {
+        // arrange
+        var called = false;
+        _options.OnOpened.Register<string>((_, args) =>
+        {
+            args.IsManual.Should().BeFalse();
+            called = true;
+        });
+        using var controller = CreateController();
+
+        await TransitionToState(controller, state);
+        _circuitBehavior.Setup(v => v.OnActionFailure(state, out shouldBreak));
+
+        // act
+        await controller.OnActionFailureAsync(new Outcome<string>("dummy"), ResilienceContext.Get());
+
+        // assert
+        controller.LastHandledOutcome!.Value.Result.Should().Be("dummy");
+        controller.CircuitState.Should().Be(expectedState);
+        _circuitBehavior.VerifyAll();
+
+        if (expectedState == CircuitState.Open && state != CircuitState.Open)
+        {
+            called.Should().BeTrue();
+        }
+    }
+
+    [InlineData(true)]
+    [InlineData(false)]
+    [Theory]
+    public async Task OnActionFailureAsync_EnsureBreakDurationNotOverflow(bool overflow)
+    {
+        // arrange
+        using var controller = CreateController();
+        var shouldBreak = true;
+        await TransitionToState(controller, CircuitState.HalfOpen);
+        _utcNow = DateTime.MaxValue - _options.BreakDuration;
+        if (overflow)
+        {
+            _utcNow += TimeSpan.FromMilliseconds(10);
+        }
+
+        _circuitBehavior.Setup(v => v.OnActionFailure(CircuitState.HalfOpen, out shouldBreak));
+
+        // act
+        await controller.OnActionFailureAsync(new Outcome<string>("dummy"), ResilienceContext.Get());
+
+        // assert
+        var blockedTill = GetBlockedTill(controller);
+
+        if (overflow)
+        {
+            blockedTill.Should().Be(DateTimeOffset.MaxValue);
+        }
+        else
+        {
+            blockedTill.Should().Be(_utcNow + _options.BreakDuration);
+        }
+    }
+
+    [Fact]
+    public async Task OnActionFailureAsync_VoidResult_EnsureBreakingExceptionNotSet()
+    {
+        // arrange
+        using var controller = CreateController();
+        bool shouldBreak = true;
+        await TransitionToState(controller, CircuitState.Open);
+        _circuitBehavior.Setup(v => v.OnActionFailure(CircuitState.Open, out shouldBreak));
+
+        // act
+        await controller.OnActionFailureAsync(new Outcome<VoidResult>(VoidResult.Instance), ResilienceContext.Get());
+
+        // assert
+        controller.LastException.Should().BeNull();
+        await Assert.ThrowsAsync<BrokenCircuitException>(async () => await controller.OnActionPreExecuteAsync(ResilienceContext.Get()));
+    }
+
+    [Fact]
+    public async Task Flow_Closed_HalfOpen_Closed()
+    {
+        using var controller = CreateController();
+
+        await TransitionToState(controller, CircuitState.HalfOpen);
+        _circuitBehavior.Setup(v => v.OnActionSuccess(CircuitState.HalfOpen));
+        _circuitBehavior.Setup(v => v.OnCircuitClosed());
+
+        await controller.OnActionSuccessAsync(new Outcome<int>(0), ResilienceContext.Get());
+        controller.CircuitState.Should().Be(CircuitState.Closed);
+    }
+
+    [Fact]
+    public async Task Flow_Closed_HalfOpen_Open_HalfOpen_Closed()
+    {
+        var context = ResilienceContext.Get();
+        using var controller = CreateController();
+        bool shouldBreak = true;
+
+        await TransitionToState(controller, CircuitState.HalfOpen);
+
+        _circuitBehavior.Setup(v => v.OnActionFailure(CircuitState.HalfOpen, out shouldBreak));
+        await controller.OnActionFailureAsync(new Outcome<int>(0), context);
+        controller.CircuitState.Should().Be(CircuitState.Open);
+
+        // execution rejected
+        AdvanceTime(TimeSpan.FromMilliseconds(1));
+        await Assert.ThrowsAsync<BrokenCircuitException<int>>(async () => await controller.OnActionPreExecuteAsync(context));
+
+        // wait and try, transition to half open
+        AdvanceTime(_options.BreakDuration + _options.BreakDuration);
+        await controller.OnActionPreExecuteAsync(context);
+        controller.CircuitState.Should().Be(CircuitState.HalfOpen);
+
+        // close circuit
+        _circuitBehavior.Setup(v => v.OnActionSuccess(CircuitState.HalfOpen));
+        _circuitBehavior.Setup(v => v.OnCircuitClosed());
+        await controller.OnActionSuccessAsync(new Outcome<int>(0), ResilienceContext.Get());
+        controller.CircuitState.Should().Be(CircuitState.Closed);
+    }
+
+    private static DateTimeOffset? GetBlockedTill(CircuitStateController controller) =>
+        (DateTimeOffset?)controller.GetType().GetField("_blockedUntil", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(controller)!;
+
+    private async Task TransitionToState(CircuitStateController controller, CircuitState state)
+    {
+        switch (state)
+        {
+            case CircuitState.Closed:
+                break;
+            case CircuitState.Open:
+                await OpenCircuit(controller);
+                break;
+            case CircuitState.HalfOpen:
+                await OpenCircuit(controller);
+                AdvanceTime(_options.BreakDuration);
+                await controller.OnActionPreExecuteAsync(ResilienceContext.Get());
+                break;
+            case CircuitState.Isolated:
+                await controller.IsolateCircuitAsync(ResilienceContext.Get());
+                break;
+        }
+
+        controller.CircuitState.Should().Be(state);
+    }
+
+    private async Task OpenCircuit(CircuitStateController controller, Outcome<int>? outcome = null)
+    {
+        bool breakCircuit = true;
+        _circuitBehavior.Setup(v => v.OnActionFailure(CircuitState.Closed, out breakCircuit));
+        await controller.OnActionFailureAsync(outcome ?? new Outcome<int>(10), ResilienceContext.Get().Initialize<int>(true));
+    }
+
+    private void AdvanceTime(TimeSpan timespan) => _utcNow += timespan;
+
+    private CircuitStateController CreateController() => new(
+        _options,
+        _circuitBehavior.Object,
+        _timeProvider.Object,
+        TestUtilities.CreateResilienceTelemetry(args => _onTelemetry.Invoke(args)));
+}

--- a/src/Polly.Core.Tests/CircuitBreaker/Controller/ConsecutiveFailuresCircuitBehaviorTests.cs
+++ b/src/Polly.Core.Tests/CircuitBreaker/Controller/ConsecutiveFailuresCircuitBehaviorTests.cs
@@ -1,0 +1,49 @@
+using Polly.CircuitBreaker;
+
+namespace Polly.Core.Tests.CircuitBreaker.Controller;
+public class ConsecutiveFailuresCircuitBehaviorTests
+{
+    [Fact]
+    public void OnCircuitReset_Ok()
+    {
+        var behavior = new ConsecutiveFailuresCircuitBehavior(new CircuitBreakerStrategyOptions { FailureThreshold = 2 });
+
+        behavior.OnActionFailure(CircuitState.Closed, out var shouldBreak);
+        behavior.OnCircuitClosed();
+        behavior.OnActionFailure(CircuitState.Closed, out shouldBreak);
+
+        shouldBreak.Should().BeFalse();
+    }
+
+    [InlineData(1, 1, true)]
+    [InlineData(2, 1, false)]
+    [Theory]
+    public void OnActionFailure_Ok(int threshold, int failures, bool expectedShouldBreak)
+    {
+        var behavior = new ConsecutiveFailuresCircuitBehavior(new CircuitBreakerStrategyOptions { FailureThreshold = threshold });
+
+        for (int i = 0; i < failures - 1; i++)
+        {
+            behavior.OnActionFailure(CircuitState.Closed, out _);
+        }
+
+        behavior.OnActionFailure(CircuitState.Closed, out var shouldBreak);
+        shouldBreak.Should().Be(expectedShouldBreak);
+    }
+
+    [InlineData(CircuitState.Closed, false)]
+    [InlineData(CircuitState.Open, true)]
+    [InlineData(CircuitState.Isolated, true)]
+    [InlineData(CircuitState.HalfOpen, true)]
+    [Theory]
+    public void OnActionSuccess_Ok(CircuitState state, bool expected)
+    {
+        var behavior = new ConsecutiveFailuresCircuitBehavior(new CircuitBreakerStrategyOptions { FailureThreshold = 2 });
+
+        behavior.OnActionFailure(CircuitState.Closed, out var shouldBreak);
+        behavior.OnActionSuccess(state);
+        behavior.OnActionFailure(CircuitState.Closed, out shouldBreak);
+
+        shouldBreak.Should().Be(expected);
+    }
+}

--- a/src/Polly.Core.Tests/CircuitBreaker/Controller/ScheduledTaskExecutorTests.cs
+++ b/src/Polly.Core.Tests/CircuitBreaker/Controller/ScheduledTaskExecutorTests.cs
@@ -124,11 +124,11 @@ public class ScheduledTaskExecutorTests
             ResilienceContext.Get(),
             out var task);
 
-        ready.WaitOne();
+        ready.WaitOne(TimeSpan.FromSeconds(2)).Should().BeTrue();
         scheduler.Dispose();
         disposed.Set();
 
-        scheduler.ProcessingTask.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
+        scheduler.ProcessingTask.Wait(TimeSpan.FromSeconds(2)).Should().BeTrue();
     }
 
     [Fact]

--- a/src/Polly.Core.Tests/CircuitBreaker/Controller/ScheduledTaskExecutorTests.cs
+++ b/src/Polly.Core.Tests/CircuitBreaker/Controller/ScheduledTaskExecutorTests.cs
@@ -108,7 +108,7 @@ public class ScheduledTaskExecutorTests
     }
 
     [Fact]
-    public async Task Dispose_WhenScheduledTaskExecuting()
+    public void Dispose_WhenScheduledTaskExecuting()
     {
         using var disposed = new ManualResetEvent(false);
         using var ready = new ManualResetEvent(false);
@@ -128,7 +128,7 @@ public class ScheduledTaskExecutorTests
         scheduler.Dispose();
         disposed.Set();
 
-        await scheduler.Invoking(async s => await s.ProcessingTask).Should().NotThrowAsync();
+        scheduler.ProcessingTask.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
     }
 
     [Fact]

--- a/src/Polly.Core.Tests/CircuitBreaker/Controller/ScheduledTaskExecutorTests.cs
+++ b/src/Polly.Core.Tests/CircuitBreaker/Controller/ScheduledTaskExecutorTests.cs
@@ -1,0 +1,149 @@
+using System.Threading.Tasks;
+using Polly.CircuitBreaker;
+
+namespace Polly.Core.Tests.CircuitBreaker.Controller;
+
+public class ScheduledTaskExecutorTests
+{
+    [Fact]
+    public async Task ScheduleTask_Success_EnsureExecuted()
+    {
+        using var scheduler = new ScheduledTaskExecutor();
+        var executed = false;
+        scheduler.ScheduleTask(
+            () =>
+            {
+                executed = true;
+                return Task.CompletedTask;
+            },
+            ResilienceContext.Get(),
+            out var task);
+
+        await task;
+
+        executed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ScheduleTask_OperationCancelledException_EnsureExecuted()
+    {
+        using var scheduler = new ScheduledTaskExecutor();
+        scheduler.ScheduleTask(
+            () => throw new OperationCanceledException(),
+            ResilienceContext.Get(),
+            out var task);
+
+        await task.Invoking(async t => await task).Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task ScheduleTask_Exception_EnsureExecuted()
+    {
+        using var scheduler = new ScheduledTaskExecutor();
+        scheduler.ScheduleTask(
+            () => throw new InvalidOperationException(),
+            ResilienceContext.Get(),
+            out var task);
+
+        await task.Invoking(async t => await task).Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task ScheduleTask_Multiple_EnsureExecutionSerialized()
+    {
+        using var executing = new ManualResetEvent(false);
+        using var verified = new ManualResetEvent(false);
+
+        using var scheduler = new ScheduledTaskExecutor();
+        scheduler.ScheduleTask(
+            () =>
+            {
+                executing.Set();
+                verified.WaitOne();
+                return Task.CompletedTask;
+            },
+            ResilienceContext.Get(),
+            out var task);
+
+        executing.WaitOne();
+
+        scheduler.ScheduleTask(() => Task.CompletedTask, ResilienceContext.Get(), out var otherTask);
+        otherTask.Wait(50).Should().BeFalse();
+
+        verified.Set();
+
+        await task;
+        await otherTask;
+    }
+
+    [Fact]
+    public async Task Dispose_ScheduledTaskCancelled()
+    {
+        using var executing = new ManualResetEvent(false);
+        using var verified = new ManualResetEvent(false);
+
+        var scheduler = new ScheduledTaskExecutor();
+        scheduler.ScheduleTask(
+            () =>
+            {
+                executing.Set();
+                verified.WaitOne();
+                return Task.CompletedTask;
+            },
+            ResilienceContext.Get(),
+            out var task);
+
+        executing.WaitOne();
+        scheduler.ScheduleTask(() => Task.CompletedTask, ResilienceContext.Get(), out var otherTask);
+        scheduler.Dispose();
+        verified.Set();
+        await task;
+
+        await otherTask.Invoking(t => otherTask).Should().ThrowAsync<OperationCanceledException>();
+
+        scheduler
+            .Invoking(s => s.ScheduleTask(() => Task.CompletedTask, ResilienceContext.Get(), out _))
+            .Should()
+            .Throw<ObjectDisposedException>();
+    }
+
+    [Fact]
+    public async Task Dispose_WhenScheduledTaskExecuting()
+    {
+        using var disposed = new ManualResetEvent(false);
+        using var ready = new ManualResetEvent(false);
+
+        var scheduler = new ScheduledTaskExecutor();
+        scheduler.ScheduleTask(
+            () =>
+            {
+                ready.Set();
+                disposed.WaitOne();
+                return Task.CompletedTask;
+            },
+            ResilienceContext.Get(),
+            out var task);
+
+        ready.WaitOne();
+        scheduler.Dispose();
+        disposed.Set();
+
+        await scheduler.Invoking(async s => await s.ProcessingTask).Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task Dispose_EnsureNoBackgroundProcessing()
+    {
+        var scheduler = new ScheduledTaskExecutor();
+        scheduler.ScheduleTask(() => Task.CompletedTask, ResilienceContext.Get(), out var otherTask);
+        await otherTask;
+        scheduler.Dispose();
+#pragma warning disable S3966 // Objects should not be disposed more than once
+        scheduler.Dispose();
+#pragma warning restore S3966 // Objects should not be disposed more than once
+
+        await scheduler.ProcessingTask;
+
+        scheduler.ProcessingTask.IsCompleted.Should().BeTrue();
+    }
+}

--- a/src/Polly.Core.Tests/CircuitBreaker/OnCircuitClosedArgumentsTests.cs
+++ b/src/Polly.Core.Tests/CircuitBreaker/OnCircuitClosedArgumentsTests.cs
@@ -9,8 +9,9 @@ public class OnCircuitClosedArgumentsTests
     {
         var context = ResilienceContext.Get();
 
-        var args = new OnCircuitClosedArguments(context);
+        var args = new OnCircuitClosedArguments(context, true);
 
         args.Context.Should().Be(context);
+        args.IsManual.Should().BeTrue();
     }
 }

--- a/src/Polly.Core.Tests/CircuitBreaker/OnCircuitOpenedArgumentsTests.cs
+++ b/src/Polly.Core.Tests/CircuitBreaker/OnCircuitOpenedArgumentsTests.cs
@@ -9,9 +9,10 @@ public class OnCircuitOpenedArgumentsTests
     {
         var context = ResilienceContext.Get();
 
-        var args = new OnCircuitOpenedArguments(context, TimeSpan.FromSeconds(2));
+        var args = new OnCircuitOpenedArguments(context, TimeSpan.FromSeconds(2), true);
 
         args.Context.Should().Be(context);
         args.BreakDuration.Should().Be(TimeSpan.FromSeconds(2));
+        args.IsManual.Should().BeTrue();
     }
 }

--- a/src/Polly.Core/CircuitBreaker/BaseCircuitBreakerStrategyOptions.TResult.cs
+++ b/src/Polly.Core/CircuitBreaker/BaseCircuitBreakerStrategyOptions.TResult.cs
@@ -40,18 +40,48 @@ public abstract class BaseCircuitBreakerStrategyOptions<TResult> : ResilienceStr
     /// <summary>
     /// Gets or sets the event that is raised when the circuit resets to a <see cref="CircuitState.Closed"/> state.
     /// </summary>
+    /// <remarks>
+    /// The callbacks registered to this event are invoked with eventual consistency. There is no guarantee that the circuit breaker
+    /// doesn't change the state before the callbacks finish. If you need to know the up-to-date state of the circuit breaker use
+    /// the <see cref="CircuitBreakerStateProvider.CircuitState"/> property.
+    /// <para>
+    /// Note that these events might be executed asynchronously at a later time when the circuit state is no longer the same as at the point of invocation of the event.
+    /// However, the invocation order of the <see cref="OnOpened"/>, <see cref="OnClosed"/>, and <see cref="OnHalfOpened"/> events is always
+    /// maintained to ensure the correct sequence of state transitions.
+    /// </para>
+    /// </remarks>
     [Required]
     public OutcomeEvent<OnCircuitClosedArguments, TResult> OnClosed { get; set; } = new();
 
     /// <summary>
     /// Gets or sets the event that is raised when the circuit transitions to an <see cref="CircuitState.Open"/> state.
     /// </summary>
+    /// <remarks>
+    /// The callbacks registered to this event are invoked with eventual consistency. There is no guarantee that the circuit breaker
+    /// doesn't change the state before the callbacks finish. If you need to know the up-to-date state of the circuit breaker use
+    /// the <see cref="CircuitBreakerStateProvider.CircuitState"/> property.
+    /// <para>
+    /// Note that these events might be executed asynchronously at a later time when the circuit state is no longer the same as at the point of invocation of the event.
+    /// However, the invocation order of the <see cref="OnOpened"/>, <see cref="OnClosed"/>, and <see cref="OnHalfOpened"/> events is always
+    /// maintained to ensure the correct sequence of state transitions.
+    /// </para>
+    /// </remarks>
     [Required]
     public OutcomeEvent<OnCircuitOpenedArguments, TResult> OnOpened { get; set; } = new();
 
     /// <summary>
     /// Gets or sets the event that is raised when when the circuit transitions to an <see cref="CircuitState.HalfOpen"/> state.
     /// </summary>
+    /// <remarks>
+    /// The callbacks registered to this event are invoked with eventual consistency. There is no guarantee that the circuit breaker
+    /// doesn't change the state before the callbacks finish. If you need to know the up-to-date state of the circuit breaker use
+    /// the <see cref="CircuitBreakerStateProvider.CircuitState"/> property.
+    /// <para>
+    /// Note that these events might be executed asynchronously at a later time when the circuit state is no longer the same as at the point of invocation of the event.
+    /// However, the invocation order of the <see cref="OnOpened"/>, <see cref="OnClosed"/>, and <see cref="OnHalfOpened"/> events is always
+    /// maintained to ensure the correct sequence of state transitions.
+    /// </para>
+    /// </remarks>
     [Required]
     public NoOutcomeEvent<OnCircuitHalfOpenedArguments> OnHalfOpened { get; set; } = new();
 

--- a/src/Polly.Core/CircuitBreaker/BaseCircuitBreakerStrategyOptions.cs
+++ b/src/Polly.Core/CircuitBreaker/BaseCircuitBreakerStrategyOptions.cs
@@ -39,18 +39,48 @@ public abstract class BaseCircuitBreakerStrategyOptions : ResilienceStrategyOpti
     /// <summary>
     /// Gets or sets the event that is raised when the circuit resets to a <see cref="CircuitState.Closed"/> state.
     /// </summary>
+    /// <remarks>
+    /// The callbacks registered to this event are invoked with eventual consistency. There is no guarantee that the circuit breaker
+    /// doesn't change the state before the callbacks finish. If you need to know the up-to-date state of the circuit breaker use
+    /// the <see cref="CircuitBreakerStateProvider.CircuitState"/> property.
+    /// <para>
+    /// Note that these events might be executed asynchronously at a later time when the circuit state is no longer the same as at the point of invocation of the event.
+    /// However, the invocation order of the <see cref="OnOpened"/>, <see cref="OnClosed"/>, and <see cref="OnHalfOpened"/> events is always
+    /// maintained to ensure the correct sequence of state transitions.
+    /// </para>
+    /// </remarks>
     [Required]
     public OutcomeEvent<OnCircuitClosedArguments> OnClosed { get; set; } = new();
 
     /// <summary>
     /// Gets or sets the event that is raised when the circuit transitions to an <see cref="CircuitState.Open"/> state.
     /// </summary>
+    /// <remarks>
+    /// The callbacks registered to this event are invoked with eventual consistency. There is no guarantee that the circuit breaker
+    /// doesn't change the state before the callbacks finish. If you need to know the up-to-date state of the circuit breaker use
+    /// the <see cref="CircuitBreakerStateProvider.CircuitState"/> property.
+    /// <para>
+    /// Note that these events might be executed asynchronously at a later time when the circuit state is no longer the same as at the point of invocation of the event.
+    /// However, the invocation order of the <see cref="OnOpened"/>, <see cref="OnClosed"/>, and <see cref="OnHalfOpened"/> events is always
+    /// maintained to ensure the correct sequence of state transitions.
+    /// </para>
+    /// </remarks>
     [Required]
     public OutcomeEvent<OnCircuitOpenedArguments> OnOpened { get; set; } = new();
 
     /// <summary>
     /// Gets or sets the event that is raised when when the circuit transitions to an <see cref="CircuitState.HalfOpen"/> state.
     /// </summary>
+    /// <remarks>
+    /// The callbacks registered to this event are invoked with eventual consistency. There is no guarantee that the circuit breaker
+    /// doesn't change the state before the callbacks finish. If you need to know the up-to-date state of the circuit breaker use
+    /// the <see cref="CircuitBreakerStateProvider.CircuitState"/> property.
+    /// <para>
+    /// Note that these events might be executed asynchronously at a later time when the circuit state is no longer the same as at the point of invocation of the event.
+    /// However, the invocation order of the <see cref="OnOpened"/>, <see cref="OnClosed"/>, and <see cref="OnHalfOpened"/> events is always
+    /// maintained to ensure the correct sequence of state transitions.
+    /// </para>
+    /// </remarks>
     [Required]
     public NoOutcomeEvent<OnCircuitHalfOpenedArguments> OnHalfOpened { get; set; } = new();
 

--- a/src/Polly.Core/CircuitBreaker/BrokenCircuitException.cs
+++ b/src/Polly.Core/CircuitBreaker/BrokenCircuitException.cs
@@ -12,10 +12,13 @@ namespace Polly.CircuitBreaker;
 #endif
 public class BrokenCircuitException : ExecutionRejectedException
 {
+    internal const string DefaultMessage = "The circuit is now open and is not allowing calls.";
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BrokenCircuitException"/> class.
     /// </summary>
     public BrokenCircuitException()
+        : base(DefaultMessage)
     {
     }
 

--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerConstants.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerConstants.cs
@@ -4,11 +4,11 @@ internal static class CircuitBreakerConstants
 {
     public const string StrategyType = "CircuitBreaker";
 
-    public const string OnResetEvent = "OnCircuitReset";
+    public const string OnCircuitClosed = "OnCircuitClosed";
 
-    public const string OnHalfOpenEvent = "OnCircuitHalfOpen";
+    public const string OnHalfOpenEvent = "OnCircuitHalfOpened";
 
-    public const string OnBreakEvent = "OnCircuitBreak";
+    public const string OnCircuitOpened = "OnCircuitOpened";
 
     public const double DefaultAdvancedFailureThreshold = 0.1;
 

--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerResilienceStrategy.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerResilienceStrategy.cs
@@ -4,22 +4,57 @@ namespace Polly.CircuitBreaker;
 
 internal sealed class CircuitBreakerResilienceStrategy : ResilienceStrategy
 {
-#pragma warning disable IDE0052 // Remove unread private members
-    private readonly TimeProvider _timeProvider;
-    private readonly ResilienceStrategyTelemetry _telemetry;
-    private readonly BaseCircuitBreakerStrategyOptions _options;
-#pragma warning restore IDE0052 // Remove unread private members
+    private readonly CircuitStateController _controller;
+    private readonly OutcomePredicate<CircuitBreakerPredicateArguments>.Handler? _handler;
 
-    public CircuitBreakerResilienceStrategy(TimeProvider timeProvider, ResilienceStrategyTelemetry telemetry, BaseCircuitBreakerStrategyOptions options)
+    public CircuitBreakerResilienceStrategy(BaseCircuitBreakerStrategyOptions options, CircuitStateController controller)
     {
-        _timeProvider = timeProvider;
-        _telemetry = telemetry;
-        _options = options;
+        _controller = controller;
+        _handler = options.ShouldHandle.CreateHandler();
+
+        options.StateProvider?.Initialize(() => _controller.CircuitState, () => _controller.LastHandledOutcome);
+        options.ManualControl?.Initialize(
+            async c => await _controller.IsolateCircuitAsync(c).ConfigureAwait(c.ContinueOnCapturedContext),
+            async c => await _controller.CloseCircuitAsync(c).ConfigureAwait(c.ContinueOnCapturedContext),
+            _controller.Dispose);
     }
 
-    protected internal override ValueTask<TResult> ExecuteCoreAsync<TResult, TState>(Func<ResilienceContext, TState, ValueTask<TResult>> callback, ResilienceContext context, TState state)
+    protected internal override async ValueTask<TResult> ExecuteCoreAsync<TResult, TState>(Func<ResilienceContext, TState, ValueTask<TResult>> callback, ResilienceContext context, TState state)
     {
-        return callback(context, state);
+        if (_handler == null)
+        {
+            return await callback(context, state).ConfigureAwait(context.ContinueOnCapturedContext);
+        }
+
+        await _controller.OnActionPreExecuteAsync(context).ConfigureAwait(context.ContinueOnCapturedContext);
+
+        try
+        {
+            var result = await callback(context, state).ConfigureAwait(context.ContinueOnCapturedContext);
+            var outcome = new Outcome<TResult>(result);
+
+            if (await _handler.ShouldHandleAsync(outcome, new CircuitBreakerPredicateArguments(context)).ConfigureAwait(context.ContinueOnCapturedContext))
+            {
+                await _controller.OnActionFailureAsync(outcome, context).ConfigureAwait(context.ContinueOnCapturedContext);
+            }
+            else
+            {
+                await _controller.OnActionSuccessAsync(outcome, context).ConfigureAwait(context.ContinueOnCapturedContext);
+            }
+
+            return result;
+        }
+        catch (Exception e)
+        {
+            var outcome = new Outcome<TResult>(e);
+
+            if (await _handler.ShouldHandleAsync(outcome, new CircuitBreakerPredicateArguments(context)).ConfigureAwait(context.ContinueOnCapturedContext))
+            {
+                await _controller.OnActionFailureAsync(outcome, context).ConfigureAwait(context.ContinueOnCapturedContext);
+            }
+
+            throw;
+        }
     }
 }
 

--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerStateProvider.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerStateProvider.cs
@@ -1,3 +1,5 @@
+using Polly.Strategy;
+
 namespace Polly.CircuitBreaker;
 
 /// <summary>
@@ -6,9 +8,9 @@ namespace Polly.CircuitBreaker;
 public sealed class CircuitBreakerStateProvider
 {
     private Func<CircuitState>? _circuitStateProvider;
-    private Func<Exception?>? _lastExceptionProvider;
+    private Func<Outcome?>? _lastHandledOutcomeProvider;
 
-    internal void Initialize(Func<CircuitState> circuitStateProvider, Func<Exception?> lastExceptionProvider)
+    internal void Initialize(Func<CircuitState> circuitStateProvider, Func<Outcome?> lastHandledOutcomeProvider)
     {
         if (_circuitStateProvider != null)
         {
@@ -16,7 +18,7 @@ public sealed class CircuitBreakerStateProvider
         }
 
         _circuitStateProvider = circuitStateProvider;
-        _lastExceptionProvider = lastExceptionProvider;
+        _lastHandledOutcomeProvider = lastHandledOutcomeProvider;
     }
 
     /// <summary>
@@ -34,8 +36,9 @@ public sealed class CircuitBreakerStateProvider
     public CircuitState CircuitState => _circuitStateProvider?.Invoke() ?? CircuitState.Closed;
 
     /// <summary>
-    /// Gets the last exception handled by the circuit-breaker.
-    /// <remarks>This will be null if no exceptions have been handled by the circuit-breaker since the circuit last closed.</remarks>
+    /// Gets the last outcome handled by the circuit-breaker.
+    /// <remarks>
+    /// This will be null if no exceptions or results have been handled by the circuit-breaker since the circuit last closed.</remarks>
     /// </summary>
-    public Exception? LastException => _lastExceptionProvider?.Invoke();
+    public Outcome? LastHandledOutcome => _lastHandledOutcomeProvider?.Invoke();
 }

--- a/src/Polly.Core/CircuitBreaker/Controller/AdvancedCircuitBehavior.cs
+++ b/src/Polly.Core/CircuitBreaker/Controller/AdvancedCircuitBehavior.cs
@@ -1,0 +1,18 @@
+namespace Polly.CircuitBreaker;
+
+internal sealed class AdvancedCircuitBehavior : CircuitBehavior
+{
+    public override void OnActionSuccess(CircuitState currentState)
+    {
+    }
+
+    public override void OnActionFailure(CircuitState currentState, out bool shouldBreak)
+    {
+        shouldBreak = false;
+    }
+
+    public override void OnCircuitClosed()
+    {
+    }
+}
+

--- a/src/Polly.Core/CircuitBreaker/Controller/CircuitBehavior.cs
+++ b/src/Polly.Core/CircuitBreaker/Controller/CircuitBehavior.cs
@@ -1,0 +1,13 @@
+namespace Polly.CircuitBreaker;
+
+/// <summary>
+/// Defines the behavior of circuit breaker. All methods on this class are performed under a lock.
+/// </summary>
+internal abstract class CircuitBehavior
+{
+    public abstract void OnActionSuccess(CircuitState currentState);
+
+    public abstract void OnActionFailure(CircuitState currentState, out bool shouldBreak);
+
+    public abstract void OnCircuitClosed();
+}

--- a/src/Polly.Core/CircuitBreaker/Controller/CircuitStateController.cs
+++ b/src/Polly.Core/CircuitBreaker/Controller/CircuitStateController.cs
@@ -1,0 +1,338 @@
+using Polly.Strategy;
+
+namespace Polly.CircuitBreaker;
+
+/// <summary>
+/// Thread-safe controller that holds and manages the circuit breaker state transitions.
+/// </summary>
+internal sealed class CircuitStateController : IDisposable
+{
+    private readonly object _lock = new();
+    private readonly ScheduledTaskExecutor _executor = new();
+    private readonly OutcomeEvent<OnCircuitOpenedArguments>.Handler? _onOpened;
+    private readonly OutcomeEvent<OnCircuitClosedArguments>.Handler? _onClosed;
+    private readonly Func<OnCircuitHalfOpenedArguments, ValueTask>? _onHalfOpen;
+    private readonly TimeProvider _timeProvider;
+    private readonly ResilienceStrategyTelemetry _telemetry;
+    private readonly CircuitBehavior _behavior;
+    private readonly TimeSpan _breakDuration;
+    private DateTimeOffset _blockedUntil;
+    private CircuitState _circuitState = CircuitState.Closed;
+    private Outcome? _lastOutcome;
+    private BrokenCircuitException? _breakingException;
+    private bool _disposed;
+
+    public CircuitStateController(BaseCircuitBreakerStrategyOptions options, CircuitBehavior behavior, TimeProvider timeProvider, ResilienceStrategyTelemetry telemetry)
+    {
+        _breakDuration = options.BreakDuration;
+        _onOpened = options.OnOpened.CreateHandler();
+        _onClosed = options.OnClosed.CreateHandler();
+        _onHalfOpen = options.OnHalfOpened.CreateHandler();
+        _behavior = behavior;
+        _timeProvider = timeProvider;
+        _telemetry = telemetry;
+    }
+
+    public CircuitState CircuitState
+    {
+        get
+        {
+            EnsureNotDisposed();
+
+            lock (_lock)
+            {
+                return _circuitState;
+            }
+        }
+    }
+
+    public Exception? LastException
+    {
+        get
+        {
+            EnsureNotDisposed();
+
+            lock (_lock)
+            {
+                return _lastOutcome?.Exception;
+            }
+        }
+    }
+
+    public Outcome? LastHandledOutcome
+    {
+        get
+        {
+            EnsureNotDisposed();
+
+            lock (_lock)
+            {
+                return _lastOutcome;
+            }
+        }
+    }
+
+    public ValueTask IsolateCircuitAsync(ResilienceContext context)
+    {
+        EnsureNotDisposed();
+
+        context.Initialize<VoidResult>(isSynchronous: false);
+
+        Task? task;
+
+        lock (_lock)
+        {
+            SetLastHandledOutcome_NeedsLock(new Outcome<VoidResult>(new IsolatedCircuitException()));
+            OpenCircuitFor_NeedsLock(new Outcome<VoidResult>(VoidResult.Instance), TimeSpan.MaxValue, manual: true, context, out task);
+            _circuitState = CircuitState.Isolated;
+        }
+
+        return ExecuteScheduledTaskAsync(task, context);
+    }
+
+    public ValueTask CloseCircuitAsync(ResilienceContext context)
+    {
+        EnsureNotDisposed();
+
+        context.Initialize<VoidResult>(isSynchronous: false);
+
+        Task? task;
+
+        lock (_lock)
+        {
+            CloseCircuit_NeedsLock(new Outcome<VoidResult>(VoidResult.Instance), manual: true, context, out task);
+        }
+
+        return ExecuteScheduledTaskAsync(task, context);
+    }
+
+    public async ValueTask OnActionPreExecuteAsync(ResilienceContext context)
+    {
+        EnsureNotDisposed();
+
+        Exception? exception = null;
+        bool isHalfOpen = false;
+
+        Task? task = null;
+
+        lock (_lock)
+        {
+            // check if circuit can be half-opened
+            if (_circuitState == CircuitState.Open && PermitHalfOpenCircuitTest_NeedsLock())
+            {
+                _circuitState = CircuitState.HalfOpen;
+                _telemetry.Report(CircuitBreakerConstants.OnHalfOpenEvent, new OnCircuitHalfOpenedArguments(context));
+                isHalfOpen = true;
+            }
+
+            exception = _circuitState switch
+            {
+                CircuitState.Open => GetBreakingException_NeedsLock(),
+                CircuitState.HalfOpen when isHalfOpen is false => GetBreakingException_NeedsLock(),
+                CircuitState.Isolated => new IsolatedCircuitException(),
+                _ => null
+            };
+
+            if (isHalfOpen && _onHalfOpen is not null)
+            {
+                _executor.ScheduleTask(() => _onHalfOpen(new OnCircuitHalfOpenedArguments(context)).AsTask(), context, out task);
+            }
+        }
+
+        await ExecuteScheduledTaskAsync(task, context).ConfigureAwait(context.ContinueOnCapturedContext);
+
+        if (exception is not null)
+        {
+            throw exception;
+        }
+    }
+
+    public ValueTask OnActionSuccessAsync<TResult>(Outcome<TResult> outcome, ResilienceContext context)
+    {
+        EnsureNotDisposed();
+
+        Task? task = null;
+
+        lock (_lock)
+        {
+            _behavior.OnActionSuccess(_circuitState);
+
+            switch (_circuitState)
+            {
+                case CircuitState.HalfOpen:
+                    CloseCircuit_NeedsLock(outcome, manual: false, context, out task);
+                    break;
+
+                case CircuitState.Closed:
+                    break;
+
+                case CircuitState.Open:
+                case CircuitState.Isolated:
+                    // A successful call result may arrive when the circuit is open, if it was placed before the circuit broke.
+                    // We take no special action; only time passing governs transitioning from Open to HalfOpen state.
+                    break;
+            }
+
+        }
+
+        return ExecuteScheduledTaskAsync(task, context);
+    }
+
+    public ValueTask OnActionFailureAsync<TResult>(Outcome<TResult> outcome, ResilienceContext context)
+    {
+        EnsureNotDisposed();
+
+        Task? task = null;
+
+        lock (_lock)
+        {
+            SetLastHandledOutcome_NeedsLock(outcome);
+
+            _behavior.OnActionFailure(_circuitState, out var shouldBreak);
+
+            switch (_circuitState)
+            {
+                case CircuitState.HalfOpen:
+                    OpenCircuit_NeedsLock(outcome, manual: false, context, out task);
+                    break;
+
+                case CircuitState.Closed:
+
+                    if (shouldBreak)
+                    {
+                        OpenCircuit_NeedsLock(outcome, manual: false, context, out task);
+                    }
+
+                    break;
+
+                case CircuitState.Open:
+                case CircuitState.Isolated:
+                    // A failure call result may arrive when the circuit is open,
+                    // if it was placed before the circuit broke. We take no action beyond tracking
+                    // the metric; we do not want to duplicate-signal onBreak; we do not want to extend time for which the circuit is broken.
+                    // We do not want to mask the fact that the call executed (as replacing its result with a Broken/IsolatedCircuitException would do).
+                    break;
+            }
+        }
+
+        return ExecuteScheduledTaskAsync(task, context);
+    }
+
+    public void Dispose()
+    {
+        _executor.Dispose();
+        _disposed = true;
+    }
+
+    private static async ValueTask ExecuteScheduledTaskAsync(Task? task, ResilienceContext context)
+    {
+        if (task is not null)
+        {
+            if (context.IsSynchronous)
+            {
+#pragma warning disable CA1849 // Call async methods when in an async method
+                // because this is synchronous execution we need to block
+                task.GetAwaiter().GetResult();
+#pragma warning restore CA1849 // Call async methods when in an async method
+            }
+            else
+            {
+                await task.ConfigureAwait(context.ContinueOnCapturedContext);
+            }
+        }
+    }
+
+    private static bool IsDateTimeOverflow(DateTimeOffset utcNow, TimeSpan breakDuration)
+    {
+        TimeSpan maxDifference = DateTime.MaxValue - utcNow;
+
+        // stryker disable once equality : no means to test this
+        return breakDuration > maxDifference;
+    }
+
+    private void EnsureNotDisposed()
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(nameof(CircuitStateController));
+        }
+    }
+
+    private void CloseCircuit_NeedsLock<TResult>(Outcome<TResult> outcome, bool manual, ResilienceContext context, out Task? scheduledTask)
+    {
+        scheduledTask = null;
+
+        _blockedUntil = DateTimeOffset.MinValue;
+        _lastOutcome = null;
+        _breakingException = null;
+
+        CircuitState priorState = _circuitState;
+        _circuitState = CircuitState.Closed;
+        _behavior.OnCircuitClosed();
+
+        if (priorState != CircuitState.Closed)
+        {
+            var args = new OnCircuitClosedArguments(context, manual);
+            _telemetry.Report(CircuitBreakerConstants.OnCircuitClosed, outcome, args);
+
+            if (_onClosed is not null)
+            {
+                _executor.ScheduleTask(() => _onClosed.HandleAsync(outcome, args).AsTask(), context, out scheduledTask);
+            }
+        }
+    }
+
+    private bool PermitHalfOpenCircuitTest_NeedsLock()
+    {
+        var now = _timeProvider.UtcNow;
+        if (now >= _blockedUntil)
+        {
+            _blockedUntil = now + _breakDuration;
+            return true;
+        }
+
+        return false;
+    }
+
+    private void SetLastHandledOutcome_NeedsLock<TResult>(Outcome<TResult> outcome)
+    {
+        _lastOutcome = outcome.AsOutcome();
+        _breakingException = null;
+
+        if (outcome.Exception is Exception exception)
+        {
+            _breakingException = new BrokenCircuitException(BrokenCircuitException.DefaultMessage, exception);
+        }
+        else if (outcome.TryGetResult(out var result))
+        {
+            _breakingException = new BrokenCircuitException<TResult>(BrokenCircuitException.DefaultMessage, result!);
+        }
+    }
+
+    private BrokenCircuitException GetBreakingException_NeedsLock() => _breakingException ?? new BrokenCircuitException();
+
+    private void OpenCircuit_NeedsLock<TResult>(Outcome<TResult> outcome, bool manual, ResilienceContext context, out Task? scheduledTask)
+    {
+        OpenCircuitFor_NeedsLock(outcome, _breakDuration, manual, context, out scheduledTask);
+    }
+
+    private void OpenCircuitFor_NeedsLock<TResult>(Outcome<TResult> outcome, TimeSpan breakDuration, bool manual, ResilienceContext context, out Task? scheduledTask)
+    {
+        scheduledTask = null;
+        var utcNow = _timeProvider.UtcNow;
+
+        _blockedUntil = IsDateTimeOverflow(utcNow, breakDuration) ? DateTimeOffset.MaxValue : utcNow + breakDuration;
+
+        var transitionedState = _circuitState;
+        _circuitState = CircuitState.Open;
+
+        var args = new OnCircuitOpenedArguments(context, breakDuration, manual);
+        _telemetry.Report(CircuitBreakerConstants.OnCircuitOpened, outcome, args);
+
+        if (_onOpened is not null)
+        {
+            _executor.ScheduleTask(() => _onOpened.HandleAsync(outcome, args).AsTask(), context, out scheduledTask);
+        }
+    }
+}
+

--- a/src/Polly.Core/CircuitBreaker/Controller/ConsecutiveFailuresCircuitBehavior.cs
+++ b/src/Polly.Core/CircuitBreaker/Controller/ConsecutiveFailuresCircuitBehavior.cs
@@ -1,0 +1,37 @@
+namespace Polly.CircuitBreaker;
+
+internal sealed class ConsecutiveFailuresCircuitBehavior : CircuitBehavior
+{
+    private readonly int _failureThreshold;
+    private int _consecutiveFailures;
+
+    public ConsecutiveFailuresCircuitBehavior(CircuitBreakerStrategyOptions options) => _failureThreshold = options.FailureThreshold;
+
+    public override void OnActionSuccess(CircuitState currentState)
+    {
+        if (currentState == CircuitState.Closed)
+        {
+            _consecutiveFailures = 0;
+        }
+    }
+
+    public override void OnActionFailure(CircuitState currentState, out bool shouldBreak)
+    {
+        shouldBreak = false;
+
+        if (currentState == CircuitState.Closed)
+        {
+            _consecutiveFailures += 1;
+            if (_consecutiveFailures >= _failureThreshold)
+            {
+                shouldBreak = true;
+            }
+        }
+    }
+
+    public override void OnCircuitClosed()
+    {
+        _consecutiveFailures = 0;
+    }
+}
+

--- a/src/Polly.Core/CircuitBreaker/Controller/ScheduledTaskExecutor.cs
+++ b/src/Polly.Core/CircuitBreaker/Controller/ScheduledTaskExecutor.cs
@@ -14,7 +14,7 @@ internal sealed class ScheduledTaskExecutor : IDisposable
     private readonly SemaphoreSlim _semaphore = new(0);
     private bool _disposed;
 
-    public ScheduledTaskExecutor() => ProcessingTask = StartProcessingAsync();
+    public ScheduledTaskExecutor() => ProcessingTask = Task.Run(StartProcessingAsync);
 
     public Task ProcessingTask { get; }
 
@@ -52,9 +52,6 @@ internal sealed class ScheduledTaskExecutor : IDisposable
 
     private async Task StartProcessingAsync()
     {
-        // spawn task
-        await Task.Yield();
-
         while (true)
         {
             await _semaphore.WaitAsync().ConfigureAwait(false);

--- a/src/Polly.Core/CircuitBreaker/Controller/ScheduledTaskExecutor.cs
+++ b/src/Polly.Core/CircuitBreaker/Controller/ScheduledTaskExecutor.cs
@@ -1,0 +1,90 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Polly.CircuitBreaker;
+
+#pragma warning disable CA1031 // Do not catch general exception types
+
+/// <summary>
+/// The scheduled task executor makes sure that tasks are executed in the order they were scheduled and not concurrently.
+/// </summary>
+internal sealed class ScheduledTaskExecutor : IDisposable
+{
+    private readonly ConcurrentQueue<Entry> _tasks = new();
+    private readonly SemaphoreSlim _semaphore = new(0);
+    private bool _disposed;
+
+    public ScheduledTaskExecutor() => ProcessingTask = StartProcessingAsync();
+
+    public Task ProcessingTask { get; }
+
+    public void ScheduleTask(Func<Task> taskFactory, ResilienceContext context, out Task task)
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(nameof(ScheduledTaskExecutor));
+        }
+
+        var source = new TaskCompletionSource<object>();
+        task = source.Task;
+
+        _tasks.Enqueue(new Entry(taskFactory, context.ContinueOnCapturedContext, source));
+        _semaphore.Release();
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _semaphore.Release();
+
+        while (_tasks.TryDequeue(out var e))
+        {
+            e.TaskCompletion.TrySetCanceled();
+        }
+
+        _semaphore.Dispose();
+    }
+
+    private async Task StartProcessingAsync()
+    {
+        // spawn task
+        await Task.Yield();
+
+        while (true)
+        {
+            await _semaphore.WaitAsync().ConfigureAwait(false);
+            if (_disposed)
+            {
+                return;
+            }
+
+            _ = _tasks.TryDequeue(out var entry);
+
+            try
+            {
+                await entry!.TaskFactory().ConfigureAwait(entry.ContinueOnCapturedContext);
+                entry.TaskCompletion.SetResult(null!);
+            }
+            catch (OperationCanceledException)
+            {
+                entry!.TaskCompletion.SetCanceled();
+            }
+            catch (Exception e)
+            {
+                entry!.TaskCompletion.SetException(e);
+            }
+
+            if (_disposed)
+            {
+                return;
+            }
+        }
+    }
+
+    private record Entry(Func<Task> TaskFactory, bool ContinueOnCapturedContext, TaskCompletionSource<object> TaskCompletion);
+}

--- a/src/Polly.Core/CircuitBreaker/OnCircuitClosedArguments.cs
+++ b/src/Polly.Core/CircuitBreaker/OnCircuitClosedArguments.cs
@@ -1,4 +1,4 @@
-﻿using Polly.Strategy;
+using Polly.Strategy;
 
 namespace Polly.CircuitBreaker;
 
@@ -9,7 +9,16 @@ namespace Polly.CircuitBreaker;
 /// </summary>
 public readonly struct OnCircuitClosedArguments : IResilienceArguments
 {
-    internal OnCircuitClosedArguments(ResilienceContext context) => Context = context;
+    internal OnCircuitClosedArguments(ResilienceContext context, bool isManual)
+    {
+        Context = context;
+        IsManual = isManual;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the circuit was closed manually by using <see cref="CircuitBreakerManualControl"/>.
+    /// </summary>
+    public bool IsManual { get; }
 
     /// <inheritdoc/>
     public ResilienceContext Context { get; }

--- a/src/Polly.Core/CircuitBreaker/OnCircuitOpenedArguments.cs
+++ b/src/Polly.Core/CircuitBreaker/OnCircuitOpenedArguments.cs
@@ -9,9 +9,10 @@ namespace Polly.CircuitBreaker;
 /// </summary>
 public readonly struct OnCircuitOpenedArguments : IResilienceArguments
 {
-    internal OnCircuitOpenedArguments(ResilienceContext context, TimeSpan breakDuration)
+    internal OnCircuitOpenedArguments(ResilienceContext context, TimeSpan breakDuration, bool isManual)
     {
         BreakDuration = breakDuration;
+        IsManual = isManual;
         Context = context;
     }
 
@@ -19,6 +20,11 @@ public readonly struct OnCircuitOpenedArguments : IResilienceArguments
     /// Gets the duration of break.
     /// </summary>
     public TimeSpan BreakDuration { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the circuit was opened manually by using <see cref="CircuitBreakerManualControl"/>.
+    /// </summary>
+    public bool IsManual { get; }
 
     /// <inheritdoc/>
     public ResilienceContext Context { get; }

--- a/src/Polly.TestUtils/TestUtilities.cs
+++ b/src/Polly.TestUtils/TestUtilities.cs
@@ -41,6 +41,9 @@ public static class TestUtilities
     public static ResilienceStrategyTelemetry CreateResilienceTelemetry(DiagnosticSource source)
         => new(new ResilienceTelemetrySource("dummy-builder", new ResilienceProperties(), "strategy-name", "strategy-type"), source);
 
+    public static ResilienceStrategyTelemetry CreateResilienceTelemetry(Action<IResilienceArguments> callback)
+        => new(new ResilienceTelemetrySource("dummy-builder", new ResilienceProperties(), "strategy-name", "strategy-type"), new CallbackDiagnosticSource(callback));
+
     public static ILoggerFactory CreateLoggerFactory(out FakeLogger logger)
     {
         logger = new FakeLogger();
@@ -92,5 +95,16 @@ public static class TestUtilities
     {
         context.Initialize<T>(true);
         return context;
+    }
+
+    private sealed class CallbackDiagnosticSource : DiagnosticSource
+    {
+        private readonly Action<IResilienceArguments> _callback;
+
+        public CallbackDiagnosticSource(Action<IResilienceArguments> callback) => _callback = callback;
+
+        public override bool IsEnabled(string name) => true;
+
+        public override void Write(string name, object? value) => _callback((value as TelemetryEventArguments)!.Arguments);
     }
 }


### PR DESCRIPTION
### The issue or feature being addressed

Contributes to #1098 

### Details on the issue fix or feature implementation

In this PR I am migrating `CircuitStateController` to V8 with the following changes:

- It's API is now asynchronous. 
- `TimedLock` is no longer used. Instead, just buil-in lock is used as it gives better warnings if away inside lock statement is used. 
- The registered callbacks are now invoked outside of lock. We still ensure consistent ordering of delivery.
- General cleanup and some simplifications.
- The synchronization is no longer exposed outside of the class. Locks are private. Any customization is done through `CircuitBehavior`.

Additionaly, I have finished the implementation of `CircutBreakerResilienceStrategy` and simple (consecutive) circuit breaker. 

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
