### PR TITLE
Introduce `ResilienceContext.OperationKey`

### DIFF
--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerManualControl.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerManualControl.cs
@@ -57,8 +57,7 @@ public sealed class CircuitBreakerManualControl : IDisposable
     /// <exception cref="ObjectDisposedException">Thrown when calling this method after this object is disposed.</exception>
     public async Task IsolateAsync(CancellationToken cancellationToken = default)
     {
-        var context = ResilienceContext.Get().Initialize<VoidResult>(isSynchronous: false);
-        context.CancellationToken = cancellationToken;
+        var context = ResilienceContext.Get(cancellationToken).Initialize<VoidResult>(isSynchronous: false);
 
         try
         {
@@ -99,8 +98,7 @@ public sealed class CircuitBreakerManualControl : IDisposable
     /// <exception cref="ObjectDisposedException">Thrown when calling this method after this object is disposed.</exception>
     public async Task CloseAsync(CancellationToken cancellationToken = default)
     {
-        var context = ResilienceContext.Get();
-        context.CancellationToken = cancellationToken;
+        var context = ResilienceContext.Get(cancellationToken);
 
         try
         {

--- a/src/Polly.Core/ResilienceStrategy.Async.ValueTaskT.cs
+++ b/src/Polly.Core/ResilienceStrategy.Async.ValueTaskT.cs
@@ -191,8 +191,7 @@ public abstract partial class ResilienceStrategy
 
     private static ResilienceContext GetAsyncContext<TResult>(CancellationToken cancellationToken)
     {
-        var context = ResilienceContext.Get();
-        context.CancellationToken = cancellationToken;
+        var context = ResilienceContext.Get(cancellationToken);
 
         InitializeAsyncContext<TResult>(context);
 

--- a/src/Polly.Core/ResilienceStrategy.SyncT.cs
+++ b/src/Polly.Core/ResilienceStrategy.SyncT.cs
@@ -232,8 +232,7 @@ public abstract partial class ResilienceStrategy
 
     private static ResilienceContext GetSyncContext<TResult>(CancellationToken cancellationToken)
     {
-        var context = ResilienceContext.Get();
-        context.CancellationToken = cancellationToken;
+        var context = ResilienceContext.Get(cancellationToken);
 
         InitializeSyncContext<TResult>(context);
 

--- a/src/Polly.Extensions/Telemetry/Log.cs
+++ b/src/Polly.Extensions/Telemetry/Log.cs
@@ -16,6 +16,7 @@ internal static partial class Log
                 "Strategy Name: '{StrategyName}', " +
                 "Strategy Type: '{StrategyType}', " +
                 "Strategy Key: '{StrategyKey}', " +
+                "Operation Key: '{OperationKey}', " +
                 "Result: '{Result}'",
         EventName = "ResilienceEvent")]
     public static partial void ResilienceEvent(
@@ -26,6 +27,7 @@ internal static partial class Log
         string? strategyName,
         string strategyType,
         string? strategyKey,
+        string? operationKey,
         object? result,
         Exception? exception);
 
@@ -35,12 +37,14 @@ internal static partial class Log
         "Resilience strategy executing. " +
         "Builder Name: '{BuilderName}', " +
         "Strategy Key: '{StrategyKey}', " +
+        "Operation Key: '{OperationKey}', " +
         "Result Type: '{ResultType}'",
         EventName = "StrategyExecuting")]
     public static partial void ExecutingStrategy(
         this ILogger logger,
         string? builderName,
         string? strategyKey,
+        string? operationKey,
         string resultType);
 
     [LoggerMessage(
@@ -48,6 +52,7 @@ internal static partial class Log
         Message = "Resilience strategy executed. " +
             "Builder Name: '{BuilderName}', " +
             "Strategy Key: '{StrategyKey}', " +
+            "Operation Key: '{OperationKey}', " +
             "Result Type: '{ResultType}', " +
             "Result: '{Result}', " +
             "Execution Health: '{ExecutionHealth}', " +
@@ -58,6 +63,7 @@ internal static partial class Log
         LogLevel logLevel,
         string? builderName,
         string? strategyKey,
+        string? operationKey,
         string resultType,
         object? result,
         string executionHealth,
@@ -71,6 +77,7 @@ internal static partial class Log
                 "Strategy Name: '{StrategyName}', " +
                 "Strategy Type: '{StrategyType}', " +
                 "Strategy Key: '{StrategyKey}', " +
+                "Operation Key: '{OperationKey}', " +
                 "Result: '{Result}', " +
                 "Handled: '{Handled}', " +
                 "Attempt: '{Attempt}', " +
@@ -84,6 +91,7 @@ internal static partial class Log
         string? strategyName,
         string strategyType,
         string? strategyKey,
+        string? operationKey,
         object? result,
         bool handled,
         int attempt,

--- a/src/Polly.Extensions/Telemetry/ResilienceTelemetryDiagnosticSource.cs
+++ b/src/Polly.Extensions/Telemetry/ResilienceTelemetryDiagnosticSource.cs
@@ -53,6 +53,7 @@ internal class ResilienceTelemetryDiagnosticSource : DiagnosticSource
         enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.StrategyName, source.StrategyName));
         enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.StrategyType, source.StrategyType));
         enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.StrategyKey, source.BuilderProperties.GetValue(TelemetryUtil.StrategyKey, null!)));
