### PR TITLE
Simplify AddStrategy method

### DIFF
--- a/src/Polly.Core.Benchmarks/Internals/Helper.StrategyPipeline.cs
+++ b/src/Polly.Core.Benchmarks/Internals/Helper.StrategyPipeline.cs
@@ -1,5 +1,4 @@
 using Polly;
-using Polly.Strategy;
 
 namespace Polly.Core.Benchmarks;
 
@@ -13,14 +12,9 @@ internal static partial class Helper
         {
             for (var i = 0; i < count; i++)
             {
-                builder.AddStrategy(new EmptyResilienceStrategy(), new BenchmarkResilienceStrategyOptions());
+                builder.AddStrategy(new EmptyResilienceStrategy());
             }
         }),
         _ => throw new NotSupportedException()
     };
-
-    private class BenchmarkResilienceStrategyOptions : ResilienceStrategyOptions
-    {
-        public override string StrategyType => "Benchmark";
-    }
 }

--- a/src/Polly.Core.Tests/Registry/ResilienceStrategyRegistryTests.cs
+++ b/src/Polly.Core.Tests/Registry/ResilienceStrategyRegistryTests.cs
@@ -42,7 +42,7 @@ public class ResilienceStrategyRegistryTests
     {
         var registry = new ResilienceStrategyRegistry<string>();
 
-        registry.TryAddBuilder("C", (_, b) => b.AddStrategy(new TestResilienceStrategy(), new TestResilienceStrategyOptions()));
+        registry.TryAddBuilder("C", (_, b) => b.AddStrategy(new TestResilienceStrategy()));
 
         registry.TryAdd("A", new TestResilienceStrategy());
         registry.TryAdd("B", new TestResilienceStrategy());
@@ -74,7 +74,7 @@ public class ResilienceStrategyRegistryTests
     public void RemoveBuilder_Ok()
     {
         var registry = new ResilienceStrategyRegistry<string>();
-        registry.TryAddBuilder("A", (_, b) => b.AddStrategy(new TestResilienceStrategy(), new TestResilienceStrategyOptions()));
+        registry.TryAddBuilder("A", (_, b) => b.AddStrategy(new TestResilienceStrategy()));
 
         registry.RemoveBuilder("A").Should().BeTrue();
         registry.RemoveBuilder("A").Should().BeFalse();
@@ -88,7 +88,7 @@ public class ResilienceStrategyRegistryTests
         var builderName = "A";
         var registry = CreateRegistry();
         var strategies = new HashSet<ResilienceStrategy>();
-        registry.TryAddBuilder(StrategyId.Create(builderName), (_, builder) => builder.AddStrategy(new TestResilienceStrategy(), new TestResilienceStrategyOptions()));
+        registry.TryAddBuilder(StrategyId.Create(builderName), (_, builder) => builder.AddStrategy(new TestResilienceStrategy()));
 
         for (int i = 0; i < 100; i++)
         {
@@ -112,7 +112,7 @@ public class ResilienceStrategyRegistryTests
         var called = 0;
         registry.TryAddBuilder(StrategyId.Create("A"), (key, builder) =>
         {
-            builder.AddStrategy(new TestResilienceStrategy(), new TestResilienceStrategyOptions());
+            builder.AddStrategy(new TestResilienceStrategy());
             builder.Properties.Set(StrategyId.ResilienceKey, key);
             called++;
         });
@@ -142,7 +142,7 @@ public class ResilienceStrategyRegistryTests
         var registry = CreateRegistry();
         registry.TryAddBuilder(StrategyId.Create("A"), (_, builder) =>
         {
-            builder.AddStrategy(new TestResilienceStrategy(), new TestResilienceStrategyOptions());
+            builder.AddStrategy(new TestResilienceStrategy());
             builder.BuilderName.Should().Be("A");
             builder.Properties.TryGetValue(TelemetryUtil.StrategyKey, out var val).Should().BeTrue();
             val.Should().Be("Instance1");

--- a/src/Polly.Core.Tests/ResilienceStrategyBuilderTests.cs
+++ b/src/Polly.Core.Tests/ResilienceStrategyBuilderTests.cs
@@ -174,6 +174,24 @@ The BuilderName field is required.
     }
 
     [Fact]
+    public void AddStrategy_InvalidOptions_Throws()
+    {
+        var builder = new ResilienceStrategyBuilder();
+
+        builder
+            .Invoking(b => b.AddStrategy(_ => NullResilienceStrategy.Instance, new TestResilienceStrategyOptions { StrategyName = null! }))
+            .Should()
+            .Throw<ValidationException>()
+            .WithMessage(
+"""
+The 'ResilienceStrategyOptions' options are not valid.
+
+Validation Errors:
+The StrategyName field is required.
+""");
+    }
+
+    [Fact]
     public void AddStrategy_NullFactory_Throws()
     {
         var builder = new ResilienceStrategyBuilder();

--- a/src/Polly.Core.Tests/ResilienceStrategyBuilderTests.cs
+++ b/src/Polly.Core.Tests/ResilienceStrategyBuilderTests.cs
@@ -29,7 +29,7 @@ public class ResilienceStrategyBuilderTests
             After = (_, _) => executions.Add(3),
         };
 
-        builder.AddStrategy(first, new TestResilienceStrategyOptions());
+        builder.AddStrategy(first);
 
         // act
         var strategy = builder.Build();
@@ -63,9 +63,9 @@ public class ResilienceStrategyBuilderTests
             After = (_, _) => executions.Add(5),
         };
 
-        builder.AddStrategy(first, new TestResilienceStrategyOptions());
-        builder.AddStrategy(second, new TestResilienceStrategyOptions());
-        builder.AddStrategy(third, new TestResilienceStrategyOptions());
+        builder.AddStrategy(first);
+        builder.AddStrategy(second);
+        builder.AddStrategy(third);
 
         // act
         var strategy = builder.Build();
@@ -88,8 +88,8 @@ public class ResilienceStrategyBuilderTests
         // arrange
         var executions = new List<int>();
         var builder = new ResilienceStrategyBuilder()
-            .AddStrategy(NullResilienceStrategy.Instance, new TestResilienceStrategyOptions())
-            .AddStrategy(NullResilienceStrategy.Instance, new TestResilienceStrategyOptions());
+            .AddStrategy(NullResilienceStrategy.Instance)
+            .AddStrategy(NullResilienceStrategy.Instance);
 
         builder.Invoking(b => b.Build())
             .Should()
@@ -119,9 +119,9 @@ public class ResilienceStrategyBuilderTests
             After = () => executions.Add(5),
         };
 
-        builder.AddStrategy(first, new TestResilienceStrategyOptions());
-        builder.AddStrategy(second, new TestResilienceStrategyOptions());
-        builder.AddStrategy(third, new TestResilienceStrategyOptions());
+        builder.AddStrategy(first);
+        builder.AddStrategy(second);
+        builder.AddStrategy(third);
 
         // act
         var strategy = builder.Build();
@@ -147,7 +147,7 @@ public class ResilienceStrategyBuilderTests
         builder.Build();
 
         builder
-            .Invoking(b => b.AddStrategy(NullResilienceStrategy.Instance, new TestResilienceStrategyOptions()))
+            .Invoking(b => b.AddStrategy(NullResilienceStrategy.Instance))
             .Should()
             .Throw<InvalidOperationException>()
             .WithMessage("Cannot add any more resilience strategies to the builder after it has been used to build a strategy once.");
@@ -174,30 +174,12 @@ The BuilderName field is required.
     }
 
     [Fact]
-    public void AddStrategy_InvalidOptions_Throws()
-    {
-        var builder = new ResilienceStrategyBuilder();
-
-        builder
-            .Invoking(b => b.AddStrategy(NullResilienceStrategy.Instance, new TestResilienceStrategyOptions { StrategyName = null! }))
-            .Should()
-            .Throw<ValidationException>()
-            .WithMessage(
-"""
-The 'ResilienceStrategyOptions' options are not valid.
-
-Validation Errors:
-The StrategyName field is required.
-""");
-    }
-
-    [Fact]
     public void AddStrategy_NullFactory_Throws()
     {
         var builder = new ResilienceStrategyBuilder();
 
         builder
-            .Invoking(b => b.AddStrategy((Func<ResilienceStrategyBuilderContext, ResilienceStrategy>)null!, new TestResilienceStrategyOptions()))
+            .Invoking(b => b.AddStrategy(null!, new TestResilienceStrategyOptions()))
             .Should()
             .Throw<ArgumentNullException>()
             .And.ParamName
@@ -221,17 +203,17 @@ The StrategyName field is required.
             After = (_, _) => executions.Add(6),
         };
 
-        var pipeline1 = new ResilienceStrategyBuilder().AddStrategy(first, new TestResilienceStrategyOptions()).AddStrategy(second, new TestResilienceStrategyOptions()).Build();
+        var pipeline1 = new ResilienceStrategyBuilder().AddStrategy(first).AddStrategy(second).Build();
 
         var third = new TestResilienceStrategy
         {
             Before = (_, _) => executions.Add(3),
             After = (_, _) => executions.Add(5),
         };
-        var pipeline2 = new ResilienceStrategyBuilder().AddStrategy(third, new TestResilienceStrategyOptions()).Build();
+        var pipeline2 = new ResilienceStrategyBuilder().AddStrategy(third).Build();
 
         // act
-        var strategy = new ResilienceStrategyBuilder().AddStrategy(pipeline1, new TestResilienceStrategyOptions()).AddStrategy(pipeline2, new TestResilienceStrategyOptions()).Build();
+        var strategy = new ResilienceStrategyBuilder().AddStrategy(pipeline1).AddStrategy(pipeline2).Build();
 
         // assert
         strategy.Execute(_ => executions.Add(4));
@@ -305,13 +287,19 @@ The StrategyName field is required.
             }
         };
 
