### PR TITLE
Introduce ResilienceEventSeverity

### DIFF
--- a/bench/Polly.Core.Benchmarks/TelemetryBenchmark.cs
+++ b/bench/Polly.Core.Benchmarks/TelemetryBenchmark.cs
@@ -78,7 +78,7 @@ public class TelemetryBenchmark
             ResilienceContext context,
             TState state)
         {
-            _telemetry.Report("DummyEvent", context, "dummy-args");
+            _telemetry.Report(new ResilienceEvent(ResilienceEventSeverity.Warning, "DummyEvent"), context, "dummy-args");
             return callback(context, state);
         }
     }

--- a/src/Polly.Core/CircuitBreaker/Controller/CircuitStateController.cs
+++ b/src/Polly.Core/CircuitBreaker/Controller/CircuitStateController.cs
@@ -128,7 +128,7 @@ internal sealed class CircuitStateController<T> : IDisposable
             if (_circuitState == CircuitState.Open && PermitHalfOpenCircuitTest_NeedsLock())
             {
                 _circuitState = CircuitState.HalfOpen;
-                _telemetry.Report(CircuitBreakerConstants.OnHalfOpenEvent, context, new OnCircuitHalfOpenedArguments());
+                _telemetry.Report(new(ResilienceEventSeverity.Warning, CircuitBreakerConstants.OnHalfOpenEvent), context, new OnCircuitHalfOpenedArguments());
                 isHalfOpen = true;
             }
 
