### PR TITLE
API feedback

### DIFF
--- a/bench/Polly.Core.Benchmarks/ResilienceStrategyProviderBenchmark.cs
+++ b/bench/Polly.Core.Benchmarks/ResilienceStrategyProviderBenchmark.cs
@@ -17,8 +17,8 @@ public class ResilienceStrategyProviderBenchmark
     }
 
     [Benchmark]
-    public void Get_Ok() => _provider!.Get("dummy");
+    public void Get_Ok() => _provider!.GetStrategy("dummy");
 
     [Benchmark]
-    public void Get_Generic_Ok() => _provider!.Get<string>("dummy");
+    public void Get_Generic_Ok() => _provider!.GetStrategy<string>("dummy");
 }

--- a/bench/Polly.Core.Benchmarks/TelemetryBenchmark.cs
+++ b/bench/Polly.Core.Benchmarks/TelemetryBenchmark.cs
@@ -61,7 +61,7 @@ public class TelemetryBenchmark
                 });
             }
 
-            builder.EnableTelemetry(options);
+            builder.ConfigureTelemetry(options);
         }
 
         return builder.Build();

--- a/bench/Polly.Core.Benchmarks/Utils/Helper.MultipleStrategies.cs
+++ b/bench/Polly.Core.Benchmarks/Utils/Helper.MultipleStrategies.cs
@@ -44,7 +44,7 @@ internal static partial class Helper
 
             if (telemetry)
             {
-                builder.EnableTelemetry(NullLoggerFactory.Instance);
+                builder.ConfigureTelemetry(NullLoggerFactory.Instance);
             }
         }),
         _ => throw new NotSupportedException()

