### PR TITLE
[Proposal] Use delegates instead of callback API

### DIFF
--- a/src/Polly.Core.Benchmarks/Internals/Helper.CircuitBreaker.cs
+++ b/src/Polly.Core.Benchmarks/Internals/Helper.CircuitBreaker.cs
@@ -13,8 +13,8 @@ internal static partial class Helper
         {
             PollyVersion.V7 =>
                 Policy
-                    .HandleResult(10)
-                    .Or<InvalidOperationException>()
+                    .HandleResult<HttpResponseMessage>(m => !m.IsSuccessStatusCode)
+                    .Or<HttpRequestException>()
                     .AdvancedCircuitBreakerAsync(0.5, TimeSpan.FromSeconds(30), 10, TimeSpan.FromSeconds(5)),
 
             PollyVersion.V8 => CreateStrategy(builder =>

--- a/src/Polly.Core.Benchmarks/Internals/Helper.Pipeline.cs
+++ b/src/Polly.Core.Benchmarks/Internals/Helper.Pipeline.cs
@@ -24,7 +24,12 @@ internal static partial class Helper
                 })
                 .AddTimeout(TimeSpan.FromSeconds(10))
                 .AddRetry(
-                    predicate => predicate.HandleException<InvalidOperationException>().HandleResult(10),
+                    (outcome, _) => outcome switch
+                    {
+                        (int result, _) when result == 10 => true,
+                        (_, InvalidOperationException) => true,
+                        _ => false
+                    },
                     RetryBackoffType.Constant,
                     3,
                     TimeSpan.FromSeconds(1))

