### PR TITLE
Add support for ResilienceStrategyBuilder<TResult>

### DIFF
--- a/src/Polly.Core.Tests/Registry/ResilienceStrategyProviderTests.cs
+++ b/src/Polly.Core.Tests/Registry/ResilienceStrategyProviderTests.cs
@@ -16,6 +16,17 @@ public class ResilienceStrategyProviderTests
     }
 
     [Fact]
+    public void Get_GenericDoesNotExist_Throws()
+    {
+        new Provider()
+            .Invoking(o => o.Get<string>("not-exists"))
+            .Should()
+            .Throw<KeyNotFoundException>()
+            .WithMessage("Unable to find a generic resilience strategy of 'String' associated with the key 'not-exists'. " +
+            "Please ensure that either the generic resilience strategy or the generic builder is registered.");
+    }
+
+    [Fact]
     public void Get_Exist_Ok()
     {
         var provider = new Provider { Strategy = new TestResilienceStrategy() };
@@ -23,14 +34,30 @@ public class ResilienceStrategyProviderTests
         provider.Get("exists").Should().Be(provider.Strategy);
     }
 
+    [Fact]
+    public void Get_GenericExist_Ok()
+    {
+        var provider = new Provider { GenericStrategy = new TestResilienceStrategy<string>() };
+
+        provider.Get<string>("exists").Should().Be(provider.GenericStrategy);
+    }
+
     private class Provider : ResilienceStrategyProvider<string>
     {
         public ResilienceStrategy? Strategy { get; set; }
+
+        public object? GenericStrategy { get; set; }
 
         public override bool TryGet(string key, [NotNullWhen(true)] out ResilienceStrategy? strategy)
         {
             strategy = Strategy;
             return Strategy != null;
+        }
+
+        public override bool TryGet<TResult>(string key, [NotNullWhen(true)] out ResilienceStrategy<TResult>? strategy)
+        {
+            strategy = (ResilienceStrategy<TResult>?)GenericStrategy;
+            return GenericStrategy != null;
         }
     }
 }

--- a/src/Polly.Core/Registry/ResilienceStrategyProvider.cs
+++ b/src/Polly.Core/Registry/ResilienceStrategyProvider.cs
@@ -29,10 +29,37 @@ public abstract class ResilienceStrategyProvider<TKey>
     }
 
     /// <summary>
+    /// Retrieves a generic resilience strategy from the provider using the specified key.
+    /// </summary>
+    /// <typeparam name="TResult">The type of result that the resilience strategy handles.</typeparam>
+    /// <param name="key">The key used to identify the resilience strategy.</param>
+    /// <returns>The resilience strategy associated with the specified key.</returns>
+    /// <exception cref="KeyNotFoundException">Thrown when no resilience strategy is found for the specified key.</exception>
+    public virtual ResilienceStrategy<TResult> Get<TResult>(TKey key)
+    {
+        if (TryGet<TResult>(key, out var strategy))
+        {
+            return strategy;
+        }
+
+        throw new KeyNotFoundException($"Unable to find a generic resilience strategy of '{typeof(TResult).Name}' associated with the key '{key}'. " +
+            $"Please ensure that either the generic resilience strategy or the generic builder is registered.");
+    }
+
+    /// <summary>
     /// Tries to get a resilience strategy from the provider using the specified key.
     /// </summary>
     /// <param name="key">The key used to identify the resilience strategy.</param>
     /// <param name="strategy">The output resilience strategy if found, null otherwise.</param>
-    /// <returns>true if the strategy was found, false otherwise.</returns>
+    /// <returns><see langword="true"/> if the strategy was found, <see langword="false"/> otherwise.</returns>
     public abstract bool TryGet(TKey key, [NotNullWhen(true)] out ResilienceStrategy? strategy);