--- a/samples/GenericStrategies/Program.cs
+++ b/samples/GenericStrategies/Program.cs
@@ -66,7 +66,7 @@ ResilienceStrategy<HttpResponseMessage> strategy = new ResilienceStrategyBuilder
 var response = await strategy.ExecuteAsync(
     async token =>
     {
-        await Task.Delay(10);
+        await Task.Delay(10, token);
         // This causes the action fail, thus using the fallback strategy above
         return new HttpResponseMessage(HttpStatusCode.InternalServerError);
     },

--- a/samples/Intro/Program.cs
+++ b/samples/Intro/Program.cs
@@ -22,13 +22,13 @@ ResilienceStrategy strategy = new ResilienceStrategyBuilder()
 strategy.Execute(() => { });
 
 // Asynchronously
-await strategy.ExecuteAsync(async token => { await Task.Delay(10); }, CancellationToken.None);
+await strategy.ExecuteAsync(async token => { await Task.Delay(10, token); }, CancellationToken.None);
 
 // Synchronously with result
 strategy.Execute(token => "some-result");
 
 // Asynchronously with result
-await strategy.ExecuteAsync(async token => { await Task.Delay(10); return "some-result"; }, CancellationToken.None);
+await strategy.ExecuteAsync(async token => { await Task.Delay(10, token); return "some-result"; }, CancellationToken.None);
 
 // Use state to avoid lambda allocation
 strategy.Execute(static state => state, "my-state");

--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerResilienceStrategyBuilderExtensions.cs
@@ -102,7 +102,7 @@ public static class CircuitBreakerResilienceStrategyBuilderExtensions
     private static TBuilder AddAdvancedCircuitBreakerCore<TBuilder, TResult>(this TBuilder builder, AdvancedCircuitBreakerStrategyOptions<TResult> options)
         where TBuilder : ResilienceStrategyBuilderBase
     {
-        builder.AddStrategy(
+        return builder.AddStrategy(
             context =>
             {
                 var behavior = new AdvancedCircuitBehavior(
@@ -113,15 +113,12 @@ public static class CircuitBreakerResilienceStrategyBuilderExtensions
                 return CreateStrategy(context, options, behavior);
             },
             options);
-
-        return builder;
     }
 
     private static TBuilder AddSimpleCircuitBreakerCore<TBuilder, TResult>(this TBuilder builder, SimpleCircuitBreakerStrategyOptions<TResult> options)
         where TBuilder : ResilienceStrategyBuilderBase
     {
-        builder.AddStrategy(context => CreateStrategy(context, options, new ConsecutiveFailuresCircuitBehavior(options.FailureThreshold)), options);
-        return builder;
+        return builder.AddStrategy(context => CreateStrategy(context, options, new ConsecutiveFailuresCircuitBehavior(options.FailureThreshold)), options);
     }
 
     internal static CircuitBreakerResilienceStrategy CreateStrategy<TResult>(ResilienceStrategyBuilderContext context, CircuitBreakerStrategyOptions<TResult> options, CircuitBehavior behavior)

--- a/src/Polly.Core/Registry/ResilienceStrategyProvider.cs
+++ b/src/Polly.Core/Registry/ResilienceStrategyProvider.cs
@@ -17,9 +17,9 @@ public abstract class ResilienceStrategyProvider<TKey>
     /// <param name="key">The key used to identify the resilience strategy.</param>
     /// <returns>The resilience strategy associated with the specified key.</returns>
     /// <exception cref="KeyNotFoundException">Thrown when no resilience strategy is found for the specified key.</exception>
-    public virtual ResilienceStrategy Get(TKey key)
+    public virtual ResilienceStrategy GetStrategy(TKey key)
     {
-        if (TryGet(key, out var strategy))
+        if (TryGetStrategy(key, out var strategy))
         {
             return strategy;
         }
@@ -35,9 +35,9 @@ public abstract class ResilienceStrategyProvider<TKey>
     /// <param name="key">The key used to identify the resilience strategy.</param>
     /// <returns>The resilience strategy associated with the specified key.</returns>
     /// <exception cref="KeyNotFoundException">Thrown when no resilience strategy is found for the specified key.</exception>
-    public virtual ResilienceStrategy<TResult> Get<TResult>(TKey key)
+    public virtual ResilienceStrategy<TResult> GetStrategy<TResult>(TKey key)
     {
-        if (TryGet<TResult>(key, out var strategy))
+        if (TryGetStrategy<TResult>(key, out var strategy))
         {
             return strategy;
         }
@@ -52,7 +52,7 @@ public abstract class ResilienceStrategyProvider<TKey>
     /// <param name="key">The key used to identify the resilience strategy.</param>
     /// <param name="strategy">The output resilience strategy if found, <see langword="null"/> otherwise.</param>
     /// <returns><see langword="true"/> if the strategy was found, <see langword="false"/> otherwise.</returns>
-    public abstract bool TryGet(TKey key, [NotNullWhen(true)] out ResilienceStrategy? strategy);
+    public abstract bool TryGetStrategy(TKey key, [NotNullWhen(true)] out ResilienceStrategy? strategy);
 
     /// <summary>
     /// Tries to get a generic resilience strategy from the provider using the specified key.
@@ -61,5 +61,5 @@ public abstract class ResilienceStrategyProvider<TKey>
     /// <param name="key">The key used to identify the resilience strategy.</param>
     /// <param name="strategy">The output resilience strategy if found, <see langword="null"/> otherwise.</param>
     /// <returns><see langword="true"/> if the strategy was found, <see langword="false"/> otherwise.</returns>
-    public abstract bool TryGet<TResult>(TKey key, [NotNullWhen(true)] out ResilienceStrategy<TResult>? strategy);
+    public abstract bool TryGetStrategy<TResult>(TKey key, [NotNullWhen(true)] out ResilienceStrategy<TResult>? strategy);
 }

--- a/src/Polly.Core/Registry/ResilienceStrategyRegistry.cs
+++ b/src/Polly.Core/Registry/ResilienceStrategyRegistry.cs
@@ -65,7 +65,7 @@ public sealed partial class ResilienceStrategyRegistry<TKey> : ResilienceStrateg
     /// <param name="strategy">The resilience strategy instance.</param>
     /// <returns><see langword="true"/> if the strategy was added successfully, <see langword="false"/> otherwise.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="strategy"/> is <see langword="null"/>.</exception>
-    public bool TryAdd(TKey key, ResilienceStrategy strategy)
+    public bool TryAddStrategy(TKey key, ResilienceStrategy strategy)
     {
         Guard.NotNull(strategy);
 
@@ -80,7 +80,7 @@ public sealed partial class ResilienceStrategyRegistry<TKey> : ResilienceStrateg
     /// <param name="strategy">The resilience strategy instance.</param>
     /// <returns><see langword="true"/> if the strategy was added successfully, <see langword="false"/> otherwise.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="strategy"/> is <see langword="null"/>.</exception>
-    public bool TryAdd<TResult>(TKey key, ResilienceStrategy<TResult> strategy)
+    public bool TryAddStrategy<TResult>(TKey key, ResilienceStrategy<TResult> strategy)
     {
         Guard.NotNull(strategy);
 
@@ -92,7 +92,7 @@ public sealed partial class ResilienceStrategyRegistry<TKey> : ResilienceStrateg
     /// </summary>
     /// <param name="key">The key used to identify the resilience strategy.</param>
     /// <returns><see langword="true"/> if the strategy was removed successfully, <see langword="false"/> otherwise.</returns>
-    public bool Remove(TKey key) => _strategies.TryRemove(key, out _);
+    public bool RemoveStrategy(TKey key) => _strategies.TryRemove(key, out _);
 
     /// <summary>
     /// Removes a generic resilience strategy from the registry.
@@ -100,16 +100,16 @@ public sealed partial class ResilienceStrategyRegistry<TKey> : ResilienceStrateg
     /// <typeparam name="TResult">The type of result that the resilience strategy handles.</typeparam>
     /// <param name="key">The key used to identify the resilience strategy.</param>
     /// <returns><see langword="true"/> if the strategy was removed successfully, <see langword="false"/> otherwise.</returns>
-    public bool Remove<TResult>(TKey key) => GetGenericRegistry<TResult>().Remove(key);
+    public bool RemoveStrategy<TResult>(TKey key) => GetGenericRegistry<TResult>().Remove(key);
 
     /// <inheritdoc/>
-    public override bool TryGet<TResult>(TKey key, [NotNullWhen(true)] out ResilienceStrategy<TResult>? strategy)
+    public override bool TryGetStrategy<TResult>(TKey key, [NotNullWhen(true)] out ResilienceStrategy<TResult>? strategy)
     {
         return GetGenericRegistry<TResult>().TryGet(key, out strategy);
     }
 
     /// <inheritdoc/>
-    public override bool TryGet(TKey key, [NotNullWhen(true)] out ResilienceStrategy? strategy)
+    public override bool TryGetStrategy(TKey key, [NotNullWhen(true)] out ResilienceStrategy? strategy)
     {
         if (_strategies.TryGetValue(key, out strategy))
         {
@@ -192,7 +192,7 @@ public sealed partial class ResilienceStrategyRegistry<TKey> : ResilienceStrateg
     /// <remarks>
     /// This method only clears the cached strategies, the registered builders are kept unchanged.
     /// </remarks>
-    public void Clear() => _strategies.Clear();
+    public void ClearStrategies() => _strategies.Clear();
 
     /// <summary>
     /// Clears all cached generic strategies.
@@ -201,7 +201,7 @@ public sealed partial class ResilienceStrategyRegistry<TKey> : ResilienceStrateg
     /// <remarks>
     /// This method only clears the cached strategies, the registered builders are kept unchanged.
     /// </remarks>
-    public void Clear<TResult>() => GetGenericRegistry<TResult>().Clear();
+    public void ClearStrategies<TResult>() => GetGenericRegistry<TResult>().Clear();
 
     private static ResilienceStrategy CreateStrategy<TBuilder>(
         Func<TBuilder> activator,

--- a/src/Polly.Core/ResilienceStrategyBuilderBase.cs
+++ b/src/Polly.Core/ResilienceStrategyBuilderBase.cs
@@ -72,15 +72,7 @@ public abstract class ResilienceStrategyBuilderBase
 
     internal abstract bool IsGenericBuilder { get; }
 
-    /// <summary>
-    /// Adds a strategy to the builder.
-    /// </summary>
-    /// <param name="factory">The factory that creates a resilience strategy.</param>
-    /// <param name="options">The options associated with the strategy. If none are provided the default instance of <see cref="ResilienceStrategyOptions"/> is created.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="factory"/> is null.</exception>
-    /// <exception cref="InvalidOperationException">Thrown when this builder was already used to create a strategy. The builder cannot be modified after it has been used.</exception>
-    /// <exception cref="ValidationException">Thrown when the <paramref name="options"/> are invalid.</exception>
-    public void AddStrategy(Func<ResilienceStrategyBuilderContext, ResilienceStrategy> factory, ResilienceStrategyOptions options)
+    internal void AddStrategyCore(Func<ResilienceStrategyBuilderContext, ResilienceStrategy> factory, ResilienceStrategyOptions options)
     {
         Guard.NotNull(factory);
         Guard.NotNull(options);

--- a/src/Polly.Core/ResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/ResilienceStrategyBuilderExtensions.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Polly;
 
 /// <summary>
@@ -20,7 +22,28 @@ public static class ResilienceStrategyBuilderExtensions
         Guard.NotNull(builder);
         Guard.NotNull(strategy);
 
-        builder.AddStrategy(_ => strategy, EmptyOptions.Instance);
+        return builder.AddStrategy(_ => strategy, EmptyOptions.Instance);
+    }
+
+    /// <summary>
+    /// Adds a strategy to the builder.
+    /// </summary>
+    /// <typeparam name="TBuilder">The builder type.</typeparam>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="factory">The factory that creates a resilience strategy.</param>
+    /// <param name="options">The options associated with the strategy. If none are provided the default instance of <see cref="ResilienceStrategyOptions"/> is created.</param>
+    /// <returns>The same builder instance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/>, <paramref name="factory"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when this builder was already used to create a strategy. The builder cannot be modified after it has been used.</exception>
+    /// <exception cref="ValidationException">Thrown when the <paramref name="options"/> are invalid.</exception>
+    public static TBuilder AddStrategy<TBuilder>(this TBuilder builder, Func<ResilienceStrategyBuilderContext, ResilienceStrategy> factory, ResilienceStrategyOptions options)
+        where TBuilder : ResilienceStrategyBuilderBase
+    {
+        Guard.NotNull(builder);
+        Guard.NotNull(factory);
+        Guard.NotNull(options);
+
+        builder.AddStrategyCore(factory, options);
         return builder;
     }
 

--- a/src/Polly.Core/ResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/ResilienceStrategyBuilderExtensions.cs
@@ -35,7 +35,7 @@ public static class ResilienceStrategyBuilderExtensions
     /// <returns>The same builder instance.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/>, <paramref name="factory"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
     /// <exception cref="InvalidOperationException">Thrown when this builder was already used to create a strategy. The builder cannot be modified after it has been used.</exception>
-    /// <exception cref="ValidationException">Thrown when the <paramref name="options"/> are invalid.</exception>
+    /// <exception cref="ValidationException">Thrown when <paramref name="options"/> is invalid.</exception>
     public static TBuilder AddStrategy<TBuilder>(this TBuilder builder, Func<ResilienceStrategyBuilderContext, ResilienceStrategy> factory, ResilienceStrategyOptions options)
         where TBuilder : ResilienceStrategyBuilderBase
     {

--- a/src/Polly.Core/Retry/RetryResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/Retry/RetryResilienceStrategyBuilderExtensions.cs
@@ -78,7 +78,7 @@ public static class RetryResilienceStrategyBuilderExtensions
     private static TBuilder AddRetryCore<TBuilder, TResult>(this TBuilder builder, RetryStrategyOptions<TResult> options)
         where TBuilder : ResilienceStrategyBuilderBase
     {
-        builder.AddStrategy(context =>
+        return builder.AddStrategy(context =>
             new RetryResilienceStrategy(
                 options.BaseDelay,
                 options.BackoffType,
@@ -90,8 +90,6 @@ public static class RetryResilienceStrategyBuilderExtensions
                 context.Telemetry,
                 RandomUtil.Instance),
             options);
-
-        return builder;
     }
 
     private static void ConfigureShouldRetry<TResult>(Action<PredicateBuilder<TResult>> shouldRetry, RetryStrategyOptions<TResult> options)

--- a/src/Polly.Core/Retry/RetryStrategyOptions.TResult.cs
+++ b/src/Polly.Core/Retry/RetryStrategyOptions.TResult.cs
@@ -27,6 +27,9 @@ public class RetryStrategyOptions<TResult> : ResilienceStrategyOptions
     /// Gets or sets the type of the back-off.
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// This property is ignored when <see cref="RetryDelayGenerator"/> is set.
+    /// </para>
     /// Defaults to <see cref="RetryBackoffType.Constant"/>.
     /// </remarks>
     public RetryBackoffType BackoffType { get; set; } = RetryConstants.DefaultBackoffType;
@@ -51,6 +54,9 @@ public class RetryStrategyOptions<TResult> : ResilienceStrategyOptions
     /// </item>
     /// </list>
     /// <para>
+    /// This property is ignored when <see cref="RetryDelayGenerator"/> is set.
+    /// </para>
+    /// <para>
     /// Defaults to 2 seconds.
     /// </para>
     /// </remarks>
@@ -71,6 +77,9 @@ public class RetryStrategyOptions<TResult> : ResilienceStrategyOptions
     /// Gets or sets the generator instance that is used to calculate the time between retries.
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// The generator has precedence over <see cref="BaseDelay"/> and <see cref="BackoffType"/>.
+    /// </para>
     /// Defaults to <see langword="null"/>.
     /// </remarks>
     public Func<OutcomeArguments<TResult, RetryDelayArguments>, ValueTask<TimeSpan>>? RetryDelayGenerator { get; set; }

--- a/src/Polly.Extensions/DependencyInjection/PollyServiceCollectionExtensions.cs
+++ b/src/Polly.Extensions/DependencyInjection/PollyServiceCollectionExtensions.cs
@@ -219,7 +219,7 @@ public static class PollyServiceCollectionExtensions
         {
             var builder = new ResilienceStrategyBuilder();
             builder.Properties.Set(PollyDependencyInjectionKeys.ServiceProvider, serviceProvider);
-            builder.EnableTelemetry(serviceProvider.GetRequiredService<IOptions<TelemetryOptions>>().Value);
+            builder.ConfigureTelemetry(serviceProvider.GetRequiredService<IOptions<TelemetryOptions>>().Value);
             return builder;
         });
     }

--- a/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategyBuilderExtensions.cs
@@ -22,13 +22,13 @@ public static class TelemetryResilienceStrategyBuilderExtensions
     /// Additionally, the telemetry strategy that logs and meters the executions is added to the beginning of the strategy pipeline.
     /// </remarks>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="loggerFactory"/> is <see langword="null"/>.</exception>
-    public static TBuilder EnableTelemetry<TBuilder>(this TBuilder builder, ILoggerFactory loggerFactory)
+    public static TBuilder ConfigureTelemetry<TBuilder>(this TBuilder builder, ILoggerFactory loggerFactory)
         where TBuilder : ResilienceStrategyBuilderBase
     {
         Guard.NotNull(builder);
         Guard.NotNull(loggerFactory);
 
-        return builder.EnableTelemetry(new TelemetryOptions { LoggerFactory = loggerFactory });
+        return builder.ConfigureTelemetry(new TelemetryOptions { LoggerFactory = loggerFactory });
     }
 
     /// <summary>
@@ -43,7 +43,7 @@ public static class TelemetryResilienceStrategyBuilderExtensions
     /// Additionally, the telemetry strategy that logs and meters the executions is added to the beginning of the strategy pipeline.
     /// </remarks>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
-    public static TBuilder EnableTelemetry<TBuilder>(this TBuilder builder, TelemetryOptions options)
+    public static TBuilder ConfigureTelemetry<TBuilder>(this TBuilder builder, TelemetryOptions options)
         where TBuilder : ResilienceStrategyBuilderBase
     {
         Guard.NotNull(builder);

--- a/src/Polly.RateLimiting/RateLimiterResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.RateLimiting/RateLimiterResilienceStrategyBuilderExtensions.cs
@@ -101,7 +101,7 @@ public static class RateLimiterResilienceStrategyBuilderExtensions
         Guard.NotNull(builder);
         Guard.NotNull(options);
 
-        builder.AddStrategy(
+        return builder.AddStrategy(
             context =>
             {
                 return new RateLimiterResilienceStrategy(
@@ -110,6 +110,5 @@ public static class RateLimiterResilienceStrategyBuilderExtensions
                     context.Telemetry);
             },
             options);
-        return builder;
     }
 }

--- a/test/Polly.Core.Tests/Registry/ResilienceStrategyProviderTests.cs
+++ b/test/Polly.Core.Tests/Registry/ResilienceStrategyProviderTests.cs
@@ -9,7 +9,7 @@ public class ResilienceStrategyProviderTests
     public void Get_DoesNotExist_Throws()
     {
         new Provider()
-            .Invoking(o => o.Get("not-exists"))
+            .Invoking(o => o.GetStrategy("not-exists"))
             .Should()
             .Throw<KeyNotFoundException>()
             .WithMessage("Unable to find a resilience strategy associated with the key 'not-exists'. Please ensure that either the resilience strategy or the builder is registered.");
@@ -19,7 +19,7 @@ public class ResilienceStrategyProviderTests
     public void Get_GenericDoesNotExist_Throws()
     {
         new Provider()
-            .Invoking(o => o.Get<string>("not-exists"))
+            .Invoking(o => o.GetStrategy<string>("not-exists"))
             .Should()
             .Throw<KeyNotFoundException>()
             .WithMessage("Unable to find a generic resilience strategy of 'String' associated with the key 'not-exists'. " +
@@ -31,7 +31,7 @@ public class ResilienceStrategyProviderTests
     {
         var provider = new Provider { Strategy = new TestResilienceStrategy() };
 
-        provider.Get("exists").Should().Be(provider.Strategy);
+        provider.GetStrategy("exists").Should().Be(provider.Strategy);
     }
 
     [Fact]
@@ -39,7 +39,7 @@ public class ResilienceStrategyProviderTests
     {
         var provider = new Provider { GenericStrategy = new TestResilienceStrategy<string>() };
 
-        provider.Get<string>("exists").Should().Be(provider.GenericStrategy);
+        provider.GetStrategy<string>("exists").Should().Be(provider.GenericStrategy);
     }
 
     private class Provider : ResilienceStrategyProvider<string>
@@ -48,13 +48,13 @@ public class ResilienceStrategyProviderTests
 
         public object? GenericStrategy { get; set; }
 
-        public override bool TryGet(string key, [NotNullWhen(true)] out ResilienceStrategy? strategy)
+        public override bool TryGetStrategy(string key, [NotNullWhen(true)] out ResilienceStrategy? strategy)
         {
             strategy = Strategy;
             return Strategy != null;
         }
 
-        public override bool TryGet<TResult>(string key, [NotNullWhen(true)] out ResilienceStrategy<TResult>? strategy)
+        public override bool TryGetStrategy<TResult>(string key, [NotNullWhen(true)] out ResilienceStrategy<TResult>? strategy)
         {
             strategy = (ResilienceStrategy<TResult>?)GenericStrategy;
             return GenericStrategy != null;

--- a/test/Polly.Core.Tests/Registry/ResilienceStrategyRegistryTests.cs
+++ b/test/Polly.Core.Tests/Registry/ResilienceStrategyRegistryTests.cs
@@ -45,15 +45,15 @@ public class ResilienceStrategyRegistryTests
 
         registry.TryAddBuilder("C", (b, _) => b.AddStrategy(new TestResilienceStrategy()));
 
-        registry.TryAdd("A", new TestResilienceStrategy());
-        registry.TryAdd("B", new TestResilienceStrategy());
-        registry.TryAdd("C", new TestResilienceStrategy());
+        registry.TryAddStrategy("A", new TestResilienceStrategy());
+        registry.TryAddStrategy("B", new TestResilienceStrategy());
+        registry.TryAddStrategy("C", new TestResilienceStrategy());
 
-        registry.Clear();
+        registry.ClearStrategies();
 
-        registry.TryGet("A", out _).Should().BeFalse();
-        registry.TryGet("B", out _).Should().BeFalse();
-        registry.TryGet("C", out _).Should().BeTrue();
+        registry.TryGetStrategy("A", out _).Should().BeFalse();
+        registry.TryGetStrategy("B", out _).Should().BeFalse();
+        registry.TryGetStrategy("C", out _).Should().BeTrue();
     }
 
     [Fact]
@@ -63,15 +63,15 @@ public class ResilienceStrategyRegistryTests
 
         registry.TryAddBuilder<string>("C", (b, _) => b.AddStrategy(new TestResilienceStrategy()));
 
-        registry.TryAdd("A", new TestResilienceStrategy<string>());
-        registry.TryAdd("B", new TestResilienceStrategy<string>());
-        registry.TryAdd("C", new TestResilienceStrategy<string>());
+        registry.TryAddStrategy("A", new TestResilienceStrategy<string>());
+        registry.TryAddStrategy("B", new TestResilienceStrategy<string>());
+        registry.TryAddStrategy("C", new TestResilienceStrategy<string>());
 
-        registry.Clear<string>();
+        registry.ClearStrategies<string>();
 
-        registry.TryGet<string>("A", out _).Should().BeFalse();
-        registry.TryGet<string>("B", out _).Should().BeFalse();
-        registry.TryGet<string>("C", out _).Should().BeTrue();
+        registry.TryGetStrategy<string>("A", out _).Should().BeFalse();
+        registry.TryGetStrategy<string>("B", out _).Should().BeFalse();
+        registry.TryGetStrategy<string>("C", out _).Should().BeTrue();
     }
 
     [Fact]
@@ -79,14 +79,14 @@ public class ResilienceStrategyRegistryTests
     {
         var registry = new ResilienceStrategyRegistry<string>();
 
-        registry.TryAdd("A", new TestResilienceStrategy());
-        registry.TryAdd("B", new TestResilienceStrategy());
+        registry.TryAddStrategy("A", new TestResilienceStrategy());
+        registry.TryAddStrategy("B", new TestResilienceStrategy());
 
-        registry.Remove("A").Should().BeTrue();
-        registry.Remove("A").Should().BeFalse();
+        registry.RemoveStrategy("A").Should().BeTrue();
+        registry.RemoveStrategy("A").Should().BeFalse();
 
-        registry.TryGet("A", out _).Should().BeFalse();
-        registry.TryGet("B", out _).Should().BeTrue();
+        registry.TryGetStrategy("A", out _).Should().BeFalse();
+        registry.TryGetStrategy("B", out _).Should().BeTrue();
     }
 
     [Fact]
@@ -94,14 +94,14 @@ public class ResilienceStrategyRegistryTests
     {
         var registry = new ResilienceStrategyRegistry<string>();
 
-        registry.TryAdd("A", new TestResilienceStrategy<string>());
-        registry.TryAdd("B", new TestResilienceStrategy<string>());
+        registry.TryAddStrategy("A", new TestResilienceStrategy<string>());
+        registry.TryAddStrategy("B", new TestResilienceStrategy<string>());
 
-        registry.Remove<string>("A").Should().BeTrue();
-        registry.Remove<string>("A").Should().BeFalse();
+        registry.RemoveStrategy<string>("A").Should().BeTrue();
+        registry.RemoveStrategy<string>("A").Should().BeFalse();
 
-        registry.TryGet<string>("A", out _).Should().BeFalse();
-        registry.TryGet<string>("B", out _).Should().BeTrue();
+        registry.TryGetStrategy<string>("A", out _).Should().BeFalse();
+        registry.TryGetStrategy<string>("B", out _).Should().BeTrue();
     }
 
     [Fact]
@@ -113,7 +113,7 @@ public class ResilienceStrategyRegistryTests
         registry.RemoveBuilder("A").Should().BeTrue();
         registry.RemoveBuilder("A").Should().BeFalse();
 
-        registry.TryGet("A", out _).Should().BeFalse();
+        registry.TryGetStrategy("A", out _).Should().BeFalse();
     }
 
     [Fact]
@@ -125,7 +125,7 @@ public class ResilienceStrategyRegistryTests
         registry.RemoveBuilder<string>("A").Should().BeTrue();
         registry.RemoveBuilder<string>("A").Should().BeFalse();
 
-        registry.TryGet<string>("A", out _).Should().BeFalse();
+        registry.TryGetStrategy<string>("A", out _).Should().BeFalse();
     }
 
     [Fact]
@@ -140,10 +140,10 @@ public class ResilienceStrategyRegistryTests
         {
             var key = StrategyId.Create(builderName, i.ToString(CultureInfo.InvariantCulture));
 
-            strategies.Add(registry.Get(key));
+            strategies.Add(registry.GetStrategy(key));
 
             // call again, the strategy should be already cached
-            strategies.Add(registry.Get(key));
+            strategies.Add(registry.GetStrategy(key));
         }
 
         strategies.Should().HaveCount(100);
@@ -161,10 +161,10 @@ public class ResilienceStrategyRegistryTests
         {
             var key = StrategyId.Create(builderName, i.ToString(CultureInfo.InvariantCulture));
 
-            strategies.Add(registry.Get<string>(key));
+            strategies.Add(registry.GetStrategy<string>(key));
 
             // call again, the strategy should be already cached
-            strategies.Add(registry.Get<string>(key));
+            strategies.Add(registry.GetStrategy<string>(key));
         }
 
         strategies.Should().HaveCount(100);
@@ -188,10 +188,10 @@ public class ResilienceStrategyRegistryTests
         var key2 = StrategyId.Create("A", "Instance1");
         var key3 = StrategyId.Create("A", "Instance2");
         var keys = new[] { key1, key2, key3 };
-        var strategies = keys.ToDictionary(k => k, registry.Get);
+        var strategies = keys.ToDictionary(k => k, registry.GetStrategy);
         foreach (var key in keys)
         {
-            registry.Get(key);
+            registry.GetStrategy(key);
         }
 
         called.Should().Be(3);
@@ -217,10 +217,10 @@ public class ResilienceStrategyRegistryTests
         var key2 = StrategyId.Create("A", "Instance1");
         var key3 = StrategyId.Create("A", "Instance2");
         var keys = new[] { key1, key2, key3 };
-        var strategies = keys.ToDictionary(k => k, registry.Get<string>);
+        var strategies = keys.ToDictionary(k => k, registry.GetStrategy<string>);
         foreach (var key in keys)
         {
-            registry.Get<string>(key);
+            registry.GetStrategy<string>(key);
         }
 
         called.Should().Be(3);
@@ -247,7 +247,7 @@ public class ResilienceStrategyRegistryTests
             called = true;
         });
 
-        registry.Get(StrategyId.Create("A", "Instance1"));
+        registry.GetStrategy(StrategyId.Create("A", "Instance1"));
         called.Should().BeTrue();
     }
 
@@ -258,8 +258,8 @@ public class ResilienceStrategyRegistryTests
         registry.TryAddBuilder<string>(StrategyId.Create("A"), (builder, _) => builder.AddStrategy(new TestResilienceStrategy()));
         registry.TryAddBuilder<int>(StrategyId.Create("A"), (builder, _) => builder.AddStrategy(new TestResilienceStrategy()));
 
-        registry.Get<string>(StrategyId.Create("A", "Instance1")).Should().BeSameAs(registry.Get<string>(StrategyId.Create("A", "Instance1")));
-        registry.Get<int>(StrategyId.Create("A", "Instance1")).Should().BeSameAs(registry.Get<int>(StrategyId.Create("A", "Instance1")));
+        registry.GetStrategy<string>(StrategyId.Create("A", "Instance1")).Should().BeSameAs(registry.GetStrategy<string>(StrategyId.Create("A", "Instance1")));
+        registry.GetStrategy<int>(StrategyId.Create("A", "Instance1")).Should().BeSameAs(registry.GetStrategy<int>(StrategyId.Create("A", "Instance1")));
     }
 
     [Fact]
@@ -279,7 +279,7 @@ public class ResilienceStrategyRegistryTests
             called = true;
         });
 
-        registry.Get<string>(StrategyId.Create("A", "Instance1"));
+        registry.GetStrategy<string>(StrategyId.Create("A", "Instance1"));
         called.Should().BeTrue();
     }
 
@@ -289,7 +289,7 @@ public class ResilienceStrategyRegistryTests
         var registry = CreateRegistry();
         var key = StrategyId.Create("A");
 
-        registry.TryGet(key, out var strategy).Should().BeFalse();
+        registry.TryGetStrategy(key, out var strategy).Should().BeFalse();
         strategy.Should().BeNull();
     }
 
@@ -299,7 +299,7 @@ public class ResilienceStrategyRegistryTests
         var registry = CreateRegistry();
         var key = StrategyId.Create("A");
 
-        registry.TryGet<string>(key, out var strategy).Should().BeFalse();
+        registry.TryGetStrategy<string>(key, out var strategy).Should().BeFalse();
         strategy.Should().BeNull();
     }
 
