### PR TITLE
ResilienceStrategyRegistry now also uses  BuilderName

### DIFF
--- a/src/Polly.Core.Tests/Registry/ResilienceStrategyRegistryOptionsTests.cs
+++ b/src/Polly.Core.Tests/Registry/ResilienceStrategyRegistryOptionsTests.cs
@@ -8,8 +8,12 @@ public class ResilienceStrategyRegistryOptionsTests
     {
         ResilienceStrategyRegistryOptions<object> options = new();
 
-        options.KeyFormatter.Should().NotBeNull();
-        options.KeyFormatter(null!).Should().Be("");
-        options.KeyFormatter("ABC").Should().Be("ABC");
+        options.StrategyKeyFormatter.Should().NotBeNull();
+        options.StrategyKeyFormatter(null!).Should().Be("");
+        options.StrategyKeyFormatter("ABC").Should().Be("ABC");
+
+        options.BuilderNameFormatter.Should().NotBeNull();
+        options.BuilderNameFormatter(null!).Should().Be("");
+        options.BuilderNameFormatter("ABC").Should().Be("ABC");
     }
 }

--- a/src/Polly.Core.Tests/Registry/ResilienceStrategyRegistryTests.cs
+++ b/src/Polly.Core.Tests/Registry/ResilienceStrategyRegistryTests.cs
@@ -11,20 +11,17 @@ public class ResilienceStrategyRegistryTests
 
     private Action<ResilienceStrategyBuilder> _callback = _ => { };
 
-    public ResilienceStrategyRegistryTests()
+    public ResilienceStrategyRegistryTests() => _options = new()
     {
-        _options = new()
+        BuilderFactory = () =>
         {
-            BuilderFactory = () =>
-            {
-                var builder = new ResilienceStrategyBuilder();
-                _callback(builder);
-                return builder;
-            },
-            StrategyComparer = StrategyId.Comparer,
-            BuilderComparer = StrategyId.BuilderComparer
-        };
-    }
+            var builder = new ResilienceStrategyBuilder();
+            _callback(builder);
+            return builder;
+        },
+        StrategyComparer = StrategyId.Comparer,
+        BuilderComparer = StrategyId.BuilderComparer
+    };
 
     [Fact]
     public void Ctor_Default_Ok()
@@ -143,7 +140,7 @@ public class ResilienceStrategyRegistryTests
 
         var called = false;
         var registry = CreateRegistry();
