### PR TITLE
Adopt FakeTimeProvider

### DIFF
--- a/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerResilienceStrategyTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Polly.CircuitBreaker;
 using Polly.Telemetry;
@@ -6,7 +7,7 @@ namespace Polly.Core.Tests.CircuitBreaker;
 
 public class CircuitBreakerResilienceStrategyTests : IDisposable
 {
-    private readonly MockTimeProvider _timeProvider;
+    private readonly FakeTimeProvider _timeProvider;
     private readonly Mock<CircuitBehavior> _behavior;
     private readonly ResilienceStrategyTelemetry _telemetry;
     private readonly SimpleCircuitBreakerStrategyOptions<int> _options;
@@ -14,8 +15,7 @@ public class CircuitBreakerResilienceStrategyTests : IDisposable
 
     public CircuitBreakerResilienceStrategyTests()
     {
-        _timeProvider = new MockTimeProvider();
-        _timeProvider.Setup(v => v.GetUtcNow()).Returns(DateTime.UtcNow);
+        _timeProvider = new FakeTimeProvider();
         _behavior = new Mock<CircuitBehavior>(MockBehavior.Strict);
         _telemetry = TestUtilities.CreateResilienceTelemetry(Mock.Of<DiagnosticSource>());
         _options = new SimpleCircuitBreakerStrategyOptions<int>();
@@ -25,7 +25,7 @@ public class CircuitBreakerResilienceStrategyTests : IDisposable
             null,
             null,
             _behavior.Object,
-            _timeProvider.Object,
+            _timeProvider,
             _telemetry);
     }
 

--- a/test/Polly.Core.Tests/CircuitBreaker/Health/SingleHealthMetricsTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/Health/SingleHealthMetricsTests.cs
@@ -1,16 +1,18 @@
+using Microsoft.Extensions.Time.Testing;
 using Polly.CircuitBreaker.Health;
 
 namespace Polly.Core.Tests.CircuitBreaker.Health;