@@ -309,9 +309,9 @@ public class ResilienceStrategyRegistryTests
         var expectedStrategy = new TestResilienceStrategy();
         var registry = CreateRegistry();
         var key = StrategyId.Create("A", "Instance");
-        registry.TryAdd(key, expectedStrategy).Should().BeTrue();
+        registry.TryAddStrategy(key, expectedStrategy).Should().BeTrue();
 
-        registry.TryGet(key, out var strategy).Should().BeTrue();
+        registry.TryGetStrategy(key, out var strategy).Should().BeTrue();
 
         strategy.Should().BeSameAs(expectedStrategy);
     }
@@ -322,9 +322,9 @@ public class ResilienceStrategyRegistryTests
         var expectedStrategy = new TestResilienceStrategy<string>();
         var registry = CreateRegistry();
         var key = StrategyId.Create("A", "Instance");
-        registry.TryAdd<string>(key, expectedStrategy).Should().BeTrue();
+        registry.TryAddStrategy<string>(key, expectedStrategy).Should().BeTrue();
 
-        registry.TryGet<string>(key, out var strategy).Should().BeTrue();
+        registry.TryGetStrategy<string>(key, out var strategy).Should().BeTrue();
 
         strategy.Should().BeSameAs(expectedStrategy);
     }
@@ -335,11 +335,11 @@ public class ResilienceStrategyRegistryTests
         var expectedStrategy = new TestResilienceStrategy();
         var registry = CreateRegistry();
         var key = StrategyId.Create("A", "Instance");
