### PR TITLE
Introduce `ResilienceStrategyBuilder.InstanceName` and use it in telemetry

### DIFF
--- a/src/Polly.Core/Registry/ConfigureBuilderContext.cs
+++ b/src/Polly.Core/Registry/ConfigureBuilderContext.cs
@@ -9,11 +9,11 @@ namespace Polly.Registry;
 public class ConfigureBuilderContext<TKey>
     where TKey : notnull
 {
-    internal ConfigureBuilderContext(TKey strategyKey, string builderName, string strategyKeyString)
+    internal ConfigureBuilderContext(TKey strategyKey, string builderName, string? builderInstanceName)
     {
         StrategyKey = strategyKey;
         BuilderName = builderName;
-        StrategyKeyString = strategyKeyString;
+        BuilderInstanceName = builderInstanceName;
     }
 
     /// <summary>
@@ -27,9 +27,9 @@ public class ConfigureBuilderContext<TKey>
     public string BuilderName { get; }
 
     /// <summary>
-    /// Gets the string representation of strategy key for the strategy being created.
+    /// Gets the instance name for the builder being used to create the strategy.
     /// </summary>
-    public string StrategyKeyString { get; }
+    public string? BuilderInstanceName { get; }
 
     internal Func<Func<CancellationToken>>? ReloadTokenProducer { get; private set; }
 

--- a/src/Polly.Core/Registry/ResilienceStrategyRegistryOptions.cs
+++ b/src/Polly.Core/Registry/ResilienceStrategyRegistryOptions.cs
@@ -37,17 +37,16 @@ public class ResilienceStrategyRegistryOptions<TKey>
 
     /// <summary>
     /// Gets or sets the formatter that is used by the registry to format the <typeparamref name="TKey"/> to a string that
-    /// represents the strategy key.
+    /// represents the instance name of the builder.
     /// </summary>
     /// <remarks>
-    /// By default, the formatter uses the <see cref="object.ToString"/> method.
+    /// Defaults to <see langword="null"/>.
     /// <para>
-    /// Use custom formatter for composite keys in case you want to have different metric values for a builder and strategy key.
-    /// In general, strategies can have the same builder name and different strategy keys.
+    /// Use custom formatter for composite keys in case you want to have different metric values for a builder and instance key.
+    /// In general, strategies can have the same builder name and different instance names.
     /// </para>
     /// </remarks>
-    [Required]
-    public Func<TKey, string> StrategyKeyFormatter { get; set; } = (key) => key?.ToString() ?? string.Empty;
+    public Func<TKey, string>? InstanceNameFormatter { get; set; }
 
     /// <summary>
     /// Gets or sets the formatter that is used by the registry to format the <typeparamref name="TKey"/> to a string that

--- a/src/Polly.Core/ResilienceStrategyBuilderBase.cs
+++ b/src/Polly.Core/ResilienceStrategyBuilderBase.cs
@@ -41,6 +41,16 @@ public abstract class ResilienceStrategyBuilderBase
     public string? BuilderName { get; set; }
 
     /// <summary>
+    /// Gets or sets the instance name of the builder.
+    /// </summary>
+    /// <remarks>
+    /// This property is also included in the telemetry that is produced by the individual resilience strategies.
+    /// The instance name can be used to differentiate between multiple builder instances with the same <see cref="BuilderName"/>.
+    /// Defaults to <see langword="null"/>.
+    /// </remarks>
+    public string? InstanceName { get; set; }
+
+    /// <summary>
     /// Gets the custom properties attached to builder options.
     /// </summary>
     public ResilienceProperties Properties { get; } = new();
@@ -125,6 +135,7 @@ public abstract class ResilienceStrategyBuilderBase
     {
         var context = new ResilienceStrategyBuilderContext(
             builderName: BuilderName,
+            builderInstanceName: InstanceName,
             builderProperties: Properties,
             strategyName: entry.Properties.StrategyName,
             strategyType: entry.Properties.StrategyType,

--- a/src/Polly.Core/ResilienceStrategyBuilderContext.cs
+++ b/src/Polly.Core/ResilienceStrategyBuilderContext.cs
@@ -11,6 +11,7 @@ public sealed class ResilienceStrategyBuilderContext
 {
     internal ResilienceStrategyBuilderContext(
         string? builderName,
+        string? builderInstanceName,
         ResilienceProperties builderProperties,
         string? strategyName,
         string strategyType,
@@ -20,12 +21,13 @@ public sealed class ResilienceStrategyBuilderContext
         Func<double> randomizer)
     {
         BuilderName = builderName;
+        BuilderInstanceName = builderInstanceName;
         BuilderProperties = builderProperties;
         StrategyName = strategyName;
         StrategyType = strategyType;
         TimeProvider = timeProvider;
         IsGenericBuilder = isGenericBuilder;
-        Telemetry = TelemetryUtil.CreateTelemetry(diagnosticSource, builderName, builderProperties, strategyName, strategyType);
+        Telemetry = TelemetryUtil.CreateTelemetry(diagnosticSource, builderName, builderInstanceName, builderProperties, strategyName, strategyType);
         Randomizer = randomizer;
     }
 
@@ -33,6 +35,11 @@ public sealed class ResilienceStrategyBuilderContext
     /// Gets the name of the builder.
     /// </summary>
     public string? BuilderName { get; }
+
+    /// <summary>
+    /// Gets the instance name of the builder.
+    /// </summary>
+    public string? BuilderInstanceName { get; }
 
     /// <summary>
     /// Gets the custom properties attached to the builder.

--- a/src/Polly.Core/Telemetry/ResilienceTelemetrySource.cs
+++ b/src/Polly.Core/Telemetry/ResilienceTelemetrySource.cs
@@ -4,6 +4,7 @@ namespace Polly.Telemetry;
 /// The source of resilience telemetry events.
 /// </summary>
 /// <param name="BuilderName">The builder name.</param>
+/// <param name="BuilderInstanceName">The builder instance name.</param>
 /// <param name="BuilderProperties">The builder properties.</param>
 /// <param name="StrategyName">The strategy name. </param>
 /// <param name="StrategyType">The strategy type.</param>
@@ -12,6 +13,7 @@ namespace Polly.Telemetry;
 /// </remarks>
 public sealed record class ResilienceTelemetrySource(
     string? BuilderName,
+    string? BuilderInstanceName,
     ResilienceProperties BuilderProperties,
     string? StrategyName,
     string StrategyType);

--- a/src/Polly.Core/Telemetry/TelemetryUtil.cs
+++ b/src/Polly.Core/Telemetry/TelemetryUtil.cs
@@ -6,16 +6,15 @@ internal static class TelemetryUtil
 
     internal const string ExecutionAttempt = "ExecutionAttempt";
 
-    internal static readonly ResiliencePropertyKey<string> StrategyKey = new("Polly.StrategyKey");
-
     public static ResilienceStrategyTelemetry CreateTelemetry(
         DiagnosticSource? diagnosticSource,
         string? builderName,
+        string? builderInstanceName,
         ResilienceProperties builderProperties,
         string? strategyName,
         string strategyType)
     {
-        var telemetrySource = new ResilienceTelemetrySource(builderName, builderProperties, strategyName, strategyType);
+        var telemetrySource = new ResilienceTelemetrySource(builderName, builderInstanceName, builderProperties, strategyName, strategyType);
 
         return new ResilienceStrategyTelemetry(telemetrySource, diagnosticSource);
     }

--- a/src/Polly.Extensions/Telemetry/Log.cs
+++ b/src/Polly.Extensions/Telemetry/Log.cs
@@ -12,10 +12,7 @@ internal static partial class Log
         EventId = 0,
         Message = "Resilience event occurred. " +
                 "EventName: '{EventName}', " +
-                "Builder Name: '{BuilderName}', " +
-                "Strategy Name: '{StrategyName}', " +
-                "Strategy Type: '{StrategyType}', " +
-                "Strategy Key: '{StrategyKey}', " +
+                "Source: '{BuilderName}[{BuilderInstance}]/{StrategyType}[{StrategyName}]', " +
                 "Operation Key: '{OperationKey}', " +
                 "Result: '{Result}'",
         EventName = "ResilienceEvent")]
@@ -24,9 +21,9 @@ internal static partial class Log
         LogLevel logLevel,
         string eventName,
         string? builderName,
+        string? builderInstance,
         string? strategyName,
         string strategyType,
-        string? strategyKey,
         string? operationKey,
         object? result,
         Exception? exception);
@@ -35,23 +32,21 @@ internal static partial class Log
         1,
         LogLevel.Debug,
         "Resilience strategy executing. " +
-        "Builder Name: '{BuilderName}', " +
-        "Strategy Key: '{StrategyKey}', " +
+        "Source: '{BuilderName}[{BuilderInstance}]', " +
         "Operation Key: '{OperationKey}', " +
         "Result Type: '{ResultType}'",
         EventName = "StrategyExecuting")]
     public static partial void ExecutingStrategy(
         this ILogger logger,
         string? builderName,
-        string? strategyKey,
+        string? builderInstance,
         string? operationKey,
         string resultType);
 
     [LoggerMessage(
         EventId = 2,
         Message = "Resilience strategy executed. " +
-            "Builder Name: '{BuilderName}', " +
-            "Strategy Key: '{StrategyKey}', " +
+            "Source: '{BuilderName}[{BuilderInstance}]', " +
             "Operation Key: '{OperationKey}', " +
             "Result Type: '{ResultType}', " +
             "Result: '{Result}', " +
@@ -62,7 +57,7 @@ internal static partial class Log
         this ILogger logger,
         LogLevel logLevel,
         string? builderName,
-        string? strategyKey,
+        string? builderInstance,
         string? operationKey,
         string resultType,
         object? result,
@@ -73,10 +68,7 @@ internal static partial class Log
     [LoggerMessage(
         EventId = 3,
         Message = "Execution attempt. " +
-                "Builder Name: '{BuilderName}', " +
-                "Strategy Name: '{StrategyName}', " +
-                "Strategy Type: '{StrategyType}', " +
-                "Strategy Key: '{StrategyKey}', " +
+                "Source: '{BuilderName}[{BuilderInstance}]/{StrategyType}[{StrategyName}]', " +
                 "Operation Key: '{OperationKey}', " +
                 "Result: '{Result}', " +
                 "Handled: '{Handled}', " +
@@ -88,9 +80,9 @@ internal static partial class Log
         this ILogger logger,
         LogLevel level,
         string? builderName,
+        string? builderInstance,
         string? strategyName,
         string strategyType,
-        string? strategyKey,
         string? operationKey,
         object? result,
         bool handled,

--- a/src/Polly.Extensions/Telemetry/ResilienceTelemetryDiagnosticSource.cs
+++ b/src/Polly.Extensions/Telemetry/ResilienceTelemetryDiagnosticSource.cs
@@ -54,9 +54,9 @@ internal class ResilienceTelemetryDiagnosticSource : DiagnosticSource
         enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.EventName, args.Event.EventName));
         enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.EventSeverity, args.Event.Severity.AsString()));
         enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.BuilderName, source.BuilderName));
