### PR TITLE
Implement HedgingResilienceStrategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,4 @@ updates:
     - dependency-name: "Microsoft.Extensions.Logging"
     - dependency-name: "System.Diagnostics.DiagnosticSource"
     - dependency-name: "System.Threading.RateLimiting"
+    - dependency-name: "Microsoft.Bcl.AsyncInterfaces"

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,6 +4,7 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.5" />
     <PackageVersion Include="FluentAssertions" Version="6.10.0" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.0.1" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />

--- a/src/Polly.Core.Benchmarks/Benchmarks/HedgingBenchmark.cs
+++ b/src/Polly.Core.Benchmarks/Benchmarks/HedgingBenchmark.cs
@@ -1,0 +1,42 @@
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Polly.Core.Benchmarks;
+
+namespace Polly.Benchmarks;
+
+public class HedgingBenchmark
+{
+    private ResilienceStrategy? _strategy;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _strategy = Helper.CreateHedging();
+    }
+
+    [Benchmark(Baseline = true)]
+    public async ValueTask Hedging_Primary()
+        => await _strategy!.ExecuteValueTaskAsync(static _ => new ValueTask<string>("primary")).ConfigureAwait(false);
+
+    [Benchmark]
+    public async ValueTask Hedging_Secondary()
+        => await _strategy!.ExecuteValueTaskAsync(static _ => new ValueTask<string>(Helper.Failure)).ConfigureAwait(false);
+
+    [Benchmark]
+    public async ValueTask Hedging_Primary_AsyncWork()
+        => await _strategy!.ExecuteValueTaskAsync(
+            static async _ =>
+            {
+                await Task.Yield();
+                return "primary";
+            }).ConfigureAwait(false);
+
+    [Benchmark]
+    public async ValueTask Hedging_Secondary_AsyncWork()
+        => await _strategy!.ExecuteValueTaskAsync(
+            static async _ =>
+            {
+                await Task.Yield();
+                return Helper.Failure;
+            }).ConfigureAwait(false);
+}

--- a/src/Polly.Core.Benchmarks/Internals/Helper.Hedging.cs
+++ b/src/Polly.Core.Benchmarks/Internals/Helper.Hedging.cs
@@ -1,0 +1,23 @@
+using Polly.Hedging;
+
+namespace Polly.Core.Benchmarks;
+
+internal static partial class Helper
+{
+    public const string Failure = "failure";
+
+    public static ResilienceStrategy CreateHedging()
+    {
+        return CreateStrategy(builder =>
+        {
+            builder.AddHedging(new HedgingStrategyOptions
+            {
+                Handler = new HedgingHandler().SetHedging<string>(handler =>
+                {
+                    handler.ShouldHandle.HandleResult(Failure);
+                    handler.HedgingActionGenerator = args => () => Task.FromResult("hedged response");
+                })
+            });
+        });
+    }
+}

--- a/src/Polly.Core.Benchmarks/README.md
+++ b/src/Polly.Core.Benchmarks/README.md
@@ -60,3 +60,12 @@ LaunchCount=2  WarmupCount=10
 |--------------------------- |---------:|----------:|----------:|------:|-------:|----------:|------------:|
 | ExecuteStrategyPipeline_V7 | 1.523 us | 0.0092 us | 0.0137 us |  1.00 | 0.3433 |    2872 B |        1.00 |
 | ExecuteStrategyPipeline_V8 | 1.276 us | 0.0128 us | 0.0191 us |  0.84 | 0.0114 |      96 B |        0.03 |
+
+## HEDGING
+
+|                      Method |       Mean |     Error |    StdDev | Ratio | RatioSD |   Gen0 |   Gen1 | Allocated | Alloc Ratio |
+|---------------------------- |-----------:|----------:|----------:|------:|--------:|-------:|-------:|----------:|------------:|
+|             Hedging_Primary |   891.3 ns |  39.39 ns |  58.96 ns |  1.00 |    0.00 | 0.0048 |      - |      40 B |        1.00 |
+|           Hedging_Secondary | 1,500.0 ns |   7.88 ns |  11.80 ns |  1.69 |    0.11 | 0.0229 |      - |     200 B |        5.00 |
+|   Hedging_Primary_AsyncWork | 4,250.9 ns | 140.89 ns | 206.52 ns |  4.78 |    0.34 | 0.1831 | 0.0305 |    1518 B |       37.95 |
+| Hedging_Secondary_AsyncWork | 6,544.9 ns |  99.90 ns | 143.27 ns |  7.34 |    0.39 | 0.2213 | 0.0839 |    1872 B |       46.80 |

--- a/src/Polly.Core.Tests/Hedging/Controller/HedgingControllerTests.cs
+++ b/src/Polly.Core.Tests/Hedging/Controller/HedgingControllerTests.cs
@@ -1,0 +1,36 @@
+using Polly.Hedging;
+using Polly.Hedging.Utils;
+
+namespace Polly.Core.Tests.Hedging.Controller;
+
+public class HedgingControllerTests
+{
+    [Fact]
+    public async Task Pooling_Ok()
+    {
+        var handler = new HedgingHandler().SetHedging<int>(handler => handler.HedgingActionGenerator = args => null).CreateHandler();
+        var controller = new HedgingController(new HedgingTimeProvider(), handler!, 3);
+
+        var context1 = controller.GetContext(ResilienceContext.Get());
+        await PrepareAsync(context1);
+
+        var context2 = controller.GetContext(ResilienceContext.Get());
+        await PrepareAsync(context2);
+
+        controller.RentedContexts.Should().Be(2);
+        controller.RentedExecutions.Should().Be(2);
+
+        context1.Complete();
+        context2.Complete();
+
+        controller.RentedContexts.Should().Be(0);
+        controller.RentedExecutions.Should().Be(0);
+    }
+
+    private static async Task PrepareAsync(HedgingExecutionContext context)
+    {
+        await context.LoadExecutionAsync((_, _) => new ValueTask<int>(10), "state");
+        await context.TryWaitForCompletedExecutionAsync(HedgingStrategyOptions.InfiniteHedgingDelay);
+        context.Tasks[0].AcceptOutcome();
+    }
+}

--- a/src/Polly.Core.Tests/Hedging/Controller/HedgingExecutionContextTests.cs
+++ b/src/Polly.Core.Tests/Hedging/Controller/HedgingExecutionContextTests.cs
@@ -9,6 +9,7 @@ using Polly.Strategy;
 using Polly.Utils;
 
 namespace Polly.Core.Tests.Hedging.Controller;
+
 public class HedgingExecutionContextTests : IDisposable
 {
     private const string Handled = "Handled";

--- a/src/Polly.Core.Tests/Hedging/Controller/HedgingExecutionContextTests.cs
+++ b/src/Polly.Core.Tests/Hedging/Controller/HedgingExecutionContextTests.cs
@@ -329,10 +329,13 @@ public class HedgingExecutionContextTests : IDisposable
     }
 
     [Fact]
-    public void Complete_NoTasks_Throws()
+    public void Complete_NoTasks_EnsureCleaned()
     {
+        var props = _resilienceContext.Properties;
         var context = Create();
-        context.Invoking(c => c.Complete()).Should().Throw<InvalidOperationException>().WithMessage("The hedging must execute at least one task.");
+        context.Initialize(_resilienceContext);
+        context.Complete();
+        _resilienceContext.Properties.Should().BeSameAs(props);
     }
 
     [Fact]