@@ -269,7 +269,7 @@ internal sealed class CircuitStateController<T> : IDisposable
         if (priorState != CircuitState.Closed)
         {
             var args = new OutcomeArguments<T, OnCircuitClosedArguments>(context, outcome, new OnCircuitClosedArguments(manual));
-            _telemetry.Report(CircuitBreakerConstants.OnCircuitClosed, args);
+            _telemetry.Report(new(ResilienceEventSeverity.Information, CircuitBreakerConstants.OnCircuitClosed), args);
 
             if (_onClosed is not null)
             {
@@ -320,7 +320,7 @@ internal sealed class CircuitStateController<T> : IDisposable
         _circuitState = CircuitState.Open;
 
         var args = new OutcomeArguments<T, OnCircuitOpenedArguments>(context, outcome, new OnCircuitOpenedArguments(breakDuration, manual));
-        _telemetry.Report(CircuitBreakerConstants.OnCircuitOpened, args);
+        _telemetry.Report(new(ResilienceEventSeverity.Error, CircuitBreakerConstants.OnCircuitOpened), args);
 
         if (_onOpened is not null)
         {

--- a/src/Polly.Core/Fallback/FallbackResilienceStrategy.cs
+++ b/src/Polly.Core/Fallback/FallbackResilienceStrategy.cs
@@ -29,7 +29,7 @@ internal sealed class FallbackResilienceStrategy<T> : OutcomeResilienceStrategy<
 
         var onFallbackArgs = new OutcomeArguments<T, OnFallbackArguments>(context, outcome, new OnFallbackArguments());
 
-        _telemetry.Report(FallbackConstants.OnFallback, onFallbackArgs);
+        _telemetry.Report(new(ResilienceEventSeverity.Warning, FallbackConstants.OnFallback), onFallbackArgs);
 
         if (_onFallback is not null)
         {

--- a/src/Polly.Core/Hedging/HedgingResilienceStrategy.cs
+++ b/src/Polly.Core/Hedging/HedgingResilienceStrategy.cs
@@ -126,7 +126,7 @@ internal sealed class HedgingResilienceStrategy<T> : OutcomeResilienceStrategy<T
             outcome,
             args);
 
-        _telemetry.Report(HedgingConstants.OnHedgingEventName, onHedgingArgs);
+        _telemetry.Report(new(ResilienceEventSeverity.Warning, HedgingConstants.OnHedgingEventName), onHedgingArgs);
 
         if (OnHedging is not null)
         {

--- a/src/Polly.Core/ResilienceContext.cs
+++ b/src/Polly.Core/ResilienceContext.cs
@@ -64,7 +64,7 @@ public sealed class ResilienceContext
     /// <remarks>
     /// If the number of resilience events is greater than zero it's an indication that the execution was unhealthy.
     /// </remarks>
-    public IReadOnlyCollection<ResilienceEvent> ResilienceEvents => _resilienceEvents;
+    public IReadOnlyList<ResilienceEvent> ResilienceEvents => _resilienceEvents;
 
     /// <summary>
     /// Gets a <see cref="ResilienceContext"/> instance from the pool.

--- a/src/Polly.Core/Retry/RetryResilienceStrategy.cs
+++ b/src/Polly.Core/Retry/RetryResilienceStrategy.cs
@@ -74,7 +74,7 @@ internal sealed class RetryResilienceStrategy<T> : OutcomeResilienceStrategy<T>
             }
 
             var onRetryArgs = new OutcomeArguments<T, OnRetryArguments>(context, outcome, new OnRetryArguments(attempt, delay, executionTime));
-            _telemetry.Report(RetryConstants.OnRetryEvent, onRetryArgs);
+            _telemetry.Report(new(ResilienceEventSeverity.Warning, RetryConstants.OnRetryEvent), onRetryArgs);
 
             if (OnRetry is not null)
             {

--- a/src/Polly.Core/Telemetry/ResilienceEvent.cs
+++ b/src/Polly.Core/Telemetry/ResilienceEvent.cs
@@ -3,11 +3,12 @@ namespace Polly.Telemetry;
 /// <summary>
 /// Represents a resilience event that has been reported.
 /// </summary>
+/// <param name="Severity">The severity of the event.</param>
 /// <param name="EventName">The event name.</param>
 /// <remarks>
 /// Always use the constructor when creating this struct, otherwise we do not guarantee binary compatibility.
 /// </remarks>
-public readonly record struct ResilienceEvent(string EventName)
+public readonly record struct ResilienceEvent(ResilienceEventSeverity Severity, string EventName)
 {
     /// <summary>
     /// Returns an <see cref="EventName"/>.

--- a/src/Polly.Core/Telemetry/ResilienceEventSeverity.cs
+++ b/src/Polly.Core/Telemetry/ResilienceEventSeverity.cs
@@ -16,7 +16,7 @@ public enum ResilienceEventSeverity
     Warning,
 
     /// <summary>
-    /// The resilience event should be treated as a warning.
+    /// The resilience event should be treated as an error.
     /// </summary>
     Error,
 }

--- a/src/Polly.Core/Telemetry/ResilienceEventSeverity.cs
+++ b/src/Polly.Core/Telemetry/ResilienceEventSeverity.cs
@@ -6,6 +6,16 @@
 public enum ResilienceEventSeverity
 {
     /// <summary>
+    /// The resilience event is not recorded.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// The resilience event is used for debugging purposes only.
+    /// </summary>
+    Debug,
+
+    /// <summary>
     /// The resilience event is informational.
     /// </summary>
     Information,
@@ -19,4 +29,9 @@ public enum ResilienceEventSeverity
     /// The resilience event should be treated as an error.
     /// </summary>
     Error,
+
+    /// <summary>
+    /// The resilience event should be treated as a critical error.
+    /// </summary>
+    Critical,
 }

--- a/src/Polly.Core/Telemetry/ResilienceEventSeverity.cs
+++ b/src/Polly.Core/Telemetry/ResilienceEventSeverity.cs
@@ -1,0 +1,22 @@
+﻿namespace Polly.Telemetry;
+
+/// <summary>
+/// The severity of reported resilience event.
+/// </summary>
+public enum ResilienceEventSeverity
+{
+    /// <summary>
+    /// The resilience event is informational.
+    /// </summary>
+    Information,
+
+    /// <summary>
+    /// The resilience event should be treated as a warning.
+    /// </summary>
+    Warning,
+
+    /// <summary>
+    /// The resilience event should be treated as a warning.
+    /// </summary>
+    Error,
+}

--- a/src/Polly.Core/Telemetry/ResilienceStrategyTelemetry.cs
+++ b/src/Polly.Core/Telemetry/ResilienceStrategyTelemetry.cs
@@ -37,7 +37,7 @@ public sealed class ResilienceStrategyTelemetry
 
         context.AddResilienceEvent(resilienceEvent);
 
-        if (DiagnosticSource is null || !DiagnosticSource.IsEnabled(resilienceEvent.EventName))
+        if (DiagnosticSource is null || !DiagnosticSource.IsEnabled(resilienceEvent.EventName) || resilienceEvent.Severity == ResilienceEventSeverity.None)
         {
             return;
         }
@@ -60,7 +60,7 @@ public sealed class ResilienceStrategyTelemetry
     {
         args.Context.AddResilienceEvent(resilienceEvent);
 
-        if (DiagnosticSource is null || !DiagnosticSource.IsEnabled(resilienceEvent.EventName))
+        if (DiagnosticSource is null || !DiagnosticSource.IsEnabled(resilienceEvent.EventName) || resilienceEvent.Severity == ResilienceEventSeverity.None)
         {
             return;
         }

--- a/src/Polly.Core/Telemetry/TelemetryEventArguments.Pool.cs
+++ b/src/Polly.Core/Telemetry/TelemetryEventArguments.Pool.cs
@@ -5,7 +5,7 @@ public sealed partial record class TelemetryEventArguments
     private static readonly ObjectPool<TelemetryEventArguments> Pool = new(() => new TelemetryEventArguments(), args =>
     {
         args.Source = null!;
-        args.EventName = null!;
+        args.Event = default;
         args.Context = null!;
         args.Outcome = default;
         args.Arguments = null!;
@@ -13,7 +13,7 @@ public sealed partial record class TelemetryEventArguments
 
     internal static TelemetryEventArguments Get(
         ResilienceTelemetrySource source,
-        string eventName,
+        ResilienceEvent resilienceEvent,
         ResilienceContext context,
         Outcome<object>? outcome,
         object arguments)
@@ -21,7 +21,7 @@ public sealed partial record class TelemetryEventArguments
         var args = Pool.Get();
 
         args.Source = source;
-        args.EventName = eventName;
+        args.Event = resilienceEvent;
         args.Context = context;
         args.Outcome = outcome;
         args.Arguments = arguments;

--- a/src/Polly.Core/Telemetry/TelemetryEventArguments.cs
+++ b/src/Polly.Core/Telemetry/TelemetryEventArguments.cs
@@ -18,7 +18,7 @@ public sealed partial record class TelemetryEventArguments
     public ResilienceTelemetrySource Source { get; private set; } = null!;
 
     /// <summary>
-    /// Gets the event name.
+    /// Gets the event.
     /// </summary>
     public ResilienceEvent Event { get; private set; }
 

--- a/src/Polly.Core/Telemetry/TelemetryEventArguments.cs
+++ b/src/Polly.Core/Telemetry/TelemetryEventArguments.cs
@@ -20,7 +20,7 @@ public sealed partial record class TelemetryEventArguments
     /// <summary>
     /// Gets the event name.
     /// </summary>
-    public string EventName { get; private set; } = null!;
+    public ResilienceEvent Event { get; private set; }
 
     /// <summary>
     /// Gets the resilience context.

--- a/src/Polly.Core/Telemetry/TelemetryUtil.cs
+++ b/src/Polly.Core/Telemetry/TelemetryUtil.cs
@@ -34,7 +34,9 @@ internal static class TelemetryUtil
         }
 
         var attemptArgs = ExecutionAttemptArguments.Get(attempt, executionTime, handled);
-        telemetry.Report<ExecutionAttemptArguments, TResult>(ExecutionAttempt, new(context, outcome, attemptArgs));
+        telemetry.Report<ExecutionAttemptArguments, TResult>(
+            new(handled ? ResilienceEventSeverity.Warning : ResilienceEventSeverity.Information, ExecutionAttempt),
+            new(context, outcome, attemptArgs));
         ExecutionAttemptArguments.Return(attemptArgs);
     }
 }

--- a/src/Polly.Core/Timeout/TimeoutResilienceStrategy.cs
+++ b/src/Polly.Core/Timeout/TimeoutResilienceStrategy.cs
@@ -60,7 +60,7 @@ internal sealed class TimeoutResilienceStrategy : ResilienceStrategy
         if (isCancellationRequested && outcome.Exception is OperationCanceledException e && !previousToken.IsCancellationRequested)
         {
             var args = new OnTimeoutArguments(context, e, timeout);
-            _telemetry.Report(TimeoutConstants.OnTimeoutEvent, context, args);
+            _telemetry.Report(new(ResilienceEventSeverity.Error, TimeoutConstants.OnTimeoutEvent), context, args);
 
             if (OnTimeout is not null)
             {

--- a/src/Polly.Extensions/Telemetry/Log.cs
+++ b/src/Polly.Extensions/Telemetry/Log.cs
@@ -1,9 +1,11 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 
 namespace Polly.Extensions.Telemetry;
 
 #pragma warning disable S107 // Methods should not have too many parameters
 
+[ExcludeFromCodeCoverage]
 internal static partial class Log
 {
     [LoggerMessage(

--- a/src/Polly.Extensions/Telemetry/Log.cs
+++ b/src/Polly.Extensions/Telemetry/Log.cs
@@ -6,40 +6,19 @@ namespace Polly.Extensions.Telemetry;
 
 internal static partial class Log
 {
-    private const string StrategyExecutedMessage = "Resilience strategy executed. " +
-            "Builder Name: '{BuilderName}', " +
-            "Strategy Key: '{StrategyKey}', " +
-            "Result Type: '{ResultType}', " +
-            "Result: '{Result}', " +
-            "Execution Health: '{ExecutionHealth}', " +
-            "Execution Time: {ExecutionTime}ms";
-
-    private const string ResilienceEventMessage = "Resilience event occurred. " +
+    [LoggerMessage(
+        EventId = 0,
+        Message = "Resilience event occurred. " +
                 "EventName: '{EventName}', " +
                 "Builder Name: '{BuilderName}', " +
                 "Strategy Name: '{StrategyName}', " +
                 "Strategy Type: '{StrategyType}', " +
                 "Strategy Key: '{StrategyKey}', " +
-                "Result: '{Result}'";
-
-    private const string ExecutionAttemptMessage = "Execution attempt. " +
-                "Builder Name: '{BuilderName}', " +
-                "Strategy Name: '{StrategyName}', " +
-                "Strategy Type: '{StrategyType}', " +
-                "Strategy Key: '{StrategyKey}', " +
-                "Result: '{Result}', " +
-                "Handled: '{Handled}', " +
-                "Attempt: '{Attempt}', " +
-                "Execution Time: '{ExecutionTimeMs}'";
-
-    private const string StrategyExecutingMessage = "Resilience strategy executing. " +
-            "Builder Name: '{BuilderName}', " +
-            "Strategy Key: '{StrategyKey}', " +
-            "Result Type: '{ResultType}'";
-
-    [LoggerMessage(0, LogLevel.Warning, ResilienceEventMessage, EventName = "ResilienceEvent")]
+                "Result: '{Result}'",
+        EventName = "ResilienceEvent")]
     public static partial void ResilienceEvent(
         this ILogger logger,
+        LogLevel logLevel,
         string eventName,
         string? builderName,
         string? strategyName,
@@ -48,14 +27,30 @@ internal static partial class Log
         object? result,
         Exception? exception);
 
-    [LoggerMessage(1, LogLevel.Debug, StrategyExecutingMessage, EventName = "StrategyExecuting")]
+    [LoggerMessage(
+        1,
+        LogLevel.Debug,
+        "Resilience strategy executing. " +
+        "Builder Name: '{BuilderName}', " +
+        "Strategy Key: '{StrategyKey}', " +
+        "Result Type: '{ResultType}'",
+        EventName = "StrategyExecuting")]
     public static partial void ExecutingStrategy(
         this ILogger logger,
         string? builderName,
         string? strategyKey,
         string resultType);
 
-    [LoggerMessage(EventId = 2, Message = StrategyExecutedMessage, EventName = "StrategyExecuted")]
+    [LoggerMessage(
+        EventId = 2,
+        Message = "Resilience strategy executed. " +
+            "Builder Name: '{BuilderName}', " +
+            "Strategy Key: '{StrategyKey}', " +
+            "Result Type: '{ResultType}', " +
+            "Result: '{Result}', " +
+            "Execution Health: '{ExecutionHealth}', " +
+            "Execution Time: {ExecutionTime}ms",
+        EventName = "StrategyExecuted")]
     public static partial void StrategyExecuted(
         this ILogger logger,
         LogLevel logLevel,
@@ -67,7 +62,19 @@ internal static partial class Log
         double executionTime,
         Exception? exception);
 
-    [LoggerMessage(EventId = 3, Message = ExecutionAttemptMessage, EventName = "ExecutionAttempt", SkipEnabledCheck = true)]
+    [LoggerMessage(
+        EventId = 3,
+        Message = "Execution attempt. " +
+                "Builder Name: '{BuilderName}', " +
+                "Strategy Name: '{StrategyName}', " +
+                "Strategy Type: '{StrategyType}', " +
+                "Strategy Key: '{StrategyKey}', " +
+                "Result: '{Result}', " +
+                "Handled: '{Handled}', " +
+                "Attempt: '{Attempt}', " +
+                "Execution Time: '{ExecutionTimeMs}'",
+        EventName = "ExecutionAttempt",
+        SkipEnabledCheck = true)]
     public static partial void ExecutionAttempt(
         this ILogger logger,
         LogLevel level,

--- a/src/Polly.Extensions/Telemetry/ResilienceContextExtensions.cs
+++ b/src/Polly.Extensions/Telemetry/ResilienceContextExtensions.cs
@@ -8,5 +8,16 @@ internal static class ResilienceContextExtensions
 
     public static string GetExecutionHealth(this ResilienceContext context) => context.IsExecutionHealthy() ? "Healthy" : "Unhealthy";
 
-    public static bool IsExecutionHealthy(this ResilienceContext context) => context.ResilienceEvents.Count == 0;
+    public static bool IsExecutionHealthy(this ResilienceContext context)
+    {
+        for (int i = 0; i < context.ResilienceEvents.Count; i++)
+        {
+            if (context.ResilienceEvents[i].Severity != Polly.Telemetry.ResilienceEventSeverity.Information)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/src/Polly.Extensions/Telemetry/ResilienceContextExtensions.cs
+++ b/src/Polly.Extensions/Telemetry/ResilienceContextExtensions.cs
@@ -12,7 +12,7 @@ internal static class ResilienceContextExtensions
     {
         for (int i = 0; i < context.ResilienceEvents.Count; i++)
         {
-            if (context.ResilienceEvents[i].Severity != Polly.Telemetry.ResilienceEventSeverity.Information)
+            if (context.ResilienceEvents[i].Severity > Polly.Telemetry.ResilienceEventSeverity.Information)
             {
                 return false;
             }

--- a/src/Polly.Extensions/Telemetry/ResilienceTelemetryDiagnosticSource.cs
+++ b/src/Polly.Extensions/Telemetry/ResilienceTelemetryDiagnosticSource.cs
@@ -47,7 +47,8 @@ internal class ResilienceTelemetryDiagnosticSource : DiagnosticSource
 
     private static void AddCommonTags(TelemetryEventArguments args, ResilienceTelemetrySource source, EnrichmentContext enrichmentContext)
     {
-        enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.EventName, args.EventName));
+        enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.EventName, args.Event.EventName));
+        enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.EventSeverity, args.Event.Severity.AsString()));
         enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.BuilderName, source.BuilderName));
         enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.StrategyName, source.StrategyName));
         enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.StrategyType, source.StrategyType));
@@ -98,10 +99,10 @@ internal class ResilienceTelemetryDiagnosticSource : DiagnosticSource
             result = e.Message;
         }
 
+        var level = args.Event.Severity.AsLogLevel();
+
         if (args.Arguments is ExecutionAttemptArguments executionAttempt)
         {
-            var level = executionAttempt.Handled ? LogLevel.Warning : LogLevel.Debug;
-
             if (_logger.IsEnabled(level))
             {
                 Log.ExecutionAttempt(
@@ -120,7 +121,7 @@ internal class ResilienceTelemetryDiagnosticSource : DiagnosticSource
         }
         else
         {
-            Log.ResilienceEvent(_logger, args.EventName, args.Source.BuilderName, args.Source.StrategyName, args.Source.StrategyType, strategyKey, result, args.Outcome?.Exception);
+            Log.ResilienceEvent(_logger, level, args.Event.EventName, args.Source.BuilderName, args.Source.StrategyName, args.Source.StrategyType, strategyKey, result, args.Outcome?.Exception);
         }
     }
 }

--- a/src/Polly.Extensions/Telemetry/ResilienceTelemetryTags.cs
+++ b/src/Polly.Extensions/Telemetry/ResilienceTelemetryTags.cs
@@ -4,6 +4,8 @@ internal class ResilienceTelemetryTags
 {
     public const string EventName = "event-name";
 
+    public const string EventSeverity = "event-severity";
+
     public const string BuilderName = "builder-name";
 
     public const string StrategyName = "strategy-name";
@@ -21,4 +23,5 @@ internal class ResilienceTelemetryTags
     public const string AttemptNumber = "attempt-number";
 
     public const string AttemptHandled = "attempt-handled";
+
 }

--- a/src/Polly.Extensions/Telemetry/TelemetryUtil.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryUtil.cs
@@ -1,3 +1,6 @@
+using Microsoft.Extensions.Logging;
+using Polly.Telemetry;
+
 namespace Polly.Extensions.Telemetry;
 
 internal static class TelemetryUtil
@@ -24,5 +27,21 @@ internal static class TelemetryUtil
     {
         >= 0 and < MaxIntegers => Integers[value],
         _ => value,
+    };
+
+    public static LogLevel AsLogLevel(this ResilienceEventSeverity severity) => severity switch
+    {
+        ResilienceEventSeverity.Information => LogLevel.Information,
+        ResilienceEventSeverity.Warning => LogLevel.Warning,
+        ResilienceEventSeverity.Error => LogLevel.Error,
+        _ => LogLevel.Information,
+    };
+
+    public static string AsString(this ResilienceEventSeverity severity) => severity switch
+    {
+        ResilienceEventSeverity.Information => nameof(ResilienceEventSeverity.Information),
+        ResilienceEventSeverity.Warning => nameof(ResilienceEventSeverity.Warning),
+        ResilienceEventSeverity.Error => nameof(ResilienceEventSeverity.Error),
+        _ => severity.ToString(),
     };
 }

--- a/src/Polly.Extensions/Telemetry/TelemetryUtil.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryUtil.cs
@@ -31,17 +31,22 @@ internal static class TelemetryUtil
 
     public static LogLevel AsLogLevel(this ResilienceEventSeverity severity) => severity switch
     {
+        ResilienceEventSeverity.Debug => LogLevel.Debug,
         ResilienceEventSeverity.Information => LogLevel.Information,
         ResilienceEventSeverity.Warning => LogLevel.Warning,
         ResilienceEventSeverity.Error => LogLevel.Error,
-        _ => LogLevel.Information,
+        ResilienceEventSeverity.Critical => LogLevel.Critical,
+        _ => LogLevel.None,
     };
 
     public static string AsString(this ResilienceEventSeverity severity) => severity switch
     {
+        ResilienceEventSeverity.None => nameof(ResilienceEventSeverity.None),
+        ResilienceEventSeverity.Debug => nameof(ResilienceEventSeverity.Debug),
         ResilienceEventSeverity.Information => nameof(ResilienceEventSeverity.Information),
         ResilienceEventSeverity.Warning => nameof(ResilienceEventSeverity.Warning),
         ResilienceEventSeverity.Error => nameof(ResilienceEventSeverity.Error),
+        ResilienceEventSeverity.Critical => nameof(ResilienceEventSeverity.Critical),
         _ => severity.ToString(),
     };
 }

--- a/src/Polly.RateLimiting/RateLimiterResilienceStrategy.cs
+++ b/src/Polly.RateLimiting/RateLimiterResilienceStrategy.cs
@@ -44,7 +44,7 @@ internal sealed class RateLimiterResilienceStrategy : ResilienceStrategy
         }
 
         var args = new OnRateLimiterRejectedArguments(context, lease, retryAfter);
