### PR TITLE
Fix OnHedging not being called

### DIFF
--- a/src/Polly.Core/Hedging/HedgingStrategyOptions.TResult.cs
+++ b/src/Polly.Core/Hedging/HedgingStrategyOptions.TResult.cs
@@ -85,6 +85,10 @@ public class HedgingStrategyOptions<TResult> : ResilienceStrategyOptions
     /// </summary>
     /// <remarks>
     /// Defaults to <see langword="null"/>.
+    /// <para>
+    /// The hedging is executed when the current attempt outcome is not successful and the <see cref="ShouldHandle"/> predicate returns <see langword="true"/> or when
+    /// the current attempt did not finish within the <see cref="HedgingDelay"/>.
+    /// </para>
     /// </remarks>
     public Func<OutcomeArguments<TResult, OnHedgingArguments>, ValueTask>? OnHedging { get; set; }
 }

--- a/src/Polly.Core/Hedging/OnHedgingArguments.cs
+++ b/src/Polly.Core/Hedging/OnHedgingArguments.cs
@@ -6,6 +6,6 @@ namespace Polly.Hedging;
 /// <param name="Attempt">The zero-based hedging attempt number.</param>
 /// <param name="HasOutcome">
 /// Determines whether the outcome is available before loading the next hedged task.
-/// No outcome indicates that the previous action did not finish within hedging delay.
+/// No outcome indicates that the previous action did not finish within the hedging delay.
 /// </param>
 public record OnHedgingArguments(int Attempt, bool HasOutcome);

--- a/src/Polly.Core/Hedging/OnHedgingArguments.cs
+++ b/src/Polly.Core/Hedging/OnHedgingArguments.cs
@@ -3,6 +3,9 @@ namespace Polly.Hedging;
 /// <summary>
 /// Represents arguments used by the on-hedging event.
 /// </summary>
-/// <param name="Context">The context associated with the execution of a user-provided callback.</param>
 /// <param name="Attempt">The zero-based hedging attempt number.</param>
-public record OnHedgingArguments(ResilienceContext Context, int Attempt);
+/// <param name="HasOutcome">
+/// Determines whether the outcome is available before loading the next hedged task.
+/// No outcome indicates that the previous action did not finish within hedging delay.
+/// </param>
+public record OnHedgingArguments(int Attempt, bool HasOutcome);

--- a/test/Polly.Core.Tests/Hedging/HedgingResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Hedging/HedgingResilienceStrategyTests.cs
@@ -843,6 +843,7 @@ public class HedgingResilienceStrategyTests : IDisposable
         var attempts = new List<int>();
         _options.OnHedging = args =>
         {
+            args.Arguments.HasOutcome.Should().BeTrue();
             args.Result.Should().Be(Failure);
             attempts.Add(args.Arguments.Attempt);
             return default;

--- a/test/Polly.Core.Tests/Hedging/HedgingResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Hedging/HedgingResilienceStrategyTests.cs
@@ -244,6 +244,35 @@ public class HedgingResilienceStrategyTests : IDisposable
     }
 
     [Fact]
+    public async Task ExecuteAsync_EnsureSecondaryHedgedTaskReportedWithNoOutcome()
+    {
+        // arrange
+        using var cancelled = new ManualResetEvent(false);
+        var hasOutcome = true;
+        _options.OnHedging = args =>
+        {
+            hasOutcome = args.Arguments.HasOutcome;
+            return default;
+        };
+
+        ConfigureHedging(context => Success.AsOutcomeAsync());
+
+        var strategy = Create();
+
+        // act
+        var task = strategy.ExecuteAsync(async token =>
+        {
+            await _timeProvider.Delay(TimeSpan.FromHours(24), token);
+            return Success;
+        });
+
+        // assert
+        _timeProvider.Advance(TimeSpan.FromHours(2));
+        hasOutcome.Should().BeFalse();
+        await task;
+    }
+
+    [Fact]
     public async Task ExecuteAsync_EnsureDiscardedResultDisposed()
     {
         // arrange


### PR DESCRIPTION
### Details on the issue fix or feature implementation

The `OnHedging` callback was not called when the outcome is not available due to the callback taking too long.

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