--- a/src/Polly.Core.Benchmarks/Internals/Helper.cs
+++ b/src/Polly.Core.Benchmarks/Internals/Helper.cs
@@ -4,15 +4,17 @@ namespace Polly.Core.Benchmarks;
 
 internal static partial class Helper
 {
+    private static readonly HttpResponseMessage ResponseMessage = new();
+
     public static async ValueTask ExecuteAsync(this object obj, PollyVersion version)
     {
         switch (version)
         {
             case PollyVersion.V7:
-                await ((IAsyncPolicy<int>)obj).ExecuteAsync(static _ => Task.FromResult(999), CancellationToken.None).ConfigureAwait(false);
+                await ((IAsyncPolicy<HttpResponseMessage>)obj).ExecuteAsync(static _ => Task.FromResult(ResponseMessage), CancellationToken.None).ConfigureAwait(false);
                 return;
             case PollyVersion.V8:
-                await ((ResilienceStrategy)obj).ExecuteAsync(static _ => new ValueTask<int>(999), CancellationToken.None).ConfigureAwait(false);
+                await ((ResilienceStrategy)obj).ExecuteAsync(static _ => new ValueTask<HttpResponseMessage>(ResponseMessage), CancellationToken.None).ConfigureAwait(false);
                 return;
         }
 

--- a/src/Polly.Core.Benchmarks/README.md
+++ b/src/Polly.Core.Benchmarks/README.md
@@ -12,60 +12,60 @@ LaunchCount=2  WarmupCount=10
 
 ## PIPELINES
 
-|             Method | Components |        Mean |     Error |     StdDev |      Median | Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
-|------------------- |----------- |------------:|----------:|-----------:|------------:|------:|--------:|-------:|----------:|------------:|
-| ExecutePipeline_V7 |          1 |    74.78 ns |  1.555 ns |   2.279 ns |    75.63 ns |  1.00 |    0.00 | 0.0362 |     304 B |        1.00 |
-| ExecutePipeline_V8 |          1 |    85.69 ns |  0.500 ns |   0.732 ns |    85.36 ns |  1.15 |    0.04 |      - |         - |        0.00 |
-|                    |            |             |           |            |             |       |         |        |           |             |
-| ExecutePipeline_V7 |          2 |   165.37 ns |  1.157 ns |   1.732 ns |   165.59 ns |  1.00 |    0.00 | 0.0658 |     552 B |        1.00 |
-| ExecutePipeline_V8 |          2 |   119.10 ns |  0.653 ns |   0.915 ns |   119.63 ns |  0.72 |    0.01 |      - |         - |        0.00 |
-|                    |            |             |           |            |             |       |         |        |           |             |
-| ExecutePipeline_V7 |          5 |   533.97 ns |  7.327 ns |  10.967 ns |   536.79 ns |  1.00 |    0.00 | 0.1545 |    1296 B |        1.00 |
-| ExecutePipeline_V8 |          5 |   227.69 ns |  1.236 ns |   1.812 ns |   227.72 ns |  0.43 |    0.01 |      - |         - |        0.00 |
-|                    |            |             |           |            |             |       |         |        |           |             |
-| ExecutePipeline_V7 |         10 | 1,191.41 ns | 35.512 ns |  53.152 ns | 1,192.79 ns |  1.00 |    0.00 | 0.3014 |    2536 B |        1.00 |
-| ExecutePipeline_V8 |         10 |   557.95 ns | 76.434 ns | 112.036 ns |   505.58 ns |  0.47 |    0.09 |      - |         - |        0.00 |
+|             Method | Components |        Mean |     Error |    StdDev | Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
+|------------------- |----------- |------------:|----------:|----------:|------:|--------:|-------:|----------:|------------:|
+| ExecutePipeline_V7 |          1 |    91.11 ns |  0.628 ns |  0.939 ns |  1.00 |    0.00 | 0.0120 |     304 B |        1.00 |
+| ExecutePipeline_V8 |          1 |   158.94 ns |  0.914 ns |  1.311 ns |  1.75 |    0.02 |      - |         - |        0.00 |
+|                    |            |             |           |           |       |         |        |           |             |
+| ExecutePipeline_V7 |          2 |   180.26 ns |  1.257 ns |  1.881 ns |  1.00 |    0.00 | 0.0219 |     552 B |        1.00 |
+| ExecutePipeline_V8 |          2 |   311.17 ns |  1.193 ns |  1.748 ns |  1.73 |    0.02 |      - |         - |        0.00 |
+|                    |            |             |           |           |       |         |        |           |             |
+| ExecutePipeline_V7 |          5 |   644.61 ns |  6.817 ns | 10.203 ns |  1.00 |    0.00 | 0.0515 |    1296 B |        1.00 |
+| ExecutePipeline_V8 |          5 |   639.76 ns |  2.951 ns |  4.233 ns |  0.99 |    0.02 |      - |         - |        0.00 |
+|                    |            |             |           |           |       |         |        |           |             |
+| ExecutePipeline_V7 |         10 | 1,392.30 ns | 15.508 ns | 21.741 ns |  1.00 |    0.00 | 0.0992 |    2536 B |        1.00 |
+| ExecutePipeline_V8 |         10 | 1,144.47 ns |  6.144 ns |  9.005 ns |  0.82 |    0.02 |      - |         - |        0.00 |
 
 ## TIMEOUT
 
-|            Method |     Mean |   Error |   StdDev | Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
-|------------------ |---------:|--------:|---------:|------:|--------:|-------:|----------:|------------:|
-| ExecuteTimeout_V7 | 304.9 ns | 7.53 ns | 11.27 ns |  1.00 |    0.00 | 0.0868 |     728 B |        1.00 |
-| ExecuteTimeout_V8 | 266.5 ns | 5.95 ns |  8.72 ns |  0.88 |    0.04 |      - |         - |        0.00 |
+|            Method |     Mean |   Error |  StdDev | Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
+|------------------ |---------:|--------:|--------:|------:|--------:|-------:|----------:|------------:|
+| ExecuteTimeout_V7 | 332.3 ns | 6.37 ns | 9.34 ns |  1.00 |    0.00 | 0.0286 |     728 B |        1.00 |
+| ExecuteTimeout_V8 | 368.1 ns | 4.70 ns | 7.03 ns |  1.11 |    0.04 |      - |         - |        0.00 |
 
 ## RETRY
 
-|          Method |     Mean |   Error |  StdDev | Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
-|---------------- |---------:|--------:|--------:|------:|--------:|-------:|----------:|------------:|
-| ExecuteRetry_V7 | 169.8 ns | 4.98 ns | 6.98 ns |  1.00 |    0.00 | 0.0687 |     576 B |        1.00 |
-| ExecuteRetry_V8 | 144.9 ns | 2.35 ns | 3.52 ns |  0.85 |    0.04 |      - |         - |        0.00 |
+|          Method |     Mean |   Error |  StdDev | Ratio |   Gen0 | Allocated | Alloc Ratio |
+|---------------- |---------:|--------:|--------:|------:|-------:|----------:|------------:|
+| ExecuteRetry_V7 | 192.6 ns | 1.55 ns | 2.22 ns |  1.00 | 0.0229 |     576 B |        1.00 |
+| ExecuteRetry_V8 | 232.8 ns | 0.66 ns | 0.91 ns |  1.21 |      - |         - |        0.00 |
 
 ## RATE LIMITER
 
-|                Method |     Mean |    Error |   StdDev | Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
-|---------------------- |---------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
-| ExecuteRateLimiter_V7 | 190.8 ns | 10.01 ns | 14.98 ns |  1.00 |    0.00 | 0.0448 |     376 B |        1.00 |
-| ExecuteRateLimiter_V8 | 199.6 ns |  2.54 ns |  3.64 ns |  1.05 |    0.09 | 0.0048 |      40 B |        0.11 |
+|                Method |     Mean |   Error |  StdDev | Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
+|---------------------- |---------:|--------:|--------:|------:|--------:|-------:|----------:|------------:|
+| ExecuteRateLimiter_V7 | 195.1 ns | 1.16 ns | 1.69 ns |  1.00 |    0.00 | 0.0148 |     376 B |        1.00 |
+| ExecuteRateLimiter_V8 | 308.6 ns | 3.92 ns | 5.74 ns |  1.58 |    0.03 | 0.0014 |      40 B |        0.11 |
 
 ## CIRCUIT BREAKER
 
 |                   Method |     Mean |   Error |  StdDev | Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
 |------------------------- |---------:|--------:|--------:|------:|--------:|-------:|----------:|------------:|
-| ExecuteCircuitBreaker_V7 | 198.4 ns | 2.78 ns | 3.99 ns |  1.00 |    0.00 | 0.0629 |     528 B |        1.00 |
-| ExecuteCircuitBreaker_V8 | 297.9 ns | 2.63 ns | 3.77 ns |  1.50 |    0.04 | 0.0038 |      32 B |        0.06 |
+| ExecuteCircuitBreaker_V7 | 257.2 ns | 3.45 ns | 5.16 ns |  1.00 |    0.00 | 0.0210 |     528 B |        1.00 |
+| ExecuteCircuitBreaker_V8 | 422.4 ns | 2.16 ns | 3.09 ns |  1.64 |    0.03 | 0.0010 |      32 B |        0.06 |
 
 ## STRATEGY PIPELINE (RATE LIMITER + TIMEOUT + RETRY + TIMEOUT + CIRCUIT BREAKER)
 
 |                     Method |     Mean |     Error |    StdDev | Ratio |   Gen0 | Allocated | Alloc Ratio |
 |--------------------------- |---------:|----------:|----------:|------:|-------:|----------:|------------:|
-| ExecuteStrategyPipeline_V7 | 1.523 us | 0.0092 us | 0.0137 us |  1.00 | 0.3433 |    2872 B |        1.00 |
-| ExecuteStrategyPipeline_V8 | 1.276 us | 0.0128 us | 0.0191 us |  0.84 | 0.0114 |      96 B |        0.03 |
+| ExecuteStrategyPipeline_V7 | 1.890 us | 0.0062 us | 0.0093 us |  1.00 | 0.1144 |    2872 B |        1.00 |
+| ExecuteStrategyPipeline_V8 | 1.989 us | 0.0067 us | 0.0096 us |  1.05 | 0.0038 |      96 B |        0.03 |
 
 ## HEDGING
 
-|                      Method |       Mean |     Error |    StdDev | Ratio | RatioSD |   Gen0 |   Gen1 | Allocated | Alloc Ratio |
-|---------------------------- |-----------:|----------:|----------:|------:|--------:|-------:|-------:|----------:|------------:|
-|             Hedging_Primary |   891.3 ns |  39.39 ns |  58.96 ns |  1.00 |    0.00 | 0.0048 |      - |      40 B |        1.00 |
-|           Hedging_Secondary | 1,500.0 ns |   7.88 ns |  11.80 ns |  1.69 |    0.11 | 0.0229 |      - |     200 B |        5.00 |
-|   Hedging_Primary_AsyncWork | 4,250.9 ns | 140.89 ns | 206.52 ns |  4.78 |    0.34 | 0.1831 | 0.0305 |    1518 B |       37.95 |
-| Hedging_Secondary_AsyncWork | 6,544.9 ns |  99.90 ns | 143.27 ns |  7.34 |    0.39 | 0.2213 | 0.0839 |    1872 B |       46.80 |
+|                      Method |     Mean |     Error |    StdDev | Ratio | RatioSD |   Gen0 |   Gen1 | Allocated | Alloc Ratio |
+|---------------------------- |---------:|----------:|----------:|------:|--------:|-------:|-------:|----------:|------------:|
+|             Hedging_Primary | 1.182 us | 0.0203 us | 0.0297 us |  1.00 |    0.00 | 0.0019 |      - |      80 B |        1.00 |
+|           Hedging_Secondary | 2.071 us | 0.0214 us | 0.0321 us |  1.75 |    0.05 | 0.0076 |      - |     280 B |        3.50 |
+|   Hedging_Primary_AsyncWork | 5.843 us | 0.1018 us | 0.1460 us |  4.96 |    0.20 | 0.0687 | 0.0229 |    1778 B |       22.23 |
+| Hedging_Secondary_AsyncWork | 8.526 us | 0.2354 us | 0.3376 us |  7.23 |    0.34 | 0.0763 | 0.0381 |    2025 B |       25.31 |

--- a/src/Polly.Core.Tests/Retry/RetryResilienceStrategyTests.cs
+++ b/src/Polly.Core.Tests/Retry/RetryResilienceStrategyTests.cs
@@ -18,7 +18,7 @@ public class RetryResilienceStrategyTests
     public void ShouldRetryEmpty_Skipped()
     {
         bool called = false;
-        _options.OnRetry.Register<int>(() => called = true);
+        _options.OnRetry = (_, _) => { called = true; return default; };
         SetupNoDelay();
         var sut = CreateSut();
 
@@ -44,7 +44,11 @@ public class RetryResilienceStrategyTests
         _options.RetryCount = 5;
         SetupNoDelay();
         _timeProvider.SetupAnyDelay();
-        _options.ShouldRetry.HandleResult<DisposableResult>(_ => true);
+        _options.ShouldRetry = (o, _) => o.Result switch
+        {
+            DisposableResult => PredicateResult.True,
+            _ => PredicateResult.False
+        };
         var results = new List<DisposableResult>();
         var sut = CreateSut();
 

--- a/src/Polly.Core/Retry/RetryResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/Retry/RetryResilienceStrategyBuilderExtensions.cs
@@ -13,81 +13,82 @@ public static class RetryResilienceStrategyBuilderExtensions
     /// <summary>
     /// Adds a retry strategy to the builder.
     /// </summary>
+    /// <typeparam name="TResult">The type of result the retry strategy handles.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="shouldRetry">A predicate that defines the retry conditions.</param>
     /// <returns>The builder instance with the retry strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="shouldRetry"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when the options constructed from the arguments are invalid.</exception>
-    public static ResilienceStrategyBuilder AddRetry(
+    public static ResilienceStrategyBuilder AddRetry<TResult>(
         this ResilienceStrategyBuilder builder,
-        Action<OutcomePredicate<ShouldRetryArguments>> shouldRetry)
+        Func<Outcome<TResult>, bool> shouldRetry)
     {
         Guard.NotNull(builder);
         Guard.NotNull(shouldRetry);
 
-        var options = new RetryStrategyOptions();
-        shouldRetry(options.ShouldRetry);
-
-        return builder.AddRetry(options);
+        return builder.AddRetry(new RetryStrategyOptions<TResult>
+        {
+            ShouldRetry = (o, _) => new ValueTask<bool>(shouldRetry(o))
+        });
     }
 
     /// <summary>
     /// Adds a retry strategy to the builder.
     /// </summary>
+    /// <typeparam name="TResult">The type of result the retry strategy handles.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="shouldRetry">A predicate that defines the retry conditions.</param>
     /// <param name="retryDelayGenerator">The generator for retry delays. The argument is zero-based attempt number.</param>
     /// <returns>The builder instance with the retry strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/>, <paramref name="shouldRetry"/> or <paramref name="retryDelayGenerator"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when the options constructed from the arguments are invalid.</exception>
-    public static ResilienceStrategyBuilder AddRetry(
+    public static ResilienceStrategyBuilder AddRetry<TResult>(
         this ResilienceStrategyBuilder builder,
-        Action<OutcomePredicate<ShouldRetryArguments>> shouldRetry,
+        Func<Outcome, bool> shouldRetry,
         Func<int, TimeSpan> retryDelayGenerator)
     {
         Guard.NotNull(builder);
         Guard.NotNull(shouldRetry);
         Guard.NotNull(retryDelayGenerator);
 
-        var options = new RetryStrategyOptions();
-        shouldRetry(options.ShouldRetry);
-        options.RetryDelayGenerator.SetGenerator((_, args) => retryDelayGenerator(args.Attempt));
-
-        return builder.AddRetry(options);
+        return builder.AddRetry(new RetryStrategyOptions
+        {
+            ShouldRetry = (o, _) => new ValueTask<bool>(shouldRetry(o)),
+            RetryDelayGenerator = (_, args) => new ValueTask<TimeSpan>(retryDelayGenerator(args.Attempt))
+        });
     }
 
     /// <summary>
     /// Adds a retry strategy to the builder.
     /// </summary>
+    /// <typeparam name="TResult">The type of result the retry strategy handles.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="shouldRetry">A predicate that defines the retry conditions.</param>
     /// <param name="backoffType">The backoff type to use for the retry strategy.</param>
     /// <returns>The builder instance with the retry strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="shouldRetry"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when the options constructed from the arguments are invalid.</exception>
-    public static ResilienceStrategyBuilder AddRetry(
+    public static ResilienceStrategyBuilder AddRetry<TResult>(
         this ResilienceStrategyBuilder builder,
-        Action<OutcomePredicate<ShouldRetryArguments>> shouldRetry,
+        Func<Outcome<TResult>, bool> shouldRetry,
         RetryBackoffType backoffType)
     {
         Guard.NotNull(builder);
         Guard.NotNull(shouldRetry);
 
-        var options = new RetryStrategyOptions
+        return builder.AddRetry(new RetryStrategyOptions<TResult>
         {
             BackoffType = backoffType,
             RetryCount = RetryConstants.DefaultRetryCount,
-            BaseDelay = RetryConstants.DefaultBaseDelay
-        };
-
-        shouldRetry(options.ShouldRetry);
-
-        return builder.AddRetry(options);
+            BaseDelay = RetryConstants.DefaultBaseDelay,
+            ShouldRetry = (o, _) => new ValueTask<bool>(shouldRetry(o))
+        });
     }
 
     /// <summary>
     /// Adds a retry strategy to the builder.
     /// </summary>
+    /// <typeparam name="TResult">The type of result the retry strategy handles.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="shouldRetry">A predicate that defines the retry conditions.</param>
     /// <param name="backoffType">The backoff type to use for the retry strategy.</param>
@@ -96,9 +97,9 @@ public static class RetryResilienceStrategyBuilderExtensions
     /// <returns>The builder instance with the retry strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="shouldRetry"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when the options constructed from the arguments are invalid.</exception>
-    public static ResilienceStrategyBuilder AddRetry(
+    public static ResilienceStrategyBuilder AddRetry<TResult>(
         this ResilienceStrategyBuilder builder,
-        Action<OutcomePredicate<ShouldRetryArguments>> shouldRetry,
+        Func<Outcome<TResult>, bool> shouldRetry,
         RetryBackoffType backoffType,
         int retryCount,
         TimeSpan baseDelay)
@@ -106,16 +107,13 @@ public static class RetryResilienceStrategyBuilderExtensions
         Guard.NotNull(builder);
         Guard.NotNull(shouldRetry);
 
-        var options = new RetryStrategyOptions
+        return builder.AddRetry(new RetryStrategyOptions<TResult>
         {
             BackoffType = backoffType,
             RetryCount = retryCount,
-            BaseDelay = baseDelay
-        };
-
-        shouldRetry(options.ShouldRetry);
-
-        return builder.AddRetry(options);
+            BaseDelay = baseDelay,
+            ShouldRetry = (o, _) => new ValueTask<bool>(shouldRetry(o))
+        });
     }
 
     /// <summary>

--- a/src/Polly.Core/Retry/RetryStrategyOptions.TResult.cs
+++ b/src/Polly.Core/Retry/RetryStrategyOptions.TResult.cs
@@ -64,7 +64,7 @@ public class RetryStrategyOptions<TResult> : ResilienceStrategyOptions
     /// By default, the predicate is empty and no results or exceptions are retried.
     /// </remarks>
     [Required]
-    public OutcomePredicate<ShouldRetryArguments, TResult> ShouldRetry { get; set; } = new();
+    public Func<Outcome<TResult>, ShouldRetryArguments, ValueTask<bool>>? ShouldRetry { get; set; }
 
     /// <summary>
     /// Gets or sets the generator instance that is used to calculate the time between retries.
@@ -72,8 +72,7 @@ public class RetryStrategyOptions<TResult> : ResilienceStrategyOptions
     /// <remarks>
     /// By default, the generator is empty and it does not affect the delay between retries.
     /// </remarks>
-    [Required]
-    public OutcomeGenerator<RetryDelayArguments, TimeSpan, TResult> RetryDelayGenerator { get; set; } = new();
+    public Func<Outcome<TResult>, RetryDelayArguments, ValueTask<TimeSpan>>? RetryDelayGenerator { get; set; }
 
     /// <summary>
     /// Gets or sets an outcome event that is used to register on-retry callbacks.
@@ -86,21 +85,46 @@ public class RetryStrategyOptions<TResult> : ResilienceStrategyOptions
     /// from the result within the event.
     /// </para>
     /// </remarks>
-    [Required]
-    public OutcomeEvent<OnRetryArguments, TResult> OnRetry { get; set; } = new();
+    public Func<Outcome<TResult>, OnRetryArguments, ValueTask>? OnRetry { get; set; }
 
     internal RetryStrategyOptions AsNonGenericOptions()
     {
-        return new RetryStrategyOptions
+        var options = new RetryStrategyOptions
         {
             BackoffType = BackoffType,
             BaseDelay = BaseDelay,
             RetryCount = RetryCount,
-            OnRetry = new OutcomeEvent<OnRetryArguments>().SetCallbacks(OnRetry),
-            RetryDelayGenerator = new OutcomeGenerator<RetryDelayArguments, TimeSpan>().SetGenerator(RetryDelayGenerator),
-            ShouldRetry = new OutcomePredicate<ShouldRetryArguments>().SetPredicates(ShouldRetry),
             StrategyName = StrategyName,
             StrategyType = StrategyType
         };
+
+        if (ShouldRetry is var shouldRetry)
+        {
+            options.ShouldRetry = (outcome, args) =>
+            {
+                if (args.Context.ResultType != typeof(TResult))
+                {
+                    return PredicateResult.False;
+                }
+
+                return shouldRetry!(outcome.AsOutcome<TResult>(), args);
+            };
+        }
+
+        if (OnRetry is var onRetry)
+        {
+            // no need to do type-check again because result will be retried so the type check was
+            // already done in ShouldRetry
+            options.OnRetry = (outcome, args) => onRetry!(outcome.AsOutcome<TResult>(), args);
+        }
+
+        if (RetryDelayGenerator is var generator)
+        {
+            // no need to do type-check again because result will be retried so the type check was
+            // already done in ShouldRetry
+            options.RetryDelayGenerator = (outcome, args) => generator!(outcome.AsOutcome<TResult>(), args);
+        }
+
+        return options;
     }
 }

--- a/src/Polly.Core/Retry/RetryStrategyOptions.cs
+++ b/src/Polly.Core/Retry/RetryStrategyOptions.cs
@@ -68,7 +68,7 @@ public class RetryStrategyOptions : ResilienceStrategyOptions
     /// By default, the predicate is empty and no results or exceptions are retried.
     /// </remarks>
     [Required]
-    public OutcomePredicate<ShouldRetryArguments> ShouldRetry { get; set; } = new();
+    public Func<Outcome, ShouldRetryArguments, ValueTask<bool>>? ShouldRetry { get; set; }
 
     /// <summary>
     /// Gets or sets the generator instance that is used to calculate the time between retries.
@@ -76,8 +76,7 @@ public class RetryStrategyOptions : ResilienceStrategyOptions
     /// <remarks>
     /// By default, the generator is empty and it does not affect the delay between retries.
     /// </remarks>
-    [Required]
-    public OutcomeGenerator<RetryDelayArguments, TimeSpan> RetryDelayGenerator { get; set; } = new();
+    public Func<Outcome, RetryDelayArguments, ValueTask<TimeSpan>>? RetryDelayGenerator { get; set; }
 
     /// <summary>
     /// Gets or sets an outcome event that is used to register on-retry callbacks.
@@ -90,6 +89,5 @@ public class RetryStrategyOptions : ResilienceStrategyOptions
     /// from the result within the event.
     /// </para>
     /// </remarks>
-    [Required]
-    public OutcomeEvent<OnRetryArguments> OnRetry { get; set; } = new();
+    public Func<Outcome, OnRetryArguments, ValueTask>? OnRetry { get; set; }
 }

--- a/src/Polly.Core/Strategy/Outcome.TResult.cs
+++ b/src/Polly.Core/Strategy/Outcome.TResult.cs
@@ -24,6 +24,17 @@ public readonly struct Outcome<TResult>
         : this() => Result = result;
 
     /// <summary>
+    /// The object de-constructor.
+    /// </summary>
+    /// <param name="result">The outcome result, if any.</param>
+    /// <param name="exception">The outcome exception, if any.</param>
+    public void Deconstruct(out TResult? result, out Exception? exception)
+    {
+        exception = Exception;
+        result = Result;
+    }
+
+    /// <summary>
     /// Gets the exception that occurred during the operation, if any.
     /// </summary>
     public Exception? Exception { get; }

--- a/src/Polly.Core/Strategy/Outcome.cs
+++ b/src/Polly.Core/Strategy/Outcome.cs
@@ -23,6 +23,17 @@ public readonly struct Outcome
         : this() => Result = result;
 
     /// <summary>
+    /// The object de-constructor.
+    /// </summary>
+    /// <param name="result">The outcome result, if any.</param>
+    /// <param name="exception">The outcome exception, if any.</param>
+    public void Deconstruct(out object? result, out Exception? exception)
+    {
+        exception = Exception;
+        result = Result;
+    }
+
+    /// <summary>
     /// Gets the exception that occurred during the operation, if any.
     /// </summary>
     public Exception? Exception { get; }

--- a/src/Polly.Core/Strategy/PredicateResult.cs
+++ b/src/Polly.Core/Strategy/PredicateResult.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+
+namespace Polly.Strategy;
+
+/// <summary>
+/// Class that represents the results that can be used in predicates.
+/// </summary>
+public static class PredicateResult
+{
+    /// <summary>
+    /// Gets a finished <see cref="ValueTask{TResult}"/> that returns <see langword="false"/> value.
+    /// </summary>
+    public static ValueTask<bool> True => new(true);
+
+    /// <summary>
+    /// Gets a finished <see cref="ValueTask{TResult}"/> that returns <see langword="true"/> value.
+    /// </summary>
+    public static ValueTask<bool> False => new(false);
+}


### PR DESCRIPTION
### Details on the issue fix or feature implementation

Going through the code together internally we are investigating the possibility of replacing the Callback API with simple delegates. 

So the syntax for callbacks will be:

Generic:

- Generators: `Func<Outcome<T>, Args, ValueTask<TValue>>`
- Predicates: `Func<Outcome<T>, Args, ValueTask<bool>>`
- Events: `Func<Outcome<T>, Args, ValueTask>`

Non-Generic:

- Generators: `Func<Outcome, Args, ValueTask<TValue>>`
- Predicates: `Func<Outcome, Args, ValueTask<bool>>`
- Events: `Func<Outcome, Args, ValueTask>`

So instead of:

``` csharp
var options = new RetryStrategyOptions();
options.ShouldRetry
   .HandleException<HttpRequestException>()
   .HandleResult<HttpResponseMessage>(response => !response.IsSuccessStatusCode);
```
We can embrace simple delegates with switch expresions:

``` csharp
var options = new RetryStrategyOptions();
options.ShouldRetry = (outcome, args) => outcome switch
{
    { Exception: HttpRequestException error } => PredicateResult.True,
    { Result: HttpResponseMessage response } when !response.IsSuccessStatusCode => PredicateResult.True,
    _ => PredicateResult.False
}
```

Note that `PredicateResult.False` is just a shorthand to `new ValueTask<bool>(false)`.

Upsides:

- We can drop the callback API and save considerable amount of code, meaning it's less maintenance for us in the future.
- Using the native C# features.
- API simplicity, no hidden magic.

Downsides:

- No more fluent API for callbacks. For users used to Polly V7 this is completely new.
- The configuration is not as readable (for some).
- Every delegate returns async `ValueTask` which is not used very often; however, the caller needs to return it.
- No extensibility for delegates. Once we expose the delegate it's fixed. The only extensibility can be done by adding new member to arguments. The customer cannot create convenience extensions for their specific scenarios. 

@martincostello , @joelhulen , @juraj-blazek , @geeknoid 

Your opinions please? Shall we keep the callback API or drop it and replace with simple delegates?

### Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build
