### PR TITLE
Add NuGet configuration file

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="NuGet">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>


### PR DESCRIPTION
- Add an explicit NuGet configuration file that only restores from NuGet.org. This also makes it easier to configure an additional NuGet package source (such as GitHub Packages) to consume pre-release packages in the samples.
- Add NuGet package source mappings.
