### PR TITLE
Make the ResilienceStrategyOptions abstract

### DIFF
--- a/src/Polly.Core.Benchmarks/Internals/Helper.StrategyPipeline.cs
+++ b/src/Polly.Core.Benchmarks/Internals/Helper.StrategyPipeline.cs
@@ -1,4 +1,5 @@
 using Polly;
+using Polly.Strategy;
 
 namespace Polly.Core.Benchmarks;
 
@@ -12,9 +13,14 @@ internal static partial class Helper
         {
             for (var i = 0; i < count; i++)
             {
-                builder.AddStrategy(new EmptyResilienceStrategy());
+                builder.AddStrategy(new EmptyResilienceStrategy(), new BenchmarkResilienceStrategyOptions());
             }
         }),
         _ => throw new NotSupportedException()
     };
+
+    private class BenchmarkResilienceStrategyOptions : ResilienceStrategyOptions
+    {
+        public override string StrategyType => "Benchmark";
+    }
 }

--- a/src/Polly.Core.Tests/CircuitBreaker/AdvancedCircuitBreakerOptionsTests.cs
+++ b/src/Polly.Core.Tests/CircuitBreaker/AdvancedCircuitBreakerOptionsTests.cs
@@ -71,7 +71,6 @@ public class AdvancedCircuitBreakerOptionsTests
             FailureThreshold = 23,
             SamplingDuration = TimeSpan.FromSeconds(124),
             MinimumThroughput = 6,
-            StrategyType = "dummy-type",
             StrategyName = "dummy-name",
             OnOpened = new OutcomeEvent<OnCircuitOpenedArguments, int>().Register(() => onBreakCalled = true),
             OnClosed = new OutcomeEvent<OnCircuitClosedArguments, int>().Register(() => onResetCalled = true),
@@ -84,7 +83,7 @@ public class AdvancedCircuitBreakerOptionsTests
         var converted = options.AsNonGenericOptions();
 
         // assert converted options
-        converted.StrategyType.Should().Be("dummy-type");
+        converted.StrategyType.Should().Be("CircuitBreaker");
         converted.StrategyName.Should().Be("dummy-name");
         converted.FailureThreshold.Should().Be(23);
         converted.BreakDuration.Should().Be(TimeSpan.FromSeconds(123));

--- a/src/Polly.Core.Tests/CircuitBreaker/SimpleCircuitBreakerOptionsTests.cs
+++ b/src/Polly.Core.Tests/CircuitBreaker/SimpleCircuitBreakerOptionsTests.cs
@@ -61,7 +61,6 @@ public class SimpleCircuitBreakerOptionsTests
         {
             BreakDuration = TimeSpan.FromSeconds(123),
             FailureThreshold = 23,
-            StrategyType = "dummy-type",
             StrategyName = "dummy-name",
             OnOpened = new OutcomeEvent<OnCircuitOpenedArguments, int>().Register(() => onBreakCalled = true),
             OnClosed = new OutcomeEvent<OnCircuitClosedArguments, int>().Register(() => onResetCalled = true),
@@ -74,7 +73,7 @@ public class SimpleCircuitBreakerOptionsTests
         var converted = options.AsNonGenericOptions();
 
         // assert converted options
-        converted.StrategyType.Should().Be("dummy-type");
+        converted.StrategyType.Should().Be("CircuitBreaker");
         converted.StrategyName.Should().Be("dummy-name");
         converted.FailureThreshold.Should().Be(23);
         converted.BreakDuration.Should().Be(TimeSpan.FromSeconds(123));

--- a/src/Polly.Core.Tests/Fallback/FallbackStrategyOptionsTResultTests.cs
+++ b/src/Polly.Core.Tests/Fallback/FallbackStrategyOptionsTResultTests.cs
@@ -51,13 +51,12 @@ public class FallbackStrategyOptionsTResultTests
             ShouldHandle = new OutcomePredicate<HandleFallbackArguments, int>().HandleResult(-1),
             FallbackAction = (_, _) => new ValueTask<int>(1),
             StrategyName = "Dummy",
-            StrategyType = "Dummy-Fallback"
         };
 
         var nonGeneric = options.AsNonGenericOptions();
 
         nonGeneric.Should().NotBeNull();
