### PR TITLE
Allow reusing CircuitBreakerManualControl across multiple CBs

### DIFF
--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerManualControl.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerManualControl.cs
@@ -5,6 +5,9 @@ namespace Polly.CircuitBreaker;
 /// <summary>
 /// Allows manual control of the circuit-breaker.
 /// </summary>
+/// <remarks>
+/// The instance of this class can be reused across multiple circuit breakers.
+/// </remarks>
 public sealed class CircuitBreakerManualControl : IDisposable
 {
     private readonly HashSet<Action> _onDispose = new();
@@ -33,7 +36,6 @@ public sealed class CircuitBreakerManualControl : IDisposable
     /// <param name="context">The resilience context.</param>
     /// <returns>The instance of <see cref="Task"/> that represents the asynchronous execution.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="context"/> is <see langword="null"/>.</exception>
-    /// <exception cref="InvalidOperationException">Thrown when manual control is not initialized.</exception>
     /// <exception cref="ObjectDisposedException">Thrown when calling this method after this object is disposed.</exception>
     internal async Task IsolateAsync(ResilienceContext context)
     {
@@ -52,7 +54,6 @@ public sealed class CircuitBreakerManualControl : IDisposable
     /// </summary>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The instance of <see cref="Task"/> that represents the asynchronous execution.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if manual control is not initialized.</exception>
     /// <exception cref="ObjectDisposedException">Thrown when calling this method after this object is disposed.</exception>
     public async Task IsolateAsync(CancellationToken cancellationToken = default)
     {
@@ -75,7 +76,6 @@ public sealed class CircuitBreakerManualControl : IDisposable
     /// <param name="context">The resilience context.</param>
     /// <returns>The instance of <see cref="Task"/> that represents the asynchronous execution.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="context"/> is <see langword="null"/>.</exception>
-    /// <exception cref="InvalidOperationException">Thrown if manual control is not initialized.</exception>
     /// <exception cref="ObjectDisposedException">Thrown when calling this method after this object is disposed.</exception>
     internal async Task CloseAsync(ResilienceContext context)
     {
@@ -96,7 +96,6 @@ public sealed class CircuitBreakerManualControl : IDisposable
     /// </summary>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The instance of <see cref="Task"/> that represents the asynchronous execution.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if manual control is not initialized.</exception>
     /// <exception cref="ObjectDisposedException">Thrown when calling this method after this object is disposed.</exception>
     public async Task CloseAsync(CancellationToken cancellationToken = default)
     {

--- a/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerManualControlTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerManualControlTests.cs
@@ -4,11 +4,18 @@ namespace Polly.Core.Tests.CircuitBreaker;
 
 public class CircuitBreakerManualControlTests
 {
-    [Fact]
-    public async Task IsolateAsync_NotInitialized_Ok()
+    [InlineData(true)]
+    [InlineData(false)]
+    [Theory]
+    public async Task IsolateAsync_NotInitialized_Ok(bool closedAfter)
     {
         using var control = new CircuitBreakerManualControl();
         await control.IsolateAsync();
+        if (closedAfter)
+        {
+            await control.CloseAsync();
+        }
+
         var isolated = false;
 
         control.Initialize(
@@ -21,7 +28,7 @@ public class CircuitBreakerManualControlTests
             _ => Task.CompletedTask,
             () => { });
 
-        isolated.Should().BeTrue();
+        isolated.Should().Be(!closedAfter);
     }
 
     [Fact]

--- a/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerManualControlTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerManualControlTests.cs
@@ -35,15 +35,19 @@ public class CircuitBreakerManualControlTests
     }
 
     [Fact]
-    public void Initialize_Twice_Throws()
+    public async Task Initialize_Twice_Ok()
     {
-        using var control = new CircuitBreakerManualControl();
+        int called = 0;
+        var control = new CircuitBreakerManualControl();
         control.Initialize(_ => Task.CompletedTask, _ => Task.CompletedTask, () => { });
+        control.Initialize(_ => { called++; return Task.CompletedTask; }, _ => { called++; return Task.CompletedTask; }, () => { called++; });
 
-        control
-            .Invoking(c => c.Initialize(_ => Task.CompletedTask, _ => Task.CompletedTask, () => { }))
-            .Should()
-            .Throw<InvalidOperationException>();
+        await control.IsolateAsync();
+        await control.CloseAsync();
+
+        control.Dispose();
+
+        called.Should().Be(3);
     }
 
     [Fact]

--- a/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerManualControlTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerManualControlTests.cs
@@ -5,33 +5,34 @@ namespace Polly.Core.Tests.CircuitBreaker;
 public class CircuitBreakerManualControlTests
 {
     [Fact]
-    public void Ctor_Ok()
+    public async Task IsolateAsync_NotInitialized_Ok()
     {
         using var control = new CircuitBreakerManualControl();
+        await control.IsolateAsync();
+        var isolated = false;
 
-        control.IsInitialized.Should().BeFalse();
+        control.Initialize(
+            c =>
+            {
+                c.IsSynchronous.Should().BeTrue();
+                isolated = true;
+                return Task.CompletedTask;
+            },
+            _ => Task.CompletedTask,
+            () => { });
+
+        isolated.Should().BeTrue();
     }
 
     [Fact]
-    public async Task IsolateAsync_NotInitialized_Throws()
-    {
-        using var control = new CircuitBreakerManualControl();
-
-        await control
-            .Invoking(c => c.IsolateAsync(CancellationToken.None))
-            .Should()
-            .ThrowAsync<InvalidOperationException>();
-    }
-
-    [Fact]
-    public async Task ResetAsync_NotInitialized_Throws()
+    public async Task ResetAsync_NotInitialized_Ok()
     {
         using var control = new CircuitBreakerManualControl();
 
         await control
             .Invoking(c => c.CloseAsync(CancellationToken.None))
             .Should()
-            .ThrowAsync<InvalidOperationException>();
+            .NotThrowAsync();
     }
 
     [Fact]

--- a/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerResilienceStrategyTests.cs
@@ -54,8 +54,6 @@ public class CircuitBreakerResilienceStrategyTests : IDisposable
         _options.ManualControl = new CircuitBreakerManualControl();
         var strategy = Create();
 
-        _options.ManualControl.IsInitialized.Should().BeTrue();
-
         await _options.ManualControl.IsolateAsync(CancellationToken.None);
         strategy.Invoking(s => s.Execute(_ => 0)).Should().Throw<IsolatedCircuitException>();
 

--- a/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerStateProviderTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerStateProviderTests.cs
@@ -29,7 +29,7 @@ public class CircuitBreakerStateProviderTests
         await control
             .Invoking(c => c.CloseAsync(CancellationToken.None))
             .Should()
-            .ThrowAsync<InvalidOperationException>();
+            .NotThrowAsync<InvalidOperationException>();
     }
 
     [Fact]


### PR DESCRIPTION
### Details on the issue fix or feature implementation

I don't see any reason why this shouldn't be allowed.

Additionally, don't throw unnecessary. The user can isolate the manual control even before and the CB will be isolated once it's attached.

Contributes to #1365 

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