-        _telemetry.Report(RateLimiterConstants.OnRateLimiterRejectedEvent, context, args);
+        _telemetry.Report(new(ResilienceEventSeverity.Error, RateLimiterConstants.OnRateLimiterRejectedEvent), context, args);
 
         if (OnLeaseRejected != null)
         {

--- a/test/Polly.Core.Tests/CircuitBreaker/Controller/CircuitStateControllerTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/Controller/CircuitStateControllerTests.cs
@@ -59,7 +59,7 @@ public class CircuitStateControllerTests
         _circuitBehavior.Setup(v => v.OnCircuitClosed());
         await controller.CloseCircuitAsync(ResilienceContext.Get());
         await controller.OnActionPreExecuteAsync(ResilienceContext.Get());
-        context.ResilienceEvents.Should().Contain(new ResilienceEvent("OnCircuitOpened"));
+        context.ResilienceEvents.Should().Contain(new ResilienceEvent(ResilienceEventSeverity.Error, "OnCircuitOpened"));
     }
 
     [Fact]
@@ -93,7 +93,7 @@ public class CircuitStateControllerTests
 
         await controller.OnActionPreExecuteAsync(ResilienceContext.Get());
         _circuitBehavior.VerifyAll();
-        context.ResilienceEvents.Should().Contain(new ResilienceEvent("OnCircuitClosed"));
+        context.ResilienceEvents.Should().Contain(new ResilienceEvent(ResilienceEventSeverity.Information, "OnCircuitClosed"));
     }
 
     [Fact]

