### PR TITLE
Introduce ResilienceStrategyBuilder.Validator

### DIFF
--- a/src/Polly.Core/PublicAPI.Unshipped.txt
+++ b/src/Polly.Core/PublicAPI.Unshipped.txt
@@ -292,6 +292,8 @@ Polly.ResilienceStrategyBuilderBase.OnCreatingStrategy.set -> void
 Polly.ResilienceStrategyBuilderBase.Properties.get -> Polly.ResilienceProperties!
 Polly.ResilienceStrategyBuilderBase.Randomizer.get -> System.Func<double>!
 Polly.ResilienceStrategyBuilderBase.Randomizer.set -> void
+Polly.ResilienceStrategyBuilderBase.Validator.get -> System.Action<Polly.ResilienceValidationContext!>!
+Polly.ResilienceStrategyBuilderBase.Validator.set -> void
 Polly.ResilienceStrategyBuilderContext
 Polly.ResilienceStrategyBuilderContext.BuilderInstanceName.get -> string?
 Polly.ResilienceStrategyBuilderContext.BuilderName.get -> string?
@@ -304,6 +306,10 @@ Polly.ResilienceStrategyOptions
 Polly.ResilienceStrategyOptions.ResilienceStrategyOptions() -> void
 Polly.ResilienceStrategyOptions.StrategyName.get -> string?
 Polly.ResilienceStrategyOptions.StrategyName.set -> void
+Polly.ResilienceValidationContext
+Polly.ResilienceValidationContext.Instance.get -> object!
+Polly.ResilienceValidationContext.PrimaryMessage.get -> string!
+Polly.ResilienceValidationContext.ResilienceValidationContext(object! instance, string! primaryMessage) -> void
 Polly.Retry.OnRetryArguments
 Polly.Retry.OnRetryArguments.Attempt.get -> int
 Polly.Retry.OnRetryArguments.Attempt.init -> void

