### PR TITLE
Reimplement CancellationTokenSourcePool

### DIFF
--- a/src/Polly.Core.Tests/Hedging/Controller/HedgingExecutionContextTests.cs
+++ b/src/Polly.Core.Tests/Hedging/Controller/HedgingExecutionContextTests.cs
@@ -475,7 +475,7 @@ public class HedgingExecutionContextTests : IDisposable
         var pool = new ObjectPool<TaskExecution>(
             () =>
             {
-                var execution = new TaskExecution(handler);
+                var execution = new TaskExecution(handler, CancellationTokenSourcePool.Create(_timeProvider));
                 _createdExecutions.Add(execution);
                 return execution;
             },

--- a/src/Polly.Core.Tests/Hedging/Controller/TaskExecutionTests.cs
+++ b/src/Polly.Core.Tests/Hedging/Controller/TaskExecutionTests.cs
@@ -5,6 +5,7 @@ using Polly.Hedging;
 using Polly.Hedging.Controller;
 using Polly.Hedging.Utils;
 using Polly.Strategy;
+using Polly.Utils;
 
 namespace Polly.Core.Tests.Hedging.Controller;
 
@@ -265,5 +266,5 @@ public class TaskExecutionTests : IDisposable
 
     private Func<HedgingActionGeneratorArguments<DisposableResult>, Func<Task<DisposableResult>>?> Generator { get; set; } = args => () => Task.FromResult(new DisposableResult { Name = Handled });
 
-    private TaskExecution Create() => new(_hedgingHandler.CreateHandler()!);
+    private TaskExecution Create() => new(_hedgingHandler.CreateHandler()!, CancellationTokenSourcePool.Create(TimeProvider.System));
 }

--- a/src/Polly.Core.Tests/Hedging/HedgingResilienceStrategyTests.cs
+++ b/src/Polly.Core.Tests/Hedging/HedgingResilienceStrategyTests.cs
@@ -120,6 +120,8 @@ public class HedgingResilienceStrategyTests : IDisposable
     public async void ExecuteAsync_EnsureHedgedTasksCancelled_Ok()
     {
         // arrange
+        _testOutput.WriteLine("ExecuteAsync_EnsureHedgedTasksCancelled_Ok executing...");
+
         _options.MaxHedgedAttempts = 2;
         using var cancelled = new ManualResetEvent(false);
         ConfigureHedging(async context =>
@@ -155,6 +157,11 @@ public class HedgingResilienceStrategyTests : IDisposable
         });
 
         // assert
+        _timeProvider.Advance(_options.HedgingDelay);
+        await Task.Delay(20);
+        _timeProvider.Advance(_options.HedgingDelay);
+        await Task.Delay(20);
+
         _timeProvider.Advance(TimeSpan.FromHours(1));
         (await result).Should().Be(Success);
         cancelled.WaitOne(AssertTimeout).Should().BeTrue();

--- a/src/Polly.Core.Tests/Utils/CancellationTokenSourcePoolTests.cs
+++ b/src/Polly.Core.Tests/Utils/CancellationTokenSourcePoolTests.cs
@@ -1,33 +1,102 @@
+using System.Threading;
+using Moq;
+using Polly.Core.Tests.Helpers;
 using Polly.Utils;
