### PR TITLE
Improve the V8 -> V7 bridge implementation and add benchmarks

### DIFF
--- a/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.BridgeBenchmark-report-github.md
+++ b/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.BridgeBenchmark-report-github.md
@@ -1,0 +1,15 @@
+``` ini
+
+BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22621.1702/22H2/2022Update/SunValley2), VM=Hyper-V
+Intel Xeon Platinum 8370C CPU 2.80GHz, 1 CPU, 16 logical and 8 physical cores
+.NET SDK=7.0.302
+  [Host] : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
+
+Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
+LaunchCount=2  WarmupCount=10  
+
+```
+|                 Method |      Mean |    Error |   StdDev | Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
+|----------------------- |----------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
+|              NoOpAsync |  85.38 ns | 1.001 ns | 1.371 ns |  1.00 |    0.00 | 0.0120 |     304 B |        1.00 |
+| NullResilienceStrategy | 416.38 ns | 1.924 ns | 2.820 ns |  4.87 |    0.10 | 0.0148 |     376 B |        1.24 |

--- a/src/Polly.Core.Benchmarks/BridgeBenchmark.cs
+++ b/src/Polly.Core.Benchmarks/BridgeBenchmark.cs
@@ -1,0 +1,22 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Polly.Core.Benchmarks;
+
+public class BridgeBenchmark
+{
+    private IAsyncPolicy<string>? _policy;
+    private IAsyncPolicy<string>? _policyWrapped;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _policy = Policy.NoOpAsync<string>();
+        _policyWrapped = NullResilienceStrategy<string>.Instance.AsAsyncPolicy();
+    }
+
+    [Benchmark(Baseline = true)]
+    public Task NoOpAsync() => _policy!.ExecuteAsync(() => Task.FromResult("dummy"));
+
+    [Benchmark]
+    public Task NullResilienceStrategy() => _policyWrapped!.ExecuteAsync(() => Task.FromResult("dummy"));
+}

--- a/src/Polly.Core.Tests/Utils/LegacySupportTests.cs
+++ b/src/Polly.Core.Tests/Utils/LegacySupportTests.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using Polly.Utils;
+
+namespace Polly.Core.Tests.Utils;
+
+public class LegacySupportTests
+{
+    [Fact]
+    public void SetProperties_Ok()
+    {
+        var resilienceProperties = new ResilienceProperties();
+        var oldProps = resilienceProperties.Options;
+        var newProps = new Dictionary<string, object?>();
+
+        resilienceProperties.SetProperties(newProps, out var oldProperties2);
+
+        resilienceProperties.Options.Should().BeSameAs(newProps);
+        oldProperties2.Should().BeSameAs(oldProps);
+    }
+}

--- a/src/Polly.Core/ResilienceProperties.cs
+++ b/src/Polly.Core/ResilienceProperties.cs
@@ -9,7 +9,7 @@ namespace Polly;
 /// </summary>
 public sealed class ResilienceProperties : IDictionary<string, object?>
 {
-    private Dictionary<string, object?> Options { get; } = new();
+    internal IDictionary<string, object?> Options { get; set; } = new Dictionary<string, object?>();
 
     /// <summary>
     /// Gets the value of a given property.
@@ -87,26 +87,26 @@ public sealed class ResilienceProperties : IDictionary<string, object?>
     int ICollection<KeyValuePair<string, object?>>.Count => Options.Count;
 
     /// <inheritdoc/>
-    bool ICollection<KeyValuePair<string, object?>>.IsReadOnly => ((IDictionary<string, object?>)Options).IsReadOnly;
+    bool ICollection<KeyValuePair<string, object?>>.IsReadOnly => Options.IsReadOnly;
 
     /// <inheritdoc/>
     void IDictionary<string, object?>.Add(string key, object? value) => Options.Add(key, value);
 
     /// <inheritdoc/>
-    void ICollection<KeyValuePair<string, object?>>.Add(KeyValuePair<string, object?> item) => ((IDictionary<string, object?>)Options).Add(item);
+    void ICollection<KeyValuePair<string, object?>>.Add(KeyValuePair<string, object?> item) => Options.Add(item);
 
     /// <inheritdoc/>
     void ICollection<KeyValuePair<string, object?>>.Clear() => Options.Clear();
 
     /// <inheritdoc/>
-    bool ICollection<KeyValuePair<string, object?>>.Contains(KeyValuePair<string, object?> item) => ((IDictionary<string, object?>)Options).Contains(item);
+    bool ICollection<KeyValuePair<string, object?>>.Contains(KeyValuePair<string, object?> item) => Options.Contains(item);
 
     /// <inheritdoc/>
     bool IDictionary<string, object?>.ContainsKey(string key) => Options.ContainsKey(key);
 
     /// <inheritdoc/>
     void ICollection<KeyValuePair<string, object?>>.CopyTo(KeyValuePair<string, object?>[] array, int arrayIndex) =>
-        ((IDictionary<string, object?>)Options).CopyTo(array, arrayIndex);
+        Options.CopyTo(array, arrayIndex);
 
     /// <inheritdoc/>
     IEnumerator<KeyValuePair<string, object?>> IEnumerable<KeyValuePair<string, object?>>.GetEnumerator() => Options.GetEnumerator();
@@ -118,7 +118,7 @@ public sealed class ResilienceProperties : IDictionary<string, object?>
     bool IDictionary<string, object?>.Remove(string key) => Options.Remove(key);
 
     /// <inheritdoc/>
-    bool ICollection<KeyValuePair<string, object?>>.Remove(KeyValuePair<string, object?> item) => ((IDictionary<string, object?>)Options).Remove(item);
+    bool ICollection<KeyValuePair<string, object?>>.Remove(KeyValuePair<string, object?> item) => Options.Remove(item);
 
     /// <inheritdoc/>
     bool IDictionary<string, object?>.TryGetValue(string key, out object? value) => Options.TryGetValue(key, out value);

--- a/src/Polly.Core/Utils/LegacySupport.cs
+++ b/src/Polly.Core/Utils/LegacySupport.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel;
+
+namespace Polly.Utils;
+
+/// <summary>
+/// Legacy support for older versions of Polly.
+/// </summary>
+/// <remarks>
+/// This class is used by the legacy Polly infrastructure and should not be used directly by user code.
+/// </remarks>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static class LegacySupport
+{
+    /// <summary>
+    /// Changes the underlying properties of a <see cref="ResilienceProperties"/> instance.
+    /// </summary>
+    /// <param name="resilienceProperties">The resilience properties.</param>
+    /// <param name="properties">The properties to use.</param>
+    /// <param name="oldProperties">The old properties used by <paramref name="resilienceProperties"/>.</param>
+    /// <remarks>
+    /// This method is used by the legacy Polly infrastructure and should not be used directly by user code.
+    /// </remarks>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static void SetProperties(
+        this ResilienceProperties resilienceProperties,
+        IDictionary<string, object?> properties,
+        out IDictionary<string, object?> oldProperties)
+    {
+        Guard.NotNull(resilienceProperties);
+        Guard.NotNull(properties);
+
+        oldProperties = resilienceProperties.Options;
+        resilienceProperties.Options = properties;
+    }
+}