-        registry.TryAdd(key, expectedStrategy).Should().BeTrue();
+        registry.TryAddStrategy(key, expectedStrategy).Should().BeTrue();
 
-        registry.TryAdd(key, new TestResilienceStrategy()).Should().BeFalse();
+        registry.TryAddStrategy(key, new TestResilienceStrategy()).Should().BeFalse();
 
-        registry.TryGet(key, out var strategy).Should().BeTrue();
+        registry.TryGetStrategy(key, out var strategy).Should().BeTrue();
         strategy.Should().BeSameAs(expectedStrategy);
     }
 
@@ -349,11 +349,11 @@ public class ResilienceStrategyRegistryTests
         var expectedStrategy = new TestResilienceStrategy<string>();
         var registry = CreateRegistry();
         var key = StrategyId.Create("A", "Instance");
-        registry.TryAdd(key, expectedStrategy).Should().BeTrue();
+        registry.TryAddStrategy(key, expectedStrategy).Should().BeTrue();
 
-        registry.TryAdd(key, new TestResilienceStrategy<string>()).Should().BeFalse();
+        registry.TryAddStrategy(key, new TestResilienceStrategy<string>()).Should().BeFalse();
 
-        registry.TryGet<string>(key, out var strategy).Should().BeTrue();
+        registry.TryGetStrategy<string>(key, out var strategy).Should().BeTrue();
         strategy.Should().BeSameAs(expectedStrategy);
     }
 
