### PR TITLE
Enhance callback API with handling of void-based results

### DIFF
--- a/src/Polly.Core.Tests/CircuitBreaker/Controller/CircuitStateControllerTests.cs
+++ b/src/Polly.Core.Tests/CircuitBreaker/Controller/CircuitStateControllerTests.cs
@@ -30,7 +30,7 @@ public class CircuitStateControllerTests
     {
         // arrange
         bool called = false;
-        _options.OnOpened.Register<VoidResult>((outcome, args) =>
+        _options.OnOpened.RegisterVoid((outcome, args) =>
         {
             args.BreakDuration.Should().Be(TimeSpan.MaxValue);
             args.Context.IsSynchronous.Should().BeFalse();
@@ -65,7 +65,7 @@ public class CircuitStateControllerTests
     {
         // arrange
         bool called = false;
-        _options.OnClosed.Register<VoidResult>((outcome, args) =>
+        _options.OnClosed.RegisterVoid((outcome, args) =>
         {
             args.Context.IsSynchronous.Should().BeFalse();
             args.Context.IsVoid.Should().BeTrue();

--- a/src/Polly.Core.Tests/Retry/RetryStrategyOptionsTResultTests.cs
+++ b/src/Polly.Core.Tests/Retry/RetryStrategyOptionsTResultTests.cs
@@ -77,11 +77,13 @@ public class RetryStrategyOptionsTResultTests
         nonGenericOptions.StrategyName.Should().Be("my-name");
         nonGenericOptions.StrategyType.Should().Be("my-type");
 
-        (await nonGenericOptions.ShouldRetry.CreateHandler()!.ShouldHandleAsync(new Outcome<int>(999), default)).Should().BeTrue();
-        await nonGenericOptions.OnRetry.CreateHandler()!.HandleAsync(new Outcome<int>(999), default);
-        called.Should().BeTrue();
-        var args = new RetryDelayArguments(ResilienceContext.Get(), 2, TimeSpan.FromMinutes(1));
-        (await nonGenericOptions.RetryDelayGenerator.CreateHandler(default, _ => true)!.GenerateAsync(new Outcome<int>(999), args)).Should().Be(TimeSpan.FromSeconds(123));
+        var args = new ShouldRetryArguments(ResilienceContext.Get(), 0);
+        var delayArgs = new RetryDelayArguments(ResilienceContext.Get(), 2, TimeSpan.FromMinutes(1));
+        var retryArgs = new OnRetryArguments(ResilienceContext.Get(), 0, TimeSpan.Zero);
 
+        (await nonGenericOptions.ShouldRetry.CreateHandler()!.ShouldHandleAsync(new Outcome<int>(999), args)).Should().BeTrue();
+        await nonGenericOptions.OnRetry.CreateHandler()!.HandleAsync(new Outcome<int>(999), retryArgs);
+        called.Should().BeTrue();
+        (await nonGenericOptions.RetryDelayGenerator.CreateHandler(default, _ => true)!.GenerateAsync(new Outcome<int>(999), delayArgs)).Should().Be(TimeSpan.FromSeconds(123));
     }
 }

--- a/src/Polly.Core.Tests/Strategy/OutcomeEventTests.cs
+++ b/src/Polly.Core.Tests/Strategy/OutcomeEventTests.cs
@@ -79,16 +79,105 @@ public class OutcomeEventTests
         },
         sut =>
         {
-            sut.ConfigureCallbacks<double>(callbacks => callbacks.IsEmpty.Should().BeTrue());
-            InvokeHandler(sut, new Outcome<double>(1.0));
-        },
-        sut =>
-        {
             bool called = false;
             sut.Register<double>((_, _) => { called = true; return default; });
             sut.SetCallbacks(new OutcomeEvent<TestArguments, double>());
             InvokeHandler(sut, new Outcome<double>(1.0));
             called.Should().BeFalse();
+        },
+        sut =>
+        {
+            int called = 0;
+            sut.Register<double>((_, _) => { called ++; return default; });
+            sut.RegisterVoid((_, _) => { called ++; return default; });
+            InvokeHandler(sut, new Outcome<VoidResult>(VoidResult.Instance));
+            called.Should().Be(1);
+        },
+        sut =>
+        {
+            int called = 0;
+            sut.RegisterVoid((_) => called ++);
+            InvokeHandler(sut, new Outcome<VoidResult>(VoidResult.Instance));
+            called.Should().Be(1);
+        },
+        sut =>
+        {
+            int called = 0;
+            sut.RegisterVoid(() => called ++);
+            InvokeHandler(sut, new Outcome<VoidResult>(VoidResult.Instance));
+            called.Should().Be(1);
+        },
+        sut =>
+        {
+            int called = 0;
+            sut.RegisterVoid((_, _) => called ++);
+            InvokeHandler(sut, new Outcome<VoidResult>(VoidResult.Instance));
+            called.Should().Be(1);
+        },
+        sut =>
+        {
+            int called = 0;
+            sut.RegisterVoid((_, _) => called ++);
+            sut.RegisterVoid((_, _) => called ++);
+            InvokeHandler(sut, new Outcome<VoidResult>(VoidResult.Instance));
+            called.Should().Be(2);
+        },
+        sut =>
+        {
+            sut.SetVoidCallbacks(new VoidOutcomeEvent<TestArguments>());
+            InvokeHandler(sut, new Outcome<VoidResult>(VoidResult.Instance));
+        },
+        sut =>
+        {
+            int called = 0;
+            sut.Register(() => called ++);
+            InvokeHandler(sut, new Outcome<int>(10));
+            called.Should().Be(1);
+        },
+        sut =>
+        {
+            int called = 0;
+            sut.Register(() => called ++);
+            sut.Register(() => called ++);
+            InvokeHandler(sut, new Outcome<int>(10));
+            called.Should().Be(2);
+        },
+        sut =>
+        {
+            int called = 0;
+            sut.Register(() => called ++);
+            sut.Register(() => called ++);
+            sut.Register<int>(() => called ++);
+            InvokeHandler(sut, new Outcome<int>(10));
+            called.Should().Be(3);
+        },
+        sut =>
+        {
+            int called = 0;
+            sut.Register(o => { o.Result.Should().Be(10); called ++; });
+            InvokeHandler(sut, new Outcome<int>(10));
+            called.Should().Be(1);
+        },
+        sut =>
+        {
+            int called = 0;
+            sut.Register(o => { o.Exception.Should().BeOfType<InvalidOperationException>(); called ++; });
+            InvokeHandler(sut, new Outcome<int>(new InvalidOperationException()));
+            called.Should().Be(1);
+        },
+        sut =>
+        {
+            int called = 0;
+            sut.Register((_, _) => called ++);
+            InvokeHandler(sut, new Outcome<int>(10));
+            called.Should().Be(1);
+        },
+        sut =>
+        {
+            int called = 0;
+            sut.Register((_, _) => { called ++; return default; });
+            InvokeHandler(sut, new Outcome<int>(10));
+            called.Should().Be(1);
         },
     };
 

--- a/src/Polly.Core.Tests/Strategy/OutcomeGeneratorTests.cs
+++ b/src/Polly.Core.Tests/Strategy/OutcomeGeneratorTests.cs
@@ -118,19 +118,28 @@ public class OutcomeGeneratorTests
         },
         sut =>
         {
-            sut.ConfigureGenerator<int>(generator => generator.IsEmpty.Should().BeTrue());
-            InvokeHandler(sut, new Outcome<int>(10), GeneratedValue.Default);
-        },
-        sut =>
-        {
-            sut.ConfigureGenerator<int>(generator => generator.SetGenerator((_, _) => GeneratedValue.Valid1));
-            sut.SetGenerator(new OutcomeGenerator<TestArguments, GeneratedValue, int>());
-            InvokeHandler(sut, new Outcome<int>(10), GeneratedValue.Default);
-        },
-        sut =>
-        {
             sut.SetGenerator((_, _) => new ValueTask<GeneratedValue>(GeneratedValue.Valid1));
             InvokeHandler(sut, new Outcome<int>(10), GeneratedValue.Valid1);
+        },
+        sut =>
+        {
+            sut.SetVoidGenerator((_, _) => new ValueTask<GeneratedValue>(GeneratedValue.Valid1));
+            InvokeHandler(sut, new Outcome<VoidResult>(VoidResult.Instance), GeneratedValue.Valid1);
+        },
+        sut =>
+        {
+            sut.SetVoidGenerator((_, _) => GeneratedValue.Valid1);
+            InvokeHandler(sut, new Outcome<VoidResult>(VoidResult.Instance), GeneratedValue.Valid1);
+        },
+        sut =>
+        {
+            sut.SetVoidGenerator((_, _) => new ValueTask<GeneratedValue>(GeneratedValue.Valid1));
+            InvokeHandler(sut, new Outcome<int>(10), GeneratedValue.Default);
+        },
+        sut =>
+        {
+            sut.SetVoidGenerator((_, _) => GeneratedValue.Valid1);
+            InvokeHandler(sut, new Outcome<int>(10), GeneratedValue.Default);
         },
     };
 

--- a/src/Polly.Core.Tests/Strategy/OutcomePredicateTests.cs
+++ b/src/Polly.Core.Tests/Strategy/OutcomePredicateTests.cs
@@ -20,9 +20,6 @@ public class OutcomePredicateTests
     public void Empty_ConfigurePredicates_Ok()
     {
         _sut.IsEmpty.Should().BeTrue();
-        _sut.ConfigurePredicates<int>(p => p.IsEmpty.Should().BeTrue());
-        _sut.ConfigurePredicates<int>(p => p.IsEmpty.Should().BeTrue());
-        _sut.IsEmpty.Should().BeFalse();
         _sut.CreateHandler().Should().BeNull();
     }
 
@@ -89,6 +86,62 @@ public class OutcomePredicateTests
             sut.HandleException<InvalidOperationException>((e, _) => new ValueTask<bool>(e.Message.Contains("dummy")));
             InvokeHandler(sut, new InvalidOperationException("dummy"), true);
         },
+        sut =>
+        {
+            sut.HandleVoidException<InvalidOperationException>();
+            InvokeVoidHandler(sut, new InvalidOperationException("dummy"), true);
+        },
+        sut =>
+        {
+            sut.HandleVoidException<InvalidOperationException>(_=> true);
+            InvokeVoidHandler(sut, new ArgumentNullException("dummy"), false);
+        },
+        sut =>
+        {
+            sut.HandleVoidException<InvalidOperationException>((_, _)=> true);
+            InvokeVoidHandler(sut, new ArgumentNullException("dummy"), false);
+        },
+        sut =>
+        {
+            sut.HandleVoidException<InvalidOperationException>((_, _)=> new ValueTask<bool>(true));
+            InvokeVoidHandler(sut, new ArgumentNullException("dummy"), false);
+        },
+        sut =>
+        {
+            sut.HandleVoidException<InvalidOperationException>();
+            InvokeVoidHandler(sut, new ArgumentNullException("dummy"), false);
+        },
+        sut =>
+        {
+            sut.HandleVoidException<InvalidOperationException>();
+            InvokeVoidHandler(sut, new InvalidOperationException("dummy"), true);
+        },
+        sut =>
+        {
+            sut.HandleVoidException<InvalidOperationException>(e => e.Message.Contains("dummy"));
+            InvokeVoidHandler(sut, new InvalidOperationException("other message"), false);
+        },
+        sut =>
+        {
+            sut.HandleVoidException<InvalidOperationException>((e, _) => e.Message.Contains("dummy"));
+            InvokeVoidHandler(sut, new InvalidOperationException("other message"), false);
+        },
+        sut =>
+        {
+            sut.HandleVoidException<InvalidOperationException>((e, _) => e.Message.Contains("dummy"));
+            InvokeVoidHandler(sut, new InvalidOperationException("dummy"), true);
+        },
+        sut =>
+        {
+            sut.HandleVoidException<InvalidOperationException>((e, _) => new ValueTask<bool>(e.Message.Contains("dummy")));
+            InvokeVoidHandler(sut, new InvalidOperationException("other message"), false);
+        },
+        sut =>
+        {
+            sut.HandleVoidException<InvalidOperationException>((e, _) => new ValueTask<bool>(e.Message.Contains("dummy")));
+            InvokeVoidHandler(sut, new InvalidOperationException("dummy"), true);
+        },
+
     };
 
     [MemberData(nameof(ExceptionPredicates))]
