### PR TITLE
Validate NuGet package signatures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -271,6 +271,15 @@ jobs:
           } else {
             Write-Output "All $($dlls.Length) DLLs in NuGet package $package have valid signatures."
           }
+
+          dotnet nuget verify $package
+
+          if ($LASTEXITCODE -ne 0) {
+            Write-Output "::warning::$package failed signature validation."
+            $invalidPackages++
+          } else {
+            Write-Output "$package has a valid signature."
+          }
         }
         if ($invalidPackages -gt 0) {
           Write-Output "::error::$invalidPackages NuGet package(s) failed signature validation."

--- a/build.cake
+++ b/build.cake
@@ -174,7 +174,7 @@ Task("__RunMutationTests")
     TestProject(File("../src/Polly/Polly.csproj"), File("./Polly.Specs/Polly.Specs.csproj"), "Polly.csproj");
 
     context.Environment.WorkingDirectory = oldDirectory;
-    
+
     void TestProject(FilePath proj, FilePath testProj, string project)
     {
         var dotNetBuildSettings = new DotNetBuildSettings
@@ -191,9 +191,9 @@ Task("__RunMutationTests")
         var score = int.Parse(mutationScore);
 
         Information($"Running mutation tests for '{proj}'. Test Project: '{testProj}'");
-        
+
         var args = $"{strykerPath} --project {project} --test-project {testProj.FullPath} --break-at {score} --config-file {strykerConfig} --output {strykerOutput}/{project}";
-        
+
         var result = StartProcess("dotnet", args);
         if (result != 0)
         {


### PR DESCRIPTION
A step to validate the NuGet package signature before pushing to NuGet.org with `nuget verify`.

Added in response to #1323 and #1333.