--- a/test/Polly.Core.Tests/Hedging/Controller/HedgingExecutionContextTests.cs
+++ b/test/Polly.Core.Tests/Hedging/Controller/HedgingExecutionContextTests.cs
@@ -316,12 +316,12 @@ public class HedgingExecutionContextTests : IDisposable
         if (primary)
         {
             _resilienceContext.Properties.Should().HaveCount(1);
-            _resilienceContext.ResilienceEvents.Should().HaveCount(0);
+            _resilienceContext.ResilienceEvents.Should().HaveCount(1);
         }
         else
         {
             _resilienceContext.Properties.Should().HaveCount(2);
-            _resilienceContext.ResilienceEvents.Should().HaveCount(1);
+            _resilienceContext.ResilienceEvents.Should().HaveCount(4);
         }
     }
 
@@ -456,7 +456,7 @@ public class HedgingExecutionContextTests : IDisposable
                 return null;
             }
 
-            args.ActionContext.AddResilienceEvent(new ResilienceEvent("dummy-event"));
+            args.ActionContext.AddResilienceEvent(new ResilienceEvent(ResilienceEventSeverity.Information, "dummy-event"));
 
             return async () =>
             {

--- a/test/Polly.Core.Tests/Hedging/HedgingResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Hedging/HedgingResilienceStrategyTests.cs
@@ -915,8 +915,8 @@ public class HedgingResilienceStrategyTests : IDisposable
         var strategy = Create();
         await strategy.ExecuteAsync((_, _) => new ValueTask<string>(Failure), context, "state");
 
-        context.ResilienceEvents.Should().HaveCount(_options.MaxHedgedAttempts);
-        context.ResilienceEvents.Select(v => v.EventName).Distinct().Should().ContainSingle("OnHedging");
+        context.ResilienceEvents.Should().HaveCount(_options.MaxHedgedAttempts + 1);
+        context.ResilienceEvents.Select(v => v.EventName).Distinct().Should().HaveCount(2);
     }
 
     private void ConfigureHedging()