@@ -331,6 +384,16 @@ public class OutcomePredicateTests
         // again with result
         sut.HandleResult(12345);
         sut.CreateHandler()!.ShouldHandleAsync(new Outcome<int>(10), args).AsTask().Result.Should().Be(false);
+    }
+
+    private static void InvokeVoidHandler(OutcomePredicate<TestArguments> sut, Exception exception, bool expectedResult)
+    {
+        var args = new TestArguments();
+
+        sut.CreateHandler()!.ShouldHandleAsync(new Outcome<int>(exception), args).AsTask().Result.Should().Be(false);
+
+        // again with void result
+        sut.CreateHandler()!.ShouldHandleAsync(new Outcome<VoidResult>(exception), args).AsTask().Result.Should().Be(expectedResult);
     }
 
     private static void InvokeResultHandler<T>(OutcomePredicate<TestArguments> sut, T result, bool expectedResult)

--- a/src/Polly.Core.Tests/Strategy/VoidOutcomeEventTests.cs
+++ b/src/Polly.Core.Tests/Strategy/VoidOutcomeEventTests.cs
@@ -1,0 +1,18 @@
+using Polly.Strategy;
+
+namespace Polly.Core.Tests.Strategy;
+
+public class VoidOutcomeEventTests
+{
+    [Fact]
+    public void IsEmpty_Ok()
+    {
+        var ev = new VoidOutcomeEvent<TestArguments>();
+
+        ev.IsEmpty.Should().BeTrue();
+
+        ev.Register(() => { });
+
+        ev.IsEmpty.Should().BeFalse();
+    }
+}