+
+    /// <summary>
+    /// Tries to get a generic resilience strategy from the provider using the specified key.
+    /// </summary>
+    /// <typeparam name="TResult">The type of result that the resilience strategy handles.</typeparam>
+    /// <param name="key">The key used to identify the resilience strategy.</param>
+    /// <param name="strategy">The output resilience strategy if found, null otherwise.</param>
+    /// <returns><see langword="true"/> if the strategy was found, <see langword="false"/> otherwise.</returns>
+    public abstract bool TryGet<TResult>(TKey key, [NotNullWhen(true)] out ResilienceStrategy<TResult>? strategy);
 }

--- a/src/Polly.Core/Registry/ResilienceStrategyRegistry.TResult.cs
+++ b/src/Polly.Core/Registry/ResilienceStrategyRegistry.TResult.cs
@@ -1,0 +1,67 @@
+using System.Diagnostics.CodeAnalysis;
+using Polly.Telemetry;
+
+namespace Polly.Registry;
+
+public sealed partial class ResilienceStrategyRegistry<TKey> : ResilienceStrategyProvider<TKey>
+    where TKey : notnull
+{
+    private sealed class GenericRegistry<TResult>
+    {
+        private readonly Func<ResilienceStrategyBuilder<TResult>> _activator;
+        private readonly ConcurrentDictionary<TKey, Action<TKey, ResilienceStrategyBuilder<TResult>>> _builders;
+        private readonly ConcurrentDictionary<TKey, ResilienceStrategy<TResult>> _strategies;
+
+        private readonly Func<TKey, string> _strategyKeyFormatter;
+        private readonly Func<TKey, string> _builderNameFormatter;
+
+        public GenericRegistry(
+            Func<ResilienceStrategyBuilder<TResult>> activator,
+            IEqualityComparer<TKey> builderComparer,
+            IEqualityComparer<TKey> strategyComparer,
+            Func<TKey, string> strategyKeyFormatter,
+            Func<TKey, string> builderNameFormatter)
+        {
+            _activator = activator;
+            _builders = new ConcurrentDictionary<TKey, Action<TKey, ResilienceStrategyBuilder<TResult>>>(builderComparer);
+            _strategies = new ConcurrentDictionary<TKey, ResilienceStrategy<TResult>>(strategyComparer);
+            _strategyKeyFormatter = strategyKeyFormatter;
+            _builderNameFormatter = builderNameFormatter;
+        }
+
+        public bool TryAdd(TKey key, ResilienceStrategy<TResult> strategy) => _strategies.TryAdd(key, strategy);
+
+        public bool Remove(TKey key) => _strategies.TryRemove(key, out _);
+
+        public bool TryGet(TKey key, [NotNullWhen(true)] out ResilienceStrategy<TResult>? strategy)
+        {
+            if (_strategies.TryGetValue(key, out strategy))
+            {
+                return true;
+            }
+
+            if (_builders.TryGetValue(key, out var configure))
+            {
+                strategy = _strategies.GetOrAdd(key, key =>
+                {
+                    var builder = _activator();
+                    builder.BuilderName = _builderNameFormatter(key);
+                    builder.Properties.Set(TelemetryUtil.StrategyKey, _strategyKeyFormatter(key));
+                    configure(key, builder);
+                    return builder.Build();
+                });
+
+                return true;
+            }
+
+            strategy = null;
+            return false;
+        }
+
+        public bool TryAddBuilder(TKey key, Action<TKey, ResilienceStrategyBuilder<TResult>> configure) => _builders.TryAdd(key, configure);
+
+        public bool RemoveBuilder(TKey key) => _builders.TryRemove(key, out _);
+
+        public void Clear() => _strategies.Clear();
+    }
+}

--- a/src/Polly.Core/Registry/ResilienceStrategyRegistry.cs
+++ b/src/Polly.Core/Registry/ResilienceStrategyRegistry.cs
@@ -16,14 +16,18 @@ namespace Polly.Registry;
 /// These callbacks are called when the resilience strategy is not yet cached and it's retrieved for the first time.
 /// </para>
 /// </remarks>
