### PR TITLE
[Proposal] Introduce ResilienceContextPool

### DIFF
--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerManualControl.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerManualControl.cs
@@ -62,7 +62,7 @@ public sealed class CircuitBreakerManualControl : IDisposable
     /// <exception cref="ObjectDisposedException">Thrown when calling this method after this object is disposed.</exception>
     public async Task IsolateAsync(CancellationToken cancellationToken = default)
     {
-        var context = ResilienceContext.Get();
+        var context = ResilienceContextPool.Shared.Get();
         context.CancellationToken = cancellationToken;
 
         try
@@ -71,7 +71,7 @@ public sealed class CircuitBreakerManualControl : IDisposable
         }
         finally
         {
-            ResilienceContext.Return(context);
+            ResilienceContextPool.Shared.Return(context);
         }
     }
 
@@ -105,7 +105,7 @@ public sealed class CircuitBreakerManualControl : IDisposable
     /// <exception cref="ObjectDisposedException">Thrown when calling this method after this object is disposed.</exception>
     public async Task CloseAsync(CancellationToken cancellationToken = default)
     {
-        var context = ResilienceContext.Get();
+        var context = ResilienceContextPool.Shared.Get();
         context.CancellationToken = cancellationToken;
 
         try
@@ -114,7 +114,7 @@ public sealed class CircuitBreakerManualControl : IDisposable
         }
         finally
         {
-            ResilienceContext.Return(context);
+            ResilienceContextPool.Shared.Return(context);
         }
     }
 

