### PR TITLE
Use records for resilience arguments

### DIFF
--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerPredicateArguments.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerPredicateArguments.cs
@@ -2,15 +2,8 @@ using Polly.Strategy;
 
 namespace Polly.CircuitBreaker;
 
-#pragma warning disable CA1815 // Override equals and operator equals on value types
-
 /// <summary>
 /// Arguments used by <see cref="BaseCircuitBreakerStrategyOptions.ShouldHandle"/> predicate.
 /// </summary>
-public readonly struct CircuitBreakerPredicateArguments : IResilienceArguments
-{
-    internal CircuitBreakerPredicateArguments(ResilienceContext context) => Context = context;
-
-    /// <inheritdoc/>
-    public ResilienceContext Context { get; }
-}
+/// <param name="Context">The context associated with the execution of user-provided callback.</param>
+public readonly record struct CircuitBreakerPredicateArguments(ResilienceContext Context) : IResilienceArguments;

--- a/src/Polly.Core/CircuitBreaker/OnCircuitClosedArguments.cs
+++ b/src/Polly.Core/CircuitBreaker/OnCircuitClosedArguments.cs
@@ -2,24 +2,9 @@ using Polly.Strategy;
 
 namespace Polly.CircuitBreaker;
 
-#pragma warning disable CA1815 // Override equals and operator equals on value types
-
 /// <summary>
 /// Arguments used by <see cref="BaseCircuitBreakerStrategyOptions.OnClosed"/> event.
 /// </summary>
-public readonly struct OnCircuitClosedArguments : IResilienceArguments
-{
-    internal OnCircuitClosedArguments(ResilienceContext context, bool isManual)
-    {
-        Context = context;
-        IsManual = isManual;
-    }
-
-    /// <summary>
-    /// Gets a value indicating whether the circuit was closed manually by using <see cref="CircuitBreakerManualControl"/>.
-    /// </summary>
-    public bool IsManual { get; }
-
-    /// <inheritdoc/>
-    public ResilienceContext Context { get; }
-}
+/// <param name="Context">The context associated with the execution of user-provided callback.</param>
+/// <param name="IsManual">Indicates whether the circuit was closed manually by using <see cref="CircuitBreakerManualControl"/>.</param>
+public readonly record struct OnCircuitClosedArguments(ResilienceContext Context, bool IsManual) : IResilienceArguments;

--- a/src/Polly.Core/CircuitBreaker/OnCircuitHalfOpenedArguments.cs
+++ b/src/Polly.Core/CircuitBreaker/OnCircuitHalfOpenedArguments.cs
@@ -2,15 +2,8 @@ using Polly.Strategy;
 
 namespace Polly.CircuitBreaker;
 
-#pragma warning disable CA1815 // Override equals and operator equals on value types
-
 /// <summary>
 /// Arguments used by <see cref="BaseCircuitBreakerStrategyOptions.OnHalfOpened"/> event.
 /// </summary>
-public readonly struct OnCircuitHalfOpenedArguments : IResilienceArguments
-{
-    internal OnCircuitHalfOpenedArguments(ResilienceContext context) => Context = context;
-
-    /// <inheritdoc/>
-    public ResilienceContext Context { get; }
-}
+/// <param name="Context">The context associated with the execution of user-provided callback.</param>
+public readonly record struct OnCircuitHalfOpenedArguments(ResilienceContext Context) : IResilienceArguments;

--- a/src/Polly.Core/CircuitBreaker/OnCircuitOpenedArguments.cs
+++ b/src/Polly.Core/CircuitBreaker/OnCircuitOpenedArguments.cs
@@ -2,31 +2,10 @@ using Polly.Strategy;
 
 namespace Polly.CircuitBreaker;
 
-#pragma warning disable CA1815 // Override equals and operator equals on value types
-
 /// <summary>
 /// Arguments used by <see cref="BaseCircuitBreakerStrategyOptions.OnOpened"/> event.
 /// </summary>