--- a/test/Polly.Core.Tests/ResilienceContextTests.cs
+++ b/test/Polly.Core.Tests/ResilienceContextTests.cs
@@ -42,10 +42,10 @@ public class ResilienceContextTests
     {
         var context = ResilienceContext.Get();
 
-        context.AddResilienceEvent(new ResilienceEvent("Dummy"));
+        context.AddResilienceEvent(new ResilienceEvent(ResilienceEventSeverity.Information, "Dummy"));
 
         context.ResilienceEvents.Should().HaveCount(1);
-        context.ResilienceEvents.Should().Contain(new ResilienceEvent("Dummy"));
+        context.ResilienceEvents.Should().Contain(new ResilienceEvent(ResilienceEventSeverity.Information, "Dummy"));
     }
 
     [Fact]
@@ -59,7 +59,7 @@ public class ResilienceContextTests
             context.Initialize<bool>(true);
             context.CancellationToken.Should().Be(cts.Token);
             context.Properties.Set(new ResiliencePropertyKey<int>("abc"), 10);
-            context.AddResilienceEvent(new ResilienceEvent("dummy"));
+            context.AddResilienceEvent(new ResilienceEvent(ResilienceEventSeverity.Information, "dummy"));
             ResilienceContext.Return(context);
 
             AssertDefaults(context);

--- a/test/Polly.Core.Tests/Telemetry/ResilienceEventTests.cs
+++ b/test/Polly.Core.Tests/Telemetry/ResilienceEventTests.cs
@@ -7,16 +7,19 @@ public class ResilienceEventTests
     [Fact]
     public void Ctor_Ok()
     {
-        var ev = new ResilienceEvent("A");
+        var ev = new ResilienceEvent(ResilienceEventSeverity.Warning, "A");
 
         ev.ToString().Should().Be("A");
+        ev.Severity.Should().Be(ResilienceEventSeverity.Warning);
+
     }
 
     [Fact]
     public void Equality_Ok()
     {
-        (new ResilienceEvent("A") == new ResilienceEvent("A")).Should().BeTrue();
-        (new ResilienceEvent("A") != new ResilienceEvent("A")).Should().BeFalse();
-        (new ResilienceEvent("A") == new ResilienceEvent("B")).Should().BeFalse();
+        (new ResilienceEvent(ResilienceEventSeverity.Warning, "A") == new ResilienceEvent(ResilienceEventSeverity.Warning, "A")).Should().BeTrue();
+        (new ResilienceEvent(ResilienceEventSeverity.Warning, "A") != new ResilienceEvent(ResilienceEventSeverity.Warning, "A")).Should().BeFalse();
+        (new ResilienceEvent(ResilienceEventSeverity.Warning, "A") == new ResilienceEvent(ResilienceEventSeverity.Warning, "B")).Should().BeFalse();
+        (new ResilienceEvent(ResilienceEventSeverity.Information, "A") == new ResilienceEvent(ResilienceEventSeverity.Warning, "A")).Should().BeFalse();
     }
 }

--- a/test/Polly.Core.Tests/Telemetry/ResilienceStrategyTelemetryTests.cs
+++ b/test/Polly.Core.Tests/Telemetry/ResilienceStrategyTelemetryTests.cs
@@ -22,30 +22,20 @@ public class ResilienceStrategyTelemetryTests
                 obj.Should().BeOfType<TelemetryEventArguments>();
                 var args = (TelemetryEventArguments)obj;
 
-                args.EventName.Should().Be("dummy-event");
+                args.Event.EventName.Should().Be("dummy-event");
+                args.Event.Severity.Should().Be(ResilienceEventSeverity.Warning);
                 args.Outcome.Should().BeNull();
                 args.Source.StrategyName.Should().Be("strategy-name");
                 args.Source.StrategyType.Should().Be("strategy-type");
                 args.Source.BuilderProperties.Should().NotBeNull();
                 args.Arguments.Should().BeOfType<TestArguments>();
-                args.EventName.Should().Be("dummy-event");
                 args.Outcome.Should().BeNull();
                 args.Context.Should().NotBeNull();
             });
 
-        _sut.Report("dummy-event", ResilienceContext.Get(), new TestArguments());
+        _sut.Report(new(ResilienceEventSeverity.Warning, "dummy-event"), ResilienceContext.Get(), new TestArguments());
 
         _diagnosticSource.VerifyAll();