+        enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.OperationKey, enrichmentContext.Context.OperationKey));
         enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.ResultType, args.Context.GetResultType()));
         enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.ExceptionName, args.Outcome?.Exception?.GetType().FullName));
     }
@@ -112,6 +113,7 @@ internal class ResilienceTelemetryDiagnosticSource : DiagnosticSource
                     args.Source.StrategyName,
                     args.Source.StrategyType,
                     strategyKey,
+                    args.Context.OperationKey,
                     result,
                     executionAttempt.Handled,
                     executionAttempt.Attempt,
@@ -121,7 +123,17 @@ internal class ResilienceTelemetryDiagnosticSource : DiagnosticSource
         }
         else
         {
-            Log.ResilienceEvent(_logger, level, args.Event.EventName, args.Source.BuilderName, args.Source.StrategyName, args.Source.StrategyType, strategyKey, result, args.Outcome?.Exception);
+            Log.ResilienceEvent(
+                _logger,
+                level,
+                args.Event.EventName,
+                args.Source.BuilderName,
+                args.Source.StrategyName,
+                args.Source.StrategyType,
+                strategyKey,
+                args.Context.OperationKey,
+                result,
+                args.Outcome?.Exception);
         }
     }
 }

--- a/src/Polly.Extensions/Telemetry/ResilienceTelemetryTags.cs
+++ b/src/Polly.Extensions/Telemetry/ResilienceTelemetryTags.cs
@@ -16,6 +16,8 @@ internal class ResilienceTelemetryTags
 
     public const string ResultType = "result-type";
 
+    public const string OperationKey = "operation-key";
+
     public const string ExceptionName = "exception-name";
 
     public const string ExecutionHealth = "execution-health";
@@ -23,5 +25,4 @@ internal class ResilienceTelemetryTags
     public const string AttemptNumber = "attempt-number";
 
     public const string AttemptHandled = "attempt-handled";
-
 }

--- a/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategy.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategy.cs
@@ -51,7 +51,7 @@ internal sealed class TelemetryResilienceStrategy : ResilienceStrategy
         TState state)
     {
         var stamp = _timeProvider.GetTimestamp();
-        Log.ExecutingStrategy(_logger, _builderName, _strategyKey, context.GetResultType());
+        Log.ExecutingStrategy(_logger, _builderName, _strategyKey, context.OperationKey, context.GetResultType());
 
         var outcome = await callback(context, state).ConfigureAwait(context.ContinueOnCapturedContext);
 
@@ -63,6 +63,7 @@ internal sealed class TelemetryResilienceStrategy : ResilienceStrategy
             logLevel,
             _builderName,
             _strategyKey,
+            context.OperationKey,
             context.GetResultType(),
             ExpandOutcome(context, outcome),
             context.GetExecutionHealth(),
@@ -88,6 +89,7 @@ internal sealed class TelemetryResilienceStrategy : ResilienceStrategy
         var enrichmentContext = EnrichmentContext.Get(context, null, CreateOutcome(outcome));
         enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.BuilderName, _builderName));
         enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.StrategyKey, _strategyKey));