-public readonly struct OnCircuitOpenedArguments : IResilienceArguments
-{
-    internal OnCircuitOpenedArguments(ResilienceContext context, TimeSpan breakDuration, bool isManual)
-    {
-        BreakDuration = breakDuration;
-        IsManual = isManual;
-        Context = context;
-    }
-
-    /// <summary>
-    /// Gets the duration of break.
-    /// </summary>
-    public TimeSpan BreakDuration { get; }
-
-    /// <summary>
-    /// Gets a value indicating whether the circuit was opened manually by using <see cref="CircuitBreakerManualControl"/>.
-    /// </summary>
-    public bool IsManual { get; }
-
-    /// <inheritdoc/>
-    public ResilienceContext Context { get; }
-}
-
+/// <param name="Context">The context associated with the execution of user-provided callback.</param>
+/// <param name="BreakDuration">The duration of break.</param>
+/// <param name="IsManual">Indicates whether the circuit was opened manually by using <see cref="CircuitBreakerManualControl"/>.</param>
+public readonly record struct OnCircuitOpenedArguments(ResilienceContext Context, TimeSpan BreakDuration, bool IsManual) : IResilienceArguments;

--- a/src/Polly.Core/Fallback/HandleFallbackArguments.cs
+++ b/src/Polly.Core/Fallback/HandleFallbackArguments.cs
@@ -2,15 +2,8 @@ using Polly.Strategy;
 
 namespace Polly.Fallback;
 
-#pragma warning disable CA1815 // Override equals and operator equals on value types
-
 /// <summary>
 /// Represents arguments used in fallback handling scenarios.
 /// </summary>
-public readonly struct HandleFallbackArguments : IResilienceArguments
-{
-    internal HandleFallbackArguments(ResilienceContext context) => Context = context;
-
-    /// <inheritdoc/>
-    public ResilienceContext Context { get; }
-}
+/// <param name="Context">The context associated with the execution of user-provided callback.</param>
+public readonly record struct HandleFallbackArguments(ResilienceContext Context) : IResilienceArguments;

--- a/src/Polly.Core/Fallback/OnFallbackArguments.cs
+++ b/src/Polly.Core/Fallback/OnFallbackArguments.cs
@@ -2,15 +2,8 @@ using Polly.Strategy;
 
 namespace Polly.Fallback;
 
-#pragma warning disable CA1815 // Override equals and operator equals on value types
-
 /// <summary>
-/// Represents arguments used when the fallback is about to be executed.
+/// Represents arguments used in fallback handling scenarios.
 /// </summary>
-public readonly struct OnFallbackArguments : IResilienceArguments
-{
-    internal OnFallbackArguments(ResilienceContext context) => Context = context;
-
-    /// <inheritdoc/>
-    public ResilienceContext Context { get; }
-}
+/// <param name="Context">The context associated with the execution of user-provided callback.</param>
+public readonly record struct OnFallbackArguments(ResilienceContext Context) : IResilienceArguments;

--- a/src/Polly.Core/Hedging/HandleHedgingArguments.cs
+++ b/src/Polly.Core/Hedging/HandleHedgingArguments.cs
@@ -2,15 +2,8 @@ using Polly.Strategy;
 
 namespace Polly.Hedging;
 
-#pragma warning disable CA1815 // Override equals and operator equals on value types
-
 /// <summary>
 /// Represents arguments used in hedging handling scenarios.
 /// </summary>
-public readonly struct HandleHedgingArguments : IResilienceArguments
-{
-    internal HandleHedgingArguments(ResilienceContext context) => Context = context;
-
-    /// <inheritdoc/>
-    public ResilienceContext Context { get; }
-}
+/// <param name="Context">The context associated with the execution of user-provided callback.</param>
+public readonly record struct HandleHedgingArguments(ResilienceContext Context) : IResilienceArguments;

--- a/src/Polly.Core/Hedging/HedgingActionGeneratorArguments.TResult.cs
+++ b/src/Polly.Core/Hedging/HedgingActionGeneratorArguments.TResult.cs
@@ -2,26 +2,10 @@ using Polly.Strategy;
 
 namespace Polly.Hedging;
 
-#pragma warning disable CA1815 // Override equals and operator equals on value types
-
 /// <summary>
 /// Represents arguments used in <see cref="HedgingActionGenerator"/>.
 /// </summary>
 /// <typeparam name="TResult">The type of the result.</typeparam>
-public readonly struct HedgingActionGeneratorArguments<TResult> : IResilienceArguments
-{
-    internal HedgingActionGeneratorArguments(ResilienceContext context, int attempt)
-    {
-        Context = context;
-        Attempt = attempt;
-    }
-
-    /// <inheritdoc/>
-    public ResilienceContext Context { get; }
-
-    /// <summary>
-    /// Gets the zero-based hedging attempt number.
-    /// </summary>
-    public int Attempt { get; }
-}
-
+/// <param name="Context">The context associated with the execution of user-provided callback.</param>
+/// <param name="Attempt">The zero-based hedging attempt number.</param>
+public readonly record struct HedgingActionGeneratorArguments<TResult>(ResilienceContext Context, int Attempt) : IResilienceArguments;

