### PR TITLE
Improve AddResilienceStrategy API

### DIFF
--- a/src/Polly.Extensions.Tests/Issues/IssuesTests.OnCircuitBreakWithServiceProvider_796.cs
+++ b/src/Polly.Extensions.Tests/Issues/IssuesTests.OnCircuitBreakWithServiceProvider_796.cs
@@ -30,9 +30,9 @@ public partial class IssuesTests
         options.ShouldHandle.HandleResult("error");
 
         // create the strategy
-        var serviceCollection = new ServiceCollection().AddResilienceStrategy("my-strategy", context =>
+        var serviceCollection = new ServiceCollection().AddResilienceStrategy("my-strategy", (builder, context) =>
         {
-            context.Builder
+            builder
                 .AddStrategy(new ServiceProviderStrategy(context.ServiceProvider))
                 .AddAdvancedCircuitBreaker(options);
         });

--- a/src/Polly.Extensions/DependencyInjection/AddResilienceStrategyContext.cs
+++ b/src/Polly.Extensions/DependencyInjection/AddResilienceStrategyContext.cs
@@ -7,10 +7,9 @@ namespace Polly.Extensions.DependencyInjection;
 public sealed class AddResilienceStrategyContext<TKey>
     where TKey : notnull
 {
-    internal AddResilienceStrategyContext(TKey key, ResilienceStrategyBuilder builder, IServiceProvider serviceProvider)
+    internal AddResilienceStrategyContext(TKey key, IServiceProvider serviceProvider)
     {
         Key = key;
-        Builder = builder;
         ServiceProvider = serviceProvider;
     }
 
@@ -18,11 +17,6 @@ public sealed class AddResilienceStrategyContext<TKey>
     /// Gets the key used to identify the resilience strategy.
     /// </summary>
     public TKey Key { get; }
-
-    /// <summary>
-    /// Gets the <see cref="ResilienceStrategyBuilder"/> used to build the resilience strategy.
-    /// </summary>
-    public ResilienceStrategyBuilder Builder { get; }
 
     /// <summary>
     /// Gets the <see cref="IServiceProvider"/> that provides access to the dependency injection container.

--- a/src/Polly.Extensions/DependencyInjection/ConfigureResilienceStrategyRegistryOptions.cs
+++ b/src/Polly.Extensions/DependencyInjection/ConfigureResilienceStrategyRegistryOptions.cs
@@ -5,5 +5,5 @@ internal sealed class ConfigureResilienceStrategyRegistryOptions<TKey>
 {
     public List<Entry> Actions { get; } = new();
 
-    public record Entry(TKey Key, Action<AddResilienceStrategyContext<TKey>> Configure);
+    public record Entry(TKey Key, Action<ResilienceStrategyBuilder, AddResilienceStrategyContext<TKey>> Configure);
 }

--- a/src/Polly.Extensions/DependencyInjection/PollyServiceCollectionExtensions.cs
+++ b/src/Polly.Extensions/DependencyInjection/PollyServiceCollectionExtensions.cs
@@ -34,7 +34,34 @@ public static class PollyServiceCollectionExtensions
     public static IServiceCollection AddResilienceStrategy<TKey>(
         this IServiceCollection services,
         TKey key,
-        Action<AddResilienceStrategyContext<TKey>> configure)
+        Action<ResilienceStrategyBuilder> configure)
+        where TKey : notnull
+    {
+        Guard.NotNull(services);
+        Guard.NotNull(configure);
+
+        return services.AddResilienceStrategy(key, (builder, _) => configure(builder));
+    }
+
+    /// <summary>
+    /// Adds a resilience strategy to service collection.
+    /// </summary>
+    /// <typeparam name="TKey">The type of the key used to identify the resilience strategy.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add the resilience strategy to.</param>
+    /// <param name="key">The key used to identify the resilience strategy.</param>
+    /// <param name="configure">An action that configures the resilience strategy.</param>
+    /// <returns>The updated <see cref="IServiceCollection"/> with the registered resilience strategy.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if the resilience strategy builder with the provided key has already been added to the registry.</exception>
+    /// <remarks>
+    /// You can retrieve the registered strategy by resolving the <see cref="ResilienceStrategyProvider{TKey}"/> class from the dependency injection container.
+    /// <para>
+    /// This call enables the telemetry for the registered resilience strategy.
+    /// </para>
+    /// </remarks>
+    public static IServiceCollection AddResilienceStrategy<TKey>(
+        this IServiceCollection services,
+        TKey key,
+        Action<ResilienceStrategyBuilder, AddResilienceStrategyContext<TKey>> configure)
         where TKey : notnull
     {
         Guard.NotNull(services);
@@ -75,8 +102,8 @@ public static class PollyServiceCollectionExtensions
                 registry.RemoveBuilder(entry.Key);
                 registry.TryAddBuilder(entry.Key, (key, builder) =>
                 {
-                    var context = new AddResilienceStrategyContext<TKey>(key, builder, serviceProvider);
-                    entry.Configure(context);
+                    var context = new AddResilienceStrategyContext<TKey>(key, serviceProvider);
+                    entry.Configure(builder, context);
                 });
             }
 


### PR DESCRIPTION
### Details on the issue fix or feature implementation

While playing with the DI API I got bothered by the need to access the builder as `context.Builder`. This PR allows accessing the builder directly so instead of:

``` csharp
services.AddResilienceStrategy("myKey", context => context.Builder.AddTimeout());
```
We can now do:

``` csharp
// simple case
services.AddResilienceStrategy("myKey", builder => builder.AddTimeout());

// builder + context
services.AddResilienceStrategy("myKey", (builder, context) => builder.AddTimeout());
```

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