-    }
-
-    [Fact]
-    public void Report_Attempt_EnsureNotRecordedOnResilienceContext()
-    {
-        var context = ResilienceContext.Get();
-        _diagnosticSource.Setup(o => o.IsEnabled("dummy-event")).Returns(false);
-        _sut.Report("dummy-event", context, ExecutionAttemptArguments.Get(0, TimeSpan.Zero, true));
-
-        context.ResilienceEvents.Should().BeEmpty();
     }
 
     [Fact]
@@ -53,7 +43,7 @@ public class ResilienceStrategyTelemetryTests
     {
         _diagnosticSource.Setup(o => o.IsEnabled("dummy-event")).Returns(false);
 
-        _sut.Report("dummy-event", ResilienceContext.Get(), new TestArguments());
+        _sut.Report(new(ResilienceEventSeverity.Warning, "dummy-event"), ResilienceContext.Get(), new TestArguments());
 
         _diagnosticSource.VerifyAll();
         _diagnosticSource.VerifyNoOtherCalls();
@@ -66,8 +56,8 @@ public class ResilienceStrategyTelemetryTests
         var sut = new ResilienceStrategyTelemetry(source, null);
         var context = ResilienceContext.Get();
 
-        sut.Invoking(s => s.Report("dummy", context, new TestArguments())).Should().NotThrow();
-        sut.Invoking(s => s.Report("dummy", new OutcomeArguments<int, TestArguments>(context, Outcome.FromResult(1), new TestArguments()))).Should().NotThrow();
+        sut.Invoking(s => s.Report(new(ResilienceEventSeverity.Warning, "dummy"), context, new TestArguments())).Should().NotThrow();
+        sut.Invoking(s => s.Report(new(ResilienceEventSeverity.Warning, "dummy"), new OutcomeArguments<int, TestArguments>(context, Outcome.FromResult(1), new TestArguments()))).Should().NotThrow();
     }
 
     [Fact]
@@ -81,19 +71,19 @@ public class ResilienceStrategyTelemetryTests
                 obj.Should().BeOfType<TelemetryEventArguments>();
                 var args = (TelemetryEventArguments)obj;
 
-                args.EventName.Should().Be("dummy-event");
+                args.Event.EventName.Should().Be("dummy-event");
+                args.Event.Severity.Should().Be(ResilienceEventSeverity.Warning);
                 args.Source.StrategyName.Should().Be("strategy-name");
                 args.Source.StrategyType.Should().Be("strategy-type");
                 args.Source.BuilderProperties.Should().NotBeNull();
                 args.Arguments.Should().BeOfType<TestArguments>();
-                args.EventName.Should().Be("dummy-event");
                 args.Outcome.Should().NotBeNull();
                 args.Outcome!.Value.Result.Should().Be(99);
                 args.Context.Should().NotBeNull();
             });
 
         var context = ResilienceContext.Get();
-        _sut.Report("dummy-event", new OutcomeArguments<int, TestArguments>(context, Outcome.FromResult(99), new TestArguments()));
+        _sut.Report(new(ResilienceEventSeverity.Warning, "dummy-event"), new OutcomeArguments<int, TestArguments>(context, Outcome.FromResult(99), new TestArguments()));
 
         _diagnosticSource.VerifyAll();
     }
@@ -103,7 +93,7 @@ public class ResilienceStrategyTelemetryTests
     {
         _diagnosticSource.Setup(o => o.IsEnabled("dummy-event")).Returns(false);
         var context = ResilienceContext.Get();
-        _sut.Report("dummy-event", new OutcomeArguments<int, TestArguments>(context, Outcome.FromResult(10), new TestArguments()));
+        _sut.Report(new(ResilienceEventSeverity.Warning, "dummy-event"), new OutcomeArguments<int, TestArguments>(context, Outcome.FromResult(10), new TestArguments()));
 
         _diagnosticSource.VerifyAll();
         _diagnosticSource.VerifyNoOtherCalls();

--- a/test/Polly.Core.Tests/Telemetry/ResilienceStrategyTelemetryTests.cs
+++ b/test/Polly.Core.Tests/Telemetry/ResilienceStrategyTelemetryTests.cs
@@ -89,6 +89,19 @@ public class ResilienceStrategyTelemetryTests
     }
 
     [Fact]