+        enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.BuilderInstance, source.BuilderInstanceName));
         enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.StrategyName, source.StrategyName));
         enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.StrategyType, source.StrategyType));
-        enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.StrategyKey, source.BuilderProperties.GetValue(TelemetryUtil.StrategyKey, null!)));
         enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.OperationKey, enrichmentContext.Context.OperationKey));
         enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.ResultType, args.Context.GetResultType()));
         enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.ExceptionName, args.Outcome?.Exception?.GetType().FullName));
@@ -93,7 +93,6 @@ internal class ResilienceTelemetryDiagnosticSource : DiagnosticSource
 
     private void LogEvent(TelemetryEventArguments args)
     {
-        var strategyKey = args.Source.BuilderProperties.GetValue(TelemetryUtil.StrategyKey, null!);
         var result = args.Outcome?.Result;
         if (result is not null)
         {
@@ -114,9 +113,9 @@ internal class ResilienceTelemetryDiagnosticSource : DiagnosticSource
                     _logger,
                     level,
                     args.Source.BuilderName,
+                    args.Source.BuilderInstanceName,
                     args.Source.StrategyName,
                     args.Source.StrategyType,
-                    strategyKey,
                     args.Context.OperationKey,
                     result,
                     executionAttempt.Handled,
@@ -132,9 +131,9 @@ internal class ResilienceTelemetryDiagnosticSource : DiagnosticSource
                 level,
                 args.Event.EventName,
                 args.Source.BuilderName,
+                args.Source.BuilderInstanceName,
                 args.Source.StrategyName,
                 args.Source.StrategyType,
-                strategyKey,
                 args.Context.OperationKey,
                 result,
                 args.Outcome?.Exception);

--- a/src/Polly.Extensions/Telemetry/ResilienceTelemetryTags.cs
+++ b/src/Polly.Extensions/Telemetry/ResilienceTelemetryTags.cs
@@ -8,11 +8,11 @@ internal class ResilienceTelemetryTags
 
     public const string BuilderName = "builder-name";
 
+    public const string BuilderInstance = "builder-instance";
+
     public const string StrategyName = "strategy-name";
 
     public const string StrategyType = "strategy-type";
-
-    public const string StrategyKey = "strategy-key";
 
     public const string ResultType = "result-type";
 

--- a/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategy.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategy.cs
@@ -7,7 +7,7 @@ internal sealed class TelemetryResilienceStrategy : ResilienceStrategy
 {
     private readonly TimeProvider _timeProvider;
     private readonly string? _builderName;
-    private readonly string? _strategyKey;
+    private readonly string? _builderInstance;
     private readonly List<Action<EnrichmentContext>> _enrichers;
     private readonly ILogger _logger;
     private readonly Func<ResilienceContext, object?, object?> _resultFormatter;
@@ -15,25 +15,25 @@ internal sealed class TelemetryResilienceStrategy : ResilienceStrategy
     // Temporary only, until the TimeProvider is exposed
     public TelemetryResilienceStrategy(
         string builderName,
-        string? strategyKey,
+        string? builderInstance,
         ILoggerFactory loggerFactory,
         Func<ResilienceContext, object?, object?> resultFormatter,
         List<Action<EnrichmentContext>> enrichers)
-        : this(TimeProvider.System, builderName, strategyKey, loggerFactory, resultFormatter, enrichers)
+        : this(TimeProvider.System, builderName, builderInstance, loggerFactory, resultFormatter, enrichers)
     {
     }
 
     public TelemetryResilienceStrategy(
         TimeProvider timeProvider,
         string? builderName,
-        string? strategyKey,
+        string? builderInstance,
         ILoggerFactory loggerFactory,
         Func<ResilienceContext, object?, object?> resultFormatter,
         List<Action<EnrichmentContext>> enrichers)
     {
         _timeProvider = timeProvider;
         _builderName = builderName;
-        _strategyKey = strategyKey;
+        _builderInstance = builderInstance;
         _resultFormatter = resultFormatter;
         _enrichers = enrichers;
         _logger = loggerFactory.CreateLogger(TelemetryUtil.PollyDiagnosticSource);
@@ -51,7 +51,7 @@ internal sealed class TelemetryResilienceStrategy : ResilienceStrategy
         TState state)
     {
         var stamp = _timeProvider.GetTimestamp();
-        Log.ExecutingStrategy(_logger, _builderName, _strategyKey, context.OperationKey, context.GetResultType());
+        Log.ExecutingStrategy(_logger, _builderName, _builderInstance, context.OperationKey, context.GetResultType());
 
         var outcome = await callback(context, state).ConfigureAwait(context.ContinueOnCapturedContext);
 
@@ -62,7 +62,7 @@ internal sealed class TelemetryResilienceStrategy : ResilienceStrategy
             _logger,
             logLevel,
             _builderName,
-            _strategyKey,
+            _builderInstance,
             context.OperationKey,
             context.GetResultType(),
             ExpandOutcome(context, outcome),
@@ -88,7 +88,7 @@ internal sealed class TelemetryResilienceStrategy : ResilienceStrategy
 
         var enrichmentContext = EnrichmentContext.Get(context, null, CreateOutcome(outcome));
         enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.BuilderName, _builderName));
-        enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.StrategyKey, _strategyKey));
+        enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.BuilderInstance, _builderInstance));
         enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.OperationKey, context.OperationKey));
         enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.ResultType, context.GetResultType()));
         enrichmentContext.Tags.Add(new(ResilienceTelemetryTags.ExceptionName, outcome.Exception?.GetType().FullName));