+using Xunit;
 
 namespace Polly.Core.Tests.Utils;
 
 public class CancellationTokenSourcePoolTests
 {
-    [Fact]
-    public void RentReturn_Reusable_EnsureProperBehavior()
+    public static IEnumerable<object[]> TimeProviders()
     {
-        var cts = CancellationTokenSourcePool.Get();
-        CancellationTokenSourcePool.Return(cts);
+        yield return new object[] { TimeProvider.System };
+        yield return new object[] { new FakeTimeProvider() };
+    }
 
-        var cts2 = CancellationTokenSourcePool.Get();
+    [MemberData(nameof(TimeProviders))]
+    [Theory]
+    public void RentReturn_Reusable_EnsureProperBehavior(object timeProvider)
+    {
+        var pool = CancellationTokenSourcePool.Create(GetTimeProvider(timeProvider));
+        var cts = pool.Get(System.Threading.Timeout.InfiniteTimeSpan);
+        pool.Return(cts);
+
+        var cts2 = pool.Get(System.Threading.Timeout.InfiniteTimeSpan);
 #if NET6_0_OR_GREATER
-        cts2.Should().BeSameAs(cts);
+        if (timeProvider == TimeProvider.System)
+        {
+            cts2.Should().BeSameAs(cts);
+        }
+        else
+        {
+            cts2.Should().NotBeSameAs(cts);
+        }
 #else
         cts2.Should().NotBeSameAs(cts);
 #endif
     }
 
-    [Fact]
-    public void RentReturn_NotReusable_EnsureProperBehavior()
+    [MemberData(nameof(TimeProviders))]
+    [Theory]
+    public void RentReturn_NotReusable_EnsureProperBehavior(object timeProvider)
     {
-        var cts = CancellationTokenSourcePool.Get();
+        var pool = CancellationTokenSourcePool.Create(GetTimeProvider(timeProvider));
+        var cts = pool.Get(System.Threading.Timeout.InfiniteTimeSpan);
         cts.Cancel();
-        CancellationTokenSourcePool.Return(cts);
+        pool.Return(cts);
 
         cts.Invoking(c => c.Token).Should().Throw<ObjectDisposedException>();
 
-        var cts2 = CancellationTokenSourcePool.Get();
+        var cts2 = pool.Get(System.Threading.Timeout.InfiniteTimeSpan);
         cts2.Token.Should().NotBeNull();
     }
+
+    [MemberData(nameof(TimeProviders))]
+    [Theory]
+    public async Task Rent_Cancellable_EnsureCancelled(object timeProvider)
+    {
+        if (timeProvider is Mock<TimeProvider> fakeTimeProvider)
+        {
+            fakeTimeProvider
+                .Setup(v => v.CancelAfter(It.IsAny<CancellationTokenSource>(), TimeSpan.FromMilliseconds(1)))
+                .Callback<CancellationTokenSource, TimeSpan>((source, _) => source.Cancel());
+        }
+        else
+        {
+            fakeTimeProvider = null!;
+        }
+
+        var pool = CancellationTokenSourcePool.Create(GetTimeProvider(timeProvider));
+        var cts = pool.Get(TimeSpan.FromMilliseconds(1));
+
+        await Task.Delay(100);
+
+        cts.IsCancellationRequested.Should().BeTrue();
+        fakeTimeProvider?.VerifyAll();
+    }
+
+    [MemberData(nameof(TimeProviders))]
+    [Theory]
+    public async Task Rent_NotCancellable_EnsureNotCancelled(object timeProvider)
+    {
+        var pool = CancellationTokenSourcePool.Create(GetTimeProvider(timeProvider));
+        var cts = pool.Get(System.Threading.Timeout.InfiniteTimeSpan);
+
+        await Task.Delay(20);
+
+        cts.IsCancellationRequested.Should().BeFalse();
+
+        if (timeProvider is Mock<TimeProvider> fakeTimeProvider)
+        {
+            fakeTimeProvider
+                .Verify(v => v.CancelAfter(It.IsAny<CancellationTokenSource>(), It.IsAny<TimeSpan>()), Times.Never());
+        }
+    }
+
+    private static TimeProvider GetTimeProvider(object timeProvider) => timeProvider switch
+    {
+        Mock<TimeProvider> m => m.Object,
+        _ => (TimeProvider)timeProvider
+    };
 }

--- a/src/Polly.Core.Tests/Utils/CancellationTokenSourcePoolTests.cs
+++ b/src/Polly.Core.Tests/Utils/CancellationTokenSourcePoolTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using Moq;
 using Polly.Core.Tests.Helpers;
@@ -12,6 +13,17 @@ public class CancellationTokenSourcePoolTests
     {
         yield return new object[] { TimeProvider.System };
         yield return new object[] { new FakeTimeProvider() };
+    }
+
+    [Fact]
+    public void ArgValidation_Ok()
+    {
+        var pool = CancellationTokenSourcePool.Create(TimeProvider.System);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => pool.Get(TimeSpan.Zero));
+        Assert.Throws<ArgumentOutOfRangeException>(() => pool.Get(TimeSpan.FromMilliseconds(-2)));
+
+        pool.Get(System.Threading.Timeout.InfiniteTimeSpan).Should().NotBeNull();
     }
 
     [MemberData(nameof(TimeProviders))]

