### PR TITLE
Add the option to configure default predicates

### DIFF
--- a/src/Polly.Core.Tests/Strategy/OutcomePredicateTests.cs
+++ b/src/Polly.Core.Tests/Strategy/OutcomePredicateTests.cs
@@ -279,6 +279,30 @@ public class OutcomePredicateTests
         {
             sut.HandleOutcome<int>((outcome, _) => new ValueTask<bool>(outcome.Exception is InvalidOperationException));
             InvokeHandler<int>(sut, new InvalidOperationException(), true);
+        },
+        sut =>
+        {
+            sut.SetPredicates(new OutcomePredicate<TestArguments, int>().SetDefaults(p => p.HandleResult(-1)).HandleResult(r => false));
+            InvokeResultHandler(sut, -1, false);
+            InvokeResultHandler(sut, 0, false);
+        },
+        sut =>
+        {
+            sut.SetPredicates(new OutcomePredicate<TestArguments, int>().SetDefaults(p => p.HandleResult(-1)));
+            InvokeResultHandler(sut, -1, true);
+            InvokeResultHandler(sut, 0, false);
+        },
+        sut =>
+        {
+            sut.SetVoidPredicates(new VoidOutcomePredicate<TestArguments>().SetDefaults(p => p.HandleException<InvalidOperationException>()).HandleException<Exception>(e => false));
+            InvokeHandler<VoidResult>(sut, new InvalidOperationException(), false);
+            InvokeHandler<VoidResult>(sut, new InvalidOperationException(), false);
+        },
+        sut =>
+        {
+            sut.SetVoidPredicates(new VoidOutcomePredicate<TestArguments>().SetDefaults(p => p.HandleException<InvalidOperationException>()));
+            InvokeHandler<VoidResult>(sut, new InvalidOperationException(), true);
+            InvokeHandler<VoidResult>(sut, new FormatException(), false);
         }
     };
 


### PR DESCRIPTION
### Details on the issue fix or feature implementation

This API allows us to configure the default predicates for a give result type that are used only when the user did not explicitly configured any. The sample usage:

``` csharp
public class HttpRetryStrategyOptions : RetryStrategyOptions<HttpResponseMessage>
{
    public HttpRetryStrategyOptions()
    {
        ShouldRetry.SetDefaults(predicate => predicate
            .HandleException<HttpRequestException>()
            .HandleResult(r => !r.IsSuccessStatusCode));
    }
}
```

This allows us to define the default behavior while still giving user the option to provide their own handling. 
If in the above sample the user did:

``` csharp
var options = new HttpRetryStrategyOptions();
options.ShouldRetry.HandleException<HttpRequestException>();
```

The defaults are not applied and only `HttpRequestException` will be retried.

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