@@ -379,7 +379,7 @@ public class ResilienceStrategyRegistryTests
         });
 
         // act
-        var strategy = registry.Get("dummy");
+        var strategy = registry.GetStrategy("dummy");
 
         // assert
         var tries = 0;
@@ -415,7 +415,7 @@ public class ResilienceStrategyRegistryTests
         });
 
         // act
-        var strategy = registry.Get<string>("dummy");
+        var strategy = registry.GetStrategy<string>("dummy");
 
         // assert
         var tries = 0;

--- a/test/Polly.Extensions.Tests/DependencyInjection/PollyServiceCollectionExtensionTests.cs
+++ b/test/Polly.Extensions.Tests/DependencyInjection/PollyServiceCollectionExtensionTests.cs
@@ -75,13 +75,13 @@ public class PollyServiceCollectionExtensionTests
 
         var serviceProvider = _services.BuildServiceProvider();
 
-        serviceProvider.GetRequiredService<ResilienceStrategyRegistry<string>>().Get(Key).Should().NotBeNull();
-        serviceProvider.GetRequiredService<ResilienceStrategyRegistry<string>>().Get<string>(Key).Should().NotBeNull();
-        serviceProvider.GetRequiredService<ResilienceStrategyRegistry<string>>().Get<int>(Key).Should().NotBeNull();
+        serviceProvider.GetRequiredService<ResilienceStrategyRegistry<string>>().GetStrategy(Key).Should().NotBeNull();
+        serviceProvider.GetRequiredService<ResilienceStrategyRegistry<string>>().GetStrategy<string>(Key).Should().NotBeNull();
+        serviceProvider.GetRequiredService<ResilienceStrategyRegistry<string>>().GetStrategy<int>(Key).Should().NotBeNull();
 