--- a/src/Polly.Core.Tests/Utils/CancellationTokenSourcePoolTests.cs
+++ b/src/Polly.Core.Tests/Utils/CancellationTokenSourcePoolTests.cs
@@ -21,7 +21,9 @@ public class CancellationTokenSourcePoolTests
         var pool = CancellationTokenSourcePool.Create(TimeProvider.System);
 
         Assert.Throws<ArgumentOutOfRangeException>(() => pool.Get(TimeSpan.Zero));
-        Assert.Throws<ArgumentOutOfRangeException>(() => pool.Get(TimeSpan.FromMilliseconds(-2)));
+        var e = Assert.Throws<ArgumentOutOfRangeException>(() => pool.Get(TimeSpan.FromMilliseconds(-2)));
+        e.Message.Should().StartWith("Invalid delay specified.");
+        e.ActualValue.Should().Be(TimeSpan.FromMilliseconds(-2));
 
         pool.Get(System.Threading.Timeout.InfiniteTimeSpan).Should().NotBeNull();
     }

--- a/src/Polly.Core/Hedging/Controller/HedgingController.cs
+++ b/src/Polly.Core/Hedging/Controller/HedgingController.cs
@@ -12,10 +12,13 @@ internal sealed class HedgingController
 
     public HedgingController(TimeProvider provider, HedgingHandler.Handler handler, int maxAttempts)
     {
+        // retrieve the cancellation pool for this time provider
+        var pool = CancellationTokenSourcePool.Create(provider);
+
         _executionPool = new ObjectPool<TaskExecution>(() =>
         {
             Interlocked.Increment(ref _rentedExecutions);
-            return new TaskExecution(handler);
+            return new TaskExecution(handler, pool);
         },
         _ =>
         {

--- a/src/Polly.Core/Utils/CancellationTokenSourcePool.Disposable.cs
+++ b/src/Polly.Core/Utils/CancellationTokenSourcePool.Disposable.cs
@@ -8,7 +8,7 @@ internal abstract partial class CancellationTokenSourcePool
 
         public DisposableCancellationTokenSourcePool(TimeProvider timeProvider) => _timeProvider = timeProvider;
 
-        public override CancellationTokenSource Get(TimeSpan delay)
+        protected override CancellationTokenSource GetCore(TimeSpan delay)
         {
             var source = new CancellationTokenSource();
 

--- a/src/Polly.Core/Utils/CancellationTokenSourcePool.Disposable.cs
+++ b/src/Polly.Core/Utils/CancellationTokenSourcePool.Disposable.cs
@@ -1,0 +1,25 @@
+namespace Polly.Utils;
+
+internal abstract partial class CancellationTokenSourcePool
+{
+    private sealed class DisposableCancellationTokenSourcePool : CancellationTokenSourcePool
+    {
+        private readonly TimeProvider _timeProvider;
+
+        public DisposableCancellationTokenSourcePool(TimeProvider timeProvider) => _timeProvider = timeProvider;
+
+        public override CancellationTokenSource Get(TimeSpan delay)
+        {
+            var source = new CancellationTokenSource();
+
+            if (IsCancellable(delay))
+            {
+                _timeProvider.CancelAfter(source, delay);
+            }
+
+            return source;
+        }
+
+        public override void Return(CancellationTokenSource source) => source.Dispose();
+    }
+}

--- a/src/Polly.Core/Utils/CancellationTokenSourcePool.Pooled.cs
+++ b/src/Polly.Core/Utils/CancellationTokenSourcePool.Pooled.cs
@@ -1,0 +1,42 @@
+namespace Polly.Utils;
+
+internal abstract partial class CancellationTokenSourcePool
+{
+#if NET6_0_OR_GREATER
+    private sealed class PooledCancellationTokenSourcePool : CancellationTokenSourcePool
+    {
+        public static readonly PooledCancellationTokenSourcePool SystemInstance = new(TimeProvider.System);
+
+        public PooledCancellationTokenSourcePool(TimeProvider timeProvider) => _timeProvider = timeProvider;
+
+        private readonly ObjectPool<CancellationTokenSource> _pool = new(
+            static () => new CancellationTokenSource(),
+            static cts => true);
+        private readonly TimeProvider _timeProvider;
+
+        public override CancellationTokenSource Get(TimeSpan delay)
+        {
+            var source = _pool.Get();
+
+            if (IsCancellable(delay))
+            {
+                _timeProvider.CancelAfter(source, delay);
+            }
+
+            return source;
+        }
+
+        public override void Return(CancellationTokenSource source)
+        {
+            if (source.TryReset())
+            {
+                _pool.Return(source);
+            }
+            else
+            {
+                source.Dispose();
+            }
+        }
+    }
+#endif
+}

--- a/src/Polly.Core/Utils/CancellationTokenSourcePool.Pooled.cs
+++ b/src/Polly.Core/Utils/CancellationTokenSourcePool.Pooled.cs
@@ -14,7 +14,7 @@ internal abstract partial class CancellationTokenSourcePool
             static cts => true);
         private readonly TimeProvider _timeProvider;
 
-        public override CancellationTokenSource Get(TimeSpan delay)
+        protected override CancellationTokenSource GetCore(TimeSpan delay)
         {
             var source = _pool.Get();
 

--- a/src/Polly.Core/Utils/CancellationTokenSourcePool.cs
+++ b/src/Polly.Core/Utils/CancellationTokenSourcePool.cs
@@ -1,31 +1,23 @@
-namespace Polly.Utils
+namespace Polly.Utils;
+
+#pragma warning disable CA1716 // Identifiers should not match keywords
+
+internal abstract partial class CancellationTokenSourcePool
 {
-    internal static class CancellationTokenSourcePool
+    public static CancellationTokenSourcePool Create(TimeProvider timeProvider)
     {
 #if NET6_0_OR_GREATER
-        private static readonly ObjectPool<CancellationTokenSource> Pool = new(
-            static () => new CancellationTokenSource(),
-            static cts => true);
-#endif
-        public static CancellationTokenSource Get()
+        if (timeProvider == TimeProvider.System)
         {
-#if NET6_0_OR_GREATER
-            return Pool.Get();
-#else
-            return new CancellationTokenSource();
-#endif
+            return PooledCancellationTokenSourcePool.SystemInstance;
         }
-
-        public static void Return(CancellationTokenSource source)
-        {
-#if NET6_0_OR_GREATER
-            if (source.TryReset())
-            {
-                Pool.Return(source);
-                return;
-            }
 #endif
-            source.Dispose();
-        }
+        return new DisposableCancellationTokenSourcePool(timeProvider);
     }
+
+    public abstract CancellationTokenSource Get(TimeSpan delay);
+
+    public abstract void Return(CancellationTokenSource source);
+
+    protected static bool IsCancellable(TimeSpan delay) => delay > TimeSpan.Zero;
 }

--- a/src/Polly.Core/Utils/CancellationTokenSourcePool.cs
+++ b/src/Polly.Core/Utils/CancellationTokenSourcePool.cs
@@ -15,9 +15,19 @@ internal abstract partial class CancellationTokenSourcePool
         return new DisposableCancellationTokenSourcePool(timeProvider);
     }
 
-    public abstract CancellationTokenSource Get(TimeSpan delay);
+    public CancellationTokenSource Get(TimeSpan delay)
+    {
+        if (delay <= TimeSpan.Zero && delay != System.Threading.Timeout.InfiniteTimeSpan)
+        {
+            throw new ArgumentOutOfRangeException(nameof(delay), "Invalid delay specified.");
+        }
+
+        return GetCore(delay);
+    }
+
+    protected abstract CancellationTokenSource GetCore(TimeSpan delay);
 
     public abstract void Return(CancellationTokenSource source);
 
-    protected static bool IsCancellable(TimeSpan delay) => delay > TimeSpan.Zero;
+    protected static bool IsCancellable(TimeSpan delay) => delay != System.Threading.Timeout.InfiniteTimeSpan;
 }

--- a/src/Polly.Core/Utils/CancellationTokenSourcePool.cs
+++ b/src/Polly.Core/Utils/CancellationTokenSourcePool.cs
@@ -19,7 +19,7 @@ internal abstract partial class CancellationTokenSourcePool
     {
         if (delay <= TimeSpan.Zero && delay != System.Threading.Timeout.InfiniteTimeSpan)
         {
-            throw new ArgumentOutOfRangeException(nameof(delay), "Invalid delay specified.");
+            throw new ArgumentOutOfRangeException(nameof(delay), delay, "Invalid delay specified.");
         }
 
         return GetCore(delay);


### PR DESCRIPTION
### Details on the issue fix or feature implementation

This PR changes the way the `CancellationTokenSourcePool` works to allign better with the .NET 8 `TimeProvider`.

Unblock further work on #1144


### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