--- a/src/Polly.Core.Tests/Strategy/VoidOutcomeGeneratorTests.cs
+++ b/src/Polly.Core.Tests/Strategy/VoidOutcomeGeneratorTests.cs
@@ -1,0 +1,18 @@
+using Polly.Strategy;
+
+namespace Polly.Core.Tests.Strategy;
+
+public class VoidOutcomeGeneratorTests
+{
+    [Fact]
+    public void IsEmpty_Ok()
+    {
+        var ev = new VoidOutcomeGenerator<TestArguments, int>();
+
+        ev.IsEmpty.Should().BeTrue();
+
+        ev.SetGenerator((_, _) => 10);
+
+        ev.IsEmpty.Should().BeFalse();
+    }
+}

--- a/src/Polly.Core.Tests/Strategy/VoidOutcomePredicateTests.cs
+++ b/src/Polly.Core.Tests/Strategy/VoidOutcomePredicateTests.cs
@@ -1,0 +1,18 @@
+using Polly.Strategy;
+
+namespace Polly.Core.Tests.Strategy;
+
+public class VoidOutcomePredicateTests
+{
+    [Fact]
+    public void IsEmpty_Ok()
+    {
+        var ev = new VoidOutcomePredicate<TestArguments>();
+
+        ev.IsEmpty.Should().BeTrue();
+
+        ev.HandleException<InvalidOperationException>();
+
+        ev.IsEmpty.Should().BeFalse();
+    }
+}

--- a/src/Polly.Core/Strategy/OutcomeEvent.Void.cs
+++ b/src/Polly.Core/Strategy/OutcomeEvent.Void.cs
@@ -1,0 +1,91 @@
+using System;
+using Polly.Strategy;
+
+namespace Polly.Strategy;
+
+public sealed partial class OutcomeEvent<TArgs>
+    where TArgs : IResilienceArguments
+{
+    /// <summary>
+    /// Registers a callback for void-based results.
+    /// </summary>
+    /// <param name="callback">The event callback associated with the result type.</param>
+    /// <returns>The current updated instance.</returns>
+    public OutcomeEvent<TArgs> RegisterVoid(Action callback)
+    {
+        Guard.NotNull(callback);
+
+        return ConfigureVoidCallbacks(c => c.Register(callback));
+    }
+
+    /// <summary>
+    /// Registers a callback for void-based results.
+    /// </summary>
+    /// <param name="callback">The event callback associated with the void result type.</param>
+    /// <returns>The current updated instance.</returns>
+    public OutcomeEvent<TArgs> RegisterVoid(Action<Outcome> callback)
+    {
+        Guard.NotNull(callback);
+
+        return ConfigureVoidCallbacks(c => c.Register(callback));
+    }
+
+    /// <summary>
+    /// Registers a callback for void-based results.
+    /// </summary>
+    /// <param name="callback">The event callback associated with the void result type.</param>
+    /// <returns>The current updated instance.</returns>
+    public OutcomeEvent<TArgs> RegisterVoid(Action<Outcome, TArgs> callback)
+    {
+        Guard.NotNull(callback);
+
+        return ConfigureVoidCallbacks(c => c.Register(callback));
+    }
+
+    /// <summary>
+    /// Registers a callback for void-based results.
+    /// </summary>
+    /// <param name="callback">The event callback associated with the void result type.</param>
+    /// <returns>The current updated instance.</returns>
+    public OutcomeEvent<TArgs> RegisterVoid(Func<Outcome, TArgs, ValueTask> callback)
+    {
+        Guard.NotNull(callback);
+
+        return ConfigureVoidCallbacks(c => c.Register(callback));
+    }
+
+    /// <summary>
+    /// Registers a callback for void-based results.
+    /// </summary>
+    /// <param name="configure">Action that configures the callbacks.</param>
+    /// <returns>The current updated instance.</returns>
+    private OutcomeEvent<TArgs> ConfigureVoidCallbacks(Action<VoidOutcomeEvent<TArgs>> configure)
+    {
+        Guard.NotNull(configure);
+
+        if (!_callbacks.TryGetValue(typeof(VoidResult), out var callbacks))
+        {
+            SetVoidCallbacks(new VoidOutcomeEvent<TArgs>());
+            callbacks = _callbacks[typeof(VoidResult)];
+        }
+
+        configure((VoidOutcomeEvent<TArgs>)callbacks.callback);
+        return this;
+    }
+
+    /// <summary>
+    /// Sets callbacks for void-based results.
+    /// </summary>
+    /// <param name="callbacks">The callbacks instance.</param>
+    /// <returns>The current updated instance.</returns>
+    /// <remarks>
+    /// This method replaces all previously registered callbacks for void-based results.
+    /// </remarks>
+    public OutcomeEvent<TArgs> SetVoidCallbacks(VoidOutcomeEvent<TArgs> callbacks)
+    {
+        Guard.NotNull(callbacks);
+
+        _callbacks[typeof(VoidResult)] = (callbacks, callbacks.CreateHandler);
+        return this;
+    }
+}