-        nonGeneric.StrategyType.Should().Be("Dummy-Fallback");
+        nonGeneric.StrategyType.Should().Be("Fallback");
         nonGeneric.StrategyName.Should().Be("Dummy");
         nonGeneric.Handler.IsEmpty.Should().BeFalse();
 

--- a/src/Polly.Core.Tests/Hedging/HedgingStrategyOptionsTResultTests.cs
+++ b/src/Polly.Core.Tests/Hedging/HedgingStrategyOptionsTResultTests.cs
@@ -57,7 +57,6 @@ public class HedgingStrategyOptionsTResultTests
             HedgingDelayGenerator = new NoOutcomeGenerator<HedgingDelayArguments, TimeSpan>().SetGenerator(args => TimeSpan.FromSeconds(123)),
             ShouldHandle = new OutcomePredicate<HandleHedgingArguments, int>().HandleResult(-1),
             StrategyName = "Dummy",
-            StrategyType = "Dummy-Hedging",
             HedgingDelay = TimeSpan.FromSeconds(3),
             MaxHedgedAttempts = 4,
             HedgingActionGenerator = args => () => Task.FromResult(555),
@@ -72,7 +71,7 @@ public class HedgingStrategyOptionsTResultTests
         var nonGeneric = options.AsNonGenericOptions();
 
         nonGeneric.Should().NotBeNull();
-        nonGeneric.StrategyType.Should().Be("Dummy-Hedging");
+        nonGeneric.StrategyType.Should().Be("Hedging");
         nonGeneric.StrategyName.Should().Be("Dummy");
         nonGeneric.Handler.IsEmpty.Should().BeFalse();
         nonGeneric.MaxHedgedAttempts.Should().Be(4);

