### PR TITLE
Add v8 alpha.1 changelog and fix-up package README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 8.0.0-alpha.1
+
+- The first public preview of our [new high-performance core API and extensions](https://github.com/App-vNext/Polly/issues/1048) - Thanks to:
+  - [@andrey-noskov](https://github.com/andrey-noskov)
+  - [@joelhulen](https://github.com/joelhulen)
+  - [@juraj-blazek](https://github.com/juraj-blazek)
+  - [@geeknoid](https://github.com/geeknoid)
+  - [@martincostello](https://github.com/martincostello)
+  - [@martintmk](https://github.com/martintmk)
+  - [@SimonCropp](https://github.com/SimonCropp)
+  - [@terrajobst](https://github.com/terrajobst)
+
 ## 7.2.4
 
 - Fixed an incorrect exception argument - Thanks to [@FoxTes](https://github.com/FoxTes)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
 ## 8.0.0-alpha.1
 
-- The first public preview of our [new high-performance core API and extensions](https://github.com/App-vNext/Polly/issues/1048) - Thanks to:
+- The first public preview of [Polly v8](https://github.com/App-vNext/Polly/issues/1048) with our [new high-performance core API](https://github.com/App-vNext/Polly/blob/main/src/Polly.Core/README.md) and extensions - Thanks to:
+  - [@adamnova](https://github.com/adamnova)
   - [@andrey-noskov](https://github.com/andrey-noskov)
   - [@joelhulen](https://github.com/joelhulen)
   - [@juraj-blazek](https://github.com/juraj-blazek)
   - [@geeknoid](https://github.com/geeknoid)
+  - [@laura-mi](https://github.com/laura-mi)
   - [@martincostello](https://github.com/martincostello)
   - [@martintmk](https://github.com/martintmk)
   - [@SimonCropp](https://github.com/SimonCropp)
+  - [@tekian](https://github.com/tekian)
   - [@terrajobst](https://github.com/terrajobst)
 
 ## 7.2.4

--- a/eng/Library.targets
+++ b/eng/Library.targets
@@ -37,7 +37,7 @@
     <PackageProjectUrl>https://github.com/App-vNext/Polly</PackageProjectUrl>
     <PackageTags>Exception Handling Resilience Transient Fault Policy Circuit Breaker CircuitBreaker Retry Wait Cache Cache-aside Bulkhead Rate-limit Fallback Timeout Throttle Parallelization</PackageTags>
     <PackageReleaseNotes>See https://github.com/App-vNext/Polly/blob/master/CHANGELOG.md for details</PackageReleaseNotes>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReadmeFile>package-readme.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/package-readme.md
+++ b/package-readme.md
@@ -1,0 +1,16 @@
+# Polly
+
+Polly is a .NET resilience and transient-fault-handling library that allows developers to express policies such as Retry, Circuit Breaker, Timeout, Rate-limiting, Hedging and Fallback in a fluent and thread-safe manner.
+
+[![NuGet version](https://buildstats.info/nuget/Polly?includePreReleases=false)](https://www.nuget.org/packages/Polly/) [![Build status](https://github.com/App-vNext/Polly/workflows/build/badge.svg?branch=main&event=push)](https://github.com/App-vNext/Polly/actions?query=workflow%3Abuild+branch%3Amain+event%3Apush) [![Code coverage](https://codecov.io/gh/App-vNext/Polly/branch/main/graph/badge.svg)](https://codecov.io/gh/App-vNext/Polly)
+
+![Polly logo](https://raw.github.com/App-vNext/Polly/main/Polly-Logo.png)
+
+## Release notes
+
+- The repository's [changelog](https://github.com/App-vNext/Polly/blob/main/CHANGELOG.md) describes changes by release.
+- We tag Pull Requests and Issues with [milestones](https://github.com/App-vNext/Polly/milestones) which match to NuGet package release numbers.
+
+## Documentation and Samples
+
+Documentation, and samples, for using Polly can be found in the repository's [README](https://github.com/App-vNext/Polly#readme) and [wiki](https://github.com/App-vNext/Polly/wiki).


### PR DESCRIPTION
- Update the CHANGELOG for `8.0.0-alpha.1`.
- Add dedicated NuGet package README that is much simpler and delegates most content to the repository.
 Resolves #1293.