--- a/src/Polly.Core/Hedging/Controller/TaskExecution.cs
+++ b/src/Polly.Core/Hedging/Controller/TaskExecution.cs
@@ -21,7 +21,7 @@ namespace Polly.Hedging.Controller;
 /// </summary>
 internal sealed class TaskExecution
 {
-    private readonly ResilienceContext _cachedContext = ResilienceContext.Get();
+    private readonly ResilienceContext _cachedContext = ResilienceContextPool.Shared.Get();
     private readonly HedgingHandler.Handler _handler;
     private readonly CancellationTokenSourcePool _cancellationTokenSourcePool;
     private CancellationTokenSource? _cancellationSource;

--- a/src/Polly.Core/ResilienceContextPool.Pooled.cs
+++ b/src/Polly.Core/ResilienceContextPool.Pooled.cs
@@ -1,0 +1,18 @@
+namespace Polly;
+
+public abstract partial class ResilienceContextPool
+{
+    private sealed class Pooled : ResilienceContextPool
+    {
+        private readonly ObjectPool<ResilienceContext> _pool = new(static () => new ResilienceContext(), static c => c.Reset());
+
+        public override ResilienceContext Get() => _pool.Get();
+
+        public override void Return(ResilienceContext context)
+        {
+            Guard.NotNull(context);
+
+            _pool.Return(context);
+        }
+    }
+}

--- a/src/Polly.Core/ResilienceContextPool.cs
+++ b/src/Polly.Core/ResilienceContextPool.cs
@@ -6,18 +6,12 @@ namespace Polly;
 /// <remarks>
 /// All members on this class are thread safe.
 /// </remarks>
-public sealed class ResilienceContextPool
+public abstract partial class ResilienceContextPool
 {
-    private readonly ObjectPool<ResilienceContext> _pool = new(static () => new ResilienceContext(), static c => c.Reset());
-
-    private ResilienceContextPool()
-    {
-    }
-
     /// <summary>
     /// Gets the shared instance of <see cref="ResilienceContextPool"/>.
     /// </summary>
-    public static readonly ResilienceContextPool Shared = new();
+    public static readonly ResilienceContextPool Shared = new Pooled();
 
     /// <summary>
     /// Gets a <see cref="ResilienceContext"/> instance from the pool.
@@ -27,17 +21,12 @@ public sealed class ResilienceContextPool
     /// After the execution is finished you should return the <see cref="ResilienceContext"/> back to the pool
     /// by calling <see cref="Return(ResilienceContext)"/> method.
     /// </remarks>
-    public ResilienceContext Get() => _pool.Get();
+    public abstract ResilienceContext Get();
 
     /// <summary>
     /// Returns a <paramref name="context"/> back to the pool.
     /// </summary>
     /// <param name="context">The context instance.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="context"/> is <see langword="null"/>.</exception>
-    public void Return(ResilienceContext context)
-    {
-        Guard.NotNull(context);
-
-        _pool.Return(context);
-    }
+    public abstract void Return(ResilienceContext context);
 }

--- a/src/Polly.Core/ResilienceContextPool.cs
+++ b/src/Polly.Core/ResilienceContextPool.cs
@@ -1,0 +1,43 @@
+namespace Polly;
+
+/// <summary>
+/// The pool of <see cref="ResilienceContext"/> instances.
+/// </summary>
+/// <remarks>
+/// All members on this class are thread safe.
+/// </remarks>
+public sealed class ResilienceContextPool
+{
+    private readonly ObjectPool<ResilienceContext> _pool = new(static () => new ResilienceContext(), static c => c.Reset());
+
+    private ResilienceContextPool()
+    {
+    }
+
+    /// <summary>
+    /// Gets the shared instance of <see cref="ResilienceContextPool"/>.
+    /// </summary>
+    public static readonly ResilienceContextPool Shared = new();
+
+    /// <summary>
+    /// Gets a <see cref="ResilienceContext"/> instance from the pool.
+    /// </summary>
+    /// <returns>An instance of <see cref="ResilienceContext"/>.</returns>
+    /// <remarks>
+    /// After the execution is finished you should return the <see cref="ResilienceContext"/> back to the pool
+    /// by calling <see cref="Return(ResilienceContext)"/> method.
+    /// </remarks>
+    public ResilienceContext Get() => _pool.Get();
+
+    /// <summary>
+    /// Returns a <paramref name="context"/> back to the pool.
+    /// </summary>
+    /// <param name="context">The context instance.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context"/> is <see langword="null"/>.</exception>
+    public void Return(ResilienceContext context)
+    {
+        Guard.NotNull(context);
+
+        _pool.Return(context);
+    }
+}

--- a/src/Polly.Core/ResilienceStrategy.Async.ValueTask.cs
+++ b/src/Polly.Core/ResilienceStrategy.Async.ValueTask.cs
@@ -122,7 +122,7 @@ public abstract partial class ResilienceStrategy
         }
         finally
         {
-            ResilienceContextPool.Shared.Return(context);
+            Pool.Return(context);
         }
     }
 
@@ -164,7 +164,7 @@ public abstract partial class ResilienceStrategy
         }
         finally
         {
-            ResilienceContextPool.Shared.Return(context);
+            Pool.Return(context);
         }
     }
 

--- a/src/Polly.Core/ResilienceStrategy.Async.ValueTask.cs
+++ b/src/Polly.Core/ResilienceStrategy.Async.ValueTask.cs
@@ -122,7 +122,7 @@ public abstract partial class ResilienceStrategy
         }
         finally
         {
-            ResilienceContext.Return(context);
+            ResilienceContextPool.Shared.Return(context);
         }
     }
 
@@ -164,7 +164,7 @@ public abstract partial class ResilienceStrategy
         }
         finally
         {
-            ResilienceContext.Return(context);
+            ResilienceContextPool.Shared.Return(context);
         }
     }
 

--- a/src/Polly.Core/ResilienceStrategy.Async.ValueTaskT.cs
+++ b/src/Polly.Core/ResilienceStrategy.Async.ValueTaskT.cs
@@ -147,7 +147,7 @@ public abstract partial class ResilienceStrategy
         }
         finally
         {
-            ResilienceContext.Return(context);
+            ResilienceContextPool.Shared.Return(context);
         }
     }
 
