### PR TITLE
[Proposal] Introduce ResilienceStrategyBuilderBase

### DIFF
--- a/src/Polly.Core.Tests/GenericResilienceStrategyBuilderTests.cs
+++ b/src/Polly.Core.Tests/GenericResilienceStrategyBuilderTests.cs
@@ -15,13 +15,13 @@ public class GenericResilienceStrategyBuilderTests
         _builder.Properties.Should().NotBeNull();
         _builder.TimeProvider.Should().Be(TimeProvider.System);
         _builder.OnCreatingStrategy.Should().BeNull();
-        _builder.Builder.IsGenericBuilder.Should().BeTrue();
+        _builder.IsGenericBuilder.Should().BeTrue();
     }
 
     [Fact]
     public void CopyCtor_Ok()
     {
-        new ResilienceStrategyBuilder<string>(new ResilienceStrategyBuilder()).Builder.IsGenericBuilder.Should().BeTrue();
+        new ResilienceStrategyBuilder<string>(new ResilienceStrategyBuilder()).IsGenericBuilder.Should().BeTrue();
     }
 
     [Fact]

--- a/src/Polly.Core.Tests/ResilienceStrategyBuilderTests.cs
+++ b/src/Polly.Core.Tests/ResilienceStrategyBuilderTests.cs
@@ -252,13 +252,12 @@ The StrategyName field is required.
         {
             BuilderName = "builder-name",
             TimeProvider = new FakeTimeProvider().Object,
-            IsGenericBuilder = true
         };
 
         builder.AddStrategy(
             context =>
             {
-                context.IsGenericBuilder.Should().BeTrue();
+                context.IsGenericBuilder.Should().BeFalse();
                 context.BuilderName.Should().Be("builder-name");
                 context.StrategyName.Should().Be("strategy-name");
                 context.StrategyType.Should().Be("Test");

--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerResilienceStrategyBuilderExtensions.cs
@@ -13,6 +13,7 @@ public static class CircuitBreakerResilienceStrategyBuilderExtensions
     /// <summary>
     /// Add advanced circuit breaker strategy to the builder.
     /// </summary>
+    /// <typeparam name="TBuilder">The builder type.</typeparam>
     /// <typeparam name="TResult">The type of result the circuit breaker strategy handles.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="options">The options instance.</param>
@@ -25,14 +26,15 @@ public static class CircuitBreakerResilienceStrategyBuilderExtensions
     /// </remarks>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
-    public static ResilienceStrategyBuilder<TResult> AddAdvancedCircuitBreaker<TResult>(this ResilienceStrategyBuilder<TResult> builder, AdvancedCircuitBreakerStrategyOptions<TResult> options)
+    public static TBuilder AddAdvancedCircuitBreaker<TBuilder, TResult>(this TBuilder builder, AdvancedCircuitBreakerStrategyOptions<TResult> options)
+        where TBuilder : ResilienceStrategyBuilderBase
     {
         Guard.NotNull(builder);
         Guard.NotNull(options);
 
         ValidationHelper.ValidateObject(options, "The advanced circuit breaker strategy options are invalid.");
 
-        return builder.AddStrategy(
+        builder.AddStrategy(
             context =>
             {
                 var behavior = new AdvancedCircuitBehavior(
@@ -43,45 +45,14 @@ public static class CircuitBreakerResilienceStrategyBuilderExtensions
                 return CreateStrategy(context, options, behavior);
             },
             options);
-    }
 
-    /// <summary>
-    /// Add advanced circuit breaker strategy to the builder.
-    /// </summary>
-    /// <param name="builder">The builder instance.</param>
-    /// <param name="options">The options instance.</param>
-    /// <returns>A builder with the circuit breaker strategy added.</returns>
-    /// <remarks>
-    /// See <see cref="AdvancedCircuitBreakerStrategyOptions"/> for more details about the advanced circuit breaker strategy.
-    /// <para>
-    /// If you are discarding the strategy created by this call make sure to use <see cref="CircuitBreakerManualControl"/> and dispose the manual control instance when the strategy is no longer used.
-    /// </para>
-    /// </remarks>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
-    public static ResilienceStrategyBuilder AddAdvancedCircuitBreaker(this ResilienceStrategyBuilder builder, AdvancedCircuitBreakerStrategyOptions options)
-    {
-        Guard.NotNull(builder);
-        Guard.NotNull(options);
-
-        ValidationHelper.ValidateObject(options, "The advanced circuit breaker strategy options are invalid.");
-
-        return builder.AddStrategy(
-            context =>
-            {
-                var behavior = new AdvancedCircuitBehavior(
-                    options.FailureThreshold,
-                    options.MinimumThroughput,
-                    HealthMetrics.Create(options.SamplingDuration, context.TimeProvider));
-
-                return CreateStrategy(context, options, behavior);
-            },
-            options);
+        return builder;
     }
 
     /// <summary>
     /// Add simple circuit breaker strategy to the builder.
     /// </summary>
+    /// <typeparam name="TBuilder">The builder type.</typeparam>
     /// <typeparam name="TResult">The type of result the circuit breaker strategy handles.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="options">The options instance.</param>
@@ -94,38 +65,16 @@ public static class CircuitBreakerResilienceStrategyBuilderExtensions
     /// </remarks>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
-    public static ResilienceStrategyBuilder<TResult> AddSimpleCircuitBreaker<TResult>(this ResilienceStrategyBuilder<TResult> builder, SimpleCircuitBreakerStrategyOptions<TResult> options)
+    public static TBuilder AddSimpleCircuitBreaker<TBuilder, TResult>(this TBuilder builder, SimpleCircuitBreakerStrategyOptions<TResult> options)
+        where TBuilder : ResilienceStrategyBuilderBase
     {
         Guard.NotNull(builder);
         Guard.NotNull(options);
 
         ValidationHelper.ValidateObject(options, "The circuit breaker strategy options are invalid.");
 
-        return builder.AddStrategy(context => CreateStrategy<TResult>(context, options, new ConsecutiveFailuresCircuitBehavior(options.FailureThreshold)), options);
-    }
-
-    /// <summary>
-    /// Add simple circuit breaker strategy to the builder.
-    /// </summary>
-    /// <param name="builder">The builder instance.</param>
-    /// <param name="options">The options instance.</param>
-    /// <returns>A builder with the circuit breaker strategy added.</returns>
-    /// <remarks>
-    /// See <see cref="SimpleCircuitBreakerStrategyOptions"/> for more details about the advanced circuit breaker strategy.
-    /// <para>
-    /// If you are discarding the strategy created by this call make sure to use <see cref="CircuitBreakerManualControl"/> and dispose the manual control instance when the strategy is no longer used.
-    /// </para>
-    /// </remarks>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
-    public static ResilienceStrategyBuilder AddSimpleCircuitBreaker(this ResilienceStrategyBuilder builder, SimpleCircuitBreakerStrategyOptions options)
-    {
-        Guard.NotNull(builder);
-        Guard.NotNull(options);
-
-        ValidationHelper.ValidateObject(options, "The circuit breaker strategy options are invalid.");
-
-        return builder.AddStrategy(context => CreateStrategy(context, options, new ConsecutiveFailuresCircuitBehavior(options.FailureThreshold)), options);
+        builder.AddStrategy(context => CreateStrategy<TResult>(context, options, new ConsecutiveFailuresCircuitBehavior(options.FailureThreshold)), options);
+        return builder;
     }
 
     internal static CircuitBreakerResilienceStrategy CreateStrategy(ResilienceStrategyBuilderContext context, CircuitBreakerStrategyOptions<object> options, CircuitBehavior behavior)

--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerResilienceStrategyBuilderExtensions.cs
@@ -13,7 +13,28 @@ public static class CircuitBreakerResilienceStrategyBuilderExtensions
     /// <summary>
     /// Add advanced circuit breaker strategy to the builder.
     /// </summary>
-    /// <typeparam name="TBuilder">The builder type.</typeparam>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="options">The options instance.</param>
+    /// <returns>A builder with the circuit breaker strategy added.</returns>
+    /// <remarks>
+    /// See <see cref="AdvancedCircuitBreakerStrategyOptions{TResult}"/> for more details about the advanced circuit breaker strategy.
+    /// <para>
+    /// If you are discarding the strategy created by this call make sure to use <see cref="CircuitBreakerManualControl"/> and dispose the manual control instance when the strategy is no longer used.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
+    public static ResilienceStrategyBuilder AddAdvancedCircuitBreaker(this ResilienceStrategyBuilder builder, AdvancedCircuitBreakerStrategyOptions options)
+    {
+        Guard.NotNull(builder);
+        Guard.NotNull(options);
+
+        return builder.AddAdvancedCircuitBreakerCore(options);
+    }
+
+    /// <summary>
+    /// Add advanced circuit breaker strategy to the builder.
+    /// </summary>
     /// <typeparam name="TResult">The type of result the circuit breaker strategy handles.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="options">The options instance.</param>
@@ -26,12 +47,62 @@ public static class CircuitBreakerResilienceStrategyBuilderExtensions
     /// </remarks>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
-    public static TBuilder AddAdvancedCircuitBreaker<TBuilder, TResult>(this TBuilder builder, AdvancedCircuitBreakerStrategyOptions<TResult> options)
-        where TBuilder : ResilienceStrategyBuilderBase
+    public static ResilienceStrategyBuilder<TResult> AddAdvancedCircuitBreaker<TResult>(this ResilienceStrategyBuilder<TResult> builder, AdvancedCircuitBreakerStrategyOptions<TResult> options)
     {
         Guard.NotNull(builder);
         Guard.NotNull(options);
 
+        return builder.AddAdvancedCircuitBreakerCore(options);
+    }
+
+    /// <summary>
+    /// Add simple circuit breaker strategy to the builder.
+    /// </summary>
+    /// <typeparam name="TResult">The type of result the circuit breaker strategy handles.</typeparam>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="options">The options instance.</param>
+    /// <returns>A builder with the circuit breaker strategy added.</returns>
+    /// <remarks>
+    /// See <see cref="SimpleCircuitBreakerStrategyOptions{TResult}"/> for more details about the advanced circuit breaker strategy.
+    /// <para>
+    /// If you are discarding the strategy created by this call make sure to use <see cref="CircuitBreakerManualControl"/> and dispose the manual control instance when the strategy is no longer used.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
+    public static ResilienceStrategyBuilder<TResult> AddSimpleCircuitBreaker<TResult>(this ResilienceStrategyBuilder<TResult> builder, SimpleCircuitBreakerStrategyOptions<TResult> options)
+    {
+        Guard.NotNull(builder);
+        Guard.NotNull(options);
+
+        return builder.AddSimpleCircuitBreakerCore(options);
+    }
+
+    /// <summary>
+    /// Add simple circuit breaker strategy to the builder.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="options">The options instance.</param>
+    /// <returns>A builder with the circuit breaker strategy added.</returns>
+    /// <remarks>
+    /// See <see cref="SimpleCircuitBreakerStrategyOptions{TResult}"/> for more details about the advanced circuit breaker strategy.
+    /// <para>
+    /// If you are discarding the strategy created by this call make sure to use <see cref="CircuitBreakerManualControl"/> and dispose the manual control instance when the strategy is no longer used.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
+    public static ResilienceStrategyBuilder AddSimpleCircuitBreaker(this ResilienceStrategyBuilder builder, SimpleCircuitBreakerStrategyOptions options)
+    {
+        Guard.NotNull(builder);
+        Guard.NotNull(options);
+
+        return builder.AddSimpleCircuitBreakerCore(options);
+    }
+
+    private static TBuilder AddAdvancedCircuitBreakerCore<TBuilder, TResult>(this TBuilder builder, AdvancedCircuitBreakerStrategyOptions<TResult> options)
+        where TBuilder : ResilienceStrategyBuilderBase
+    {
         ValidationHelper.ValidateObject(options, "The advanced circuit breaker strategy options are invalid.");
 
         builder.AddStrategy(
@@ -49,50 +120,13 @@ public static class CircuitBreakerResilienceStrategyBuilderExtensions
         return builder;
     }
 
-    /// <summary>
-    /// Add simple circuit breaker strategy to the builder.
-    /// </summary>
-    /// <typeparam name="TBuilder">The builder type.</typeparam>
-    /// <typeparam name="TResult">The type of result the circuit breaker strategy handles.</typeparam>
-    /// <param name="builder">The builder instance.</param>
-    /// <param name="options">The options instance.</param>
-    /// <returns>A builder with the circuit breaker strategy added.</returns>
-    /// <remarks>
-    /// See <see cref="SimpleCircuitBreakerStrategyOptions{TResult}"/> for more details about the advanced circuit breaker strategy.
-    /// <para>
-    /// If you are discarding the strategy created by this call make sure to use <see cref="CircuitBreakerManualControl"/> and dispose the manual control instance when the strategy is no longer used.
-    /// </para>
-    /// </remarks>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
-    public static TBuilder AddSimpleCircuitBreaker<TBuilder, TResult>(this TBuilder builder, SimpleCircuitBreakerStrategyOptions<TResult> options)
+    private static TBuilder AddSimpleCircuitBreakerCore<TBuilder, TResult>(this TBuilder builder, SimpleCircuitBreakerStrategyOptions<TResult> options)
         where TBuilder : ResilienceStrategyBuilderBase
     {
-        Guard.NotNull(builder);
-        Guard.NotNull(options);
-
         ValidationHelper.ValidateObject(options, "The circuit breaker strategy options are invalid.");
 
-        builder.AddStrategy(context => CreateStrategy<TResult>(context, options, new ConsecutiveFailuresCircuitBehavior(options.FailureThreshold)), options);
+        builder.AddStrategy(context => CreateStrategy(context, options, new ConsecutiveFailuresCircuitBehavior(options.FailureThreshold)), options);
         return builder;
-    }
-
-    internal static CircuitBreakerResilienceStrategy CreateStrategy(ResilienceStrategyBuilderContext context, CircuitBreakerStrategyOptions<object> options, CircuitBehavior behavior)
-    {
-        var controller = new CircuitStateController(
-            options.BreakDuration,
-            context.CreateInvoker(options.OnOpened),
-            context.CreateInvoker(options.OnClosed),
-            options.OnHalfOpened,
-            behavior,
-            context.TimeProvider,
-            context.Telemetry);
-
-        return new CircuitBreakerResilienceStrategy(
-            context.CreateInvoker(options.ShouldHandle)!,
-            controller,
-            options.StateProvider,
-            options.ManualControl);
     }
 
     internal static CircuitBreakerResilienceStrategy CreateStrategy<TResult>(ResilienceStrategyBuilderContext context, CircuitBreakerStrategyOptions<TResult> options, CircuitBehavior behavior)

--- a/src/Polly.Core/ResilienceStrategyBuilder.TResult.cs
+++ b/src/Polly.Core/ResilienceStrategyBuilder.TResult.cs
@@ -26,6 +26,8 @@ public sealed class ResilienceStrategyBuilder<TResult> : ResilienceStrategyBuild
     {
     }
 
+    internal override bool IsGenericBuilder => true;
+
     /// <summary>
     /// Adds an already created strategy instance to the builder.
     /// </summary>

--- a/src/Polly.Core/ResilienceStrategyBuilder.TResult.cs
+++ b/src/Polly.Core/ResilienceStrategyBuilder.TResult.cs
@@ -12,61 +12,19 @@ namespace Polly;
 /// The resulting instance of <see cref="ResilienceStrategy{TResult}"/> created by the <see cref="Build"/> call will execute the strategies in the same order they were added to the builder.
 /// The order of the strategies is important.
 /// </remarks>
-public class ResilienceStrategyBuilder<TResult>
+public sealed class ResilienceStrategyBuilder<TResult> : ResilienceStrategyBuilderBase
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="ResilienceStrategyBuilder{TResult}"/> class.
     /// </summary>
-    public ResilienceStrategyBuilder() => Builder = new()
+    public ResilienceStrategyBuilder()
     {
-        IsGenericBuilder = true
-    };
-
-    internal ResilienceStrategyBuilder(ResilienceStrategyBuilder builder)
-    {
-        Builder = builder;
-        Builder.IsGenericBuilder = true;
     }
 
-    /// <summary>
-    /// Gets or sets the name of the builder.
-    /// </summary>
-    /// <remarks>This property is also included in the telemetry that is produced by the individual resilience strategies.</remarks>
-    [Required(AllowEmptyStrings = true)]
-    public string BuilderName
+    internal ResilienceStrategyBuilder(ResilienceStrategyBuilderBase other)
+        : base(other)
     {
-        get => Builder.BuilderName;
-        set => Builder.BuilderName = value;
     }
-
-    /// <summary>
-    /// Gets the custom properties attached to builder options.
-    /// </summary>
-    public ResilienceProperties Properties => Builder.Properties;
-
-    /// <summary>
-    /// Gets or sets a <see cref="TimeProvider"/> that is used by strategies that work with time.
-    /// </summary>
-    /// <remarks>
-    /// This property is internal until we switch to official System.TimeProvider.
-    /// </remarks>
-    [Required]
-    internal TimeProvider TimeProvider
-    {
-        get => Builder.TimeProvider;
-        set => Builder.TimeProvider = value;
-    }
-
-    /// <summary>
-    /// Gets or sets the callback that is invoked just before the final resilience strategy is being created.
-    /// </summary>
-    internal Action<IList<ResilienceStrategy>>? OnCreatingStrategy
-    {
-        get => Builder.OnCreatingStrategy;
-        set => Builder.OnCreatingStrategy = value;
-    }
-
-    internal ResilienceStrategyBuilder Builder { get; }
 
     /// <summary>
     /// Adds an already created strategy instance to the builder.
@@ -75,11 +33,11 @@ public class ResilienceStrategyBuilder<TResult>
     /// <returns>The same builder instance.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="strategy"/> is <see langword="null"/>.</exception>
     /// <exception cref="InvalidOperationException">Thrown when this builder was already used to create a strategy. The builder cannot be modified after it has been used.</exception>
-    public ResilienceStrategyBuilder<TResult> AddStrategy(ResilienceStrategy strategy)
+    public new ResilienceStrategyBuilder<TResult> AddStrategy(ResilienceStrategy strategy)
     {
         Guard.NotNull(strategy);
 
-        Builder.AddStrategy(strategy);
+        base.AddStrategy(strategy);
         return this;
     }
 
@@ -92,15 +50,14 @@ public class ResilienceStrategyBuilder<TResult>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="factory"/> is <see langword="null"/>.</exception>
     /// <exception cref="InvalidOperationException">Thrown when this builder was already used to create a strategy. The builder cannot be modified after it has been used.</exception>
     /// <exception cref="ValidationException">Thrown when the <paramref name="options"/> are invalid.</exception>
-    public ResilienceStrategyBuilder<TResult> AddStrategy(
+    public new ResilienceStrategyBuilder<TResult> AddStrategy(
         Func<ResilienceStrategyBuilderContext, ResilienceStrategy> factory,
         ResilienceStrategyOptions options)
     {
         Guard.NotNull(factory);
         Guard.NotNull(options);
 
-        Builder.AddStrategy(factory, options);
-
+        base.AddStrategy(factory, options);
         return this;
     }
 
@@ -109,5 +66,5 @@ public class ResilienceStrategyBuilder<TResult>
     /// </summary>
     /// <returns>An instance of <see cref="ResilienceStrategy{TResult}"/>.</returns>
     /// <exception cref="ValidationException">Thrown when this builder has invalid configuration.</exception>
-    public ResilienceStrategy<TResult> Build() => new(Builder.Build());
+    public ResilienceStrategy<TResult> Build() => new(BuildStrategy());
 }

--- a/src/Polly.Core/ResilienceStrategyBuilder.cs
+++ b/src/Polly.Core/ResilienceStrategyBuilder.cs
@@ -13,6 +13,8 @@ namespace Polly;
 /// </remarks>
 public sealed class ResilienceStrategyBuilder : ResilienceStrategyBuilderBase
 {
+    internal override bool IsGenericBuilder => false;
+
     /// <summary>
     /// Adds an already created strategy instance to the builder.
     /// </summary>

--- a/src/Polly.Core/ResilienceStrategyBuilder.cs
+++ b/src/Polly.Core/ResilienceStrategyBuilder.cs
@@ -11,39 +11,8 @@ namespace Polly;
 /// The resulting instance of <see cref="ResilienceStrategy"/> created by the <see cref="Build"/> call will execute the strategies in the same order they were added to the builder.
 /// The order of the strategies is important.
 /// </remarks>
-public class ResilienceStrategyBuilder
+public sealed class ResilienceStrategyBuilder : ResilienceStrategyBuilderBase
 {
-    private readonly List<Entry> _entries = new();
-    private bool _used;
-
-    /// <summary>
-    /// Gets or sets the name of the builder.
-    /// </summary>
-    /// <remarks>This property is also included in the telemetry that is produced by the individual resilience strategies.</remarks>
-    [Required(AllowEmptyStrings = true)]
-    public string BuilderName { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Gets the custom properties attached to builder options.
-    /// </summary>
-    public ResilienceProperties Properties { get; } = new();
-
-    /// <summary>
-    /// Gets or sets a <see cref="TimeProvider"/> that is used by strategies that work with time.
-    /// </summary>
-    /// <remarks>
-    /// This property is internal until we switch to official System.TimeProvider.
-    /// </remarks>
-    [Required]
-    internal TimeProvider TimeProvider { get; set; } = TimeProvider.System;
-
-    /// <summary>
-    /// Gets or sets the callback that is invoked just before the final resilience strategy is being created.
-    /// </summary>
-    internal Action<IList<ResilienceStrategy>>? OnCreatingStrategy { get; set; }
-
-    internal bool IsGenericBuilder { get; set; }
-
     /// <summary>
     /// Adds an already created strategy instance to the builder.
     /// </summary>
@@ -51,11 +20,12 @@ public class ResilienceStrategyBuilder
     /// <returns>The same builder instance.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="strategy"/> is null.</exception>
     /// <exception cref="InvalidOperationException">Thrown when this builder was already used to create a strategy. The builder cannot be modified after it has been used.</exception>
-    public ResilienceStrategyBuilder AddStrategy(ResilienceStrategy strategy)
+    public new ResilienceStrategyBuilder AddStrategy(ResilienceStrategy strategy)
     {
         Guard.NotNull(strategy);
 
-        return AddStrategy(_ => strategy, EmptyOptions.Instance);
+        base.AddStrategy(strategy);
+        return this;
     }
 
     /// <summary>
@@ -67,20 +37,9 @@ public class ResilienceStrategyBuilder
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="factory"/> is null.</exception>
     /// <exception cref="InvalidOperationException">Thrown when this builder was already used to create a strategy. The builder cannot be modified after it has been used.</exception>
     /// <exception cref="ValidationException">Thrown when the <paramref name="options"/> are invalid.</exception>
-    public ResilienceStrategyBuilder AddStrategy(Func<ResilienceStrategyBuilderContext, ResilienceStrategy> factory, ResilienceStrategyOptions options)
+    public new ResilienceStrategyBuilder AddStrategy(Func<ResilienceStrategyBuilderContext, ResilienceStrategy> factory, ResilienceStrategyOptions options)
     {
-        Guard.NotNull(factory);
-        Guard.NotNull(options);
-
-        ValidationHelper.ValidateObject(options, $"The '{nameof(ResilienceStrategyOptions)}' options are not valid.");
-
-        if (_used)
-        {
-            throw new InvalidOperationException("Cannot add any more resilience strategies to the builder after it has been used to build a strategy once.");
-        }
-
-        _entries.Add(new Entry(factory, options));
-
+        base.AddStrategy(factory, options);
         return this;
     }
 
@@ -89,47 +48,5 @@ public class ResilienceStrategyBuilder
     /// </summary>
     /// <returns>An instance of <see cref="ResilienceStrategy"/>.</returns>
     /// <exception cref="ValidationException">Thrown when this builder has invalid configuration.</exception>
-    public ResilienceStrategy Build()
-    {
-        ValidationHelper.ValidateObject(this, $"The '{nameof(ResilienceStrategyBuilder)}' configuration is invalid.");
-
-        _used = true;
-
-        var strategies = _entries.Select(CreateResilienceStrategy).ToList();
-        OnCreatingStrategy?.Invoke(strategies);
-
-        if (strategies.Count == 0)
-        {
-            return NullResilienceStrategy.Instance;
-        }
-
-        if (strategies.Count == 1)
-        {
-            return strategies[0];
-        }
-
-        return ResilienceStrategyPipeline.CreatePipeline(strategies);
-    }
-
-    private ResilienceStrategy CreateResilienceStrategy(Entry entry)
-    {
-        var context = new ResilienceStrategyBuilderContext(
-            builderName: BuilderName,
-            builderProperties: Properties,
-            strategyName: entry.Properties.StrategyName,
-            strategyType: entry.Properties.StrategyType,
-            timeProvider: TimeProvider,
-            IsGenericBuilder);
-
-        return entry.Factory(context);
-    }
-
-    private sealed record Entry(Func<ResilienceStrategyBuilderContext, ResilienceStrategy> Factory, ResilienceStrategyOptions Properties);
-
-    internal sealed class EmptyOptions : ResilienceStrategyOptions
-    {
-        public static readonly EmptyOptions Instance = new();
-
-        public override string StrategyType => "Empty";
-    }
+    public ResilienceStrategy Build() => BuildStrategy();
 }

--- a/src/Polly.Core/Retry/RetryResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/Retry/RetryResilienceStrategyBuilderExtensions.cs
@@ -125,20 +125,22 @@ public static class RetryResilienceStrategyBuilderExtensions
     /// <summary>
     /// Adds a retry strategy to the builder.
     /// </summary>
+    /// <typeparam name="TBuilder">The builder type.</typeparam>
     /// <typeparam name="TResult">The type of result the retry strategy handles.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="options">The retry strategy options.</param>
     /// <returns>The builder instance with the retry strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
-    public static ResilienceStrategyBuilder<TResult> AddRetry<TResult>(this ResilienceStrategyBuilder<TResult> builder, RetryStrategyOptions<TResult> options)
+    public static TBuilder AddRetry<TBuilder, TResult>(this TBuilder builder, RetryStrategyOptions<TResult> options)
+        where TBuilder : ResilienceStrategyBuilderBase
     {
         Guard.NotNull(builder);
         Guard.NotNull(options);
 
         ValidationHelper.ValidateObject(options, "The retry strategy options are invalid.");
 
-        return builder.AddStrategy(context =>
+        builder.AddStrategy(context =>
             new RetryResilienceStrategy(
                 options.BaseDelay,
                 options.BackoffType,
@@ -150,35 +152,8 @@ public static class RetryResilienceStrategyBuilderExtensions
                 context.Telemetry,
                 RandomUtil.Instance),
             options);
-    }
 
-    /// <summary>
-    /// Adds a retry strategy to the builder.
-    /// </summary>
-    /// <param name="builder">The builder instance.</param>
-    /// <param name="options">The retry strategy options.</param>
-    /// <returns>The builder instance with the retry strategy added.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
-    public static ResilienceStrategyBuilder AddRetry(this ResilienceStrategyBuilder builder, RetryStrategyOptions options)
-    {
-        Guard.NotNull(builder);
-        Guard.NotNull(options);
-
-        ValidationHelper.ValidateObject(options, "The retry strategy options are invalid.");
-
-        return builder.AddStrategy(context =>
-            new RetryResilienceStrategy(
-                options.BaseDelay,
-                options.BackoffType,
-                options.RetryCount,
-                context.CreateInvoker(options.ShouldRetry)!,
-                context.CreateInvoker(options.OnRetry),
-                context.CreateInvoker(options.RetryDelayGenerator, TimeSpan.MinValue),
-                context.TimeProvider,
-                context.Telemetry,
-                RandomUtil.Instance),
-            options);
+        return builder;
     }
 
     private static void ConfigureShouldRetry<TResult>(Action<PredicateBuilder<TResult>> shouldRetry, RetryStrategyOptions<TResult> options)

--- a/src/Polly.Core/Retry/RetryResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/Retry/RetryResilienceStrategyBuilderExtensions.cs
@@ -125,19 +125,39 @@ public static class RetryResilienceStrategyBuilderExtensions
     /// <summary>
     /// Adds a retry strategy to the builder.
     /// </summary>
-    /// <typeparam name="TBuilder">The builder type.</typeparam>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="options">The retry strategy options.</param>
+    /// <returns>The builder instance with the retry strategy added.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
+    public static ResilienceStrategyBuilder AddRetry(this ResilienceStrategyBuilder builder, RetryStrategyOptions options)
+    {
+        Guard.NotNull(builder);
+        Guard.NotNull(options);
+
+        return builder.AddRetryCore(options);
+    }
+
+    /// <summary>
+    /// Adds a retry strategy to the builder.
+    /// </summary>
     /// <typeparam name="TResult">The type of result the retry strategy handles.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="options">The retry strategy options.</param>
     /// <returns>The builder instance with the retry strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
-    public static TBuilder AddRetry<TBuilder, TResult>(this TBuilder builder, RetryStrategyOptions<TResult> options)
-        where TBuilder : ResilienceStrategyBuilderBase
+    public static ResilienceStrategyBuilder<TResult> AddRetry<TResult>(this ResilienceStrategyBuilder<TResult> builder, RetryStrategyOptions<TResult> options)
     {
         Guard.NotNull(builder);
         Guard.NotNull(options);
 
+        return builder.AddRetryCore(options);
+    }
+
+    private static TBuilder AddRetryCore<TBuilder, TResult>(this TBuilder builder, RetryStrategyOptions<TResult> options)
+        where TBuilder : ResilienceStrategyBuilderBase
+    {
         ValidationHelper.ValidateObject(options, "The retry strategy options are invalid.");
 
         builder.AddStrategy(context =>

--- a/src/Polly.Core/Strategy/ResilienceStrategyBuilderBase.cs
+++ b/src/Polly.Core/Strategy/ResilienceStrategyBuilderBase.cs
@@ -1,0 +1,135 @@
+using System.ComponentModel.DataAnnotations;
+using Polly.Strategy;
+
+namespace Polly.Strategy;
+
+/// <summary>
+/// A builder that is used to create an instance of <see cref="ResilienceStrategy"/>.
+/// </summary>
+/// <remarks>
+/// The builder supports chaining multiple strategies into a pipeline of strategies.
+/// The resulting instance of <see cref="ResilienceStrategy"/> executes the strategies in the same order they were added to the builder.
+/// The order of the strategies is important.
+/// </remarks>
+public abstract class ResilienceStrategyBuilderBase
+{
+    private readonly List<Entry> _entries = new();
+    private bool _used;
+
+    private protected ResilienceStrategyBuilderBase()
+    {
+    }
+
+    private protected ResilienceStrategyBuilderBase(ResilienceStrategyBuilderBase other)
+    {
+        BuilderName = other.BuilderName;
+        Properties = other.Properties;
+        TimeProvider = other.TimeProvider;
+        OnCreatingStrategy = other.OnCreatingStrategy;
+    }
+
+    /// <summary>
+    /// Gets or sets the name of the builder.
+    /// </summary>
+    /// <remarks>This property is also included in the telemetry that is produced by the individual resilience strategies.</remarks>
+    [Required(AllowEmptyStrings = true)]
+    public string BuilderName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the custom properties attached to builder options.
+    /// </summary>
+    public ResilienceProperties Properties { get; } = new();
+
+    /// <summary>
+    /// Gets or sets a <see cref="TimeProvider"/> that is used by strategies that work with time.
+    /// </summary>
+    /// <remarks>
+    /// This property is internal until we switch to official System.TimeProvider.
+    /// </remarks>
+    [Required]
+    internal TimeProvider TimeProvider { get; set; } = TimeProvider.System;
+
+    /// <summary>
+    /// Gets or sets the callback that is invoked just before the final resilience strategy is being created.
+    /// </summary>
+    internal Action<IList<ResilienceStrategy>>? OnCreatingStrategy { get; set; }
+
+    /// <summary>
+    /// Adds an already created strategy instance to the builder.
+    /// </summary>
+    /// <param name="strategy">The strategy instance.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="strategy"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when this builder was already used to create a strategy. The builder cannot be modified after it has been used.</exception>
+    public void AddStrategy(ResilienceStrategy strategy)
+    {
+        Guard.NotNull(strategy);
+
+        AddStrategy(_ => strategy, EmptyOptions.Instance);
+    }
+
+    /// <summary>
+    /// Adds a strategy to the builder.
+    /// </summary>
+    /// <param name="factory">The factory that creates a resilience strategy.</param>
+    /// <param name="options">The options associated with the strategy. If none are provided the default instance of <see cref="ResilienceStrategyOptions"/> is created.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="factory"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when this builder was already used to create a strategy. The builder cannot be modified after it has been used.</exception>
+    /// <exception cref="ValidationException">Thrown when the <paramref name="options"/> are invalid.</exception>
+    public void AddStrategy(Func<ResilienceStrategyBuilderContext, ResilienceStrategy> factory, ResilienceStrategyOptions options)
+    {
+        Guard.NotNull(factory);
+        Guard.NotNull(options);
+
+        ValidationHelper.ValidateObject(options, $"The '{nameof(ResilienceStrategyOptions)}' options are not valid.");
+
+        if (_used)
+        {
+            throw new InvalidOperationException("Cannot add any more resilience strategies to the builder after it has been used to build a strategy once.");
+        }
+
+        _entries.Add(new Entry(factory, options));
+    }
+
+    internal ResilienceStrategy BuildStrategy()
+    {
+        ValidationHelper.ValidateObject(this, $"The '{nameof(ResilienceStrategyBuilder)}' configuration is invalid.");
+
+        _used = true;
+
+        var strategies = _entries.Select(CreateResilienceStrategy).ToList();
+        OnCreatingStrategy?.Invoke(strategies);
+
+        if (strategies.Count == 0)
+        {
+            return NullResilienceStrategy.Instance;
+        }
+
+        if (strategies.Count == 1)
+        {
+            return strategies[0];
+        }
+
+        return ResilienceStrategyPipeline.CreatePipeline(strategies);
+    }
+
+    private ResilienceStrategy CreateResilienceStrategy(Entry entry)
+    {
+        var context = new ResilienceStrategyBuilderContext(
+            builderName: BuilderName,
+            builderProperties: Properties,
+            strategyName: entry.Properties.StrategyName,
+            strategyType: entry.Properties.StrategyType,
+            timeProvider: TimeProvider);
+
+        return entry.Factory(context);
+    }
+
+    private sealed record Entry(Func<ResilienceStrategyBuilderContext, ResilienceStrategy> Factory, ResilienceStrategyOptions Properties);
+
+    internal sealed class EmptyOptions : ResilienceStrategyOptions
+    {
+        public static readonly EmptyOptions Instance = new();
+
+        public override string StrategyType => "Empty";
+    }
+}

--- a/src/Polly.Core/Strategy/ResilienceStrategyBuilderBase.cs
+++ b/src/Polly.Core/Strategy/ResilienceStrategyBuilderBase.cs
@@ -54,6 +54,8 @@ public abstract class ResilienceStrategyBuilderBase
     /// </summary>
     internal Action<IList<ResilienceStrategy>>? OnCreatingStrategy { get; set; }
 
+    internal abstract bool IsGenericBuilder { get; }
+
     /// <summary>
     /// Adds an already created strategy instance to the builder.
     /// </summary>
@@ -119,7 +121,8 @@ public abstract class ResilienceStrategyBuilderBase
             builderProperties: Properties,
             strategyName: entry.Properties.StrategyName,
             strategyType: entry.Properties.StrategyType,
-            timeProvider: TimeProvider);
+            timeProvider: TimeProvider,
+            IsGenericBuilder);
 
         return entry.Factory(context);
     }

--- a/src/Polly.Core/Timeout/TimeoutResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/Timeout/TimeoutResilienceStrategyBuilderExtensions.cs
@@ -13,13 +13,14 @@ public static class TimeoutResilienceStrategyBuilderExtensions
     /// <summary>
     /// Adds a timeout resilience strategy to the builder.
     /// </summary>
-    /// <typeparam name="TResult">The type of the result.</typeparam>
+    /// <typeparam name="TBuilder">The builder type.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="timeout">The timeout value. This value should be greater than <see cref="TimeSpan.Zero"/> or <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>.</param>
     /// <returns>The same builder instance.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when the options produced from the arguments are invalid.</exception>
-    public static ResilienceStrategyBuilder<TResult> AddTimeout<TResult>(this ResilienceStrategyBuilder<TResult> builder, TimeSpan timeout)
+    public static TBuilder AddTimeout<TBuilder>(this TBuilder builder, TimeSpan timeout)
+        where TBuilder : ResilienceStrategyBuilderBase
     {
         Guard.NotNull(builder);
 
@@ -32,19 +33,20 @@ public static class TimeoutResilienceStrategyBuilderExtensions
     /// <summary>
     /// Adds a timeout resilience strategy to the builder.
     /// </summary>
-    /// <typeparam name="TResult">The type of the result.</typeparam>
+    /// <typeparam name="TBuilder">The builder type.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="timeout">The timeout value. This value should be greater than <see cref="TimeSpan.Zero"/> or <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>.</param>
     /// <param name="onTimeout">The callback that is executed when timeout happens.</param>
     /// <returns>The same builder instance.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when the options produced from the arguments are invalid.</exception>
-    public static ResilienceStrategyBuilder<TResult> AddTimeout<TResult>(this ResilienceStrategyBuilder<TResult> builder, TimeSpan timeout, Action<OnTimeoutArguments> onTimeout)
+    public static TBuilder AddTimeout<TBuilder>(this TBuilder builder, TimeSpan timeout, Action<OnTimeoutArguments> onTimeout)
+        where TBuilder : ResilienceStrategyBuilderBase
     {
         Guard.NotNull(builder);
         Guard.NotNull(onTimeout);
 
-        return builder.AddTimeout(new TimeoutStrategyOptions
+        builder.AddTimeout(new TimeoutStrategyOptions
         {
             Timeout = timeout,
             OnTimeout = (args) =>
@@ -53,40 +55,26 @@ public static class TimeoutResilienceStrategyBuilderExtensions
                 return default;
             }
         });
+
+        return builder;
     }
 
     /// <summary>
     /// Adds a timeout resilience strategy to the builder.
     /// </summary>
-    /// <typeparam name="TResult">The type of the result.</typeparam>
+    /// <typeparam name="TBuilder">The builder type.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="options">The timeout options.</param>
     /// <returns>The same builder instance.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
-    public static ResilienceStrategyBuilder<TResult> AddTimeout<TResult>(this ResilienceStrategyBuilder<TResult> builder, TimeoutStrategyOptions options)
+    public static TBuilder AddTimeout<TBuilder>(this TBuilder builder, TimeoutStrategyOptions options)
+        where TBuilder : ResilienceStrategyBuilderBase
     {
         Guard.NotNull(builder);
         Guard.NotNull(options);
 
-        return builder.AddStrategy(context => new TimeoutResilienceStrategy(options, context.TimeProvider, context.Telemetry), options);
-    }
-
-    /// <summary>
-    /// Adds a timeout resilience strategy to the builder.
-    /// </summary>
-    /// <param name="builder">The builder instance.</param>
-    /// <param name="options">The timeout options.</param>
-    /// <returns>The same builder instance.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
-    public static ResilienceStrategyBuilder AddTimeout(this ResilienceStrategyBuilder builder, TimeoutStrategyOptions options)
-    {
-        Guard.NotNull(builder);
-        Guard.NotNull(options);
-
-        ValidationHelper.ValidateObject(options, "The timeout strategy options are invalid.");
-
-        return builder.AddStrategy(context => new TimeoutResilienceStrategy(options, context.TimeProvider, context.Telemetry), options);
+        builder.AddStrategy(context => new TimeoutResilienceStrategy(options, context.TimeProvider, context.Telemetry), options);
+        return builder;
     }
 }

--- a/src/Polly.Core/Timeout/TimeoutResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/Timeout/TimeoutResilienceStrategyBuilderExtensions.cs
@@ -74,6 +74,8 @@ public static class TimeoutResilienceStrategyBuilderExtensions
         Guard.NotNull(builder);
         Guard.NotNull(options);
 
+        ValidationHelper.ValidateObject(options, "The timeout strategy options are invalid.*");
+
         builder.AddStrategy(context => new TimeoutResilienceStrategy(options, context.TimeProvider, context.Telemetry), options);
         return builder;
     }

--- a/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategyBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Polly.Extensions.Telemetry;
+using Polly.Strategy;
 using Polly.Telemetry;
 using Polly.Utils;
 
@@ -13,7 +14,7 @@ public static class TelemetryResilienceStrategyBuilderExtensions
     /// <summary>
     /// Enables telemetry for this builder.
     /// </summary>
-    /// <typeparam name="TResult">The type of result.</typeparam>
+    /// <typeparam name="TBuilder">The builder type.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="loggerFactory">The logger factory to be used for logging.</param>
     /// <returns>The builder instance with the telemetry enabled.</returns>
@@ -22,7 +23,8 @@ public static class TelemetryResilienceStrategyBuilderExtensions
     /// Additionally, the telemetry strategy that logs and meters the executions is added to the beginning of the strategy pipeline.
     /// </remarks>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="loggerFactory"/> is <see langword="null"/>.</exception>
-    public static ResilienceStrategyBuilder<TResult> EnableTelemetry<TResult>(this ResilienceStrategyBuilder<TResult> builder, ILoggerFactory loggerFactory)
+    public static TBuilder EnableTelemetry<TBuilder>(this TBuilder builder, ILoggerFactory loggerFactory)
+        where TBuilder : ResilienceStrategyBuilderBase
     {
         Guard.NotNull(builder);
         Guard.NotNull(loggerFactory);
@@ -33,7 +35,7 @@ public static class TelemetryResilienceStrategyBuilderExtensions
     /// <summary>
     /// Enables telemetry for this builder.
     /// </summary>
-    /// <typeparam name="TResult">The type of result.</typeparam>
+    /// <typeparam name="TBuilder">The builder type.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="options">The resilience telemetry options.</param>
     /// <returns>The builder instance with the telemetry enabled.</returns>
@@ -42,46 +44,8 @@ public static class TelemetryResilienceStrategyBuilderExtensions
     /// Additionally, the telemetry strategy that logs and meters the executions is added to the beginning of the strategy pipeline.
     /// </remarks>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
-    public static ResilienceStrategyBuilder<TResult> EnableTelemetry<TResult>(this ResilienceStrategyBuilder<TResult> builder, TelemetryResilienceStrategyOptions options)
-    {
-        Guard.NotNull(builder);
-        Guard.NotNull(options);
-
-        builder.Builder.EnableTelemetry(options);
-        return builder;
-    }
-
-    /// <summary>
-    /// Enables telemetry for this builder.
-    /// </summary>
-    /// <param name="builder">The builder instance.</param>
-    /// <param name="loggerFactory">The logger factory to be used for logging.</param>
-    /// <returns>The builder instance with the telemetry enabled.</returns>
-    /// <remarks>
-    /// By enabling telemetry, the resilience strategy will log and meter all resilience events.
-    /// Additionally, the telemetry strategy that logs and meters the executions is added to the beginning of the strategy pipeline.
-    /// </remarks>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="loggerFactory"/> is <see langword="null"/>.</exception>
-    public static ResilienceStrategyBuilder EnableTelemetry(this ResilienceStrategyBuilder builder, ILoggerFactory loggerFactory)
-    {
-        Guard.NotNull(builder);
-        Guard.NotNull(loggerFactory);
-
-        return builder.EnableTelemetry(new TelemetryResilienceStrategyOptions { LoggerFactory = loggerFactory });
-    }
-
-    /// <summary>
-    /// Enables telemetry for this builder.
-    /// </summary>
-    /// <param name="builder">The builder instance.</param>
-    /// <param name="options">The resilience telemetry options.</param>
-    /// <returns>The builder instance with the telemetry enabled.</returns>
-    /// <remarks>
-    /// By enabling telemetry, the resilience strategy will log and meter all resilience events.
-    /// Additionally, the telemetry strategy that logs and meters the executions is added to the beginning of the strategy pipeline.
-    /// </remarks>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
-    public static ResilienceStrategyBuilder EnableTelemetry(this ResilienceStrategyBuilder builder, TelemetryResilienceStrategyOptions options)
+    public static TBuilder EnableTelemetry<TBuilder>(this TBuilder builder, TelemetryResilienceStrategyOptions options)
+        where TBuilder : ResilienceStrategyBuilderBase
     {
         Guard.NotNull(builder);
         Guard.NotNull(options);

--- a/src/Polly.RateLimiting/RateLimiterResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.RateLimiting/RateLimiterResilienceStrategyBuilderExtensions.cs
@@ -14,17 +14,18 @@ public static class RateLimiterResilienceStrategyBuilderExtensions
     /// <summary>
     /// Adds the concurrency limiter strategy.
     /// </summary>
-    /// <typeparam name="TResult">The type of the result.</typeparam>
+    /// <typeparam name="TBuilder">The builder type.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="permitLimit">Maximum number of permits that can be leased concurrently.</param>
     /// <param name="queueLimit">Maximum number of permits that can be queued concurrently.</param>
     /// <returns>The builder instance with the concurrency limiter strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when the options constructed from the arguments are invalid.</exception>
-    public static ResilienceStrategyBuilder<TResult> AddConcurrencyLimiter<TResult>(
-        this ResilienceStrategyBuilder<TResult> builder,
+    public static TBuilder AddConcurrencyLimiter<TBuilder>(
+        this TBuilder builder,
         int permitLimit,
         int queueLimit = 0)
+        where TBuilder : ResilienceStrategyBuilderBase
     {
         Guard.NotNull(builder);
 
@@ -38,15 +39,16 @@ public static class RateLimiterResilienceStrategyBuilderExtensions
     /// <summary>
     /// Adds the concurrency limiter strategy.
     /// </summary>
-    /// <typeparam name="TResult">The type of the result.</typeparam>
+    /// <typeparam name="TBuilder">The builder type.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="options">The concurrency limiter options.</param>
     /// <returns>The builder instance with the concurrency limiter strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when the options constructed from the arguments are invalid.</exception>
-    public static ResilienceStrategyBuilder<TResult> AddConcurrencyLimiter<TResult>(
-        this ResilienceStrategyBuilder<TResult> builder,
+    public static TBuilder AddConcurrencyLimiter<TBuilder>(
+        this TBuilder builder,
         ConcurrencyLimiterOptions options)
+        where TBuilder : ResilienceStrategyBuilderBase
     {
         Guard.NotNull(builder);
         Guard.NotNull(options);
@@ -60,17 +62,18 @@ public static class RateLimiterResilienceStrategyBuilderExtensions
     /// <summary>
     /// Adds the concurrency limiter strategy.
     /// </summary>
-    /// <typeparam name="TResult">The type of the result.</typeparam>
+    /// <typeparam name="TBuilder">The builder type.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="options">The concurrency limiter options.</param>
     /// <param name="onRejected">The callback that is raised when rate limiter is rejected.</param>
     /// <returns>The builder instance with the concurrency limiter strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/>, <paramref name="options"/> or <paramref name="onRejected"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when the options constructed from the arguments are invalid.</exception>
-    public static ResilienceStrategyBuilder<TResult> AddConcurrencyLimiter<TResult>(
-        this ResilienceStrategyBuilder<TResult> builder,
+    public static TBuilder AddConcurrencyLimiter<TBuilder>(
+        this TBuilder builder,
         ConcurrencyLimiterOptions options,
         Action<OnRateLimiterRejectedArguments> onRejected)
+        where TBuilder : ResilienceStrategyBuilderBase
     {
         Guard.NotNull(builder);
         Guard.NotNull(options);
@@ -90,15 +93,16 @@ public static class RateLimiterResilienceStrategyBuilderExtensions
     /// <summary>
     /// Adds the rate limiter strategy.
     /// </summary>
-    /// <typeparam name="TResult">The type of the result.</typeparam>
+    /// <typeparam name="TBuilder">The builder type.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="limiter">The rate limiter to use.</param>
     /// <returns>The builder instance with the rate limiter strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="limiter"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when the options constructed from the arguments are invalid.</exception>
-    public static ResilienceStrategyBuilder<TResult> AddRateLimiter<TResult>(
-        this ResilienceStrategyBuilder<TResult> builder,
+    public static TBuilder AddRateLimiter<TBuilder>(
+        this TBuilder builder,
         RateLimiter limiter)
+        where TBuilder : ResilienceStrategyBuilderBase
     {
         Guard.NotNull(builder);
         Guard.NotNull(limiter);
@@ -112,17 +116,18 @@ public static class RateLimiterResilienceStrategyBuilderExtensions
     /// <summary>
     /// Adds the rate limiter strategy.
     /// </summary>
-    /// <typeparam name="TResult">The type of the result.</typeparam>
+    /// <typeparam name="TBuilder">The builder type.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="limiter">The rate limiter to use.</param>
     /// <param name="onRejected">The callback that is raised when rate limiter is rejected.</param>
     /// <returns>The builder instance with the rate limiter strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when the options constructed from the arguments are invalid.</exception>
-    public static ResilienceStrategyBuilder<TResult> AddRateLimiter<TResult>(
-        this ResilienceStrategyBuilder<TResult> builder,
+    public static TBuilder AddRateLimiter<TBuilder>(
+        this TBuilder builder,
         RateLimiter limiter,
         Action<OnRateLimiterRejectedArguments> onRejected)
+        where TBuilder : ResilienceStrategyBuilderBase
     {
         Guard.NotNull(builder);
         Guard.NotNull(limiter);
@@ -142,41 +147,23 @@ public static class RateLimiterResilienceStrategyBuilderExtensions
     /// <summary>
     /// Adds the rate limiter strategy.
     /// </summary>
-    /// <typeparam name="TResult">The type of the result.</typeparam>
+    /// <typeparam name="TBuilder">The builder type.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="options">The rate limiter strategy options.</param>
     /// <returns>The builder instance with the rate limiter strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
-    public static ResilienceStrategyBuilder<TResult> AddRateLimiter<TResult>(
-        this ResilienceStrategyBuilder<TResult> builder,
+    public static TBuilder AddRateLimiter<TBuilder>(
+        this TBuilder builder,
         RateLimiterStrategyOptions options)
+        where TBuilder : ResilienceStrategyBuilderBase
     {
         Guard.NotNull(builder);
         Guard.NotNull(options);
 
         ValidationHelper.ValidateObject(options, "The rate limiter strategy options are invalid.");
 
-        return builder.AddStrategy(context => new RateLimiterResilienceStrategy(options.RateLimiter!, options.OnRejected, context.Telemetry), options);
-    }
-
-    /// <summary>
-    /// Adds the rate limiter strategy.
-    /// </summary>
-    /// <param name="builder">The builder instance.</param>
-    /// <param name="options">The rate limiter strategy options.</param>
-    /// <returns>The builder instance with the rate limiter strategy added.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
-    public static ResilienceStrategyBuilder AddRateLimiter(
-        this ResilienceStrategyBuilder builder,
-        RateLimiterStrategyOptions options)
-    {
-        Guard.NotNull(builder);
-        Guard.NotNull(options);
-
-        ValidationHelper.ValidateObject(options, "The rate limiter strategy options are invalid.");
-
-        return builder.AddStrategy(context => new RateLimiterResilienceStrategy(options.RateLimiter!, options.OnRejected, context.Telemetry), options);
+        builder.AddStrategy(context => new RateLimiterResilienceStrategy(options.RateLimiter!, options.OnRejected, context.Telemetry), options);
+        return builder;
     }
 }


### PR DESCRIPTION
### Details on the issue fix or feature implementation

One thing I wasn't a big fan of was the duplications of extensions for non-reactive strategies such as `Timeout` or `RateLimiter`.

In this PR I am introducing `ResilienceStrategyBuilderBase` class. The extensibility author can use is to target extensions that work for both generic and non-generic strategies. 

This way full set of extensions are always exposed for both generic and non-generic builders and there are no duplications.

The extension bellow will be visible for both builder types:

``` csharp
public static TBuilder AddTimeout<TBuilder>(this TBuilder builder, TimeoutStrategyOptions options)
    where TBuilder : ResilienceStrategyBuilderBase
{
    builder.AddStrategy(context => new TimeoutResilienceStrategy(options, context.TimeProvider, context.Telemetry), options);
    return builder;
}
```

I have dropped a bunch of duplicate extensions.

What do you think about this idea?

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