--- a/src/Polly.Core/Strategy/OutcomeEvent.cs
+++ b/src/Polly.Core/Strategy/OutcomeEvent.cs
@@ -4,7 +4,7 @@ using Polly.Strategy;
 namespace Polly.Strategy;
 
 /// <summary>
-/// The base class for events that use <see cref="Outcome{TResult}"/> and <typeparamref name="TArgs"/> in the registered event callbacks.
+/// Class for events that use <see cref="Outcome{TResult}"/> and <typeparamref name="TArgs"/> in the registered event callbacks.
 /// </summary>
 /// <typeparam name="TArgs">The type of arguments the event uses.</typeparam>
 public sealed partial class OutcomeEvent<TArgs>
@@ -18,7 +18,7 @@ public sealed partial class OutcomeEvent<TArgs>
     public bool IsEmpty => _callbacks.Count == 0;
 
     /// <summary>
-    /// Adds a callback for the specified result type.
+    /// Registers a callback for the specified result type.
     /// </summary>
     /// <typeparam name="TResult">The result type to add a callback for.</typeparam>
     /// <param name="callback">The event callback associated with the result type.</param>
@@ -31,7 +31,7 @@ public sealed partial class OutcomeEvent<TArgs>
     }
 
     /// <summary>
-    /// Adds a callback for the specified result type.
+    /// Registers a callback for the specified result type.
     /// </summary>
     /// <typeparam name="TResult">The result type to add a callback for.</typeparam>
     /// <param name="callback">The event callback associated with the result type.</param>
@@ -44,7 +44,7 @@ public sealed partial class OutcomeEvent<TArgs>
     }
 
     /// <summary>
-    /// Adds a callback for the specified result type.
+    /// Registers a callback for the specified result type.
     /// </summary>
     /// <typeparam name="TResult">The result type to add a callback for.</typeparam>
     /// <param name="callback">The event callback associated with the result type.</param>
@@ -57,7 +57,7 @@ public sealed partial class OutcomeEvent<TArgs>
     }
 
     /// <summary>
-    /// Adds a callback for the specified result type.
+    /// Registers a callback for the specified result type.
     /// </summary>
     /// <typeparam name="TResult">The result type to add a callback for.</typeparam>
     /// <param name="callback">The event callback associated with the result type.</param>
@@ -70,12 +70,60 @@ public sealed partial class OutcomeEvent<TArgs>
     }
 
     /// <summary>
-    /// Adds a callback for the specified result type.
+    /// Registers a callback for all result types including void-based results.
+    /// </summary>
+    /// <param name="callback">The event callback associated with the result type.</param>
+    /// <returns>The current updated instance.</returns>
+    public OutcomeEvent<TArgs> Register(Action callback)
+    {
+        Guard.NotNull(callback);
+
+        return ConfigureCallbacks<object>(c => c.Register(callback));
+    }
+
+    /// <summary>
+    /// Registers a callback for all result types including void-based results.
+    /// </summary>
+    /// <param name="callback">The event callback associated with the result type.</param>
+    /// <returns>The current updated instance.</returns>
+    public OutcomeEvent<TArgs> Register(Action<Outcome> callback)
+    {
+        Guard.NotNull(callback);
+
+        return ConfigureCallbacks<object>(c => c.Register(outcome => callback(outcome.AsOutcome())));
+    }
+
+    /// <summary>
+    /// Registers a callback for all result types including void-based results.
+    /// </summary>
+    /// <param name="callback">The event callback associated with the result type.</param>
+    /// <returns>The current updated instance.</returns>
+    public OutcomeEvent<TArgs> Register(Action<Outcome, TArgs> callback)
+    {
+        Guard.NotNull(callback);
+
+        return ConfigureCallbacks<object>(c => c.Register((outcome, args) => callback(outcome.AsOutcome(), args)));
+    }
+
+    /// <summary>
+    /// Registers a callback for all result types including void-based results.
+    /// </summary>
+    /// <param name="callback">The event callback associated with the result type.</param>
+    /// <returns>The current updated instance.</returns>
+    public OutcomeEvent<TArgs> Register(Func<Outcome, TArgs, ValueTask> callback)
+    {
+        Guard.NotNull(callback);
+
+        return ConfigureCallbacks<object>(c => c.Register((outcome, args) => callback(outcome.AsOutcome(), args)));
+    }
+
+    /// <summary>
+    /// Registers a callback for the specified result type.
     /// </summary>
     /// <typeparam name="TResult">The result type to add a callbacks for.</typeparam>
     /// <param name="configure">Action that configures the callbacks.</param>
     /// <returns>The current updated instance.</returns>