--- a/src/Polly.Core/Hedging/HedgingActionGeneratorArguments.cs
+++ b/src/Polly.Core/Hedging/HedgingActionGeneratorArguments.cs
@@ -2,24 +2,9 @@ using Polly.Strategy;
 
 namespace Polly.Hedging;
 
-#pragma warning disable CA1815 // Override equals and operator equals on value types
-
 /// <summary>
 /// Represents arguments used in <see cref="HedgingActionGenerator"/>.
 /// </summary>
-public readonly struct HedgingActionGeneratorArguments : IResilienceArguments
-{
-    internal HedgingActionGeneratorArguments(ResilienceContext context, int attempt)
-    {
-        Context = context;
-        Attempt = attempt;
-    }
-
-    /// <inheritdoc/>
-    public ResilienceContext Context { get; }
-
-    /// <summary>
-    /// Gets the zero-based hedging attempt number.
-    /// </summary>
-    public int Attempt { get; }
-}
+/// <param name="Context">The context associated with the execution of user-provided callback.</param>
+/// <param name="Attempt">The zero-based hedging attempt number.</param>
+public readonly record struct HedgingActionGeneratorArguments(ResilienceContext Context, int Attempt) : IResilienceArguments;

--- a/src/Polly.Core/Hedging/HedgingDelayArguments.cs
+++ b/src/Polly.Core/Hedging/HedgingDelayArguments.cs
@@ -2,24 +2,9 @@ using Polly.Strategy;
 
 namespace Polly.Hedging;
 
-#pragma warning disable CA1815 // Override equals and operator equals on value types
-
 /// <summary>
 /// Arguments used by hedging delay generator.
 /// </summary>
-public readonly struct HedgingDelayArguments : IResilienceArguments
-{
-    internal HedgingDelayArguments(ResilienceContext context, int attempt)
-    {
-        Context = context;
-        Attempt = attempt;
-    }
-
-    /// <summary>
-    /// Gets the zero-based hedging attempt number.
-    /// </summary>
-    public int Attempt { get; }
-
-    /// <inheritdoc/>
-    public ResilienceContext Context { get; }
-}
+/// <param name="Context">The context associated with the execution of user-provided callback.</param>
+/// <param name="Attempt">The zero-based hedging attempt number.</param>
+public readonly record struct HedgingDelayArguments(ResilienceContext Context, int Attempt) : IResilienceArguments;

--- a/src/Polly.Core/Hedging/OnHedgingArguments.cs
+++ b/src/Polly.Core/Hedging/OnHedgingArguments.cs
@@ -2,24 +2,9 @@ using Polly.Strategy;
 
 namespace Polly.Hedging;
 
-#pragma warning disable CA1815 // Override equals and operator equals on value types
-
 /// <summary>
 /// Represents arguments used by the on-hedging event.
 /// </summary>
-public readonly struct OnHedgingArguments : IResilienceArguments
-{
-    internal OnHedgingArguments(ResilienceContext context, int attempt)
-    {
-        Context = context;
-        Attempt = attempt;
-    }
-
-    /// <inheritdoc/>
-    public ResilienceContext Context { get; }
-
-    /// <summary>
-    /// Gets the zero-based hedging attempt number.
-    /// </summary>
-    public int Attempt { get; }
-}
+/// <param name="Context">The context associated with the execution of user-provided callback.</param>
+/// <param name="Attempt">The zero-based hedging attempt number.</param>
+public readonly record struct OnHedgingArguments(ResilienceContext Context, int Attempt) : IResilienceArguments;

--- a/src/Polly.Core/Retry/OnRetryArguments.cs
+++ b/src/Polly.Core/Retry/OnRetryArguments.cs
@@ -2,33 +2,10 @@ using Polly.Strategy;
 
 namespace Polly.Retry;
 
-#pragma warning disable CA1815 // Override equals and operator equals on value types
-
 /// <summary>
 /// Represents the arguments used by <see cref="RetryStrategyOptions.OnRetry"/> for handling the retry event.
 /// </summary>
