### PR TITLE
Specify default action generator for hedging

### DIFF
--- a/src/Polly.Core.Tests/Hedging/HedgingActions.cs
+++ b/src/Polly.Core.Tests/Hedging/HedgingActions.cs
@@ -32,31 +32,34 @@ internal class HedgingActions
         };
     }
 
-    public Func<HedgingActionGeneratorArguments<string>, Func<Task<string>>?> Generator { get; }
+    public Func<HedgingActionGeneratorArguments<string>, Func<ValueTask<Outcome<string>>>?> Generator { get; }
 
-    public Func<HedgingActionGeneratorArguments<string>, Func<Task<string>>?> EmptyFunctionsProvider { get; } = args => null;
+    public Func<HedgingActionGeneratorArguments<string>, Func<ValueTask<Outcome<string>>>?> EmptyFunctionsProvider { get; } = args => null;
 
-    public List<Func<ResilienceContext, Task<string>>> Functions { get; }
+    public List<Func<ResilienceContext, ValueTask<Outcome<string>>>> Functions { get; }
 
-    private async Task<string> GetApples(ResilienceContext context)
+    private async ValueTask<Outcome<string>> GetApples(ResilienceContext context)
     {
         await _timeProvider.Delay(TimeSpan.FromSeconds(10), context.CancellationToken);
-        return "Apples";
+        return "Apples".AsOutcome();
     }
 
-    private async Task<string> GetPears(ResilienceContext context)
+    private async ValueTask<Outcome<string>> GetPears(ResilienceContext context)
     {
         await _timeProvider.Delay(TimeSpan.FromSeconds(3), context.CancellationToken);
-        return "Pears";
+        return "Pears".AsOutcome();
     }
 
-    private async Task<string> GetOranges(ResilienceContext context)
+    private async ValueTask<Outcome<string>> GetOranges(ResilienceContext context)
     {
         await _timeProvider.Delay(TimeSpan.FromSeconds(2), context.CancellationToken);
-        return "Oranges";
+        return "Oranges".AsOutcome();
     }
 
-    public static Func<HedgingActionGeneratorArguments<string>, Func<Task<string>>?> GetGenerator(Func<ResilienceContext, Task<string>> task) => args => () => task(args.Context);
+    public static Func<HedgingActionGeneratorArguments<string>, Func<ValueTask<Outcome<string>>>?> GetGenerator(Func<ResilienceContext, ValueTask<Outcome<string>>> task)
+    {
+        return args => () => task(args.Context);
+    }
 
     public int MaxHedgedTasks => Functions.Count + 1;
 }

--- a/src/Polly.Core.Tests/Hedging/HedgingResilienceStrategyBuilderExtensionsTests.cs
+++ b/src/Polly.Core.Tests/Hedging/HedgingResilienceStrategyBuilderExtensionsTests.cs
@@ -20,7 +20,7 @@ public class HedgingResilienceStrategyBuilderExtensionsTests
     {
         _genericBuilder.AddHedging(new HedgingStrategyOptions<string>
         {
-            HedgingActionGenerator = args => () => Task.FromResult("dummy"),
+            HedgingActionGenerator = args => () => "dummy".AsOutcomeAsync(),
             ShouldHandle = _ => PredicateResult.True
         });
         _genericBuilder.Build().Strategy.Should().BeOfType<HedgingResilienceStrategy>();
@@ -73,10 +73,10 @@ public class HedgingResilienceStrategyBuilderExtensionsTests
 
                             if (args.Attempt == 3)
                             {
-                                return "success";
+                                return "success".AsOutcome();
                             }
 
-                            return "error";
+                            return "error".AsOutcome();
                         };
                     };
                 }),

--- a/src/Polly.Core.Tests/Hedging/HedgingStrategyOptionsTResultTests.cs
+++ b/src/Polly.Core.Tests/Hedging/HedgingStrategyOptionsTResultTests.cs
@@ -13,7 +13,7 @@ public class HedgingStrategyOptionsTResultTests
 
         options.StrategyType.Should().Be("Hedging");
         options.ShouldHandle.Should().BeNull();
-        options.HedgingActionGenerator.Should().BeNull();
+        options.HedgingActionGenerator.Should().NotBeNull();
         options.HedgingDelay.Should().Be(TimeSpan.FromSeconds(2));
         options.MaxHedgedAttempts.Should().Be(2);
         options.OnHedging.Should().BeNull();