--- a/src/Polly.Core.Tests/Hedging/Controller/HedgingExecutionContextTests.cs
+++ b/src/Polly.Core.Tests/Hedging/Controller/HedgingExecutionContextTests.cs
@@ -1,0 +1,490 @@
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using Polly.Core.Tests.Helpers;
+using Polly.Hedging;
+using Polly.Hedging.Controller;
+using Polly.Hedging.Utils;
+using Polly.Strategy;
+using Polly.Utils;
+
+namespace Polly.Core.Tests.Hedging.Controller;
+public class HedgingExecutionContextTests : IDisposable
+{
+    private const string Handled = "Handled";
+    private static readonly TimeSpan AssertTimeout = TimeSpan.FromSeconds(5);
+    private readonly ResiliencePropertyKey<string> _myKey = new("my-key");
+    private readonly HedgingHandler _hedgingHandler;
+    private readonly CancellationTokenSource _cts;
+    private readonly HedgingTimeProvider _timeProvider;
+    private readonly List<TaskExecution> _createdExecutions = new();
+    private readonly List<TaskExecution> _returnedExecutions = new();
+    private readonly List<HedgingExecutionContext> _resets = new();
+    private readonly ResilienceContext _resilienceContext;
+    private readonly AutoResetEvent _onReset = new(false);
+    private int _maxAttempts = 2;
+
+    public HedgingExecutionContextTests()
+    {
+        _timeProvider = new HedgingTimeProvider();
+        _cts = new CancellationTokenSource();
+        _hedgingHandler = new HedgingHandler();
+        _hedgingHandler.SetHedging<DisposableResult>(handler =>
+        {
+            handler.ShouldHandle
+                .HandleResult(r => r!.Name == Handled)
+                .HandleException<ApplicationException>();
+            handler.HedgingActionGenerator = args => Generator(args);
+        });
+
+        _resilienceContext = ResilienceContext.Get().Initialize<string>(false);
+        _resilienceContext.CancellationToken = _cts.Token;
+        _resilienceContext.Properties.Set(_myKey, "dummy");
+    }
+
+    public void Dispose()
+    {
+        _cts.Dispose();
+        _onReset.Dispose();
+    }
+
+    [Fact]
+    public void Ctor_Ok()
+    {
+        var context = Create();
+
+        context.LoadedTasks.Should().Be(0);
+        context.Snapshot.Context.Should().BeNull();
+
+        context.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Initialize_Ok()
+    {
+        var props = _resilienceContext.Properties;
+        var context = Create();
+
+        context.Initialize(_resilienceContext);
+
+        context.Snapshot.Context.Should().Be(_resilienceContext);
+        context.Snapshot.Context.Properties.Should().NotBeSameAs(props);
+        context.Snapshot.OriginalProperties.Should().BeSameAs(props);
+        context.Snapshot.OriginalCancellationToken.Should().Be(_cts.Token);
+        context.Snapshot.Context.Properties.Should().HaveCount(1);
+        context.IsInitialized.Should().BeTrue();
+    }
+
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(-1)]
+    [Theory]
+    public async Task TryWaitForCompletedExecutionAsync_Initialized_Ok(int delay)
+    {
+        var context = Create();
+        context.Initialize(_resilienceContext);
+        var delayTimeSpan = TimeSpan.FromSeconds(delay);
+
+        var task = context.TryWaitForCompletedExecutionAsync(delayTimeSpan);
+
+        _timeProvider.Advance(TimeSpan.FromHours(1));
+
+        (await task).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TryWaitForCompletedExecutionAsync_FinishedTask_Ok()
+    {
+        var context = Create();
+        context.Initialize(_resilienceContext);
+        await context.LoadExecutionAsync((_, _) => new ValueTask<string>("dummy"), "state");
+
+        var task = await context.TryWaitForCompletedExecutionAsync(TimeSpan.Zero);
+
+        task.Should().NotBeNull();
+        task!.ExecutionTask!.IsCompleted.Should().BeTrue();
+        task.Outcome.Result.Should().Be("dummy");
+        task.AcceptOutcome();
+        context.LoadedTasks.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task TryWaitForCompletedExecutionAsync_ConcurrentExecution_Ok()
+    {
+        var context = Create();
+        context.Initialize(_resilienceContext);
+        ConfigureSecondaryTasks(TimeSpan.FromHours(1), TimeSpan.FromHours(1));
+
+        for (int i = 0; i < _maxAttempts - 1; i++)
+        {
+            await LoadExecutionAsync(context, TimeSpan.FromHours(1));
+        }
+
+        for (int i = 0; i < _maxAttempts; i++)
+        {
+            (await context.TryWaitForCompletedExecutionAsync(TimeSpan.Zero)).Should().BeNull();
+        }
+
+        _timeProvider.Advance(TimeSpan.FromDays(1));
+        await context.TryWaitForCompletedExecutionAsync(TimeSpan.Zero);
+        await context.Tasks.First().ExecutionTask!;
+        context.Tasks.First().AcceptOutcome();
+    }
+
+    [Fact]
+    public async Task TryWaitForCompletedExecutionAsync_SynchronousExecution_Ok()
+    {
+        var context = Create();
+        context.Initialize(_resilienceContext);
+        ConfigureSecondaryTasks(TimeSpan.FromHours(1), TimeSpan.FromHours(1));
+
+        for (int i = 0; i < _maxAttempts - 1; i++)
+        {
+            await LoadExecutionAsync(context, TimeSpan.FromHours(1));
+        }
+
+        var task = context.TryWaitForCompletedExecutionAsync(HedgingStrategyOptions.InfiniteHedgingDelay).AsTask();
+        task.Wait(20).Should().BeFalse();
+        _timeProvider.Advance(TimeSpan.FromDays(1));
+        await task;
+        context.Tasks.First().AcceptOutcome();
+    }
+
+    [Fact]
+    public async Task TryWaitForCompletedExecutionAsync_HedgedExecution_Ok()
+    {
+        var context = Create();
+        context.Initialize(_resilienceContext);
+        ConfigureSecondaryTasks(TimeSpan.FromHours(1), TimeSpan.FromHours(1));
+
+        for (int i = 0; i < _maxAttempts - 1; i++)
+        {
+            await LoadExecutionAsync(context, TimeSpan.FromHours(1));
+        }
+
+        var hedgingDelay = TimeSpan.FromSeconds(5);
+        var count = _timeProvider.DelayEntries.Count;
+        var task = context.TryWaitForCompletedExecutionAsync(hedgingDelay).AsTask();
+        task.Wait(20).Should().BeFalse();
+        _timeProvider.DelayEntries.Should().HaveCount(count + 1);
+        _timeProvider.DelayEntries.Last().Delay.Should().Be(hedgingDelay);
+        _timeProvider.Advance(TimeSpan.FromDays(1));
+        await task;
+        await context.Tasks.First().ExecutionTask!;
+        context.Tasks.First().AcceptOutcome();
+    }
+
+    [Fact]
+    public async Task TryWaitForCompletedExecutionAsync_TwiceWhenSecondaryGeneratorNotRegistered_Ok()
+    {
+        var context = Create();
+        context.Initialize(_resilienceContext);
+        await context.LoadExecutionAsync((_, _) => new ValueTask<string>("dummy"), "state");
+        await context.LoadExecutionAsync((_, _) => new ValueTask<string>("dummy"), "state");
+
+        var task = await context.TryWaitForCompletedExecutionAsync(TimeSpan.Zero);
+
+        task!.AcceptOutcome();
+        context.LoadedTasks.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task TryWaitForCompletedExecutionAsync_TwiceWhenSecondaryGeneratorRegistered_Ok()
+    {
+        var context = Create();
+        context.Initialize(_resilienceContext);
+        await LoadExecutionAsync(context);
+        await LoadExecutionAsync(context);
+
+        Generator = args => () => Task.FromResult(new DisposableResult { Name = "secondary" });
+
+        var task = await context.TryWaitForCompletedExecutionAsync(TimeSpan.Zero);
+        task!.Type.Should().Be(HedgedTaskType.Primary);
+        task!.AcceptOutcome();
+        context.LoadedTasks.Should().Be(2);
+        context.Tasks[0].Type.Should().Be(HedgedTaskType.Primary);
+        context.Tasks[1].Type.Should().Be(HedgedTaskType.Secondary);
+    }
+
+    [Fact]
+    public async Task LoadExecutionAsync_MaxTasks_NoMoreTasksAdded()
+    {
+        _maxAttempts = 3;
+        var context = Create();
+        context.Initialize(_resilienceContext);
+        ConfigureSecondaryTasks(TimeSpan.FromHours(1), TimeSpan.FromHours(1), TimeSpan.FromHours(1), TimeSpan.FromHours(1));
+
+        for (int i = 0; i < _maxAttempts; i++)
+        {
+            (await LoadExecutionAsync(context)).Loaded.Should().BeTrue();
+        }
+
+        (await LoadExecutionAsync(context)).Loaded.Should().BeFalse();
+
+        context.LoadedTasks.Should().Be(_maxAttempts);
+        context.Tasks[0].AcceptOutcome();
+        _returnedExecutions.Should().HaveCount(0);
+    }
+
+    [Fact]
+    public async Task LoadExecutionAsync_EnsureCorrectAttemptNumber()
+    {
+        var attempt = -1;
+        var context = Create();
+        context.Initialize(_resilienceContext);
+        Generator = args =>
+        {
+            attempt = args.Attempt;
+            return null;
+        };
+
+        await LoadExecutionAsync(context);
+        await LoadExecutionAsync(context);
+
+        // primary is 0, this one is 1
+        attempt.Should().Be(1);
+    }
+
+    [InlineData(true)]
+    [InlineData(false)]
+    [Theory]
+    public async Task LoadExecutionAsync_NoMoreSecondaryTasks_AcceptFinishedOutcome(bool allExecuted)
+    {
+        _maxAttempts = 4;
+        var context = Create();
+        context.Initialize(_resilienceContext);
+        ConfigureSecondaryTasks(allExecuted ? TimeSpan.Zero : TimeSpan.FromHours(1));
+
+        // primary
+        await LoadExecutionAsync(context);
+
+        // secondary
+        await LoadExecutionAsync(context);
+
+        // secondary couldn't be created
+        if (allExecuted)
+        {
+            await context.TryWaitForCompletedExecutionAsync(TimeSpan.Zero);
+            await context.TryWaitForCompletedExecutionAsync(TimeSpan.Zero);
+        }
+
+        var pair = await LoadExecutionAsync(context);
+        pair.Loaded.Should().BeFalse();
+
+        _returnedExecutions.Count.Should().Be(1);
+        if (allExecuted)
+        {
+            pair.Outcome.Should().NotBeNull();
+            context.Tasks[0].IsAccepted.Should().BeTrue();
+        }
+        else
+        {
+            pair.Outcome.Should().BeNull();
+            context.Tasks[0].IsAccepted.Should().BeFalse();
+        }
+
+        context.Tasks[0].AcceptOutcome();
+    }
+
+    [Fact]
+    public async Task LoadExecution_NoMoreTasks_Throws()
+    {
+        _maxAttempts = 0;
+        var context = Create();
+        context.Initialize(_resilienceContext);
+
+        await context.Invoking(c => LoadExecutionAsync(c)).Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [InlineData(true)]
+    [InlineData(false)]
+    [Theory]
+    public async Task Complete_EnsureOriginalContextPreparedWithAcceptedOutcome(bool primary)
+    {
+        // arrange
+        var type = primary ? HedgedTaskType.Primary : HedgedTaskType.Secondary;
+        var context = Create();
+        var originalProps = _resilienceContext.Properties;
+        context.Initialize(_resilienceContext);
+        ConfigureSecondaryTasks(TimeSpan.Zero);
+        await ExecuteAllTasksAsync(context, 2);
+        context.Tasks.First(v => v.Type == type).AcceptOutcome();
+
+        // act
+        context.Complete();
+
+        // assert
+        _resilienceContext.Properties.Should().BeSameAs(originalProps);
+        if (primary)
+        {
+            _resilienceContext.Properties.Should().HaveCount(1);
+            _resilienceContext.ResilienceEvents.Should().HaveCount(0);
+        }
+        else
+        {
+            _resilienceContext.Properties.Should().HaveCount(2);
+            _resilienceContext.ResilienceEvents.Should().HaveCount(1);
+        }
+    }
+
+    [Fact]
+    public void Complete_NoTasks_Throws()
+    {
+        var context = Create();
+        context.Invoking(c => c.Complete()).Should().Throw<InvalidOperationException>().WithMessage("The hedging must execute at least one task.");
+    }
+
+    [Fact]
+    public async Task Complete_NoAcceptedTasks_Throws()
+    {
+        var context = Create();
+        context.Initialize(_resilienceContext);
+        ConfigureSecondaryTasks(TimeSpan.Zero);
+        await ExecuteAllTasksAsync(context, 2);
+
+        context.Invoking(c => c.Complete()).Should().Throw<InvalidOperationException>().WithMessage("There must be exactly one accepted outcome for hedging. Found 0.");
+    }
+
+    [Fact]
+    public async Task Complete_MultipleAcceptedTasks_Throws()
+    {
+        var context = Create();
+        context.Initialize(_resilienceContext);
+        ConfigureSecondaryTasks(TimeSpan.Zero);
+        await ExecuteAllTasksAsync(context, 2);
+        context.Tasks[0].AcceptOutcome();
+        context.Tasks[1].AcceptOutcome();
+
+        context.Invoking(c => c.Complete()).Should().Throw<InvalidOperationException>().WithMessage("There must be exactly one accepted outcome for hedging. Found 2.");
+    }
+
+    [Fact]
+    public async Task Complete_EnsurePendingTasksCleaned()
+    {
+        using var assertPrimary = new ManualResetEvent(false);
+        using var assertSecondary = new ManualResetEvent(false);
+
+        var context = Create();
+        context.Initialize(_resilienceContext);
+        ConfigureSecondaryTasks(TimeSpan.FromHours(1));
+        (await LoadExecutionAsync(context)).Execution!.OnReset = (execution) =>
+        {
+            execution.Outcome.Result.Should().BeOfType<DisposableResult>();
+            execution.Outcome.Exception.Should().BeNull();
+            assertPrimary.Set();
+        };
+        (await LoadExecutionAsync(context)).Execution!.OnReset = (execution) =>
+        {
+            execution.Outcome.Exception.Should().BeAssignableTo<OperationCanceledException>();
+            assertSecondary.Set();
+        };
+
+        await context.TryWaitForCompletedExecutionAsync(HedgingStrategyOptions.InfiniteHedgingDelay);
+
+        var pending = context.Tasks[1].ExecutionTask!;
+        pending.Wait(10).Should().BeFalse();
+
+        context.Tasks[0].AcceptOutcome();
+        context.Complete();
+
+        await pending;
+
+        assertPrimary.WaitOne(AssertTimeout).Should().BeTrue();
+        assertSecondary.WaitOne(AssertTimeout).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Complete_EnsureCleaned()
+    {
+        var context = Create();
+        context.Initialize(_resilienceContext);
+        ConfigureSecondaryTasks(TimeSpan.Zero);
+        await ExecuteAllTasksAsync(context, 2);
+        context.Tasks[0].AcceptOutcome();
+
+        context.Complete();
+
+        context.LoadedTasks.Should().Be(0);
+        context.Snapshot.Context.Should().BeNull();
+
+        _onReset.WaitOne(AssertTimeout);
+        _resets.Count.Should().Be(1);
+        _returnedExecutions.Count.Should().Be(2);
+    }
+
+    private async Task ExecuteAllTasksAsync(HedgingExecutionContext context, int count)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            (await LoadExecutionAsync(context)).Loaded.Should().BeTrue();
+            await context.TryWaitForCompletedExecutionAsync(HedgingStrategyOptions.InfiniteHedgingDelay);
+        }
+    }
+
+    private async Task<HedgingExecutionContext.ExecutionInfo<DisposableResult>> LoadExecutionAsync(HedgingExecutionContext context, TimeSpan? primaryDelay = null, bool error = false)
+    {
+        return await context.LoadExecutionAsync(
+            async (c, _) =>
+            {
+                if (primaryDelay != null)
+                {
+                    await _timeProvider.Delay(primaryDelay.Value, c.CancellationToken);
+                }
+
+                if (error)
+                {
+                    throw new InvalidOperationException("Forced error.");
+                }
+
+                return new DisposableResult { Name = "primary" };
+            },
+            "state");
+    }
+
+    private void ConfigureSecondaryTasks(params TimeSpan[] delays)
+    {
+        Generator = args =>
+        {
+            var attempt = args.Attempt - 1;
+
+            if (attempt >= delays.Length)
+            {
+                return null;
+            }
+
+            args.Context.AddResilienceEvent(new ReportedResilienceEvent("dummy-event"));
+
+            return async () =>
+            {
+                args.Context.Properties.Set(new ResiliencePropertyKey<int>(attempt.ToString(CultureInfo.InvariantCulture)), attempt);
+                await _timeProvider.Delay(delays[attempt], args.Context.CancellationToken);
+                return new DisposableResult(delays[attempt].ToString());
+            };
+        };
+    }
+
+    private HedgingActionGenerator<DisposableResult> Generator { get; set; } = args => () => Task.FromResult(new DisposableResult { Name = Handled });
+
+    private HedgingExecutionContext Create()
+    {
+        var handler = _hedgingHandler.CreateHandler()!;
+        var pool = new ObjectPool<TaskExecution>(
+            () =>
+            {
+                var execution = new TaskExecution(handler);
+                _createdExecutions.Add(execution);
+                return execution;
+            },
+            execution =>
+            {
+                _returnedExecutions.Add(execution);
+                return true;
+            });
+
+        return new(pool, _timeProvider, _maxAttempts, context =>
+        {
+            _resets.Add(context);
+            _onReset.Set();
+        });
+    }
+}

--- a/src/Polly.Core.Tests/Hedging/Controller/TaskExecutionTests.cs
+++ b/src/Polly.Core.Tests/Hedging/Controller/TaskExecutionTests.cs
@@ -7,6 +7,7 @@ using Polly.Hedging.Utils;
 using Polly.Strategy;
 
 namespace Polly.Core.Tests.Hedging.Controller;
+
 public class TaskExecutionTests : IDisposable
 {
     private const string Handled = "Handled";

--- a/src/Polly.Core.Tests/Hedging/Controller/TaskExecutionTests.cs
+++ b/src/Polly.Core.Tests/Hedging/Controller/TaskExecutionTests.cs
@@ -1,0 +1,269 @@
+using System;
+using System.Threading.Tasks;
+using Polly.Core.Tests.Helpers;
+using Polly.Hedging;
+using Polly.Hedging.Controller;
+using Polly.Hedging.Utils;
+using Polly.Strategy;
+
+namespace Polly.Core.Tests.Hedging.Controller;
+public class TaskExecutionTests : IDisposable
+{
+    private const string Handled = "Handled";
+    private readonly ResiliencePropertyKey<string> _myKey = new("my-key");
+    private readonly HedgingHandler _hedgingHandler;
+    private readonly CancellationTokenSource _cts;
+    private readonly HedgingTimeProvider _timeProvider;
+    private ContextSnapshot _snapshot;
+
+    public TaskExecutionTests()
+    {
+        _timeProvider = new HedgingTimeProvider();
+        _cts = new CancellationTokenSource();
+        _hedgingHandler = new HedgingHandler();
+        _hedgingHandler.SetHedging<DisposableResult>(handler =>
+        {
+            handler.ShouldHandle
+                .HandleResult(r => r!.Name == Handled)
+                .HandleException<ApplicationException>();
+            handler.HedgingActionGenerator = args => Generator(args);
+        });
+
+        CreateSnapshot();
+    }
+
+    public void Dispose() => _cts.Dispose();
+
+    [InlineData(Handled, true)]
+    [InlineData("Unhandled", false)]
+    [Theory]
+    public async Task Initialize_Primary_Ok(string value, bool handled)
+    {
+        var execution = Create();
+        await execution.InitializeAsync(HedgedTaskType.Primary, _snapshot,
+            (context, state) =>
+            {
+                AssertPrimaryContext(context, execution);
+                state.Should().Be("dummy-state");
+                return new ValueTask<DisposableResult>(new DisposableResult { Name = value });
+            },
+            "dummy-state",
+            1);
+
+        await execution.ExecutionTask!;
+        ((DisposableResult)execution.Outcome.Result!).Name.Should().Be(value);
+        execution.IsHandled.Should().Be(handled);
+        AssertPrimaryContext(execution.Context, execution);
+    }
+
+    [InlineData(Handled, true)]
+    [InlineData("Unhandled", false)]
+    [Theory]
+    public async Task Initialize_Secondary_Ok(string value, bool handled)
+    {
+        var execution = Create();
+        Generator = args =>
+        {
+            AssertSecondaryContext(args.Context, execution);
+            args.Attempt.Should().Be(4);
+            return () => Task.FromResult(new DisposableResult { Name = value });
+        };
+
+        (await execution.InitializeAsync<DisposableResult, string>(HedgedTaskType.Secondary, _snapshot, null!, "dummy-state", 4)).Should().BeTrue();
+
+        await execution.ExecutionTask!;
+
+        ((DisposableResult)execution.Outcome.Result!).Name.Should().Be(value);
+        execution.IsHandled.Should().Be(handled);
+        AssertSecondaryContext(execution.Context, execution);
+    }
+
+    [Fact]
+    public async Task Initialize_SecondaryWhenTaskGeneratorReturnsNull_Ok()
+    {
+        var execution = Create();
+        Generator = args => null;
+
+        (await execution.InitializeAsync<DisposableResult, string>(HedgedTaskType.Secondary, _snapshot, null!, "dummy-state", 4)).Should().BeFalse();
+
+        execution.Invoking(e => e.Context).Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task Cancel_Accepted_NoEffect()
+    {
+        var execution = Create();
+        var cancelled = false;
+
+        await InitializePrimaryAsync(execution, onContext: context => context.CancellationToken.Register(() => cancelled = true));
+
+        execution.AcceptOutcome();
+        execution.Cancel();
+
+        cancelled.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Cancel_NotAccepted_Cancelled()
+    {
+        var execution = Create();
+        var cancelled = false;
+
+        await InitializePrimaryAsync(execution, onContext: context => context.CancellationToken.Register(() => cancelled = true));
+
+        execution.Cancel();
+        cancelled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Initialize_SecondaryWhenTaskGeneratorThrows_EnsureOutcome()
+    {
+        var execution = Create();
+        Generator = args => throw new FormatException();
+
+        (await execution.InitializeAsync<DisposableResult, string>(HedgedTaskType.Secondary, _snapshot, null!, "dummy-state", 4)).Should().BeTrue();
+
+        await execution.ExecutionTask!;
+        execution.Outcome.Exception.Should().BeOfType<FormatException>();
+    }
+
+    [Fact]
+    public async Task Initialize_ExecutionTaskDoesNotThrows()
+    {
+        var execution = Create();
+        Generator = args => throw new FormatException();
+
+        (await execution.InitializeAsync<DisposableResult, string>(HedgedTaskType.Secondary, _snapshot, null!, "dummy-state", 4)).Should().BeTrue();
+
+        await execution.ExecutionTask!.Invoking(async t => await t).Should().NotThrowAsync();
+    }
+
+    [InlineData(true)]
+    [InlineData(false)]
+    [Theory]
+    public async Task Initialize_Cancelled_EnsureRespected(bool primary)
+    {
+        // arrange
+        Generator = (args) =>
+        {
+            return async () =>
+            {
+                await _timeProvider.Delay(TimeSpan.FromDays(1), args.Context.CancellationToken);
+                return new DisposableResult { Name = Handled };
+            };
+        };
+
+        var execution = Create();
+
+        await execution.InitializeAsync(primary ? HedgedTaskType.Primary : HedgedTaskType.Secondary, _snapshot,
+            async (context, _) =>
+            {
+                await _timeProvider.Delay(TimeSpan.FromDays(1), context.CancellationToken);
+                return new DisposableResult();
+            },
+            "dummy-state",
+            1);
+
+        // act
+        _cts.Cancel();
+        await execution.ExecutionTask!;
+
+        // assert
+        execution.Outcome.Exception.Should().BeAssignableTo<OperationCanceledException>();
+    }
+
+    [Fact]
+    public void AcceptOutcome_NotInitialized_Throws()
+    {
+        var execution = Create();
+
+        execution.Invoking(e => e.AcceptOutcome()).Should().Throw<InvalidOperationException>();
+    }
+
+    [InlineData(true)]
+    [InlineData(false)]
+    [Theory]
+    public async Task ResetAsync_Ok(bool accept)
+    {
+        // arrange
+        using var result = new DisposableResult();
+        var execution = Create();
+        var token = default(CancellationToken);
+        await InitializePrimaryAsync(execution, result, context => token = context.CancellationToken);
+        await execution.ExecutionTask!;
+
+        if (accept)
+        {
+            execution.AcceptOutcome();
+        }
+
+        // act
+        await execution.ResetAsync();
+
+        // assert
+        execution.IsAccepted.Should().BeFalse();
+        execution.IsHandled.Should().BeFalse();
+        execution.Properties.Should().HaveCount(0);
+        execution.Outcome.IsValid.Should().BeFalse();
+        execution.Invoking(e => e.Context).Should().Throw<InvalidOperationException>();
+#if !NETCOREAPP
+        token.Invoking(t => t.WaitHandle).Should().Throw<InvalidOperationException>();
+#endif
+        if (accept)
+        {
+            result.IsDisposed.Should().BeFalse();
+        }
+        else
+        {
+            result.IsDisposed.Should().BeTrue();
+        }
+    }
+
+    private async Task InitializePrimaryAsync(TaskExecution execution, DisposableResult? result = null, Action<ResilienceContext>? onContext = null)
+    {
+        await execution.InitializeAsync(HedgedTaskType.Primary, _snapshot, (context, _) =>
+        {
+            onContext?.Invoke(context);
+            return new ValueTask<DisposableResult>(result ?? new DisposableResult { Name = Handled });
+        }, "dummy-state", 1);
+    }
+
+    private void AssertPrimaryContext(ResilienceContext context, TaskExecution execution)
+    {
+        context.IsInitialized.Should().BeTrue();
+        context.Should().BeSameAs(_snapshot.Context);
+        context.Properties.Should().NotBeSameAs(_snapshot.OriginalProperties);
+        context.Properties.Should().BeSameAs(execution.Properties);
+        context.CancellationToken.Should().NotBeSameAs(_snapshot.OriginalCancellationToken);
+        context.CancellationToken.CanBeCanceled.Should().BeTrue();
+
+        context.Properties.Should().HaveCount(1);
+        context.Properties.TryGetValue(_myKey, out var value).Should().BeTrue();
+        value.Should().Be("dummy-value");
+    }
+
+    private void AssertSecondaryContext(ResilienceContext context, TaskExecution execution)
+    {
+        context.IsInitialized.Should().BeTrue();
+        context.Should().NotBeSameAs(_snapshot.Context);
+        context.Properties.Should().NotBeSameAs(_snapshot.OriginalProperties);
+        context.Properties.Should().BeSameAs(execution.Properties);
+        context.CancellationToken.Should().NotBeSameAs(_snapshot.OriginalCancellationToken);
+        context.CancellationToken.CanBeCanceled.Should().BeTrue();
+
+        context.Properties.Should().HaveCount(1);
+        context.Properties.TryGetValue(_myKey, out var value).Should().BeTrue();
+        value.Should().Be("dummy-value");
+    }
+
+    private void CreateSnapshot(CancellationToken? token = null)
+    {
+        _snapshot = new ContextSnapshot(ResilienceContext.Get().Initialize<DisposableResult>(isSynchronous: false), new ResilienceProperties(), token ?? _cts.Token);
+        _snapshot.Context.CancellationToken = _cts.Token;
+        _snapshot.OriginalProperties.Set(_myKey, "dummy-value");
+    }
+
+    private HedgingActionGenerator<DisposableResult> Generator { get; set; } = args => () => Task.FromResult(new DisposableResult { Name = Handled });
+
+    private TaskExecution Create() => new(_hedgingHandler.CreateHandler()!);
+}

--- a/src/Polly.Core.Tests/Hedging/HedgingActionGeneratorArgumentsTests.cs
+++ b/src/Polly.Core.Tests/Hedging/HedgingActionGeneratorArgumentsTests.cs
@@ -1,0 +1,15 @@
+using Polly.Hedging;
+
+namespace Polly.Core.Tests.Hedging;
+
+public class HedgingActionGeneratorArgumentsTests
+{
+    [Fact]
+    public void Ctor_Ok()
+    {
+        var args = new HedgingActionGeneratorArguments(ResilienceContext.Get(), 5);
+
+        args.Context.Should().NotBeNull();
+        args.Attempt.Should().Be(5);
+    }
+}

--- a/src/Polly.Core.Tests/Hedging/HedgingActions.cs
+++ b/src/Polly.Core.Tests/Hedging/HedgingActions.cs
@@ -1,0 +1,62 @@
+using Polly.Hedging;
+using Polly.Utils;
+
+namespace Polly.Core.Tests.Hedging;
+
+internal class HedgingActions
+{
+    private readonly TimeProvider _timeProvider;
+
+    public HedgingActions(TimeProvider timeProvider)
+    {
+        _timeProvider = timeProvider;
+
+        Functions = new()
+        {
+            GetApples,
+            GetOranges,
+            GetPears
+        };
+
+        Generator = args =>
+        {
+            if (args.Attempt <= Functions.Count)
+            {
+                return async () =>
+                {
+                    return await Functions[args.Attempt - 1]!(args.Context);
+                };
+            }
+
+            return null;
+        };
+    }
+
+    public HedgingActionGenerator<string> Generator { get; }
+
+    public HedgingActionGenerator<string> EmptyFunctionsProvider { get; } = args => null;
+
+    public List<Func<ResilienceContext, Task<string>>> Functions { get; }
+
+    private async Task<string> GetApples(ResilienceContext context)
+    {
+        await _timeProvider.Delay(TimeSpan.FromSeconds(10), context.CancellationToken);
+        return "Apples";
+    }
+
+    private async Task<string> GetPears(ResilienceContext context)
+    {
+        await _timeProvider.Delay(TimeSpan.FromSeconds(3), context.CancellationToken);
+        return "Pears";
+    }
+
+    private async Task<string> GetOranges(ResilienceContext context)
+    {
+        await _timeProvider.Delay(TimeSpan.FromSeconds(2), context.CancellationToken);
+        return "Oranges";
+    }
+
+    public static HedgingActionGenerator<string> GetGenerator(Func<ResilienceContext, Task<string>> task) => args => () => task(args.Context);
+
+    public int MaxHedgedTasks => Functions.Count + 1;
+}

--- a/src/Polly.Core.Tests/Hedging/HedgingHandlerTests.cs
+++ b/src/Polly.Core.Tests/Hedging/HedgingHandlerTests.cs
@@ -63,8 +63,8 @@ public class HedgingHandlerTests
                 handler.HedgingActionGenerator = args => () => Task.CompletedTask;
             });
 
-        handler.IsEmpty.Should().BeTrue();
-        handler.CreateHandler().Should().BeNull();
+        handler.IsEmpty.Should().BeFalse();
+        handler.CreateHandler().Should().NotBeNull();
     }
 
     [Fact]
@@ -85,11 +85,11 @@ public class HedgingHandlerTests
 
         handler.HandlesHedging<int>().Should().BeTrue();
 
-        var action = handler.TryCreateHedgedAction<int>(ResilienceContext.Get());
+        var action = handler.TryCreateHedgedAction<int>(ResilienceContext.Get(), 0);
         action.Should().NotBeNull();
         (await (action!()!)).Should().Be(0);
 
-        handler.TryCreateHedgedAction<double>(ResilienceContext.Get()).Should().BeNull();
+        handler.TryCreateHedgedAction<double>(ResilienceContext.Get(), 0).Should().BeNull();
     }
 
     [InlineData(true)]
@@ -121,7 +121,7 @@ public class HedgingHandlerTests
 
         handler.HandlesHedging<VoidResult>().Should().BeTrue();
 
-        var action = handler.TryCreateHedgedAction<VoidResult>(ResilienceContext.Get());
+        var action = handler.TryCreateHedgedAction<VoidResult>(ResilienceContext.Get(), 0);
         if (returnsNullAction)
         {
             action.Should().BeNull();
@@ -155,6 +155,6 @@ public class HedgingHandlerTests
         var args = new HandleHedgingArguments(ResilienceContext.Get());
         (await handler!.ShouldHandleAsync(new Outcome<double>(new InvalidOperationException()), args)).Should().BeFalse();
         handler.HandlesHedging<double>().Should().BeFalse();
-        handler.TryCreateHedgedAction<double>(ResilienceContext.Get()).Should().BeNull();
+        handler.TryCreateHedgedAction<double>(ResilienceContext.Get(), 0).Should().BeNull();
     }
 }

--- a/src/Polly.Core.Tests/Hedging/HedgingResilienceStrategyBuilderExtensionsTests.cs
+++ b/src/Polly.Core.Tests/Hedging/HedgingResilienceStrategyBuilderExtensionsTests.cs
@@ -51,4 +51,47 @@ public class HedgingResilienceStrategyBuilderExtensionsTests
             .Throw<ValidationException>()
             .WithMessage("The hedging strategy options are invalid.*");
     }
+
+    [Fact]
+    public async Task AddHedging_IntegrationTest()
+    {
+        ConcurrentQueue<string> results = new();
+
+        var strategy = _builder
+            .AddHedging(new HedgingStrategyOptions
+            {
+                MaxHedgedAttempts = 4,
+                HedgingDelay = TimeSpan.FromMilliseconds(20),
+                Handler = new HedgingHandler().SetHedging<string>(handler =>
+                {
+                    handler.ShouldHandle.HandleResult("error");
+                    handler.HedgingActionGenerator = args =>
+                    {
+                        return async () =>
+                        {
+                            await Task.Delay(25, args.Context.CancellationToken);
+
+                            if (args.Attempt == 3)
+                            {
+                                return "success";
+                            }
+
+                            return "error";
+                        };
+                    };
+                }),
+                OnHedging = new Polly.Strategy.OutcomeEvent<OnHedgingArguments>().Register<string>((outcome, _) => results.Enqueue(outcome.Result!))
+            })
+            .Build();
+
+        var result = await strategy.ExecuteAsync(async token =>
+        {
+            await Task.Delay(25, token);
+            return "error";
+        });
+
+        result.Should().Be("success");
+        results.Should().HaveCountGreaterThan(0);
+        results.Distinct().Should().ContainSingle("error");
+    }
 }

