### PR TITLE
`ResilienceStrategyRegistry` API improvements

### DIFF
--- a/src/Polly.Extensions/DependencyInjection/AddResilienceStrategyContext.cs
+++ b/src/Polly.Extensions/DependencyInjection/AddResilienceStrategyContext.cs
@@ -1,7 +1,7 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Polly.Extensions.Utils;
+using Polly.Extensions.Registry;
 using Polly.Registry;
 
 namespace Polly.Extensions.DependencyInjection;
@@ -53,12 +53,7 @@ public sealed class AddResilienceStrategyContext<TKey>
     /// You can listen for changes only for single options. If you call this method multiple times, the preceding calls are ignored and only the last one wins.
     /// </para>
     /// </remarks>
-    public void EnableReloads<TOptions>(string? name = null)
-    {
-        var monitor = ServiceProvider.GetRequiredService<IOptionsMonitor<TOptions>>();
-
-        RegistryContext.EnableReloads(() => new OptionsReloadHelper<TOptions>(monitor, name ?? Options.DefaultName).GetCancellationToken);
-    }
+    public void EnableReloads<TOptions>(string? name = null) => RegistryContext.EnableReloads(ServiceProvider.GetRequiredService<IOptionsMonitor<TOptions>>(), name);
 
     /// <summary>
     /// Gets the options identified by <paramref name="name"/>.

