### PR TITLE
Add the new overloads that accept lambda that configures the options

### DIFF
--- a/src/Polly.Core/Retry/RetryResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/Retry/RetryResilienceStrategyBuilderExtensions.cs
@@ -130,6 +130,23 @@ public static class RetryResilienceStrategyBuilderExtensions
     /// Adds a retry strategy to the builder.
     /// </summary>
     /// <param name="builder">The builder instance.</param>
+    /// <param name="configure">The action that configures the retry options.</param>
+    /// <returns>The builder instance with the retry strategy added.</returns>
+    public static ResilienceStrategyBuilder AddRetry(this ResilienceStrategyBuilder builder, Action<RetryStrategyOptions> configure)
+    {
+        Guard.NotNull(builder);
+        Guard.NotNull(configure);
+
+        var options = new RetryStrategyOptions();
+        configure(options);
+
+        return builder.AddRetry(options);
+    }
+
+    /// <summary>
+    /// Adds a retry strategy to the builder.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
     /// <param name="options">The retry strategy options.</param>
     /// <returns>The builder instance with the retry strategy added.</returns>
     public static ResilienceStrategyBuilder AddRetry(this ResilienceStrategyBuilder builder, RetryStrategyOptions options)


### PR DESCRIPTION
### Details on the issue fix or feature implementation

Just creating this PR to discuss whether adding new extensions that accept lambdas that configure the options is something we want to have built-in. It simplifies the configuration of predicates, events and generators.

Adding retry strategy using the options:
``` csharp
builder.AddRetry(new RetryStrategyOptions
{
    RetryCount = 4,
    BackoffType = RetryBackoffType.Exponential,
    ShouldRetry = new OutcomePredicate<ShouldRetryArguments>().HandleResult(-1).HandleException<InvalidOperationException>(),
    OnRetry = new OutcomeEvent<OnRetryArguments>().Register(()=> Console.WriteLine("Retry occurred!")),
});
```

Using the configure callback:
``` csharp
builder.AddRetry(o =>
{
    o.RetryCount = 4;
    o.BackoffType = RetryBackoffType.Exponential;
    o.ShouldRetry.HandleResult(-1).HandleException<InvalidOperationException>();
    o.OnRetry.Register(() => Console.WriteLine("Retry occurred!"));
});
```

Note that the overload that accepts the options directly needs to stay as it will be API that can integrate with `IOptions`.

**Is the second API (in addition to the first one) something we want to have built-in?**

### Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build