-public readonly struct OnRetryArguments : IResilienceArguments
-{
-    internal OnRetryArguments(ResilienceContext context, int attempt, TimeSpan retryDelay)
-    {
-        Attempt = attempt;
-        Context = context;
-        RetryDelay = retryDelay;
-    }
-
-    /// <summary>
-    /// Gets the zero-based attempt number.
-    /// </summary>
-    /// <remarks>
-    /// The first attempt is 0, the second attempt is 1, and so on.
-    /// </remarks>
-    public int Attempt { get; }
-
-    /// <summary>
-    /// Gets the delay before the next retry.
-    /// </summary>
-    public TimeSpan RetryDelay { get; }
-
-    /// <inheritdoc/>
-    public ResilienceContext Context { get; }
-}
+/// <param name="Context">The context associated with the execution of user-provided callback.</param>
+/// <param name="Attempt">The zero-based attempt number. The first attempt is 0, the second attempt is 1, and so on.</param>
+/// <param name="RetryDelay">The delay before the next retry.</param>
+public readonly record struct OnRetryArguments(ResilienceContext Context, int Attempt, TimeSpan RetryDelay) : IResilienceArguments;

--- a/src/Polly.Core/Retry/RetryDelayArguments.cs
+++ b/src/Polly.Core/Retry/RetryDelayArguments.cs
@@ -2,33 +2,10 @@ using Polly.Strategy;
 
 namespace Polly.Retry;
 
-#pragma warning disable CA1815 // Override equals and operator equals on value types
-
 /// <summary>
 /// Represents the arguments used by <see cref="RetryStrategyOptions.RetryDelayGenerator"/> for generating the next retry delay.
 /// </summary>
-public readonly struct RetryDelayArguments : IResilienceArguments
-{
-    internal RetryDelayArguments(ResilienceContext context, int attempt, TimeSpan delayHint)
-    {
-        Attempt = attempt;
-        DelayHint = delayHint;
-        Context = context;
-    }
-
-    /// <summary>
-    /// Gets the zero-based attempt number.
-    /// </summary>
-    /// <remarks>
-    /// The first attempt is 0, the second attempt is 1, and so on.
-    /// </remarks>
-    public int Attempt { get; }
-
-    /// <summary>
-    /// Gets the delay suggested by retry strategy.
-    /// </summary>
-    public TimeSpan DelayHint { get; }
-
-    /// <inheritdoc/>
-    public ResilienceContext Context { get; }
-}
+/// <param name="Context">The context associated with the execution of user-provided callback.</param>
+/// <param name="Attempt">The zero-based attempt number. The first attempt is 0, the second attempt is 1, and so on.</param>
+/// <param name="DelayHint">The delay suggested by retry strategy.</param>
+public readonly record struct RetryDelayArguments(ResilienceContext Context, int Attempt, TimeSpan DelayHint) : IResilienceArguments;

--- a/src/Polly.Core/Retry/ShouldRetryArguments.cs
+++ b/src/Polly.Core/Retry/ShouldRetryArguments.cs
@@ -2,27 +2,9 @@ using Polly.Strategy;
 
 namespace Polly.Retry;
 
-#pragma warning disable CA1815 // Override equals and operator equals on value types
-
 /// <summary>
 /// Represents the arguments used by <see cref="RetryStrategyOptions.ShouldRetry"/> for determining whether a retry should be performed.
 /// </summary>
-public readonly struct ShouldRetryArguments : IResilienceArguments
-{
-    internal ShouldRetryArguments(ResilienceContext context, int attemptNumber)
-    {
-        Attempt = attemptNumber;
-        Context = context;
-    }
-
-    /// <summary>
-    /// Gets the zero-based attempt number.
-    /// </summary>
-    /// <remarks>
-    /// The first attempt is 0, the second attempt is 1, and so on.
-    /// </remarks>
-    public int Attempt { get; }
-
-    /// <inheritdoc/>
-    public ResilienceContext Context { get; }
-}
+/// <param name="Context">The context associated with the execution of user-provided callback.</param>
+/// <param name="Attempt">The zero-based attempt number. The first attempt is 0, the second attempt is 1, and so on.</param>
+public readonly record struct ShouldRetryArguments(ResilienceContext Context, int Attempt) : IResilienceArguments;

--- a/src/Polly.Core/Timeout/OnTimeoutArguments.cs
+++ b/src/Polly.Core/Timeout/OnTimeoutArguments.cs
@@ -2,30 +2,10 @@ using Polly.Strategy;
 
 namespace Polly.Timeout;
 