--- a/src/Polly.Core.Tests/Registry/ResilienceStrategyRegistryTests.cs
+++ b/src/Polly.Core.Tests/Registry/ResilienceStrategyRegistryTests.cs
@@ -42,7 +42,7 @@ public class ResilienceStrategyRegistryTests
     {
         var registry = new ResilienceStrategyRegistry<string>();
 
-        registry.TryAddBuilder("C", (_, b) => b.AddStrategy(new TestResilienceStrategy()));
+        registry.TryAddBuilder("C", (_, b) => b.AddStrategy(new TestResilienceStrategy(), new TestResilienceStrategyOptions()));
 
         registry.TryAdd("A", new TestResilienceStrategy());
         registry.TryAdd("B", new TestResilienceStrategy());
@@ -74,7 +74,7 @@ public class ResilienceStrategyRegistryTests
     public void RemoveBuilder_Ok()
     {
         var registry = new ResilienceStrategyRegistry<string>();
-        registry.TryAddBuilder("A", (_, b) => b.AddStrategy(new TestResilienceStrategy()));
+        registry.TryAddBuilder("A", (_, b) => b.AddStrategy(new TestResilienceStrategy(), new TestResilienceStrategyOptions()));
 
         registry.RemoveBuilder("A").Should().BeTrue();
         registry.RemoveBuilder("A").Should().BeFalse();
@@ -88,7 +88,7 @@ public class ResilienceStrategyRegistryTests
         var builderName = "A";
         var registry = CreateRegistry();
         var strategies = new HashSet<ResilienceStrategy>();
-        registry.TryAddBuilder(StrategyId.Create(builderName), (_, builder) => builder.AddStrategy(new TestResilienceStrategy()));
+        registry.TryAddBuilder(StrategyId.Create(builderName), (_, builder) => builder.AddStrategy(new TestResilienceStrategy(), new TestResilienceStrategyOptions()));
 
         for (int i = 0; i < 100; i++)
         {
@@ -112,7 +112,7 @@ public class ResilienceStrategyRegistryTests
         var called = 0;
         registry.TryAddBuilder(StrategyId.Create("A"), (key, builder) =>
         {
-            builder.AddStrategy(new TestResilienceStrategy());
+            builder.AddStrategy(new TestResilienceStrategy(), new TestResilienceStrategyOptions());
             builder.Properties.Set(StrategyId.ResilienceKey, key);
             called++;
         });
@@ -142,7 +142,7 @@ public class ResilienceStrategyRegistryTests
         var registry = CreateRegistry();
         registry.TryAddBuilder(StrategyId.Create("A"), (_, builder) =>
         {
-            builder.AddStrategy(new TestResilienceStrategy());
+            builder.AddStrategy(new TestResilienceStrategy(), new TestResilienceStrategyOptions());
             builder.BuilderName.Should().Be("A");
             builder.Properties.TryGetValue(TelemetryUtil.StrategyKey, out var val).Should().BeTrue();
             val.Should().Be("Instance1");

--- a/src/Polly.Core.Tests/Retry/RetryStrategyOptionsTResultTests.cs
+++ b/src/Polly.Core.Tests/Retry/RetryStrategyOptionsTResultTests.cs
@@ -12,6 +12,7 @@ public class RetryStrategyOptionsTResultTests
     {
         var options = new RetryStrategyOptions<int>();
 
+        options.StrategyType.Should().Be("Retry");
         options.ShouldRetry.Should().NotBeNull();
         options.ShouldRetry.IsEmpty.Should().BeTrue();
 

--- a/src/Polly.Core.Tests/Retry/RetryStrategyOptionsTResultTests.cs
+++ b/src/Polly.Core.Tests/Retry/RetryStrategyOptionsTResultTests.cs
@@ -63,7 +63,6 @@ public class RetryStrategyOptionsTResultTests
             BaseDelay = TimeSpan.FromMilliseconds(555),
             RetryCount = 7,
             StrategyName = "my-name",
-            StrategyType = "my-type",
         };
 
         options.ShouldRetry.HandleResult(999);
@@ -75,7 +74,7 @@ public class RetryStrategyOptionsTResultTests
         nonGenericOptions.BaseDelay.Should().Be(TimeSpan.FromMilliseconds(555));
         nonGenericOptions.RetryCount.Should().Be(7);
         nonGenericOptions.StrategyName.Should().Be("my-name");
-        nonGenericOptions.StrategyType.Should().Be("my-type");
+        nonGenericOptions.StrategyType.Should().Be("Retry");
 
         var args = new ShouldRetryArguments(ResilienceContext.Get(), 0);
         var delayArgs = new RetryDelayArguments(ResilienceContext.Get(), 2, TimeSpan.FromMinutes(1));

--- a/src/Polly.Core.Tests/Strategy/ResilienceStrategyOptionsTests.cs
+++ b/src/Polly.Core.Tests/Strategy/ResilienceStrategyOptionsTests.cs
@@ -7,9 +7,9 @@ public class ResilienceStrategyOptionsTests
     [Fact]
     public void Ctor_EnsureDefaults()
     {
-        var options = new ResilienceStrategyOptions();
+        var options = new TestResilienceStrategyOptions();
 
-        options.StrategyType.Should().Be("");
+        options.StrategyType.Should().Be("Test");
         options.StrategyName.Should().Be("");
     }
 }

--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerResilienceStrategyBuilderExtensions.cs
@@ -122,7 +122,8 @@ public static class CircuitBreakerResilienceStrategyBuilderExtensions
             var controller = new CircuitStateController(options, behavior, context.TimeProvider, context.Telemetry);
 
             return new CircuitBreakerResilienceStrategy(options, controller);
-        });
+        },
+        options);
     }
 }
 

--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerStrategyOptions.TResult.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerStrategyOptions.TResult.cs
@@ -19,9 +19,10 @@ namespace Polly.CircuitBreaker;
 public abstract class CircuitBreakerStrategyOptions<TResult> : ResilienceStrategyOptions
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="CircuitBreakerStrategyOptions{TResult}"/> class.
+    /// Gets the strategy type.
     /// </summary>
-    protected CircuitBreakerStrategyOptions() => StrategyType = CircuitBreakerConstants.StrategyType;
+    /// <remarks>Returns <c>CircuitBreaker</c> value.</remarks>
+    public sealed override string StrategyType => CircuitBreakerConstants.StrategyType;
 
     /// <summary>
     /// Gets or sets the duration of break the circuit will stay open before resetting.