-        serviceProvider.GetRequiredService<ResilienceStrategyRegistry<int>>().Get(10).Should().NotBeNull();
-        serviceProvider.GetRequiredService<ResilienceStrategyRegistry<int>>().Get<string>(10).Should().NotBeNull();
-        serviceProvider.GetRequiredService<ResilienceStrategyRegistry<int>>().Get<int>(10).Should().NotBeNull();
+        serviceProvider.GetRequiredService<ResilienceStrategyRegistry<int>>().GetStrategy(10).Should().NotBeNull();
+        serviceProvider.GetRequiredService<ResilienceStrategyRegistry<int>>().GetStrategy<string>(10).Should().NotBeNull();
+        serviceProvider.GetRequiredService<ResilienceStrategyRegistry<int>>().GetStrategy<int>(10).Should().NotBeNull();
     }
 
     [InlineData(true)]
@@ -103,7 +103,7 @@ public class PollyServiceCollectionExtensionTests
                 asserted = true;
             });
 
-            CreateProvider().Get<string>(Key);
+            CreateProvider().GetStrategy<string>(Key);
         }
         else
         {
@@ -116,7 +116,7 @@ public class PollyServiceCollectionExtensionTests
                 asserted = true;
             });
 
-            CreateProvider().Get(Key);
+            CreateProvider().GetStrategy(Key);
         }
 
         asserted.Should().BeTrue();
