### PR TITLE
Updates for alpha 6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
         flags: ${{ matrix.os_name }}
 
     - name: Upload Mutation Report
-      if: always() && matrix.os_name == 'linux'
+      if: always() && matrix.os_name == 'linux' && !startsWith(github.ref, 'refs/tags/') && 'true' || 'false'
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: mutation-report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## 8.0.0-alpha.6
+
+* Update docs by [@martincostello](https://github.com/martincostello) in https://github.com/App-vNext/Polly/pull/1382
+* Add support for `PartitionedRateLimiter` by [@martintmk](https://github.com/martintmk) in https://github.com/App-vNext/Polly/pull/1383
+* Fix debugger proxies by [@martintmk](https://github.com/martintmk) in https://github.com/App-vNext/Polly/pull/1384
+* Allow adding generic strategies to generic builder by [@martintmk](https://github.com/martintmk) in https://github.com/App-vNext/Polly/pull/1386
+* Add new issue that demonstrates how to use PartitionedRateLimiter by [@martintmk](https://github.com/martintmk) in https://github.com/App-vNext/Polly/pull/1385
+* Introduce `TelemetryOptions.OnTelemetryEvent` by [@martintmk](https://github.com/martintmk) in https://github.com/App-vNext/Polly/pull/1387
+* `ResilienceStrategyRegistry` API improvements by [@martintmk](https://github.com/martintmk) in https://github.com/App-vNext/Polly/pull/1388
+* Simplify condition by [@martincostello](https://github.com/martincostello) in https://github.com/App-vNext/Polly/pull/1391
+* Introduce `ResilienceStrategyBuilder.InstanceName` and use it in telemetry by [@martintmk](https://github.com/martintmk) in https://github.com/App-vNext/Polly/pull/1392
+* Introduce `Polly.Testing` package by [@martintmk](https://github.com/martintmk) in https://github.com/App-vNext/Polly/pull/1394
+* Kill mutant by [@martintmk](https://github.com/martintmk) in https://github.com/App-vNext/Polly/pull/1395
+* Fix unstable test by [@martintmk](https://github.com/martintmk) in https://github.com/App-vNext/Polly/pull/1396
+* Rename  AddResilienceStrategy to AddResilienceStrategyRegistry by [@martintmk](https://github.com/martintmk) in https://github.com/App-vNext/Polly/pull/1397
+* Update README.md for Polly.Extensions with telemetry info by [@martintmk](https://github.com/martintmk) in https://github.com/App-vNext/Polly/pull/1401
+* Kill mutant by [@martintmk](https://github.com/martintmk) in https://github.com/App-vNext/Polly/pull/1407
+* Assertion failed when running tests in Visual Studio by [@martintmk](https://github.com/martintmk) in https://github.com/App-vNext/Polly/pull/1408
+* Include PublicApiAnalyzers by [@martintmk](https://github.com/martintmk) in https://github.com/App-vNext/Polly/pull/1400
+* Kill mutant by [@martintmk](https://github.com/martintmk) in https://github.com/App-vNext/Polly/pull/1409
+* Demonstrate how to create dynamic strategies with complex keys by [@martintmk](https://github.com/martintmk) in https://github.com/App-vNext/Polly/pull/1366
+
 ## 8.0.0-alpha.5
 
 * Skip mutation tests for tagged builds by [@martincostello](https://github.com/martincostello) in https://github.com/App-vNext/Polly/pull/1354

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <MicrosoftExtensionsVersion>7.0.0</MicrosoftExtensionsVersion>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <PollyVersion>8.0.0-alpha.5</PollyVersion>
+    <PollyVersion>8.0.0-alpha.6</PollyVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.msbuild" Version="6.0.0" />

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 > Major performance improvements are on the way! Please see our [blog post](https://www.thepollyproject.org/2023/03/03/we-want-your-feedback-introducing-polly-v8/) to learn more and provide feedback in the [related GitHub issue](https://github.com/App-vNext/Polly/issues/1048).
 >
 > :rotating_light::rotating_light: **Polly v8 feature-complete!** :rotating_light::rotating_light:
-> - Polly v8 Alpha 5 is now available on [NuGet.org](https://www.nuget.org/packages/Polly/8.0.0-alpha.5)
-> - The Alpha 5 version is considered feature-complete. After an internal review of the API to address unresolved issues, we will move on to a Beta release.
+> - Polly v8 Alpha 6 is now available on [NuGet.org](https://www.nuget.org/packages/Polly/8.0.0-alpha.6)
+> - The Alpha 6 version is considered feature-complete. After an internal review of the API to address unresolved issues, we will move on to a Beta release.
 > - The v8 docs are not yet finished, but you can take a look at sample code in these locations:
 >     - Within the repo's new [Samples folder](https://github.com/App-vNext/Polly/tree/main/samples)
 >     - By reading `Polly.Core`'s [README](https://github.com/App-vNext/Polly/blob/main/src/Polly.Core/README.md)


### PR DESCRIPTION
- Update the CHANGELOG for alpha 6.
- Don't try and upload the Stryker report if it wasn't run in the first place.
- Update samples to alpha 6.
