### PR TITLE
The deafult RateLimiterStrategyOptions instance is now valid

### DIFF
--- a/src/Polly.RateLimiting/RateLimiterConstants.cs
+++ b/src/Polly.RateLimiting/RateLimiterConstants.cs
@@ -2,6 +2,10 @@ namespace Polly.RateLimiting;
 
 internal static class RateLimiterConstants
 {
+    public const int DefaultPermitLimit = 1000;
+
+    public const int DefaultQueueLimit = 0;
+
     public const string StrategyType = "RateLimiter";
 
     public const string OnRateLimiterRejectedEvent = "OnRateLimiterRejected";

--- a/src/Polly.RateLimiting/RateLimiterResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.RateLimiting/RateLimiterResilienceStrategyBuilderExtensions.cs
@@ -20,6 +20,7 @@ public static class RateLimiterResilienceStrategyBuilderExtensions
     /// <returns>The builder instance with the concurrency limiter strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when the options constructed from the arguments are invalid.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="permitLimit"/> or <paramref name="queueLimit"/> is invalid.</exception>
     public static TBuilder AddConcurrencyLimiter<TBuilder>(
         this TBuilder builder,
         int permitLimit,
@@ -44,6 +45,7 @@ public static class RateLimiterResilienceStrategyBuilderExtensions
     /// <returns>The builder instance with the concurrency limiter strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when the options constructed from the arguments are invalid.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="options"/> are invalid.</exception>
     public static TBuilder AddConcurrencyLimiter<TBuilder>(
         this TBuilder builder,
         ConcurrencyLimiterOptions options)
@@ -90,6 +92,7 @@ public static class RateLimiterResilienceStrategyBuilderExtensions
     /// <returns>The builder instance with the rate limiter strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
+    /// <exception cref="ArgumentException">Thrown when <see cref="RateLimiterStrategyOptions.DefaultRateLimiterOptions"/> for <paramref name="options"/> are invalid.</exception>
     public static TBuilder AddRateLimiter<TBuilder>(
         this TBuilder builder,
         RateLimiterStrategyOptions options)

--- a/src/Polly.RateLimiting/RateLimiterResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.RateLimiting/RateLimiterResilienceStrategyBuilderExtensions.cs
@@ -54,7 +54,7 @@ public static class RateLimiterResilienceStrategyBuilderExtensions
 
         return builder.AddRateLimiter(new RateLimiterStrategyOptions
         {
-            RateLimiter = new ConcurrencyLimiter(options),
+            DefaultRateLimiterOptions = options
         });
     }
 
@@ -98,7 +98,15 @@ public static class RateLimiterResilienceStrategyBuilderExtensions
         Guard.NotNull(builder);
         Guard.NotNull(options);
 
-        builder.AddStrategy(context => new RateLimiterResilienceStrategy(options.RateLimiter!, options.OnRejected, context.Telemetry), options);
+        builder.AddStrategy(
+            context =>
+            {
+                return new RateLimiterResilienceStrategy(
+                    options.RateLimiter ?? new ConcurrencyLimiter(options.DefaultRateLimiterOptions),
+                    options.OnRejected,
+                    context.Telemetry);
+            },
+            options);
         return builder;
     }
 }

--- a/src/Polly.RateLimiting/RateLimiterStrategyOptions.cs
+++ b/src/Polly.RateLimiting/RateLimiterStrategyOptions.cs
@@ -18,7 +18,7 @@ public class RateLimiterStrategyOptions : ResilienceStrategyOptions
     /// Gets or sets the default rate limiter options.
     /// </summary>
     /// <remarks>
-    /// The options for default limiter that will be used when <see cref="RateLimiter"/> is <see langword="null"/>.
+    /// The options for the default limiter that will be used when <see cref="RateLimiter"/> is <see langword="null"/>.
     /// <para>
     /// <see cref="ConcurrencyLimiterOptions.PermitLimit"/> defaults to 1000.
     /// <see cref="ConcurrencyLimiterOptions.QueueLimit"/> defaults to 0.
@@ -44,7 +44,7 @@ public class RateLimiterStrategyOptions : ResilienceStrategyOptions
     /// </summary>
     /// <remarks>
     /// Defaults to <see langword="null"/>. If this property is <see langword="null"/>,
