### PR TITLE
Add a generics benchmark

### DIFF
--- a/src/Polly.Core.Benchmarks/Benchmarks/GenericOverheadBenchmark.cs
+++ b/src/Polly.Core.Benchmarks/Benchmarks/GenericOverheadBenchmark.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace Polly.Benchmarks;
+
+public class GenericOverheadBenchmark
+{
+    private readonly GenericStrategy<string> _generic;
+    private readonly NonGenericStrategy _nonGeneric;
+
+    public GenericOverheadBenchmark()
+    {
+        _generic = new GenericStrategy<string>();
+        _nonGeneric = new NonGenericStrategy();
+    }
+
+    [Benchmark(Baseline = true)]
+    public async ValueTask ExecuteAsync_Generic() => await _generic.ExecuteAsync(static () => new ValueTask<string>("dummy")).ConfigureAwait(false);
+
+    [Benchmark]
+    public async ValueTask ExecuteAsync_NonGeneric() => await _nonGeneric.ExecuteAsync(static () => new ValueTask<string>("dummy")).ConfigureAwait(false);
+
+    public class GenericStrategy<T>
+    {
+        [MethodImpl(MethodImplOptions.NoOptimization)]
+        public virtual ValueTask<T> ExecuteAsync(Func<ValueTask<T>> callback)
+        {
+            return callback();
+        }
+    }
+
+    public class NonGenericStrategy
+    {
+        [MethodImpl(MethodImplOptions.NoOptimization)]
+        public virtual ValueTask<T> ExecuteAsync<T>(Func<ValueTask<T>> callback)
+        {
+            return callback();
+        }
+    }
+}

--- a/src/Polly.Core.Benchmarks/README.md
+++ b/src/Polly.Core.Benchmarks/README.md
@@ -10,6 +10,16 @@ Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15
 LaunchCount=2  WarmupCount=10
 ```
 
+## Genric vs Non-Generic classes
+
+This benchmark demonstrates that impact of having non-generic `ResilienceStrategy` is minimal.
+
+|                  Method |     Mean |    Error |   StdDev | Ratio | Allocated | Alloc Ratio |
+|------------------------ |---------:|---------:|---------:|------:|----------:|------------:|
+|    ExecuteAsync_Generic | 30.25 ns | 0.197 ns | 0.269 ns |  1.00 |         - |          NA |
+| ExecuteAsync_NonGeneric | 32.02 ns | 0.071 ns | 0.094 ns |  1.06 |         - |          NA |
+
+
 ## PIPELINES
 
 |             Method | Components |        Mean |     Error |     StdDev |      Median | Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |


### PR DESCRIPTION
### Details on the issue fix or feature implementation

Ad a benchmark that compares generic vs non-generic `ResilienceStrategy` class as it was raised during the internal review. These results demonstrate that the perf difference is marginal and can be ignored (~2ns).

There is possibly some compiler voodoo that makes the difference so small. 

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