@@ -107,7 +108,6 @@ public abstract class CircuitBreakerStrategyOptions<TResult> : ResilienceStrateg
     {
         options.BreakDuration = BreakDuration;
         options.StrategyName = StrategyName;
-        options.StrategyType = StrategyType;
         options.ShouldHandle = new OutcomePredicate<CircuitBreakerPredicateArguments>().SetPredicates(ShouldHandle);
         options.OnClosed = new OutcomeEvent<OnCircuitClosedArguments>().SetCallbacks(OnClosed);
         options.OnOpened = new OutcomeEvent<OnCircuitOpenedArguments>().SetCallbacks(OnOpened);

--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerStrategyOptions.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerStrategyOptions.cs
@@ -18,9 +18,10 @@ namespace Polly.CircuitBreaker;
 public abstract class CircuitBreakerStrategyOptions : ResilienceStrategyOptions
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="CircuitBreakerStrategyOptions"/> class.
+    /// Gets the strategy type.
     /// </summary>
-    private protected CircuitBreakerStrategyOptions() => StrategyType = CircuitBreakerConstants.StrategyType;
+    /// <remarks>Returns <c>CircuitBreaker</c> value.</remarks>
+    public sealed override string StrategyType => CircuitBreakerConstants.StrategyType;
 
     /// <summary>
     /// Gets or sets the duration of break the circuit will stay open before resetting.

--- a/src/Polly.Core/Fallback/FallbackStrategyOptions.TResult.cs
+++ b/src/Polly.Core/Fallback/FallbackStrategyOptions.TResult.cs
@@ -10,9 +10,10 @@ namespace Polly.Fallback;
 public class FallbackStrategyOptions<TResult> : ResilienceStrategyOptions
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="FallbackStrategyOptions{TResult}"/> class.
+    /// Gets the strategy type.
     /// </summary>
-    public FallbackStrategyOptions() => StrategyType = FallbackConstants.StrategyType;
+    /// <remarks>Returns <c>Fallback</c> value.</remarks>
+    public sealed override string StrategyType => FallbackConstants.StrategyType;
 
     /// <summary>
     /// Gets or sets the outcome predicate for determining whether a fallback should be executed.
@@ -45,7 +46,6 @@ public class FallbackStrategyOptions<TResult> : ResilienceStrategyOptions
     {
         return new FallbackStrategyOptions
         {
-            StrategyType = StrategyType,
             StrategyName = StrategyName,
             OnFallback = new OutcomeEvent<OnFallbackArguments>().SetCallbacks(OnFallback),
             Handler = new FallbackHandler().SetFallback<TResult>(handler =>

--- a/src/Polly.Core/Fallback/FallbackStrategyOptions.cs
+++ b/src/Polly.Core/Fallback/FallbackStrategyOptions.cs
@@ -9,9 +9,10 @@ namespace Polly.Fallback;
 public class FallbackStrategyOptions : ResilienceStrategyOptions
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="FallbackStrategyOptions"/> class.
+    /// Gets the strategy type.
     /// </summary>
-    public FallbackStrategyOptions() => StrategyType = FallbackConstants.StrategyType;
+    /// <remarks>Returns <c>Fallback</c> value.</remarks>
+    public sealed override string StrategyType => FallbackConstants.StrategyType;
 
     /// <summary>
     /// Gets or sets the <see cref="FallbackHandler"/> instance used for configure fallback scenarios.

--- a/src/Polly.Core/Hedging/HedgingStrategyOptions.TResult.cs
+++ b/src/Polly.Core/Hedging/HedgingStrategyOptions.TResult.cs
@@ -10,9 +10,10 @@ namespace Polly.Hedging;
 public class HedgingStrategyOptions<TResult> : ResilienceStrategyOptions
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="HedgingStrategyOptions{TResult}"/> class.
+    /// Gets the strategy type.
     /// </summary>
-    public HedgingStrategyOptions() => StrategyType = HedgingConstants.StrategyType;
+    /// <remarks>Returns <c>Hedging</c> value.</remarks>
+    public sealed override string StrategyType => HedgingConstants.StrategyType;
 
     /// <summary>
     /// Gets or sets the minimal time of waiting before spawning a new hedged call.
@@ -79,7 +80,6 @@ public class HedgingStrategyOptions<TResult> : ResilienceStrategyOptions
     {
         return new HedgingStrategyOptions
         {
-            StrategyType = StrategyType,
             StrategyName = StrategyName,
             HedgingDelay = HedgingDelay,
             HedgingDelayGenerator = HedgingDelayGenerator,

--- a/src/Polly.Core/Hedging/HedgingStrategyOptions.cs
+++ b/src/Polly.Core/Hedging/HedgingStrategyOptions.cs
@@ -9,9 +9,10 @@ namespace Polly.Hedging;
 public class HedgingStrategyOptions : ResilienceStrategyOptions
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="HedgingStrategyOptions"/> class.
+    /// Gets the strategy type.
     /// </summary>
-    public HedgingStrategyOptions() => StrategyType = HedgingConstants.StrategyType;
+    /// <remarks>Returns <c>Hedging</c> value.</remarks>
+    public sealed override string StrategyType => HedgingConstants.StrategyType;
 
     /// <summary>
     /// Gets or sets the minimal time of waiting before spawning a new hedged call.

--- a/src/Polly.Core/ResilienceStrategyBuilder.cs
+++ b/src/Polly.Core/ResilienceStrategyBuilder.cs
@@ -49,9 +49,10 @@ public class ResilienceStrategyBuilder
     /// <param name="options">The options associated with the strategy. If none are provided the default instance of <see cref="ResilienceStrategyOptions"/> is created.</param>
     /// <returns>The same builder instance.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="strategy"/> is null.</exception>
-    public ResilienceStrategyBuilder AddStrategy(ResilienceStrategy strategy, ResilienceStrategyOptions? options = null)
+    public ResilienceStrategyBuilder AddStrategy(ResilienceStrategy strategy, ResilienceStrategyOptions options)
     {
         Guard.NotNull(strategy);
+        Guard.NotNull(options);
 
         return AddStrategy(_ => strategy, options);
     }
@@ -63,21 +64,19 @@ public class ResilienceStrategyBuilder
     /// <param name="options">The options associated with the strategy. If none are provided the default instance of <see cref="ResilienceStrategyOptions"/> is created.</param>
     /// <returns>The same builder instance.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="factory"/> is null.</exception>
-    public ResilienceStrategyBuilder AddStrategy(Func<ResilienceStrategyBuilderContext, ResilienceStrategy> factory, ResilienceStrategyOptions? options = null)
+    public ResilienceStrategyBuilder AddStrategy(Func<ResilienceStrategyBuilderContext, ResilienceStrategy> factory, ResilienceStrategyOptions options)
     {
         Guard.NotNull(factory);
+        Guard.NotNull(options);
 
-        if (options is not null)
-        {
-            ValidationHelper.ValidateObject(options, $"The '{nameof(ResilienceStrategyOptions)}' options are not valid.");
-        }
+        ValidationHelper.ValidateObject(options, $"The '{nameof(ResilienceStrategyOptions)}' options are not valid.");
 
         if (_used)
         {
             throw new InvalidOperationException("Cannot add any more resilience strategies to the builder after it has been used to build a strategy once.");
         }
 
-        _entries.Add(new Entry(factory, options ?? new ResilienceStrategyOptions()));
+        _entries.Add(new Entry(factory, options));
 
         return this;
     }

--- a/src/Polly.Core/Retry/RetryResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/Retry/RetryResilienceStrategyBuilderExtensions.cs
@@ -152,6 +152,6 @@ public static class RetryResilienceStrategyBuilderExtensions
 
         ValidationHelper.ValidateObject(options, "The retry strategy options are invalid.");
 
-        return builder.AddStrategy(context => new RetryResilienceStrategy(options, context.TimeProvider, context.Telemetry, RandomUtil.Instance));
+        return builder.AddStrategy(context => new RetryResilienceStrategy(options, context.TimeProvider, context.Telemetry, RandomUtil.Instance), options);
     }
 }

--- a/src/Polly.Core/Retry/RetryStrategyOptions.TResult.cs
+++ b/src/Polly.Core/Retry/RetryStrategyOptions.TResult.cs
@@ -10,9 +10,10 @@ namespace Polly.Retry;
 public class RetryStrategyOptions<TResult> : ResilienceStrategyOptions
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="RetryStrategyOptions{TResult}"/> class.
+    /// Gets the strategy type.
     /// </summary>
-    public RetryStrategyOptions() => StrategyType = RetryConstants.StrategyType;
+    /// <remarks>Returns <c>Retry</c> value.</remarks>
+    public sealed override string StrategyType => RetryConstants.StrategyType;
 
     /// <summary>
     /// Gets or sets the maximum number of retries to use, in addition to the original call.
@@ -100,7 +101,6 @@ public class RetryStrategyOptions<TResult> : ResilienceStrategyOptions
             RetryDelayGenerator = new OutcomeGenerator<RetryDelayArguments, TimeSpan>().SetGenerator(RetryDelayGenerator),
             ShouldRetry = new OutcomePredicate<ShouldRetryArguments>().SetPredicates(ShouldRetry),
             StrategyName = StrategyName,
-            StrategyType = StrategyType
         };
     }
 }

--- a/src/Polly.Core/Retry/RetryStrategyOptions.cs
+++ b/src/Polly.Core/Retry/RetryStrategyOptions.cs
@@ -9,9 +9,10 @@ namespace Polly.Retry;
 public class RetryStrategyOptions : ResilienceStrategyOptions
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="RetryStrategyOptions"/> class.
+    /// Gets the strategy type.
     /// </summary>
-    public RetryStrategyOptions() => StrategyType = RetryConstants.StrategyType;
+    /// <remarks>Returns <c>Retry</c> value.</remarks>
+    public sealed override string StrategyType => RetryConstants.StrategyType;
 
     /// <summary>
     /// Value that represents infinite retries.

--- a/src/Polly.Core/Strategy/ResilienceStrategyOptions.cs
+++ b/src/Polly.Core/Strategy/ResilienceStrategyOptions.cs
@@ -5,23 +5,22 @@ namespace Polly.Strategy;
 /// <summary>
 /// The options associated with the <see cref="ResilienceStrategy"/>.
 /// </summary>
-public class ResilienceStrategyOptions
+public abstract class ResilienceStrategyOptions
 {
     /// <summary>
     /// Gets or sets the name of the strategy.
     /// </summary>
     /// <remarks>
     /// This property is also included in the telemetry that is produced by the individual resilience strategies.
-    /// Defaults to <see cref="string.Empty"/>.
+    /// Defaults to <see cref="string.Empty"/>. This name uniquely identifies particular instance of specific strategy.
     /// </remarks>
     [Required(AllowEmptyStrings = true)]
     public string StrategyName { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets the type of the strategy.
+    /// Gets the strategy type.
     /// </summary>
-    /// <remarks>This property is also included in the telemetry that is produced by the individual resilience strategies.</remarks>
-    /// Defaults to <see cref="string.Empty"/>.
-    [Required(AllowEmptyStrings = true)]
-    public string StrategyType { get; set; } = string.Empty;
+    /// <remarks>This property is also included in the telemetry that is produced by the individual resilience strategies.
+    /// The strategy type uniquely identifies the strategy in the telemetry. The name should be in PascalCase (i.e. Retry, CircuitBreaker, Timeout).</remarks>
+    public abstract string StrategyType { get; }
 }

--- a/src/Polly.Core/Timeout/TimeoutStrategyOptions.cs
+++ b/src/Polly.Core/Timeout/TimeoutStrategyOptions.cs
@@ -10,9 +10,10 @@ namespace Polly.Timeout;
 public class TimeoutStrategyOptions : ResilienceStrategyOptions
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="TimeoutStrategyOptions"/> class.
+    /// Gets the strategy type.
     /// </summary>
-    public TimeoutStrategyOptions() => StrategyType = TimeoutConstants.StrategyType;
+    /// <remarks>Returns <c>Timeout</c> value.</remarks>
+    public sealed override string StrategyType => TimeoutConstants.StrategyType;
 
     /// <summary>
     /// Gets or sets the default timeout.

--- a/src/Polly.Extensions.Tests/DependencyInjection/PollyServiceCollectionExtensionTests.cs
+++ b/src/Polly.Extensions.Tests/DependencyInjection/PollyServiceCollectionExtensionTests.cs
@@ -49,7 +49,7 @@ public class PollyServiceCollectionExtensionTests
     public void AddResilienceStrategy_MultipleRegistries_Ok()
     {
         AddResilienceStrategy(Key);
-        _services.AddResilienceStrategy(10, context => context.AddStrategy(new TestStrategy()));
+        _services.AddResilienceStrategy(10, context => context.AddStrategy(new TestStrategy(), new TestResilienceStrategyOptions()));
 
         var serviceProvider = _services.BuildServiceProvider();
 
@@ -67,7 +67,7 @@ public class PollyServiceCollectionExtensionTests
             context.Key.Should().Be(Key);
             builder.Should().NotBeNull();
             context.ServiceProvider.Should().NotBeNull();
-            builder.AddStrategy(new TestStrategy());
+            builder.AddStrategy(new TestStrategy(), new TestResilienceStrategyOptions());
             asserted = true;
         });
 
@@ -93,7 +93,8 @@ public class PollyServiceCollectionExtensionTests
             {
                 telemetry = context.Telemetry;
                 return new TestStrategy();
-            }));
+            },
+            new TestResilienceStrategyOptions()));
 
         CreateProvider().Get(Key);
 