-    public OutcomeEvent<TArgs> ConfigureCallbacks<TResult>(Action<OutcomeEvent<TArgs, TResult>> configure)
+    private OutcomeEvent<TArgs> ConfigureCallbacks<TResult>(Action<OutcomeEvent<TArgs, TResult>> configure)
     {
         Guard.NotNull(configure);
 
@@ -95,6 +143,9 @@ public sealed partial class OutcomeEvent<TArgs>
     /// <typeparam name="TResult">The result type to add a callbacks for.</typeparam>
     /// <param name="callbacks">The callbacks instance.</param>
     /// <returns>The current updated instance.</returns>
+    /// <remarks>
+    /// This method replaces all previously registered callbacks for the specified result type.
+    /// </remarks>
     public OutcomeEvent<TArgs> SetCallbacks<TResult>(OutcomeEvent<TArgs, TResult> callbacks)
     {
         Guard.NotNull(callbacks);
@@ -104,7 +155,7 @@ public sealed partial class OutcomeEvent<TArgs>
     }
 
     /// <summary>
-    /// Creates a handler that invokes the registered event callbacks.
+    /// Creates an event handler.
     /// </summary>
     /// <returns>Handler instance or <c>null</c> if no callbacks are registered.</returns>
     public Handler? CreateHandler()

--- a/src/Polly.Core/Strategy/OutcomeGenerator.Handler.cs
+++ b/src/Polly.Core/Strategy/OutcomeGenerator.Handler.cs
@@ -7,7 +7,7 @@ namespace Polly.Strategy;
 public sealed partial class OutcomeGenerator<TArgs, TValue>
 {
     /// <summary>
-    /// The resulting handler for the outcome.
+    /// The resulting generator handler.
     /// </summary>
     public abstract class Handler
     {
@@ -59,7 +59,14 @@ public sealed partial class OutcomeGenerator<TArgs, TValue>
             }
             else if (typeof(TResult) == _type)
             {
-                value = await ((Func<Outcome<TResult>, TArgs, ValueTask<TValue>>)_generator)(outcome, args).ConfigureAwait(args.Context.ContinueOnCapturedContext);
+                if (typeof(TResult) == typeof(VoidResult))
+                {
+                    value = await ((Func<Outcome, TArgs, ValueTask<TValue>>)_generator)(outcome.AsOutcome(), args).ConfigureAwait(args.Context.ContinueOnCapturedContext);
+                }
+                else
+                {
+                    value = await ((Func<Outcome<TResult>, TArgs, ValueTask<TValue>>)_generator)(outcome, args).ConfigureAwait(args.Context.ContinueOnCapturedContext);
+                }
             }
 
             if (IsValid(value))

--- a/src/Polly.Core/Strategy/OutcomeGenerator.Void.cs
+++ b/src/Polly.Core/Strategy/OutcomeGenerator.Void.cs
@@ -1,0 +1,62 @@
+namespace Polly.Strategy;
+
+public sealed partial class OutcomeGenerator<TArgs, TValue>
+    where TArgs : IResilienceArguments
+{
+    /// <summary>
+    /// Sets a result generator for void-based results.
+    /// </summary>
+    /// <param name="generator">The value generator.</param>
+    /// <returns>The current updated instance.</returns>
+    public OutcomeGenerator<TArgs, TValue> SetVoidGenerator(Func<Outcome, TArgs, TValue> generator)
+    {
+        Guard.NotNull(generator);
+
+        return ConfigureVoidGenerator(g => g.SetGenerator((outcome, args) => generator(outcome, args)));
+    }
+
+    /// <summary>
+    /// Sets a result generator for void-based results.
+    /// </summary>
+    /// <param name="generator">The value generator.</param>
+    /// <returns>The current updated instance.</returns>
+    public OutcomeGenerator<TArgs, TValue> SetVoidGenerator(Func<Outcome, TArgs, ValueTask<TValue>> generator)
+    {
+        Guard.NotNull(generator);
+
+        return ConfigureVoidGenerator(g => g.SetGenerator((outcome, args) => generator(outcome, args)));
+    }
+
+    /// <summary>
+    /// Sets a result generator for void-based results.
+    /// </summary>
+    /// <param name="generator">The generator builder.</param>
+    /// <returns>The current updated instance.</returns>
+    public OutcomeGenerator<TArgs, TValue> SetVoidGenerator(VoidOutcomeGenerator<TArgs, TValue> generator)
+    {
+        Guard.NotNull(generator);
+
+        _generators[typeof(VoidResult)] = (generator, generator.CreateHandler);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Sets a result generator for void-based results.
+    /// </summary>
+    /// <param name="configure">The callbacks that configures the generator.</param>
+    /// <returns>The current updated instance.</returns>
+    public OutcomeGenerator<TArgs, TValue> ConfigureVoidGenerator(Action<VoidOutcomeGenerator<TArgs, TValue>> configure)
+    {
+        Guard.NotNull(configure);
+
+        if (!_generators.TryGetValue(typeof(VoidResult), out var generator))
+        {
+            SetVoidGenerator(new VoidOutcomeGenerator<TArgs, TValue>());
+            generator = _generators[typeof(VoidResult)];
+        }
+
+        configure((VoidOutcomeGenerator<TArgs, TValue>)generator.generator);
+        return this;
+    }
+}

--- a/src/Polly.Core/Strategy/OutcomeGenerator.cs
+++ b/src/Polly.Core/Strategy/OutcomeGenerator.cs
@@ -20,7 +20,7 @@ public sealed partial class OutcomeGenerator<TArgs, TValue>
     public bool IsEmpty => _generators.Count == 0;
 
     /// <summary>
-    /// Adds a result generator for a specific result type.
+    /// Sets a result generator for a specific result type.
     /// </summary>
     /// <typeparam name="TResult">The result type to add a generator for.</typeparam>
     /// <param name="generator">The value generator.</param>
@@ -33,7 +33,7 @@ public sealed partial class OutcomeGenerator<TArgs, TValue>
     }
 
     /// <summary>
-    /// Adds a result generator for a specific result type.
+    /// Sets a result generator for a specific result type.
     /// </summary>
     /// <typeparam name="TResult">The result type to add a generator for.</typeparam>
     /// <param name="generator">The value generator.</param>
@@ -46,7 +46,7 @@ public sealed partial class OutcomeGenerator<TArgs, TValue>
     }
 
     /// <summary>
-    /// Adds a result generator for all result types including the void-based results.
+    /// Sets a result generator for all result types including the void-based results.
     /// </summary>
     /// <param name="generator">The value generator.</param>
     /// <returns>The current updated instance.</returns>
@@ -58,7 +58,7 @@ public sealed partial class OutcomeGenerator<TArgs, TValue>
     }
 
     /// <summary>
-    /// Adds a result generator for all result types including the void-based results.
+    /// Sets a result generator for all result types including the void-based results.
     /// </summary>
     /// <param name="generator">The value generator.</param>
     /// <returns>The current updated instance.</returns>
@@ -70,7 +70,7 @@ public sealed partial class OutcomeGenerator<TArgs, TValue>
     }
 
     /// <summary>
-    /// Adds a result generator for specific result type.
+    /// Sets a result generator for specific result type.
     /// </summary>
     /// <typeparam name="TResult">The result type to add a generator for.</typeparam>
     /// <param name="generator">The generator builder.</param>
@@ -85,12 +85,12 @@ public sealed partial class OutcomeGenerator<TArgs, TValue>
     }
 
     /// <summary>
-    /// Adds a result generator for all result types including the void-based results.
+    /// Sets a result generator for all result types including the void-based results.
     /// </summary>
     /// <typeparam name="TResult">The result type to add a generator for.</typeparam>
     /// <param name="configure">The callbacks that configures the generator.</param>
     /// <returns>The current updated instance.</returns>