-public sealed class ResilienceStrategyRegistry<TKey> : ResilienceStrategyProvider<TKey>
+public sealed partial class ResilienceStrategyRegistry<TKey> : ResilienceStrategyProvider<TKey>
     where TKey : notnull
 {
     private readonly Func<ResilienceStrategyBuilder> _activator;
     private readonly ConcurrentDictionary<TKey, Action<TKey, ResilienceStrategyBuilder>> _builders;
     private readonly ConcurrentDictionary<TKey, ResilienceStrategy> _strategies;
+    private readonly ConcurrentDictionary<Type, object> _genericRegistry = new();
+
     private readonly Func<TKey, string> _strategyKeyFormatter;
     private readonly Func<TKey, string> _builderNameFormatter;
+    private readonly IEqualityComparer<TKey> _builderComparer;
+    private readonly IEqualityComparer<TKey> _strategyComparer;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ResilienceStrategyRegistry{TKey}"/> class with the default comparer.
@@ -50,6 +54,8 @@ public sealed class ResilienceStrategyRegistry<TKey> : ResilienceStrategyProvide
         _strategies = new ConcurrentDictionary<TKey, ResilienceStrategy>(options.StrategyComparer);
         _strategyKeyFormatter = options.StrategyKeyFormatter;
         _builderNameFormatter = options.BuilderNameFormatter;
+        _builderComparer = options.BuilderComparer;
+        _strategyComparer = options.StrategyComparer;
     }
 
     /// <summary>
@@ -57,7 +63,7 @@ public sealed class ResilienceStrategyRegistry<TKey> : ResilienceStrategyProvide
     /// </summary>
     /// <param name="key">The key used to identify the resilience strategy.</param>
     /// <param name="strategy">The resilience strategy instance.</param>
-    /// <returns>true if the strategy was added successfully, false otherwise.</returns>
+    /// <returns><see langword="true"/> if the strategy was added successfully, <see langword="false"/> otherwise.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="strategy"/> is <see langword="null"/>.</exception>
     public bool TryAdd(TKey key, ResilienceStrategy strategy)
     {
@@ -67,22 +73,42 @@ public sealed class ResilienceStrategyRegistry<TKey> : ResilienceStrategyProvide
     }
 
     /// <summary>
+    /// Tries to add an existing generic resilience strategy to the registry.
+    /// </summary>
+    /// <typeparam name="TResult">The type of result that the resilience strategy handles.</typeparam>
+    /// <param name="key">The key used to identify the resilience strategy.</param>
+    /// <param name="strategy">The resilience strategy instance.</param>
+    /// <returns><see langword="true"/> if the strategy was added successfully, <see langword="false"/> otherwise.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="strategy"/> is <see langword="null"/>.</exception>
+    public bool TryAdd<TResult>(TKey key, ResilienceStrategy<TResult> strategy)
+    {
+        Guard.NotNull(strategy);
+
+        return GetGenericRegistry<TResult>().TryAdd(key, strategy);
+    }
+
+    /// <summary>
     /// Removes a resilience strategy from the registry.
     /// </summary>
     /// <param name="key">The key used to identify the resilience strategy.</param>
-    /// <returns>true if the strategy was removed successfully, false otherwise.</returns>
+    /// <returns><see langword="true"/> if the strategy was removed successfully, <see langword="false"/> otherwise.</returns>
     public bool Remove(TKey key) => _strategies.TryRemove(key, out _);
 
     /// <summary>
-    /// Tries to get a resilience strategy from the registry.
+    /// Removes a generic resilience strategy from the registry.
     /// </summary>
+    /// <typeparam name="TResult">The type of result that the resilience strategy handles.</typeparam>
     /// <param name="key">The key used to identify the resilience strategy.</param>