-    /// then strategy will use <see cref="ConcurrencyLimiter"/> created from <see cref="DefaultRateLimiterOptions"/>.
+    /// then the strategy will use a <see cref="ConcurrencyLimiter"/> created using <see cref="DefaultRateLimiterOptions"/>.
     /// </remarks>
     public RateLimiter? RateLimiter { get; set; }
 }

--- a/src/Polly.RateLimiting/RateLimiterStrategyOptions.cs
+++ b/src/Polly.RateLimiting/RateLimiterStrategyOptions.cs
@@ -15,6 +15,23 @@ public class RateLimiterStrategyOptions : ResilienceStrategyOptions
     public sealed override string StrategyType => RateLimiterConstants.StrategyType;
 
     /// <summary>
+    /// Gets or sets the default rate limiter options.
+    /// </summary>
+    /// <remarks>
+    /// The options for default limiter that will be used when <see cref="RateLimiter"/> is <see langword="null"/>.
+    /// <para>
+    /// <see cref="ConcurrencyLimiterOptions.PermitLimit"/> defaults to 1000.
+    /// <see cref="ConcurrencyLimiterOptions.QueueLimit"/> defaults to 0.
+    /// </para>
+    /// </remarks>
+    [Required]
+    public ConcurrencyLimiterOptions DefaultRateLimiterOptions { get; set; } = new()
+    {
+        QueueLimit = RateLimiterConstants.DefaultQueueLimit,
+        PermitLimit = RateLimiterConstants.DefaultPermitLimit,
+    };
+
+    /// <summary>
     /// Gets or sets an event that is raised when the execution of user-provided callback is rejected by the rate limiter.
     /// </summary>
     /// <remarks>
@@ -26,8 +43,8 @@ public class RateLimiterStrategyOptions : ResilienceStrategyOptions
     ///  Gets or sets the rate limiter that the strategy uses.
     /// </summary>
     /// <remarks>
-    /// This property is required and defaults to <see langword="null"/>.
+    /// Defaults to <see langword="null"/>. If this property is <see langword="null"/>,
+    /// then strategy will use <see cref="ConcurrencyLimiter"/> created from <see cref="DefaultRateLimiterOptions"/>.
     /// </remarks>
-    [Required]
     public RateLimiter? RateLimiter { get; set; }
 }

--- a/test/Polly.RateLimiting.Tests/RateLimiterResilienceStrategyBuilderExtensionsTests.cs
+++ b/test/Polly.RateLimiting.Tests/RateLimiterResilienceStrategyBuilderExtensionsTests.cs
@@ -44,6 +44,20 @@ public class RateLimiterResilienceStrategyBuilderExtensionsTests
     }
 
     [Fact]
+    public void AddConcurrencyLimiter_InvalidOptions_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+        {
+            return new ResilienceStrategyBuilder().AddConcurrencyLimiter(new ConcurrencyLimiterOptions
+            {
+                PermitLimit = -10,
+                QueueLimit = -10
+            })
+            .Build();
+        });
+    }
+
+    [Fact]
     public void AddRateLimiter_AllExtensions_Ok()
     {
         foreach (var configure in Data.Select(v => v[0]).Cast<Action<ResilienceStrategyBuilder<int>>>())

--- a/test/Polly.RateLimiting.Tests/RateLimiterStrategyOptionsTests.cs
+++ b/test/Polly.RateLimiting.Tests/RateLimiterStrategyOptionsTests.cs
@@ -10,5 +10,7 @@ public class RateLimiterStrategyOptionsTests
         options.StrategyType.Should().Be(RateLimiterConstants.StrategyType);
         options.RateLimiter.Should().BeNull();
         options.OnRejected.Should().BeNull();
+        options.DefaultRateLimiterOptions.PermitLimit.Should().Be(1000);
+        options.DefaultRateLimiterOptions.QueueLimit.Should().Be(0);
     }
 }


### PR DESCRIPTION
### Details on the issue fix or feature implementation

The #1313 got me thinking that `RateLimiterStrategyOptions` will be the only options that is invalid by default. 

We can address that by introducing `RateLimiterStrategyOptions.DefaultRateLimiterOptions` property that will be used unless someone explicitly assigns `RateLimiterStrategyOptions.RateLimiter`.

This provides a nice out-of-box experience.

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