@@ -28,6 +28,7 @@ public class HedgingStrategyOptionsTResultTests
             ShouldHandle = null!,
             MaxHedgedAttempts = -1,
             OnHedging = null!,
+            HedgingActionGenerator = null!
         };
 
         options

--- a/src/Polly.Core/Hedging/HedgingActionGeneratorArguments.TResult.cs
+++ b/src/Polly.Core/Hedging/HedgingActionGeneratorArguments.TResult.cs
@@ -1,9 +1,11 @@
 namespace Polly.Hedging;
 
 /// <summary>
-/// Represents arguments used in <see cref="HedgingHandler{TResult}.HedgingActionGenerator"/>.
+/// Represents arguments used in the hedging resilience strategy.
 /// </summary>
 /// <typeparam name="TResult">The type of the result.</typeparam>
 /// <param name="Context">The context associated with the execution of a user-provided callback.</param>
 /// <param name="Attempt">The zero-based hedging attempt number.</param>
-public readonly record struct HedgingActionGeneratorArguments<TResult>(ResilienceContext Context, int Attempt);
+/// <param name="Callback">The callback passed to hedging strategy.</param>
+///
+public readonly record struct HedgingActionGeneratorArguments<TResult>(ResilienceContext Context, int Attempt, Func<ResilienceContext, ValueTask<Outcome<TResult>>> Callback);

--- a/src/Polly.Core/Hedging/HedgingHandler.Handler.cs
+++ b/src/Polly.Core/Hedging/HedgingHandler.Handler.cs
@@ -33,14 +33,14 @@ internal partial class HedgingHandler
             }
         }
 
-        public Func<Task<TResult>>? TryCreateHedgedAction<TResult>(ResilienceContext context, int attempt)
+        public Func<ValueTask<Outcome<TResult>>>? TryCreateHedgedAction<TResult>(ResilienceContext context, int attempt, Func<ResilienceContext, ValueTask<Outcome<TResult>>> callback)
         {
             if (!_generators.TryGetValue(typeof(TResult), out var generator))
             {
                 return null;
             }
 
-            return ((Func<HedgingActionGeneratorArguments<TResult>, Func<Task<TResult>>?>)generator)(new HedgingActionGeneratorArguments<TResult>(context, attempt));
+            return ((Func<HedgingActionGeneratorArguments<TResult>, Func<ValueTask<Outcome<TResult>>>?>)generator)(new HedgingActionGeneratorArguments<TResult>(context, attempt, callback));
         }
     }
 }

--- a/src/Polly.Core/Hedging/HedgingHandler.TResult.cs
+++ b/src/Polly.Core/Hedging/HedgingHandler.TResult.cs
@@ -33,5 +33,5 @@ internal sealed class HedgingHandler<TResult>
     /// </para>
     /// </remarks>
     [Required]
-    public Func<HedgingActionGeneratorArguments<TResult>, Func<Task<TResult>>?>? HedgingActionGenerator { get; set; } = null;
+    public Func<HedgingActionGeneratorArguments<TResult>, Func<ValueTask<Outcome<TResult>>>?>? HedgingActionGenerator { get; set; } = null;
 }

--- a/src/Polly.Core/Hedging/HedgingHandler.cs
+++ b/src/Polly.Core/Hedging/HedgingHandler.cs
@@ -67,12 +67,12 @@ internal sealed partial class HedgingHandler
             _actions.ToDictionary(pair => pair.Key, pair => pair.Value));
     }
 
