### PR TITLE
Drop allocations when using ResilienceProperties

### DIFF
--- a/src/Polly.Core.Tests/ResiliencePropertiesTests.cs
+++ b/src/Polly.Core.Tests/ResiliencePropertiesTests.cs
@@ -69,8 +69,10 @@ public class ResiliencePropertiesTests
         props.Should().HaveCount(0);
     }
 
-    [Fact]
-    public void Replace_Ok()
+    [InlineData(true)]
+    [InlineData(false)]
+    [Theory]
+    public void Replace_Ok(bool isRawDictionary)
     {
         var key1 = new ResiliencePropertyKey<string>("A");
         var key2 = new ResiliencePropertyKey<string>("B");
@@ -79,6 +81,11 @@ public class ResiliencePropertiesTests
         props.Set(key1, "A");
 
         var otherProps = new ResilienceProperties();
+        if (!isRawDictionary)
+        {
+            otherProps.Options = new ResilienceProperties();
+        }
+
         otherProps.Set(key2, "B");
 
         props.Replace(otherProps);

--- a/src/Polly.Core/ResilienceProperties.cs
+++ b/src/Polly.Core/ResilienceProperties.cs
@@ -62,9 +62,20 @@ public sealed class ResilienceProperties : IDictionary<string, object?>
     {
         Clear();
 
-        foreach (var pair in other.Options)
+        // try to avoid enumerator allocation
+        if (other.Options is Dictionary<string, object?> otherOptions)
         {
-            Options[pair.Key] = pair.Value;
+            foreach (var pair in otherOptions)
+            {
+                Options[pair.Key] = pair.Value;
+            }
+        }
+        else
+        {
+            foreach (var pair in other.Options)
+            {
+                Options[pair.Key] = pair.Value;
+            }
         }
     }
 


### PR DESCRIPTION
### Details on the issue fix or feature implementation

Add a type check for a plain dictionary to avoid enumerator allocation.

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
