### PR TITLE
Introduce `TelemetryOptions.OnTelemetryEvent`

### DIFF
--- a/src/Polly.Core/Telemetry/ResilienceTelemetrySource.cs
+++ b/src/Polly.Core/Telemetry/ResilienceTelemetrySource.cs
@@ -1,5 +1,3 @@
-using System.ComponentModel;
-
 namespace Polly.Telemetry;
 
 /// <summary>
@@ -12,7 +10,6 @@ namespace Polly.Telemetry;
 /// <remarks>
 /// This class is used by the telemetry infrastructure and should not be used directly by user code.
 /// </remarks>
-[EditorBrowsable(EditorBrowsableState.Never)]
 public sealed record class ResilienceTelemetrySource(
     string? BuilderName,
     ResilienceProperties BuilderProperties,

--- a/src/Polly.Core/Telemetry/TelemetryEventArguments.cs
+++ b/src/Polly.Core/Telemetry/TelemetryEventArguments.cs
@@ -1,11 +1,8 @@
-using System.ComponentModel;
-
 namespace Polly.Telemetry;
 
 /// <summary>
 /// The arguments of the telemetry event.
 /// </summary>
-[EditorBrowsable(EditorBrowsableState.Never)]
 public sealed partial record class TelemetryEventArguments
 {
     private TelemetryEventArguments()

--- a/src/Polly.Extensions/Telemetry/ResilienceTelemetryDiagnosticSource.cs
+++ b/src/Polly.Extensions/Telemetry/ResilienceTelemetryDiagnosticSource.cs
@@ -10,6 +10,7 @@ internal class ResilienceTelemetryDiagnosticSource : DiagnosticSource
 
     private readonly ILogger _logger;
     private readonly Func<ResilienceContext, object?, object?> _resultFormatter;
+    private readonly Action<TelemetryEventArguments>? _onEvent;
     private readonly List<Action<EnrichmentContext>> _enrichers;
 
     public ResilienceTelemetryDiagnosticSource(TelemetryOptions options)
@@ -17,6 +18,7 @@ internal class ResilienceTelemetryDiagnosticSource : DiagnosticSource
         _enrichers = options.Enrichers.ToList();
         _logger = options.LoggerFactory.CreateLogger(TelemetryUtil.PollyDiagnosticSource);
         _resultFormatter = options.ResultFormatter;
+        _onEvent = options.OnTelemetryEvent;
 
         Counter = Meter.CreateCounter<int>(
             "resilience-events",
@@ -40,6 +42,8 @@ internal class ResilienceTelemetryDiagnosticSource : DiagnosticSource
         {
             return;
         }
+
+        _onEvent?.Invoke(args);
 
         LogEvent(args);
         MeterEvent(args);

--- a/src/Polly.Extensions/Telemetry/TelemetryOptions.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryOptions.cs
@@ -2,6 +2,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Net.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Polly.Telemetry;
 
 namespace Polly.Extensions.Telemetry;
 
@@ -10,6 +11,14 @@ namespace Polly.Extensions.Telemetry;
 /// </summary>
 public class TelemetryOptions
 {
+    /// <summary>
+    /// Gets or sets the callback that is raised when <see cref="TelemetryEventArguments"/> is received from Polly.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see langword="null"/>.
+    /// </remarks>
+    public Action<TelemetryEventArguments>? OnTelemetryEvent { get; set; }
+
     /// <summary>
     /// Gets or sets the logger factory.
     /// </summary>


### PR DESCRIPTION
### Details on the issue fix or feature implementation

This comment:
https://github.com/martincostello/polly-sandbox/pull/1#discussion_r1251636566

Made me realize that not every adopter wants to consume native Polly telemetry. This PR adds a simple way to hook into Polly telemetry and inspect `TelemetryEventArguments` that contain all necessary information to report custom events from it.

Usage:

``` csharp
var builder = new ResilienceStrategyBuilder()
    .AddTimeout(TimeSpan.FromSeconds(1))
    .ConfigureTelemetry(new TelemetryOptions
    {
        OnTelemetryEvent = args =>
        {
            // do whatever you want with args
        }
    });
```


Contributes to #1365 



### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
