### PR TITLE
Introduce `TelemetryResilienceStrategyOptions.ResultFormatter`

### DIFF
--- a/src/Polly.Extensions/Polly.Extensions.csproj
+++ b/src/Polly.Extensions/Polly.Extensions.csproj
@@ -28,5 +28,6 @@
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
+    <Reference Include="System.Net.Http" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'"/>
   </ItemGroup>
 </Project>

--- a/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategyBuilderExtensions.cs
@@ -60,6 +60,7 @@ public static class TelemetryResilienceStrategyBuilderExtensions
                 builder.BuilderName,
                 builder.Properties.GetValue(TelemetryUtil.StrategyKey, null!),
                 options.LoggerFactory,
+                options.ResultFormatter,
                 options.Enrichers.ToList());
 
             strategies.Insert(0, telemetryStrategy);

--- a/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategyOptions.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategyOptions.cs
@@ -1,4 +1,6 @@
+using System;
 using System.ComponentModel.DataAnnotations;
+using System.Net.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -25,4 +27,20 @@ public class TelemetryResilienceStrategyOptions
     /// Defaults to an empty collection.
     /// </remarks>
     public ICollection<Action<EnrichmentContext>> Enrichers { get; } = new List<Action<EnrichmentContext>>();
+
+    /// <summary>
+    /// Gets or sets the result formatter.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to a formatter that returns a status code for HTTP based responses and result as-is for all other result types.
+    /// <para>
+    /// This property is required.
+    /// </para>
+    /// </remarks>
+    [Required]
+    public Func<ResilienceContext, object?, object?> ResultFormatter { get; set; } = (_, result) => result switch
+    {
+        HttpResponseMessage response => (int)response.StatusCode,
+        _ => result,
+    };
 }

--- a/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategyOptions.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategyOptions.cs
@@ -32,7 +32,7 @@ public class TelemetryResilienceStrategyOptions
     /// Gets or sets the result formatter.
     /// </summary>
     /// <remarks>
-    /// Defaults to a formatter that returns a status code for HTTP based responses and result as-is for all other result types.
+    /// Defaults to a formatter that returns a status code for HTTP based responses and the result as-is for all other result types.
     /// <para>
     /// This property is required.
     /// </para>

--- a/test/Polly.Extensions.Tests/Telemetry/TelemetryResilienceStrategyOptionsTests.cs
+++ b/test/Polly.Extensions.Tests/Telemetry/TelemetryResilienceStrategyOptionsTests.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Net.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using Polly.Extensions.Telemetry;
 
@@ -12,5 +14,11 @@ public class TelemetryResilienceStrategyOptionsTests
 
         options.Enrichers.Should().BeEmpty();
         options.LoggerFactory.Should().Be(NullLoggerFactory.Instance);
+        var resilienceContext = ResilienceContext.Get();
+        options.ResultFormatter(resilienceContext, null).Should().BeNull();
+        options.ResultFormatter(resilienceContext, "dummy").Should().Be("dummy");
+
+        using var response = new HttpResponseMessage(HttpStatusCode.OK);
+        options.ResultFormatter(resilienceContext, response).Should().Be(200);
     }
 }

--- a/test/Polly.Extensions.Tests/Telemetry/TelemetryResilienceStrategyTests.cs
+++ b/test/Polly.Extensions.Tests/Telemetry/TelemetryResilienceStrategyTests.cs
@@ -165,7 +165,8 @@ public class TelemetryResilienceStrategyTests : IDisposable
         }
     }
 
-    private TelemetryResilienceStrategy CreateStrategy() => new("my-builder", "my-key", _loggerFactory, new List<Action<EnrichmentContext>> { c => _enricher?.Invoke(c) });
+    private TelemetryResilienceStrategy CreateStrategy() => new("my-builder", "my-key", _loggerFactory, (_, r) => r, new List<Action<EnrichmentContext>> { c => _enricher?.Invoke(c) });
+
     public void Dispose()
     {
         _metering.Dispose();


### PR DESCRIPTION
### Details on the issue fix or feature implementation

One very common scenario when using `ResilienceStrategy` is to handle `HttpResponseMessage`.

The built-in telemetry now logs the whole result simply by formatting it to string. For `HttpResponseMessage` this can be noisy, non-performant and could reveal sensitive data as demonstrated bellow:


``` csharp
var response = new HttpResponseMessage(System.Net.HttpStatusCode.OK);
response.Headers.Add("Header1", "value");
response.Headers.Add("Header2", "Sensitive Value");
response.Content = new StringContent("Sensitive Content");
```

``` text
StatusCode: 200, ReasonPhrase: 'OK', Version: 1.1, Content: System.Net.Http.StringContent, Headers:
{
  Header1: value
  Header2: Sensitive Value
  Content-Type: text/plain; charset=utf-8
}
```

This PR allows customization of how the results are formatted and also changes the default formatting behavior for `HttpResponseMessage`. 

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