--- a/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategyBuilderExtensions.cs
@@ -57,7 +57,7 @@ public static class TelemetryResilienceStrategyBuilderExtensions
             var telemetryStrategy = new TelemetryResilienceStrategy(
                 TimeProvider.System,
                 builder.BuilderName,
-                builder.Properties.GetValue(TelemetryUtil.StrategyKey, null!),
+                builder.InstanceName,
                 options.LoggerFactory,
                 options.ResultFormatter,
                 options.Enrichers.ToList());

--- a/src/Polly.Extensions/Telemetry/TelemetryUtil.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryUtil.cs
@@ -15,8 +15,6 @@ internal static class TelemetryUtil
 
     internal const string PollyDiagnosticSource = "Polly";
 
-    internal static readonly ResiliencePropertyKey<string> StrategyKey = new("Polly.StrategyKey");
-
     public static object AsBoxedBool(this bool value) => value switch
     {
         true => True,

--- a/test/Polly.Core.Tests/Registry/ResilienceStrategyRegistryOptionsTests.cs
+++ b/test/Polly.Core.Tests/Registry/ResilienceStrategyRegistryOptionsTests.cs
@@ -8,9 +8,7 @@ public class ResilienceStrategyRegistryOptionsTests
     {
         ResilienceStrategyRegistryOptions<object> options = new();
 
-        options.StrategyKeyFormatter.Should().NotBeNull();
-        options.StrategyKeyFormatter(null!).Should().Be("");
-        options.StrategyKeyFormatter("ABC").Should().Be("ABC");
+        options.InstanceNameFormatter.Should().BeNull();
 
         options.BuilderNameFormatter.Should().NotBeNull();
         options.BuilderNameFormatter(null!).Should().Be("");

--- a/test/Polly.Core.Tests/Registry/ResilienceStrategyRegistryTests.cs
+++ b/test/Polly.Core.Tests/Registry/ResilienceStrategyRegistryTests.cs
@@ -2,7 +2,6 @@ using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using Polly.Registry;
 using Polly.Retry;
-using Polly.Telemetry;
 using Polly.Timeout;
 
 namespace Polly.Core.Tests.Registry;
@@ -233,18 +232,16 @@ public class ResilienceStrategyRegistryTests
     public void AddBuilder_EnsureStrategyKey()
     {
         _options.BuilderNameFormatter = k => k.BuilderName;
-        _options.StrategyKeyFormatter = k => k.InstanceName;
+        _options.InstanceNameFormatter = k => k.InstanceName;
 
         var called = false;
         var registry = CreateRegistry();
         registry.TryAddBuilder(StrategyId.Create("A"), (builder, context) =>
         {
             context.BuilderName.Should().Be("A");
-            context.StrategyKeyString.Should().Be("Instance1");
+            context.BuilderInstanceName.Should().Be("Instance1");
             builder.AddStrategy(new TestResilienceStrategy());
             builder.BuilderName.Should().Be("A");
-            builder.Properties.TryGetValue(TelemetryUtil.StrategyKey, out var val).Should().BeTrue();
-            val.Should().Be("Instance1");
             called = true;
         });
 
@@ -267,7 +264,7 @@ public class ResilienceStrategyRegistryTests
     public void AddBuilder_Generic_EnsureStrategyKey()
     {
         _options.BuilderNameFormatter = k => k.BuilderName;
-        _options.StrategyKeyFormatter = k => k.InstanceName;
+        _options.InstanceNameFormatter = k => k.InstanceName;
 
         var called = false;
         var registry = CreateRegistry();
@@ -275,8 +272,7 @@ public class ResilienceStrategyRegistryTests
         {
             builder.AddStrategy(new TestResilienceStrategy());
             builder.BuilderName.Should().Be("A");
-            builder.Properties.TryGetValue(TelemetryUtil.StrategyKey, out var val).Should().BeTrue();
-            val.Should().Be("Instance1");
+            builder.InstanceName.Should().Be("Instance1");
             called = true;
         });
 

--- a/test/Polly.Core.Tests/ResilienceStrategyBuilderContextTests.cs
+++ b/test/Polly.Core.Tests/ResilienceStrategyBuilderContextTests.cs
@@ -10,10 +10,11 @@ public class ResilienceStrategyBuilderContextTests
     {
         var properties = new ResilienceProperties();
         var timeProvider = new FakeTimeProvider();
-        var context = new ResilienceStrategyBuilderContext("builder-name", properties, "strategy-name", "strategy-type", timeProvider, true, Mock.Of<DiagnosticSource>(), () => 1.0);
+        var context = new ResilienceStrategyBuilderContext("builder-name", "instance", properties, "strategy-name", "strategy-type", timeProvider, true, Mock.Of<DiagnosticSource>(), () => 1.0);
 
         context.IsGenericBuilder.Should().BeTrue();
         context.BuilderName.Should().Be("builder-name");
+        context.BuilderInstanceName.Should().Be("instance");
         context.BuilderProperties.Should().BeSameAs(properties);
         context.StrategyName.Should().Be("strategy-name");
         context.StrategyType.Should().Be("strategy-type");

--- a/test/Polly.Core.Tests/Telemetry/ResilienceStrategyTelemetryTests.cs
+++ b/test/Polly.Core.Tests/Telemetry/ResilienceStrategyTelemetryTests.cs
@@ -7,7 +7,12 @@ public class ResilienceStrategyTelemetryTests
 {
     private readonly Mock<DiagnosticSource> _diagnosticSource = new(MockBehavior.Strict);
 
-    public ResilienceStrategyTelemetryTests() => _sut = new(new ResilienceTelemetrySource("builder", new ResilienceProperties(), "strategy-name", "strategy-type"), _diagnosticSource.Object);
+    public ResilienceStrategyTelemetryTests() => _sut = new(new ResilienceTelemetrySource(
+        "builder",
+        "instance",
+        new ResilienceProperties(),
+        "strategy-name",
+        "strategy-type"), _diagnosticSource.Object);
 
     private readonly ResilienceStrategyTelemetry _sut;
 
@@ -52,7 +57,7 @@ public class ResilienceStrategyTelemetryTests
     [Fact]
     public void ResilienceStrategyTelemetry_NoDiagnosticSource_Ok()
     {
-        var source = new ResilienceTelemetrySource("builder", new ResilienceProperties(), "strategy-name", "strategy-type");
+        var source = new ResilienceTelemetrySource("builder", "instance", new ResilienceProperties(), "strategy-name", "strategy-type");
         var sut = new ResilienceStrategyTelemetry(source, null);
         var context = ResilienceContext.Get();
 

--- a/test/Polly.Core.Tests/Telemetry/TelemetryEventArgumentsTests.cs
+++ b/test/Polly.Core.Tests/Telemetry/TelemetryEventArgumentsTests.cs
@@ -4,7 +4,7 @@ namespace Polly.Extensions.Tests.Telemetry;
 
 public class TelemetryEventArgumentsTests
 {
-    private readonly ResilienceTelemetrySource _source = new("builder", new ResilienceProperties(), "strategy", "type");
+    private readonly ResilienceTelemetrySource _source = new("builder", "instance", new ResilienceProperties(), "strategy", "type");
 
     [Fact]
     public void Get_Ok()

--- a/test/Polly.Core.Tests/Telemetry/TelemetryUtilTests.cs
+++ b/test/Polly.Core.Tests/Telemetry/TelemetryUtilTests.cs
@@ -6,17 +6,12 @@ namespace Polly.Core.Tests.Telemetry;
 public class TelemetryUtilTests
 {
     [Fact]
-    public void Ctor_Ok()
-    {
-        TelemetryUtil.StrategyKey.Key.Should().Be("Polly.StrategyKey");
-    }
-
-    [Fact]
     public void CreateResilienceTelemetry_Ok()
     {
-        var telemetry = TelemetryUtil.CreateTelemetry(null, "builder", new ResilienceProperties(), "strategy-name", "strategy-type");
+        var telemetry = TelemetryUtil.CreateTelemetry(null, "builder", "instance", new ResilienceProperties(), "strategy-name", "strategy-type");
 
         telemetry.TelemetrySource.BuilderName.Should().Be("builder");
+        telemetry.TelemetrySource.BuilderInstanceName.Should().Be("instance");
         telemetry.TelemetrySource.StrategyName.Should().Be("strategy-name");
         telemetry.TelemetrySource.StrategyType.Should().Be("strategy-type");
         telemetry.DiagnosticSource.Should().BeNull();
@@ -28,7 +23,7 @@ public class TelemetryUtilTests
         var props = new ResilienceProperties();
         var source = Mock.Of<DiagnosticSource>();
 
-        var telemetry = TelemetryUtil.CreateTelemetry(source, "builder", props, "strategy-name", "strategy-type");
+        var telemetry = TelemetryUtil.CreateTelemetry(source, "builder", "instance", props, "strategy-name", "strategy-type");
 
         telemetry.DiagnosticSource.Should().Be(source);
     }

--- a/test/Polly.Extensions.Tests/Telemetry/ResilienceTelemetryDiagnosticSourceTests.cs
+++ b/test/Polly.Extensions.Tests/Telemetry/ResilienceTelemetryDiagnosticSourceTests.cs
@@ -72,11 +72,11 @@ public class ResilienceTelemetryDiagnosticSourceTests : IDisposable
 
         if (noOutcome)
         {
-            messages[0].Message.Should().Be("Resilience event occurred. EventName: 'my-event', Builder Name: 'my-builder', Strategy Name: 'my-strategy', Strategy Type: 'my-strategy-type', Strategy Key: 'my-strategy-key', Operation Key: 'op-key', Result: ''");
+            messages[0].Message.Should().Be("Resilience event occurred. EventName: 'my-event', Source: 'my-builder[builder-instance]/my-strategy-type[my-strategy]', Operation Key: 'op-key', Result: ''");
         }
         else
         {
-            messages[0].Message.Should().Be("Resilience event occurred. EventName: 'my-event', Builder Name: 'my-builder', Strategy Name: 'my-strategy', Strategy Type: 'my-strategy-type', Strategy Key: 'my-strategy-key', Operation Key: 'op-key', Result: '200'");
+            messages[0].Message.Should().Be("Resilience event occurred. EventName: 'my-event', Source: 'my-builder[builder-instance]/my-strategy-type[my-strategy]', Operation Key: 'op-key', Result: '200'");
         }
     }
 
@@ -99,23 +99,23 @@ public class ResilienceTelemetryDiagnosticSourceTests : IDisposable
 
         if (noOutcome)
         {
-            messages[0].Message.Should().Be("Resilience event occurred. EventName: 'my-event', Builder Name: 'my-builder', Strategy Name: 'my-strategy', Strategy Type: 'my-strategy-type', Strategy Key: 'my-strategy-key', Operation Key: 'op-key', Result: ''");
+            messages[0].Message.Should().Be("Resilience event occurred. EventName: 'my-event', Source: 'my-builder[builder-instance]/my-strategy-type[my-strategy]', Operation Key: 'op-key', Result: ''");
         }
         else
         {
-            messages[0].Message.Should().Be("Resilience event occurred. EventName: 'my-event', Builder Name: 'my-builder', Strategy Name: 'my-strategy', Strategy Type: 'my-strategy-type', Strategy Key: 'my-strategy-key', Operation Key: 'op-key', Result: 'Dummy message.'");
+            messages[0].Message.Should().Be("Resilience event occurred. EventName: 'my-event', Source: 'my-builder[builder-instance]/my-strategy-type[my-strategy]', Operation Key: 'op-key', Result: 'Dummy message.'");
         }
     }
 
     [Fact]
-    public void WriteEvent_LoggingWithoutStrategyKey_Ok()
+    public void WriteEvent_LoggingWithoutInstanceName_Ok()
     {
         var telemetry = Create();
-        ReportEvent(telemetry, null, strategyKey: null);
+        ReportEvent(telemetry, null, instanceName: null);
 
         var messages = _logger.GetRecords(new EventId(0, "ResilienceEvent")).ToList();
 
-        messages[0].Message.Should().Be("Resilience event occurred. EventName: 'my-event', Builder Name: 'my-builder', Strategy Name: 'my-strategy', Strategy Type: 'my-strategy-type', Strategy Key: '', Operation Key: 'op-key', Result: ''");
+        messages[0].Message.Should().Be("Resilience event occurred. EventName: 'my-event', Source: 'my-builder[]/my-strategy-type[my-strategy]', Operation Key: 'op-key', Result: ''");
     }
 
     [InlineData(ResilienceEventSeverity.Error, LogLevel.Error)]
@@ -150,7 +150,7 @@ public class ResilienceTelemetryDiagnosticSourceTests : IDisposable
         var messages = _logger.GetRecords(new EventId(3, "ExecutionAttempt")).ToList();
         messages.Should().HaveCount(1);
 
-        messages[0].Message.Should().Be("Execution attempt. Builder Name: 'my-builder', Strategy Name: 'my-strategy', Strategy Type: 'my-strategy-type', Strategy Key: 'my-strategy-key', Operation Key: 'op-key', Result: 'Dummy message.', Handled: 'True', Attempt: '4', Execution Time: '123'");
+        messages[0].Message.Should().Be("Execution attempt. Source: 'my-builder[builder-instance]/my-strategy-type[my-strategy]', Operation Key: 'op-key', Result: 'Dummy message.', Handled: 'True', Attempt: '4', Execution Time: '123'");
     }
 
     [InlineData(true, true)]
@@ -170,11 +170,11 @@ public class ResilienceTelemetryDiagnosticSourceTests : IDisposable
         if (noOutcome)
         {
             string resultString = string.Empty;
-            messages[0].Message.Should().Be($"Execution attempt. Builder Name: 'my-builder', Strategy Name: 'my-strategy', Strategy Type: 'my-strategy-type', Strategy Key: 'my-strategy-key', Operation Key: 'op-key', Result: '{resultString}', Handled: '{handled}', Attempt: '4', Execution Time: '123'");
+            messages[0].Message.Should().Be($"Execution attempt. Source: 'my-builder[builder-instance]/my-strategy-type[my-strategy]', Operation Key: 'op-key', Result: '{resultString}', Handled: '{handled}', Attempt: '4', Execution Time: '123'");
         }
         else
         {
-            messages[0].Message.Should().Be($"Execution attempt. Builder Name: 'my-builder', Strategy Name: 'my-strategy', Strategy Type: 'my-strategy-type', Strategy Key: 'my-strategy-key', Operation Key: 'op-key', Result: '200', Handled: '{handled}', Attempt: '4', Execution Time: '123'");
+            messages[0].Message.Should().Be($"Execution attempt. Source: 'my-builder[builder-instance]/my-strategy-type[my-strategy]', Operation Key: 'op-key', Result: '200', Handled: '{handled}', Attempt: '4', Execution Time: '123'");
         }
 
         messages[0].LogLevel.Should().Be(LogLevel.Warning);
@@ -217,7 +217,7 @@ public class ResilienceTelemetryDiagnosticSourceTests : IDisposable
         ev["event-severity"].Should().Be("Warning");
         ev["strategy-type"].Should().Be("my-strategy-type");
         ev["strategy-name"].Should().Be("my-strategy");
-        ev["strategy-key"].Should().Be("my-strategy-key");
+        ev["builder-instance"].Should().Be("builder-instance");
         ev["operation-key"].Should().Be("op-key");
         ev["builder-name"].Should().Be("my-builder");
         ev["result-type"].Should().Be("Boolean");
@@ -258,7 +258,7 @@ public class ResilienceTelemetryDiagnosticSourceTests : IDisposable
         ev["event-severity"].Should().Be("Warning");
         ev["strategy-type"].Should().Be("my-strategy-type");
         ev["strategy-name"].Should().Be("my-strategy");
-        ev["strategy-key"].Should().Be("my-strategy-key");
+        ev["builder-instance"].Should().Be("builder-instance");
         ev["operation-key"].Should().Be("op-key");
         ev["builder-name"].Should().Be("my-builder");
         ev["result-type"].Should().Be("Boolean");
@@ -313,11 +313,11 @@ public class ResilienceTelemetryDiagnosticSourceTests : IDisposable
     }
 
     [Fact]
-    public void WriteEvent_MeteringWithoutStrategyKey_Ok()
+    public void WriteEvent_MeteringWithoutBuilderInstance_Ok()
     {
         var telemetry = Create();
-        ReportEvent(telemetry, null, strategyKey: null);
-        var events = GetEvents("resilience-events")[0]["strategy-key"].Should().BeNull();
+        ReportEvent(telemetry, null, instanceName: null);
+        var events = GetEvents("resilience-events")[0]["builder-instance"].Should().BeNull();
     }
 
     [InlineData(true)]
@@ -333,7 +333,7 @@ public class ResilienceTelemetryDiagnosticSourceTests : IDisposable
         }
 
         var telemetry = Create();
-        ReportEvent(telemetry, null, strategyKey: null);
+        ReportEvent(telemetry, null, instanceName: null);
 
         called.Should().Be(hasCallback);
     }
@@ -356,21 +356,22 @@ public class ResilienceTelemetryDiagnosticSourceTests : IDisposable
     private static void ReportEvent(
         ResilienceTelemetryDiagnosticSource telemetry,
         Outcome<object>? outcome,
-        string? strategyKey = "my-strategy-key",
+        string? instanceName = "builder-instance",
         ResilienceContext? context = null,
         object? arg = null,
         ResilienceEventSeverity severity = ResilienceEventSeverity.Warning)
     {
         context ??= ResilienceContext.Get("op-key");
         var props = new ResilienceProperties();
-        if (!string.IsNullOrEmpty(strategyKey))
+        if (!string.IsNullOrEmpty(instanceName))
         {
-            props.Set(new ResiliencePropertyKey<string?>("Polly.StrategyKey"), strategyKey);
+            props.Set(new ResiliencePropertyKey<string?>("Polly.StrategyKey"), instanceName);
         }
 
         telemetry.ReportEvent(
             new ResilienceEvent(severity, "my-event"),
             "my-builder",
+            instanceName,
             props,
             "my-strategy",
             "my-strategy-type",

--- a/test/Polly.Extensions.Tests/Telemetry/TelemetryResilienceStrategyTests.cs
+++ b/test/Polly.Extensions.Tests/Telemetry/TelemetryResilienceStrategyTests.cs
@@ -50,10 +50,10 @@ public class TelemetryResilienceStrategyTests : IDisposable
 
         var messages = _logger.GetRecords(new EventId(1, "StrategyExecuting")).ToList();
         messages.Should().HaveCount(1);
-        messages[0].Message.Should().Be("Resilience strategy executing. Builder Name: 'my-builder', Strategy Key: 'my-key', Operation Key: 'op-key', Result Type: 'void'");
+        messages[0].Message.Should().Be("Resilience strategy executing. Source: 'my-builder[my-instance]', Operation Key: 'op-key', Result Type: 'void'");
         messages = _logger.GetRecords(new EventId(2, "StrategyExecuted")).ToList();
         messages.Should().HaveCount(1);
-        messages[0].Message.Should().Match($"Resilience strategy executed. Builder Name: 'my-builder', Strategy Key: 'my-key', Operation Key: 'op-key', Result Type: 'void', Result: 'void', Execution Health: '{healthString}', Execution Time: *ms");
+        messages[0].Message.Should().Match($"Resilience strategy executed. Source: 'my-builder[my-instance]', Operation Key: 'op-key', Result Type: 'void', Result: 'void', Execution Health: '{healthString}', Execution Time: *ms");
         messages[0].LogLevel.Should().Be(healthy ? LogLevel.Debug : LogLevel.Warning);
 
         // verify reported state
@@ -78,11 +78,11 @@ public class TelemetryResilienceStrategyTests : IDisposable
 
         var messages = _logger.GetRecords(new EventId(1, "StrategyExecuting")).ToList();
         messages.Should().HaveCount(1);
-        messages[0].Message.Should().Be("Resilience strategy executing. Builder Name: 'my-builder', Strategy Key: 'my-key', Operation Key: 'op-key', Result Type: 'void'");
+        messages[0].Message.Should().Be("Resilience strategy executing. Source: 'my-builder[my-instance]', Operation Key: 'op-key', Result Type: 'void'");
 
         messages = _logger.GetRecords(new EventId(2, "StrategyExecuted")).ToList();
         messages.Should().HaveCount(1);
-        messages[0].Message.Should().Match($"Resilience strategy executed. Builder Name: 'my-builder', Strategy Key: 'my-key', Operation Key: 'op-key', Result Type: 'void', Result: 'Dummy message.', Execution Health: 'Healthy', Execution Time: *ms");
+        messages[0].Message.Should().Match($"Resilience strategy executed. Source: 'my-builder[my-instance]', Operation Key: 'op-key', Result Type: 'void', Result: 'Dummy message.', Execution Health: 'Healthy', Execution Time: *ms");
         messages[0].Exception.Should().BeOfType<InvalidOperationException>();
     }
 
@@ -120,7 +120,7 @@ public class TelemetryResilienceStrategyTests : IDisposable
         var ev = _events.Single(v => v.Name == "strategy-execution-duration").Tags;
 
         ev.Count.Should().Be(6);
-        ev["strategy-key"].Should().Be("my-key");
+        ev["builder-instance"].Should().Be("my-instance");
         ev["operation-key"].Should().Be("op-key");
         ev["builder-name"].Should().Be("my-builder");
         ev["result-type"].Should().Be("void");
@@ -165,7 +165,7 @@ public class TelemetryResilienceStrategyTests : IDisposable
         var ev = _events.Single(v => v.Name == "strategy-execution-duration").Tags;
 
         ev.Count.Should().Be(6);
-        ev["strategy-key"].Should().Be("my-key");
+        ev["builder-instance"].Should().Be("my-instance");
         ev["operation-key"].Should().Be("op-key");
         ev["builder-name"].Should().Be("my-builder");
         ev["result-type"].Should().Be("Boolean");
@@ -217,7 +217,7 @@ public class TelemetryResilienceStrategyTests : IDisposable
         }
     }
 
-    private TelemetryResilienceStrategy CreateStrategy() => new("my-builder", "my-key", _loggerFactory, (_, r) => r, new List<Action<EnrichmentContext>> { c => _enricher?.Invoke(c) });
+    private TelemetryResilienceStrategy CreateStrategy() => new("my-builder", "my-instance", _loggerFactory, (_, r) => r, new List<Action<EnrichmentContext>> { c => _enricher?.Invoke(c) });
 
     public void Dispose()
     {

--- a/test/Polly.TestUtils/TestUtilities.cs
+++ b/test/Polly.TestUtils/TestUtilities.cs
@@ -38,10 +38,10 @@ public static class TestUtilities
     }
 
     public static ResilienceStrategyTelemetry CreateResilienceTelemetry(DiagnosticSource source)
-        => new(new ResilienceTelemetrySource("dummy-builder", new ResilienceProperties(), "strategy-name", "strategy-type"), source);
+        => new(new ResilienceTelemetrySource("dummy-builder", "dummy-instance", new ResilienceProperties(), "strategy-name", "strategy-type"), source);
 
     public static ResilienceStrategyTelemetry CreateResilienceTelemetry(Action<TelemetryEventArguments> callback)
-        => new(new ResilienceTelemetrySource("dummy-builder", new ResilienceProperties(), "strategy-name", "strategy-type"), new CallbackDiagnosticSource(callback));
+        => new(new ResilienceTelemetrySource("dummy-builder", "dummy-instance", new ResilienceProperties(), "strategy-name", "strategy-type"), new CallbackDiagnosticSource(callback));
 
     public static ILoggerFactory CreateLoggerFactory(out FakeLogger logger)
     {
@@ -80,6 +80,7 @@ public static class TestUtilities
         this DiagnosticSource source,
         ResilienceEvent resilienceEvent,
         string builderName,
+        string? instanceName,
         ResilienceProperties builderProperties,
         string strategyName,
         string strategyType,
@@ -89,7 +90,7 @@ public static class TestUtilities
 #pragma warning restore S107 // Methods should not have too many parameters
     {
         source.Write(resilienceEvent.EventName, TelemetryEventArguments.Get(
-            new ResilienceTelemetrySource(builderName, builderProperties, strategyName, strategyType),
+            new ResilienceTelemetrySource(builderName, instanceName, builderProperties, strategyName, strategyType),
             resilienceEvent,
             context,
             outcome,


### PR DESCRIPTION
### Details on the issue fix or feature implementation

The main purpose of `InstanceName` is to differentiate between multiple instances that have the same `BuilderName`. It defaults to `null`.

Previously, we had the `strategy-key` dimension that was not easy to configure using the API. It was also ambiguous with `strategy-name` and `strategy-type`. 

Now, every resilience event has the following dimension that can identify by wich resilience strategy is was produced:

- `builder-name`: the name of the builder, when using the `AddResilienceStrategy` extension this becomes the key identifier
- `builder-instance`: the instance of the builder. Generally, it's `null` and consumer can set it up manually or configure the `InstanceNameFormatter` delegate to fill it when using complex keys (#1366).
- `strategy-type`: hard-coded strategy type (Retry, Hedging, Timeout)
- `strategy-name`: consumer can set it up to add more details to the telemetry. Defaults to null.

As a part of this change I have also simplified the log messages to make them shorter.

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