+        enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.OperationKey, context.OperationKey));
         enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.ResultType, context.GetResultType()));
         enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.ExceptionName, outcome.Exception?.GetType().FullName));
         enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.ExecutionHealth, context.GetExecutionHealth()));

--- a/src/Polly/Utilities/Wrappers/ResilienceContextFactory.cs
+++ b/src/Polly/Utilities/Wrappers/ResilienceContextFactory.cs
@@ -10,8 +10,7 @@ internal static class ResilienceContextFactory
         bool continueOnCapturedContext,
         out IDictionary<string, object> oldProperties)
     {
-        var resilienceContext = ResilienceContext.Get();
-        resilienceContext.CancellationToken = cancellationToken;
+        var resilienceContext = ResilienceContext.Get(context.OperationKey, cancellationToken);
         resilienceContext.ContinueOnCapturedContext = continueOnCapturedContext;
         resilienceContext.Properties.SetProperties(context, out oldProperties);
 

--- a/test/Polly.Specs/ResilienceStrategyConversionExtensionsTests.cs
+++ b/test/Polly.Specs/ResilienceStrategyConversionExtensionsTests.cs
@@ -26,6 +26,7 @@ public class ResilienceStrategyConversionExtensionsTests
                 context.IsSynchronous.Should().Be(_isSynchronous);
                 context.Properties.Set(Outgoing, "outgoing-value");
                 context.Properties.GetValue(Incoming, string.Empty).Should().Be("incoming-value");
+                context.OperationKey.Should().Be("op-key");
 
                 if (_resultType != null)
                 {
@@ -44,7 +45,7 @@ public class ResilienceStrategyConversionExtensionsTests
     {
         _isVoid = true;
         _isSynchronous = true;
-        var context = new Context
+        var context = new Context("op-key")
         {
             [Incoming.Key] = "incoming-value"
         };
@@ -64,7 +65,7 @@ public class ResilienceStrategyConversionExtensionsTests
         _isVoid = false;
         _isSynchronous = true;
         _resultType = typeof(string);
-        var context = new Context
+        var context = new Context("op-key")
         {
             [Incoming.Key] = "incoming-value"
         };
@@ -80,7 +81,7 @@ public class ResilienceStrategyConversionExtensionsTests
         _isVoid = false;
         _isSynchronous = true;
         _resultType = typeof(string);
-        var context = new Context
+        var context = new Context("op-key")
         {
             [Incoming.Key] = "incoming-value"
         };
@@ -96,7 +97,7 @@ public class ResilienceStrategyConversionExtensionsTests
     {
         _isVoid = true;
         _isSynchronous = false;
-        var context = new Context
+        var context = new Context("op-key")
         {
             [Incoming.Key] = "incoming-value"
         };
@@ -117,7 +118,7 @@ public class ResilienceStrategyConversionExtensionsTests
         _isVoid = false;
         _isSynchronous = false;
         _resultType = typeof(string);
-        var context = new Context
+        var context = new Context("op-key")
         {
             [Incoming.Key] = "incoming-value"
         };
@@ -138,7 +139,7 @@ public class ResilienceStrategyConversionExtensionsTests
         _isVoid = false;
         _isSynchronous = false;
         _resultType = typeof(string);
-        var context = new Context
+        var context = new Context("op-key")
         {
             [Incoming.Key] = "incoming-value"
         };
@@ -168,7 +169,7 @@ public class ResilienceStrategyConversionExtensionsTests
             .Build()
             .AsSyncPolicy();
 
-        var context = new Context
+        var context = new Context("op-key")
         {
             ["retry"] = 0
         };


### PR DESCRIPTION
### Details on the issue fix or feature implementation

This PR introduces `ResilienceContext.OperationKey` that can be assigned to each `ResilienceContext`. It's immutable property that is specified at the time of the `ResilienceContext` creation:

``` csharp
var context= ResilienceContext.Get("my-operation");
var key = context.OperationKey; // my-operation
```

Operation key flows to telemetry and is included in logs and metrics. The main scenario is to distinguish the particular operation at call site and to improve the telemetry. It should have low cardinality.

This also fills the feature gap we had between Polly V7 and Polly V8.

Contributes to #1365 

### Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build