--- a/src/Polly.Core/Registry/ResilienceStrategyRegistry.cs
+++ b/src/Polly.Core/Registry/ResilienceStrategyRegistry.cs
@@ -46,8 +46,10 @@ public sealed partial class ResilienceStrategyRegistry<TKey> : ResilienceStrateg
     public ResilienceStrategyRegistry(ResilienceStrategyRegistryOptions<TKey> options)
     {
         Guard.NotNull(options);
-
-        ValidationHelper.ValidateObject(options, "The resilience strategy registry options are invalid.");
+        Guard.NotNull(options.BuilderFactory);
+        Guard.NotNull(options.StrategyComparer);
+        Guard.NotNull(options.BuilderComparer);
+        Guard.NotNull(options.BuilderNameFormatter);
 
         _activator = options.BuilderFactory;
         _builders = new ConcurrentDictionary<TKey, Action<ResilienceStrategyBuilder, ConfigureBuilderContext<TKey>>>(options.BuilderComparer);

--- a/src/Polly.Core/ResilienceStrategyBuilderBase.cs
+++ b/src/Polly.Core/ResilienceStrategyBuilderBase.cs
@@ -100,11 +100,12 @@ public abstract class ResilienceStrategyBuilderBase
     /// <remarks>
     /// The validator should throw <see cref="ValidationException"/> when the validated instance is invalid.
     /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown when the attempting to assign <see langword="null"/> to this property.</exception>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public Action<ResilienceValidationContext> Validator
     {
-        get => _validator ?? ValidationHelper.ValidateObject;
-        set => _validator = value;
+        get => _validator;
+        set => _validator = Guard.NotNull(value);
     }
 
     internal abstract bool IsGenericBuilder { get; }

--- a/src/Polly.Core/ResilienceStrategyBuilderBase.cs
+++ b/src/Polly.Core/ResilienceStrategyBuilderBase.cs
@@ -16,6 +16,7 @@ public abstract class ResilienceStrategyBuilderBase
 {
     private readonly List<Entry> _entries = new();
     private bool _used;
+    private Action<ResilienceValidationContext> _validator = ValidationHelper.ValidateObject;
 
     private protected ResilienceStrategyBuilderBase()
     {
@@ -92,6 +93,20 @@ public abstract class ResilienceStrategyBuilderBase
     [Required]
     public Func<double> Randomizer { get; set; } = RandomUtil.Instance.NextDouble;
 
+    /// <summary>
+    /// Gets or sets the validator that is used for the validation.
+    /// </summary>
+    /// <value>The default value is a validation function that uses data annotations for validation.</value>
+    /// <remarks>
+    /// The validator should throw <see cref="ValidationException"/> when the validated instance is invalid.
+    /// </remarks>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public Action<ResilienceValidationContext> Validator
+    {
+        get => _validator ?? ValidationHelper.ValidateObject;
+        set => _validator = value;
+    }
+
     internal abstract bool IsGenericBuilder { get; }
 
     internal void AddStrategyCore(Func<ResilienceStrategyBuilderContext, ResilienceStrategy> factory, ResilienceStrategyOptions options)
@@ -99,7 +114,7 @@ public abstract class ResilienceStrategyBuilderBase
         Guard.NotNull(factory);
         Guard.NotNull(options);
 
-        ValidationHelper.ValidateObject(options, $"The '{TypeNameFormatter.Format(options.GetType())}' are invalid.");
+        Validator(new ResilienceValidationContext(options, $"The '{TypeNameFormatter.Format(options.GetType())}' are invalid."));
 
         if (_used)
         {
@@ -111,7 +126,7 @@ public abstract class ResilienceStrategyBuilderBase
 
     internal ResilienceStrategy BuildStrategy()
     {
-        ValidationHelper.ValidateObject(this, $"The '{nameof(ResilienceStrategyBuilder)}' configuration is invalid.");
+        Validator(new(this, $"The '{nameof(ResilienceStrategyBuilder)}' configuration is invalid."));
 
         _used = true;
 

--- a/src/Polly.Core/ResilienceValidationContext.cs
+++ b/src/Polly.Core/ResilienceValidationContext.cs
@@ -1,0 +1,32 @@
+﻿namespace Polly;
+
+/// <summary>
+/// The validation context that encapsulates parameters for the validation.
+/// </summary>
+public sealed class ResilienceValidationContext
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ResilienceValidationContext"/> class.
+    /// </summary>
+    /// <param name="instance">The instance being validated.</param>
+    /// <param name="primaryMessage">The primary validation message.</param>
+    public ResilienceValidationContext(object instance, string primaryMessage)
+    {
+        Instance = Guard.NotNull(instance);
+        PrimaryMessage = Guard.NotNull(primaryMessage);
+    }
+
+    /// <summary>
+    /// Gets the instance being validated.
+    /// </summary>
+    public object Instance { get; }
+
+    /// <summary>
+    /// Gets the primary validation message.
+    /// </summary>
+    /// <remarks>
+    /// The primary message is displayed first followed by the details about the validation errors.
+    /// </remarks>
+    public string PrimaryMessage { get; }
+}
+

--- a/src/Polly.Core/Utils/ValidationHelper.cs
+++ b/src/Polly.Core/Utils/ValidationHelper.cs
@@ -7,13 +7,15 @@ namespace Polly.Utils;
 [ExcludeFromCodeCoverage]
 internal static class ValidationHelper
 {
-    public static void ValidateObject(object instance, string mainMessage)
+    public static void ValidateObject(ResilienceValidationContext context)
     {
+        Guard.NotNull(context);
+
         var errors = new List<ValidationResult>();
 
-        if (!Validator.TryValidateObject(instance, new ValidationContext(instance), errors, true))
+        if (!Validator.TryValidateObject(context.Instance, new ValidationContext(context.Instance), errors, true))
         {
-            var stringBuilder = new StringBuilder(mainMessage);
+            var stringBuilder = new StringBuilder(context.PrimaryMessage);
             stringBuilder.AppendLine();
 
             stringBuilder.AppendLine("Validation Errors:");

--- a/src/Polly.Extensions/Polly.Extensions.csproj
+++ b/src/Polly.Extensions/Polly.Extensions.csproj
@@ -13,7 +13,6 @@
     <Compile Include="..\Polly.Core\Utils\Guard.cs" Link="Utils\Guard.cs" />
     <Compile Include="..\Polly.Core\Utils\ObjectPool.cs" Link="Utils\ObjectPool.cs" />
     <Compile Include="..\Polly.Core\ToBeRemoved\TimeProvider.cs" Link="ToBeRemoved\TimeProvider.cs" />
-    <Compile Include="..\Polly.Core\Utils\ValidationHelper.cs" Link="Utils\ValidationHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategyBuilderExtensions.cs
@@ -48,7 +48,7 @@ public static class TelemetryResilienceStrategyBuilderExtensions
         Guard.NotNull(builder);
         Guard.NotNull(options);
 
-        builder.Validator(new(options, "The 'TelemetryOptions' are invalid."));
+        builder.Validator(new(options, $"The '{nameof(TelemetryOptions)}' are invalid."));
         builder.DiagnosticSource = new ResilienceTelemetryDiagnosticSource(options);
         builder.OnCreatingStrategy = strategies =>
         {

--- a/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategyBuilderExtensions.cs
@@ -48,10 +48,8 @@ public static class TelemetryResilienceStrategyBuilderExtensions
         Guard.NotNull(builder);
         Guard.NotNull(options);
 
-        ValidationHelper.ValidateObject(options, "The resilience telemetry options are invalid.");
-
+        builder.Validator(new(options, "The 'TelemetryOptions' are invalid."));
         builder.DiagnosticSource = new ResilienceTelemetryDiagnosticSource(options);
-
         builder.OnCreatingStrategy = strategies =>
         {
             var telemetryStrategy = new TelemetryResilienceStrategy(

--- a/test/Polly.Core.Tests/CircuitBreaker/AdvancedCircuitBreakerOptionsTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/AdvancedCircuitBreakerOptionsTests.cs
@@ -27,7 +27,7 @@ public class AdvancedCircuitBreakerOptionsTests
         options.MinimumThroughput = 2;
         options.SamplingDuration = TimeSpan.FromMilliseconds(500);
 
-        ValidationHelper.ValidateObject(options, "Dummy.");
+        ValidationHelper.ValidateObject(new(options, "Dummy."));
     }
 
     [Fact]
@@ -64,7 +64,7 @@ public class AdvancedCircuitBreakerOptionsTests
         options.MinimumThroughput = 2;
         options.SamplingDuration = TimeSpan.FromMilliseconds(500);
 
-        ValidationHelper.ValidateObject(options, "Dummy.");
+        ValidationHelper.ValidateObject(new(options, "Dummy."));
     }
 
     [Fact]
@@ -83,7 +83,7 @@ public class AdvancedCircuitBreakerOptionsTests
         };
 
         options
-            .Invoking(o => ValidationHelper.ValidateObject(o, "Dummy."))
+            .Invoking(o => ValidationHelper.ValidateObject(new(o, "Dummy.")))
             .Should()
             .Throw<ValidationException>()
             .WithMessage("""

--- a/test/Polly.Core.Tests/CircuitBreaker/SimpleCircuitBreakerOptionsTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/SimpleCircuitBreakerOptionsTests.cs
@@ -24,7 +24,7 @@ public class SimpleCircuitBreakerOptionsTests
         options.FailureThreshold = 1;
         options.BreakDuration = TimeSpan.FromMilliseconds(500);
 
-        ValidationHelper.ValidateObject(options, "Dummy.");
+        ValidationHelper.ValidateObject(new(options, "Dummy."));
     }
 
     [Fact]
@@ -58,7 +58,7 @@ public class SimpleCircuitBreakerOptionsTests
         options.BreakDuration = TimeSpan.FromMilliseconds(500);
 
         options.ShouldHandle = _ => PredicateResult.True;
-        ValidationHelper.ValidateObject(options, "Dummy.");
+        ValidationHelper.ValidateObject(new(options, "Dummy."));
     }
 
     [Fact]
@@ -75,7 +75,7 @@ public class SimpleCircuitBreakerOptionsTests
         };
 
         options
-            .Invoking(o => ValidationHelper.ValidateObject(o, "Dummy."))
+            .Invoking(o => ValidationHelper.ValidateObject(new(o, "Dummy.")))
             .Should()
             .Throw<ValidationException>()
             .WithMessage("""

--- a/test/Polly.Core.Tests/Fallback/FallbackStrategyOptionsTests.cs
+++ b/test/Polly.Core.Tests/Fallback/FallbackStrategyOptionsTests.cs
@@ -38,7 +38,7 @@ public class FallbackStrategyOptionsTests
         };
 
         options
-            .Invoking(o => ValidationHelper.ValidateObject(o, "Invalid."))
+            .Invoking(o => ValidationHelper.ValidateObject(new(o, "Invalid.")))
             .Should()
             .Throw<ValidationException>()
             .WithMessage("""

--- a/test/Polly.Core.Tests/Hedging/HedgingStrategyOptionsTests.cs
+++ b/test/Polly.Core.Tests/Hedging/HedgingStrategyOptionsTests.cs
@@ -71,7 +71,7 @@ public class HedgingStrategyOptionsTests
         };
 
         options
-            .Invoking(o => ValidationHelper.ValidateObject(o, "Invalid."))
+            .Invoking(o => ValidationHelper.ValidateObject(new(o, "Invalid.")))
             .Should()
             .Throw<ValidationException>()
             .WithMessage("""

--- a/test/Polly.Core.Tests/Registry/ResilienceStrategyRegistryTests.cs
+++ b/test/Polly.Core.Tests/Registry/ResilienceStrategyRegistryTests.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using Polly.Registry;
 using Polly.Retry;
@@ -35,7 +34,7 @@ public class ResilienceStrategyRegistryTests
     {
         this.Invoking(_ => new ResilienceStrategyRegistry<string>(new ResilienceStrategyRegistryOptions<string> { BuilderFactory = null! }))
             .Should()
-            .Throw<ValidationException>().WithMessage("The resilience strategy registry options are invalid.*");
+            .Throw<ArgumentNullException>();
     }
 
     [Fact]

--- a/test/Polly.Core.Tests/ResilienceStrategyBuilderTests.cs
+++ b/test/Polly.Core.Tests/ResilienceStrategyBuilderTests.cs
@@ -129,8 +129,6 @@ public class ResilienceStrategyBuilderTests
         var builder = new ResilienceStrategyBuilder();
 
         builder.Validator.Should().NotBeNull();
-        builder.Validator = null!;
-        builder.Validator.Should().NotBeNull();
 
         builder.Validator(new ResilienceValidationContext("ABC", "ABC"));
 
@@ -143,6 +141,15 @@ public class ResilienceStrategyBuilderTests
             Validation Errors:
             The field RetryCount must be between -1 and 100.
             """);
+    }
+
+    [Fact]
+    public void Validator_Null_Throws()
+    {
+        new ResilienceStrategyBuilder()
+            .Invoking(b => b.Validator = null!)
+            .Should()
+            .Throw<ArgumentNullException>();
     }
 
     [Fact]

--- a/test/Polly.Core.Tests/Retry/RetryStrategyOptionsTests.cs
+++ b/test/Polly.Core.Tests/Retry/RetryStrategyOptionsTests.cs
@@ -47,7 +47,7 @@ public class RetryStrategyOptionsTests
             BaseDelay = TimeSpan.MinValue
         };
 
-        options.Invoking(o => ValidationHelper.ValidateObject(o, "Invalid Options"))
+        options.Invoking(o => ValidationHelper.ValidateObject(new(o, "Invalid Options")))
             .Should()
             .Throw<ValidationException>()
             .WithMessage("""

--- a/test/Polly.Core.Tests/Timeout/TimeoutStrategyOptionsTests.cs
+++ b/test/Polly.Core.Tests/Timeout/TimeoutStrategyOptionsTests.cs
@@ -26,7 +26,7 @@ public class TimeoutStrategyOptionsTests
         };
 
         options
-            .Invoking(o => ValidationHelper.ValidateObject(o, "Dummy message"))
+            .Invoking(o => ValidationHelper.ValidateObject(new(o, "Dummy message")))
             .Should()
             .Throw<ValidationException>();
     }
@@ -41,7 +41,7 @@ public class TimeoutStrategyOptionsTests
         };
 
         options
-            .Invoking(o => ValidationHelper.ValidateObject(o, "Dummy message"))
+            .Invoking(o => ValidationHelper.ValidateObject(new(o, "Dummy message")))
             .Should()
             .NotThrow();
     }

--- a/test/Polly.Extensions.Tests/Telemetry/TelemetryResilienceStrategyBuilderExtensionsTests.cs
+++ b/test/Polly.Extensions.Tests/Telemetry/TelemetryResilienceStrategyBuilderExtensionsTests.cs
@@ -7,43 +7,22 @@ namespace Polly.Extensions.Tests.Telemetry;
 public class TelemetryResilienceStrategyBuilderExtensionsTests
 {
     private readonly ResilienceStrategyBuilder _builder = new();
-    private readonly ResilienceStrategyBuilder<string> _genericBuilder = new();
 
-    [InlineData(true)]
-    [InlineData(false)]
-    [Theory]
-    public void ConfigureTelemetry_EnsureDiagnosticSourceUpdated(bool generic)
+    [Fact]
+    public void ConfigureTelemetry_EnsureDiagnosticSourceUpdated()
     {
-        if (generic)
-        {
-            _genericBuilder.ConfigureTelemetry(NullLoggerFactory.Instance);
-            _genericBuilder.DiagnosticSource.Should().BeOfType<ResilienceTelemetryDiagnosticSource>();
-        }
-        else
-        {
-            _builder.ConfigureTelemetry(NullLoggerFactory.Instance);
-            _builder.DiagnosticSource.Should().BeOfType<ResilienceTelemetryDiagnosticSource>();
-            _builder.AddStrategy(new TestResilienceStrategy()).Build().Should().NotBeOfType<TestResilienceStrategy>();
-        }
+        _builder.ConfigureTelemetry(NullLoggerFactory.Instance);
+        _builder.DiagnosticSource.Should().BeOfType<ResilienceTelemetryDiagnosticSource>();
+        _builder.AddStrategy(new TestResilienceStrategy()).Build().Should().NotBeOfType<TestResilienceStrategy>();
     }
 
-    [InlineData(true)]
-    [InlineData(false)]
-    [Theory]
-    public void ConfigureTelemetry_EnsureLogging(bool generic)
+    [Fact]
+    public void ConfigureTelemetry_EnsureLogging()
     {
         using var factory = TestUtilities.CreateLoggerFactory(out var fakeLogger);
 
-        if (generic)
-        {
-            _genericBuilder.ConfigureTelemetry(factory);
-            _genericBuilder.AddStrategy(new TestResilienceStrategy()).Build().Execute(_ => string.Empty);
-        }
-        else
-        {
-            _builder.ConfigureTelemetry(factory);
-            _builder.AddStrategy(new TestResilienceStrategy()).Build().Execute(_ => { });
-        }
+        _builder.ConfigureTelemetry(factory);
+        _builder.AddStrategy(new TestResilienceStrategy()).Build().Execute(_ => { });
 
         fakeLogger.GetRecords().Should().NotBeEmpty();
         fakeLogger.GetRecords().Should().HaveCount(2);
@@ -59,20 +38,7 @@ public class TelemetryResilienceStrategyBuilderExtensionsTests
             })).Should()
             .Throw<ValidationException>()
             .WithMessage("""
-            The resilience telemetry options are invalid.
-
-            Validation Errors:
-            The LoggerFactory field is required.
-            """);
-
-        _genericBuilder
-            .Invoking(b => b.ConfigureTelemetry(new TelemetryOptions
-            {
-                LoggerFactory = null!,
-            })).Should()
-            .Throw<ValidationException>()
-            .WithMessage("""
-            The resilience telemetry options are invalid.
+            The 'TelemetryOptions' are invalid.
 
             Validation Errors:
             The LoggerFactory field is required.


### PR DESCRIPTION
### Details on the issue fix or feature implementation

This API addition allows the library to inject their own validator and get rid of the reflection that is used in the default validator. 
This allows the library that consumes the Polly to be AOT compatible.

In ideal world we could just use the generators introduced by https://github.com/dotnet/runtime/issues/85475. 
However, this would pull the heavy `Microsoft.Extensions.Options` dependency into the core package. 

As a follow-up task after #1360  is merged we can introduce `ResilienceValidator.Validate` utility API in `Polly.Extensions` that uses generated validators for validation and doesn't use reflection at all (for all built-in options). 

Contributes to #1110 

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