@@ -187,7 +188,7 @@ public class PollyServiceCollectionExtensionTests
             {
                 onBuilding?.Invoke(context);
                 return new TestStrategy();
-            });
+            }, new TestResilienceStrategyOptions());
         });
     }
 

--- a/src/Polly.Extensions.Tests/Issues/IssuesTests.OnCircuitBreakWithServiceProvider_796.cs
+++ b/src/Polly.Extensions.Tests/Issues/IssuesTests.OnCircuitBreakWithServiceProvider_796.cs
@@ -33,7 +33,7 @@ public partial class IssuesTests
         var serviceCollection = new ServiceCollection().AddResilienceStrategy("my-strategy", (builder, context) =>
         {
             builder
-                .AddStrategy(new ServiceProviderStrategy(context.ServiceProvider))
+                .AddStrategy(new ServiceProviderStrategy(context.ServiceProvider), new TestResilienceStrategyOptions())
                 .AddAdvancedCircuitBreaker(options);
         });
 

--- a/src/Polly.Extensions.Tests/Telemetry/TelemetryResilienceStrategyBuilderExtensionsTests.cs
+++ b/src/Polly.Extensions.Tests/Telemetry/TelemetryResilienceStrategyBuilderExtensionsTests.cs
@@ -13,7 +13,7 @@ public class TelemetryResilienceStrategyBuilderExtensionsTests
     {
         _builder.EnableTelemetry(NullLoggerFactory.Instance);
         _builder.Properties.GetValue(new ResiliencePropertyKey<DiagnosticSource?>("DiagnosticSource"), null).Should().BeOfType<ResilienceTelemetryDiagnosticSource>();
-        _builder.AddStrategy(new TestResilienceStrategy()).Build().Should().NotBeOfType<TestResilienceStrategy>();
+        _builder.AddStrategy(new TestResilienceStrategy(), new TestResilienceStrategyOptions()).Build().Should().NotBeOfType<TestResilienceStrategy>();
     }
 
     [Fact]