--- a/src/Polly.Extensions/DependencyInjection/PollyServiceCollectionExtensions.cs
+++ b/src/Polly.Extensions/DependencyInjection/PollyServiceCollectionExtensions.cs
@@ -25,13 +25,13 @@ public static class PollyServiceCollectionExtensions
     /// <param name="configure">An action that configures the resilience strategy.</param>
     /// <returns>The updated <see cref="IServiceCollection"/> with the registered resilience strategy.</returns>
     /// <exception cref="InvalidOperationException">Thrown if the resilience strategy builder with the provided key has already been added to the registry.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> or <paramref name="configure"/> is <see langword="null"/>.</exception>
     /// <remarks>
     /// You can retrieve the registered strategy by resolving the <see cref="ResilienceStrategyProvider{TKey}"/> class from the dependency injection container.
     /// <para>
     /// This call enables the telemetry for the registered resilience strategy.
     /// </para>
     /// </remarks>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> or <paramref name="configure"/> is <see langword="null"/>.</exception>
     public static IServiceCollection AddResilienceStrategy<TKey, TResult>(
         this IServiceCollection services,
         TKey key,
@@ -54,13 +54,13 @@ public static class PollyServiceCollectionExtensions
     /// <param name="configure">An action that configures the resilience strategy.</param>
     /// <returns>The updated <see cref="IServiceCollection"/> with the registered resilience strategy.</returns>
     /// <exception cref="InvalidOperationException">Thrown if the resilience strategy builder with the provided key has already been added to the registry.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> or <paramref name="configure"/> is <see langword="null"/>.</exception>
     /// <remarks>
     /// You can retrieve the registered strategy by resolving the <see cref="ResilienceStrategyProvider{TKey}"/> class from the dependency injection container.
     /// <para>
     /// This call enables the telemetry for the registered resilience strategy.
     /// </para>
     /// </remarks>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> or <paramref name="configure"/> is <see langword="null"/>.</exception>
     public static IServiceCollection AddResilienceStrategy<TKey, TResult>(
         this IServiceCollection services,
         TKey key,
@@ -97,13 +97,13 @@ public static class PollyServiceCollectionExtensions
     /// <param name="configure">An action that configures the resilience strategy.</param>
     /// <returns>The updated <see cref="IServiceCollection"/> with the registered resilience strategy.</returns>
     /// <exception cref="InvalidOperationException">Thrown if the resilience strategy builder with the provided key has already been added to the registry.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> or <paramref name="configure"/> is <see langword="null"/>.</exception>
     /// <remarks>
     /// You can retrieve the registered strategy by resolving the <see cref="ResilienceStrategyProvider{TKey}"/> class from the dependency injection container.
     /// <para>
     /// This call enables the telemetry for the registered resilience strategy.
     /// </para>
     /// </remarks>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> or <paramref name="configure"/> is <see langword="null"/>.</exception>
     public static IServiceCollection AddResilienceStrategy<TKey>(
         this IServiceCollection services,
         TKey key,
@@ -125,13 +125,13 @@ public static class PollyServiceCollectionExtensions
     /// <param name="configure">An action that configures the resilience strategy.</param>
     /// <returns>The updated <see cref="IServiceCollection"/> with the registered resilience strategy.</returns>
     /// <exception cref="InvalidOperationException">Thrown if the resilience strategy builder with the provided key has already been added to the registry.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> or <paramref name="configure"/> is <see langword="null"/>.</exception>
     /// <remarks>
     /// You can retrieve the registered strategy by resolving the <see cref="ResilienceStrategyProvider{TKey}"/> class from the dependency injection container.
     /// <para>
     /// This call enables the telemetry for the registered resilience strategy.
     /// </para>
     /// </remarks>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> or <paramref name="configure"/> is <see langword="null"/>.</exception>
     public static IServiceCollection AddResilienceStrategy<TKey>(
         this IServiceCollection services,
         TKey key,
@@ -165,7 +165,7 @@ public static class PollyServiceCollectionExtensions
     /// <typeparam name="TKey">The type of the key used to identify the resilience strategy.</typeparam>
     /// <param name="services">The <see cref="IServiceCollection"/> to add the resilience strategy to.</param>
     /// <returns>The updated <see cref="IServiceCollection"/> with additional services added.</returns>
-    /// <exception cref="InvalidOperationException">Thrown if the resilience strategy builder with the provided key has already been added to the registry.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> is <see langword="null"/>.</exception>
     /// <remarks>
     /// You can retrieve the strategy registry by resolving the <see cref="ResilienceStrategyProvider{TKey}"/>
     /// or <see cref="ResilienceStrategyRegistry{TKey}"/> class from the dependency injection container.
@@ -173,7 +173,6 @@ public static class PollyServiceCollectionExtensions
     /// This call enables telemetry for all resilience strategies created using <see cref="ResilienceStrategyRegistry{TKey}"/>.
     /// </para>
     /// </remarks>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> is <see langword="null"/>.</exception>
     public static IServiceCollection AddResilienceStrategy<TKey>(this IServiceCollection services)
         where TKey : notnull
     {

--- a/src/Polly.Extensions/DependencyInjection/PollyServiceCollectionExtensions.cs
+++ b/src/Polly.Extensions/DependencyInjection/PollyServiceCollectionExtensions.cs
@@ -170,7 +170,7 @@ public static class PollyServiceCollectionExtensions
     /// You can retrieve the strategy registry by resolving the <see cref="ResilienceStrategyProvider{TKey}"/>
     /// or <see cref="ResilienceStrategyRegistry{TKey}"/> class from the dependency injection container.
     /// <para>
-    /// This call enables the telemetry for al resilience strategies created using <see cref="ResilienceStrategyRegistry{TKey}"/>.
+    /// This call enables telemetry for all resilience strategies created using <see cref="ResilienceStrategyRegistry{TKey}"/>.
     /// </para>
     /// </remarks>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> is <see langword="null"/>.</exception>

--- a/src/Polly.Extensions/DependencyInjection/PollyServiceCollectionExtensions.cs
+++ b/src/Polly.Extensions/DependencyInjection/PollyServiceCollectionExtensions.cs
@@ -85,7 +85,7 @@ public static class PollyServiceCollectionExtensions
                 });
             });
 
-        return AddResilienceStrategyRegistry<TKey>(services);
+        return AddResilienceStrategy<TKey>(services);
     }
 
     /// <summary>
@@ -156,12 +156,29 @@ public static class PollyServiceCollectionExtensions
                 });
             });
 
-        return AddResilienceStrategyRegistry<TKey>(services);
+        return AddResilienceStrategy<TKey>(services);
     }
 