-    /// <param name="strategy">The output resilience strategy if found, null otherwise.</param>
-    /// <returns>true if the strategy was found, false otherwise.</returns>
-    /// <remarks>
-    /// Tries to get a strategy using the given key. If not found, it looks for a builder with the key, builds the strategy,
-    /// adds it to the registry, and returns true. If neither the strategy nor the builder is found, the method returns false.
-    /// </remarks>
+    /// <returns><see langword="true"/> if the strategy was removed successfully, <see langword="false"/> otherwise.</returns>
+    public bool Remove<TResult>(TKey key) => GetGenericRegistry<TResult>().Remove(key);
+
+    /// <inheritdoc/>
+    public override bool TryGet<TResult>(TKey key, [NotNullWhen(true)] out ResilienceStrategy<TResult>? strategy)
+    {
+        return GetGenericRegistry<TResult>().TryGet(key, out strategy);
+    }
+
+    /// <inheritdoc/>
     public override bool TryGet(TKey key, [NotNullWhen(true)] out ResilienceStrategy? strategy)
     {
         if (_strategies.TryGetValue(key, out strategy))
@@ -113,7 +139,7 @@ public sealed class ResilienceStrategyRegistry<TKey> : ResilienceStrategyProvide
     /// </summary>
     /// <param name="key">The key used to identify the strategy builder.</param>
     /// <param name="configure">The action that configures the resilience strategy builder.</param>
-    /// <returns>True if the builder was added successfully, false otherwise.</returns>
+    /// <returns><see langword="true"/> if the builder was added successfully, <see langword="false"/> otherwise.</returns>
     /// <remarks>
     /// Use this method when you want to create the strategy on-demand when it's first accessed.
     /// </remarks>
@@ -126,11 +152,37 @@ public sealed class ResilienceStrategyRegistry<TKey> : ResilienceStrategyProvide
     }
 
     /// <summary>
+    /// Tries to add a generic resilience strategy builder to the registry.
+    /// </summary>
+    /// <typeparam name="TResult">The type of result that the resilience strategy handles.</typeparam>
+    /// <param name="key">The key used to identify the strategy builder.</param>
+    /// <param name="configure">The action that configures the resilience strategy builder.</param>
+    /// <returns><see langword="true"/> if the builder was added successfully, <see langword="false"/> otherwise.</returns>
+    /// <remarks>
+    /// Use this method when you want to create the strategy on-demand when it's first accessed.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configure"/> is <see langword="null"/>.</exception>
+    public bool TryAddBuilder<TResult>(TKey key, Action<TKey, ResilienceStrategyBuilder<TResult>> configure)
+    {
+        Guard.NotNull(configure);
+
+        return GetGenericRegistry<TResult>().TryAddBuilder(key, configure);
+    }
+
+    /// <summary>
     /// Removes a resilience strategy builder from the registry.
     /// </summary>
     /// <param name="key">The key used to identify the resilience strategy builder.</param>
-    /// <returns>true if the builder was removed successfully, false otherwise.</returns>
+    /// <returns><see langword="true"/> if the builder was removed successfully, <see langword="false"/> otherwise.</returns>
     public bool RemoveBuilder(TKey key) => _builders.TryRemove(key, out _);
+
+    /// <summary>
+    /// Removes a generic resilience strategy builder from the registry.
+    /// </summary>
+    /// <typeparam name="TResult">The type of result that the resilience strategy handles.</typeparam>
+    /// <param name="key">The key used to identify the resilience strategy builder.</param>
+    /// <returns><see langword="true"/> if the builder was removed successfully, <see langword="false"/> otherwise.</returns>
+    public bool RemoveBuilder<TResult>(TKey key) => GetGenericRegistry<TResult>().RemoveBuilder(key);
 
     /// <summary>
     /// Clears all cached strategies.
@@ -139,4 +191,31 @@ public sealed class ResilienceStrategyRegistry<TKey> : ResilienceStrategyProvide
     /// This method only clears the cached strategies, the registered builders are kept unchanged.
     /// </remarks>
     public void Clear() => _strategies.Clear();