+    public void Report_SeverityNone_Skipped()
+    {
+        _diagnosticSource.Setup(o => o.IsEnabled("dummy-event")).Returns(true);
+
+        var context = ResilienceContext.Get();
+        _sut.Report(new(ResilienceEventSeverity.None, "dummy-event"), new OutcomeArguments<int, TestArguments>(context, Outcome.FromResult(99), new TestArguments()));
+        _sut.Report(new(ResilienceEventSeverity.None, "dummy-event"), ResilienceContext.Get(), new TestArguments());
+
+        _diagnosticSource.VerifyAll();
+        _diagnosticSource.VerifyNoOtherCalls();
+    }
+
+    [Fact]
     public void Report_OutcomeWhenNotSubscribed_None()
     {
         _diagnosticSource.Setup(o => o.IsEnabled("dummy-event")).Returns(false);

--- a/test/Polly.Core.Tests/Telemetry/TelemetryEventArgumentsTests.cs
+++ b/test/Polly.Core.Tests/Telemetry/TelemetryEventArgumentsTests.cs
@@ -10,11 +10,12 @@ public class TelemetryEventArgumentsTests
     public void Get_Ok()
     {
         var context = ResilienceContext.Get();
-        var args = TelemetryEventArguments.Get(_source, "ev", context, Outcome.FromResult<object>("dummy"), "arg");
+        var args = TelemetryEventArguments.Get(_source, new ResilienceEvent(ResilienceEventSeverity.Warning, "ev"), context, Outcome.FromResult<object>("dummy"), "arg");
 
         args.Outcome!.Value.Result.Should().Be("dummy");
         args.Context.Should().Be(context);
-        args.EventName.Should().Be("ev");
+        args.Event.EventName.Should().Be("ev");
+        args.Event.Severity.Should().Be(ResilienceEventSeverity.Warning);
         args.Source.Should().Be(_source);
         args.Arguments.Should().BeEquivalentTo("arg");
         args.Context.Should().Be(context);
@@ -24,7 +25,7 @@ public class TelemetryEventArgumentsTests
     public void Return_EnsurePropertiesCleared()
     {
         var context = ResilienceContext.Get();
-        var args = TelemetryEventArguments.Get(_source, "ev", context, Outcome.FromResult<object>("dummy"), "arg");
+        var args = TelemetryEventArguments.Get(_source, new ResilienceEvent(ResilienceEventSeverity.Warning, "ev"), context, Outcome.FromResult<object>("dummy"), "arg");
 
         TelemetryEventArguments.Return(args);
 
@@ -32,7 +33,7 @@ public class TelemetryEventArgumentsTests
         {
             args.Outcome.Should().BeNull();
             args.Context.Should().BeNull();
-            args.EventName.Should().BeNull();
+            args.Event.EventName.Should().BeNullOrEmpty();
             args.Source.Should().BeNull();
             args.Arguments.Should().BeNull();
             args.Context.Should().BeNull();

--- a/test/Polly.Core.Tests/Utils/ReloadableResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Utils/ReloadableResilienceStrategyTests.cs
@@ -49,7 +49,8 @@ public class ReloadableResilienceStrategyTests : IDisposable
             sut.Strategy.Should().NotBe(strategy);
         }
 
-        _events.Should().HaveCount(0);
+        _events.Where(e => e.Event.EventName == "ReloadFailed").Should().HaveCount(0);
+        _events.Where(e => e.Event.EventName == "OnReload").Should().HaveCount(10);
     }
 
     [Fact]
@@ -61,8 +62,14 @@ public class ReloadableResilienceStrategyTests : IDisposable
         _cancellationTokenSource.Cancel();
 
         sut.Strategy.Should().Be(strategy);
-        _events.Should().HaveCount(1);
-        var args = _events[0]
+        _events.Should().HaveCount(2);
+
+        _events[0]
+            .Arguments
+            .Should()
+            .BeOfType<ReloadableResilienceStrategy.OnReloadArguments>();
+
+        var args = _events[1]
             .Arguments
             .Should()
             .BeOfType<ReloadableResilienceStrategy.ReloadFailedArguments>()

--- a/test/Polly.Extensions.Tests/Telemetry/ResilienceTelemetryDiagnosticSourceTests.cs
+++ b/test/Polly.Extensions.Tests/Telemetry/ResilienceTelemetryDiagnosticSourceTests.cs
@@ -120,7 +120,10 @@ public class ResilienceTelemetryDiagnosticSourceTests : IDisposable
     [InlineData(ResilienceEventSeverity.Error, LogLevel.Error)]
     [InlineData(ResilienceEventSeverity.Warning, LogLevel.Warning)]
     [InlineData(ResilienceEventSeverity.Information, LogLevel.Information)]
-    [InlineData((ResilienceEventSeverity)99, LogLevel.Information)]
+    [InlineData(ResilienceEventSeverity.Debug, LogLevel.Debug)]
+    [InlineData(ResilienceEventSeverity.Critical, LogLevel.Critical)]
+    [InlineData(ResilienceEventSeverity.None, LogLevel.None)]
+    [InlineData((ResilienceEventSeverity)99, LogLevel.None)]
     [Theory]
     public void WriteEvent_EnsureSeverityRespected(ResilienceEventSeverity severity, LogLevel logLevel)
     {

--- a/test/Polly.Extensions.Tests/Telemetry/ResilienceTelemetryDiagnosticSourceTests.cs
+++ b/test/Polly.Extensions.Tests/Telemetry/ResilienceTelemetryDiagnosticSourceTests.cs
@@ -177,22 +177,6 @@ public class ResilienceTelemetryDiagnosticSourceTests : IDisposable
         }
 
         messages[0].LogLevel.Should().Be(LogLevel.Warning);
-
-        // verify reported state
-        var coll = messages[0].State.Should().BeAssignableTo<IReadOnlyList<KeyValuePair<string, object>>>().Subject;
-        coll.Count.Should().Be(9);
-        coll.AsEnumerable().Should().HaveCount(9);
-        (coll as IEnumerable).GetEnumerator().Should().NotBeNull();
-
-        for (int i = 0; i < coll.Count; i++)
-        {
-            if (!noOutcome)
-            {
-                coll[i].Value.Should().NotBeNull();
-            }
-        }
-
-        coll.Invoking(c => c[coll.Count + 1]).Should().Throw<IndexOutOfRangeException>();
     }
 
     [Fact]

--- a/test/Polly.Extensions.Tests/Telemetry/ResilienceTelemetryDiagnosticSourceTests.cs
+++ b/test/Polly.Extensions.Tests/Telemetry/ResilienceTelemetryDiagnosticSourceTests.cs
@@ -71,7 +71,7 @@ public class ResilienceTelemetryDiagnosticSourceTests : IDisposable
 
         if (noOutcome)
         {
-            messages[0].Message.Should().Be("Resilience event occurred. EventName: 'my-event', Builder Name: 'my-builder', Strategy Name: 'my-strategy', Strategy Type: 'my-strategy-type', Strategy Key: 'my-strategy-key', Result: '(null)'");
+            messages[0].Message.Should().Be("Resilience event occurred. EventName: 'my-event', Builder Name: 'my-builder', Strategy Name: 'my-strategy', Strategy Type: 'my-strategy-type', Strategy Key: 'my-strategy-key', Result: ''");
         }
         else
         {
@@ -98,7 +98,7 @@ public class ResilienceTelemetryDiagnosticSourceTests : IDisposable
 
         if (noOutcome)
         {
-            messages[0].Message.Should().Be("Resilience event occurred. EventName: 'my-event', Builder Name: 'my-builder', Strategy Name: 'my-strategy', Strategy Type: 'my-strategy-type', Strategy Key: 'my-strategy-key', Result: '(null)'");
+            messages[0].Message.Should().Be("Resilience event occurred. EventName: 'my-event', Builder Name: 'my-builder', Strategy Name: 'my-strategy', Strategy Type: 'my-strategy-type', Strategy Key: 'my-strategy-key', Result: ''");
         }
         else
         {
@@ -114,7 +114,26 @@ public class ResilienceTelemetryDiagnosticSourceTests : IDisposable
 
         var messages = _logger.GetRecords(new EventId(0, "ResilienceEvent")).ToList();
 
-        messages[0].Message.Should().Be("Resilience event occurred. EventName: 'my-event', Builder Name: 'my-builder', Strategy Name: 'my-strategy', Strategy Type: 'my-strategy-type', Strategy Key: '(null)', Result: '(null)'");
+        messages[0].Message.Should().Be("Resilience event occurred. EventName: 'my-event', Builder Name: 'my-builder', Strategy Name: 'my-strategy', Strategy Type: 'my-strategy-type', Strategy Key: '', Result: ''");
+    }
+
+    [InlineData(ResilienceEventSeverity.Error, LogLevel.Error)]
+    [InlineData(ResilienceEventSeverity.Warning, LogLevel.Warning)]
+    [InlineData(ResilienceEventSeverity.Information, LogLevel.Information)]
+    [InlineData((ResilienceEventSeverity)99, LogLevel.Information)]
+    [Theory]
+    public void WriteEvent_EnsureSeverityRespected(ResilienceEventSeverity severity, LogLevel logLevel)
+    {
+        var telemetry = Create();
+        ReportEvent(telemetry, null, severity: severity);
+
+        var messages = _logger.GetRecords(new EventId(0, "ResilienceEvent")).ToList();
+
+        messages[0].LogLevel.Should().Be(logLevel);
+
+        var events = GetEvents("resilience-events");
+        events.Should().HaveCount(1);
+        var ev = events[0]["event-severity"].Should().Be(severity.ToString());
     }
 
     [Fact]
@@ -154,14 +173,7 @@ public class ResilienceTelemetryDiagnosticSourceTests : IDisposable
             messages[0].Message.Should().Be($"Execution attempt. Builder Name: 'my-builder', Strategy Name: 'my-strategy', Strategy Type: 'my-strategy-type', Strategy Key: 'my-strategy-key', Result: '200', Handled: '{handled}', Attempt: '4', Execution Time: '123'");
         }
 
-        if (handled)
-        {
-            messages[0].LogLevel.Should().Be(LogLevel.Warning);
-        }
-        else
-        {
-            messages[0].LogLevel.Should().Be(LogLevel.Debug);
-        }
+        messages[0].LogLevel.Should().Be(LogLevel.Warning);
 
         // verify reported state
         var coll = messages[0].State.Should().BeAssignableTo<IReadOnlyList<KeyValuePair<string, object>>>().Subject;
@@ -212,8 +224,9 @@ public class ResilienceTelemetryDiagnosticSourceTests : IDisposable
         events.Should().HaveCount(1);
         var ev = events[0];
 
-        ev.Count.Should().Be(7);
+        ev.Count.Should().Be(8);
         ev["event-name"].Should().Be("my-event");
+        ev["event-severity"].Should().Be("Warning");
         ev["strategy-type"].Should().Be("my-strategy-type");
         ev["strategy-name"].Should().Be("my-strategy");
         ev["strategy-key"].Should().Be("my-strategy-key");
@@ -251,8 +264,9 @@ public class ResilienceTelemetryDiagnosticSourceTests : IDisposable
         events.Should().HaveCount(1);
         var ev = events[0];
 
-        ev.Count.Should().Be(9);
+        ev.Count.Should().Be(10);
         ev["event-name"].Should().Be("my-event");
+        ev["event-severity"].Should().Be("Warning");
         ev["strategy-type"].Should().Be("my-strategy-type");
         ev["strategy-name"].Should().Be("my-strategy");
         ev["strategy-key"].Should().Be("my-strategy-key");
@@ -299,7 +313,7 @@ public class ResilienceTelemetryDiagnosticSourceTests : IDisposable
 
         var events = GetEvents("resilience-events");
         var ev = events[0];
-        ev.Count.Should().Be(DefaultDimensions + count + 1);
+        ev.Count.Should().Be(DefaultDimensions + count + 2);
         ev["other"].Should().Be("other-value");
 
         for (int i = 0; i < count; i++)
@@ -335,7 +349,8 @@ public class ResilienceTelemetryDiagnosticSourceTests : IDisposable
         Outcome<object>? outcome,
         string? strategyKey = "my-strategy-key",
         ResilienceContext? context = null,
-        object? arg = null)
+        object? arg = null,
+        ResilienceEventSeverity severity = ResilienceEventSeverity.Warning)
     {
         context ??= ResilienceContext.Get();
         var props = new ResilienceProperties();
@@ -345,7 +360,7 @@ public class ResilienceTelemetryDiagnosticSourceTests : IDisposable
         }
 
         telemetry.ReportEvent(
-            "my-event",
+            new ResilienceEvent(severity, "my-event"),
             "my-builder",
             props,
             "my-strategy",

--- a/test/Polly.Extensions.Tests/Telemetry/TelemetryResilienceStrategyTests.cs
+++ b/test/Polly.Extensions.Tests/Telemetry/TelemetryResilienceStrategyTests.cs
@@ -43,7 +43,7 @@ public class TelemetryResilienceStrategyTests : IDisposable
             {
                 if (!healthy)
                 {
-                    ((List<ResilienceEvent>)c.ResilienceEvents).Add(new ResilienceEvent("dummy"));
+                    ((List<ResilienceEvent>)c.ResilienceEvents).Add(new ResilienceEvent(ResilienceEventSeverity.Warning, "dummy"));
                 }
             },
             ResilienceContext.Get(), string.Empty);
