### PR TITLE
Add net6.0 and net7.0 to Polly

### DIFF
--- a/src/Polly/CompatibilitySuppressions.xml
+++ b/src/Polly/CompatibilitySuppressions.xml
@@ -140,6 +140,48 @@
     <Right>lib/net462/Polly.dll</Right>
   </Suppression>
   <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Polly.Bulkhead.BulkheadRejectedException.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)</Target>
+    <Left>lib/netstandard2.0/Polly.dll</Left>
+    <Right>lib/net6.0/Polly.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Polly.CircuitBreaker.BrokenCircuitException.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)</Target>
+    <Left>lib/netstandard2.0/Polly.dll</Left>
+    <Right>lib/net6.0/Polly.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Polly.CircuitBreaker.BrokenCircuitException`1.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)</Target>
+    <Left>lib/netstandard2.0/Polly.dll</Left>
+    <Right>lib/net6.0/Polly.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Polly.CircuitBreaker.IsolatedCircuitException.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)</Target>
+    <Left>lib/netstandard2.0/Polly.dll</Left>
+    <Right>lib/net6.0/Polly.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Polly.ExecutionRejectedException.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)</Target>
+    <Left>lib/netstandard2.0/Polly.dll</Left>
+    <Right>lib/net6.0/Polly.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Polly.RateLimit.RateLimitRejectedException.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)</Target>
+    <Left>lib/netstandard2.0/Polly.dll</Left>
+    <Right>lib/net6.0/Polly.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Polly.Timeout.TimeoutRejectedException.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)</Target>
+    <Left>lib/netstandard2.0/Polly.dll</Left>
+    <Right>lib/net6.0/Polly.dll</Right>
+  </Suppression>
+  <Suppression>
     <DiagnosticId>PKV006</DiagnosticId>
     <Target>.NETStandard,Version=v1.1</Target>
   </Suppression>

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;net462;</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netstandard2.0;net472;net462</TargetFrameworks>
     <AssemblyTitle>Polly</AssemblyTitle>
     <ProjectType>Library</ProjectType>
     <MutationScore>70</MutationScore>
@@ -23,5 +23,5 @@
     <ProjectReference Include="..\Polly.Core\Polly.Core.csproj" />
   </ItemGroup>
 
-  
+
 </Project>

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -23,5 +23,4 @@
     <ProjectReference Include="..\Polly.Core\Polly.Core.csproj" />
   </ItemGroup>
 
-
 </Project>


### PR DESCRIPTION
Add `net6.0` and `net7.0` TFMs to Polly to match the other assemblies.