@@ -21,7 +21,7 @@ public class TelemetryResilienceStrategyBuilderExtensionsTests
     {
         using var factory = TestUtilities.CreateLoggerFactory(out var fakeLogger);
         _builder.EnableTelemetry(factory);
-        _builder.AddStrategy(new TestResilienceStrategy()).Build().Execute(_ => { });
+        _builder.AddStrategy(new TestResilienceStrategy(), new TestResilienceStrategyOptions()).Build().Execute(_ => { });
 
         fakeLogger.GetRecords().Should().NotBeEmpty();
         fakeLogger.GetRecords().Should().HaveCount(2);

--- a/src/Polly.RateLimiting/RateLimiterStrategyOptions.cs
+++ b/src/Polly.RateLimiting/RateLimiterStrategyOptions.cs
@@ -10,9 +10,10 @@ namespace Polly.RateLimiting;
 public class RateLimiterStrategyOptions : ResilienceStrategyOptions
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="RateLimiterStrategyOptions"/> class.
+    /// Gets the strategy type.
     /// </summary>
-    public RateLimiterStrategyOptions() => StrategyType = RateLimiterConstants.StrategyType;
+    /// <remarks>Returns <c>RateLimiter</c> value.</remarks>
+    public sealed override string StrategyType => RateLimiterConstants.StrategyType;
 
     /// <summary>
     /// Gets or sets an event that is raised when the execution of user-provided callback is rejected by the rate limiter.

--- a/src/Polly.TestUtils/TestResilienceStrategyOptions.cs
+++ b/src/Polly.TestUtils/TestResilienceStrategyOptions.cs
@@ -1,0 +1,8 @@
+﻿using Polly.Strategy;
+
+namespace Polly.TestUtils;
+
+public sealed class TestResilienceStrategyOptions : ResilienceStrategyOptions
+{
+    public override string StrategyType => "Test";
+}


### PR DESCRIPTION
### Details on the issue fix or feature implementation

There is no occurrence where these options are directly created. Every occurrence derives from these so these should be abstract. The `StrategyType` property should be also fixed across all particular strategy instances so making this property abstract. 

I also made these required in `ResilienceStrategyBuilder.AddStrategy`. This revealed bug in retry strategy.


### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