-        builder.AddStrategy(strategy, new TestResilienceStrategyOptions());
+        builder.AddStrategy(strategy);
 
         // act
         var finalStrategy = builder.Build();
 
         // assert
         finalStrategy.Should().BeOfType<ResilienceStrategyPipeline>();
+    }
+
+    [Fact]
+    public void EmptyOptions_Ok()
+    {
+        ResilienceStrategyBuilder.EmptyOptions.Instance.StrategyType.Should().Be("Empty");
     }
 
     private class Strategy : ResilienceStrategy

--- a/src/Polly.Core/ResilienceStrategyBuilder.cs
+++ b/src/Polly.Core/ResilienceStrategyBuilder.cs
@@ -46,15 +46,13 @@ public class ResilienceStrategyBuilder
     /// Adds an already created strategy instance to the builder.
     /// </summary>
     /// <param name="strategy">The strategy instance.</param>
-    /// <param name="options">The options associated with the strategy. If none are provided the default instance of <see cref="ResilienceStrategyOptions"/> is created.</param>
     /// <returns>The same builder instance.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="strategy"/> is null.</exception>
-    public ResilienceStrategyBuilder AddStrategy(ResilienceStrategy strategy, ResilienceStrategyOptions options)
+    public ResilienceStrategyBuilder AddStrategy(ResilienceStrategy strategy)
     {
         Guard.NotNull(strategy);
-        Guard.NotNull(options);
 
-        return AddStrategy(_ => strategy, options);
+        return AddStrategy(_ => strategy, EmptyOptions.Instance);
     }
 
     /// <summary>