-#pragma warning disable CA1815 // Equals not overridden because this class is just a data holder.
-
 /// <summary>
 /// Arguments used by the timeout strategy to notify that timeout occurred.
 /// </summary>
-public readonly struct OnTimeoutArguments : IResilienceArguments
-{
-    internal OnTimeoutArguments(ResilienceContext context, Exception exception, TimeSpan timeout)
-    {
-        Context = context;
-        Exception = exception;
-        Timeout = timeout;
-    }
-
-    /// <inheritdoc/>
-    public ResilienceContext Context { get; }
-
-    /// <summary>
-    /// Gets the original exception that caused the timeout.
-    /// </summary>
-    public Exception Exception { get; }
-
-    /// <summary>
-    /// Gets the timeout value assigned.
-    /// </summary>
-    public TimeSpan Timeout { get; }
-}
+/// <param name="Context">The context associated with the execution of user-provided callback.</param>
+/// <param name="Exception">The original exception that caused the timeout.</param>
+/// <param name="Timeout">The timeout value assigned.</param>
+public readonly record struct OnTimeoutArguments(ResilienceContext Context, Exception Exception, TimeSpan Timeout) : IResilienceArguments;

--- a/src/Polly.Core/Timeout/TimeoutGeneratorArguments.cs
+++ b/src/Polly.Core/Timeout/TimeoutGeneratorArguments.cs
@@ -2,15 +2,8 @@ using Polly.Strategy;
 
 namespace Polly.Timeout;
 
-#pragma warning disable CA1815 // Equals not overridden because this class is just a data holder.
-
 /// <summary>
 /// Arguments used by the timeout strategy to retrieve a timeout for current execution.
 /// </summary>
-public readonly struct TimeoutGeneratorArguments : IResilienceArguments
-{
-    internal TimeoutGeneratorArguments(ResilienceContext context) => Context = context;
-
-    /// <inheritdoc/>
-    public ResilienceContext Context { get; }
-}
+/// <param name="Context">The context associated with the execution of user-provided callback.</param>
+public readonly record struct TimeoutGeneratorArguments(ResilienceContext Context) : IResilienceArguments;

--- a/src/Polly.RateLimiting/OnRateLimiterRejectedArguments.cs
+++ b/src/Polly.RateLimiting/OnRateLimiterRejectedArguments.cs
@@ -3,33 +3,10 @@ using Polly.Strategy;
 
 namespace Polly.RateLimiting;
 
-#pragma warning disable CA1815 // Override equals and operator equals on value types
-
 /// <summary>
 /// The arguments used by the <see cref="RateLimiterStrategyOptions.OnRejected"/>.
 /// </summary>
-public readonly struct OnRateLimiterRejectedArguments : IResilienceArguments
-{
-    internal OnRateLimiterRejectedArguments(ResilienceContext context, RateLimitLease lease, TimeSpan? retryAfter)
-    {
-        Context = context;
-        Lease = lease;
-        RetryAfter = retryAfter;
-    }
-
-    /// <inheritdoc/>
-    public ResilienceContext Context { get; }
-
-    /// <summary>
-    /// Gets the lease that has no permits and was rejected by the rate limiter.
-    /// </summary>
-    public RateLimitLease Lease { get; }
-
-    /// <summary>
-    /// Gets the amount of time to wait before retrying again.
-    /// </summary>
-    /// <remarks>
-    /// This value is retrieved from the <see cref="Lease"/> by reading the <see cref="MetadataName.RetryAfter"/>.
-    /// </remarks>
-    public TimeSpan? RetryAfter { get; }
-}
+/// <param name="Context">The context associated with the execution of user-provided callback.</param>
+/// <param name="Lease">The lease that has no permits and was rejected by the rate limiter.</param>
+/// <param name="RetryAfter">The amount of time to wait before retrying again. This value is retrieved from the <see cref="Lease"/> by reading the <see cref="MetadataName.RetryAfter"/>.</param>
+public readonly record struct OnRateLimiterRejectedArguments(ResilienceContext Context, RateLimitLease Lease, TimeSpan? RetryAfter) : IResilienceArguments;


### PR DESCRIPTION
### Details on the issue fix or feature implementation

Just switching to records for all implementations of `IResilienceArguments` as it simplifies the implementation and reduces the unnecessary suppressions.

### Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build
