### PR TITLE
Rename FakeTimeProvider

### DIFF
--- a/src/Polly.Core/Utils/DisposeHelper.cs
+++ b/src/Polly.Core/Utils/DisposeHelper.cs
@@ -32,9 +32,9 @@ internal static class DisposeHelper
                 }
             }
         }
-        catch (Exception e)
+        catch (Exception)
         {
-            Debug.Assert(false, e.ToString());
+            // Swallow any exception
         }
     }
 }

--- a/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerResilienceStrategyBuilderTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerResilienceStrategyBuilderTests.cs
@@ -100,7 +100,7 @@ public class CircuitBreakerResilienceStrategyBuilderTests
             OnHalfOpened = (_) => { halfOpened++; return default; }
         };
 
-        var timeProvider = new FakeTimeProvider();
+        var timeProvider = new MockTimeProvider();
         var strategy = new ResilienceStrategyBuilder { TimeProvider = timeProvider.Object }.AddSimpleCircuitBreaker(options).Build();
         var time = DateTime.UtcNow;
         timeProvider.Setup(v => v.GetUtcNow()).Returns(() => time);
@@ -151,7 +151,7 @@ public class CircuitBreakerResilienceStrategyBuilderTests
             OnHalfOpened = (_) => { halfOpened++; return default; }
         };
 
-        var timeProvider = new FakeTimeProvider();
+        var timeProvider = new MockTimeProvider();
         var strategy = new ResilienceStrategyBuilder { TimeProvider = timeProvider.Object }.AddAdvancedCircuitBreaker(options).Build();
         var time = DateTime.UtcNow;
         timeProvider.Setup(v => v.GetUtcNow()).Returns(() => time);

