### PR TITLE
Expose Randomizer property and use it in retry strategy

### DIFF
--- a/src/Polly.Core/ResilienceStrategyBuilderBase.cs
+++ b/src/Polly.Core/ResilienceStrategyBuilderBase.cs
@@ -27,6 +27,8 @@ public abstract class ResilienceStrategyBuilderBase
         Properties = other.Properties;
         TimeProvider = other.TimeProvider;
         OnCreatingStrategy = other.OnCreatingStrategy;
+        Randomizer = other.Randomizer;
+        DiagnosticSource = other.DiagnosticSource;
     }
 
     /// <summary>
@@ -69,6 +71,16 @@ public abstract class ResilienceStrategyBuilderBase
     /// </remarks>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public DiagnosticSource? DiagnosticSource { get; set; }
+
+    /// <summary>
+    /// Gets or sets the randomizer that is used by strategies that need to generate random numbers.
+    /// </summary>
+    /// <remarks>
+    /// The default randomizer is thread safe and returns values between 0.0 and 1.0.
+    /// </remarks>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Required]
+    public Func<double> Randomizer { get; set; } = RandomUtil.Instance.NextDouble;
 
     internal abstract bool IsGenericBuilder { get; }
 
@@ -118,7 +130,8 @@ public abstract class ResilienceStrategyBuilderBase
             strategyType: entry.Properties.StrategyType,
             timeProvider: TimeProvider,
             isGenericBuilder: IsGenericBuilder,
-            diagnosticSource: DiagnosticSource);
+            diagnosticSource: DiagnosticSource,
+            randomizer: Randomizer);
 
         return entry.Factory(context);
     }

--- a/src/Polly.Core/ResilienceStrategyBuilderContext.cs
+++ b/src/Polly.Core/ResilienceStrategyBuilderContext.cs
@@ -2,6 +2,8 @@ using Polly.Telemetry;
 
 namespace Polly;
 
+#pragma warning disable S107
+
 /// <summary>
 /// The context used for building an individual resilience strategy.
 /// </summary>
@@ -14,7 +16,8 @@ public sealed class ResilienceStrategyBuilderContext
         string strategyType,
         TimeProvider timeProvider,
         bool isGenericBuilder,
-        DiagnosticSource? diagnosticSource)
+        DiagnosticSource? diagnosticSource,
+        Func<double> randomizer)
     {
         BuilderName = builderName;
         BuilderProperties = builderProperties;
@@ -23,6 +26,7 @@ public sealed class ResilienceStrategyBuilderContext
         TimeProvider = timeProvider;
         IsGenericBuilder = isGenericBuilder;
         Telemetry = TelemetryUtil.CreateTelemetry(diagnosticSource, builderName, builderProperties, strategyName, strategyType);
+        Randomizer = randomizer;
     }
 
     /// <summary>
@@ -54,6 +58,8 @@ public sealed class ResilienceStrategyBuilderContext
     /// Gets the <see cref="TimeProvider"/> used by this strategy.
     /// </summary>
     internal TimeProvider TimeProvider { get; }
+
+    internal Func<double> Randomizer { get; }
 
     internal bool IsGenericBuilder { get; }
 }

--- a/src/Polly.Core/Retry/RetryResilienceStrategy.cs
+++ b/src/Polly.Core/Retry/RetryResilienceStrategy.cs
@@ -1,3 +1,4 @@
+using System;
 using Polly.Telemetry;
 
 namespace Polly.Retry;
@@ -6,14 +7,14 @@ internal sealed class RetryResilienceStrategy<T> : OutcomeResilienceStrategy<T>
 {
     private readonly TimeProvider _timeProvider;
     private readonly ResilienceStrategyTelemetry _telemetry;
-    private readonly RandomUtil _randomUtil;
+    private readonly Func<double> _randomizer;
 
     public RetryResilienceStrategy(
         RetryStrategyOptions<T> options,
         bool isGeneric,
         TimeProvider timeProvider,
         ResilienceStrategyTelemetry telemetry,
-        RandomUtil randomUtil)
+        Func<double> randomizer)
         : base(isGeneric)
     {
         ShouldHandle = options.ShouldHandle;
@@ -25,7 +26,7 @@ internal sealed class RetryResilienceStrategy<T> : OutcomeResilienceStrategy<T>
 
         _timeProvider = timeProvider;
         _telemetry = telemetry;
-        _randomUtil = randomUtil;
+        _randomizer = randomizer;
     }
 
     public TimeSpan BaseDelay { get; }
@@ -61,7 +62,7 @@ internal sealed class RetryResilienceStrategy<T> : OutcomeResilienceStrategy<T>
                 return outcome;
             }
 
