### PR TITLE
Introduce PredicateBuilder

### DIFF
--- a/src/Polly.Core.Benchmarks/Utils/Helper.MultipleStrategies.cs
+++ b/src/Polly.Core.Benchmarks/Utils/Helper.MultipleStrategies.cs
@@ -23,7 +23,7 @@ internal static partial class Helper
                 })
                 .AddTimeout(TimeSpan.FromSeconds(10))
                 .AddRetry(
-                    predicate => predicate.HandleException<InvalidOperationException>().HandleResult(Failure),
+                    predicate => predicate.Handle<InvalidOperationException>().HandleResult(Failure),
                     RetryBackoffType.Constant,
                     3,
                     TimeSpan.FromSeconds(1))

--- a/src/Polly.Core.Tests/Fallback/FallbackResilienceStrategyBuilderExtensionsTests.cs
+++ b/src/Polly.Core.Tests/Fallback/FallbackResilienceStrategyBuilderExtensionsTests.cs
@@ -15,7 +15,7 @@ public class FallbackResilienceStrategyBuilderExtensionsTests
         },
         builder =>
         {
-            builder.AddFallback(handle => { }, (_, _) =>  new ValueTask<int>(0));
+            builder.AddFallback(handle => handle.HandleResult(1), (_, _) =>  new ValueTask<int>(0));
         },
     };
 