-    public OutcomeGenerator<TArgs, TValue> ConfigureGenerator<TResult>(Action<OutcomeGenerator<TArgs, TValue, TResult>> configure)
+    private OutcomeGenerator<TArgs, TValue> ConfigureGenerator<TResult>(Action<OutcomeGenerator<TArgs, TValue, TResult>> configure)
     {
         Guard.NotNull(configure);
 

--- a/src/Polly.Core/Strategy/OutcomePredicate.Handler.cs
+++ b/src/Polly.Core/Strategy/OutcomePredicate.Handler.cs
@@ -54,9 +54,17 @@ public partial class OutcomePredicate<TArgs>
 
         private ValueTask<bool> ShouldHandlerCoreAsync<TResult>(Outcome<TResult> outcome, TArgs args)
         {
-            var predicate = (Func<Outcome<TResult>, TArgs, ValueTask<bool>>)_predicate;
+            if (typeof(TResult) == typeof(VoidResult))
+            {
+                var predicate = (Func<Outcome, TArgs, ValueTask<bool>>)_predicate;
+                return predicate(outcome.AsOutcome(), args);
+            }
+            else
+            {
+                var predicate = (Func<Outcome<TResult>, TArgs, ValueTask<bool>>)_predicate;
 
-            return predicate(outcome, args);
+                return predicate(outcome, args);
+            }
         }
     }
 