--- a/src/Polly.Specs/ResilienceStrategyConversionExtensionsTests.cs
+++ b/src/Polly.Specs/ResilienceStrategyConversionExtensionsTests.cs
@@ -1,5 +1,6 @@
 using Polly.Strategy;
 using Polly.TestUtils;
+using Polly.Utilities.Wrappers;
 
 namespace Polly.Specs;
 
@@ -167,17 +168,20 @@ public class ResilienceStrategyConversionExtensionsTests
             .Build()
             .AsSyncPolicy();
 
-        var tries = 0;
+        var context = new Context();
+        context["retry"] = 0;
+
         policy.Execute(
-            () =>
+            c =>
             {
-                tries++;
+                c["retry"] = (int)c["retry"] + 1;
                 return "dummy";
-            })
+            },
+            context)
             .Should()
             .Be("dummy");
 
-        tries.Should().Be(6);
+        context["retry"].Should().Be(6);
     }
 
     private static void AssertContext(Context context)

--- a/src/Polly/Utilities/Wrappers/ResilienceStrategySyncPolicy.cs
+++ b/src/Polly/Utilities/Wrappers/ResilienceStrategySyncPolicy.cs
@@ -8,41 +8,49 @@ internal sealed class ResilienceStrategySyncPolicy : Policy
 
     protected override void Implementation(Action<Context, CancellationToken> action, Context context, CancellationToken cancellationToken)
     {
-        var resilienceContext = ResilienceContextFactory.Create(context, cancellationToken, true);
+        var resilienceContext = ResilienceContextFactory.Create(
+            context,
+            cancellationToken,
+            true,
+            out var oldProperties);
 
         try
         {
             _strategy.Execute(
                 static (context, state) =>
                 {
-                    state(context.GetContext(), context.CancellationToken);
+                    state.action(state.context, context.CancellationToken);
                 },
                 resilienceContext,
-                action);
+                (action, context));
         }
         finally
         {
-            ResilienceContextFactory.Restore(resilienceContext);
+            ResilienceContextFactory.Cleanup(resilienceContext, oldProperties);
         }
     }
 
     protected sealed override TResult Implementation<TResult>(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken)
     {
-        var resilienceContext = ResilienceContextFactory.Create(context, cancellationToken, true);
+        var resilienceContext = ResilienceContextFactory.Create(
+            context,
+            cancellationToken,
+            true,
+            out var oldProperties);
 
         try
         {
             return _strategy.Execute(
                 static (context, state) =>
                 {
-                    return state(context.GetContext(), context.CancellationToken);
+                    return state.action(state.context, context.CancellationToken);
                 },
                 resilienceContext,
-                action);
+                (action, context));
         }
         finally
         {
-            ResilienceContextFactory.Restore(resilienceContext);
+            ResilienceContextFactory.Cleanup(resilienceContext, oldProperties);
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors.  All non-trivial contributions get a public credit in the readme! -->

### The issue or feature being addressed

Follow up of #1255 

### Details on the issue fix or feature implementation

While playing with bridge I noticed some issues:

- Setting context properties in V7 is not reflected in V8 until the execution ends. To fix this, both `ResilienceProperties` need to use the same dictionary as `Context`. I have introduced pub-internal `LegacySupport` that allows this scenario.
- The bridge was setting the `Polly.Legacy.Context` value unnecessary, we can use the state for that and avoid dictionary lookup.

Additionally, I have added the benchmark for the bride. It reveals the non-trivial overhead.

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