--- a/src/Polly.Core.Tests/Hedging/HedgingResilienceStrategyTests.cs
+++ b/src/Polly.Core.Tests/Hedging/HedgingResilienceStrategyTests.cs
@@ -1,10 +1,42 @@
+using System;
 using Polly.Hedging;
+using Polly.Strategy;
 
 namespace Polly.Core.Tests.Hedging;
 
-public class HedgingResilienceStrategyTests
+public class HedgingResilienceStrategyTests : IDisposable
 {
+    private const string Success = "Success";
+
+    private const string Failure = "Failure";
+
+    private static readonly TimeSpan LongDelay = TimeSpan.FromDays(1);
+    private static readonly TimeSpan AssertTimeout = TimeSpan.FromSeconds(10);
+
     private readonly HedgingStrategyOptions _options = new();
+    private readonly List<IResilienceArguments> _events = new();
+    private readonly ResilienceStrategyTelemetry _telemetry;
+    private readonly HedgingTimeProvider _timeProvider;
+    private readonly HedgingActions _actions;
+    private readonly PrimaryStringTasks _primaryTasks;
+    private readonly List<object?> _results = new();
+    private readonly CancellationTokenSource _cts = new();
+
+    public HedgingResilienceStrategyTests()
+    {
+        _telemetry = TestUtilities.CreateResilienceTelemetry(args => _events.Add(args));
+        _timeProvider = new HedgingTimeProvider { AutoAdvance = _options.HedgingDelay };
+        _actions = new HedgingActions(_timeProvider);
+        _primaryTasks = new PrimaryStringTasks(_timeProvider);
+        _options.HedgingDelay = TimeSpan.FromSeconds(1);
+        _options.MaxHedgedAttempts = _actions.MaxHedgedTasks;
+    }
+
+    public void Dispose()
+    {
+        _cts.Dispose();
+        _timeProvider.Advance(TimeSpan.FromDays(365));
+    }
 
     [Fact]
     public void Ctor_EnsureDefaults()
@@ -55,5 +87,725 @@ public class HedgingResilienceStrategyTests
         result.Should().Be(TimeSpan.FromMilliseconds(123));
     }
 
