### PR TITLE
Rename  AddResilienceStrategy to AddResilienceStrategyRegistry

### DIFF
--- a/src/Polly.Extensions/DependencyInjection/PollyServiceCollectionExtensions.cs
+++ b/src/Polly.Extensions/DependencyInjection/PollyServiceCollectionExtensions.cs
@@ -211,7 +211,6 @@ public static class PollyServiceCollectionExtensions
         services.AddOptions();
         services.Add(RegistryMarker<TKey>.ServiceDescriptor);
         services.AddResilienceStrategyBuilder();
-        services.AddResilienceStrategyRegistry<TKey>();
 
         services.TryAddSingleton(serviceProvider =>
         {

--- a/src/Polly.Extensions/DependencyInjection/PollyServiceCollectionExtensions.cs
+++ b/src/Polly.Extensions/DependencyInjection/PollyServiceCollectionExtensions.cs
@@ -85,7 +85,7 @@ public static class PollyServiceCollectionExtensions
                 });
             });
 
-        return AddResilienceStrategy<TKey>(services);
+        return AddResilienceStrategyRegistry<TKey>(services);
     }
 
     /// <summary>
@@ -156,24 +156,47 @@ public static class PollyServiceCollectionExtensions
                 });
             });
 
-        return AddResilienceStrategy<TKey>(services);
+        return AddResilienceStrategyRegistry<TKey>(services);
     }
 
     /// <summary>
-    /// Adds the infrastructure that allows configuring and retrieving resilience strategies using the <typeparamref name="TKey"/> key.
+    /// Adds <see cref="ResilienceStrategyRegistry{TKey}"/> and <see cref="ResilienceStrategyProvider{TKey}"/> that allows configuring
+    /// and retrieving resilience strategies using the <typeparamref name="TKey"/> key.
+    /// </summary>
+    /// <typeparam name="TKey">The type of the key used to identify the resilience strategy.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add the resilience strategy to.</param>
+    /// <param name="configure">The action that configures the <see cref="ResilienceStrategyRegistryOptions{TKey}"/> that are used by the registry.</param>
+    /// <returns>The updated <see cref="IServiceCollection"/> with additional services added.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// This call enables telemetry for all resilience strategies created using <see cref="ResilienceStrategyRegistry{TKey}"/>.
+    /// </remarks>
+    public static IServiceCollection AddResilienceStrategyRegistry<TKey>(
+        this IServiceCollection services,
+        Action<ResilienceStrategyRegistryOptions<TKey>> configure)
+        where TKey : notnull
+    {
+        Guard.NotNull(services);
+        Guard.NotNull(configure);
+
+        services.AddResilienceStrategyRegistry<TKey>();
+        services.Configure(configure);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds <see cref="ResilienceStrategyRegistry{TKey}"/> and <see cref="ResilienceStrategyProvider{TKey}"/> that allows configuring
+    /// and retrieving resilience strategies using the <typeparamref name="TKey"/> key.
     /// </summary>
     /// <typeparam name="TKey">The type of the key used to identify the resilience strategy.</typeparam>
     /// <param name="services">The <see cref="IServiceCollection"/> to add the resilience strategy to.</param>
     /// <returns>The updated <see cref="IServiceCollection"/> with additional services added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> is <see langword="null"/>.</exception>
     /// <remarks>
-    /// You can retrieve the strategy registry by resolving the <see cref="ResilienceStrategyProvider{TKey}"/>
-    /// or <see cref="ResilienceStrategyRegistry{TKey}"/> class from the dependency injection container.
-    /// <para>
     /// This call enables telemetry for all resilience strategies created using <see cref="ResilienceStrategyRegistry{TKey}"/>.
-    /// </para>
     /// </remarks>
-    public static IServiceCollection AddResilienceStrategy<TKey>(this IServiceCollection services)
+    public static IServiceCollection AddResilienceStrategyRegistry<TKey>(this IServiceCollection services)
         where TKey : notnull
     {
         Guard.NotNull(services);
@@ -188,7 +211,7 @@ public static class PollyServiceCollectionExtensions
         services.AddOptions();
         services.Add(RegistryMarker<TKey>.ServiceDescriptor);
         services.AddResilienceStrategyBuilder();
-        services.AddResilienceStrategy<TKey>();
+        services.AddResilienceStrategyRegistry<TKey>();
 
         services.TryAddSingleton(serviceProvider =>
         {
@@ -204,10 +227,7 @@ public static class PollyServiceCollectionExtensions
             return registry;
         });
 
-        services.TryAddSingleton<ResilienceStrategyProvider<TKey>>(serviceProvider =>
-        {
-            return serviceProvider.GetRequiredService<ResilienceStrategyRegistry<TKey>>();
-        });
+        services.TryAddSingleton<ResilienceStrategyProvider<TKey>>(serviceProvider => serviceProvider.GetRequiredService<ResilienceStrategyRegistry<TKey>>());
 
         // configure options
         services

--- a/test/Polly.Extensions.Tests/DependencyInjection/PollyServiceCollectionExtensionTests.cs
+++ b/test/Polly.Extensions.Tests/DependencyInjection/PollyServiceCollectionExtensionTests.cs
@@ -255,13 +255,25 @@ public class PollyServiceCollectionExtensionTests
     }
 
     [Fact]
-    public void AddResilienceStrategyInfra_Ok()
+    public void AddResilienceStrategyRegistry_Ok()
     {
-        var provider = new ServiceCollection().AddResilienceStrategy<string>().BuildServiceProvider();
+        var provider = new ServiceCollection().AddResilienceStrategyRegistry<string>().BuildServiceProvider();
 
         provider.GetRequiredService<ResilienceStrategyRegistry<string>>().Should().NotBeNull();
         provider.GetRequiredService<ResilienceStrategyProvider<string>>().Should().NotBeNull();
         provider.GetRequiredService<ResilienceStrategyBuilder>().DiagnosticSource.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddResilienceStrategyRegistry_ConfigureCallback_Ok()
+    {
+        Func<string, string> formatter = s => s;
+
+        var provider = new ServiceCollection().AddResilienceStrategyRegistry<string>(options => options.InstanceNameFormatter = formatter).BuildServiceProvider();
+
+        provider.GetRequiredService<ResilienceStrategyRegistry<string>>().Should().NotBeNull();
+        provider.GetRequiredService<ResilienceStrategyProvider<string>>().Should().NotBeNull();
+        provider.GetRequiredService<IOptions<ResilienceStrategyRegistryOptions<string>>>().Value.InstanceNameFormatter.Should().Be(formatter);
     }
 
     private void AddResilienceStrategy(string key, Action<ResilienceStrategyBuilderContext>? onBuilding = null)


### PR DESCRIPTION
### Details on the issue fix or feature implementation

- Rename the `AddResilienceStrategy` extensions that adds `ResilienceStrategyRegistry` service  to `AddResilienceStrategyRegistry`.
- Introduce `AddResilienceStrategyRegistry` overload that allows configuring `ResilienceStrategyRegistryOptions` inline.

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