@@ -142,7 +142,7 @@ public class PollyServiceCollectionExtensionTests
             },
             new TestResilienceStrategyOptions()));
 
-        CreateProvider().Get(Key);
+        CreateProvider().GetStrategy(Key);
 
         var diagSource = telemetry!.GetType().GetProperty("DiagnosticSource", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(telemetry);
         diagSource.Should().BeOfType<ResilienceTelemetryDiagnosticSource>();
@@ -171,7 +171,7 @@ public class PollyServiceCollectionExtensionTests
             asserted = true;
         });
 
-        CreateProvider().Get(Key);
+        CreateProvider().GetStrategy(Key);
 
         asserted.Should().BeTrue();
     }
@@ -194,8 +194,8 @@ public class PollyServiceCollectionExtensionTests
 
         var provider = CreateProvider();
 
-        var strategy = provider.Get(Key);
-        provider.Get("my-strategy").Should().BeSameAs(provider.Get("my-strategy"));
+        var strategy = provider.GetStrategy(Key);
+        provider.GetStrategy("my-strategy").Should().BeSameAs(provider.GetStrategy("my-strategy"));
     }
 
     [InlineData(true)]
@@ -210,13 +210,13 @@ public class PollyServiceCollectionExtensionTests
         {
             AddResilienceStrategy<string>(Key, _ => firstCalled = true);
             AddResilienceStrategy<string>(Key, _ => secondCalled = true);
-            CreateProvider().Get<string>(Key);
+            CreateProvider().GetStrategy<string>(Key);
         }
         else
         {
             AddResilienceStrategy(Key, _ => firstCalled = true);
             AddResilienceStrategy(Key, _ => secondCalled = true);
-            CreateProvider().Get(Key);
+            CreateProvider().GetStrategy(Key);
         }
 
         firstCalled.Should().BeFalse();