@@ -121,4 +119,11 @@ public class ResilienceStrategyBuilder
     }
 
     private sealed record Entry(Func<ResilienceStrategyBuilderContext, ResilienceStrategy> Factory, ResilienceStrategyOptions Properties);
+
+    internal sealed class EmptyOptions : ResilienceStrategyOptions
+    {
+        public static readonly EmptyOptions Instance = new();
+
+        public override string StrategyType => "Empty";
+    }
 }

--- a/src/Polly.Core/ResilienceStrategyBuilder.cs
+++ b/src/Polly.Core/ResilienceStrategyBuilder.cs
@@ -48,6 +48,7 @@ public class ResilienceStrategyBuilder
     /// <param name="strategy">The strategy instance.</param>
     /// <returns>The same builder instance.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="strategy"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when this builder was already used to create a strategy. The builder cannot be modified after it has been used.</exception>
     public ResilienceStrategyBuilder AddStrategy(ResilienceStrategy strategy)
     {
         Guard.NotNull(strategy);
@@ -62,6 +63,8 @@ public class ResilienceStrategyBuilder
     /// <param name="options">The options associated with the strategy. If none are provided the default instance of <see cref="ResilienceStrategyOptions"/> is created.</param>
     /// <returns>The same builder instance.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="factory"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when this builder was already used to create a strategy. The builder cannot be modified after it has been used.</exception>
+    /// <exception cref="ValidationException">Thrown when the <paramref name="options"/> are invalid.</exception>
     public ResilienceStrategyBuilder AddStrategy(Func<ResilienceStrategyBuilderContext, ResilienceStrategy> factory, ResilienceStrategyOptions options)
     {
         Guard.NotNull(factory);

--- a/src/Polly.Extensions.Tests/DependencyInjection/PollyServiceCollectionExtensionTests.cs
+++ b/src/Polly.Extensions.Tests/DependencyInjection/PollyServiceCollectionExtensionTests.cs
@@ -49,7 +49,7 @@ public class PollyServiceCollectionExtensionTests
     public void AddResilienceStrategy_MultipleRegistries_Ok()
     {
         AddResilienceStrategy(Key);
-        _services.AddResilienceStrategy(10, context => context.AddStrategy(new TestStrategy(), new TestResilienceStrategyOptions()));
+        _services.AddResilienceStrategy(10, context => context.AddStrategy(new TestStrategy()));
 
         var serviceProvider = _services.BuildServiceProvider();
 
@@ -67,7 +67,7 @@ public class PollyServiceCollectionExtensionTests
             context.Key.Should().Be(Key);
             builder.Should().NotBeNull();
             context.ServiceProvider.Should().NotBeNull();
-            builder.AddStrategy(new TestStrategy(), new TestResilienceStrategyOptions());
+            builder.AddStrategy(new TestStrategy());
             asserted = true;
         });
 

--- a/src/Polly.Extensions.Tests/Issues/IssuesTests.OnCircuitBreakWithServiceProvider_796.cs
+++ b/src/Polly.Extensions.Tests/Issues/IssuesTests.OnCircuitBreakWithServiceProvider_796.cs
@@ -33,7 +33,7 @@ public partial class IssuesTests
         var serviceCollection = new ServiceCollection().AddResilienceStrategy("my-strategy", (builder, context) =>
         {
             builder
-                .AddStrategy(new ServiceProviderStrategy(context.ServiceProvider), new TestResilienceStrategyOptions())
+                .AddStrategy(new ServiceProviderStrategy(context.ServiceProvider))
                 .AddAdvancedCircuitBreaker(options);
         });
 

--- a/src/Polly.Extensions.Tests/Telemetry/TelemetryResilienceStrategyBuilderExtensionsTests.cs
+++ b/src/Polly.Extensions.Tests/Telemetry/TelemetryResilienceStrategyBuilderExtensionsTests.cs
@@ -13,7 +13,7 @@ public class TelemetryResilienceStrategyBuilderExtensionsTests
     {
         _builder.EnableTelemetry(NullLoggerFactory.Instance);
         _builder.Properties.GetValue(new ResiliencePropertyKey<DiagnosticSource?>("DiagnosticSource"), null).Should().BeOfType<ResilienceTelemetryDiagnosticSource>();
-        _builder.AddStrategy(new TestResilienceStrategy(), new TestResilienceStrategyOptions()).Build().Should().NotBeOfType<TestResilienceStrategy>();
+        _builder.AddStrategy(new TestResilienceStrategy()).Build().Should().NotBeOfType<TestResilienceStrategy>();
     }
 
     [Fact]
@@ -21,7 +21,7 @@ public class TelemetryResilienceStrategyBuilderExtensionsTests
     {
         using var factory = TestUtilities.CreateLoggerFactory(out var fakeLogger);
         _builder.EnableTelemetry(factory);
-        _builder.AddStrategy(new TestResilienceStrategy(), new TestResilienceStrategyOptions()).Build().Execute(_ => { });
+        _builder.AddStrategy(new TestResilienceStrategy()).Build().Execute(_ => { });
 
         fakeLogger.GetRecords().Should().NotBeEmpty();
         fakeLogger.GetRecords().Should().HaveCount(2);


### PR DESCRIPTION
### Details on the issue fix or feature implementation

Dropping the `ResilienceStrategyOptions` argument from the `AddStrategy` method that accepts pre-created strategy. In this case the options are never used so there is no need to pass them.

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