-    private static Func<HedgingActionGeneratorArguments<VoidResult>, Func<Task<VoidResult>>?> CreateGenericGenerator(
-        Func<HedgingActionGeneratorArguments, Func<Task>?> generator)
+    private static Func<HedgingActionGeneratorArguments<VoidResult>, Func<ValueTask<Outcome<VoidResult>>>?> CreateGenericGenerator(
+        Func<HedgingActionGeneratorArguments, Func<ValueTask>?> generator)
     {
         return (args) =>
         {
-            Func<Task>? action = generator(new HedgingActionGeneratorArguments(args.Context, args.Attempt));
+            Func<ValueTask>? action = generator(new HedgingActionGeneratorArguments(args.Context, args.Attempt));
             if (action == null)
             {
                 return null;
@@ -81,7 +81,7 @@ internal sealed partial class HedgingHandler
             return async () =>
             {
                 await action().ConfigureAwait(args.Context.ContinueOnCapturedContext);
-                return VoidResult.Instance;
+                return new Outcome<VoidResult>(VoidResult.Instance);
             };
         };
     }

--- a/src/Polly.Core/Hedging/HedgingStrategyOptions.TResult.cs
+++ b/src/Polly.Core/Hedging/HedgingStrategyOptions.TResult.cs
@@ -54,10 +54,16 @@ public class HedgingStrategyOptions<TResult> : ResilienceStrategyOptions
     /// Gets or sets the hedging action generator that creates hedged actions.
     /// </summary>
     /// <remarks>
-    /// This property is required. Defaults to <see langword="null"/>.
+    /// This property is required. The default delegate executes the original callback that was passed to the hedging resilience strategy.
     /// </remarks>
     [Required]
-    public Func<HedgingActionGeneratorArguments<TResult>, Func<Task<TResult>>?>? HedgingActionGenerator { get; set; } = null;
+    public Func<HedgingActionGeneratorArguments<TResult>, Func<ValueTask<Outcome<TResult>>>?> HedgingActionGenerator { get; set; } = args =>
+    {
+        return async () =>
+        {
+            return await args.Callback(args.Context).ConfigureAwait(args.Context.ContinueOnCapturedContext);
+        };
+    };
 
     /// <summary>
     /// Gets or sets the generator that generates hedging delays for each hedging attempt.

--- a/src/Polly.Core/Hedging/VoidHedgingHandler.cs
+++ b/src/Polly.Core/Hedging/VoidHedgingHandler.cs
@@ -32,5 +32,5 @@ internal sealed class VoidHedgingHandler
     /// </para>
     /// </remarks>
     [Required]
-    public Func<HedgingActionGeneratorArguments, Func<Task>?>? HedgingActionGenerator { get; set; } = null;
+    public Func<HedgingActionGeneratorArguments, Func<ValueTask>?>? HedgingActionGenerator { get; set; } = null;
 }

--- a/src/Polly.Core/Outcome.cs
+++ b/src/Polly.Core/Outcome.cs
@@ -1,5 +1,6 @@
 #pragma warning disable CA1815 // Override equals and operator equals on value types
 
+using System;
 using System.Runtime.ExceptionServices;
 
 namespace Polly;

--- a/src/Polly.TestUtils/Outcome.cs
+++ b/src/Polly.TestUtils/Outcome.cs
@@ -1,0 +1,12 @@
+namespace Polly.TestUtils;
+
+public static class Outcome
+{
+    public static Outcome<TResult> AsOutcome<TResult>(this TResult value) => new(value);
+
+    public static Outcome<TResult> AsOutcome<TResult>(this Exception error) => new(error);
+
+    public static ValueTask<Outcome<TResult>> AsOutcomeAsync<TResult>(this TResult value) => AsOutcome(value).AsValueTask();
+
+    public static ValueTask<Outcome<TResult>> AsOutcomeAsync<TResult>(this Exception error) => AsOutcome<TResult>(error).AsValueTask();
+}

--- a/src/Polly.TestUtils/TestResilienceStrategyOptions.cs
+++ b/src/Polly.TestUtils/TestResilienceStrategyOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace Polly.TestUtils;
+namespace Polly.TestUtils;
 
 public sealed class TestResilienceStrategyOptions : ResilienceStrategyOptions
 {


### PR DESCRIPTION
### Details on the issue fix or feature implementation

I was investigating the [original hedging engine](https://github.com/dotnet/extensions/blob/main/src/Libraries/Microsoft.Extensions.Resilience/Polly/Hedging/HedgingEngine.cs) and [standard hedging pipeline](https://github.com/dotnet/extensions/blob/main/src/Libraries/Microsoft.Extensions.Http.Resilience/Hedging/HedgingHttpClientBuilderExtensions.cs#L17) to find a ways to simplify the hedging configuration. A lot of boilerplate in hedging is around specifying the hedging action generator. 

However, we can actually allow the default for this generator. In this case the hedging just executes the original callback again ( similar to retries). This can be done by providing the original callback to the generator arguments. 

Standard hedging handler can seamlessly integrate into this enhancement by:

- Passing a callback that reads the data from resilience context. (for example cloned request message)
- Taking advantage of the enhanced `HedgingActionGeneratorArguments`

The simple API addition above will greatly simplify the code in `Microsft.Extensions.Http.Resilience` library.

On top of that I have also changed the signature of the generator action from `Task<TResult>` to `Task<Outcome<TResult>>`. This plays nicely with the overal infrastructure we have. Hedged actions can be optimized to not throw exceptions.




### Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build