-    private HedgingResilienceStrategy Create() => new(_options);
+    [Fact]
+    public async Task ExecuteAsync_ShouldReturnAnyPossibleResult()
+    {
+        ConfigureHedging();
+
+        var strategy = Create();
+        var result = await strategy.ExecuteAsync(_primaryTasks.SlowTask);
+
+        result.Should().NotBeNull();
+        _timeProvider.DelayEntries.Should().HaveCount(5);
+        result.Should().Be("Oranges");
+    }
+
+    [Fact]
+    public async void ExecuteAsync_EnsureHedgedTasksCancelled_Ok()
+    {
+        // arrange
+        _options.MaxHedgedAttempts = 2;
+        using var cancelled = new ManualResetEvent(false);
+        ConfigureHedging(async context =>
+        {
+            try
+            {
+                await _timeProvider.Delay(LongDelay, context.CancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                cancelled.Set();
+            }
+
+            return Failure;
+        });
+
+        var strategy = Create();
+
+        // act
+        var result = strategy.ExecuteAsync(async token =>
+        {
+            await _timeProvider.Delay(TimeSpan.FromHours(1), token);
+            return Success;
+        });
+
+        // assert
+        _timeProvider.Advance(TimeSpan.FromHours(1));
+        (await result).Should().Be(Success);
+        cancelled.WaitOne(AssertTimeout).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EnsurePrimaryTaskCancelled_Ok()
+    {
+        // arrange
+        using var cancelled = new ManualResetEvent(false);
+        ConfigureHedging(async context =>
+        {
+            await _timeProvider.Delay(TimeSpan.FromHours(1), context.CancellationToken);
+            return Success;
+        });
+
+        var strategy = Create();
+
+        // act
+        var task = strategy.ExecuteAsync(async token =>
+        {
+            try
+            {
+                await _timeProvider.Delay(TimeSpan.FromHours(24), token);
+            }
+            catch (OperationCanceledException)
+            {
+                cancelled.Set();
+            }
+
+            return Success;
+        });
+
+        // assert
+        _timeProvider.Advance(TimeSpan.FromHours(2));
+        cancelled.WaitOne(TimeSpan.FromSeconds(1)).Should().BeTrue();
+        await task;
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EnsureDiscardedResultDisposed()
+    {
+        // arrange
+        using var primaryResult = new DisposableResult();
+        using var secondaryResult = new DisposableResult();
+
+        ConfigureHedging<DisposableResult>(handler =>
+        {
+            handler.HedgingActionGenerator = args =>
+            {
+                return () =>
+                {
+                    return Task.FromResult(secondaryResult);
+                };
+            };
+        });
+
+        var strategy = Create();
+
+        // act
+        var result = await strategy.ExecuteAsync(async token =>
+        {
+#pragma warning disable CA2016 // Forward the 'CancellationToken' parameter to methods
+            await _timeProvider.Delay(LongDelay);
+#pragma warning restore CA2016 // Forward the 'CancellationToken' parameter to methods
+            return primaryResult;
+        });
+
+        // assert
+        _timeProvider.Advance(LongDelay);
+
+        await primaryResult.WaitForDisposalAsync();
+        primaryResult.IsDisposed.Should().BeTrue();
+        secondaryResult.IsDisposed.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EveryHedgedTaskShouldHaveDifferentContexts()
+    {
+        // arrange
+        using var cancellationSource = new CancellationTokenSource();
+        var beforeKey = new ResiliencePropertyKey<string>("before");
+        var afterKey = new ResiliencePropertyKey<string>("after");
+
+        var primaryContext = ResilienceContext.Get();
+        primaryContext.Properties.Set(beforeKey, "before");
+        var contexts = new List<ResilienceContext>();
+        var tokenHashCodes = new List<long>();
+
+        ConfigureHedging<string>(handler =>
+        {
+            handler.HedgingActionGenerator = args =>
+            {
+                return async () =>
+                {
+                    tokenHashCodes.Add(args.Context.CancellationToken.GetHashCode());
+                    args.Context.CancellationToken.CanBeCanceled.Should().BeTrue();
+                    args.Context.Properties.GetValue(beforeKey, "wrong").Should().Be("before");
+                    contexts.Add(args.Context);
+                    await Task.Yield();
+                    args.Context.Properties.Set(afterKey, "after");
+                    return "secondary";
+                };
+            };
+        });
+
+        var strategy = Create();
+
+        // act
+        var result = await strategy.ExecuteAsync(
+            async (context, _) =>
+            {
+                context.CancellationToken.CanBeCanceled.Should().BeTrue();
+                tokenHashCodes.Add(context.CancellationToken.GetHashCode());
+                context.Properties.GetValue(beforeKey, "wrong").Should().Be("before");
+                context.Should().Be(primaryContext);
+                contexts.Add(context);
+                await _timeProvider.Delay(LongDelay, context.CancellationToken);
+                return "primary";
+            },
+            primaryContext,
+            "dummy");
+
+        // assert
+        contexts.Should().HaveCountGreaterThan(1);
+        contexts.Count.Should().Be(contexts.Distinct().Count());
+        _timeProvider.Advance(LongDelay);
+        tokenHashCodes.Distinct().Should().HaveCountGreaterThan(1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EnsureOriginalCancellationTokenRestored()
+    {
+        // arrange
+        using var cancellationSource = new CancellationTokenSource();
+        var primaryContext = ResilienceContext.Get();
+        primaryContext.CancellationToken = cancellationSource.Token;
+        ConfigureHedging(TimeSpan.Zero);
+        var strategy = Create();
+
+        // act
+        var result = await strategy.ExecuteAsync((_, _) => Task.FromResult("primary"), primaryContext, "dummy");
+
+        // assert
+        primaryContext.CancellationToken.Should().Be(cancellationSource.Token);
+    }
+
+    [InlineData(true)]
+    [InlineData(false)]
+    [Theory]
+    public async Task ExecuteAsync_EnsurePropertiesConsistency(bool primaryFails)
+    {
+        // arrange
+        _options.MaxHedgedAttempts = 2;
+        var attempts = _options.MaxHedgedAttempts;
+        var primaryContext = ResilienceContext.Get();
+        var storedProps = primaryContext.Properties;
+        var contexts = new List<ResilienceContext>();
+        var primaryKey = new ResiliencePropertyKey<string>("primary-key");
+        var primaryKey2 = new ResiliencePropertyKey<string>("primary-key-2");
+        var secondaryKey = new ResiliencePropertyKey<string>("secondary-key");
+        storedProps.Set(primaryKey, "primary");
+
+        ConfigureHedging(args =>
+        {
+            return async () =>
+            {
+                contexts.Add(args.Context);
+                args.Context.Properties.GetValue(primaryKey, string.Empty).Should().Be("primary");
+                args.Context.Properties.Set(secondaryKey, "secondary");
+                await _timeProvider.Delay(TimeSpan.FromHours(1), args.Context.CancellationToken);
+                return primaryFails ? Success : Failure;
+            };
+        });
+        var strategy = Create();
+
+        // act
+        var executeTask = strategy.ExecuteAsync(
+            async (context, _) =>
+            {
+                contexts.Add(context);
+                context.Properties.GetValue(primaryKey, string.Empty).Should().Be("primary");
+                context.Properties.Set(primaryKey2, "primary-2");
+                await _timeProvider.Delay(TimeSpan.FromHours(2), context.CancellationToken);
+                return primaryFails ? Failure : Success;
+            },
+            primaryContext,
+            "state");
+
+        // assert
+
+        contexts.Should().HaveCount(2);
+        primaryContext.Properties.Should().HaveCount(2);
+        primaryContext.Properties.GetValue(primaryKey, string.Empty).Should().Be("primary");
+
+        if (primaryFails)
+        {
+            _timeProvider.Advance(TimeSpan.FromHours(1));
+            await executeTask;
+            primaryContext.Properties.GetValue(secondaryKey, string.Empty).Should().Be("secondary");
+        }
+        else
+        {
+            _timeProvider.Advance(TimeSpan.FromHours(2));
+            await executeTask;
+            primaryContext.Properties.GetValue(primaryKey2, string.Empty).Should().Be("primary-2");
+        }
+
+        primaryContext.Properties.Should().BeSameAs(storedProps);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Primary_CustomPropertiesAvailable()
+    {
+        // arrange
+        var key = new ResiliencePropertyKey<string>("my-key");
+        var key2 = new ResiliencePropertyKey<string>("my-key-2");
+        using var cancellationSource = new CancellationTokenSource();
+        var primaryContext = ResilienceContext.Get();
+        primaryContext.Properties.Set(key2, "my-value-2");
+        primaryContext.CancellationToken = cancellationSource.Token;
+        var props = primaryContext.Properties;
+        ConfigureHedging(TimeSpan.Zero);
+        var strategy = Create();
+
+        // act
+        var result = await strategy.ExecuteAsync(
+            (context, _) =>
+            {
+                primaryContext.Properties.TryGetValue(key2, out var val).Should().BeTrue();
+                val.Should().Be("my-value-2");
+                context.Properties.Set(key, "my-value");
+                return Task.FromResult("primary");
+            },
+            primaryContext, "dummy");
+
+        // assert
+        primaryContext.Properties.TryGetValue(key, out var val).Should().BeTrue();
+        val.Should().Be("my-value");
+        primaryContext.Properties.Should().BeSameAs(props);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Secondary_CustomPropertiesAvailable()
+    {
+        // arrange
+        var key = new ResiliencePropertyKey<string>("my-key");
+        var key2 = new ResiliencePropertyKey<string>("my-key-2");
+        var primaryContext = ResilienceContext.Get();
+        var storedProps = primaryContext.Properties;
+        primaryContext.Properties.Set(key2, "my-value-2");
+        ConfigureHedging(args =>
+        {
+            return () =>
+            {
+                args.Context.Properties.TryGetValue(key2, out var val).Should().BeTrue();
+                val.Should().Be("my-value-2");
+                args.Context.Properties.Set(key, "my-value");
+                return Task.FromResult(Success);
+            };
+        });
+        var strategy = Create();
+
+        // act
+        var result = await strategy.ExecuteAsync((_, _) => Task.FromResult(Failure), primaryContext, "state");
+
+        // assert
+        result.Should().Be(Success);
+        primaryContext.Properties.TryGetValue(key, out var val).Should().BeTrue();
+        primaryContext.Properties.Should().BeSameAs(storedProps);
+        val.Should().Be("my-value");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CancellationLinking_Ok()
+    {
+        // arrange
+        _options.MaxHedgedAttempts = 2;
+        using var primaryCancelled = new ManualResetEvent(false);
+        using var secondaryCancelled = new ManualResetEvent(false);
+        using var cancellationSource = new CancellationTokenSource();
+        var context = ResilienceContext.Get();
+        context.CancellationToken = cancellationSource.Token;
+
+        ConfigureHedging(async context =>
+        {
+            try
+            {
+                await _timeProvider.Delay(TimeSpan.FromDays(0.5), context.CancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                secondaryCancelled.Set();
+                throw;
+            }
+
+            return Success;
+        });
+
+        var strategy = Create();
+
+        // act
+        var task = strategy.ExecuteAsync(
+            async (context, _) =>
+            {
+                try
+                {
+                    await _primaryTasks.SlowTask(context.CancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    primaryCancelled.Set();
+                    throw;
+                }
+
+                return Success;
+            },
+            context, "dummy");
+
+        // assert
+        _timeProvider.Advance(TimeSpan.FromHours(4));
+        cancellationSource.Cancel();
+        _timeProvider.Advance(TimeSpan.FromHours(1));
+        await task.Invoking(async t => await t).Should().ThrowAsync<OperationCanceledException>();
+
+        primaryCancelled.WaitOne(AssertTimeout).Should().BeTrue();
+        secondaryCancelled.WaitOne(AssertTimeout).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EnsureBackgroundWorkInSuccessfulCallNotCancelled()
+    {
+        // arrange
+        using var cts = new CancellationTokenSource();
+        List<Task> backgroundTasks = new List<Task>();
+        ConfigureHedging(BackgroundWork);
+        var strategy = Create();
+
+        // act
+        var task = await strategy.ExecuteAsync(SlowTask, cts.Token);
+
+        // assert
+        _timeProvider.Advance(TimeSpan.FromDays(2));
+
+        await Assert.ThrowsAsync<TaskCanceledException>(() => backgroundTasks[0]);
+
+        // background task is still pending
+        Assert.False(backgroundTasks[1].IsCompleted);
+
+        cts.Cancel();
+
+        async Task<string> SlowTask(CancellationToken cancellationToken)
+        {
+            var delay = Task.Delay(TimeSpan.FromDays(1), cancellationToken);
+            backgroundTasks.Add(delay);
+            await delay;
+            return Success;
+        }
+
+        Task<string> BackgroundWork(ResilienceContext resilienceContext)
+        {
+            var delay = Task.Delay(TimeSpan.FromDays(24), resilienceContext.CancellationToken);
+            backgroundTasks.Add(delay);
+            return Task.FromResult(Success);
+        }
+    }
+
+    [Fact]
+    public async void ExecuteAsync_ZeroHedgingDelay_EnsureAllTasksSpawnedAtOnce()
+    {
+        // arrange
+        int executions = 0;
+        using var allExecutionsReached = new ManualResetEvent(false);
+        ConfigureHedging(context => Execute(context.CancellationToken));
+        _options.HedgingDelay = TimeSpan.Zero;
+
+        // act
+        var task = Create().ExecuteAsync(Execute);
+
+        // assert
+        Assert.True(allExecutionsReached.WaitOne(AssertTimeout));
+        _timeProvider.Advance(LongDelay);
+        await task;
+
+        async Task<string> Execute(CancellationToken token)
+        {
+            if (Interlocked.Increment(ref executions) == _options.MaxHedgedAttempts)
+            {
+                allExecutionsReached.Set();
+            }
+
+            await _timeProvider.Delay(LongDelay, token);
+            return Success;
+        }
+    }
+
+    [Fact]
+    public void ExecuteAsync_InfiniteHedgingDelay_EnsureNoConcurrentExecutions()
+    {
+        // arrange
+        bool executing = false;
+        int executions = 0;
+        using var allExecutions = new ManualResetEvent(true);
+        ConfigureHedging(context => Execute(context.CancellationToken));
+
+        // act
+        var pending = Create().ExecuteAsync(Execute, _cts.Token);
+
+        // assert
+        Assert.True(allExecutions.WaitOne(AssertTimeout));
+
+        async Task<string> Execute(CancellationToken token)
+        {
+            if (executing)
+            {
+                throw new InvalidOperationException("Concurrent execution detected!");
+            }
+
+            executing = true;
+            try
+            {
+                if (Interlocked.Increment(ref executions) == _options.MaxHedgedAttempts)
+                {
+                    allExecutions.Set();
+                }
+
+                await _timeProvider.Delay(LongDelay, token);
+
+                return "dummy";
+            }
+            finally
+            {
+                executing = false;
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ExceptionsHandled_ShouldThrowAnyException()
+    {
+        int attempts = 0;
+
+        ConfigureHedging<string>(handler =>
+        {
+            handler.ShouldHandle.HandleException<InvalidCastException>();
+            handler.ShouldHandle.HandleException<ArgumentException>();
+            handler.ShouldHandle.HandleException<InvalidOperationException>();
+            handler.HedgingActionGenerator = args =>
+            {
+                Exception exception = args.Attempt switch
+                {
+                    1 => new ArgumentException(),
+                    2 => new InvalidOperationException(),
+                    3 => new BadImageFormatException(),
+                    _ => new NotSupportedException()
+                };
+
+                attempts++;
+                return () => throw exception;
+            };
+        });
+
+        var strategy = Create();
+        await strategy.Invoking(s => s.ExecuteAsync<string>(_ => throw new InvalidCastException())).Should().ThrowAsync<BadImageFormatException>();
+        attempts.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ExceptionsHandled_ShouldThrowLastException()
+    {
+        int attempts = 0;
+
+        ConfigureHedging<string>(handler =>
+        {
+            handler.ShouldHandle.HandleException<InvalidCastException>();
+            handler.ShouldHandle.HandleException<ArgumentException>();
+            handler.ShouldHandle.HandleException<InvalidOperationException>();
+            handler.ShouldHandle.HandleException<BadImageFormatException>();
+            handler.HedgingActionGenerator = args =>
+            {
+                Exception exception = args.Attempt switch
+                {
+                    1 => new ArgumentException(),
+                    2 => new InvalidOperationException(),
+                    3 => new BadImageFormatException(),
+                    _ => new NotSupportedException()
+                };
+
+                attempts++;
+                return () => throw exception;
+            };
+        });
+
+        var strategy = Create();
+        await strategy.Invoking(s => s.ExecuteAsync<string>(_ => throw new InvalidCastException())).Should().ThrowAsync<InvalidCastException>();
+        attempts.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PrimaryExceptionNotHandled_Rethrow()
+    {
+        int attempts = 0;
+
+        ConfigureHedging<string>(handler =>
+        {
+            handler.ShouldHandle.HandleException<InvalidOperationException>();
+            handler.HedgingActionGenerator = args =>
+            {
+                attempts++;
+                return null;
+            };
+        });
+
+        var strategy = Create();
+        await strategy.Invoking(s => s.ExecuteAsync<string>(_ => throw new InvalidCastException())).Should().ThrowAsync<InvalidCastException>();
+        attempts.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ExceptionsHandled_ShouldReturnLastResult()
+    {
+        int attempts = 0;
+
+        ConfigureHedging<string>(handler =>
+        {
+            handler.ShouldHandle.HandleException<InvalidCastException>();
+            handler.ShouldHandle.HandleException<ArgumentException>();
+            handler.ShouldHandle.HandleException<InvalidOperationException>();
+            handler.ShouldHandle.HandleException<BadImageFormatException>();
+            handler.HedgingActionGenerator = args =>
+            {
+                Exception? exception = args.Attempt switch
+                {
+                    1 => new ArgumentException(),
+                    2 => new InvalidOperationException(),
+                    3 => null,
+                    _ => new NotSupportedException()
+                };
+
+                attempts++;
+                return () =>
+                {
+                    if (exception != null)
+                    {
+                        throw exception;
+                    }
+
+                    return Task.FromResult(Success);
+                };
+            };
+        });
+
+        var strategy = Create();
+        var result = await strategy.ExecuteAsync<string>(_ => throw new InvalidCastException());
+        result.Should().Be(Success);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EnsureHedgingDelayGeneratorRespected()
+    {
+        var delay = TimeSpan.FromMilliseconds(12345);
+        _options.HedgingDelayGenerator.SetGenerator(_ => TimeSpan.FromMilliseconds(12345));
+
+        ConfigureHedging<string>(handler =>
+        {
+            handler.HedgingActionGenerator = args => () => Task.FromResult(Success);
+        });
+
+        var strategy = Create();
+        var task = strategy.ExecuteAsync<string>(async token =>
+        {
+            await _timeProvider.Delay(TimeSpan.FromDays(1), token);
+            throw new InvalidCastException();
+        });
+
+        _timeProvider.Advance(TimeSpan.FromHours(5));
+        (await task).Should().Be(Success);
+        _timeProvider.DelayEntries.Should().Contain(e => e.Delay == delay);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EnsureExceptionStackTracePreserved()
+    {
+        ConfigureHedging<string>(handler =>
+        {
+            handler.HedgingActionGenerator = args => null;
+        });
+
+        var strategy = Create();
+
+        var exception = await strategy.Invoking(s => s.ExecuteAsync(PrimaryTaskThatThrowsError)).Should().ThrowAsync<InvalidOperationException>();
+
+        exception.WithMessage("Forced Error");
+        exception.And.StackTrace.Should().Contain(nameof(PrimaryTaskThatThrowsError));
+
+        static Task<string> PrimaryTaskThatThrowsError(CancellationToken cancellationToken) => throw new InvalidOperationException("Forced Error");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EnsureOnHedgingCalled()
+    {
+        var attempts = new List<int>();
+        _options.OnHedging.Register((o, args) =>
+        {
+            o.Result.Should().Be(Failure);
+            attempts.Add(args.Attempt);
+        });
+        ConfigureHedging<string>(handler =>
+        {
+            handler.ShouldHandle.HandleResult(Failure);
+            handler.HedgingActionGenerator = args => () => Task.FromResult(Failure);
+        });
+
+        var strategy = Create();
+        await strategy.ExecuteAsync(_ => Task.FromResult(Failure));
+
+        attempts.Should().HaveCount(_options.MaxHedgedAttempts);
+        attempts.Should().BeInAscendingOrder();
+        attempts[0].Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EnsureOnHedgingTelemetry()
+    {
+        var context = ResilienceContext.Get();
+
+        ConfigureHedging<string>(handler =>
+        {
+            handler.ShouldHandle.HandleResult(Failure);
+            handler.HedgingActionGenerator = args => () => Task.FromResult(Failure);
+        });
+
+        var strategy = Create();
+        await strategy.ExecuteAsync((_, _) => Task.FromResult(Failure), context, "state");
+
+        context.ResilienceEvents.Should().HaveCount(_options.MaxHedgedAttempts);
+        context.ResilienceEvents.Select(v => v.EventName).Distinct().Should().ContainSingle("OnHedging");
+    }
+
+    private void ConfigureHedging()
+    {
+        _options.OnHedging.Register<string>((outcome, _) =>
+        {
+            lock (_results)
+            {
+                _results.Add(outcome.Result!);
+            }
+        });
+
+        ConfigureHedging<string>(handler =>
+        {
+            handler.HedgingActionGenerator = _actions.Generator;
+        });
+    }
+
+    private void ConfigureHedging(Func<ResilienceContext, Task<string>> background)
+    {
+        ConfigureHedging(args => () => background(args.Context));
+    }
+
+    private void ConfigureHedging(HedgingActionGenerator<string> generator)
+    {
+        ConfigureHedging<string>(handler =>
+        {
+            handler.HedgingActionGenerator = generator;
+            handler.ShouldHandle.HandleResult(Failure);
+        });
+    }
+
+    private void ConfigureHedging<T>(Action<HedgingHandler<T>> configure) => _options.Handler.SetHedging(configure);
+
+    private void ConfigureHedging(TimeSpan delay) => ConfigureHedging(args => async () =>
+    {
+        await Task.Delay(delay);
+        return "secondary";
+    });
+
+    private HedgingResilienceStrategy Create() => new(_options, _timeProvider, _telemetry);
 }

--- a/src/Polly.Core.Tests/Hedging/HedgingResilienceStrategyTests.cs
+++ b/src/Polly.Core.Tests/Hedging/HedgingResilienceStrategyTests.cs
@@ -58,6 +58,19 @@ public class HedgingResilienceStrategyTests : IDisposable
         strategy.Execute(_ => 10).Should().Be(10);
     }
 
+    [Fact]
+    public async Task Execute_CancellationRequested_Throws()
+    {
+        ConfigureHedging();
+
+        var strategy = Create();
+        _cts.Cancel();
+
+        await strategy.Invoking(s => s.ExecuteAsync(_ => Task.FromResult(Success), _cts.Token))
+            .Should()
+            .ThrowAsync<OperationCanceledException>();
+    }
+
     [InlineData(-1)]
     [InlineData(-1000)]
     [InlineData(0)]

--- a/src/Polly.Core.Tests/Hedging/HedgingStrategyOptionsTResultTests.cs
+++ b/src/Polly.Core.Tests/Hedging/HedgingStrategyOptionsTResultTests.cs
@@ -81,7 +81,7 @@ public class HedgingStrategyOptionsTResultTests
         var handler = nonGeneric.Handler.CreateHandler();
         handler.Should().NotBeNull();
 
-        (await handler!.TryCreateHedgedAction<int>(ResilienceContext.Get())!()).Should().Be(555);
+        (await handler!.TryCreateHedgedAction<int>(ResilienceContext.Get(), 0)!()).Should().Be(555);
 
         var result = await handler!.ShouldHandleAsync(new Outcome<int>(-1), new HandleHedgingArguments(ResilienceContext.Get()));
         result.Should().BeTrue();

--- a/src/Polly.Core.Tests/Hedging/HedgingTimeProvider.cs
+++ b/src/Polly.Core.Tests/Hedging/HedgingTimeProvider.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Threading.Tasks;
+using Polly.Utils;
+
+namespace Polly.Core.Tests.Hedging;
+
+internal class HedgingTimeProvider : TimeProvider
+{
+    private DateTimeOffset _utcNow;
+
+    public HedgingTimeProvider()
+        : base(Stopwatch.Frequency) => _utcNow = DateTimeOffset.UtcNow;
+
+    public TimeSpan AutoAdvance { get; set; }
+
+    public void Advance(TimeSpan diff)
+    {
+        _utcNow = _utcNow.Add(diff);
+
+        foreach (var entry in DelayEntries.Where(e => e.TimeStamp <= _utcNow))
+        {
+            entry.Complete();
+        }
+    }
+
+    public List<DelayEntry> DelayEntries { get; } = new List<DelayEntry>();
+
+    public override DateTimeOffset UtcNow => _utcNow;
+
+    public override void CancelAfter(CancellationTokenSource source, TimeSpan delay)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override Task Delay(TimeSpan delayValue, CancellationToken cancellationToken = default)
+    {
+        var entry = new DelayEntry(delayValue, new TaskCompletionSource<bool>(), _utcNow.Add(delayValue));
+        cancellationToken.Register(() => entry.Source.TrySetCanceled(cancellationToken));
+        DelayEntries.Add(entry);
+
+        Advance(AutoAdvance);
+
+        return entry.Source.Task;
+    }
+
+    public override long GetTimestamp() => throw new NotSupportedException();
+
+    public record DelayEntry(TimeSpan Delay, TaskCompletionSource<bool> Source, DateTimeOffset TimeStamp)
+    {
+        public void Complete()
+        {
+            Source.TrySetResult(true);
+        }
+    }
+}

--- a/src/Polly.Core.Tests/Hedging/PrimaryStringTasks.cs
+++ b/src/Polly.Core.Tests/Hedging/PrimaryStringTasks.cs
@@ -1,0 +1,33 @@
+using Polly.Utils;
+
+namespace Polly.Core.Tests.Hedging;
+
+internal class PrimaryStringTasks
+{
+    public const string InstantTaskResult = "Instant";
+
+    public const string FastTaskResult = "I am fast!";
+
+    public const string SlowTaskResult = "I am so slow!";
+
+    private readonly TimeProvider _timeProvider;
+
+    public PrimaryStringTasks(TimeProvider timeProvider) => _timeProvider = timeProvider;
+
+    public static Task<string> InstantTask()
+    {
+        return Task.FromResult(InstantTaskResult);
+    }
+
+    public async Task<string> FastTask(CancellationToken token)
+    {
+        await _timeProvider.Delay(TimeSpan.FromMilliseconds(10), token);
+        return FastTaskResult;
+    }
+
+    public async Task<string> SlowTask(CancellationToken token)
+    {
+        await _timeProvider.Delay(TimeSpan.FromDays(1), token);
+        return SlowTaskResult;
+    }
+}

--- a/src/Polly.Core.Tests/Helpers/DisposableResult.cs
+++ b/src/Polly.Core.Tests/Helpers/DisposableResult.cs
@@ -1,0 +1,25 @@
+namespace Polly.Core.Tests.Helpers;
+
+internal sealed class DisposableResult : IDisposable
+{
+    public readonly TaskCompletionSource<bool> OnDisposed = new();
+
+    public DisposableResult() => Name = "";
+
+    public DisposableResult(string name) => Name = name;
+
+    public string Name { get; set; }
+
+    public bool IsDisposed { get; private set; }
+
+    public Task WaitForDisposalAsync() => OnDisposed.Task;
+
+    public void Dispose()
+    {
+        IsDisposed = true;
+
+        OnDisposed.TrySetResult(true);
+    }
+
+    public override string ToString() => Name;
+}

--- a/src/Polly.Core.Tests/ResilienceContextTests.cs
+++ b/src/Polly.Core.Tests/ResilienceContextTests.cs
@@ -84,6 +84,25 @@ public class ResilienceContextTests
     [InlineData(true)]
     [InlineData(false)]
     [Theory]
+    public void Initialize_From_Ok(bool synchronous)
+    {
+        var context = ResilienceContext.Get();
+        context.Initialize<bool>(synchronous);
+        context.ContinueOnCapturedContext = true;
+
+        var other = ResilienceContext.Get();
+        other.InitializeFrom(context);
+
+        other.ResultType.Should().Be(typeof(bool));
+        other.IsVoid.Should().BeFalse();
+        other.IsInitialized.Should().BeTrue();
+        other.IsSynchronous.Should().Be(synchronous);
+        other.ContinueOnCapturedContext.Should().BeTrue();
+    }
+
+    [InlineData(true)]
+    [InlineData(false)]
+    [Theory]
     public void Initialize_Void_Ok(bool synchronous)
     {
         var context = ResilienceContext.Get();

--- a/src/Polly.Core.Tests/ResiliencePropertiesTests.cs
+++ b/src/Polly.Core.Tests/ResiliencePropertiesTests.cs
@@ -57,6 +57,36 @@ public class ResiliencePropertiesTests
     }
 
     [Fact]
+    public void Clear_Ok()
+    {
+        var key1 = new ResiliencePropertyKey<long>("dummy");
+        var key2 = new ResiliencePropertyKey<string>("dummy");
+
+        var props = new ResilienceProperties();
+        props.Set(key1, 12345);
+        props.Clear();
+
+        props.Should().HaveCount(0);
+    }
+
+    [Fact]
+    public void Replace_Ok()
+    {
+        var key1 = new ResiliencePropertyKey<string>("A");
+        var key2 = new ResiliencePropertyKey<string>("B");
+
+        var props = new ResilienceProperties();
+        props.Set(key1, "A");
+
+        var otherProps = new ResilienceProperties();
+        otherProps.Set(key2, "B");
+
+        props.Replace(otherProps);
+        props.Should().HaveCount(1);
+        props.GetValue(key2, "").Should().Be("B");
+    }
+
+    [Fact]
     public void DictionaryOperations_Ok()
     {
         IDictionary<string, object?> dict = new ResilienceProperties();

--- a/src/Polly.Core.Tests/Utils/DisposeHelperTests.cs
+++ b/src/Polly.Core.Tests/Utils/DisposeHelperTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Threading.Tasks;
+using Moq;
+using Polly.Utils;
+
+namespace Polly.Core.Tests.Utils;
+
+public class DisposeHelperTests
+{
+    [Fact]
+    public void Dispose_Object_Ok()
+    {
+        DisposeHelper.TryDisposeSafeAsync(new object()).AsTask().IsCompleted.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Dispose_Disposable_Ok()
+    {
+        using var disposable = new DisposableResult();
+        await DisposeHelper.TryDisposeSafeAsync(disposable);
+        disposable.IsDisposed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Dispose_AsyncDisposable_Ok()
+    {
+        var disposable = new Mock<IAsyncDisposable>();
+        bool disposed = false;
+        disposable.Setup(v => v.DisposeAsync()).Returns(default(ValueTask)).Callback(() => disposed = true);
+
+        await DisposeHelper.TryDisposeSafeAsync(disposable.Object);
+
+        disposed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Dispose_DisposeThrows_ExceptionHandled()
+    {
+        var disposable = new Mock<IAsyncDisposable>();
+        disposable.Setup(v => v.DisposeAsync()).Throws(new InvalidOperationException());
+
+        await disposable.Object.Invoking(async _ => await DisposeHelper.TryDisposeSafeAsync(disposable.Object)).Should().NotThrowAsync();
+    }
+}

--- a/src/Polly.Core/Hedging/Controller/ContextSnapshot.cs
+++ b/src/Polly.Core/Hedging/Controller/ContextSnapshot.cs
@@ -1,0 +1,3 @@
+﻿namespace Polly.Hedging.Utils;
+
+internal readonly record struct ContextSnapshot(ResilienceContext Context, ResilienceProperties OriginalProperties, CancellationToken OriginalCancellationToken);

--- a/src/Polly.Core/Hedging/Controller/HedgedTaskType.cs
+++ b/src/Polly.Core/Hedging/Controller/HedgedTaskType.cs
@@ -1,0 +1,7 @@
+namespace Polly.Hedging.Utils;
+
+internal enum HedgedTaskType
+{
+    Primary,
+    Secondary
+}

--- a/src/Polly.Core/Hedging/Controller/HedgingController.cs
+++ b/src/Polly.Core/Hedging/Controller/HedgingController.cs
@@ -1,0 +1,55 @@
+using Polly.Hedging.Controller;
+using Polly.Utils;
+
+namespace Polly.Hedging.Utils;
+
+internal sealed class HedgingController
+{
+    private readonly IObjectPool<HedgingExecutionContext> _contextPool;
+    private readonly IObjectPool<TaskExecution> _executionPool;
+    private int _rentedContexts;
+    private int _rentedExecutions;
+
+    public HedgingController(TimeProvider provider, HedgingHandler.Handler handler, int maxAttempts)
+    {
+        _executionPool = new ObjectPool<TaskExecution>(() =>
+        {
+            Interlocked.Increment(ref _rentedExecutions);
+            return new TaskExecution(handler);
+        },
+        _ =>
+        {
+            Interlocked.Decrement(ref _rentedExecutions);
+
+            // Stryker disable once Boolean : no means to test this
+            return true;
+        });
+
+        _contextPool = new ObjectPool<HedgingExecutionContext>(
+            () =>
+            {
+                Interlocked.Increment(ref _rentedContexts);
+                return new HedgingExecutionContext(_executionPool, provider, maxAttempts, ReturnContext);
+            },
+            _ =>
+            {
+                Interlocked.Decrement(ref _rentedContexts);
+
+                // Stryker disable once Boolean : no means to test this
+                return true;
+            });
+    }
+
+    public int RentedContexts => _rentedContexts;
+
+    public int RentedExecutions => _rentedExecutions;
+
+    public HedgingExecutionContext GetContext(ResilienceContext context)
+    {
+        var executionContext = _contextPool.Get();
+        executionContext.Initialize(context);
+        return executionContext;
+    }
+
+    private void ReturnContext(HedgingExecutionContext context) => _contextPool.Return(context);
+}

--- a/src/Polly.Core/Hedging/Controller/HedgingExecutionContext.cs
+++ b/src/Polly.Core/Hedging/Controller/HedgingExecutionContext.cs
@@ -89,11 +89,6 @@ internal sealed class HedgingExecutionContext
 
     public void Complete()
     {
-        if (LoadedTasks == 0)
-        {
-            throw new InvalidOperationException("The hedging must execute at least one task.");
-        }
-
         UpdateOriginalContext();
 
         // first, cancel any pending tasks
@@ -202,6 +197,11 @@ internal sealed class HedgingExecutionContext
         var originalContext = Snapshot.Context;
         originalContext.CancellationToken = Snapshot.OriginalCancellationToken;
         originalContext.Properties = Snapshot.OriginalProperties;
+
+        if (LoadedTasks == 0)
+        {
+            return;
+        }
 
         int accepted = 0;
         TaskExecution? acceptedExecution = null;

--- a/src/Polly.Core/Hedging/Controller/HedgingExecutionContext.cs
+++ b/src/Polly.Core/Hedging/Controller/HedgingExecutionContext.cs
@@ -1,0 +1,263 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Polly.Hedging.Controller;
+using Polly.Strategy;
+using Polly.Utils;
+using static Polly.Hedging.Utils.HedgingExecutionContext;
+
+namespace Polly.Hedging.Utils;
+
+#pragma warning disable CA1031 // Do not catch general exception types
+
+/// <summary>
+/// The context associated with an execution of hedging resilience strategy.
+/// It holds the resources for all executed hedged tasks (primary + secondary) and is responsible for resource disposal.
+/// </summary>
+internal sealed class HedgingExecutionContext
+{
+    public readonly record struct ExecutionInfo<TResult>(TaskExecution? Execution, bool Loaded, Outcome<TResult>? Outcome);
+
+    private readonly List<TaskExecution> _tasks = new();
+    private readonly List<TaskExecution> _executingTasks = new();
+    private readonly IObjectPool<TaskExecution> _executionPool;
+    private readonly TimeProvider _timeProvider;
+    private readonly int _maxAttempts;
+    private readonly Action<HedgingExecutionContext> _onReset;
+    private readonly ResilienceProperties _replacedProperties = new();
+
+    public HedgingExecutionContext(IObjectPool<TaskExecution> executionPool, TimeProvider timeProvider, int maxAttempts, Action<HedgingExecutionContext> onReset)
+    {
+        _executionPool = executionPool;
+        _timeProvider = timeProvider;
+        _maxAttempts = maxAttempts;
+        _onReset = onReset;
+    }
+
+    internal void Initialize(ResilienceContext context)
+    {
+        Snapshot = new ContextSnapshot(context, context.Properties, context.CancellationToken);
+        _replacedProperties.Replace(Snapshot.OriginalProperties);
+        Snapshot.Context.Properties = _replacedProperties;
+    }
+
+    public int LoadedTasks => _tasks.Count;
+
+    public ContextSnapshot Snapshot { get; private set; }
+
+    public bool IsInitialized => Snapshot.Context != null;
+
+    public IReadOnlyList<TaskExecution> Tasks => _tasks;
+
+    private bool ContinueOnCapturedContext => Snapshot.Context.ContinueOnCapturedContext;
+
+    public async ValueTask<ExecutionInfo<TResult>> LoadExecutionAsync<TResult, TState>(Func<ResilienceContext, TState, ValueTask<TResult>> primaryCallback, TState state)
+    {
+        if (LoadedTasks >= _maxAttempts)
+        {
+            return CreateExecutionInfoWhenNoExecution<TResult>();
+        }
+
+        // determine what type of task we are creating
+        var type = LoadedTasks switch
+        {
+            0 => HedgedTaskType.Primary,
+            _ => HedgedTaskType.Secondary
+        };
+
+        var execution = _executionPool.Get();
+
+        if (await execution.InitializeAsync(type, Snapshot, primaryCallback, state, LoadedTasks).ConfigureAwait(ContinueOnCapturedContext))
+        {
+            // we were able to start a new execution, register it
+            _tasks.Add(execution);
+            _executingTasks.Add(execution);
+            return new ExecutionInfo<TResult>(execution, true, null);
+        }
+        else
+        {
+            _executionPool.Return(execution);
+            return CreateExecutionInfoWhenNoExecution<TResult>();
+        }
+    }
+
+    public void Complete()
+    {
+        if (LoadedTasks == 0)
+        {
+            throw new InvalidOperationException("The hedging must execute at least one task.");
+        }
+
+        UpdateOriginalContext();
+
+        // first, cancel any pending tasks
+        foreach (var pair in _executingTasks)
+        {
+            pair.Cancel();
+        }
+
+        // We are intentionally doing the cleanup in the background as we do not want to
+        // delay the hedging.
+        // The background cleanup is safe. All exceptions are handled.
+        _ = CleanupInBackgroundAsync();
+    }
+
+    public async ValueTask<TaskExecution?> TryWaitForCompletedExecutionAsync(TimeSpan hedgingDelay)
+    {
+        // before doing anything expensive, let's check whether any existing task is already completed
+        if (TryRemoveExecutedTask() is TaskExecution execution)
+        {
+            return execution;
+        }
+
+        if (LoadedTasks == _maxAttempts)
+        {
+            await WaitForTaskCompetitionAsync().ConfigureAwait(ContinueOnCapturedContext);
+            return TryRemoveExecutedTask();
+        }
+
+        if (hedgingDelay == TimeSpan.Zero || LoadedTasks == 0)
+        {
+            // just load the next task
+            return null;
+        }
+
+        // Stryker disable once equality : no means to test this, stryker changes '<' to '<=' where 0 is already covered in the branch above
+        if (hedgingDelay < TimeSpan.Zero)
+        {
+            await WaitForTaskCompetitionAsync().ConfigureAwait(ContinueOnCapturedContext);
+            return TryRemoveExecutedTask();
+        }
+
+        using var delayTaskCancellation = CancellationTokenSource.CreateLinkedTokenSource(Snapshot.Context.CancellationToken);
+
+        var delayTask = _timeProvider.DelayAsync(hedgingDelay, Snapshot.Context);
+        Task<Task> whenAnyHedgedTask = WaitForTaskCompetitionAsync();
+        var completedTask = await Task.WhenAny(whenAnyHedgedTask, delayTask).ConfigureAwait(ContinueOnCapturedContext);
+
+        if (completedTask == delayTask)
+        {
+            return null;
+        }
+
+        // cancel the ongoing delay task
+        // Stryker disable once boolean : no means to test this
+        delayTaskCancellation.Cancel(throwOnFirstException: false);
+        await whenAnyHedgedTask.ConfigureAwait(ContinueOnCapturedContext);
+
+        return TryRemoveExecutedTask();
+    }
+
+    private ExecutionInfo<TResult> CreateExecutionInfoWhenNoExecution<TResult>()
+    {
+        // if there are no more executing tasks we need to check finished ones
+        if (_executingTasks.Count == 0)
+        {
+            var finishedExecution = _tasks.First(static t => t.ExecutionTask!.IsCompleted);
+            finishedExecution.AcceptOutcome();
+            return new ExecutionInfo<TResult>(null, false, finishedExecution.Outcome.AsOutcome<TResult>());
+        }
+
+        return new ExecutionInfo<TResult>(null, false, null);
+    }
+
+    private Task<Task> WaitForTaskCompetitionAsync()
+    {
+#pragma warning disable S109 // Magic numbers should not be used
+        return _executingTasks.Count switch
+        {
+            1 => AwaitTask(_executingTasks[0], ContinueOnCapturedContext),
+            2 => Task.WhenAny(_executingTasks[0].ExecutionTask!, _executingTasks[1].ExecutionTask!),
+            _ => Task.WhenAny(_executingTasks.Select(v => v.ExecutionTask!))
+        };
+#pragma warning restore S109 // Magic numbers should not be used
+
+        static async Task<Task> AwaitTask(TaskExecution task, bool continueOnCapturedContext)
+        {
+            // ExecutionTask never fails
+            await task.ExecutionTask!.ConfigureAwait(continueOnCapturedContext);
+            return Task.FromResult(task);
+        }
+    }
+
+    private TaskExecution? TryRemoveExecutedTask()
+    {
+        int? index = null;
+
+        for (var i = 0; i < _executingTasks.Count; i++)
+        {
+            var task = _executingTasks[i];
+            if (task.ExecutionTask!.IsCompleted)
+            {
+                index = i;
+                break;
+            }
+        }
+
+        if (index is not null)
+        {
+            var execution = _executingTasks[index.Value];
+            _executingTasks.RemoveAt(index.Value);
+            return execution;
+        }
+
+        return null;
+    }
+
+    private void UpdateOriginalContext()
+    {
+        var originalContext = Snapshot.Context;
+        originalContext.CancellationToken = Snapshot.OriginalCancellationToken;
+        originalContext.Properties = Snapshot.OriginalProperties;
+
+        int accepted = 0;
+        TaskExecution? acceptedExecution = null;
+
+        foreach (var task in Tasks)
+        {
+            if (task.IsAccepted)
+            {
+                accepted++;
+                acceptedExecution = task;
+            }
+        }
+
+        if (accepted != 1)
+        {
+            throw new InvalidOperationException($"There must be exactly one accepted outcome for hedging. Found {accepted}.");
+        }
+
+        originalContext.Properties.Replace(acceptedExecution!.Properties);
+
+        if (acceptedExecution.Type == HedgedTaskType.Secondary)
+        {
+            foreach (var @event in acceptedExecution.Context.ResilienceEvents)
+            {
+                originalContext.AddResilienceEvent(@event);
+            }
+        }
+    }
+
+    private async Task CleanupInBackgroundAsync()
+    {
+        foreach (var task in _tasks)
+        {
+            await task.ExecutionTask!.ConfigureAwait(false);
+            await task.ResetAsync().ConfigureAwait(false);
+            _executionPool.Return(task);
+        }
+
+        Reset();
+    }
+
+    private void Reset()
+    {
+        _replacedProperties.Clear();
+        _tasks.Clear();
+
+        _executingTasks.Clear();
+        Snapshot = default;
+
+        _onReset(this);
+    }
+}

--- a/src/Polly.Core/Hedging/Controller/TaskExecution.cs
+++ b/src/Polly.Core/Hedging/Controller/TaskExecution.cs
@@ -9,6 +9,8 @@ namespace Polly.Hedging.Controller;
 /// <summary>
 /// Represents a single hedging attempt execution alongside all the necessary resources. These are:
 ///
+///  <ul>
+///  </ul>
 /// - Distinct <see cref="ResilienceContext"/> instance for this execution. One exception are primary task where the main context is reused.
 /// - The cancellation token associated with the execution.
 /// </summary>

--- a/src/Polly.Core/Hedging/Controller/TaskExecution.cs
+++ b/src/Polly.Core/Hedging/Controller/TaskExecution.cs
@@ -1,0 +1,212 @@
+using System;
+using Polly.Hedging.Utils;
+using Polly.Strategy;
+
+namespace Polly.Hedging.Controller;
+
+#pragma warning disable CA1031 // Do not catch general exception types
+
+/// <summary>
+/// Represents a single hedging attempt execution alongside all the necessary resources. These are:
+///
+/// - Distinct <see cref="ResilienceContext"/> instance for this execution. One exception are primary task where the main context is reused.
+/// - The cancellation token associated with the execution.
+/// </summary>
+internal sealed class TaskExecution
+{
+    private readonly ResilienceContext _cachedContext = ResilienceContext.Get();
+    private readonly HedgingHandler.Handler _handler;
+    private CancellationTokenSource? _cancellationSource;
+    private CancellationTokenRegistration? _cancellationRegistration;
+    private ResilienceContext? _activeContext;
+
+    public TaskExecution(HedgingHandler.Handler handler) => _handler = handler;
+
+    public Task? ExecutionTask { get; private set; }
+
+    public Outcome Outcome { get; private set; }
+
+    public bool IsHandled { get; private set; }
+
+    public bool IsAccepted { get; private set; }
+
+    public ResilienceProperties Properties { get; } = new();
+
+    public ResilienceContext Context => _activeContext ?? throw new InvalidOperationException("TaskExecution is not initialized.");
+
+    public HedgedTaskType Type { get; set; }
+
+    public Action<TaskExecution>? OnReset { get; set; }
+
+    public void AcceptOutcome()
+    {
+        if (ExecutionTask?.IsCompleted == true)
+        {
+            IsAccepted = true;
+        }
+        else
+        {
+            throw new InvalidOperationException("Unable to accept outcome for a task that is not completed.");
+        }
+    }
+
+    public void Cancel()
+    {
+        if (IsAccepted)
+        {
+            return;
+        }
+
+        _cancellationSource!.Cancel();
+    }
+
+    public async ValueTask<bool> InitializeAsync<TResult, TState>(
+        HedgedTaskType type,
+        ContextSnapshot snapshot,
+        Func<ResilienceContext, TState, ValueTask<TResult>> primaryCallback,
+        TState state,
+        int attempt)
+    {
+        Type = type;
+        _cancellationSource = CancellationTokenSourcePool.Get();
+        Properties.Replace(snapshot.OriginalProperties);
+
+        if (snapshot.OriginalCancellationToken.CanBeCanceled)
+        {
+            _cancellationRegistration = snapshot.OriginalCancellationToken.Register(o => ((CancellationTokenSource)o!).Cancel(), _cancellationSource);
+        }
+
+        PrepareContext(ref snapshot);
+
+        if (type == HedgedTaskType.Secondary)
+        {
+            Func<Task<TResult>>? action = null;
+
+            try
+            {
+                action = _handler.TryCreateHedgedAction<TResult>(Context, attempt);
+                if (action == null)
+                {
+                    await ResetAsync().ConfigureAwait(false);
+                    return false;
+                }
+            }
+            catch (Exception e)
+            {
+                ExecutionTask = ExecuteCreateActionException<TResult>(e);
+                return true;
+            }
+
+            ExecutionTask = ExecuteSecondaryActionAsync(action);
+        }
+        else
+        {
+            ExecutionTask = ExecutePrimaryActionAsync(primaryCallback, state);
+        }
+
+        return true;
+    }
+
+    public async ValueTask ResetAsync()
+    {
+        OnReset?.Invoke(this);
+
+        if (_cancellationRegistration is CancellationTokenRegistration registration)
+        {
+#if NETCOREAPP
+            await registration.DisposeAsync().ConfigureAwait(false);
+#else
+            registration.Dispose();
+#endif
+        }
+
+        _cancellationRegistration = null;
+
+        if (!IsAccepted)
+        {
+            await DisposeHelper.TryDisposeSafeAsync(Outcome.Result!).ConfigureAwait(false);
+
+            // not accepted executions are always cancelled, so the cancellation source must be
+            // disposed instead of returning it to the pool
+            _cancellationSource!.Dispose();
+        }
+        else
+        {
+            // accepted outcome means that the cancellation source can be be returned to the pool
+            // since it was most likely not cancelled
+            CancellationTokenSourcePool.Return(_cancellationSource!);
+        }
+
+        IsAccepted = false;
+        Outcome = default;
+        IsHandled = false;
+        Properties.Clear();
+        OnReset = null;
+        _activeContext = null;
+        _cachedContext.Reset();
+        _cancellationSource = null!;
+    }
+
+    private async Task ExecuteSecondaryActionAsync<TResult>(Func<Task<TResult>> action)
+    {
+        Outcome<TResult> outcome;
+
+        try
+        {
+            var result = await action().ConfigureAwait(Context.ContinueOnCapturedContext);
+            outcome = new Outcome<TResult>(result);
+        }
+        catch (Exception e)
+        {
+            outcome = new Outcome<TResult>(e);
+        }
+
+        await UpdateOutcomeAsync(outcome).ConfigureAwait(Context.ContinueOnCapturedContext);
+    }
+
+    private async Task ExecuteCreateActionException<TResult>(Exception e)
+    {
+        await UpdateOutcomeAsync(new Outcome<TResult>(e)).ConfigureAwait(Context.ContinueOnCapturedContext);
+    }
+
+    private async Task ExecutePrimaryActionAsync<TResult, TState>(Func<ResilienceContext, TState, ValueTask<TResult>> primaryCallback, TState state)
+    {
+        Outcome<TResult> outcome;
+
+        try
+        {
+            var result = await primaryCallback(Context, state).ConfigureAwait(Context.ContinueOnCapturedContext);
+            outcome = new Outcome<TResult>(result);
+        }
+        catch (Exception e)
+        {
+            outcome = new Outcome<TResult>(e);
+        }
+
+        await UpdateOutcomeAsync(outcome).ConfigureAwait(Context.ContinueOnCapturedContext);
+    }
+
+    private async Task UpdateOutcomeAsync<TResult>(Outcome<TResult> outcome)
+    {
+        Outcome = outcome.AsOutcome();
+        IsHandled = await _handler.ShouldHandleAsync(outcome, new HandleHedgingArguments(Context)).ConfigureAwait(Context.ContinueOnCapturedContext);
+    }
+
+    private void PrepareContext(ref ContextSnapshot snapshot)
+    {
+        if (Type == HedgedTaskType.Primary)
+        {
+            // now just replace the properties
+            _activeContext = snapshot.Context;
+        }
+        else
+        {
+            // secondary hedged tasks get their own unique context
+            _activeContext = _cachedContext;
+            _activeContext.InitializeFrom(snapshot.Context);
+        }
+
+        _activeContext.Properties = Properties;
+        _activeContext.CancellationToken = _cancellationSource!.Token;
+    }
+}

--- a/src/Polly.Core/Hedging/Controller/TaskExecution.cs
+++ b/src/Polly.Core/Hedging/Controller/TaskExecution.cs
@@ -54,10 +54,8 @@ internal sealed class TaskExecution
     {
         if (IsAccepted)
         {
-            return;
+            _cancellationSource!.Cancel();
         }
-
-        _cancellationSource!.Cancel();
     }
 
     public async ValueTask<bool> InitializeAsync<TResult, TState>(

--- a/src/Polly.Core/Hedging/Controller/TaskExecution.cs
+++ b/src/Polly.Core/Hedging/Controller/TaskExecution.cs
@@ -52,7 +52,7 @@ internal sealed class TaskExecution
 
     public void Cancel()
     {
-        if (IsAccepted)
+        if (!IsAccepted)
         {
             _cancellationSource!.Cancel();
         }

--- a/src/Polly.Core/Hedging/Controller/TaskExecution.cs
+++ b/src/Polly.Core/Hedging/Controller/TaskExecution.cs
@@ -9,10 +9,15 @@ namespace Polly.Hedging.Controller;
 /// <summary>
 /// Represents a single hedging attempt execution alongside all the necessary resources. These are:
 ///
-///  <ul>
-///  </ul>
-/// - Distinct <see cref="ResilienceContext"/> instance for this execution. One exception are primary task where the main context is reused.
-/// - The cancellation token associated with the execution.
+/// <list type="bullet">
+/// <item>
+/// Distinct <see cref="ResilienceContext"/> instance for this execution.
+/// One exception are primary task where the main context is reused.
+/// </item>
+/// <item>
+/// The cancellation token associated with the execution.
+/// </item>
+/// </list>
 /// </summary>
 internal sealed class TaskExecution
 {

--- a/src/Polly.Core/Hedging/HedgingActionGeneratorArguments.TResult.cs
+++ b/src/Polly.Core/Hedging/HedgingActionGeneratorArguments.TResult.cs
@@ -10,9 +10,18 @@ namespace Polly.Hedging;
 /// <typeparam name="TResult">The type of the result.</typeparam>
 public readonly struct HedgingActionGeneratorArguments<TResult> : IResilienceArguments
 {
-    internal HedgingActionGeneratorArguments(ResilienceContext context) => Context = context;
+    internal HedgingActionGeneratorArguments(ResilienceContext context, int attempt)
+    {
+        Context = context;
+        Attempt = attempt;
+    }
 
     /// <inheritdoc/>
     public ResilienceContext Context { get; }
+
+    /// <summary>
+    /// Gets the zero-based hedging attempt number.
+    /// </summary>
+    public int Attempt { get; }
 }
 

--- a/src/Polly.Core/Hedging/HedgingActionGeneratorArguments.cs
+++ b/src/Polly.Core/Hedging/HedgingActionGeneratorArguments.cs
@@ -9,8 +9,17 @@ namespace Polly.Hedging;
 /// </summary>
 public readonly struct HedgingActionGeneratorArguments : IResilienceArguments
 {
-    internal HedgingActionGeneratorArguments(ResilienceContext context) => Context = context;
+    internal HedgingActionGeneratorArguments(ResilienceContext context, int attempt)
+    {
+        Context = context;
+        Attempt = attempt;
+    }
 
     /// <inheritdoc/>
     public ResilienceContext Context { get; }
+
+    /// <summary>
+    /// Gets the zero-based hedging attempt number.
+    /// </summary>
+    public int Attempt { get; }
 }

--- a/src/Polly.Core/Hedging/HedgingConstants.cs
+++ b/src/Polly.Core/Hedging/HedgingConstants.cs
@@ -4,6 +4,8 @@ internal static class HedgingConstants
 {
     public const string StrategyType = "Hedging";
 
+    public const string OnHedgingEventName = "OnHedging";
+
     public const int DefaultMaxHedgedAttempts = 2;
 
     public const int MinimumHedgedAttempts = 2;

--- a/src/Polly.Core/Hedging/HedgingHandler.Handler.cs
+++ b/src/Polly.Core/Hedging/HedgingHandler.Handler.cs
@@ -6,27 +6,35 @@ public partial class HedgingHandler
 {
     internal sealed class Handler
     {
-        private readonly OutcomePredicate<HandleHedgingArguments>.Handler _handler;
+        private readonly OutcomePredicate<HandleHedgingArguments>.Handler? _predicateHandler;
         private readonly Dictionary<Type, object> _generators;
 
-        internal Handler(OutcomePredicate<HandleHedgingArguments>.Handler handler, Dictionary<Type, object> generators)
+        internal Handler(OutcomePredicate<HandleHedgingArguments>.Handler? handler, Dictionary<Type, object> generators)
         {
-            _handler = handler;
+            _predicateHandler = handler;
             _generators = generators;
         }
 
         public bool HandlesHedging<TResult>() => _generators.ContainsKey(typeof(TResult));
 
-        public ValueTask<bool> ShouldHandleAsync<TResult>(Outcome<TResult> outcome, HandleHedgingArguments arguments) => _handler.ShouldHandleAsync(outcome, arguments);
+        public ValueTask<bool> ShouldHandleAsync<TResult>(Outcome<TResult> outcome, HandleHedgingArguments arguments)
+        {
+            if (_predicateHandler == null)
+            {
+                return new ValueTask<bool>(false);
+            }
 
-        public Func<Task<TResult>>? TryCreateHedgedAction<TResult>(ResilienceContext context)
+            return _predicateHandler.ShouldHandleAsync(outcome, arguments);
+        }
+
+        public Func<Task<TResult>>? TryCreateHedgedAction<TResult>(ResilienceContext context, int attempt)
         {
             if (!_generators.TryGetValue(typeof(TResult), out var generator))
             {
                 return null;
             }
 
-            return ((HedgingActionGenerator<TResult>)generator)(new HedgingActionGeneratorArguments<TResult>(context));
+            return ((HedgingActionGenerator<TResult>)generator)(new HedgingActionGeneratorArguments<TResult>(context, attempt));
         }
     }
 }

--- a/src/Polly.Core/Hedging/HedgingResilienceStrategy.cs
+++ b/src/Polly.Core/Hedging/HedgingResilienceStrategy.cs
@@ -50,7 +50,8 @@ internal sealed class HedgingResilienceStrategy : ResilienceStrategy
         }
 
         var continueOnCapturedContext = context.ContinueOnCapturedContext;
-        context.CancellationToken.ThrowIfCancellationRequested();
+        var cancellationToken = context.CancellationToken;
+        cancellationToken.ThrowIfCancellationRequested();
 
         // create hedging execution context
         var hedgingContext = _controller.GetContext(context);
@@ -59,6 +60,8 @@ internal sealed class HedgingResilienceStrategy : ResilienceStrategy
         {
             while (true)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 if ((await hedgingContext.LoadExecutionAsync(callback, state).ConfigureAwait(context.ContinueOnCapturedContext)).Outcome is Outcome<TResult> outcome)
                 {
                     return HandleOutcome(outcome);

--- a/src/Polly.Core/Hedging/HedgingResilienceStrategy.cs
+++ b/src/Polly.Core/Hedging/HedgingResilienceStrategy.cs
@@ -1,15 +1,32 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+using System.Threading;
 using Polly.Hedging;
+using Polly.Hedging.Utils;
+using Polly.Strategy;
+using Polly.Utils;
 
 namespace Polly;
 
 internal sealed class HedgingResilienceStrategy : ResilienceStrategy
 {
-    public HedgingResilienceStrategy(HedgingStrategyOptions options)
+    private readonly ResilienceStrategyTelemetry _telemetry;
+    private readonly HedgingController? _controller;
+
+    public HedgingResilienceStrategy(HedgingStrategyOptions options, TimeProvider timeProvider, ResilienceStrategyTelemetry telemetry)
     {
         HedgingDelay = options.HedgingDelay;
         MaxHedgedAttempts = options.MaxHedgedAttempts;
         HedgingDelayGenerator = options.HedgingDelayGenerator.CreateHandler(HedgingConstants.DefaultHedgingDelay, static _ => true);
         HedgingHandler = options.Handler.CreateHandler();
+        OnHedgingHandler = options.OnHedging.CreateHandler();
+
+        _telemetry = telemetry;
+        if (HedgingHandler != null)
+        {
+            _controller = new HedgingController(timeProvider, HedgingHandler, options.MaxHedgedAttempts);
+        }
     }
 
     public TimeSpan HedgingDelay { get; }
@@ -20,9 +37,74 @@ internal sealed class HedgingResilienceStrategy : ResilienceStrategy
 
     public HedgingHandler.Handler? HedgingHandler { get; }
 
-    protected internal override ValueTask<TResult> ExecuteCoreAsync<TResult, TState>(Func<ResilienceContext, TState, ValueTask<TResult>> callback, ResilienceContext context, TState state)
+    public OutcomeEvent<OnHedgingArguments>.Handler? OnHedgingHandler { get; }
+
+    protected internal override async ValueTask<TResult> ExecuteCoreAsync<TResult, TState>(Func<ResilienceContext, TState, ValueTask<TResult>> callback, ResilienceContext context, TState state)
     {
-        return callback(context, state);
+        if (_controller == null || !HedgingHandler!.HandlesHedging<TResult>())
+        {
+            return await callback(context, state).ConfigureAwait(context.ContinueOnCapturedContext);
+        }
+
+        var continueOnCapturedContext = context.ContinueOnCapturedContext;
+        context.CancellationToken.ThrowIfCancellationRequested();
+
+        // create hedging execution context
+        var hedgingContext = _controller.GetContext(context);
+
+        try
+        {
+            while (true)
+            {
+                if ((await hedgingContext.LoadExecutionAsync(callback, state).ConfigureAwait(context.ContinueOnCapturedContext)).Outcome is Outcome<TResult> outcome)
+                {
+                    return HandleOutcome(outcome);
+                }
+
+                var delay = await GetHedgingDelayAsync(context, hedgingContext.LoadedTasks).ConfigureAwait(continueOnCapturedContext);
+                var execution = await hedgingContext.TryWaitForCompletedExecutionAsync(delay).ConfigureAwait(continueOnCapturedContext);
+                if (execution is null)
+                {
+                    // If completedHedgedTask is null it indicates that we still do not have any finished hedged task within the hedging delay.
+                    // We will create additional hedged task in the next iteration.
+                    continue;
+                }
+
+                outcome = execution.Outcome.AsOutcome<TResult>();
+
+                if (!execution.IsHandled)
+                {
+                    execution.AcceptOutcome();
+                    return HandleOutcome(outcome);
+                }
+
+                var onHedgingArgs = new OnHedgingArguments(context, hedgingContext.LoadedTasks - 1);
+                _telemetry.Report(HedgingConstants.OnHedgingEventName, outcome, onHedgingArgs);
+
+                if (OnHedgingHandler != null)
+                {
+                    // If nothing has been returned or thrown yet, the result is a transient failure,
+                    // and other hedged request will be awaited.
+                    // Before it, one needs to perform the task adjacent to each hedged call.
+                    await OnHedgingHandler.HandleAsync(outcome, onHedgingArgs).ConfigureAwait(continueOnCapturedContext);
+                }
+            }
+        }
+        finally
+        {
+            hedgingContext.Complete();
+        }
+    }
+
+    [ExcludeFromCodeCoverage]
+    private static TResult HandleOutcome<TResult>(Outcome<TResult> outcome)
+    {
+        if (outcome.Exception is not null)
+        {
+            ExceptionDispatchInfo.Capture(outcome.Exception).Throw();
+        }
+
+        return outcome.Result!;
     }
 
     internal ValueTask<TimeSpan> GetHedgingDelayAsync(ResilienceContext context, int attempt)
@@ -34,5 +116,4 @@ internal sealed class HedgingResilienceStrategy : ResilienceStrategy
 
         return HedgingDelayGenerator(new HedgingDelayArguments(context, attempt));
     }
-
 }

--- a/src/Polly.Core/Hedging/HedgingResilienceStrategy.cs
+++ b/src/Polly.Core/Hedging/HedgingResilienceStrategy.cs
@@ -39,7 +39,10 @@ internal sealed class HedgingResilienceStrategy : ResilienceStrategy
 
     public OutcomeEvent<OnHedgingArguments>.Handler? OnHedgingHandler { get; }
 
-    protected internal override async ValueTask<TResult> ExecuteCoreAsync<TResult, TState>(Func<ResilienceContext, TState, ValueTask<TResult>> callback, ResilienceContext context, TState state)
+    protected internal override async ValueTask<TResult> ExecuteCoreAsync<TResult, TState>(
+        Func<ResilienceContext, TState, ValueTask<TResult>> callback,
+        ResilienceContext context,
+        TState state)
     {
         if (_controller == null || !HedgingHandler!.HandlesHedging<TResult>())
         {

--- a/src/Polly.Core/Hedging/HedgingResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/Hedging/HedgingResilienceStrategyBuilderExtensions.cs
@@ -37,6 +37,6 @@ public static class HedgingResilienceStrategyBuilderExtensions
 
         ValidationHelper.ValidateObject(options, "The hedging strategy options are invalid.");
 
-        return builder.AddStrategy(context => new HedgingResilienceStrategy(options), options);
+        return builder.AddStrategy(context => new HedgingResilienceStrategy(options, context.TimeProvider, context.Telemetry), options);
     }
 }

--- a/src/Polly.Core/Polly.Core.csproj
+++ b/src/Polly.Core/Polly.Core.csproj
@@ -23,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Condition="!$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'netcoreapp3.1'))" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Condition="!$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'netcoreapp3.1'))" />
     <PackageReference Include="System.ValueTuple" Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'" />
     <PackageReference Include="System.ComponentModel.Annotations" Condition="!$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'netcoreapp3.1'))" />

--- a/src/Polly.Core/ResilienceContext.cs
+++ b/src/Polly.Core/ResilienceContext.cs
@@ -56,7 +56,7 @@ public sealed class ResilienceContext
     /// <summary>
     /// Gets the custom properties attached to the context.
     /// </summary>
-    public ResilienceProperties Properties { get; } = new();
+    public ResilienceProperties Properties { get; internal set; } = new();
 
     /// <summary>
     /// Gets the collection of resilience events that occurred while executing the resilience strategy.
@@ -75,6 +75,16 @@ public sealed class ResilienceContext
     /// by calling <see cref="Return(ResilienceContext)"/> method.
     /// </remarks>
     public static ResilienceContext Get() => Pool.Get();
+
+    internal void InitializeFrom(ResilienceContext context)
+    {
+        ResultType = context.ResultType;
+        IsSynchronous = context.IsSynchronous;
+        CancellationToken = context.CancellationToken;
+        ContinueOnCapturedContext = context.ContinueOnCapturedContext;
+        _resilienceEvents.Clear();
+        _resilienceEvents.AddRange(context.ResilienceEvents);
+    }
 
     /// <summary>
     /// Returns a <paramref name="context"/> back to the pool.
@@ -108,7 +118,7 @@ public sealed class ResilienceContext
         _resilienceEvents.Add(@event);
     }
 
-    private bool Reset()
+    internal bool Reset()
     {
         IsSynchronous = false;
         ResultType = typeof(UnknownResult);

--- a/src/Polly.Core/ResilienceProperties.cs
+++ b/src/Polly.Core/ResilienceProperties.cs
@@ -58,6 +58,18 @@ public sealed class ResilienceProperties : IDictionary<string, object?>
         Options[key.Key] = value;
     }
 
+    internal void Replace(ResilienceProperties other)
+    {
+        Clear();
+
+        foreach (var pair in other.Options)
+        {
+            Options[pair.Key] = pair.Value;
+        }
+    }
+
+    internal void Clear() => Options.Clear();
+
     /// <inheritdoc/>
     object? IDictionary<string, object?>.this[string key]
     {

--- a/src/Polly.Core/Strategy/Outcome.cs
+++ b/src/Polly.Core/Strategy/Outcome.cs
@@ -32,6 +32,11 @@ public readonly struct Outcome
     }
 
     /// <summary>
+    /// Gets a value indicating whether the outcome is valid.
+    /// </summary>
+    public bool IsValid => ResultType != null;
+
+    /// <summary>
     /// Gets the exception that occurred during the operation, if any.
     /// </summary>
     public Exception? Exception { get; }
@@ -86,5 +91,15 @@ public readonly struct Outcome
         }
 
         return Result?.ToString() ?? string.Empty;
+    }
+
+    internal Outcome<TResult> AsOutcome<TResult>()
+    {
+        if (Exception != null)
+        {
+            return new Outcome<TResult>(Exception);
+        }
+
+        return new Outcome<TResult>((TResult)Result!);
     }
 }

--- a/src/Polly.Core/Utils/DisposeHelper.cs
+++ b/src/Polly.Core/Utils/DisposeHelper.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Polly.Utils;
+
+#pragma warning disable CA1031 // Do not catch general exception types
+
+internal static class DisposeHelper
+{
+    public static async ValueTask TryDisposeSafeAsync<T>(T value)
+    {
+        try
+        {
+            if (value is IAsyncDisposable asyncDisposable)
+            {
+                await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+            }
+            else if (value is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
+        catch (Exception e)
+        {
+            Debug.Assert(false, e.ToString());
+        }
+    }
+}

--- a/src/Polly.Core/Utils/IObjectPool.cs
+++ b/src/Polly.Core/Utils/IObjectPool.cs
@@ -1,0 +1,23 @@
+namespace Polly.Utils;
+
+#pragma warning disable CA1716 // Identifiers should not match keywords
+
+/// <summary>
+/// Represents a pool of objects.
+/// </summary>
+/// <typeparam name="T">The type of objects in the pool.</typeparam>
+internal interface IObjectPool<T>
+    where T : class
+{
+    /// <summary>
+    /// Gets an object from the pool.
+    /// </summary>
+    /// <returns>Object instance.</returns>
+    T Get();
+
+    /// <summary>
+    /// Returns an object to the pool.
+    /// </summary>
+    /// <param name="obj">The object instance to return.</param>
+    void Return(T obj);
+}


### PR DESCRIPTION
### The issue or feature being addressed

Closes #876

### Details on the issue fix or feature implementation

This PR adds all necessary infrastructure and implements Hedging Resilience Strategy. 

- When the callbacks are hedged each execution gets its own `ResilienceContext` and `CancellationToken` so the concurrent calls won't interfere with each other and can be cancelled individually. 
- Once any callback gets acceptable result the properties from cloned `ResilienceContext` are merged bac to the main one.
- The primary callback still re-uses the main context.

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