--- a/src/Polly.Core/Strategy/OutcomePredicate.Void.cs
+++ b/src/Polly.Core/Strategy/OutcomePredicate.Void.cs
@@ -1,0 +1,89 @@
+namespace Polly.Strategy;
+
+public sealed partial class OutcomePredicate<TArgs>
+    where TArgs : IResilienceArguments
+{
+    /// <summary>
+    /// Adds an exception predicate for void-based results.
+    /// </summary>
+    /// <typeparam name="TException">The exception type to add a predicate for.</typeparam>
+    /// <returns>The current updated instance.</returns>
+    public OutcomePredicate<TArgs> HandleVoidException<TException>()
+        where TException : Exception
+    {
+        return ConfigureVoidPredicates(p => p.HandleException<TException>());
+    }
+
+    /// <summary>
+    /// Adds an exception predicate for void-based results.
+    /// </summary>
+    /// <typeparam name="TException">The exception type to add a predicate for.</typeparam>
+    /// <param name="predicate">The predicate to determine if the exception should be retried.</param>
+    /// <returns>The current updated instance.</returns>
+    public OutcomePredicate<TArgs> HandleVoidException<TException>(Func<TException, bool> predicate)
+        where TException : Exception
+    {
+        Guard.NotNull(predicate);
+
+        return ConfigureVoidPredicates(p => p.HandleException(predicate));
+    }
+
+    /// <summary>
+    /// Adds an exception predicate for void-based results.
+    /// </summary>
+    /// <typeparam name="TException">The exception type to add a predicate for.</typeparam>
+    /// <param name="predicate">The predicate to determine if the exception should be retried.</param>
+    /// <returns>The current updated instance.</returns>
+    public OutcomePredicate<TArgs> HandleVoidException<TException>(Func<TException, TArgs, bool> predicate)
+        where TException : Exception
+    {
+        Guard.NotNull(predicate);
+
+        return ConfigureVoidPredicates(p => p.HandleException(predicate));
+    }
+
+    /// <summary>
+    /// Adds an exception predicate for void-based results.
+    /// </summary>
+    /// <typeparam name="TException">The exception type to add a predicate for.</typeparam>
+    /// <param name="predicate">The predicate to determine if the exception should be retried.</param>
+    /// <returns>The current updated instance.</returns>
+    public OutcomePredicate<TArgs> HandleVoidException<TException>(Func<TException, TArgs, ValueTask<bool>> predicate)
+        where TException : Exception
+    {
+        Guard.NotNull(predicate);
+
+        return ConfigureVoidPredicates(p => p.HandleException(predicate));
+    }
+
+    /// <summary>
+    /// Sets the predicates for the void-based results.
+    /// </summary>
+    /// <param name="predicates">The configured predicates.</param>
+    /// <returns>The current updated instance.</returns>
+    public OutcomePredicate<TArgs> SetVoidPredicates(VoidOutcomePredicate<TArgs> predicates)
+    {
+        Guard.NotNull(predicates);
+        _predicates[typeof(VoidResult)] = (predicates, predicates.CreateHandler);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a result predicate for void outcomes.
+    /// </summary>
+    /// <param name="configure">Callback that configures a result predicate.</param>
+    /// <returns>The current updated instance.</returns>
+    private OutcomePredicate<TArgs> ConfigureVoidPredicates(Action<VoidOutcomePredicate<TArgs>> configure)
+    {
+        Guard.NotNull(configure);
+
+        if (!_predicates.TryGetValue(typeof(VoidResult), out var predicate))
+        {
+            SetVoidPredicates(new VoidOutcomePredicate<TArgs>());
+            predicate = _predicates[typeof(VoidResult)];
+        }
+
+        configure((VoidOutcomePredicate<TArgs>)predicate.predicate);
+        return this;
+    }
+}

--- a/src/Polly.Core/Strategy/OutcomePredicate.cs
+++ b/src/Polly.Core/Strategy/OutcomePredicate.cs
@@ -157,7 +157,7 @@ public sealed partial class OutcomePredicate<TArgs>
     /// <typeparam name="TResult">The result type to add a predicate for.</typeparam>
     /// <param name="configure">Callback that configures a result predicate.</param>
     /// <returns>The current updated instance.</returns>
-    public OutcomePredicate<TArgs> ConfigurePredicates<TResult>(Action<OutcomePredicate<TArgs, TResult>> configure)
+    private OutcomePredicate<TArgs> ConfigurePredicates<TResult>(Action<OutcomePredicate<TArgs, TResult>> configure)
     {
         Guard.NotNull(configure);
 

--- a/src/Polly.Core/Strategy/VoidOutcomeEvent.cs
+++ b/src/Polly.Core/Strategy/VoidOutcomeEvent.cs
@@ -4,14 +4,13 @@ using Polly.Strategy;
 namespace Polly.Strategy;
 
 /// <summary>
-/// The base class for events that use <see cref="Outcome{TResult}"/> and <typeparamref name="TArgs"/> in the registered event callbacks.
+/// Class for void-based events that use <see cref="Outcome"/> and <typeparamref name="TArgs"/> in the registered event callbacks.
 /// </summary>
 /// <typeparam name="TArgs">The type of arguments the event uses.</typeparam>
-/// <typeparam name="TResult">The result type that this event handles.</typeparam>
-public sealed class OutcomeEvent<TArgs, TResult>
+public sealed class VoidOutcomeEvent<TArgs>
     where TArgs : IResilienceArguments
 {
-    private readonly List<Func<Outcome<TResult>, TArgs, ValueTask>> _callbacks = new();
+    private readonly List<Func<Outcome, TArgs, ValueTask>> _callbacks = new();
 
     /// <summary>
     /// Gets a value indicating whether the event is empty.
@@ -19,11 +18,11 @@ public sealed class OutcomeEvent<TArgs, TResult>
     public bool IsEmpty => _callbacks.Count == 0;
 
     /// <summary>
-    /// Registers a callback for the specified result type.
+    /// Registers a callback for void-based results.
     /// </summary>
-    /// <param name="callback">The event callback associated with the result type.</param>
+    /// <param name="callback">The event callback associated with the void result type.</param>
     /// <returns>The current updated instance.</returns>
-    public OutcomeEvent<TArgs, TResult> Register(Action callback)
+    public VoidOutcomeEvent<TArgs> Register(Action callback)
     {
         Guard.NotNull(callback);
 
@@ -35,11 +34,11 @@ public sealed class OutcomeEvent<TArgs, TResult>
     }
 
     /// <summary>
-    /// Registers a callback for the specified result type.
+    /// Registers a callback for void-based results.
     /// </summary>
-    /// <param name="callback">The event callback associated with the result type.</param>
+    /// <param name="callback">The event callback associated with the void result type.</param>
     /// <returns>The current updated instance.</returns>
-    public OutcomeEvent<TArgs, TResult> Register(Action<Outcome<TResult>> callback)
+    public VoidOutcomeEvent<TArgs> Register(Action<Outcome> callback)
     {
         Guard.NotNull(callback);
 
@@ -51,11 +50,11 @@ public sealed class OutcomeEvent<TArgs, TResult>
     }
 
     /// <summary>
-    /// Registers a callback for the specified result type.
+    /// Registers a callback for void-based results.
     /// </summary>
-    /// <param name="callback">The event callback associated with the result type.</param>
+    /// <param name="callback">The event callback associated with the void result type.</param>
     /// <returns>The current updated instance.</returns>
-    public OutcomeEvent<TArgs, TResult> Register(Action<Outcome<TResult>, TArgs> callback)
+    public VoidOutcomeEvent<TArgs> Register(Action<Outcome, TArgs> callback)
     {
         Guard.NotNull(callback);
 
@@ -67,11 +66,11 @@ public sealed class OutcomeEvent<TArgs, TResult>
     }
 
     /// <summary>
-    /// Registers a callback for the specified result type.
+    /// Registers a callback for void-based results.
     /// </summary>
-    /// <param name="callback">The event callback associated with the result type.</param>
+    /// <param name="callback">The event callback associated with the void result type.</param>
     /// <returns>The current updated instance.</returns>
-    public OutcomeEvent<TArgs, TResult> Register(Func<Outcome<TResult>, TArgs, ValueTask> callback)
+    public VoidOutcomeEvent<TArgs> Register(Func<Outcome, TArgs, ValueTask> callback)
     {
         Guard.NotNull(callback);
 
@@ -84,7 +83,7 @@ public sealed class OutcomeEvent<TArgs, TResult>
     /// Creates a handler that invokes the registered event callbacks.
     /// </summary>
     /// <returns>Handler instance or <c>null</c> if no callbacks are registered.</returns>
-    public Func<Outcome<TResult>, TArgs, ValueTask>? CreateHandler()
+    public Func<Outcome, TArgs, ValueTask>? CreateHandler()
     {
         return _callbacks.Count switch
         {
@@ -94,7 +93,7 @@ public sealed class OutcomeEvent<TArgs, TResult>
         };
     }
 
-    private static Func<Outcome<TResult>, TArgs, ValueTask> CreateHandler(Func<Outcome<TResult>, TArgs, ValueTask>[] callbacks)
+    private static Func<Outcome, TArgs, ValueTask> CreateHandler(Func<Outcome, TArgs, ValueTask>[] callbacks)
     {
         return async (outcome, args) =>
         {

--- a/src/Polly.Core/Strategy/VoidOutcomeGenerator.cs
+++ b/src/Polly.Core/Strategy/VoidOutcomeGenerator.cs
@@ -3,19 +3,15 @@ using Polly.Strategy;
 
 namespace Polly.Strategy;
 
-#pragma warning disable S2436 // Types and methods should not have too many generic parameters
-#pragma warning disable CA1005 // Avoid excessive parameters on generic types
-
 /// <summary>
-/// A class that generates values based on the <see cref="Outcome{TResult}"/> and <typeparamref name="TArgs"/>.
+/// A class that generates values based on the void-based <see cref="Outcome"/> and <typeparamref name="TArgs"/>.
 /// </summary>
 /// <typeparam name="TArgs">The arguments the generator uses.</typeparam>
 /// <typeparam name="TValue">The type of the generated value.</typeparam>
-/// <typeparam name="TResult">The result type that this event handles.</typeparam>
-public sealed class OutcomeGenerator<TArgs, TValue, TResult>
+public sealed class VoidOutcomeGenerator<TArgs, TValue>
     where TArgs : IResilienceArguments
 {
-    private Func<Outcome<TResult>, TArgs, ValueTask<TValue>>? _generator;
+    private Func<Outcome, TArgs, ValueTask<TValue>>? _generator;
 
     /// <summary>
     /// Gets a value indicating whether the generator is empty.
@@ -23,11 +19,11 @@ public sealed class OutcomeGenerator<TArgs, TValue, TResult>
     public bool IsEmpty => _generator is null;
 
     /// <summary>
-    /// Sets a result generator for a specific result type.
+    /// Sets a result generator.
     /// </summary>
     /// <param name="generator">The value generator.</param>
     /// <returns>The current updated instance.</returns>
-    public OutcomeGenerator<TArgs, TValue, TResult> SetGenerator(Func<Outcome<TResult>, TArgs, TValue> generator)
+    public VoidOutcomeGenerator<TArgs, TValue> SetGenerator(Func<Outcome, TArgs, TValue> generator)
     {
         Guard.NotNull(generator);
 
@@ -35,11 +31,11 @@ public sealed class OutcomeGenerator<TArgs, TValue, TResult>
     }
 
     /// <summary>
-    /// Sets a result generator for a specific result type.
+    /// Sets a result generator.
     /// </summary>
     /// <param name="generator">The value generator.</param>
     /// <returns>The current updated instance.</returns>
-    public OutcomeGenerator<TArgs, TValue, TResult> SetGenerator(Func<Outcome<TResult>, TArgs, ValueTask<TValue>> generator)
+    public VoidOutcomeGenerator<TArgs, TValue> SetGenerator(Func<Outcome, TArgs, ValueTask<TValue>> generator)
     {
         Guard.NotNull(generator);
 
@@ -52,5 +48,5 @@ public sealed class OutcomeGenerator<TArgs, TValue, TResult>
     /// Creates a generator handler.
     /// </summary>
     /// <returns>Handler instance or null if no generators are registered.</returns>
-    public Func<Outcome<TResult>, TArgs, ValueTask<TValue>>? CreateHandler() => _generator;
+    public Func<Outcome, TArgs, ValueTask<TValue>>? CreateHandler() => _generator;
 }

--- a/src/Polly.Core/Strategy/VoidOutcomePredicate.cs
+++ b/src/Polly.Core/Strategy/VoidOutcomePredicate.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using Polly.Strategy;
+
+namespace Polly.Strategy;
+
+/// <summary>
+/// Predicate that uses void-based <see cref="Outcome"/> as an input.
+/// </summary>
+/// <typeparam name="TArgs">The type of arguments the predicate uses.</typeparam>
+public sealed class VoidOutcomePredicate<TArgs>
+    where TArgs : IResilienceArguments
+{
+    private readonly List<Func<Outcome, TArgs, ValueTask<bool>>> _predicates = new();
+
+    /// <summary>
+    /// Gets a value indicating whether the predicate is empty.
+    /// </summary>
+    public bool IsEmpty => _predicates.Count == 0;
+
+    /// <summary>
+    /// Adds an exception predicate for void-based results.
+    /// </summary>
+    /// <typeparam name="TException">The exception type to add a predicate for.</typeparam>
+    /// <returns>The current updated instance.</returns>
+    public VoidOutcomePredicate<TArgs> HandleException<TException>()
+        where TException : Exception
+    {
+        return HandleOutcome((outcome, _) =>
+        {
+            if (outcome.Exception is TException)
+            {
+                return new ValueTask<bool>(true);
+            }
+
+            return new ValueTask<bool>(false);
+        });
+    }
+
+    /// <summary>
+    /// Adds an exception predicate for void-based results.
+    /// </summary>
+    /// <typeparam name="TException">The exception type to add a predicate for.</typeparam>
+    /// <param name="predicate">The predicate to determine if the exception should be retried.</param>
+    /// <returns>The current updated instance.</returns>
+    public VoidOutcomePredicate<TArgs> HandleException<TException>(Func<TException, bool> predicate)
+        where TException : Exception
+    {
+        Guard.NotNull(predicate);
+
+        return HandleOutcome((outcome, _) =>
+        {
+            if (outcome.Exception is TException typedException)
+            {
+                return new ValueTask<bool>(predicate(typedException));
+            }
+
+            return new ValueTask<bool>(false);
+        });
+    }
+
+    /// <summary>
+    /// Adds an exception predicate for void-based results.
+    /// </summary>
+    /// <typeparam name="TException">The exception type to add a predicate for.</typeparam>
+    /// <param name="predicate">The predicate to determine if the exception should be retried.</param>
+    /// <returns>The current updated instance.</returns>
+    public VoidOutcomePredicate<TArgs> HandleException<TException>(Func<TException, TArgs, bool> predicate)
+        where TException : Exception
+    {
+        Guard.NotNull(predicate);
+
+        return HandleOutcome((outcome, args) =>
+        {
+            if (outcome.Exception is TException typedException)
+            {
+                return new ValueTask<bool>(predicate(typedException, args));
+            }
+
+            return new ValueTask<bool>(false);
+        });
+    }
+
+    /// <summary>
+    /// Adds an exception predicate for void-based results.
+    /// </summary>
+    /// <typeparam name="TException">The exception type to add a predicate for.</typeparam>
+    /// <param name="predicate">The predicate to determine if the exception should be retried.</param>
+    /// <returns>The current updated instance.</returns>
+    public VoidOutcomePredicate<TArgs> HandleException<TException>(Func<TException, TArgs, ValueTask<bool>> predicate)
+        where TException : Exception
+    {
+        Guard.NotNull(predicate);
+
+        return HandleOutcome((outcome, args) =>
+        {
+            if (outcome.Exception is TException typedException)
+            {
+                return predicate(typedException, args);
+            }
+
+            return new ValueTask<bool>(false);
+        });
+    }
+
+    /// <summary>
+    /// Adds a result predicate for the specified result type.
+    /// </summary>
+    /// <param name="predicate">The predicate to determine if the result should be retried.</param>
+    /// <returns>The current updated instance.</returns>
+    private VoidOutcomePredicate<TArgs> HandleOutcome(Func<Outcome, TArgs, ValueTask<bool>> predicate)
+    {
+        Guard.NotNull(predicate);
+
+        _predicates.Add(predicate);
+        return this;
+    }
+
+    /// <summary>
+    /// Creates a handler for the specified predicates.
+    /// </summary>
+    /// <returns>Handler instance or null if no predicates are registered.</returns>
+    public Func<Outcome, TArgs, ValueTask<bool>>? CreateHandler()
+    {
+        var pairs = _predicates.ToArray();
+
+        return pairs.Length switch
+        {
+            0 => null,
+            1 => _predicates[0],
+            _ => CreateHandler(_predicates.ToArray())
+        };
+    }
+
+    private static Func<Outcome, TArgs, ValueTask<bool>> CreateHandler(Func<Outcome, TArgs, ValueTask<bool>>[] predicates)
+    {
+        return async (outcome, args) =>
+        {
+            foreach (var predicate in predicates)
+            {
+                if (await predicate(outcome, args).ConfigureAwait(args.Context.ContinueOnCapturedContext))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        };
+    }
+}


### PR DESCRIPTION
### Details on the issue fix or feature implementation

While investigating how to implement the fallback resilience strategy I realized we do not have callback infrastructure for void-based result handling.  This PR adds all the necessary APIs that we will use later for fallbacks and hedging.

Additional changes:

- Added non-generic methods in `OutcomeEvent` that handle any result type.
- Improved docs.

### Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build