@@ -188,13 +188,13 @@ public abstract partial class ResilienceStrategy
         }
         finally
         {
-            ResilienceContext.Return(context);
+            ResilienceContextPool.Shared.Return(context);
         }
     }
 
     private static ResilienceContext GetAsyncContext<TResult>(CancellationToken cancellationToken)
     {
-        var context = ResilienceContext.Get();
+        var context = ResilienceContextPool.Shared.Get();
         context.CancellationToken = cancellationToken;
 
         InitializeAsyncContext<TResult>(context);

--- a/src/Polly.Core/ResilienceStrategy.Async.ValueTaskT.cs
+++ b/src/Polly.Core/ResilienceStrategy.Async.ValueTaskT.cs
@@ -147,7 +147,7 @@ public abstract partial class ResilienceStrategy
         }
         finally
         {
-            ResilienceContextPool.Shared.Return(context);
+            Pool.Return(context);
         }
     }
 
@@ -188,13 +188,13 @@ public abstract partial class ResilienceStrategy
         }
         finally
         {
-            ResilienceContextPool.Shared.Return(context);
+            Pool.Return(context);
         }
     }
 
-    private static ResilienceContext GetAsyncContext<TResult>(CancellationToken cancellationToken)
+    private ResilienceContext GetAsyncContext<TResult>(CancellationToken cancellationToken)
     {
-        var context = ResilienceContextPool.Shared.Get();
+        var context = Pool.Get();
         context.CancellationToken = cancellationToken;
 
         InitializeAsyncContext<TResult>(context);

--- a/src/Polly.Core/ResilienceStrategy.Sync.cs
+++ b/src/Polly.Core/ResilienceStrategy.Sync.cs
@@ -112,7 +112,7 @@ public abstract partial class ResilienceStrategy
         }
         finally
         {
-            ResilienceContext.Return(context);
+            ResilienceContextPool.Shared.Return(context);
         }
     }
 
@@ -150,7 +150,7 @@ public abstract partial class ResilienceStrategy
         }
         finally
         {
-            ResilienceContext.Return(context);
+            ResilienceContextPool.Shared.Return(context);
         }
     }
 
@@ -189,7 +189,7 @@ public abstract partial class ResilienceStrategy
         }
         finally
         {
-            ResilienceContext.Return(context);
+            ResilienceContextPool.Shared.Return(context);
         }
     }
 
@@ -224,7 +224,7 @@ public abstract partial class ResilienceStrategy
         }
         finally
         {
-            ResilienceContext.Return(context);
+            ResilienceContextPool.Shared.Return(context);
         }
     }
 

--- a/src/Polly.Core/ResilienceStrategy.Sync.cs
+++ b/src/Polly.Core/ResilienceStrategy.Sync.cs
@@ -112,7 +112,7 @@ public abstract partial class ResilienceStrategy
         }
         finally
         {
-            ResilienceContextPool.Shared.Return(context);
+            Pool.Return(context);
         }
     }
 
@@ -150,7 +150,7 @@ public abstract partial class ResilienceStrategy
         }
         finally
         {
-            ResilienceContextPool.Shared.Return(context);
+            Pool.Return(context);
         }
     }
 
@@ -189,7 +189,7 @@ public abstract partial class ResilienceStrategy
         }
         finally
         {
-            ResilienceContextPool.Shared.Return(context);
+            Pool.Return(context);
         }
     }
 
@@ -224,7 +224,7 @@ public abstract partial class ResilienceStrategy
         }
         finally
         {
-            ResilienceContextPool.Shared.Return(context);
+            Pool.Return(context);
         }
     }
 

--- a/src/Polly.Core/ResilienceStrategy.SyncT.cs
+++ b/src/Polly.Core/ResilienceStrategy.SyncT.cs
@@ -115,7 +115,7 @@ public abstract partial class ResilienceStrategy
         }
         finally
         {
-            ResilienceContextPool.Shared.Return(context);
+            Pool.Return(context);
         }
     }
 
@@ -152,7 +152,7 @@ public abstract partial class ResilienceStrategy
         }
         finally
         {
-            ResilienceContextPool.Shared.Return(context);
+            Pool.Return(context);
         }
     }
 