@@ -243,9 +243,9 @@ public class PollyServiceCollectionExtensionTests
 
                 return new object[]
                 {
-                    provider.Get(name),
-                    provider.Get<string>(name),
-                    provider.Get<int>(name)
+                    provider.GetStrategy(name),
+                    provider.GetStrategy<string>(name),
+                    provider.GetStrategy<int>(name)
                 };
             })
             .Distinct()

--- a/test/Polly.Extensions.Tests/Issues/IssuesTests.OnCircuitBreakWithServiceProvider_796.cs
+++ b/test/Polly.Extensions.Tests/Issues/IssuesTests.OnCircuitBreakWithServiceProvider_796.cs
@@ -39,7 +39,7 @@ public partial class IssuesTests
 
         // retrieve the provider
         var strategyProvider = serviceCollection.BuildServiceProvider().GetRequiredService<ResilienceStrategyProvider<string>>();
-        var strategy = strategyProvider.Get("my-strategy");
+        var strategy = strategyProvider.GetStrategy("my-strategy");
 
         // now trigger the circuit breaker by evaluating multiple result types
         for (int i = 0; i < 10; i++)

--- a/test/Polly.Extensions.Tests/Issues/IssuesTests.OverrideLibraryStrategies_1072.cs
+++ b/test/Polly.Extensions.Tests/Issues/IssuesTests.OverrideLibraryStrategies_1072.cs
@@ -78,7 +78,7 @@ public partial class IssuesTests
     {
         private readonly ResilienceStrategy _strategy;
 
-        public LibraryApi(ResilienceStrategyProvider<string> provider) => _strategy = provider.Get("library-strategy");
+        public LibraryApi(ResilienceStrategyProvider<string> provider) => _strategy = provider.GetStrategy("library-strategy");
 
         public void ExecuteLibrary(Action execute) => _strategy.Execute(execute);
     }

--- a/test/Polly.Extensions.Tests/ReloadableResilienceStrategyTests.cs
+++ b/test/Polly.Extensions.Tests/ReloadableResilienceStrategyTests.cs
@@ -41,7 +41,7 @@ public class ReloadableResilienceStrategyTests
         });
 
         var serviceProvider = services.BuildServiceProvider();
-        var strategy = serviceProvider.GetRequiredService<ResilienceStrategyProvider<string>>().Get("my-strategy");
+        var strategy = serviceProvider.GetRequiredService<ResilienceStrategyProvider<string>>().GetStrategy("my-strategy");
         var context = ResilienceContext.Get();
         var registry = serviceProvider.GetRequiredService<OptionsReloadHelperRegistry<string>>();
 

--- a/test/Polly.Extensions.Tests/Telemetry/TelemetryResilienceStrategyBuilderExtensionsTests.cs
+++ b/test/Polly.Extensions.Tests/Telemetry/TelemetryResilienceStrategyBuilderExtensionsTests.cs
@@ -12,16 +12,16 @@ public class TelemetryResilienceStrategyBuilderExtensionsTests
     [InlineData(true)]
     [InlineData(false)]
     [Theory]
-    public void EnableTelemetry_EnsureDiagnosticSourceUpdated(bool generic)
+    public void ConfigureTelemetry_EnsureDiagnosticSourceUpdated(bool generic)
     {
         if (generic)
         {
-            _genericBuilder.EnableTelemetry(NullLoggerFactory.Instance);
+            _genericBuilder.ConfigureTelemetry(NullLoggerFactory.Instance);
             _genericBuilder.DiagnosticSource.Should().BeOfType<ResilienceTelemetryDiagnosticSource>();
         }
         else
         {
-            _builder.EnableTelemetry(NullLoggerFactory.Instance);
+            _builder.ConfigureTelemetry(NullLoggerFactory.Instance);
             _builder.DiagnosticSource.Should().BeOfType<ResilienceTelemetryDiagnosticSource>();
             _builder.AddStrategy(new TestResilienceStrategy()).Build().Should().NotBeOfType<TestResilienceStrategy>();
         }
@@ -30,18 +30,18 @@ public class TelemetryResilienceStrategyBuilderExtensionsTests
     [InlineData(true)]
     [InlineData(false)]
     [Theory]
-    public void EnableTelemetry_EnsureLogging(bool generic)
+    public void ConfigureTelemetry_EnsureLogging(bool generic)
     {
         using var factory = TestUtilities.CreateLoggerFactory(out var fakeLogger);
 
         if (generic)
         {
-            _genericBuilder.EnableTelemetry(factory);
+            _genericBuilder.ConfigureTelemetry(factory);
             _genericBuilder.AddStrategy(new TestResilienceStrategy()).Build().Execute(_ => string.Empty);
         }
         else
         {
-            _builder.EnableTelemetry(factory);
+            _builder.ConfigureTelemetry(factory);
             _builder.AddStrategy(new TestResilienceStrategy()).Build().Execute(_ => { });
         }
 
@@ -50,10 +50,10 @@ public class TelemetryResilienceStrategyBuilderExtensionsTests
     }
 
     [Fact]
-    public void EnableTelemetry_InvalidOptions_Throws()
+    public void ConfigureTelemetry_InvalidOptions_Throws()
     {
         _builder
-            .Invoking(b => b.EnableTelemetry(new TelemetryOptions
+            .Invoking(b => b.ConfigureTelemetry(new TelemetryOptions
             {
                 LoggerFactory = null!,
             })).Should()
@@ -66,7 +66,7 @@ public class TelemetryResilienceStrategyBuilderExtensionsTests
             """);
 
         _genericBuilder
-            .Invoking(b => b.EnableTelemetry(new TelemetryOptions
+            .Invoking(b => b.ConfigureTelemetry(new TelemetryOptions
             {
                 LoggerFactory = null!,
             })).Should()


### PR DESCRIPTION
### Details on the issue fix or feature implementation

- `EnableTelemetry` -> `ConfigureTelemetry`
- In `ResilienceStrategyRegistry` and `ResilienceStrategyProvider` some methodnames are more explicit `Get` -> `GetStrategy`
- `AddStrategy` extension method now returns the builder instead of just `void`. (reported in #1324)


### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
