### PR TITLE
Speed-up and drop allocations in ResilienceStrategyRegistry

### DIFF
--- a/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.ResilienceStrategyProviderBenchmark-report-github.md
+++ b/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.ResilienceStrategyProviderBenchmark-report-github.md
@@ -9,7 +9,7 @@ Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15
 LaunchCount=2  WarmupCount=10  
 
 ```
-|         Method |     Mean |    Error |   StdDev |   Gen0 | Allocated |
-|--------------- |---------:|---------:|---------:|-------:|----------:|
-|         Get_Ok | 25.41 ns | 0.186 ns | 0.273 ns | 0.0016 |      40 B |
-| Get_Generic_Ok | 53.83 ns | 0.672 ns | 1.005 ns | 0.0013 |      32 B |
+|         Method |     Mean |    Error |   StdDev | Allocated |
+|--------------- |---------:|---------:|---------:|----------:|
+|         Get_Ok | 19.24 ns | 0.038 ns | 0.056 ns |         - |
+| Get_Generic_Ok | 48.37 ns | 0.170 ns | 0.249 ns |         - |


### PR DESCRIPTION
### Details on the issue fix or feature implementation

The anonymous lambda was allocating the display class per call. This change drops this allocation.

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