-            var delay = RetryHelper.GetRetryDelay(BackoffType, attempt, BaseDelay, ref retryState, _randomUtil);
+            var delay = RetryHelper.GetRetryDelay(BackoffType, attempt, BaseDelay, ref retryState, _randomizer);
             if (DelayGenerator is not null)
             {
                 var delayArgs = new OutcomeArguments<T, RetryDelayArguments>(context, outcome, new RetryDelayArguments(attempt, delay));

--- a/src/Polly.Core/Retry/RetryResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/Retry/RetryResilienceStrategyBuilderExtensions.cs
@@ -50,7 +50,7 @@ public static class RetryResilienceStrategyBuilderExtensions
                 context.IsGenericBuilder,
                 context.TimeProvider,
                 context.Telemetry,
-                RandomUtil.Instance),
+                context.Randomizer),
             options);
     }
 }

--- a/test/Polly.Core.Tests/ResilienceStrategyBuilderContextTests.cs
+++ b/test/Polly.Core.Tests/ResilienceStrategyBuilderContextTests.cs
@@ -9,7 +9,7 @@ public class ResilienceStrategyBuilderContextTests
     {
         var properties = new ResilienceProperties();
         var timeProvider = new FakeTimeProvider();
-        var context = new ResilienceStrategyBuilderContext("builder-name", properties, "strategy-name", "strategy-type", timeProvider.Object, true, Mock.Of<DiagnosticSource>());
+        var context = new ResilienceStrategyBuilderContext("builder-name", properties, "strategy-name", "strategy-type", timeProvider.Object, true, Mock.Of<DiagnosticSource>(), () => 1.0);
 
         context.IsGenericBuilder.Should().BeTrue();
         context.BuilderName.Should().Be("builder-name");
@@ -18,6 +18,7 @@ public class ResilienceStrategyBuilderContextTests
         context.StrategyType.Should().Be("strategy-type");
         context.TimeProvider.Should().Be(timeProvider.Object);
         context.Telemetry.Should().NotBeNull();
+        context.Randomizer.Should().NotBeNull();
 
         context.Telemetry.TelemetrySource.BuilderName.Should().Be("builder-name");
         context.Telemetry.TelemetrySource.BuilderProperties.Should().BeSameAs(properties);

--- a/test/Polly.Core.Tests/Retry/RetryHelperTests.cs
+++ b/test/Polly.Core.Tests/Retry/RetryHelperTests.cs
@@ -6,7 +6,7 @@ namespace Polly.Core.Tests.Retry;
 
 public class RetryHelperTests
 {
-    private readonly RandomUtil _randomUtil = new(0);
+    private readonly Func<double> _randomizer = new RandomUtil(0).NextDouble;
 
     [Fact]
     public void IsValidDelay_Ok()
@@ -26,7 +26,7 @@ public class RetryHelperTests
         Assert.Throws<ArgumentOutOfRangeException>(() =>
         {
             double state = 0;
-            return RetryHelper.GetRetryDelay(type, 0, TimeSpan.FromSeconds(1), ref state, _randomUtil);
+            return RetryHelper.GetRetryDelay(type, 0, TimeSpan.FromSeconds(1), ref state, _randomizer);
         });
     }
 
@@ -35,13 +35,13 @@ public class RetryHelperTests
     {
         double state = 0;
 
-        RetryHelper.GetRetryDelay(RetryBackoffType.Constant, 0, TimeSpan.Zero, ref state, _randomUtil).Should().Be(TimeSpan.Zero);
-        RetryHelper.GetRetryDelay(RetryBackoffType.Constant, 1, TimeSpan.Zero, ref state, _randomUtil).Should().Be(TimeSpan.Zero);
-        RetryHelper.GetRetryDelay(RetryBackoffType.Constant, 2, TimeSpan.Zero, ref state, _randomUtil).Should().Be(TimeSpan.Zero);
+        RetryHelper.GetRetryDelay(RetryBackoffType.Constant, 0, TimeSpan.Zero, ref state, _randomizer).Should().Be(TimeSpan.Zero);
+        RetryHelper.GetRetryDelay(RetryBackoffType.Constant, 1, TimeSpan.Zero, ref state, _randomizer).Should().Be(TimeSpan.Zero);
+        RetryHelper.GetRetryDelay(RetryBackoffType.Constant, 2, TimeSpan.Zero, ref state, _randomizer).Should().Be(TimeSpan.Zero);
 
-        RetryHelper.GetRetryDelay(RetryBackoffType.Constant, 0, TimeSpan.FromSeconds(1), ref state, _randomUtil).Should().Be(TimeSpan.FromSeconds(1));
-        RetryHelper.GetRetryDelay(RetryBackoffType.Constant, 1, TimeSpan.FromSeconds(1), ref state, _randomUtil).Should().Be(TimeSpan.FromSeconds(1));
-        RetryHelper.GetRetryDelay(RetryBackoffType.Constant, 2, TimeSpan.FromSeconds(1), ref state, _randomUtil).Should().Be(TimeSpan.FromSeconds(1));
+        RetryHelper.GetRetryDelay(RetryBackoffType.Constant, 0, TimeSpan.FromSeconds(1), ref state, _randomizer).Should().Be(TimeSpan.FromSeconds(1));
+        RetryHelper.GetRetryDelay(RetryBackoffType.Constant, 1, TimeSpan.FromSeconds(1), ref state, _randomizer).Should().Be(TimeSpan.FromSeconds(1));
+        RetryHelper.GetRetryDelay(RetryBackoffType.Constant, 2, TimeSpan.FromSeconds(1), ref state, _randomizer).Should().Be(TimeSpan.FromSeconds(1));
     }
 
     [Fact]
@@ -49,13 +49,13 @@ public class RetryHelperTests
     {
         double state = 0;
 
-        RetryHelper.GetRetryDelay(RetryBackoffType.Linear, 0, TimeSpan.Zero, ref state, _randomUtil).Should().Be(TimeSpan.Zero);
-        RetryHelper.GetRetryDelay(RetryBackoffType.Linear, 1, TimeSpan.Zero, ref state, _randomUtil).Should().Be(TimeSpan.Zero);
-        RetryHelper.GetRetryDelay(RetryBackoffType.Linear, 2, TimeSpan.Zero, ref state, _randomUtil).Should().Be(TimeSpan.Zero);
+        RetryHelper.GetRetryDelay(RetryBackoffType.Linear, 0, TimeSpan.Zero, ref state, _randomizer).Should().Be(TimeSpan.Zero);
+        RetryHelper.GetRetryDelay(RetryBackoffType.Linear, 1, TimeSpan.Zero, ref state, _randomizer).Should().Be(TimeSpan.Zero);
+        RetryHelper.GetRetryDelay(RetryBackoffType.Linear, 2, TimeSpan.Zero, ref state, _randomizer).Should().Be(TimeSpan.Zero);
 
-        RetryHelper.GetRetryDelay(RetryBackoffType.Linear, 0, TimeSpan.FromSeconds(1), ref state, _randomUtil).Should().Be(TimeSpan.FromSeconds(1));
-        RetryHelper.GetRetryDelay(RetryBackoffType.Linear, 1, TimeSpan.FromSeconds(1), ref state, _randomUtil).Should().Be(TimeSpan.FromSeconds(2));
-        RetryHelper.GetRetryDelay(RetryBackoffType.Linear, 2, TimeSpan.FromSeconds(1), ref state, _randomUtil).Should().Be(TimeSpan.FromSeconds(3));
+        RetryHelper.GetRetryDelay(RetryBackoffType.Linear, 0, TimeSpan.FromSeconds(1), ref state, _randomizer).Should().Be(TimeSpan.FromSeconds(1));
+        RetryHelper.GetRetryDelay(RetryBackoffType.Linear, 1, TimeSpan.FromSeconds(1), ref state, _randomizer).Should().Be(TimeSpan.FromSeconds(2));
+        RetryHelper.GetRetryDelay(RetryBackoffType.Linear, 2, TimeSpan.FromSeconds(1), ref state, _randomizer).Should().Be(TimeSpan.FromSeconds(3));
     }
 
     [Fact]
@@ -63,13 +63,13 @@ public class RetryHelperTests
     {
         double state = 0;
 
-        RetryHelper.GetRetryDelay(RetryBackoffType.Exponential, 0, TimeSpan.Zero, ref state, _randomUtil).Should().Be(TimeSpan.Zero);
-        RetryHelper.GetRetryDelay(RetryBackoffType.Exponential, 1, TimeSpan.Zero, ref state, _randomUtil).Should().Be(TimeSpan.Zero);
-        RetryHelper.GetRetryDelay(RetryBackoffType.Exponential, 2, TimeSpan.Zero, ref state, _randomUtil).Should().Be(TimeSpan.Zero);
+        RetryHelper.GetRetryDelay(RetryBackoffType.Exponential, 0, TimeSpan.Zero, ref state, _randomizer).Should().Be(TimeSpan.Zero);
+        RetryHelper.GetRetryDelay(RetryBackoffType.Exponential, 1, TimeSpan.Zero, ref state, _randomizer).Should().Be(TimeSpan.Zero);
+        RetryHelper.GetRetryDelay(RetryBackoffType.Exponential, 2, TimeSpan.Zero, ref state, _randomizer).Should().Be(TimeSpan.Zero);
 
-        RetryHelper.GetRetryDelay(RetryBackoffType.Exponential, 0, TimeSpan.FromSeconds(1), ref state, _randomUtil).Should().Be(TimeSpan.FromSeconds(1));
-        RetryHelper.GetRetryDelay(RetryBackoffType.Exponential, 1, TimeSpan.FromSeconds(1), ref state, _randomUtil).Should().Be(TimeSpan.FromSeconds(2));
-        RetryHelper.GetRetryDelay(RetryBackoffType.Exponential, 2, TimeSpan.FromSeconds(1), ref state, _randomUtil).Should().Be(TimeSpan.FromSeconds(4));
+        RetryHelper.GetRetryDelay(RetryBackoffType.Exponential, 0, TimeSpan.FromSeconds(1), ref state, _randomizer).Should().Be(TimeSpan.FromSeconds(1));
+        RetryHelper.GetRetryDelay(RetryBackoffType.Exponential, 1, TimeSpan.FromSeconds(1), ref state, _randomizer).Should().Be(TimeSpan.FromSeconds(2));
+        RetryHelper.GetRetryDelay(RetryBackoffType.Exponential, 2, TimeSpan.FromSeconds(1), ref state, _randomizer).Should().Be(TimeSpan.FromSeconds(4));
     }
 
     [InlineData(1)]
@@ -94,20 +94,20 @@ public class RetryHelperTests
     public void ExponentialWithJitter_EnsureRandomness()
     {
         var delay = TimeSpan.FromSeconds(7.8);
-        var delays1 = GetExponentialWithJitterBackoff(false, delay, 100, RandomUtil.Instance);
-        var delays2 = GetExponentialWithJitterBackoff(false, delay, 100, RandomUtil.Instance);
+        var delays1 = GetExponentialWithJitterBackoff(false, delay, 100, RandomUtil.Instance.NextDouble);
+        var delays2 = GetExponentialWithJitterBackoff(false, delay, 100, RandomUtil.Instance.NextDouble);
 
         delays1.SequenceEqual(delays2).Should().BeFalse();
     }
 
-    private static IReadOnlyList<TimeSpan> GetExponentialWithJitterBackoff(bool contrib, TimeSpan baseDelay, int retryCount, RandomUtil? util = null)
+    private static IReadOnlyList<TimeSpan> GetExponentialWithJitterBackoff(bool contrib, TimeSpan baseDelay, int retryCount, Func<double>? randomizer = null)
     {
         if (contrib)
         {
             return Backoff.DecorrelatedJitterBackoffV2(baseDelay, retryCount, 0, false).Take(retryCount).ToArray();
         }
 
-        var random = util ?? new RandomUtil(0);
+        var random = randomizer ?? new RandomUtil(0).NextDouble;
         double state = 0;
         var result = new List<TimeSpan>();
 

--- a/test/Polly.Core.Tests/Retry/RetryResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Retry/RetryResilienceStrategyTests.cs
@@ -1,7 +1,6 @@
 using Moq;
 using Polly.Retry;
 using Polly.Telemetry;
-using Polly.Utils;
 
 namespace Polly.Core.Tests.Retry;
 
@@ -314,13 +313,10 @@ public class RetryResilienceStrategyTests
 
     private void SetupNoDelay() => _options.RetryDelayGenerator = _ => new ValueTask<TimeSpan>(TimeSpan.Zero);
 
-    private RetryResilienceStrategy<object> CreateSut(TimeProvider? timeProvider = null)
-    {
-        return new RetryResilienceStrategy<object>(
-            _options,
+    private RetryResilienceStrategy<object> CreateSut(TimeProvider? timeProvider = null) =>
+        new(_options,
             false,
             timeProvider ?? _timeProvider.Object,
             _telemetry,
-            RandomUtil.Instance);
-    }
+            () => 1.0);
 }


### PR DESCRIPTION
### Details on the issue fix or feature implementation

This PR exposes `ResilienceStrategyBuilder.Randomizer` (altought hidden for now) that allows to control the randomization behavior in tests. Additionally, I have fixed the copy constructor which omitted some properties. 

This change also allows (with some tricks) to calculate the aggregated delays of retry strategy.

I will use this here instead of custom code:
https://github.com/dotnet/extensions/blob/52ebc1b123613254f9dfe250515027c1332fba35/src/Libraries/Microsoft.Extensions.Http.Resilience/Resilience/Internal/Validators/ValidationHelper.cs#L13





### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