+
+    /// <summary>
+    /// Clears all cached generic strategies.
+    /// </summary>
+    /// <typeparam name="TResult">The type of result that the resilience strategy handles.</typeparam>
+    /// <remarks>
+    /// This method only clears the cached strategies, the registered builders are kept unchanged.
+    /// </remarks>
+    public void Clear<TResult>() => GetGenericRegistry<TResult>().Clear();
+
+    private GenericRegistry<TResult> GetGenericRegistry<TResult>()
+    {
+        if (_genericRegistry.TryGetValue(typeof(TResult), out var genericRegistry))
+        {
+            return (GenericRegistry<TResult>)genericRegistry;
+        }
+
+        return (GenericRegistry<TResult>)_genericRegistry.GetOrAdd(typeof(TResult), _ =>
+        {
+            return new GenericRegistry<TResult>(
+                () => new ResilienceStrategyBuilder<TResult>(_activator()),
+                _builderComparer,
+                _strategyComparer,
+                _strategyKeyFormatter,
+                _builderNameFormatter);
+        });
+    }
 }

--- a/src/Polly.Core/ResilienceStrategyBuilder.TResult.cs
+++ b/src/Polly.Core/ResilienceStrategyBuilder.TResult.cs
@@ -14,7 +14,12 @@ namespace Polly;
 /// </remarks>
 public class ResilienceStrategyBuilder<TResult>
 {
-    private readonly ResilienceStrategyBuilder _builder = new();
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ResilienceStrategyBuilder{TResult}"/> class.
+    /// </summary>
+    public ResilienceStrategyBuilder() => Builder = new();
+
+    internal ResilienceStrategyBuilder(ResilienceStrategyBuilder builder) => Builder = builder;
 
     /// <summary>
     /// Gets or sets the name of the builder.
@@ -23,14 +28,14 @@ public class ResilienceStrategyBuilder<TResult>
     [Required(AllowEmptyStrings = true)]
     public string BuilderName
     {
-        get => _builder.BuilderName;
-        set => _builder.BuilderName = value;
+        get => Builder.BuilderName;
+        set => Builder.BuilderName = value;
     }
 
     /// <summary>
     /// Gets the custom properties attached to builder options.
     /// </summary>
-    public ResilienceProperties Properties => _builder.Properties;
+    public ResilienceProperties Properties => Builder.Properties;
 
     /// <summary>
     /// Gets or sets a <see cref="TimeProvider"/> that is used by strategies that work with time.
@@ -41,8 +46,8 @@ public class ResilienceStrategyBuilder<TResult>
     [Required]
     internal TimeProvider TimeProvider
     {
-        get => _builder.TimeProvider;
-        set => _builder.TimeProvider = value;
+        get => Builder.TimeProvider;
+        set => Builder.TimeProvider = value;
     }
 
     /// <summary>
@@ -50,9 +55,11 @@ public class ResilienceStrategyBuilder<TResult>
     /// </summary>
     internal Action<IList<ResilienceStrategy>>? OnCreatingStrategy
     {
-        get => _builder.OnCreatingStrategy;
-        set => _builder.OnCreatingStrategy = value;
+        get => Builder.OnCreatingStrategy;
+        set => Builder.OnCreatingStrategy = value;
     }
+
+    internal ResilienceStrategyBuilder Builder { get; }
 
     /// <summary>
     /// Adds an already created strategy instance to the builder.
@@ -65,7 +72,7 @@ public class ResilienceStrategyBuilder<TResult>
     {
         Guard.NotNull(strategy);
 
-        _builder.AddStrategy(strategy);
+        Builder.AddStrategy(strategy);
         return this;
     }
 
@@ -85,7 +92,7 @@ public class ResilienceStrategyBuilder<TResult>
         Guard.NotNull(factory);
         Guard.NotNull(options);
 
-        _builder.AddStrategy(factory, options);
+        Builder.AddStrategy(factory, options);
 
         return this;
     }
