### PR TITLE
Hide non-generic Hedging and Fallback API

### DIFF
--- a/src/Polly.Core/Fallback/FallbackHandler.Handler.cs
+++ b/src/Polly.Core/Fallback/FallbackHandler.Handler.cs
@@ -2,7 +2,7 @@ using Polly.Strategy;
 
 namespace Polly.Fallback;
 
-public sealed partial class FallbackHandler
+internal sealed partial class FallbackHandler
 {
     internal sealed class Handler
     {

--- a/src/Polly.Core/Fallback/FallbackHandler.cs
+++ b/src/Polly.Core/Fallback/FallbackHandler.cs
@@ -6,7 +6,7 @@ namespace Polly.Fallback;
 /// <summary>
 /// Represents a class for managing fallback handlers.
 /// </summary>
-public sealed partial class FallbackHandler
+internal sealed partial class FallbackHandler
 {
     private readonly OutcomePredicate<HandleFallbackArguments> _predicates = new();
     private readonly Dictionary<Type, object> _actions = new();

--- a/src/Polly.Core/Fallback/FallbackResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/Fallback/FallbackResilienceStrategyBuilderExtensions.cs
@@ -68,7 +68,7 @@ public static class FallbackResilienceStrategyBuilderExtensions
     /// <returns>The builder instance with the fallback strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
-    public static ResilienceStrategyBuilder AddFallback(this ResilienceStrategyBuilder builder, FallbackStrategyOptions options)
+    internal static ResilienceStrategyBuilder AddFallback(this ResilienceStrategyBuilder builder, FallbackStrategyOptions options)
     {
         Guard.NotNull(builder);
         Guard.NotNull(options);

--- a/src/Polly.Core/Fallback/FallbackStrategyOptions.cs
+++ b/src/Polly.Core/Fallback/FallbackStrategyOptions.cs
@@ -6,7 +6,7 @@ namespace Polly.Fallback;
 /// <summary>
 /// Represents the options for configuring a fallback resilience strategy.
 /// </summary>
-public class FallbackStrategyOptions : ResilienceStrategyOptions
+internal class FallbackStrategyOptions : ResilienceStrategyOptions
 {
     /// <summary>
     /// Gets the strategy type.

--- a/src/Polly.Core/Fallback/VoidFallbackHandler.cs
+++ b/src/Polly.Core/Fallback/VoidFallbackHandler.cs
@@ -10,7 +10,7 @@ namespace Polly.Fallback;
 /// Every fallback handler requires a predicate that determines whether a fallback should be performed for a given
 /// void-based result and also the fallback action to execute.
 /// </remarks>
-public sealed class VoidFallbackHandler
+internal sealed class VoidFallbackHandler
 {
     /// <summary>
     /// Gets or sets the predicate that determines whether a fallback should be handled.

--- a/src/Polly.Core/Hedging/HedgingActionGeneratorArguments.cs
+++ b/src/Polly.Core/Hedging/HedgingActionGeneratorArguments.cs
@@ -7,4 +7,4 @@ namespace Polly.Hedging;
 /// </summary>
 /// <param name="Context">The context associated with the execution of a user-provided callback.</param>
 /// <param name="Attempt">The zero-based hedging attempt number.</param>
-public readonly record struct HedgingActionGeneratorArguments(ResilienceContext Context, int Attempt) : IResilienceArguments;
+internal readonly record struct HedgingActionGeneratorArguments(ResilienceContext Context, int Attempt) : IResilienceArguments;

--- a/src/Polly.Core/Hedging/HedgingHandler.Handler.cs
+++ b/src/Polly.Core/Hedging/HedgingHandler.Handler.cs
@@ -2,7 +2,7 @@ using Polly.Strategy;
 
 namespace Polly.Hedging;
 
-public partial class HedgingHandler
+internal partial class HedgingHandler
 {
     internal sealed class Handler
     {

--- a/src/Polly.Core/Hedging/HedgingHandler.TResult.cs
+++ b/src/Polly.Core/Hedging/HedgingHandler.TResult.cs
@@ -11,7 +11,7 @@ namespace Polly.Hedging;
 /// Every hedging handler requires a predicate that determines whether a hedging should be performed for a given result and also
 /// the hedging generator that creates a hedged action to execute.
 /// </remarks>
-public sealed class HedgingHandler<TResult>
+internal sealed class HedgingHandler<TResult>
 {
     /// <summary>
     /// Gets or sets the predicate that determines whether a hedging should be performed for a given result.

--- a/src/Polly.Core/Hedging/HedgingHandler.cs
+++ b/src/Polly.Core/Hedging/HedgingHandler.cs
@@ -6,7 +6,7 @@ namespace Polly.Hedging;
 /// <summary>
 /// Represents a class for managing hedging handlers.
 /// </summary>
-public sealed partial class HedgingHandler
+internal sealed partial class HedgingHandler
 {
     private readonly OutcomePredicate<HandleHedgingArguments> _predicates = new();
     private readonly Dictionary<Type, object> _actions = new();

--- a/src/Polly.Core/Hedging/HedgingResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/Hedging/HedgingResilienceStrategyBuilderExtensions.cs
@@ -35,7 +35,7 @@ public static class HedgingResilienceStrategyBuilderExtensions
     /// <returns>The builder instance with the hedging strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
-    public static ResilienceStrategyBuilder AddHedging(this ResilienceStrategyBuilder builder, HedgingStrategyOptions options)
+    internal static ResilienceStrategyBuilder AddHedging(this ResilienceStrategyBuilder builder, HedgingStrategyOptions options)
     {
         Guard.NotNull(builder);
         Guard.NotNull(options);

--- a/src/Polly.Core/Hedging/HedgingStrategyOptions.cs
+++ b/src/Polly.Core/Hedging/HedgingStrategyOptions.cs
@@ -6,7 +6,7 @@ namespace Polly.Hedging;
 /// <summary>
 /// Hedging strategy options.
 /// </summary>
-public class HedgingStrategyOptions : ResilienceStrategyOptions
+internal class HedgingStrategyOptions : ResilienceStrategyOptions
 {
     /// <summary>
     /// Gets the strategy type.

--- a/src/Polly.Core/Hedging/VoidHedgingHandler.cs
+++ b/src/Polly.Core/Hedging/VoidHedgingHandler.cs
@@ -10,7 +10,7 @@ namespace Polly.Hedging;
 /// Every hedging handler requires a predicate that determines whether a hedging should be performed for a given void result and also
 /// the hedging generator that creates a hedged action to execute.
 /// </remarks>
-public sealed class VoidHedgingHandler
+internal sealed class VoidHedgingHandler
 {
     /// <summary>
     /// Gets or sets the predicate that determines whether a hedging should be performed for a given void-based result.


### PR DESCRIPTION
### Details on the issue fix or feature implementation

There are not many use-cases for these and with the introduction of `ResilienceStrategyBuilder<TResult>` we are able to target particular result type. Hiding these reduces the API surface of V8, while still allowing us to just expose this API if there is a need for it in the future. 

What makes `Hedging` and `Fallback` a good candidate for hiding is that these require to define an action that needs to be executed when handling occurs. 

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