--- a/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerResilienceStrategyTests.cs
@@ -6,7 +6,7 @@ namespace Polly.Core.Tests.CircuitBreaker;
 
 public class CircuitBreakerResilienceStrategyTests : IDisposable
 {
-    private readonly FakeTimeProvider _timeProvider;
+    private readonly MockTimeProvider _timeProvider;
     private readonly Mock<CircuitBehavior> _behavior;
     private readonly ResilienceStrategyTelemetry _telemetry;
     private readonly SimpleCircuitBreakerStrategyOptions<int> _options;
@@ -14,7 +14,7 @@ public class CircuitBreakerResilienceStrategyTests : IDisposable
 
     public CircuitBreakerResilienceStrategyTests()
     {
-        _timeProvider = new FakeTimeProvider();
+        _timeProvider = new MockTimeProvider();
         _timeProvider.Setup(v => v.GetUtcNow()).Returns(DateTime.UtcNow);
         _behavior = new Mock<CircuitBehavior>(MockBehavior.Strict);
         _telemetry = TestUtilities.CreateResilienceTelemetry(Mock.Of<DiagnosticSource>());

--- a/test/Polly.Core.Tests/CircuitBreaker/Controller/CircuitStateControllerTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/Controller/CircuitStateControllerTests.cs
@@ -5,7 +5,7 @@ using Polly.Telemetry;
 namespace Polly.Core.Tests.CircuitBreaker.Controller;
 public class CircuitStateControllerTests
 {
-    private readonly FakeTimeProvider _timeProvider = new();
+    private readonly MockTimeProvider _timeProvider = new();
     private readonly CircuitBreakerStrategyOptions<int> _options = new SimpleCircuitBreakerStrategyOptions<int>();
     private readonly Mock<CircuitBehavior> _circuitBehavior = new(MockBehavior.Strict);
     private readonly Action<TelemetryEventArguments> _onTelemetry = _ => { };

--- a/test/Polly.Core.Tests/CircuitBreaker/Health/RollingHealthMetricsTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/Health/RollingHealthMetricsTests.cs
@@ -3,11 +3,11 @@ using Polly.CircuitBreaker.Health;
 namespace Polly.Core.Tests.CircuitBreaker.Health;
 public class RollingHealthMetricsTests
 {
-    private readonly FakeTimeProvider _timeProvider;
+    private readonly MockTimeProvider _timeProvider;
     private readonly TimeSpan _samplingDuration = TimeSpan.FromSeconds(10);
     private readonly short _windows = 10;
 
-    public RollingHealthMetricsTests() => _timeProvider = new FakeTimeProvider().SetupUtcNow();
+    public RollingHealthMetricsTests() => _timeProvider = new MockTimeProvider().SetupUtcNow();
 
     [Fact]
     public void Ctor_EnsureDefaults()

--- a/test/Polly.Core.Tests/CircuitBreaker/Health/SingleHealthMetricsTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/Health/SingleHealthMetricsTests.cs
@@ -3,9 +3,9 @@ using Polly.CircuitBreaker.Health;
 namespace Polly.Core.Tests.CircuitBreaker.Health;
 public class SingleHealthMetricsTests
 {
-    private readonly FakeTimeProvider _timeProvider;
+    private readonly MockTimeProvider _timeProvider;
 
-    public SingleHealthMetricsTests() => _timeProvider = new FakeTimeProvider().SetupUtcNow();
+    public SingleHealthMetricsTests() => _timeProvider = new MockTimeProvider().SetupUtcNow();
 
     [Fact]
     public void Ctor_EnsureDefaults()

--- a/test/Polly.Core.Tests/GenericResilienceStrategyBuilderTests.cs
+++ b/test/Polly.Core.Tests/GenericResilienceStrategyBuilderTests.cs
@@ -28,7 +28,7 @@ public class GenericResilienceStrategyBuilderTests
         _builder.BuilderName = "dummy";
         _builder.BuilderName.Should().Be("dummy");
 
-        var timeProvider = new FakeTimeProvider().Object;
+        var timeProvider = new MockTimeProvider().Object;
         _builder.TimeProvider = timeProvider;
         _builder.TimeProvider.Should().Be(timeProvider);
 

--- a/test/Polly.Core.Tests/Helpers/MockTimeProvider.cs
+++ b/test/Polly.Core.Tests/Helpers/MockTimeProvider.cs
@@ -2,23 +2,23 @@ using Moq;
 
 namespace Polly.Core.Tests.Helpers;
 
-internal class FakeTimeProvider : Mock<TimeProvider>
+internal class MockTimeProvider : Mock<TimeProvider>
 {
     private DateTimeOffset? _time;
 
-    public FakeTimeProvider()
+    public MockTimeProvider()
         : base(MockBehavior.Strict)
     {
     }
 
-    public FakeTimeProvider SetupUtcNow(DateTimeOffset? time = null)
+    public MockTimeProvider SetupUtcNow(DateTimeOffset? time = null)
     {
         _time = time ?? DateTimeOffset.UtcNow;
         Setup(x => x.GetUtcNow()).Returns(() => _time.Value);
         return this;
     }
 
-    public FakeTimeProvider AdvanceTime(TimeSpan time)
+    public MockTimeProvider AdvanceTime(TimeSpan time)
     {
         if (_time == null)
         {
@@ -29,37 +29,37 @@ internal class FakeTimeProvider : Mock<TimeProvider>
         return this;
     }
 
-    public FakeTimeProvider SetupTimestampFrequency()
+    public MockTimeProvider SetupTimestampFrequency()
     {
         Setup(x => x.TimestampFrequency).Returns(Stopwatch.Frequency);
         return this;
     }
 
-    public FakeTimeProvider SetupAnyDelay(CancellationToken cancellationToken = default)
+    public MockTimeProvider SetupAnyDelay(CancellationToken cancellationToken = default)
     {
         Setup(x => x.Delay(It.IsAny<TimeSpan>(), cancellationToken)).Returns(Task.CompletedTask);
         return this;
     }
 
-    public FakeTimeProvider SetupGetTimestamp()
+    public MockTimeProvider SetupGetTimestamp()
     {
         Setup(x => x.GetTimestamp()).Returns(0);
         return this;
     }
 
-    public FakeTimeProvider SetupDelay(TimeSpan delay, CancellationToken cancellationToken = default)
+    public MockTimeProvider SetupDelay(TimeSpan delay, CancellationToken cancellationToken = default)
     {
         Setup(x => x.Delay(delay, cancellationToken)).Returns(Task.CompletedTask);
         return this;
     }
 
-    public FakeTimeProvider SetupDelayCancelled(TimeSpan delay, CancellationToken cancellationToken = default)
+    public MockTimeProvider SetupDelayCancelled(TimeSpan delay, CancellationToken cancellationToken = default)
     {
         Setup(x => x.Delay(delay, cancellationToken)).ThrowsAsync(new OperationCanceledException());
         return this;
     }
 
-    public FakeTimeProvider SetupCancelAfterNow(TimeSpan delay)
+    public MockTimeProvider SetupCancelAfterNow(TimeSpan delay)
     {
         Setup(v => v.CancelAfter(It.IsAny<CancellationTokenSource>(), delay)).Callback<CancellationTokenSource, TimeSpan>((cts, _) => cts.Cancel());
         return this;

--- a/test/Polly.Core.Tests/Issues/IssuesTests.cs
+++ b/test/Polly.Core.Tests/Issues/IssuesTests.cs
@@ -2,5 +2,5 @@ namespace Polly.Core.Tests.Issues;
 
 public partial class IssuesTests
 {
-    private FakeTimeProvider TimeProvider { get; } = new FakeTimeProvider().SetupUtcNow().SetupAnyDelay().SetupGetTimestamp().SetupTimestampFrequency();
+    private MockTimeProvider TimeProvider { get; } = new MockTimeProvider().SetupUtcNow().SetupAnyDelay().SetupGetTimestamp().SetupTimestampFrequency();
 }

--- a/test/Polly.Core.Tests/ResilienceStrategyBuilderContextTests.cs
+++ b/test/Polly.Core.Tests/ResilienceStrategyBuilderContextTests.cs
@@ -8,7 +8,7 @@ public class ResilienceStrategyBuilderContextTests
     public void Ctor_EnsureDefaults()
     {
         var properties = new ResilienceProperties();
-        var timeProvider = new FakeTimeProvider();
+        var timeProvider = new MockTimeProvider();
         var context = new ResilienceStrategyBuilderContext("builder-name", properties, "strategy-name", "strategy-type", timeProvider.Object, true, Mock.Of<DiagnosticSource>(), () => 1.0);
 
         context.IsGenericBuilder.Should().BeTrue();

--- a/test/Polly.Core.Tests/ResilienceStrategyBuilderTests.cs
+++ b/test/Polly.Core.Tests/ResilienceStrategyBuilderTests.cs
@@ -268,7 +268,7 @@ The RequiredProperty field is required.
         var builder = new ResilienceStrategyBuilder
         {
             BuilderName = "builder-name",
-            TimeProvider = new FakeTimeProvider().Object,
+            TimeProvider = new MockTimeProvider().Object,
         };
 
         builder.AddStrategy(

--- a/test/Polly.Core.Tests/Retry/RetryResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Retry/RetryResilienceStrategyTests.cs
@@ -7,7 +7,7 @@ namespace Polly.Core.Tests.Retry;
 public class RetryResilienceStrategyTests
 {
     private readonly RetryStrategyOptions _options = new();
-    private readonly FakeTimeProvider _timeProvider = new();
+    private readonly MockTimeProvider _timeProvider = new();
     private readonly Mock<DiagnosticSource> _diagnosticSource = new();
     private ResilienceStrategyTelemetry _telemetry;
 

--- a/test/Polly.Core.Tests/Timeout/TimeoutResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Timeout/TimeoutResilienceStrategyTests.cs
@@ -7,7 +7,7 @@ namespace Polly.Core.Tests.Timeout;
 public class TimeoutResilienceStrategyTests : IDisposable
 {
     private readonly ResilienceStrategyTelemetry _telemetry;
-    private readonly FakeTimeProvider _timeProvider;
+    private readonly MockTimeProvider _timeProvider;
     private readonly TimeoutStrategyOptions _options;
     private readonly CancellationTokenSource _cancellationSource;
     private readonly TimeSpan _delay = TimeSpan.FromSeconds(12);
@@ -16,7 +16,7 @@ public class TimeoutResilienceStrategyTests : IDisposable
     public TimeoutResilienceStrategyTests()
     {
         _telemetry = TestUtilities.CreateResilienceTelemetry(_diagnosticSource.Object);
-        _timeProvider = new FakeTimeProvider();
+        _timeProvider = new MockTimeProvider();
         _options = new TimeoutStrategyOptions();
         _cancellationSource = new CancellationTokenSource();
     }

--- a/test/Polly.Core.Tests/Utils/CancellationTokenSourcePoolTests.cs
+++ b/test/Polly.Core.Tests/Utils/CancellationTokenSourcePoolTests.cs
@@ -8,7 +8,7 @@ public class CancellationTokenSourcePoolTests
     public static IEnumerable<object[]> TimeProviders()
     {
         yield return new object[] { TimeProvider.System };
-        yield return new object[] { new FakeTimeProvider() };
+        yield return new object[] { new MockTimeProvider() };
     }
 
     [Fact]

--- a/test/Polly.Core.Tests/Utils/TimeProviderExtensionsTests.cs
+++ b/test/Polly.Core.Tests/Utils/TimeProviderExtensionsTests.cs
@@ -18,7 +18,7 @@ public class TimeProviderExtensionsTests
         using var tcs = new CancellationTokenSource();
         var token = hasCancellation ? tcs.Token : default;
         var delay = TimeSpan.FromMilliseconds(10);
-        var mock = new FakeTimeProvider();
+        var mock = new MockTimeProvider();
         var timeProvider = mocked ? mock.Object : TimeProvider.System;
         var context = ResilienceContext.Get();
         context.Initialize<VoidResult>(isSynchronous: synchronous);
@@ -83,7 +83,7 @@ public class TimeProviderExtensionsTests
         tcs.Cancel();
         var token = tcs.Token;
         var delay = TimeSpan.FromMilliseconds(10);
-        var mock = new FakeTimeProvider();
+        var mock = new MockTimeProvider();
         var timeProvider = mocked ? mock.Object : TimeProvider.System;
         var context = ResilienceContext.Get();
         context.Initialize<VoidResult>(isSynchronous: synchronous);
@@ -104,7 +104,7 @@ public class TimeProviderExtensionsTests
 
         await TestUtilities.AssertWithTimeoutAsync(async () =>
         {
-            var mock = new FakeTimeProvider();
+            var mock = new MockTimeProvider();
             using var tcs = new CancellationTokenSource();
             var token = tcs.Token;
             var timeProvider = mocked ? mock.Object : TimeProvider.System;

--- a/test/Polly.Extensions.Tests/Polly.Extensions.Tests.csproj
+++ b/test/Polly.Extensions.Tests/Polly.Extensions.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Polly.Core.Tests\Helpers\FakeTimeProvider.cs" Link="Utils\FakeTimeProvider.cs" />
+    <Compile Include="..\Polly.Core.Tests\Helpers\MockTimeProvider.cs" Link="Utils\MockTimeProvider.cs" />
     <Compile Include="..\Polly.Core.Tests\Utils\ObjectPoolTests.cs" Link="Utils\ObjectPoolTests.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
- Rename `FakeTimeProvider` to `MockTimeProvider` to make it easier to migrate to `FakeTimeProvider` when `TimeProvider` from Microsoft.Bcl.TimeProvider (or .NET 8) is used.
- Fix test failure when running in Debug instead of Release caused by `Microsoft.VisualStudio.TestPlatform.TestHost.DebugAssertException` when `Debug.Assert()` fires.