@@ -154,7 +154,7 @@ public class TelemetryResilienceStrategyTests : IDisposable
             {
                 if (!healthy)
                 {
-                    ((List<ResilienceEvent>)c.ResilienceEvents).Add(new ResilienceEvent("dummy"));
+                    ((List<ResilienceEvent>)c.ResilienceEvents).Add(new ResilienceEvent(ResilienceEventSeverity.Warning, "dummy"));
                 }
 
                 return true;

--- a/test/Polly.TestUtils/TestUtilities.cs
+++ b/test/Polly.TestUtils/TestUtilities.cs
@@ -78,7 +78,7 @@ public static class TestUtilities
 #pragma warning disable S107 // Methods should not have too many parameters
     public static void ReportEvent(
         this DiagnosticSource source,
-        string eventName,
+        ResilienceEvent resilienceEvent,
         string builderName,
         ResilienceProperties builderProperties,
         string strategyName,
@@ -88,9 +88,9 @@ public static class TestUtilities
         object arguments)
 #pragma warning restore S107 // Methods should not have too many parameters
     {
-        source.Write(eventName, TelemetryEventArguments.Get(
+        source.Write(resilienceEvent.EventName, TelemetryEventArguments.Get(
             new ResilienceTelemetrySource(builderName, builderProperties, strategyName, strategyType),
-            eventName,
+            resilienceEvent,
             context,
             outcome,
             arguments));
@@ -122,7 +122,7 @@ public static class TestUtilities
             }
 
             // copy the args because these are pooled and in tests we want to preserve them
-            args = TelemetryEventArguments.Get(args.Source, args.EventName, args.Context, args.Outcome, arguments);
+            args = TelemetryEventArguments.Get(args.Source, args.Event, args.Context, args.Outcome, arguments);
 
             lock (_syncRoot)
             {


### PR DESCRIPTION
### Details on the issue fix or feature implementation

Even though we are feature complete I want to squeeze this in to drop some workarounds around `ExecutionAttempt` event that should have informational severity. This change allows that.

Closes #1143 

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
