### PR TITLE
ResilienceStrategyRegistry now uses context to configure the builder

### DIFF
--- a/src/Polly.Core/Registry/ConfigureBuilderContext.cs
+++ b/src/Polly.Core/Registry/ConfigureBuilderContext.cs
@@ -1,0 +1,37 @@
+namespace Polly.Registry;
+
+/// <summary>
+/// The context used by <see cref="ResilienceStrategyRegistry{TKey}"/>.
+/// </summary>
+/// <typeparam name="TKey">The type of the key.</typeparam>
+public class ConfigureBuilderContext<TKey>
+    where TKey : notnull
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigureBuilderContext{TKey}"/> class.
+    /// </summary>
+    /// <param name="strategyKey">The strategy key.</param>
+    /// <param name="builderName">The builder name.</param>
+    /// <param name="strategyKeyString">The strategy key as string.</param>
+    public ConfigureBuilderContext(TKey strategyKey, string builderName, string strategyKeyString)
+    {
+        StrategyKey = strategyKey;
+        BuilderName = builderName;
+        StrategyKeyString = strategyKeyString;
+    }
+
+    /// <summary>
+    /// Gets the strategy key for the strategy being created.
+    /// </summary>
+    public TKey StrategyKey { get; }
+
+    /// <summary>
+    /// Gets the builder name for the builder being used to create the strategy.
+    /// </summary>
+    public string BuilderName { get; }
+
+    /// <summary>
+    /// Gets the string representation of strategy key for the strategy being created.
+    /// </summary>
+    public string StrategyKeyString { get; }
+}

--- a/src/Polly.Extensions.Tests/DependencyInjection/PollyServiceCollectionExtensionTests.cs
+++ b/src/Polly.Extensions.Tests/DependencyInjection/PollyServiceCollectionExtensionTests.cs
@@ -95,7 +95,7 @@ public class PollyServiceCollectionExtensionTests
         {
             _services.AddResilienceStrategy<string, string>(Key, (builder, context) =>
             {
-                context.Key.Should().Be(Key);
+                context.StrategyKey.Should().Be(Key);
                 builder.Should().NotBeNull();
                 context.ServiceProvider.Should().NotBeNull();
                 builder.AddStrategy(new TestStrategy());
@@ -108,7 +108,7 @@ public class PollyServiceCollectionExtensionTests
         {
             _services.AddResilienceStrategy(Key, (builder, context) =>
             {
-                context.Key.Should().Be(Key);
+                context.StrategyKey.Should().Be(Key);
                 builder.Should().NotBeNull();
                 context.ServiceProvider.Should().NotBeNull();
                 builder.AddStrategy(new TestStrategy());

--- a/src/Polly.Extensions/DependencyInjection/AddResilienceStrategyContext.cs
+++ b/src/Polly.Extensions/DependencyInjection/AddResilienceStrategyContext.cs
@@ -1,22 +1,16 @@
+using Polly.Registry;
+
 namespace Polly.Extensions.DependencyInjection;
 
 /// <summary>
 /// Represents the context for adding a resilience strategy with the specified key.
 /// </summary>
 /// <typeparam name="TKey">The type of the key used to identify the resilience strategy.</typeparam>
-public sealed class AddResilienceStrategyContext<TKey>
+public sealed class AddResilienceStrategyContext<TKey> : ConfigureBuilderContext<TKey>
     where TKey : notnull
 {
-    internal AddResilienceStrategyContext(TKey key, IServiceProvider serviceProvider)
-    {
-        Key = key;
-        ServiceProvider = serviceProvider;
-    }
-
-    /// <summary>
-    /// Gets the key used to identify the resilience strategy.
-    /// </summary>
-    public TKey Key { get; }
+    internal AddResilienceStrategyContext(ConfigureBuilderContext<TKey> context, IServiceProvider serviceProvider)
+        : base(context.StrategyKey, context.BuilderName, context.StrategyKeyString) => ServiceProvider = serviceProvider;
 
     /// <summary>
     /// Gets the <see cref="IServiceProvider"/> that provides access to the dependency injection container.

--- a/src/Polly.Extensions/DependencyInjection/PollyServiceCollectionExtensions.cs
+++ b/src/Polly.Extensions/DependencyInjection/PollyServiceCollectionExtensions.cs
@@ -80,9 +80,9 @@ public static class PollyServiceCollectionExtensions
                 {
                     // the last added builder with the same key wins, this allows overriding the builders
                     registry.RemoveBuilder<TResult>(key);
-                    registry.TryAddBuilder<TResult>(key, (key, builder) =>
+                    registry.TryAddBuilder<TResult>(key, (builder, context) =>
                     {
-                        configure(builder, new AddResilienceStrategyContext<TKey>(key, serviceProvider));
+                        configure(builder, new AddResilienceStrategyContext<TKey>(context, serviceProvider));
                     });
                 });
             });
@@ -151,9 +151,9 @@ public static class PollyServiceCollectionExtensions
                 {
                     // the last added builder with the same key wins, this allows overriding the builders
                     registry.RemoveBuilder(key);
-                    registry.TryAddBuilder(key, (key, builder) =>
+                    registry.TryAddBuilder(key, (builder, context) =>
                     {
-                        configure(builder, new AddResilienceStrategyContext<TKey>(key, serviceProvider));
+                        configure(builder, new AddResilienceStrategyContext<TKey>(context, serviceProvider));
                     });
                 });
             });


### PR DESCRIPTION
### Details on the issue fix or feature implementation

Having just key as a parameter when configuring the builder was not enough and could cause some compatibility issues in the future. Using context is future-proof and allows us to add new members without breaking changes. 

I have also fixed the order inconsistency; the builder is first followed by context in the provided callback.

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
