### PR TITLE
Improve the code readability of health info method

### DIFF
--- a/src/Polly.Core/CircuitBreaker/Health/HealthInfo.cs
+++ b/src/Polly.Core/CircuitBreaker/Health/HealthInfo.cs
@@ -4,12 +4,12 @@ internal readonly record struct HealthInfo(int Throughput, double FailureRate)
 {
     public static HealthInfo Create(int successes, int failures)
     {
-        var total = successes + failures;
-        if (total == 0)
+        if (successes + failures == 0)
         {
-            return new HealthInfo(0, 0);
+          return new HealthInfo(0, 0);
         }
 
-        return new(total, failures / (double)total);
+       double failureRate = failures / (double)(successes + failures);
+       return new HealthInfo(successes + failures, failureRate);
     }
 }


### PR DESCRIPTION
In the refactored code:

The calculation of the total variable has been moved within the if condition to eliminate the need for a separate variable declaration.
Instead of comparing total with 0 in the if statement, we directly compare successes + failures with 0.
The calculation of failureRate has been separated into its own variable for clarity.
The result is returned as a HealthInfo object, with the successes + failures value and the failureRate value passed as arguments.
These changes improve readability and maintain the original functionality of the code.