--- a/src/Polly.Core.Tests/Strategy/PredicateBuilderTests.cs
+++ b/src/Polly.Core.Tests/Strategy/PredicateBuilderTests.cs
@@ -8,14 +8,14 @@ public class PredicateBuilderTests
 {
     public static TheoryData<Action<PredicateBuilder<string>>, Outcome<string>, bool> HandleResultData = new()
     {
-        { builder => builder.HandleResult("val") ,new Outcome<string>("val"), true },
-        { builder => builder.HandleResult("val") ,new Outcome<string>("val2"), false },
-        { builder => builder.HandleResult("val") ,new Outcome<string>(new InvalidOperationException()), false },
+        { builder => builder.HandleResult("val"), new Outcome<string>("val"), true },
+        { builder => builder.HandleResult("val"), new Outcome<string>("val2"), false },
+        { builder => builder.HandleResult("val"), new Outcome<string>(new InvalidOperationException()), false },
         { builder => builder.HandleResult("val", StringComparer.OrdinalIgnoreCase) ,new Outcome<string>("VAL"), true },
-        { builder => builder.HandleResult(r=>r == "val") ,new Outcome<string>("val"), true },
-        { builder => builder.HandleResult(r=>r == "val2") ,new Outcome<string>("val"), false },
-        { builder => builder.Handle<InvalidOperationException>() ,new Outcome<string>(new InvalidOperationException()), true },
-        { builder => builder.Handle<InvalidOperationException>() ,new Outcome<string>(new FormatException()), false },
+        { builder => builder.HandleResult(r => r == "val"), new Outcome<string>("val"), true },
+        { builder => builder.HandleResult(r => r == "val2"), new Outcome<string>("val"), false },
+        { builder => builder.Handle<InvalidOperationException>(), new Outcome<string>(new InvalidOperationException()), true },
+        { builder => builder.Handle<InvalidOperationException>(), new Outcome<string>(new FormatException()), false },
         { builder => builder.Handle<InvalidOperationException>(e => false), new Outcome<string>(new InvalidOperationException()), false },
         { builder => builder.HandleInner<InvalidOperationException>(e => false), new Outcome<string>(new InvalidOperationException()), false },
         { builder => builder.HandleInner<InvalidOperationException>(), new Outcome<string>("value"), false },

--- a/src/Polly.Core.Tests/Strategy/PredicateBuilderTests.cs
+++ b/src/Polly.Core.Tests/Strategy/PredicateBuilderTests.cs
@@ -1,0 +1,52 @@
+using System.ComponentModel.DataAnnotations;
+using Polly.Strategy;
+using Xunit;
+
+namespace Polly.Core.Tests.Strategy;
+
+public class PredicateBuilderTests
+{
+    public static TheoryData<Action<PredicateBuilder<string>>, Outcome<string>, bool> HandleResultData = new()
+    {
+        { builder => builder.HandleResult("val") ,new Outcome<string>("val"), true },
+        { builder => builder.HandleResult("val") ,new Outcome<string>("val2"), false },
+        { builder => builder.HandleResult("val") ,new Outcome<string>(new InvalidOperationException()), false },
+        { builder => builder.HandleResult("val", StringComparer.OrdinalIgnoreCase) ,new Outcome<string>("VAL"), true },
+        { builder => builder.HandleResult(r=>r == "val") ,new Outcome<string>("val"), true },
+        { builder => builder.HandleResult(r=>r == "val2") ,new Outcome<string>("val"), false },
+        { builder => builder.Handle<InvalidOperationException>() ,new Outcome<string>(new InvalidOperationException()), true },
+        { builder => builder.Handle<InvalidOperationException>() ,new Outcome<string>(new FormatException()), false },
+        { builder => builder.Handle<InvalidOperationException>(e => false), new Outcome<string>(new InvalidOperationException()), false },
+        { builder => builder.HandleInner<InvalidOperationException>(e => false), new Outcome<string>(new InvalidOperationException()), false },
+        { builder => builder.HandleInner<InvalidOperationException>(), new Outcome<string>("value"), false },
+        { builder => builder.Handle<InvalidOperationException>(), new Outcome<string>("value"), false },
+        { builder => builder.Handle<InvalidOperationException>().HandleResult("value"), new Outcome<string>("value"), true },
+        { builder => builder.Handle<InvalidOperationException>().HandleResult("value"), new Outcome<string>("value2"), false },
+        { builder => builder.HandleInner<FormatException>(), new Outcome<string>(new InvalidOperationException("dummy", new FormatException() )), true },
+        { builder => builder.HandleInner<ArgumentNullException>(e => false), new Outcome<string>(new InvalidOperationException("dummy", new FormatException() )), false },
+        { builder => builder.HandleInner<FormatException>(e => e.Message == "m"), new Outcome<string>(new InvalidOperationException("dummy", new FormatException("m") )), true },
+        { builder => builder.HandleInner<FormatException>(e => e.Message == "x"), new Outcome<string>(new InvalidOperationException("dummy", new FormatException("m") )), false },
+    };
+
+    [MemberData(nameof(HandleResultData))]
+    [Theory]
+    public async Task HandleResult_Ok(Action<PredicateBuilder<string>> configure, Outcome<string> value, bool handled)
+    {
+        var predicate = new PredicateBuilder<string>();
+
+        configure(predicate);
+
+        var result = await predicate.CreatePredicate<string>()(value, string.Empty);
+        result.Should().Be(handled);
+    }
+
+    [Fact]
+    public void CreatePredicate_NotConfigured_Throws()
+    {
+        var predicate = new PredicateBuilder<string>()
+            .Invoking(b => b.CreatePredicate<string>())
+            .Should()
+            .Throw<ValidationException>()
+            .WithMessage("No predicates were configured. There must be at least one predicate added.");
+    }
+}

--- a/src/Polly.Core/Fallback/FallbackResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/Fallback/FallbackResilienceStrategyBuilderExtensions.cs
@@ -21,7 +21,7 @@ public static class FallbackResilienceStrategyBuilderExtensions
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="shouldHandle"/> or <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
     public static ResilienceStrategyBuilder<TResult> AddFallback<TResult>(
         this ResilienceStrategyBuilder<TResult> builder,
-        Action<OutcomePredicate<HandleFallbackArguments, TResult>> shouldHandle,
+        Action<PredicateBuilder<TResult>> shouldHandle,
         Func<Outcome<TResult>, HandleFallbackArguments, ValueTask<TResult>> fallbackAction)
     {
         Guard.NotNull(builder);
@@ -33,7 +33,10 @@ public static class FallbackResilienceStrategyBuilderExtensions
             FallbackAction = fallbackAction,
         };
 
-        shouldHandle(options.ShouldHandle);
+        var predicateBuilder = new PredicateBuilder<TResult>();
+        shouldHandle(predicateBuilder);
+
+        options.ShouldHandle.HandleOutcome(predicateBuilder.CreatePredicate<HandleFallbackArguments>());
 
         return builder.AddFallback(options);
     }

--- a/src/Polly.Core/Strategy/PredicateBuilder.cs
+++ b/src/Polly.Core/Strategy/PredicateBuilder.cs
@@ -21,7 +21,7 @@ public sealed class PredicateBuilder<TResult>
     public PredicateBuilder<TResult> Handle<TException>()
         where TException : Exception
     {
-        return Handle<TException>(_ => true);
+        return Handle<TException>(static _ => true);
     }
 
     /// <summary>
@@ -47,7 +47,7 @@ public sealed class PredicateBuilder<TResult>
     public PredicateBuilder<TResult> HandleInner<TException>()
         where TException : Exception
     {
-        return HandleInner<TException>(_ => true);
+        return HandleInner<TException>(static _ => true);
     }
 
     /// <summary>
@@ -62,7 +62,7 @@ public sealed class PredicateBuilder<TResult>
     {
         Guard.NotNull(predicate);
 
-        return Add(outcome => outcome.Exception?.InnerException is TException exception && predicate(exception));
+        return Add(outcome => outcome.Exception?.InnerException is TException innerException && predicate(innerException));
     }
 
     /// <summary>

--- a/src/Polly.Core/Strategy/PredicateBuilder.cs
+++ b/src/Polly.Core/Strategy/PredicateBuilder.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Polly.Strategy;
+
+namespace Polly;
+
+/// <summary>
+/// Defines a builder for creating predicates for <typeparamref name="TResult"/> and <see cref="Exception"/> combinations.
+/// </summary>
+/// <typeparam name="TResult">The type of the result.</typeparam>
+public sealed class PredicateBuilder<TResult>
+{
+    private readonly List<Predicate<Outcome<TResult>>> _predicates = new();
+
+    /// <summary>
+    /// Adds a predicate for handling exceptions of the specified type.
+    /// </summary>
+    /// <typeparam name="TException">The type of the exception to handle.</typeparam>
+    /// <returns>The same instance of the <see cref="PredicateBuilder{TResult}"/> for chaining.</returns>
+    public PredicateBuilder<TResult> Handle<TException>()
+        where TException : Exception
+    {
+        return Handle<TException>(_ => true);
+    }
+
+    /// <summary>
+    /// Adds a predicate for handling exceptions of the specified type.
+    /// </summary>
+    /// <typeparam name="TException">The type of the exception to handle.</typeparam>
+    /// <param name="predicate">The predicate function to use for handling the exception.</param>
+    /// <returns>The same instance of the <see cref="PredicateBuilder{TResult}"/> for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when the <paramref name="predicate"/> is <see langword="null"/>.</exception>
+    public PredicateBuilder<TResult> Handle<TException>(Func<TException, bool> predicate)
+        where TException : Exception
+    {
+        Guard.NotNull(predicate);
+
+        return Add(outcome => outcome.Exception is TException exception && predicate(exception));
+    }
+
+    /// <summary>
+    /// Adds a predicate for handling inner exceptions of the specified type.
+    /// </summary>
+    /// <typeparam name="TException">The type of the inner exception to handle.</typeparam>
+    /// <returns>The same instance of the <see cref="PredicateBuilder{TResult}"/> for chaining.</returns>
+    public PredicateBuilder<TResult> HandleInner<TException>()
+        where TException : Exception
+    {
+        return HandleInner<TException>(_ => true);
+    }
+
+    /// <summary>
+    /// Adds a predicate for handling inner exceptions of the specified type.
+    /// </summary>
+    /// <typeparam name="TException">The type of the inner exception to handle.</typeparam>
+    /// <param name="predicate">The predicate function to use for handling the inner exception.</param>
+    /// <returns>The same instance of the <see cref="PredicateBuilder{TResult}"/> for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when the <paramref name="predicate"/> is <see langword="null"/>.</exception>
+    public PredicateBuilder<TResult> HandleInner<TException>(Func<TException, bool> predicate)
+        where TException : Exception
+    {
+        Guard.NotNull(predicate);
+
+        return Add(outcome => outcome.Exception?.InnerException is TException exception && predicate(exception));
+    }
+
+    /// <summary>
+    /// Adds a predicate for handling results.
+    /// </summary>
+    /// <param name="predicate">The predicate function to use for handling the result.</param>
+    /// <returns>The same instance of the <see cref="PredicateBuilder{TResult}"/> for chaining.</returns>
+    public PredicateBuilder<TResult> HandleResult(Func<TResult, bool> predicate)
+        => Add(outcome => outcome.TryGetResult(out var result) && predicate(result!));
+
+    /// <summary>
+    /// Adds a predicate for handling results with a specific value.
+    /// </summary>
+    /// <param name="result">The result value to handle.</param>
+    /// <param name="comparer">The comparer to use for comparing results. If null, the default comparer is used.</param>
+    /// <returns>The same instance of the <see cref="PredicateBuilder{TResult}"/> for chaining.</returns>
+    public PredicateBuilder<TResult> HandleResult(TResult result, IEqualityComparer<TResult>? comparer = null)
+    {
+        comparer ??= EqualityComparer<TResult>.Default;
+
+        return HandleResult(r => comparer.Equals(r, result));
+    }
+
+    internal Func<Outcome<TResult>, TArgs, ValueTask<bool>> CreatePredicate<TArgs>() => _predicates.Count switch
+    {
+        0 => throw new ValidationException("No predicates were configured. There must be at least one predicate added."),
+        1 => CreatePredicate<TArgs>(_predicates[0]),
+        _ => CreatePredicate<TArgs>(_predicates.ToArray()),
+    };
+
+    private static Func<Outcome<TResult>, TArgs, ValueTask<bool>> CreatePredicate<TArgs>(Predicate<Outcome<TResult>> predicate)
+        => (outcome, _) => new ValueTask<bool>(predicate(outcome));
+
+    private static Func<Outcome<TResult>, TArgs, ValueTask<bool>> CreatePredicate<TArgs>(Predicate<Outcome<TResult>>[] predicates)
+    {
+        return (outcome, _) =>
+        {
+            foreach (var predicate in predicates)
+            {
+                if (predicate(outcome))
+                {
+                    return new ValueTask<bool>(true);
+                }
+            }
+
+            return new ValueTask<bool>(false);
+        };
+    }
+
+    private PredicateBuilder<TResult> Add(Predicate<Outcome<TResult>> predicate)
+    {
+        _predicates.Add(predicate);
+        return this;
+    }
+}


### PR DESCRIPTION
### The issue or feature being addressed

Contributes to #1130 and #1200

### Details on the issue fix or feature implementation

Simplified version of the Callback API that allows Polly V7 customers easier migration to V8. Will be used in the convenience extensions for individual strategies.

Example:

``` csharp
var strategy = new ResilienceStrategyBuilder<string>()
   .AddRetry(builder => builder
       .Handle<InvalidOperationException>()
       .HandleResult("error"))
   .Build();
```

The builder will produce a delegate which can used in the options directly.

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