-    private static IServiceCollection AddResilienceStrategyRegistry<TKey>(this IServiceCollection services)
+    /// <summary>
+    /// Adds the infrastructure that allows configuring and retrieving resilience strategies using the <typeparamref name="TKey"/> key.
+    /// </summary>
+    /// <typeparam name="TKey">The type of the key used to identify the resilience strategy.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add the resilience strategy to.</param>
+    /// <returns>The updated <see cref="IServiceCollection"/> with additional services added.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if the resilience strategy builder with the provided key has already been added to the registry.</exception>
+    /// <remarks>
+    /// You can retrieve the strategy registry by resolving the <see cref="ResilienceStrategyProvider{TKey}"/>
+    /// or <see cref="ResilienceStrategyRegistry{TKey}"/> class from the dependency injection container.
+    /// <para>
+    /// This call enables the telemetry for al resilience strategies created using <see cref="ResilienceStrategyRegistry{TKey}"/>.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> is <see langword="null"/>.</exception>
+    public static IServiceCollection AddResilienceStrategy<TKey>(this IServiceCollection services)
         where TKey : notnull
     {
+        Guard.NotNull(services);
+
         // check marker to ensure the APIs bellow are called only once for each TKey type
         // this prevents polluting the service collection with unnecessary Configure calls
         if (services.Contains(RegistryMarker<TKey>.ServiceDescriptor))
@@ -172,7 +189,7 @@ public static class PollyServiceCollectionExtensions
         services.AddOptions();
         services.Add(RegistryMarker<TKey>.ServiceDescriptor);
         services.AddResilienceStrategyBuilder();
-        services.AddResilienceStrategyRegistry<TKey>();
+        services.AddResilienceStrategy<TKey>();
 
         services.TryAddSingleton(serviceProvider =>
         {

--- a/src/Polly.Extensions/Polly.Extensions.csproj
+++ b/src/Polly.Extensions/Polly.Extensions.csproj
@@ -29,6 +29,6 @@
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
-    <Reference Include="System.Net.Http" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'"/>
+    <Reference Include="System.Net.Http" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
   </ItemGroup>
 </Project>

--- a/src/Polly.Extensions/Registry/ConfigureBuilderContextExtensions.cs
+++ b/src/Polly.Extensions/Registry/ConfigureBuilderContextExtensions.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Extensions.Options;
+using Polly.Extensions.Utils;
+using Polly.Registry;
+using Polly.Utils;
+
+namespace Polly.Extensions.Registry;
+
+/// <summary>
+/// Extensions for <see cref="ConfigureBuilderContext{TKey}"/>.
+/// </summary>
+public static class ConfigureBuilderContextExtensions
+{
+    /// <summary>
+    /// Enables dynamic reloading of the resilience strategy whenever the <typeparamref name="TOptions"/> options are changed.
+    /// </summary>
+    /// <typeparam name="TKey">The type of the key used to identify the resilience strategy.</typeparam>
+    /// <typeparam name="TOptions">The options type to listen to.</typeparam>
+    /// <param name="context">The builder context.</param>
+    /// <param name="optionsMonitor">The options monitor.</param>
+    /// <param name="name">The named options, if any.</param>
+    /// <remarks>
+    /// You can decide based on the <paramref name="name"/> to listen for changes in global options or named options.
+    /// If <paramref name="name"/> is <see langword="null"/> then the global options are listened to.
+    /// <para>
+    /// You can listen for changes only for single options. If you call this method multiple times, the preceding calls are ignored and only the last one wins.
+    /// </para>
+    /// </remarks>
+    public static void EnableReloads<TKey, TOptions>(this ConfigureBuilderContext<TKey> context, IOptionsMonitor<TOptions> optionsMonitor, string? name = null)
+        where TKey : notnull
+    {
+        Guard.NotNull(context);
+        Guard.NotNull(optionsMonitor);
+
+        context.EnableReloads(() => new OptionsReloadHelper<TOptions>(optionsMonitor, name ?? Options.DefaultName).GetCancellationToken);
+    }
+}

--- a/test/Polly.Core.Tests/Registry/ResilienceStrategyRegistryTests.cs
+++ b/test/Polly.Core.Tests/Registry/ResilienceStrategyRegistryTests.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using Polly.Registry;
 using Polly.Retry;
 using Polly.Telemetry;
+using Polly.Timeout;
 
 namespace Polly.Core.Tests.Registry;
 
@@ -427,6 +428,32 @@ public class ResilienceStrategyRegistryTests
         changeSource.Cancel();
         strategy.Execute(() => { tries++; return "dummy"; });
         tries.Should().Be(retryCount + 1);
+    }
+
+    [Fact]
+    public void GetOrAddStrategy_Ok()
+    {
+        var id = new StrategyId(typeof(string), "A");
+
+        var registry = CreateRegistry();
+        var strategy = registry.GetOrAddStrategy(id, builder => builder.AddTimeout(TimeSpan.FromSeconds(1)));
+        var otherStrategy = registry.GetOrAddStrategy(id, builder => builder.AddTimeout(TimeSpan.FromSeconds(1)));
+
+        strategy.Should().BeOfType<TimeoutResilienceStrategy>();
+        strategy.Should().BeSameAs(otherStrategy);
+    }
+
+    [Fact]
+    public void GetOrAddStrategy_Generic_Ok()
+    {
+        var id = new StrategyId(typeof(string), "A");
+
+        var registry = CreateRegistry();
+        var strategy = registry.GetOrAddStrategy<string>(id, builder => builder.AddTimeout(TimeSpan.FromSeconds(1)));
+        var otherStrategy = registry.GetOrAddStrategy<string>(id, builder => builder.AddTimeout(TimeSpan.FromSeconds(1)));
+
+        strategy.Strategy.Should().BeOfType<TimeoutResilienceStrategy>();
+        strategy.Should().BeSameAs(otherStrategy);
     }
 
     private ResilienceStrategyRegistry<StrategyId> CreateRegistry() => new(_options);

--- a/test/Polly.Core.Tests/Registry/ResilienceStrategyRegistryTests.cs
+++ b/test/Polly.Core.Tests/Registry/ResilienceStrategyRegistryTests.cs
@@ -434,23 +434,26 @@ public class ResilienceStrategyRegistryTests
     public void GetOrAddStrategy_Ok()
     {
         var id = new StrategyId(typeof(string), "A");
+        var called = 0;
 
         var registry = CreateRegistry();
-        var strategy = registry.GetOrAddStrategy(id, builder => builder.AddTimeout(TimeSpan.FromSeconds(1)));
-        var otherStrategy = registry.GetOrAddStrategy(id, builder => builder.AddTimeout(TimeSpan.FromSeconds(1)));
+        var strategy = registry.GetOrAddStrategy(id, builder => { builder.AddTimeout(TimeSpan.FromSeconds(1)); called++; });
+        var otherStrategy = registry.GetOrAddStrategy(id, builder => { builder.AddTimeout(TimeSpan.FromSeconds(1)); called++; });
 
         strategy.Should().BeOfType<TimeoutResilienceStrategy>();
         strategy.Should().BeSameAs(otherStrategy);
+        called.Should().Be(1);
     }
 
     [Fact]
     public void GetOrAddStrategy_Generic_Ok()
     {
         var id = new StrategyId(typeof(string), "A");
+        var called = 0;
 
         var registry = CreateRegistry();
-        var strategy = registry.GetOrAddStrategy<string>(id, builder => builder.AddTimeout(TimeSpan.FromSeconds(1)));
-        var otherStrategy = registry.GetOrAddStrategy<string>(id, builder => builder.AddTimeout(TimeSpan.FromSeconds(1)));
+        var strategy = registry.GetOrAddStrategy<string>(id, builder => { builder.AddTimeout(TimeSpan.FromSeconds(1)); called++; });
+        var otherStrategy = registry.GetOrAddStrategy<string>(id, builder => { builder.AddTimeout(TimeSpan.FromSeconds(1)); called++; });
 
         strategy.Strategy.Should().BeOfType<TimeoutResilienceStrategy>();
         strategy.Should().BeSameAs(otherStrategy);

--- a/test/Polly.Extensions.Tests/DependencyInjection/PollyServiceCollectionExtensionTests.cs
+++ b/test/Polly.Extensions.Tests/DependencyInjection/PollyServiceCollectionExtensionTests.cs
@@ -254,6 +254,16 @@ public class PollyServiceCollectionExtensionTests
             .HaveCount(30);
     }
 
+    [Fact]
+    public void AddResilienceStrategyInfra_Ok()
+    {
+        var provider = new ServiceCollection().AddResilienceStrategy<string>().BuildServiceProvider();
+
+        provider.GetRequiredService<ResilienceStrategyRegistry<string>>().Should().NotBeNull();
+        provider.GetRequiredService<ResilienceStrategyProvider<string>>().Should().NotBeNull();
+        provider.GetRequiredService<ResilienceStrategyBuilder>().DiagnosticSource.Should().NotBeNull();
+    }
+
     private void AddResilienceStrategy(string key, Action<ResilienceStrategyBuilderContext>? onBuilding = null)
     {
         _services.AddResilienceStrategy(key, builder =>


### PR DESCRIPTION
### Details on the issue fix or feature implementation

Bunch of API improvements for working with `ResilienceStrategyRegistry`

- Adding `GetOrAddStrategy` method for non-generic and generic strategies.
- Adding `AddResilienceStrategy<TKey>` extension that adds all the necessary infra without requiring to configuring any strategy.
- Allowing to enable reloads when using the registry directly.

Api Usage:

``` csharp
var registry = new ResilienceStrategyRegistry<string>();
IOptionsMonitor<MyOptions> monitor = ... ;

ResilienceStrategy strategy = registry.GetOrAddStrategy("my-strategy", (builder, context) =>
{
    context.EnableReloads(monitor);
    builder.AddTimeout(monitor.CurrentValue.Timeout);
});
```

Contributes to #1365


### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