@@ -95,5 +102,5 @@ public class ResilienceStrategyBuilder<TResult>
     /// </summary>
     /// <returns>An instance of <see cref="ResilienceStrategy{TResult}"/>.</returns>
     /// <exception cref="ValidationException">Thrown when this builder has invalid configuration.</exception>
-    public ResilienceStrategy<TResult> Build() => new(_builder.Build());
+    public ResilienceStrategy<TResult> Build() => new(Builder.Build());
 }

--- a/src/Polly.Extensions.Tests/Telemetry/TelemetryResilienceStrategyBuilderExtensionsTests.cs
+++ b/src/Polly.Extensions.Tests/Telemetry/TelemetryResilienceStrategyBuilderExtensionsTests.cs
@@ -7,31 +7,65 @@ namespace Polly.Extensions.Tests.Telemetry;
 public class TelemetryResilienceStrategyBuilderExtensionsTests
 {
     private readonly ResilienceStrategyBuilder _builder = new();
+    private readonly ResilienceStrategyBuilder<string> _genericBuilder = new();
 
-    [Fact]
-    public void EnableTelemetry_EnsureDiagnosticSourceUpdated()
+    [InlineData(true)]
+    [InlineData(false)]
+    [Theory]
+    public void EnableTelemetry_EnsureDiagnosticSourceUpdated(bool generic)
     {
-        _builder.EnableTelemetry(NullLoggerFactory.Instance);
-        _builder.Properties.GetValue(new ResiliencePropertyKey<DiagnosticSource?>("DiagnosticSource"), null).Should().BeOfType<ResilienceTelemetryDiagnosticSource>();
-        _builder.AddStrategy(new TestResilienceStrategy()).Build().Should().NotBeOfType<TestResilienceStrategy>();
+        if (generic)
+        {
+            _genericBuilder.EnableTelemetry(NullLoggerFactory.Instance);
+            _genericBuilder.Properties.GetValue(new ResiliencePropertyKey<DiagnosticSource?>("DiagnosticSource"), null).Should().BeOfType<ResilienceTelemetryDiagnosticSource>();
+        }
+        else
+        {
+            _builder.EnableTelemetry(NullLoggerFactory.Instance);
+            _builder.Properties.GetValue(new ResiliencePropertyKey<DiagnosticSource?>("DiagnosticSource"), null).Should().BeOfType<ResilienceTelemetryDiagnosticSource>();
+            _builder.AddStrategy(new TestResilienceStrategy()).Build().Should().NotBeOfType<TestResilienceStrategy>();
+        }
     }
 
-    [Fact]
-    public void EnableTelemetry_EnsureLogging()
+    [InlineData(true)]
+    [InlineData(false)]
+    [Theory]
+    public void EnableTelemetry_EnsureLogging(bool generic)
     {
         using var factory = TestUtilities.CreateLoggerFactory(out var fakeLogger);
-        _builder.EnableTelemetry(factory);
-        _builder.AddStrategy(new TestResilienceStrategy()).Build().Execute(_ => { });
+
+        if (generic)
+        {
+            _genericBuilder.EnableTelemetry(factory);
+            _genericBuilder.AddStrategy(new TestResilienceStrategy()).Build().Execute(_ => string.Empty);
+        }
+        else
+        {
+            _builder.EnableTelemetry(factory);
+            _builder.AddStrategy(new TestResilienceStrategy()).Build().Execute(_ => { });
+        }
 
         fakeLogger.GetRecords().Should().NotBeEmpty();
         fakeLogger.GetRecords().Should().HaveCount(2);
-
     }
 
     [Fact]
     public void EnableTelemetry_InvalidOptions_Throws()
     {
         _builder
+            .Invoking(b => b.EnableTelemetry(new TelemetryResilienceStrategyOptions
+            {
+                LoggerFactory = null!,
+            })).Should()
+            .Throw<ValidationException>()
+            .WithMessage("""
+            The resilience telemetry options are invalid.
+
+            Validation Errors:
+            The LoggerFactory field is required.
+            """);
+
+        _genericBuilder
             .Invoking(b => b.EnableTelemetry(new TelemetryResilienceStrategyOptions
             {
                 LoggerFactory = null!,

--- a/src/Polly.Extensions/DependencyInjection/ConfigureResilienceStrategyRegistryOptions.cs
+++ b/src/Polly.Extensions/DependencyInjection/ConfigureResilienceStrategyRegistryOptions.cs
@@ -1,9 +1,9 @@
+using Polly.Registry;
+
 namespace Polly.Extensions.DependencyInjection;
 
 internal sealed class ConfigureResilienceStrategyRegistryOptions<TKey>
     where TKey : notnull
 {
-    public List<Entry> Actions { get; } = new();
-
-    public record Entry(TKey Key, Action<ResilienceStrategyBuilder, AddResilienceStrategyContext<TKey>> Configure);
+    public List<Action<ResilienceStrategyRegistry<TKey>>> Actions { get; } = new();
 }

--- a/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategyBuilderExtensions.cs
@@ -13,6 +13,47 @@ public static class TelemetryResilienceStrategyBuilderExtensions
     /// <summary>
     /// Enables telemetry for this builder.
     /// </summary>
+    /// <typeparam name="TResult">The type of result.</typeparam>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="loggerFactory">The logger factory to be used for logging.</param>
+    /// <returns>The builder instance with the telemetry enabled.</returns>
+    /// <remarks>
+    /// By enabling the telemetry the resilience strategy will log and meter all resilience events.
+    /// Additionally, the telemetry strategy that logs and meters the executions is added to the beginning of the strategy pipeline.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="loggerFactory"/> is <see langword="null"/>.</exception>
+    public static ResilienceStrategyBuilder<TResult> EnableTelemetry<TResult>(this ResilienceStrategyBuilder<TResult> builder, ILoggerFactory loggerFactory)
+    {
+        Guard.NotNull(builder);
+        Guard.NotNull(loggerFactory);
+
+        return builder.EnableTelemetry(new TelemetryResilienceStrategyOptions { LoggerFactory = loggerFactory });
+    }
+
+    /// <summary>
+    /// Enables telemetry for this builder.
+    /// </summary>
+    /// <typeparam name="TResult">The type of result.</typeparam>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="options">The resilience telemetry options.</param>
+    /// <returns>The builder instance with the telemetry enabled.</returns>
+    /// <remarks>
+    /// By enabling the telemetry the resilience strategy will log and meter all resilience events.
+    /// Additionally, the telemetry strategy that logs and meters the executions is added to the beginning of the strategy pipeline.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
+    public static ResilienceStrategyBuilder<TResult> EnableTelemetry<TResult>(this ResilienceStrategyBuilder<TResult> builder, TelemetryResilienceStrategyOptions options)
+    {
+        Guard.NotNull(builder);
+        Guard.NotNull(options);
+
+        builder.Builder.EnableTelemetry(options);
+        return builder;
+    }
+
+    /// <summary>
+    /// Enables telemetry for this builder.
+    /// </summary>
     /// <param name="builder">The builder instance.</param>
     /// <param name="loggerFactory">The logger factory to be used for logging.</param>
     /// <returns>The builder instance with the telemetry enabled.</returns>

--- a/src/Polly.TestUtils/TestResilienceStrategy.TResult.cs
+++ b/src/Polly.TestUtils/TestResilienceStrategy.TResult.cs
@@ -1,0 +1,9 @@
+namespace Polly.TestUtils;
+
+public class TestResilienceStrategy<T> : ResilienceStrategy<T>
+{
+    public TestResilienceStrategy()
+        : base(new TestResilienceStrategy())
+    {
+    }
+}


### PR DESCRIPTION
## Details on the issue fix or feature implementation

This PR fills some missing gaps for `ResilienceStrategyBuilder<TResult>`:

- Added support to configure and retrieve `ResilienceStrategy<T>` from the registry.
- Added DI support.
- Added telemetry support.

### Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build
