### PR TITLE
[Proposal] Introduce ResilienceStrategyBuilder<TResult>

### DIFF
--- a/src/Polly.Core.Benchmarks/Benchmarks/HedgingBenchmark.cs
+++ b/src/Polly.Core.Benchmarks/Benchmarks/HedgingBenchmark.cs
@@ -6,7 +6,7 @@ namespace Polly.Benchmarks;
 
 public class HedgingBenchmark
 {
-    private ResilienceStrategy? _strategy;
+    private ResilienceStrategy<string>? _strategy;
 
     [GlobalSetup]
     public void Setup()

--- a/src/Polly.Core.Benchmarks/Internals/Helper.CircuitBreaker.cs
+++ b/src/Polly.Core.Benchmarks/Internals/Helper.CircuitBreaker.cs
@@ -13,13 +13,13 @@ internal static partial class Helper
         {
             PollyVersion.V7 =>
                 Policy
-                    .HandleResult(10)
+                    .HandleResult(Failure)
                     .Or<InvalidOperationException>()
                     .AdvancedCircuitBreakerAsync(0.5, TimeSpan.FromSeconds(30), 10, TimeSpan.FromSeconds(5)),
 
             PollyVersion.V8 => CreateStrategy(builder =>
             {
-                var options = new AdvancedCircuitBreakerStrategyOptions
+                var options = new AdvancedCircuitBreakerStrategyOptions<string>
                 {
                     FailureThreshold = 0.5,
                     SamplingDuration = TimeSpan.FromSeconds(30),
@@ -27,7 +27,7 @@ internal static partial class Helper
                     BreakDuration = TimeSpan.FromSeconds(5),
                 };
 
-                options.ShouldHandle.HandleOutcome<int>((outcome, _) => outcome.Result == 10 || outcome.Exception is InvalidOperationException);
+                options.ShouldHandle.HandleOutcome((outcome, _) => outcome.Result == Failure || outcome.Exception is InvalidOperationException);
                 builder.AddAdvancedCircuitBreaker(options);
             }),
             _ => throw new NotSupportedException()

--- a/src/Polly.Core.Benchmarks/Internals/Helper.Hedging.cs
+++ b/src/Polly.Core.Benchmarks/Internals/Helper.Hedging.cs
@@ -1,4 +1,5 @@
 using Polly.Hedging;
+using Polly.Strategy;
 
 namespace Polly.Core.Benchmarks;
 
@@ -6,17 +7,14 @@ internal static partial class Helper
 {
     public const string Failure = "failure";
 
-    public static ResilienceStrategy CreateHedging()
+    public static ResilienceStrategy<string> CreateHedging()
     {
         return CreateStrategy(builder =>
         {
-            builder.AddHedging(new HedgingStrategyOptions
+            builder.AddHedging(new HedgingStrategyOptions<string>
             {
-                Handler = new HedgingHandler().SetHedging<string>(handler =>
-                {
-                    handler.ShouldHandle.HandleResult(Failure);
-                    handler.HedgingActionGenerator = args => () => Task.FromResult("hedged response");
-                })
+                ShouldHandle = new OutcomePredicate<HandleHedgingArguments, string>().HandleResult(Failure),
+                HedgingActionGenerator = args => () => Task.FromResult("hedged response"),
             });
         });
     }

--- a/src/Polly.Core.Benchmarks/Internals/Helper.RateLimiting.cs
+++ b/src/Polly.Core.Benchmarks/Internals/Helper.RateLimiting.cs
@@ -13,7 +13,7 @@ internal static partial class Helper
 
         return technology switch
         {
-            PollyVersion.V7 => Policy.BulkheadAsync<int>(10, 10),
+            PollyVersion.V7 => Policy.BulkheadAsync<string>(10, 10),
             PollyVersion.V8 => CreateStrategy(builder => builder.AddConcurrencyLimiter(new ConcurrencyLimiterOptions
             {
                 PermitLimit = 10,

--- a/src/Polly.Core.Benchmarks/Internals/Helper.Retry.cs
+++ b/src/Polly.Core.Benchmarks/Internals/Helper.Retry.cs
@@ -12,21 +12,21 @@ internal static partial class Helper
         {
             PollyVersion.V7 =>
                 Policy
-                    .HandleResult(10)
+                    .HandleResult(Failure)
                     .Or<InvalidOperationException>()
                     .WaitAndRetryAsync(3, attempt => delay, (_, _) => Task.CompletedTask),
 
             PollyVersion.V8 => CreateStrategy(builder =>
             {
-                var options = new RetryStrategyOptions
+                var options = new RetryStrategyOptions<string>
                 {
                     RetryCount = 3,
                     BackoffType = RetryBackoffType.Constant,
                     BaseDelay = delay
                 };
 
-                options.ShouldRetry.HandleOutcome<int>((outcome, _) => outcome.Result == 10 || outcome.Exception is InvalidOperationException);
-                options.OnRetry.Register<int>(() => { });
+                options.ShouldRetry.HandleOutcome((outcome, _) => outcome.Result == Failure || outcome.Exception is InvalidOperationException);
+                options.OnRetry.Register(() => { });
 
                 builder.AddRetry(options);
             }),

--- a/src/Polly.Core.Benchmarks/Internals/Helper.StrategyPipeline.cs
+++ b/src/Polly.Core.Benchmarks/Internals/Helper.StrategyPipeline.cs
@@ -6,7 +6,7 @@ internal static partial class Helper
 {
     public static object CreatePipeline(PollyVersion technology, int count) => technology switch
     {
-        PollyVersion.V7 => count == 1 ? Policy.NoOpAsync<int>() : Policy.WrapAsync(Enumerable.Repeat(0, count).Select(_ => Policy.NoOpAsync<int>()).ToArray()),
+        PollyVersion.V7 => count == 1 ? Policy.NoOpAsync<string>() : Policy.WrapAsync(Enumerable.Repeat(0, count).Select(_ => Policy.NoOpAsync<string>()).ToArray()),
 
         PollyVersion.V8 => CreateStrategy(builder =>
         {

--- a/src/Polly.Core.Benchmarks/Internals/Helper.cs
+++ b/src/Polly.Core.Benchmarks/Internals/Helper.cs
@@ -9,19 +9,19 @@ internal static partial class Helper
         switch (version)
         {
             case PollyVersion.V7:
-                await ((IAsyncPolicy<int>)obj).ExecuteAsync(static _ => Task.FromResult(999), CancellationToken.None).ConfigureAwait(false);
+                await ((IAsyncPolicy<string>)obj).ExecuteAsync(static _ => Task.FromResult("dummy"), CancellationToken.None).ConfigureAwait(false);
                 return;
             case PollyVersion.V8:
-                await ((ResilienceStrategy)obj).ExecuteAsync(static _ => new ValueTask<int>(999), CancellationToken.None).ConfigureAwait(false);
+                await ((ResilienceStrategy<string>)obj).ExecuteAsync(static _ => new ValueTask<string>("dummy"), CancellationToken.None).ConfigureAwait(false);
                 return;
         }
 
         throw new NotSupportedException();
     }
 
-    private static ResilienceStrategy CreateStrategy(Action<ResilienceStrategyBuilder> configure)
+    private static ResilienceStrategy<string> CreateStrategy(Action<ResilienceStrategyBuilder<string>> configure)
     {
-        var builder = new ResilienceStrategyBuilder();
+        var builder = new ResilienceStrategyBuilder<string>();
         configure(builder);
         return builder.Build();
     }

--- a/src/Polly.Core.Tests/Fallback/FallbackResilienceStrategyBuilderExtensionsTests.cs
+++ b/src/Polly.Core.Tests/Fallback/FallbackResilienceStrategyBuilderExtensionsTests.cs
@@ -7,53 +7,51 @@ namespace Polly.Core.Tests.Fallback;
 
 public class FallbackResilienceStrategyBuilderExtensionsTests
 {
-    private readonly ResilienceStrategyBuilder _builder = new();
-
-    public static readonly TheoryData<Action<ResilienceStrategyBuilder>> FallbackCases = new()
+    public static readonly TheoryData<Action<ResilienceStrategyBuilder<int>>> FallbackOverloadsGeneric = new()
     {
         builder =>
         {
-            builder.AddFallback(new FallbackStrategyOptions());
+            builder.AddFallback(new FallbackStrategyOptions<int>{ FallbackAction = (_, _) =>  new ValueTask<int>(0) });
         },
         builder =>
         {
-            builder.AddFallback(new FallbackStrategyOptions<double>{ FallbackAction = (_, _) =>  new ValueTask<double>(0) });
-        },
-        builder =>
-        {
-            builder.AddFallback<double>(handle => { }, (_, _) =>  new ValueTask<double>(0));
+            builder.AddFallback(handle => { }, (_, _) =>  new ValueTask<int>(0));
         },
     };
 
-    [MemberData(nameof(FallbackCases))]
+    [MemberData(nameof(FallbackOverloadsGeneric))]
     [Theory]
-    public void AddFallback_Ok(Action<ResilienceStrategyBuilder> configure)
+    public void AddFallback_Generic_Ok(Action<ResilienceStrategyBuilder<int>> configure)
     {
-        configure(_builder);
-        _builder.Build().Should().BeOfType<FallbackResilienceStrategy>();
+        var builder = new ResilienceStrategyBuilder<int>();
+        configure(builder);
+        builder.Build().Strategy.Should().BeOfType<FallbackResilienceStrategy>();
     }
 
     [Fact]
-    public void AddFallback_Generic_Ok()
+    public void AddFallback_Ok()
     {
-        var strategy = _builder
-            .AddFallback<int>(
-                handler => handler.HandleResult(-1).HandleException<InvalidOperationException>(),
-                (_, args) =>
-                {
-                    args.Context.Should().NotBeNull();
-                    return new ValueTask<int>(1);
-                })
-            .Build();
+        var options = new FallbackStrategyOptions();
+        options.Handler.SetFallback<int>(handler =>
+        {
+            handler.ShouldHandle.HandleResult(-1).HandleException<InvalidOperationException>();
+            handler.FallbackAction = (_, args) =>
+            {
+                args.Context.Should().NotBeNull();
+                return new ValueTask<int>(1);
+            };
+        });
 
-        strategy.Execute(_ => -1).Should().Be(1);
+        var strategy = new ResilienceStrategyBuilder().AddFallback(options).Build();
+
+        strategy.Execute<int>(_ => -1).Should().Be(1);
         strategy.Execute<int>(_ => throw new InvalidOperationException()).Should().Be(1);
     }
 
     [Fact]
     public void AddFallback_InvalidOptions_Throws()
     {
-        _builder
+        new ResilienceStrategyBuilder()
             .Invoking(b => b.AddFallback(new FallbackStrategyOptions { Handler = null! }))
             .Should()
             .Throw<ValidationException>()
@@ -63,7 +61,7 @@ public class FallbackResilienceStrategyBuilderExtensionsTests
     [Fact]
     public void AddFallbackT_InvalidOptions_Throws()
     {
-        _builder
+        new ResilienceStrategyBuilder<double>()
             .Invoking(b => b.AddFallback(new FallbackStrategyOptions<double> { ShouldHandle = null! }))
             .Should()
             .Throw<ValidationException>()

--- a/src/Polly.Core.Tests/GenericResilienceStrategyBuilderTests.cs
+++ b/src/Polly.Core.Tests/GenericResilienceStrategyBuilderTests.cs
@@ -1,0 +1,48 @@
+using FluentAssertions;
+using Polly.Strategy;
+using Polly.Utils;
+
+namespace Polly.Core.Tests;
+
+public class GenericResilienceStrategyBuilderTests
+{
+    private readonly ResilienceStrategyBuilder<string> _builder = new();
+
+    [Fact]
+    public void Ctor_EnsureDefaults()
+    {
+        _builder.BuilderName.Should().Be("");
+        _builder.Properties.Should().NotBeNull();
+        _builder.TimeProvider.Should().Be(TimeProvider.System);
+        _builder.OnCreatingStrategy.Should().BeNull();
+    }
+
+    [Fact]
+    public void Properties_GetSet_Ok()
+    {
+        _builder.BuilderName = "dummy";
+        _builder.BuilderName.Should().Be("dummy");
+
+        var timeProvider = new FakeTimeProvider().Object;
+        _builder.TimeProvider = timeProvider;
+        _builder.TimeProvider.Should().Be(timeProvider);
+
+        _builder.OnCreatingStrategy = s => { };
+        _builder.OnCreatingStrategy.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Build_Ok()
+    {
+        // arrange
+        _builder.AddStrategy(new TestResilienceStrategy());
+        _builder.AddStrategy(_ => new TestResilienceStrategy(), new TestResilienceStrategyOptions());
+
+        // act
+        var strategy = _builder.Build();
+
+        // assert
+        strategy.Should().NotBeNull();
+        strategy.Strategy.Should().BeOfType<ResilienceStrategyPipeline>().Subject.Strategies.Should().HaveCount(2);
+    }
+}

--- a/src/Polly.Core.Tests/NullResilienceStrategyTests.cs
+++ b/src/Polly.Core.Tests/NullResilienceStrategyTests.cs
@@ -6,6 +6,8 @@ public class NullResilienceStrategyTests
     public void Instance_ShouldNotBeNull()
     {
         NullResilienceStrategy.Instance.Should().NotBeNull();
+        NullResilienceStrategy<string>.Instance.Should().NotBeNull();
+
     }
 
     [Fact]
@@ -13,7 +15,8 @@ public class NullResilienceStrategyTests
     {
         bool executed = false;
         NullResilienceStrategy.Instance.Execute(_ => executed = true);
-
         executed.Should().BeTrue();
+
+        NullResilienceStrategy<string>.Instance.Execute(_ => "res").Should().Be("res");
     }
 }

--- a/src/Polly.Core.Tests/ResilienceStrategyTests.TResult.Async.cs
+++ b/src/Polly.Core.Tests/ResilienceStrategyTests.TResult.Async.cs
@@ -1,0 +1,80 @@
+using Xunit;
+
+namespace Polly.Core.Tests;
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+
+public partial class ResilienceStrategyTests
+{
+    public static TheoryData<Func<ResilienceStrategy<string>, ValueTask>> ExecuteAsyncGenericStrategyData = new()
+    {
+        async strategy =>
+        {
+            (await strategy.ExecuteAsync(
+                token =>
+                {
+                    token.Should().Be(CancellationToken);
+                    return new ValueTask<string>("res");
+                },
+                CancellationToken)).Should().Be("res");
+        },
+
+        async strategy =>
+        {
+            (await strategy.ExecuteAsync(
+                (state, token) =>
+                {
+                    state.Should().Be("state");
+                    token.Should().Be(CancellationToken);
+                    return new ValueTask<string>("res");
+                },
+                "state",
+                CancellationToken)).Should().Be("res");
+        },
+
+        async strategy =>
+        {
+            var context = ResilienceContext.Get();
+            context.CancellationToken = CancellationToken;
+            (await strategy.ExecuteAsync(
+                (context, state) =>
+                {
+                    state.Should().Be("state");
+                    context.Should().Be(context);
+                    return new ValueTask<string>("res");
+                },
+                context,
+                "state")).Should().Be("res");
+        },
+
+        async strategy =>
+        {
+            var context = ResilienceContext.Get();
+            context.CancellationToken = CancellationToken;
+            (await strategy.ExecuteAsync(
+                (context) =>
+                {
+                    context.Should().Be(context);
+                    return new ValueTask<string>("res");
+                },
+                context)).Should().Be("res");
+        }
+    };
+
+    [MemberData(nameof(ExecuteAsyncGenericStrategyData))]
+    [Theory]
+    public async Task ExecuteAsync_GenericStrategy_Ok(Func<ResilienceStrategy<string>, ValueTask> execute)
+    {
+        var strategy = new ResilienceStrategy<string>(new TestResilienceStrategy
+        {
+            Before = (c, _) =>
+            {
+                c.IsSynchronous.Should().BeFalse();
+                c.ResultType.Should().Be(typeof(string));
+                c.CancellationToken.CanBeCanceled.Should().BeTrue();
+            },
+        });
+
+        await execute(strategy);
+    }
+}

--- a/src/Polly.Core.Tests/ResilienceStrategyTests.TResult.Sync.cs
+++ b/src/Polly.Core.Tests/ResilienceStrategyTests.TResult.Sync.cs
@@ -1,0 +1,93 @@
+using Xunit;
+
+namespace Polly.Core.Tests;
+
+public partial class ResilienceStrategyTests
+{
+    public static TheoryData<Action<ResilienceStrategy<string>>> ExecuteGenericStrategyData = new()
+    {
+        strategy =>
+        {
+            strategy.Execute(() => "res").Should().Be("res");
+        },
+
+        strategy =>
+        {
+            strategy.Execute(state =>
+            {
+                state.Should().Be("state");
+                return "res";
+            },
+            "state").Should().Be("res");
+        },
+
+        strategy =>
+        {
+            strategy.Execute(
+                token =>
+                {
+                    token.Should().Be(CancellationToken);
+                    return "res";
+                },
+                CancellationToken).Should().Be("res");
+        },
+
+        strategy =>
+        {
+            strategy.Execute(
+                (state, token) =>
+                {
+                    state.Should().Be("state");
+                    token.Should().Be(CancellationToken);
+                    return "res";
+                },
+                "state",
+                CancellationToken).Should().Be("res");
+        },
+
+        strategy =>
+        {
+            var context = ResilienceContext.Get();
+            context.CancellationToken = CancellationToken;
+            strategy.Execute(
+                (context, state) =>
+                {
+                    state.Should().Be("state");
+                    context.Should().Be(context);
+                    context.CancellationToken.Should().Be(CancellationToken);
+                    return "res";
+                },
+                context,
+                "state").Should().Be("res");
+        },
+
+        strategy =>
+        {
+            var context = ResilienceContext.Get();
+            context.CancellationToken = CancellationToken;
+            strategy.Execute(
+                (context) =>
+                {
+                    context.Should().Be(context);
+                    return "res";
+                },
+                context).Should().Be("res");
+        }
+    };
+
+    [MemberData(nameof(ExecuteGenericStrategyData))]
+    [Theory]
+    public void Execute_GenericStrategy_Ok(Action<ResilienceStrategy<string>> execute)
+    {
+        var strategy = new ResilienceStrategy<string>(new TestResilienceStrategy
+        {
+            Before = (c, _) =>
+            {
+                c.IsSynchronous.Should().BeTrue();
+                c.ResultType.Should().Be(typeof(string));
+            },
+        });
+
+        execute(strategy);
+    }
+}

--- a/src/Polly.Core.Tests/Strategy/OutcomeGeneratorTests.cs
+++ b/src/Polly.Core.Tests/Strategy/OutcomeGeneratorTests.cs
@@ -81,6 +81,12 @@ public class OutcomeGeneratorTests
         },
         sut =>
         {
+            sut.SetGenerator<object>((_, _) => GeneratedValue.Valid1);
+            InvokeHandler(sut, new Outcome<bool>(true), GeneratedValue.Valid1);
+            InvokeHandler(sut, new Outcome<int>(0), GeneratedValue.Valid1);
+        },
+        sut =>
+        {
             sut.SetGenerator<int>((_, _) => GeneratedValue.Valid1);
             sut.SetGenerator((_, _) => GeneratedValue.Valid2);
             InvokeHandler(sut, new Outcome<int>(10), GeneratedValue.Valid1);

--- a/src/Polly.Core.Tests/Strategy/OutcomeGeneratorTests.cs
+++ b/src/Polly.Core.Tests/Strategy/OutcomeGeneratorTests.cs
@@ -84,6 +84,8 @@ public class OutcomeGeneratorTests
             sut.SetGenerator<object>((_, _) => GeneratedValue.Valid1);
             InvokeHandler(sut, new Outcome<bool>(true), GeneratedValue.Valid1);
             InvokeHandler(sut, new Outcome<int>(0), GeneratedValue.Valid1);
+            InvokeHandler(sut, new Outcome<int>(new InvalidOperationException()), GeneratedValue.Valid1);
+            InvokeHandler(sut, new Outcome<bool>(new InvalidOperationException()), GeneratedValue.Valid1);
         },
         sut =>
         {

--- a/src/Polly.Core.Tests/Timeout/TimeoutResilienceStrategyBuilderExtensionsTests.cs
+++ b/src/Polly.Core.Tests/Timeout/TimeoutResilienceStrategyBuilderExtensionsTests.cs
@@ -12,7 +12,7 @@ public class TimeoutResilienceStrategyBuilderExtensionsTests
         yield return new object[]
         {
             timeout,
-            (ResilienceStrategyBuilder builder) => { builder.AddTimeout(timeout); },
+            (ResilienceStrategyBuilder<int> builder) => { builder.AddTimeout(timeout); },
             (TimeoutResilienceStrategy strategy) => { GetTimeout(strategy).Should().Be(timeout); }
         };
 
@@ -21,7 +21,7 @@ public class TimeoutResilienceStrategyBuilderExtensionsTests
         yield return new object[]
         {
             timeout,
-            (ResilienceStrategyBuilder builder) => { builder.AddTimeout(timeout, _=> called = true); },
+            (ResilienceStrategyBuilder<int> builder) => { builder.AddTimeout(timeout, _=> called = true); },
             (TimeoutResilienceStrategy strategy) =>
             {
                 GetTimeout(strategy).Should().Be(timeout);
@@ -35,7 +35,7 @@ public class TimeoutResilienceStrategyBuilderExtensionsTests
     [Theory]
     public void AddTimeout_InvalidTimeout_EnsureValidated(TimeSpan timeout)
     {
-        var builder = new ResilienceStrategyBuilder();
+        var builder = new ResilienceStrategyBuilder<int>();
 
         Assert.Throws<ValidationException>(() => builder.AddTimeout(timeout));
         Assert.Throws<ValidationException>(() => builder.AddTimeout(timeout, args => { }));
@@ -43,11 +43,11 @@ public class TimeoutResilienceStrategyBuilderExtensionsTests
 
     [MemberData(nameof(AddTimeout_Ok_Data))]
     [Theory]
-    internal void AddTimeout_Ok(TimeSpan timeout, Action<ResilienceStrategyBuilder> configure, Action<TimeoutResilienceStrategy> assert)
+    internal void AddTimeout_Ok(TimeSpan timeout, Action<ResilienceStrategyBuilder<int>> configure, Action<TimeoutResilienceStrategy> assert)
     {
-        var builder = new ResilienceStrategyBuilder();
+        var builder = new ResilienceStrategyBuilder<int>();
         configure(builder);
-        var strategy = builder.Build().Should().BeOfType<TimeoutResilienceStrategy>().Subject;
+        var strategy = builder.Build().Strategy.Should().BeOfType<TimeoutResilienceStrategy>().Subject;
         assert(strategy);
 
         GetTimeout(strategy).Should().Be(timeout);

--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerResilienceStrategyBuilderExtensions.cs
@@ -25,14 +25,14 @@ public static class CircuitBreakerResilienceStrategyBuilderExtensions
     /// </remarks>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
-    public static ResilienceStrategyBuilder AddAdvancedCircuitBreaker<TResult>(this ResilienceStrategyBuilder builder, AdvancedCircuitBreakerStrategyOptions<TResult> options)
+    public static ResilienceStrategyBuilder<TResult> AddAdvancedCircuitBreaker<TResult>(this ResilienceStrategyBuilder<TResult> builder, AdvancedCircuitBreakerStrategyOptions<TResult> options)
     {
         Guard.NotNull(builder);
         Guard.NotNull(options);
 
         ValidationHelper.ValidateObject(options, "The advanced circuit breaker strategy options are invalid.");
 
-        return builder.AddCircuitBreakerCore(options.AsNonGenericOptions());
+        return builder.ConfigureBuilder(buider => AddCircuitBreakerCore(buider, options.AsNonGenericOptions()));
     }
 
     /// <summary>
@@ -74,14 +74,14 @@ public static class CircuitBreakerResilienceStrategyBuilderExtensions
     /// </remarks>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
-    public static ResilienceStrategyBuilder AddSimpleCircuitBreaker<TResult>(this ResilienceStrategyBuilder builder, SimpleCircuitBreakerStrategyOptions<TResult> options)
+    public static ResilienceStrategyBuilder<TResult> AddSimpleCircuitBreaker<TResult>(this ResilienceStrategyBuilder<TResult> builder, SimpleCircuitBreakerStrategyOptions<TResult> options)
     {
         Guard.NotNull(builder);
         Guard.NotNull(options);
 
         ValidationHelper.ValidateObject(options, "The circuit breaker strategy options are invalid.");
 
-        return builder.AddCircuitBreakerCore(options.AsNonGenericOptions());
+        return builder.ConfigureBuilder(builder => builder.AddCircuitBreakerCore(options.AsNonGenericOptions()));
     }
 
     /// <summary>

--- a/src/Polly.Core/Fallback/FallbackResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/Fallback/FallbackResilienceStrategyBuilderExtensions.cs
@@ -54,7 +54,7 @@ public static class FallbackResilienceStrategyBuilderExtensions
 
         ValidationHelper.ValidateObject(options, "The fallback strategy options are invalid.");
 
-        return builder.ConfigureBuilder(builder => builder.AddFallback(options.AsNonGenericOptions()));
+        return builder.AddStrategy(context => new FallbackResilienceStrategy(options.AsNonGenericOptions(), context.Telemetry), options);
     }
 
     /// <summary>

--- a/src/Polly.Core/Fallback/FallbackResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/Fallback/FallbackResilienceStrategyBuilderExtensions.cs
@@ -19,8 +19,8 @@ public static class FallbackResilienceStrategyBuilderExtensions
     /// <param name="fallbackAction">The fallback action to be executed.</param>
     /// <returns>The builder instance with the fallback strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="shouldHandle"/> or <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
-    public static ResilienceStrategyBuilder AddFallback<TResult>(
-        this ResilienceStrategyBuilder builder,
+    public static ResilienceStrategyBuilder<TResult> AddFallback<TResult>(
+        this ResilienceStrategyBuilder<TResult> builder,
         Action<OutcomePredicate<HandleFallbackArguments, TResult>> shouldHandle,
         Func<Outcome<TResult>, HandleFallbackArguments, ValueTask<TResult>> fallbackAction)
     {
@@ -47,14 +47,14 @@ public static class FallbackResilienceStrategyBuilderExtensions
     /// <returns>The builder instance with the fallback strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
-    public static ResilienceStrategyBuilder AddFallback<TResult>(this ResilienceStrategyBuilder builder, FallbackStrategyOptions<TResult> options)
+    public static ResilienceStrategyBuilder<TResult> AddFallback<TResult>(this ResilienceStrategyBuilder<TResult> builder, FallbackStrategyOptions<TResult> options)
     {
         Guard.NotNull(builder);
         Guard.NotNull(options);
 
         ValidationHelper.ValidateObject(options, "The fallback strategy options are invalid.");
 
-        return builder.AddFallback(options.AsNonGenericOptions());
+        return builder.ConfigureBuilder(builder => builder.AddFallback(options.AsNonGenericOptions()));
     }
 
     /// <summary>

--- a/src/Polly.Core/Hedging/HedgingResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/Hedging/HedgingResilienceStrategyBuilderExtensions.cs
@@ -24,7 +24,7 @@ public static class HedgingResilienceStrategyBuilderExtensions
 
         ValidationHelper.ValidateObject(options, "The hedging strategy options are invalid.");
 
-        return builder.ConfigureBuilder(builder => builder.AddHedging(options.AsNonGenericOptions()));
+        return builder.AddStrategy(context => new HedgingResilienceStrategy(options.AsNonGenericOptions(), context.TimeProvider, context.Telemetry), options);
     }
 
     /// <summary>

--- a/src/Polly.Core/Hedging/HedgingResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/Hedging/HedgingResilienceStrategyBuilderExtensions.cs
@@ -17,14 +17,14 @@ public static class HedgingResilienceStrategyBuilderExtensions
     /// <returns>The builder instance with the hedging strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
-    public static ResilienceStrategyBuilder AddHedging<TResult>(this ResilienceStrategyBuilder builder, HedgingStrategyOptions<TResult> options)
+    public static ResilienceStrategyBuilder<TResult> AddHedging<TResult>(this ResilienceStrategyBuilder<TResult> builder, HedgingStrategyOptions<TResult> options)
     {
         Guard.NotNull(builder);
         Guard.NotNull(options);
 
         ValidationHelper.ValidateObject(options, "The hedging strategy options are invalid.");
 
-        return builder.AddHedging(options.AsNonGenericOptions());
+        return builder.ConfigureBuilder(builder => builder.AddHedging(options.AsNonGenericOptions()));
     }
 
     /// <summary>

--- a/src/Polly.Core/NullResilienceStrategy.TResult.cs
+++ b/src/Polly.Core/NullResilienceStrategy.TResult.cs
@@ -1,0 +1,18 @@
+namespace Polly;
+
+/// <summary>
+/// A resilience strategy that executes an user-provided callback without any additional logic.
+/// </summary>
+/// <typeparam name="TResult">The type of result this strategy handles.</typeparam>
+public sealed class NullResilienceStrategy<TResult> : ResilienceStrategy<TResult>
+{
+    /// <summary>
+    /// Gets the singleton instance of the <see cref="NullResilienceStrategy"/>.
+    /// </summary>
+    public static readonly NullResilienceStrategy<TResult> Instance = new();
+
+    private NullResilienceStrategy()
+        : base(NullResilienceStrategy.Instance)
+    {
+    }
+}

--- a/src/Polly.Core/ResilienceStrategy.TResult.Async.cs
+++ b/src/Polly.Core/ResilienceStrategy.TResult.Async.cs
@@ -1,0 +1,88 @@
+namespace Polly;
+
+/// <summary>
+/// Resilience strategy is used to execute the user-provided callbacks.
+/// </summary>
+/// <typeparam name="TResult">The type of result this strategy supports.</typeparam>
+/// <remarks>
+/// Resilience strategy supports various types of callbacks of <typeparamref name="TResult"/> result type
+/// and provides a unified way to execute them. This includes overloads for synchronous and asynchronous callbacks.
+/// </remarks>
+public partial class ResilienceStrategy<TResult>
+{
+    internal ResilienceStrategy(ResilienceStrategy strategy) => Strategy = strategy;
+
+    internal ResilienceStrategy Strategy { get; }
+
+    /// <summary>
+    /// Executes the specified callback.
+    /// </summary>
+    /// <typeparam name="TState">The type of state associated with the callback.</typeparam>
+    /// <param name="callback">The user-provided callback.</param>
+    /// <param name="context">The context associated with the callback.</param>
+    /// <param name="state">The state associated with the callback.</param>
+    /// <returns>The instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> or <paramref name="context"/> is <see langword="null"/>.</exception>
+    public ValueTask<TResult> ExecuteAsync<TState>(
+        Func<ResilienceContext, TState, ValueTask<TResult>> callback,
+        ResilienceContext context,
+        TState state)
+    {
+        Guard.NotNull(callback);
+        Guard.NotNull(context);
+
+        return Strategy.ExecuteAsync(callback, context, state);
+    }
+
+    /// <summary>
+    /// Executes the specified callback.
+    /// </summary>
+    /// <param name="callback">The user-provided callback.</param>
+    /// <param name="context">The context associated with the callback.</param>
+    /// <returns>The instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> or <paramref name="context"/> is <see langword="null"/>.</exception>
+    public ValueTask<TResult> ExecuteAsync(
+        Func<ResilienceContext, ValueTask<TResult>> callback,
+        ResilienceContext context)
+    {
+        Guard.NotNull(callback);
+        Guard.NotNull(context);
+
+        return Strategy.ExecuteAsync(callback, context);
+    }
+
+    /// <summary>
+    /// Executes the specified callback.
+    /// </summary>
+    /// <typeparam name="TState">The type of state associated with the callback.</typeparam>
+    /// <param name="callback">The user-provided callback.</param>
+    /// <param name="state">The state associated with the callback.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> associated with the callback.</param>
+    /// <returns>The instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> is <see langword="null"/>.</exception>
+    public ValueTask<TResult> ExecuteAsync<TState>(
+        Func<TState, CancellationToken, ValueTask<TResult>> callback,
+        TState state,
+        CancellationToken cancellationToken = default)
+    {
+        Guard.NotNull(callback);
+
+        return Strategy.ExecuteAsync(callback, state, cancellationToken);
+    }
+
+    /// <summary>
+    /// Executes the specified callback.
+    /// </summary>
+    /// <param name="callback">The user-provided callback.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> associated with the callback.</param>
+    /// <returns>The instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> is <see langword="null"/>.</exception>
+    public ValueTask<TResult> ExecuteAsync(
+        Func<CancellationToken, ValueTask<TResult>> callback,
+        CancellationToken cancellationToken = default)
+    {
+        Guard.NotNull(callback);
+
+        return Strategy.ExecuteAsync(callback, cancellationToken);
+    }
+}

--- a/src/Polly.Core/ResilienceStrategy.TResult.Sync.cs
+++ b/src/Polly.Core/ResilienceStrategy.TResult.Sync.cs
@@ -1,0 +1,107 @@
+using System.Threading;
+using Polly;
+
+namespace Polly;
+
+public partial class ResilienceStrategy<TResult>
+{
+    /// <summary>
+    /// Executes the specified callback.
+    /// </summary>
+    /// <typeparam name="TState">The type of state associated with the callback.</typeparam>
+    /// <param name="callback">The user-provided callback.</param>
+    /// <param name="context">The context associated with the callback.</param>
+    /// <param name="state">The state associated with the callback.</param>
+    /// <returns>An instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> or <paramref name="context"/> is <see langword="null"/>.</exception>
+    public TResult Execute<TState>(
+        Func<ResilienceContext, TState, TResult> callback,
+        ResilienceContext context,
+        TState state)
+    {
+        Guard.NotNull(callback);
+        Guard.NotNull(context);
+
+        return Strategy.Execute(callback, context, state);
+    }
+
+    /// <summary>
+    /// Executes the specified callback.
+    /// </summary>
+    /// <param name="callback">The user-provided callback.</param>
+    /// <param name="context">The context associated with the callback.</param>
+    /// <returns>An instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> or <paramref name="context"/> is <see langword="null"/>.</exception>
+    public TResult Execute(
+        Func<ResilienceContext, TResult> callback,
+        ResilienceContext context)
+    {
+        Guard.NotNull(callback);
+        Guard.NotNull(context);
+
+        return Strategy.Execute(callback, context);
+    }
+
+    /// <summary>
+    /// Executes the specified callback.
+    /// </summary>
+    /// <param name="callback">The user-provided callback.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> associated with the callback.</param>
+    /// <returns>An instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> is <see langword="null"/>.</exception>
+    public TResult Execute(
+        Func<CancellationToken, TResult> callback,
+        CancellationToken cancellationToken = default)
+    {
+        Guard.NotNull(callback);
+
+        return Strategy.Execute(callback, cancellationToken);
+    }
+
+    /// <summary>
+    /// Executes the specified callback.
+    /// </summary>
+    /// <param name="callback">The user-provided callback.</param>
+    /// <returns>An instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> is <see langword="null"/>.</exception>
+    public TResult Execute(Func<TResult> callback)
+    {
+        Guard.NotNull(callback);
+
+        return Strategy.Execute(callback);
+    }
+
+    /// <summary>
+    /// Executes the specified callback.
+    /// </summary>
+    /// <typeparam name="TState">The type of state associated with the callback.</typeparam>
+    /// <param name="callback">The user-provided callback.</param>
+    /// <param name="state">The state associated with the callback.</param>
+    /// <returns>An instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> is <see langword="null"/>.</exception>
+    public TResult Execute<TState>(Func<TState, TResult> callback, TState state)
+    {
+        Guard.NotNull(callback);
+
+        return Strategy.Execute(callback, state);
+    }
+
+    /// <summary>
+    /// Executes the specified callback.
+    /// </summary>
+    /// <typeparam name="TState">The type of state associated with the callback.</typeparam>
+    /// <param name="callback">The user-provided callback.</param>
+    /// <param name="state">The state associated with the callback.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> associated with the callback.</param>
+    /// <returns>An instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> is <see langword="null"/>.</exception>
+    public TResult Execute<TState>(
+        Func<TState, CancellationToken, TResult> callback,
+        TState state,
+        CancellationToken cancellationToken = default)
+    {
+        Guard.NotNull(callback);
+
+        return Strategy.Execute(callback, state, cancellationToken);
+    }
+}

--- a/src/Polly.Core/ResilienceStrategyBuilder.TResult.cs
+++ b/src/Polly.Core/ResilienceStrategyBuilder.TResult.cs
@@ -1,0 +1,103 @@
+using System.ComponentModel.DataAnnotations;
+using Polly.Strategy;
+
+namespace Polly;
+
+/// <summary>
+/// A builder that is used to create an instance of <see cref="ResilienceStrategy{TResult}"/>.
+/// </summary>
+/// <typeparam name="TResult">The type of result to handle.</typeparam>
+/// <remarks>
+/// The builder supports chaining multiple strategies into a pipeline of strategies.
+/// The resulting instance of <see cref="ResilienceStrategy{TResult}"/> created by the <see cref="Build"/> call will execute the strategies in the same order they were added to the builder.
+/// The order of the strategies is important.
+/// </remarks>
+public class ResilienceStrategyBuilder<TResult>
+{
+    private readonly ResilienceStrategyBuilder _builder = new();
+
+    /// <summary>
+    /// Gets or sets the name of the builder.
+    /// </summary>
+    /// <remarks>This property is also included in the telemetry that is produced by the individual resilience strategies.</remarks>
+    [Required(AllowEmptyStrings = true)]
+    public string BuilderName
+    {
+        get => _builder.BuilderName;
+        set => _builder.BuilderName = value;
+    }
+
+    /// <summary>
+    /// Gets the custom properties attached to builder options.
+    /// </summary>
+    public ResilienceProperties Properties => _builder.Properties;
+
+    /// <summary>
+    /// Gets or sets a <see cref="TimeProvider"/> that is used by strategies that work with time.
+    /// </summary>
+    /// <remarks>
+    /// This property is internal until we switch to official System.TimeProvider.
+    /// </remarks>
+    [Required]
+    internal TimeProvider TimeProvider
+    {
+        get => _builder.TimeProvider;
+        set => _builder.TimeProvider = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the callback that is invoked just before the final resilience strategy is being created.
+    /// </summary>
+    internal Action<IList<ResilienceStrategy>>? OnCreatingStrategy
+    {
+        get => _builder.OnCreatingStrategy;
+        set => _builder.OnCreatingStrategy = value;
+    }
+
+    /// <summary>
+    /// Adds an already created strategy instance to the builder.
+    /// </summary>
+    /// <param name="strategy">The strategy instance.</param>
+    /// <returns>The same builder instance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="strategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when this builder was already used to create a strategy. The builder cannot be modified after it has been used.</exception>
+    public ResilienceStrategyBuilder<TResult> AddStrategy(ResilienceStrategy strategy)
+    {
+        Guard.NotNull(strategy);
+
+        _builder.AddStrategy(strategy);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a strategy to the builder.
+    /// </summary>
+    /// <param name="factory">The factory that creates a resilience strategy.</param>
+    /// <param name="options">The options associated with the strategy. If none are provided the default instance of <see cref="ResilienceStrategyOptions"/> is created.</param>
+    /// <returns>The same builder instance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="factory"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when this builder was already used to create a strategy. The builder cannot be modified after it has been used.</exception>
+    /// <exception cref="ValidationException">Thrown when the <paramref name="options"/> are invalid.</exception>
+    public ResilienceStrategyBuilder<TResult> AddStrategy(Func<ResilienceStrategyBuilderContext, ResilienceStrategy> factory, ResilienceStrategyOptions options)
+    {
+        Guard.NotNull(factory);
+        Guard.NotNull(options);
+
+        _builder.AddStrategy(factory, options);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Builds the resilience strategy.
+    /// </summary>
+    /// <returns>An instance of <see cref="ResilienceStrategy{TResult}"/>.</returns>
+    /// <exception cref="ValidationException">Thrown when this builder has invalid configuration.</exception>
+    public ResilienceStrategy<TResult> Build() => new(_builder.Build());
+
+    internal ResilienceStrategyBuilder<TResult> ConfigureBuilder(Action<ResilienceStrategyBuilder> configure)
+    {
+        configure(_builder);
+        return this;
+    }
+}

--- a/src/Polly.Core/ResilienceStrategyBuilder.TResult.cs
+++ b/src/Polly.Core/ResilienceStrategyBuilder.TResult.cs
@@ -78,7 +78,9 @@ public class ResilienceStrategyBuilder<TResult>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="factory"/> is <see langword="null"/>.</exception>
     /// <exception cref="InvalidOperationException">Thrown when this builder was already used to create a strategy. The builder cannot be modified after it has been used.</exception>
     /// <exception cref="ValidationException">Thrown when the <paramref name="options"/> are invalid.</exception>
-    public ResilienceStrategyBuilder<TResult> AddStrategy(Func<ResilienceStrategyBuilderContext, ResilienceStrategy> factory, ResilienceStrategyOptions options)
+    public ResilienceStrategyBuilder<TResult> AddStrategy(
+        Func<ResilienceStrategyBuilderContext, ResilienceStrategy> factory,
+        ResilienceStrategyOptions options)
     {
         Guard.NotNull(factory);
         Guard.NotNull(options);
@@ -94,10 +96,4 @@ public class ResilienceStrategyBuilder<TResult>
     /// <returns>An instance of <see cref="ResilienceStrategy{TResult}"/>.</returns>
     /// <exception cref="ValidationException">Thrown when this builder has invalid configuration.</exception>
     public ResilienceStrategy<TResult> Build() => new(_builder.Build());
-
-    internal ResilienceStrategyBuilder<TResult> ConfigureBuilder(Action<ResilienceStrategyBuilder> configure)
-    {
-        configure(_builder);
-        return this;
-    }
 }

--- a/src/Polly.Core/Retry/RetryResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/Retry/RetryResilienceStrategyBuilderExtensions.cs
@@ -138,7 +138,7 @@ public static class RetryResilienceStrategyBuilderExtensions
 
         ValidationHelper.ValidateObject(options, "The retry strategy options are invalid.");
 
-        return builder.ConfigureBuilder(b => b.AddRetry(options.AsNonGenericOptions()));
+        return builder.AddStrategy(context => new RetryResilienceStrategy(options.AsNonGenericOptions(), context.TimeProvider, context.Telemetry, RandomUtil.Instance), options);
     }
 
     /// <summary>

--- a/src/Polly.Core/Retry/RetryResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/Retry/RetryResilienceStrategyBuilderExtensions.cs
@@ -13,19 +13,20 @@ public static class RetryResilienceStrategyBuilderExtensions
     /// <summary>
     /// Adds a retry strategy to the builder.
     /// </summary>
+    /// <typeparam name="TResult">The type of result the retry strategy handles.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="shouldRetry">A predicate that defines the retry conditions.</param>
     /// <returns>The builder instance with the retry strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="shouldRetry"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when the options constructed from the arguments are invalid.</exception>
-    public static ResilienceStrategyBuilder AddRetry(
-        this ResilienceStrategyBuilder builder,
-        Action<OutcomePredicate<ShouldRetryArguments>> shouldRetry)
+    public static ResilienceStrategyBuilder<TResult> AddRetry<TResult>(
+        this ResilienceStrategyBuilder<TResult> builder,
+        Action<OutcomePredicate<ShouldRetryArguments, TResult>> shouldRetry)
     {
         Guard.NotNull(builder);
         Guard.NotNull(shouldRetry);
 
-        var options = new RetryStrategyOptions();
+        var options = new RetryStrategyOptions<TResult>();
         shouldRetry(options.ShouldRetry);
 
         return builder.AddRetry(options);
@@ -34,22 +35,23 @@ public static class RetryResilienceStrategyBuilderExtensions
     /// <summary>
     /// Adds a retry strategy to the builder.
     /// </summary>
+    /// <typeparam name="TResult">The type of result the retry strategy handles.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="shouldRetry">A predicate that defines the retry conditions.</param>
     /// <param name="retryDelayGenerator">The generator for retry delays. The argument is zero-based attempt number.</param>
     /// <returns>The builder instance with the retry strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/>, <paramref name="shouldRetry"/> or <paramref name="retryDelayGenerator"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when the options constructed from the arguments are invalid.</exception>
-    public static ResilienceStrategyBuilder AddRetry(
-        this ResilienceStrategyBuilder builder,
-        Action<OutcomePredicate<ShouldRetryArguments>> shouldRetry,
+    public static ResilienceStrategyBuilder<TResult> AddRetry<TResult>(
+        this ResilienceStrategyBuilder<TResult> builder,
+        Action<OutcomePredicate<ShouldRetryArguments, TResult>> shouldRetry,
         Func<int, TimeSpan> retryDelayGenerator)
     {
         Guard.NotNull(builder);
         Guard.NotNull(shouldRetry);
         Guard.NotNull(retryDelayGenerator);
 
-        var options = new RetryStrategyOptions();
+        var options = new RetryStrategyOptions<TResult>();
         shouldRetry(options.ShouldRetry);
         options.RetryDelayGenerator.SetGenerator((_, args) => retryDelayGenerator(args.Attempt));
 
@@ -59,21 +61,22 @@ public static class RetryResilienceStrategyBuilderExtensions
     /// <summary>
     /// Adds a retry strategy to the builder.
     /// </summary>
+    /// <typeparam name="TResult">The type of result the retry strategy handles.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="shouldRetry">A predicate that defines the retry conditions.</param>
     /// <param name="backoffType">The backoff type to use for the retry strategy.</param>
     /// <returns>The builder instance with the retry strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="shouldRetry"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when the options constructed from the arguments are invalid.</exception>
-    public static ResilienceStrategyBuilder AddRetry(
-        this ResilienceStrategyBuilder builder,
-        Action<OutcomePredicate<ShouldRetryArguments>> shouldRetry,
+    public static ResilienceStrategyBuilder<TResult> AddRetry<TResult>(
+        this ResilienceStrategyBuilder<TResult> builder,
+        Action<OutcomePredicate<ShouldRetryArguments, TResult>> shouldRetry,
         RetryBackoffType backoffType)
     {
         Guard.NotNull(builder);
         Guard.NotNull(shouldRetry);
 
-        var options = new RetryStrategyOptions
+        var options = new RetryStrategyOptions<TResult>
         {
             BackoffType = backoffType,
             RetryCount = RetryConstants.DefaultRetryCount,
@@ -88,6 +91,7 @@ public static class RetryResilienceStrategyBuilderExtensions
     /// <summary>
     /// Adds a retry strategy to the builder.
     /// </summary>
+    /// <typeparam name="TResult">The type of result the retry strategy handles.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="shouldRetry">A predicate that defines the retry conditions.</param>
     /// <param name="backoffType">The backoff type to use for the retry strategy.</param>
@@ -96,9 +100,9 @@ public static class RetryResilienceStrategyBuilderExtensions
     /// <returns>The builder instance with the retry strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="shouldRetry"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when the options constructed from the arguments are invalid.</exception>
-    public static ResilienceStrategyBuilder AddRetry(
-        this ResilienceStrategyBuilder builder,
-        Action<OutcomePredicate<ShouldRetryArguments>> shouldRetry,
+    public static ResilienceStrategyBuilder<TResult> AddRetry<TResult>(
+        this ResilienceStrategyBuilder<TResult> builder,
+        Action<OutcomePredicate<ShouldRetryArguments, TResult>> shouldRetry,
         RetryBackoffType backoffType,
         int retryCount,
         TimeSpan baseDelay)
@@ -106,7 +110,7 @@ public static class RetryResilienceStrategyBuilderExtensions
         Guard.NotNull(builder);
         Guard.NotNull(shouldRetry);
 
-        var options = new RetryStrategyOptions
+        var options = new RetryStrategyOptions<TResult>
         {
             BackoffType = backoffType,
             RetryCount = retryCount,
@@ -127,14 +131,14 @@ public static class RetryResilienceStrategyBuilderExtensions
     /// <returns>The builder instance with the retry strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
-    public static ResilienceStrategyBuilder AddRetry<TResult>(this ResilienceStrategyBuilder builder, RetryStrategyOptions<TResult> options)
+    public static ResilienceStrategyBuilder<TResult> AddRetry<TResult>(this ResilienceStrategyBuilder<TResult> builder, RetryStrategyOptions<TResult> options)
     {
         Guard.NotNull(builder);
         Guard.NotNull(options);
 
         ValidationHelper.ValidateObject(options, "The retry strategy options are invalid.");
 
-        return builder.AddRetry(options.AsNonGenericOptions());
+        return builder.ConfigureBuilder(b => b.AddRetry(options.AsNonGenericOptions()));
     }
 
     /// <summary>

--- a/src/Polly.Core/Timeout/TimeoutResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/Timeout/TimeoutResilienceStrategyBuilderExtensions.cs
@@ -65,7 +65,7 @@ public static class TimeoutResilienceStrategyBuilderExtensions
         Guard.NotNull(builder);
         Guard.NotNull(options);
 
-        return builder.ConfigureBuilder(b => b.AddTimeout(options));
+        return builder.AddStrategy(context => new TimeoutResilienceStrategy(options, context.TimeProvider, context.Telemetry), options);
     }
 
     /// <summary>

--- a/src/Polly.Core/Timeout/TimeoutResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/Timeout/TimeoutResilienceStrategyBuilderExtensions.cs
@@ -13,12 +13,13 @@ public static class TimeoutResilienceStrategyBuilderExtensions
     /// <summary>
     /// Adds a timeout resilience strategy to the builder.
     /// </summary>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="timeout">The timeout value. This value should be greater than <see cref="TimeSpan.Zero"/> or <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>.</param>
     /// <returns>The same builder instance.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when the options produced from the arguments are invalid.</exception>
-    public static ResilienceStrategyBuilder AddTimeout(this ResilienceStrategyBuilder builder, TimeSpan timeout)
+    public static ResilienceStrategyBuilder<TResult> AddTimeout<TResult>(this ResilienceStrategyBuilder<TResult> builder, TimeSpan timeout)
     {
         Guard.NotNull(builder);
 
@@ -31,13 +32,14 @@ public static class TimeoutResilienceStrategyBuilderExtensions
     /// <summary>
     /// Adds a timeout resilience strategy to the builder.
     /// </summary>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="timeout">The timeout value. This value should be greater than <see cref="TimeSpan.Zero"/> or <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>.</param>
     /// <param name="onTimeout">The callback that is executed when timeout happens.</param>
     /// <returns>The same builder instance.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when the options produced from the arguments are invalid.</exception>
-    public static ResilienceStrategyBuilder AddTimeout(this ResilienceStrategyBuilder builder, TimeSpan timeout, Action<OnTimeoutArguments> onTimeout)
+    public static ResilienceStrategyBuilder<TResult> AddTimeout<TResult>(this ResilienceStrategyBuilder<TResult> builder, TimeSpan timeout, Action<OnTimeoutArguments> onTimeout)
     {
         Guard.NotNull(builder);
         Guard.NotNull(onTimeout);
@@ -47,6 +49,23 @@ public static class TimeoutResilienceStrategyBuilderExtensions
             Timeout = timeout,
             OnTimeout = new NoOutcomeEvent<OnTimeoutArguments>().Register(onTimeout),
         });
+    }
+
+    /// <summary>
+    /// Adds a timeout resilience strategy to the builder.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="options">The timeout options.</param>
+    /// <returns>The same builder instance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
+    public static ResilienceStrategyBuilder<TResult> AddTimeout<TResult>(this ResilienceStrategyBuilder<TResult> builder, TimeoutStrategyOptions options)
+    {
+        Guard.NotNull(builder);
+        Guard.NotNull(options);
+
+        return builder.ConfigureBuilder(b => b.AddTimeout(options));
     }
 
     /// <summary>

--- a/src/Polly.RateLimiting.Tests/RateLimiterResilienceStrategyBuilderExtensionsTests.cs
+++ b/src/Polly.RateLimiting.Tests/RateLimiterResilienceStrategyBuilderExtensionsTests.cs
@@ -106,6 +106,20 @@ public class RateLimiterResilienceStrategyBuilderExtensionsTests
     }
 
     [Fact]
+    public void AddGenericRateLimiter_InvalidOptions_Throws()
+    {
+        new ResilienceStrategyBuilder<int>().Invoking(b => b.AddRateLimiter(new RateLimiterStrategyOptions()))
+            .Should()
+            .Throw<ValidationException>()
+            .WithMessage("""
+            The rate limiter strategy options are invalid.
+
+            Validation Errors:
+            The RateLimiter field is required.
+            """);
+    }
+
+    [Fact]
     public void AddRateLimiter_Options_Ok()
     {
         var strategy = new ResilienceStrategyBuilder()

--- a/src/Polly.RateLimiting.Tests/RateLimiterResilienceStrategyBuilderExtensionsTests.cs
+++ b/src/Polly.RateLimiting.Tests/RateLimiterResilienceStrategyBuilderExtensionsTests.cs
@@ -79,6 +79,19 @@ public class RateLimiterResilienceStrategyBuilderExtensionsTests
     }
 
     [Fact]
+    public void AddRateLimiter_Ok()
+    {
+        new ResilienceStrategyBuilder().AddRateLimiter(new RateLimiterStrategyOptions
+        {
+            RateLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
+            {
+                QueueLimit = 10,
+                PermitLimit = 10
+            })
+        }).Build().Should().BeOfType<RateLimiterResilienceStrategy>();
+    }
+
+    [Fact]
     public void AddRateLimiter_InvalidOptions_Throws()
     {
         new ResilienceStrategyBuilder().Invoking(b => b.AddRateLimiter(new RateLimiterStrategyOptions()))

--- a/src/Polly.RateLimiting/RateLimiterResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.RateLimiting/RateLimiterResilienceStrategyBuilderExtensions.cs
@@ -14,14 +14,15 @@ public static class RateLimiterResilienceStrategyBuilderExtensions
     /// <summary>
     /// Adds the concurrency limiter strategy.
     /// </summary>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="permitLimit">Maximum number of permits that can be leased concurrently.</param>
     /// <param name="queueLimit">Maximum number of permits that can be queued concurrently.</param>
     /// <returns>The builder instance with the concurrency limiter strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when the options constructed from the arguments are invalid.</exception>
-    public static ResilienceStrategyBuilder AddConcurrencyLimiter(
-        this ResilienceStrategyBuilder builder,
+    public static ResilienceStrategyBuilder<TResult> AddConcurrencyLimiter<TResult>(
+        this ResilienceStrategyBuilder<TResult> builder,
         int permitLimit,
         int queueLimit = 0)
     {
@@ -37,13 +38,14 @@ public static class RateLimiterResilienceStrategyBuilderExtensions
     /// <summary>
     /// Adds the concurrency limiter strategy.
     /// </summary>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="options">The concurrency limiter options.</param>
     /// <returns>The builder instance with the concurrency limiter strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when the options constructed from the arguments are invalid.</exception>
-    public static ResilienceStrategyBuilder AddConcurrencyLimiter(
-        this ResilienceStrategyBuilder builder,
+    public static ResilienceStrategyBuilder<TResult> AddConcurrencyLimiter<TResult>(
+        this ResilienceStrategyBuilder<TResult> builder,
         ConcurrencyLimiterOptions options)
     {
         Guard.NotNull(builder);
@@ -58,14 +60,15 @@ public static class RateLimiterResilienceStrategyBuilderExtensions
     /// <summary>
     /// Adds the concurrency limiter strategy.
     /// </summary>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="options">The concurrency limiter options.</param>
     /// <param name="onRejected">The callback that is raised when rate limiter is rejected.</param>
     /// <returns>The builder instance with the concurrency limiter strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/>, <paramref name="options"/> or <paramref name="onRejected"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when the options constructed from the arguments are invalid.</exception>
-    public static ResilienceStrategyBuilder AddConcurrencyLimiter(
-        this ResilienceStrategyBuilder builder,
+    public static ResilienceStrategyBuilder<TResult> AddConcurrencyLimiter<TResult>(
+        this ResilienceStrategyBuilder<TResult> builder,
         ConcurrencyLimiterOptions options,
         Action<OnRateLimiterRejectedArguments> onRejected)
     {
@@ -83,13 +86,14 @@ public static class RateLimiterResilienceStrategyBuilderExtensions
     /// <summary>
     /// Adds the rate limiter strategy.
     /// </summary>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="limiter">The rate limiter to use.</param>
     /// <returns>The builder instance with the rate limiter strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="limiter"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when the options constructed from the arguments are invalid.</exception>
-    public static ResilienceStrategyBuilder AddRateLimiter(
-        this ResilienceStrategyBuilder builder,
+    public static ResilienceStrategyBuilder<TResult> AddRateLimiter<TResult>(
+        this ResilienceStrategyBuilder<TResult> builder,
         RateLimiter limiter)
     {
         Guard.NotNull(builder);
@@ -104,14 +108,15 @@ public static class RateLimiterResilienceStrategyBuilderExtensions
     /// <summary>
     /// Adds the rate limiter strategy.
     /// </summary>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="limiter">The rate limiter to use.</param>
     /// <param name="onRejected">The callback that is raised when rate limiter is rejected.</param>
     /// <returns>The builder instance with the rate limiter strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when the options constructed from the arguments are invalid.</exception>
-    public static ResilienceStrategyBuilder AddRateLimiter(
-        this ResilienceStrategyBuilder builder,
+    public static ResilienceStrategyBuilder<TResult> AddRateLimiter<TResult>(
+        this ResilienceStrategyBuilder<TResult> builder,
         RateLimiter limiter,
         Action<OnRateLimiterRejectedArguments> onRejected)
     {
@@ -124,6 +129,27 @@ public static class RateLimiterResilienceStrategyBuilderExtensions
             RateLimiter = limiter,
             OnRejected = new NoOutcomeEvent<OnRateLimiterRejectedArguments>().Register(onRejected)
         });
+    }
+
+    /// <summary>
+    /// Adds the rate limiter strategy.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="options">The rate limiter strategy options.</param>
+    /// <returns>The builder instance with the rate limiter strategy added.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
+    public static ResilienceStrategyBuilder<TResult> AddRateLimiter<TResult>(
+        this ResilienceStrategyBuilder<TResult> builder,
+        RateLimiterStrategyOptions options)
+    {
+        Guard.NotNull(builder);
+        Guard.NotNull(options);
+
+        ValidationHelper.ValidateObject(options, "The rate limiter strategy options are invalid.");
+
+        return builder.AddStrategy(context => new RateLimiterResilienceStrategy(options.RateLimiter!, options.OnRejected, context.Telemetry), options);
     }
 
     /// <summary>


### PR DESCRIPTION
# Introducing `ResilienceStrategyBuilder<T>` and `ResilienceStrategy<T>`

This PR introduces the `ResilienceStrategyBuilder<T>` and `ResilienceStrategy<T>` classes. They are designed for scenarios that require a strategy for handling a single result type. The infrastructure introduced in V8 supports this feature.

The `ResilienceStrategyBuilder<T>` class serves as a simple wrapper over the `ResilienceStrategyBuilder` class. Similarly, the `ResilienceStrategy<T>` class is a basic wrapper for `ResilienceStrategy` and doesn't support inheritance.

The core infrastructure is still centered on `ResilienceStrategy`, which prevents implementation fragmentation as we observed in V7. The V8 infrastructure facilitates the integration of non-generic strategies with generic ones. It also enables scenarios, such as sharing a single circuit breaker that handles multiple result types with numerous `ResilienceStrategy<T>` instances.

Upsides:
- Strong contract for resilience strategies that work with a single result type. (common use-case)

Downsides:
- Code duplication, although very limited. Mostly on some extensions that need to target both generic and non-generic resilience strategies.

## Usage

Here is a simple usage example:

```csharp
ResilienceStrategy<HttpResponseMessage> builder = new ResilienceStrategyBuilder<HttpResponseMessage>()
    .AddRetry(shouldRetry => shouldRetry.HandleException<HttpRequestException>())
    .AddTimeout()
    .Build();
```

## Additional Changes

- Strategy extensions employing generic options now operate with `ResilienceStrategyBuilder<T>`.
- Several extensions originally targeting `ResilienceStrategyBuilder` have been shifted to `ResilienceStrategyBuilder<T>`.
- All convenience extensions now target `ResilienceStrategyBuilder<T>`.
- Extensions for strategies that do not work with results (like `Timeout`,`RateLimiter`) have been duplicated to target both `ResilienceStrategyBuilder` and `ResilienceStrategyBuilder<T>`.
- All extensions to `ResilienceStrategyBuilder` now solely accept options. The goal behind the use of the non-generic `ResilienceStrategyBuilder` is for advanced scenarios where additional typing does not create significant inconvenience.