-        registry.TryAddBuilder(StrategyId.Create("A"), (key, builder) =>
+        registry.TryAddBuilder(StrategyId.Create("A"), (_, builder) =>
         {
             builder.AddStrategy(new TestResilienceStrategy());
             builder.BuilderName.Should().Be("A");

--- a/src/Polly.Core/Registry/ResilienceStrategyRegistry.cs
+++ b/src/Polly.Core/Registry/ResilienceStrategyRegistry.cs
@@ -22,6 +22,7 @@ public sealed class ResilienceStrategyRegistry<TKey> : ResilienceStrategyProvide
     private readonly ConcurrentDictionary<TKey, Action<TKey, ResilienceStrategyBuilder>> _builders;
     private readonly ConcurrentDictionary<TKey, ResilienceStrategy> _strategies;
     private readonly Func<TKey, string> _keyFormatter;
+    private readonly Func<TKey, string> _builderNameFormatter;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ResilienceStrategyRegistry{TKey}"/> class with the default comparer.
@@ -44,7 +45,8 @@ public sealed class ResilienceStrategyRegistry<TKey> : ResilienceStrategyProvide
         _activator = options.BuilderFactory;
         _builders = new ConcurrentDictionary<TKey, Action<TKey, ResilienceStrategyBuilder>>(options.BuilderComparer);
         _strategies = new ConcurrentDictionary<TKey, ResilienceStrategy>(options.StrategyComparer);
-        _keyFormatter = options.KeyFormatter;
+        _keyFormatter = options.StrategyKeyFormatter;
+        _builderNameFormatter = options.BuilderNameFormatter;
     }
 
     /// <summary>
@@ -89,6 +91,7 @@ public sealed class ResilienceStrategyRegistry<TKey> : ResilienceStrategyProvide
             strategy = _strategies.GetOrAdd(key, key =>
             {
                 var builder = _activator();
+                builder.BuilderName = _builderNameFormatter(key);
                 builder.Properties.Set(TelemetryUtil.StrategyKey, _keyFormatter(key));
                 configure(key, builder);
                 return builder.Build();

--- a/src/Polly.Core/Registry/ResilienceStrategyRegistry.cs
+++ b/src/Polly.Core/Registry/ResilienceStrategyRegistry.cs
@@ -21,7 +21,7 @@ public sealed class ResilienceStrategyRegistry<TKey> : ResilienceStrategyProvide
     private readonly Func<ResilienceStrategyBuilder> _activator;
     private readonly ConcurrentDictionary<TKey, Action<TKey, ResilienceStrategyBuilder>> _builders;
     private readonly ConcurrentDictionary<TKey, ResilienceStrategy> _strategies;
-    private readonly Func<TKey, string> _keyFormatter;
+    private readonly Func<TKey, string> _strategyKeyFormatter;
     private readonly Func<TKey, string> _builderNameFormatter;
 
     /// <summary>
@@ -45,7 +45,7 @@ public sealed class ResilienceStrategyRegistry<TKey> : ResilienceStrategyProvide
         _activator = options.BuilderFactory;
         _builders = new ConcurrentDictionary<TKey, Action<TKey, ResilienceStrategyBuilder>>(options.BuilderComparer);
         _strategies = new ConcurrentDictionary<TKey, ResilienceStrategy>(options.StrategyComparer);
-        _keyFormatter = options.StrategyKeyFormatter;
+        _strategyKeyFormatter = options.StrategyKeyFormatter;
         _builderNameFormatter = options.BuilderNameFormatter;
     }
 
@@ -92,7 +92,7 @@ public sealed class ResilienceStrategyRegistry<TKey> : ResilienceStrategyProvide
             {
                 var builder = _activator();
                 builder.BuilderName = _builderNameFormatter(key);
-                builder.Properties.Set(TelemetryUtil.StrategyKey, _keyFormatter(key));
+                builder.Properties.Set(TelemetryUtil.StrategyKey, _strategyKeyFormatter(key));
                 configure(key, builder);
                 return builder.Build();
             });

--- a/src/Polly.Core/Registry/ResilienceStrategyRegistryOptions.cs
+++ b/src/Polly.Core/Registry/ResilienceStrategyRegistryOptions.cs
@@ -36,8 +36,30 @@ public class ResilienceStrategyRegistryOptions<TKey>
     public IEqualityComparer<TKey> BuilderComparer { get; set; } = EqualityComparer<TKey>.Default;
 
     /// <summary>
-    /// Gets or sets the formatter that is used by the registry to format the keys as a string.
+    /// Gets or sets the formatter that is used by the registry to format the <typeparamref name="TKey"/> to a string that
+    /// represents the strategy key.
     /// </summary>
+    /// <remarks>
+    /// By default, the formatter uses the <see cref="object.ToString"/> method.
+    /// <para>
+    /// Use custom formatter for composite keys in case you want to have different metric values for a builder and strategy key.
+    /// In general, strategies can have the same builder name and different strategy keys.
+    /// </para>
+    /// </remarks>
     [Required]
-    public Func<TKey, string> KeyFormatter { get; set; } = (key) => key?.ToString() ?? string.Empty;
+    public Func<TKey, string> StrategyKeyFormatter { get; set; } = (key) => key?.ToString() ?? string.Empty;
+
+    /// <summary>
+    /// Gets or sets the formatter that is used by the registry to format the <typeparamref name="TKey"/> to a string that
+    /// represents the builder name.
+    /// </summary>
+    /// <remarks>
+    /// By default, the formatter uses the <see cref="object.ToString"/> method.
+    /// <para>
+    /// Use custom formatter for composite keys in case you want to have different metric values for a builder and strategy key.
+    /// In general, strategies can have the same builder name and different strategy keys.
+    /// </para>
+    /// </remarks>
+    [Required]
+    public Func<TKey, string> BuilderNameFormatter { get; set; } = (key) => key?.ToString() ?? string.Empty;
 }


### PR DESCRIPTION
### Details on the issue fix or feature implementation

Noticed when checking the telemetry that the `builder-name` dimension is empty when using `ResilienceStrategyRegistry`.

I have also added an option to customize the formatting of generic key to either builder name or strategy key. This comes handy for multi-dimensional keys.


### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