+
 public class SingleHealthMetricsTests
 {
-    private readonly MockTimeProvider _timeProvider;
+    private readonly FakeTimeProvider _timeProvider;
 
-    public SingleHealthMetricsTests() => _timeProvider = new MockTimeProvider().SetupUtcNow();
+    public SingleHealthMetricsTests() => _timeProvider = new FakeTimeProvider();
 
     [Fact]
     public void Ctor_EnsureDefaults()
     {
-        var metrics = new SingleHealthMetrics(TimeSpan.FromMilliseconds(100), _timeProvider.Object);
+        var metrics = new SingleHealthMetrics(TimeSpan.FromMilliseconds(100), _timeProvider);
         var health = metrics.GetHealthInfo();
 
         health.FailureRate.Should().Be(0);
@@ -20,7 +22,7 @@ public class SingleHealthMetricsTests
     [Fact]
     public void Increment_Ok()
     {
-        var metrics = new SingleHealthMetrics(TimeSpan.FromMilliseconds(100), _timeProvider.Object);
+        var metrics = new SingleHealthMetrics(TimeSpan.FromMilliseconds(100), _timeProvider);
 
         metrics.IncrementFailure();
         metrics.IncrementSuccess();
@@ -37,7 +39,7 @@ public class SingleHealthMetricsTests
     [Fact]
     public void Reset_Ok()
     {
-        var metrics = new SingleHealthMetrics(TimeSpan.FromMilliseconds(100), _timeProvider.Object);
+        var metrics = new SingleHealthMetrics(TimeSpan.FromMilliseconds(100), _timeProvider);
 
         metrics.IncrementSuccess();
         metrics.Reset();
@@ -48,12 +50,12 @@ public class SingleHealthMetricsTests
     [Fact]
     public void SamplingDurationRespected_Ok()
     {
-        var metrics = new SingleHealthMetrics(TimeSpan.FromMilliseconds(100), _timeProvider.Object);
+        var metrics = new SingleHealthMetrics(TimeSpan.FromMilliseconds(100), _timeProvider);
 
         metrics.IncrementSuccess();
         metrics.IncrementSuccess();
 
-        _timeProvider.AdvanceTime(TimeSpan.FromMilliseconds(100));
+        _timeProvider.Advance(TimeSpan.FromMilliseconds(100));
 
         metrics.GetHealthInfo().Throughput.Should().Be(0);
     }

--- a/test/Polly.Core.Tests/GenericResilienceStrategyBuilderTests.cs
+++ b/test/Polly.Core.Tests/GenericResilienceStrategyBuilderTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Time.Testing;
 using Polly.Utils;
 
 namespace Polly.Core.Tests;
@@ -28,7 +29,7 @@ public class GenericResilienceStrategyBuilderTests
         _builder.BuilderName = "dummy";
         _builder.BuilderName.Should().Be("dummy");
 
-        var timeProvider = new MockTimeProvider().Object;
+        var timeProvider = new FakeTimeProvider();
         _builder.TimeProvider = timeProvider;
         _builder.TimeProvider.Should().Be(timeProvider);
 

--- a/test/Polly.Core.Tests/Helpers/FakeTimeProvider.cs
+++ b/test/Polly.Core.Tests/Helpers/FakeTimeProvider.cs
@@ -1,0 +1,279 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable
+
+// Replace with Microsoft.Extensions.TimeProvider.Testing when TimeProvider is used (see https://github.com/App-vNext/Polly/pull/1144)
+// Based on https://github.com/dotnet/extensions/blob/14917b87e8fc81f10d44ceea52d9b24e50e26550/src/Libraries/Microsoft.Extensions.TimeProvider.Testing/FakeTimeProvider.cs
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Threading;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Microsoft.Extensions.Time.Testing;
+
+/// <summary>
+/// A synthetic time provider used to enable deterministic behavior in tests.
+/// </summary>
+internal class FakeTimeProvider : TimeProvider
+{
+    internal readonly HashSet<Waiter> Waiters = new();
+    private DateTimeOffset _now = new(2000, 1, 1, 0, 0, 0, 0, TimeSpan.Zero);
+    private TimeZoneInfo _localTimeZone = TimeZoneInfo.Utc;
+    private int _wakeWaitersGate;
+    private TimeSpan _autoAdvanceAmount;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FakeTimeProvider"/> class.
+    /// </summary>
+    /// <remarks>
+    /// This creates a provider whose time is initially set to midnight January 1st 2000.
+    /// The provider is set to not automatically advance time each time it is read.
+    /// </remarks>
+    public FakeTimeProvider()
+    {
+        Start = _now;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FakeTimeProvider"/> class.
+    /// </summary>
+    /// <param name="startDateTime">The initial time and date reported by the provider.</param>
+    /// <remarks>
+    /// The provider is set to not automatically advance time each time it is read.
+    /// </remarks>
+    public FakeTimeProvider(DateTimeOffset startDateTime)
+    {
+        _now = startDateTime;
+        Start = _now;
+    }
+
+    /// <summary>
+    /// Gets the starting date and time for this provider.
+    /// </summary>
+    public DateTimeOffset Start { get; }
+
+    /// <summary>
+    /// Gets or sets the amount of time by which time advances whenever the clock is read.
+    /// </summary>
+    /// <remarks>
+    /// This defaults to <see cref="TimeSpan.Zero"/>.
+    /// </remarks>
+    public TimeSpan AutoAdvanceAmount
+    {
+        get => _autoAdvanceAmount;
+        set
+        {
+            _autoAdvanceAmount = value;
+        }
+    }
+
+    /// <inheritdoc />
+    public override DateTimeOffset GetUtcNow()
+    {
+        DateTimeOffset result;
+
+        lock (Waiters)
+        {
+            result = _now;
+            _now += _autoAdvanceAmount;
+        }
+
+        WakeWaiters();
+        return result;
+    }
+
+    /// <summary>
+    /// Sets the date and time in the UTC time zone.
+    /// </summary>
+    /// <param name="value">The date and time in the UTC time zone.</param>
+    public void SetUtcNow(DateTimeOffset value)
+    {
+        lock (Waiters)
+        {
+            if (value < _now)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), $"Cannot go back in time. Current time is {_now}.");
+            }
+
+            _now = value;
+        }
+
+        WakeWaiters();
+    }
+
+    /// <summary>
+    /// Advances time by a specific amount.
+    /// </summary>
+    /// <param name="delta">The amount of time to advance the clock by.</param>
+    /// <remarks>
+    /// Advancing time affects the timers created from this provider, and all other operations that are directly or
+    /// indirectly using this provider as a time source. Whereas when using <see cref="TimeProvider.System"/>, time
+    /// marches forward automatically in hardware, for the fake time provider the application is responsible for
+    /// doing this explicitly by calling this method.
+    /// </remarks>
+    public void Advance(TimeSpan delta)
+    {
+        lock (Waiters)
+        {
+            _now += delta;
+        }
+
+        WakeWaiters();
+    }
+
+    /// <inheritdoc />
+    public override long GetTimestamp()
+    {
+        // Notionally we're multiplying by frequency and dividing by ticks per second,
+        // which are the same value for us. Don't actually do the math as the full
+        // precision of ticks (a long) cannot be represented in a double during division.
+        // For test stability we want a reproducible result.
+        //
+        // The same issue could occur converting back, in GetElapsedTime(). Unfortunately
+        // that isn't virtual so we can't do the same trick. However, if tests advance
+        // the clock in multiples of 1ms or so this loss of precision will not be visible.
+        Debug.Assert(TimestampFrequency == TimeSpan.TicksPerSecond, "Assuming frequency equals ticks per second");
+        return _now.Ticks;
+    }
+
+    /// <inheritdoc />
+    public override TimeZoneInfo LocalTimeZone => _localTimeZone;
+
+    /// <summary>
+    /// Sets the local time zone.
+    /// </summary>
+    /// <param name="localTimeZone">The local time zone.</param>
+    public void SetLocalTimeZone(TimeZoneInfo localTimeZone) => _localTimeZone = localTimeZone;
+
+    /// <summary>
+    /// Gets the amount by which the value from <see cref="GetTimestamp"/> increments per second.
+    /// </summary>
+    /// <remarks>
+    /// This is fixed to the value of <see cref="TimeSpan.TicksPerSecond"/>.
+    /// </remarks>
+    public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+    /// <summary>
+    /// Returns a string representation this provider's idea of current time.
+    /// </summary>
+    /// <returns>A string representing the provider's current time.</returns>
+    public override string ToString() => GetUtcNow().ToString("yyyy-MM-ddTHH:mm:ss.fff", CultureInfo.InvariantCulture);
+
+    internal void RemoveWaiter(Waiter waiter)
+    {
+        lock (Waiters)
+        {
+            _ = Waiters.Remove(waiter);
+        }
+    }
+
+    internal void AddWaiter(Waiter waiter, long dueTime)
+    {
+        lock (Waiters)
+        {
+            waiter.ScheduledOn = _now.Ticks;
+            waiter.WakeupTime = _now.Ticks + dueTime;
+            _ = Waiters.Add(waiter);
+        }
+
+        WakeWaiters();
+    }
+
+    private void WakeWaiters()
+    {
+        if (Interlocked.CompareExchange(ref _wakeWaitersGate, 1, 0) == 1)
+        {
+            // some other thread is already in here, so let it take care of things
+            return;
+        }
+
+        while (true)
+        {
+            Waiter? candidate = null;
+            lock (Waiters)
+            {
+                // find an expired waiter
+                foreach (var waiter in Waiters)
+                {
+                    if (waiter.WakeupTime > _now.Ticks)
+                    {
+                        // not expired yet
+                    }
+                    else if (candidate is null)
+                    {
+                        // our first candidate
+                        candidate = waiter;
+                    }
+                    else if (waiter.WakeupTime < candidate.WakeupTime)
+                    {
+                        // found a waiter with an earlier wake time, it's our new candidate
+                        candidate = waiter;
+                    }
+                    else if (waiter.WakeupTime > candidate.WakeupTime)
+                    {
+                        // the waiter has a later wake time, so keep the current candidate
+                    }
+                    else if (waiter.ScheduledOn < candidate.ScheduledOn)
+                    {
+                        // the new waiter has the same wake time aa the candidate, pick whichever was scheduled earliest to maintain order
+                        candidate = waiter;
+                    }
+                }
+            }
+
+            if (candidate == null)
+            {
+                // didn't find a candidate to wake, we're done
+                _wakeWaitersGate = 0;
+                return;
+            }
+
+            // invoke the callback
+            candidate.InvokeCallback();
+
+            // see if we need to reschedule the waiter
+            if (candidate.Period > 0)
+            {
+                // update the waiter's state
+                candidate.ScheduledOn = _now.Ticks;
+                candidate.WakeupTime += candidate.Period;
+            }
+            else
+            {
+                // this waiter is never running again, so remove from the set.
+                RemoveWaiter(candidate);
+            }
+        }
+    }
+}
+
+// We keep all timer state here in order to prevent Timer instances from being self-referential,
+// which would block them being collected when someone forgets to call Dispose on the timer. With
+// this arrangement, the Timer object will always be collectible, which will end up calling Dispose
+// on this object due to the timer's finalizer.
+internal sealed class Waiter
+{
+    private readonly TimerCallback _callback;
+    private readonly object? _state;
+
+    public long ScheduledOn { get; set; } = -1;
+    public long WakeupTime { get; set; } = -1;
+    public long Period { get; }
+
+    public Waiter(TimerCallback callback, object? state, long period)
+    {
+        _callback = callback;
+        _state = state;
+        Period = period;
+    }
+
+    public void InvokeCallback()
+    {
+        _callback(_state);
+    }
+}

--- a/test/Polly.Core.Tests/Helpers/MockTimeProvider.cs
+++ b/test/Polly.Core.Tests/Helpers/MockTimeProvider.cs
@@ -4,46 +4,14 @@ namespace Polly.Core.Tests.Helpers;
 
 internal class MockTimeProvider : Mock<TimeProvider>
 {
-    private DateTimeOffset? _time;
-
     public MockTimeProvider()
         : base(MockBehavior.Strict)
     {
     }
 
-    public MockTimeProvider SetupUtcNow(DateTimeOffset? time = null)
-    {
-        _time = time ?? DateTimeOffset.UtcNow;
-        Setup(x => x.GetUtcNow()).Returns(() => _time.Value);
-        return this;
-    }
-
-    public MockTimeProvider AdvanceTime(TimeSpan time)
-    {
-        if (_time == null)
-        {
-            SetupUtcNow(DateTimeOffset.UtcNow);
-        }
-
-        _time = _time!.Value.Add(time);
-        return this;
-    }
-
-    public MockTimeProvider SetupTimestampFrequency()
-    {
-        Setup(x => x.TimestampFrequency).Returns(Stopwatch.Frequency);
-        return this;
-    }
-
     public MockTimeProvider SetupAnyDelay(CancellationToken cancellationToken = default)
     {
         Setup(x => x.Delay(It.IsAny<TimeSpan>(), cancellationToken)).Returns(Task.CompletedTask);
-        return this;
-    }
-
-    public MockTimeProvider SetupGetTimestamp()
-    {
-        Setup(x => x.GetTimestamp()).Returns(0);
         return this;
     }
 

--- a/test/Polly.Core.Tests/Issues/IssuesTests.CircuitBreakerStateSharing_959.cs
+++ b/test/Polly.Core.Tests/Issues/IssuesTests.CircuitBreakerStateSharing_959.cs
@@ -23,7 +23,7 @@ public partial class IssuesTests
         };
 
         // create the strategy
-        var strategy = new ResilienceStrategyBuilder { TimeProvider = TimeProvider.Object }.AddAdvancedCircuitBreaker(options).Build();
+        var strategy = new ResilienceStrategyBuilder { TimeProvider = TimeProvider }.AddAdvancedCircuitBreaker(options).Build();
 
         // now trigger the circuit breaker by evaluating multiple result types
         for (int i = 0; i < 5; i++)
@@ -37,7 +37,7 @@ public partial class IssuesTests
         strategy.Invoking(s => s.Execute(_ => "valid-result")).Should().Throw<BrokenCircuitException>();
 
         // now wait for recovery
-        TimeProvider.AdvanceTime(options.BreakDuration);
+        TimeProvider.Advance(options.BreakDuration);
 
         // OK, circuit is closed now
         strategy.Execute(_ => 0);

--- a/test/Polly.Core.Tests/Issues/IssuesTests.HandleMultipleResults_898.cs
+++ b/test/Polly.Core.Tests/Issues/IssuesTests.HandleMultipleResults_898.cs
@@ -31,7 +31,7 @@ public partial class IssuesTests
         };
 
         // create the strategy
-        var strategy = new ResilienceStrategyBuilder { TimeProvider = TimeProvider.Object }.AddRetry(options).Build();
+        var strategy = new ResilienceStrategyBuilder { TimeProvider = TimeProvider }.AddRetry(options).Build();
 
         // check that int-based results is retried
         bool isRetry = false;

--- a/test/Polly.Core.Tests/Issues/IssuesTests.cs
+++ b/test/Polly.Core.Tests/Issues/IssuesTests.cs
@@ -1,6 +1,8 @@
+using Microsoft.Extensions.Time.Testing;
+
 namespace Polly.Core.Tests.Issues;
 
 public partial class IssuesTests
 {
-    private MockTimeProvider TimeProvider { get; } = new MockTimeProvider().SetupUtcNow().SetupAnyDelay().SetupGetTimestamp().SetupTimestampFrequency();
+    private FakeTimeProvider TimeProvider { get; } = new FakeTimeProvider();
 }

--- a/test/Polly.Core.Tests/ResilienceStrategyBuilderContextTests.cs
+++ b/test/Polly.Core.Tests/ResilienceStrategyBuilderContextTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 
 namespace Polly.Core.Tests;
@@ -8,15 +9,15 @@ public class ResilienceStrategyBuilderContextTests
     public void Ctor_EnsureDefaults()
     {
         var properties = new ResilienceProperties();
-        var timeProvider = new MockTimeProvider();
-        var context = new ResilienceStrategyBuilderContext("builder-name", properties, "strategy-name", "strategy-type", timeProvider.Object, true, Mock.Of<DiagnosticSource>(), () => 1.0);
+        var timeProvider = new FakeTimeProvider();
+        var context = new ResilienceStrategyBuilderContext("builder-name", properties, "strategy-name", "strategy-type", timeProvider, true, Mock.Of<DiagnosticSource>(), () => 1.0);
 
         context.IsGenericBuilder.Should().BeTrue();
         context.BuilderName.Should().Be("builder-name");
         context.BuilderProperties.Should().BeSameAs(properties);
         context.StrategyName.Should().Be("strategy-name");
         context.StrategyType.Should().Be("strategy-type");
-        context.TimeProvider.Should().Be(timeProvider.Object);
+        context.TimeProvider.Should().Be(timeProvider);
         context.Telemetry.Should().NotBeNull();
         context.Randomizer.Should().NotBeNull();
 

--- a/test/Polly.Core.Tests/ResilienceStrategyBuilderTests.cs
+++ b/test/Polly.Core.Tests/ResilienceStrategyBuilderTests.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Polly.Utils;
 
@@ -268,7 +269,7 @@ The RequiredProperty field is required.
         var builder = new ResilienceStrategyBuilder
         {
             BuilderName = "builder-name",
-            TimeProvider = new MockTimeProvider().Object,
+            TimeProvider = new FakeTimeProvider(),
         };
 
         builder.AddStrategy(


### PR DESCRIPTION
- Use a source copy of `FakeTimeProvider` for tests that do not depend on cancellation behaviours or verify the implementation's internal calls. We can then drop this code as part of #1144 once #1348 is resolved.
- Remove methods on `MockTimeProvider` that are unused after the adoption of `FakeTimeProvider`.

Builds on top of #1349.