@@ -191,7 +191,7 @@ public abstract partial class ResilienceStrategy
         }
         finally
         {
-            ResilienceContextPool.Shared.Return(context);
+            Pool.Return(context);
         }
     }
 
@@ -234,13 +234,13 @@ public abstract partial class ResilienceStrategy
         }
         finally
         {
-            ResilienceContextPool.Shared.Return(context);
+            Pool.Return(context);
         }
     }
 
-    private static ResilienceContext GetSyncContext<TResult>(CancellationToken cancellationToken)
+    private ResilienceContext GetSyncContext<TResult>(CancellationToken cancellationToken)
     {
-        var context = ResilienceContextPool.Shared.Get();
+        var context = Pool.Get();
         context.CancellationToken = cancellationToken;
 
         InitializeSyncContext<TResult>(context);

--- a/src/Polly.Core/ResilienceStrategy.SyncT.cs
+++ b/src/Polly.Core/ResilienceStrategy.SyncT.cs
@@ -115,7 +115,7 @@ public abstract partial class ResilienceStrategy
         }
         finally
         {
-            ResilienceContext.Return(context);
+            ResilienceContextPool.Shared.Return(context);
         }
     }
 
@@ -152,7 +152,7 @@ public abstract partial class ResilienceStrategy
         }
         finally
         {
-            ResilienceContext.Return(context);
+            ResilienceContextPool.Shared.Return(context);
         }
     }
 
@@ -191,7 +191,7 @@ public abstract partial class ResilienceStrategy
         }
         finally
         {
-            ResilienceContext.Return(context);
+            ResilienceContextPool.Shared.Return(context);
         }
     }
 
@@ -234,13 +234,13 @@ public abstract partial class ResilienceStrategy
         }
         finally
         {
-            ResilienceContext.Return(context);
+            ResilienceContextPool.Shared.Return(context);
         }
     }
 
     private static ResilienceContext GetSyncContext<TResult>(CancellationToken cancellationToken)
     {
-        var context = ResilienceContext.Get();
+        var context = ResilienceContextPool.Shared.Get();
         context.CancellationToken = cancellationToken;
 
         InitializeSyncContext<TResult>(context);

--- a/src/Polly.Core/ResilienceStrategy.cs
+++ b/src/Polly.Core/ResilienceStrategy.cs
@@ -11,6 +11,8 @@ namespace Polly;
 /// </remarks>
 public abstract partial class ResilienceStrategy
 {
+    internal ResilienceContextPool Pool { get; set; }
+
     /// <summary>
     /// Executes the specified callback.
     /// </summary>

--- a/src/Polly.Core/Strategy/ResilienceStrategyBuilderBase.cs
+++ b/src/Polly.Core/Strategy/ResilienceStrategyBuilderBase.cs
@@ -41,6 +41,9 @@ public abstract class ResilienceStrategyBuilderBase
     /// </summary>
     public ResilienceProperties Properties { get; } = new();
 
+    [Required]
+    public ResilienceContextPool ResilienceContextPool { get; set; } = ResilienceContextPool.Shared;
+
     /// <summary>
     /// Gets or sets a <see cref="TimeProvider"/> that is used by strategies that work with time.
     /// </summary>
@@ -106,6 +109,8 @@ public abstract class ResilienceStrategyBuilderBase
         {
             return NullResilienceStrategy.Instance;
         }
+
+        strategies[0].Pool = ResilienceContextPool;
 
         if (strategies.Count == 1)
         {


### PR DESCRIPTION
### Details on the issue fix or feature implementation

We might have more explicit API regarding the pooling of `ResilienceContext`. This PR introduces `ResilienceContextPool` that can be used to rent and return instances of `ResilienceContext`.

Alternative names:
`ResilienceContextFactory`?

``` csharp
// old
var context = ResilienceContext.Get();
ResilienceContext.Return(context);

// new
var context = ResilienceContextPool.Shared.Get();
ResilienceContextPool.Shared.Return(context);
```

Or we can just keep the API as it is.

### Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build
