### PR TITLE
Improve usability of ResilienceStrategy<T>

### DIFF
--- a/src/Polly.Core/PublicAPI.Unshipped.txt
+++ b/src/Polly.Core/PublicAPI.Unshipped.txt
@@ -249,17 +249,17 @@ Polly.ResilienceStrategy.ExecuteAsync<TState>(System.Func<TState, System.Threadi
 Polly.ResilienceStrategy.ExecuteOutcomeAsync<TResult, TState>(System.Func<Polly.ResilienceContext!, TState, System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>>! callback, Polly.ResilienceContext! context, TState state) -> System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>
 Polly.ResilienceStrategy.ResilienceStrategy() -> void
 Polly.ResilienceStrategy<TResult>
-Polly.ResilienceStrategy<TResult>.Execute(System.Func<Polly.ResilienceContext!, TResult>! callback, Polly.ResilienceContext! context) -> TResult
-Polly.ResilienceStrategy<TResult>.Execute(System.Func<System.Threading.CancellationToken, TResult>! callback, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> TResult
-Polly.ResilienceStrategy<TResult>.Execute(System.Func<TResult>! callback) -> TResult
-Polly.ResilienceStrategy<TResult>.Execute<TState>(System.Func<Polly.ResilienceContext!, TState, TResult>! callback, Polly.ResilienceContext! context, TState state) -> TResult
-Polly.ResilienceStrategy<TResult>.Execute<TState>(System.Func<TState, System.Threading.CancellationToken, TResult>! callback, TState state, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> TResult
-Polly.ResilienceStrategy<TResult>.Execute<TState>(System.Func<TState, TResult>! callback, TState state) -> TResult
-Polly.ResilienceStrategy<TResult>.ExecuteAsync(System.Func<Polly.ResilienceContext!, System.Threading.Tasks.ValueTask<TResult>>! callback, Polly.ResilienceContext! context) -> System.Threading.Tasks.ValueTask<TResult>
-Polly.ResilienceStrategy<TResult>.ExecuteAsync(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! callback, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<TResult>
-Polly.ResilienceStrategy<TResult>.ExecuteAsync<TState>(System.Func<Polly.ResilienceContext!, TState, System.Threading.Tasks.ValueTask<TResult>>! callback, Polly.ResilienceContext! context, TState state) -> System.Threading.Tasks.ValueTask<TResult>
-Polly.ResilienceStrategy<TResult>.ExecuteAsync<TState>(System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! callback, TState state, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<TResult>
-Polly.ResilienceStrategy<TResult>.ExecuteOutcomeAsync<TState>(System.Func<Polly.ResilienceContext!, TState, System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>>! callback, Polly.ResilienceContext! context, TState state) -> System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>
+Polly.ResilienceStrategy<TResult>.Execute<T, TState>(System.Func<Polly.ResilienceContext!, TState, T>! callback, Polly.ResilienceContext! context, TState state) -> T
+Polly.ResilienceStrategy<TResult>.Execute<T, TState>(System.Func<TState, System.Threading.CancellationToken, T>! callback, TState state, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> T
+Polly.ResilienceStrategy<TResult>.Execute<T, TState>(System.Func<TState, T>! callback, TState state) -> T
+Polly.ResilienceStrategy<TResult>.Execute<T>(System.Func<Polly.ResilienceContext!, T>! callback, Polly.ResilienceContext! context) -> T
+Polly.ResilienceStrategy<TResult>.Execute<T>(System.Func<System.Threading.CancellationToken, T>! callback, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> T
+Polly.ResilienceStrategy<TResult>.Execute<T>(System.Func<T>! callback) -> T
+Polly.ResilienceStrategy<TResult>.ExecuteAsync<T, TState>(System.Func<Polly.ResilienceContext!, TState, System.Threading.Tasks.ValueTask<T>>! callback, Polly.ResilienceContext! context, TState state) -> System.Threading.Tasks.ValueTask<T>
+Polly.ResilienceStrategy<TResult>.ExecuteAsync<T, TState>(System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<T>>! callback, TState state, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<T>
+Polly.ResilienceStrategy<TResult>.ExecuteAsync<T>(System.Func<Polly.ResilienceContext!, System.Threading.Tasks.ValueTask<T>>! callback, Polly.ResilienceContext! context) -> System.Threading.Tasks.ValueTask<T>
+Polly.ResilienceStrategy<TResult>.ExecuteAsync<T>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<T>>! callback, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<T>
+Polly.ResilienceStrategy<TResult>.ExecuteOutcomeAsync<T, TState>(System.Func<Polly.ResilienceContext!, TState, System.Threading.Tasks.ValueTask<Polly.Outcome<T>>>! callback, Polly.ResilienceContext! context, TState state) -> System.Threading.Tasks.ValueTask<Polly.Outcome<T>>
 Polly.ResilienceStrategyBuilder
 Polly.ResilienceStrategyBuilder.Build() -> Polly.ResilienceStrategy!
 Polly.ResilienceStrategyBuilder.ResilienceStrategyBuilder() -> void

--- a/src/Polly.Core/PublicAPI.Unshipped.txt
+++ b/src/Polly.Core/PublicAPI.Unshipped.txt
@@ -248,18 +248,18 @@ Polly.ResilienceStrategy.ExecuteAsync<TState>(System.Func<Polly.ResilienceContex
 Polly.ResilienceStrategy.ExecuteAsync<TState>(System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! callback, TState state, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
 Polly.ResilienceStrategy.ExecuteOutcomeAsync<TResult, TState>(System.Func<Polly.ResilienceContext!, TState, System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>>! callback, Polly.ResilienceContext! context, TState state) -> System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>
 Polly.ResilienceStrategy.ResilienceStrategy() -> void
-Polly.ResilienceStrategy<TResult>
-Polly.ResilienceStrategy<TResult>.Execute<T, TState>(System.Func<Polly.ResilienceContext!, TState, T>! callback, Polly.ResilienceContext! context, TState state) -> T
-Polly.ResilienceStrategy<TResult>.Execute<T, TState>(System.Func<TState, System.Threading.CancellationToken, T>! callback, TState state, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> T
-Polly.ResilienceStrategy<TResult>.Execute<T, TState>(System.Func<TState, T>! callback, TState state) -> T
-Polly.ResilienceStrategy<TResult>.Execute<T>(System.Func<Polly.ResilienceContext!, T>! callback, Polly.ResilienceContext! context) -> T
-Polly.ResilienceStrategy<TResult>.Execute<T>(System.Func<System.Threading.CancellationToken, T>! callback, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> T
-Polly.ResilienceStrategy<TResult>.Execute<T>(System.Func<T>! callback) -> T
-Polly.ResilienceStrategy<TResult>.ExecuteAsync<T, TState>(System.Func<Polly.ResilienceContext!, TState, System.Threading.Tasks.ValueTask<T>>! callback, Polly.ResilienceContext! context, TState state) -> System.Threading.Tasks.ValueTask<T>
-Polly.ResilienceStrategy<TResult>.ExecuteAsync<T, TState>(System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<T>>! callback, TState state, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<T>
-Polly.ResilienceStrategy<TResult>.ExecuteAsync<T>(System.Func<Polly.ResilienceContext!, System.Threading.Tasks.ValueTask<T>>! callback, Polly.ResilienceContext! context) -> System.Threading.Tasks.ValueTask<T>
-Polly.ResilienceStrategy<TResult>.ExecuteAsync<T>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<T>>! callback, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<T>
-Polly.ResilienceStrategy<TResult>.ExecuteOutcomeAsync<T, TState>(System.Func<Polly.ResilienceContext!, TState, System.Threading.Tasks.ValueTask<Polly.Outcome<T>>>! callback, Polly.ResilienceContext! context, TState state) -> System.Threading.Tasks.ValueTask<Polly.Outcome<T>>
+Polly.ResilienceStrategy<T>
+Polly.ResilienceStrategy<T>.Execute<TResult, TState>(System.Func<Polly.ResilienceContext!, TState, TResult>! callback, Polly.ResilienceContext! context, TState state) -> TResult
+Polly.ResilienceStrategy<T>.Execute<TResult, TState>(System.Func<TState, System.Threading.CancellationToken, TResult>! callback, TState state, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> TResult
+Polly.ResilienceStrategy<T>.Execute<TResult, TState>(System.Func<TState, TResult>! callback, TState state) -> TResult
+Polly.ResilienceStrategy<T>.Execute<TResult>(System.Func<Polly.ResilienceContext!, TResult>! callback, Polly.ResilienceContext! context) -> TResult
+Polly.ResilienceStrategy<T>.Execute<TResult>(System.Func<System.Threading.CancellationToken, TResult>! callback, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> TResult
+Polly.ResilienceStrategy<T>.Execute<TResult>(System.Func<TResult>! callback) -> TResult
+Polly.ResilienceStrategy<T>.ExecuteAsync<TResult, TState>(System.Func<Polly.ResilienceContext!, TState, System.Threading.Tasks.ValueTask<TResult>>! callback, Polly.ResilienceContext! context, TState state) -> System.Threading.Tasks.ValueTask<TResult>
+Polly.ResilienceStrategy<T>.ExecuteAsync<TResult, TState>(System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! callback, TState state, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<TResult>
+Polly.ResilienceStrategy<T>.ExecuteAsync<TResult>(System.Func<Polly.ResilienceContext!, System.Threading.Tasks.ValueTask<TResult>>! callback, Polly.ResilienceContext! context) -> System.Threading.Tasks.ValueTask<TResult>
+Polly.ResilienceStrategy<T>.ExecuteAsync<TResult>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! callback, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<TResult>
+Polly.ResilienceStrategy<T>.ExecuteOutcomeAsync<TResult, TState>(System.Func<Polly.ResilienceContext!, TState, System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>>! callback, Polly.ResilienceContext! context, TState state) -> System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>
 Polly.ResilienceStrategyBuilder
 Polly.ResilienceStrategyBuilder.Build() -> Polly.ResilienceStrategy!
 Polly.ResilienceStrategyBuilder.ResilienceStrategyBuilder() -> void

--- a/src/Polly.Core/ResilienceStrategy.TResult.Async.cs
+++ b/src/Polly.Core/ResilienceStrategy.TResult.Async.cs
@@ -7,12 +7,12 @@ namespace Polly;
 /// <summary>
 /// Resilience strategy is used to execute the user-provided callbacks.
 /// </summary>
-/// <typeparam name="TResult">The type of result this strategy supports.</typeparam>
+/// <typeparam name="T">The type of result this strategy supports.</typeparam>
 /// <remarks>
-/// Resilience strategy supports various types of callbacks of <typeparamref name="TResult"/> result type
+/// Resilience strategy supports various types of callbacks of <typeparamref name="T"/> result type
 /// and provides a unified way to execute them. This includes overloads for synchronous and asynchronous callbacks.
 /// </remarks>
-public partial class ResilienceStrategy<TResult>
+public partial class ResilienceStrategy<T>
 {
     internal ResilienceStrategy(ResilienceStrategy strategy) => Strategy = strategy;
 
@@ -21,18 +21,18 @@ public partial class ResilienceStrategy<TResult>
     /// <summary>
     /// Executes the specified callback.
     /// </summary>
-    /// <typeparam name="T">The type of the result.</typeparam>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <typeparam name="TState">The type of state associated with the callback.</typeparam>
     /// <param name="callback">The user-provided callback.</param>
     /// <param name="context">The context associated with the callback.</param>
     /// <param name="state">The state associated with the callback.</param>
     /// <returns>The instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> or <paramref name="context"/> is <see langword="null"/>.</exception>
-    public ValueTask<T> ExecuteAsync<T, TState>(
-        Func<ResilienceContext, TState, ValueTask<T>> callback,
+    public ValueTask<TResult> ExecuteAsync<TResult, TState>(
+        Func<ResilienceContext, TState, ValueTask<TResult>> callback,
         ResilienceContext context,
         TState state)
-        where T : TResult
+        where TResult : T
     {
         Guard.NotNull(callback);
         Guard.NotNull(context);
@@ -43,15 +43,15 @@ public partial class ResilienceStrategy<TResult>
     /// <summary>
     /// Executes the specified callback.
     /// </summary>
-    /// <typeparam name="T">The type of the result.</typeparam>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="callback">The user-provided callback.</param>
     /// <param name="context">The context associated with the callback.</param>
     /// <returns>The instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> or <paramref name="context"/> is <see langword="null"/>.</exception>
-    public ValueTask<T> ExecuteAsync<T>(
-        Func<ResilienceContext, ValueTask<T>> callback,
+    public ValueTask<TResult> ExecuteAsync<TResult>(
+        Func<ResilienceContext, ValueTask<TResult>> callback,
         ResilienceContext context)
-        where T : TResult
+        where TResult : T
     {
         Guard.NotNull(callback);
         Guard.NotNull(context);
@@ -62,18 +62,18 @@ public partial class ResilienceStrategy<TResult>
     /// <summary>
     /// Executes the specified callback.
     /// </summary>
-    /// <typeparam name="T">The type of the result.</typeparam>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <typeparam name="TState">The type of state associated with the callback.</typeparam>
     /// <param name="callback">The user-provided callback.</param>
     /// <param name="state">The state associated with the callback.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> associated with the callback.</param>
     /// <returns>The instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> is <see langword="null"/>.</exception>
-    public ValueTask<T> ExecuteAsync<T, TState>(
-        Func<TState, CancellationToken, ValueTask<T>> callback,
+    public ValueTask<TResult> ExecuteAsync<TResult, TState>(
+        Func<TState, CancellationToken, ValueTask<TResult>> callback,
         TState state,
         CancellationToken cancellationToken = default)
-        where T : TResult
+        where TResult : T
     {
         Guard.NotNull(callback);
 
@@ -83,13 +83,13 @@ public partial class ResilienceStrategy<TResult>
     /// <summary>
     /// Executes the specified callback.
     /// </summary>
-    /// <typeparam name="T">The type of the result.</typeparam>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="callback">The user-provided callback.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> associated with the callback.</param>
     /// <returns>The instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> is <see langword="null"/>.</exception>
-    public ValueTask<T> ExecuteAsync<T>(
-        Func<CancellationToken, ValueTask<T>> callback,
+    public ValueTask<TResult> ExecuteAsync<TResult>(
+        Func<CancellationToken, ValueTask<TResult>> callback,
         CancellationToken cancellationToken = default)
     {
         Guard.NotNull(callback);
@@ -100,7 +100,7 @@ public partial class ResilienceStrategy<TResult>
     /// <summary>
     /// Executes the specified outcome-based callback.
     /// </summary>
-    /// <typeparam name="T">The type of the result.</typeparam>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <typeparam name="TState">The type of state associated with the callback.</typeparam>
     /// <param name="callback">The user-provided callback.</param>
     /// <param name="context">The context associated with the callback.</param>
@@ -111,11 +111,11 @@ public partial class ResilienceStrategy<TResult>
     /// This method is for advanced and high performance scenarios. The caller must make sure that the <paramref name="callback"/>
     /// does not throw any exceptions. Instead, it converts them to <see cref="Outcome{TResult}"/>.
     /// </remarks>
-    public ValueTask<Outcome<T>> ExecuteOutcomeAsync<T, TState>(
-        Func<ResilienceContext, TState, ValueTask<Outcome<T>>> callback,
+    public ValueTask<Outcome<TResult>> ExecuteOutcomeAsync<TResult, TState>(
+        Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
         ResilienceContext context,
         TState state)
-        where T : TResult
+        where TResult : T
     {
         Guard.NotNull(callback);
         Guard.NotNull(context);

--- a/src/Polly.Core/ResilienceStrategy.TResult.Async.cs
+++ b/src/Polly.Core/ResilienceStrategy.TResult.Async.cs
@@ -21,16 +21,18 @@ public partial class ResilienceStrategy<TResult>
     /// <summary>
     /// Executes the specified callback.
     /// </summary>
+    /// <typeparam name="T">The type of the result.</typeparam>
     /// <typeparam name="TState">The type of state associated with the callback.</typeparam>
     /// <param name="callback">The user-provided callback.</param>
     /// <param name="context">The context associated with the callback.</param>
     /// <param name="state">The state associated with the callback.</param>
     /// <returns>The instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> or <paramref name="context"/> is <see langword="null"/>.</exception>
-    public ValueTask<TResult> ExecuteAsync<TState>(
-        Func<ResilienceContext, TState, ValueTask<TResult>> callback,
+    public ValueTask<T> ExecuteAsync<T, TState>(
+        Func<ResilienceContext, TState, ValueTask<T>> callback,
         ResilienceContext context,
         TState state)
+        where T : TResult
     {
         Guard.NotNull(callback);
         Guard.NotNull(context);
@@ -41,13 +43,15 @@ public partial class ResilienceStrategy<TResult>
     /// <summary>
     /// Executes the specified callback.
     /// </summary>
+    /// <typeparam name="T">The type of the result.</typeparam>
     /// <param name="callback">The user-provided callback.</param>
     /// <param name="context">The context associated with the callback.</param>
     /// <returns>The instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> or <paramref name="context"/> is <see langword="null"/>.</exception>
-    public ValueTask<TResult> ExecuteAsync(
-        Func<ResilienceContext, ValueTask<TResult>> callback,
+    public ValueTask<T> ExecuteAsync<T>(
+        Func<ResilienceContext, ValueTask<T>> callback,
         ResilienceContext context)
+        where T : TResult
     {
         Guard.NotNull(callback);
         Guard.NotNull(context);
@@ -58,16 +62,18 @@ public partial class ResilienceStrategy<TResult>
     /// <summary>
     /// Executes the specified callback.
     /// </summary>
+    /// <typeparam name="T">The type of the result.</typeparam>
     /// <typeparam name="TState">The type of state associated with the callback.</typeparam>
     /// <param name="callback">The user-provided callback.</param>
     /// <param name="state">The state associated with the callback.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> associated with the callback.</param>
     /// <returns>The instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> is <see langword="null"/>.</exception>
-    public ValueTask<TResult> ExecuteAsync<TState>(
-        Func<TState, CancellationToken, ValueTask<TResult>> callback,
+    public ValueTask<T> ExecuteAsync<T, TState>(
+        Func<TState, CancellationToken, ValueTask<T>> callback,
         TState state,
         CancellationToken cancellationToken = default)
+        where T : TResult
     {
         Guard.NotNull(callback);
 
@@ -77,12 +83,13 @@ public partial class ResilienceStrategy<TResult>
     /// <summary>
     /// Executes the specified callback.
     /// </summary>
+    /// <typeparam name="T">The type of the result.</typeparam>
     /// <param name="callback">The user-provided callback.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> associated with the callback.</param>
     /// <returns>The instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> is <see langword="null"/>.</exception>
-    public ValueTask<TResult> ExecuteAsync(
-        Func<CancellationToken, ValueTask<TResult>> callback,
+    public ValueTask<T> ExecuteAsync<T>(
+        Func<CancellationToken, ValueTask<T>> callback,
         CancellationToken cancellationToken = default)
     {
         Guard.NotNull(callback);
@@ -93,6 +100,7 @@ public partial class ResilienceStrategy<TResult>
     /// <summary>
     /// Executes the specified outcome-based callback.
     /// </summary>
+    /// <typeparam name="T">The type of the result.</typeparam>
     /// <typeparam name="TState">The type of state associated with the callback.</typeparam>
     /// <param name="callback">The user-provided callback.</param>
     /// <param name="context">The context associated with the callback.</param>
@@ -103,10 +111,11 @@ public partial class ResilienceStrategy<TResult>
     /// This method is for advanced and high performance scenarios. The caller must make sure that the <paramref name="callback"/>
     /// does not throw any exceptions. Instead, it converts them to <see cref="Outcome{TResult}"/>.
     /// </remarks>
-    public ValueTask<Outcome<TResult>> ExecuteOutcomeAsync<TState>(
-        Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
+    public ValueTask<Outcome<T>> ExecuteOutcomeAsync<T, TState>(
+        Func<ResilienceContext, TState, ValueTask<Outcome<T>>> callback,
         ResilienceContext context,
         TState state)
+        where T : TResult
     {
         Guard.NotNull(callback);
         Guard.NotNull(context);

--- a/src/Polly.Core/ResilienceStrategy.TResult.Sync.cs
+++ b/src/Polly.Core/ResilienceStrategy.TResult.Sync.cs
@@ -7,16 +7,18 @@ public partial class ResilienceStrategy<TResult>
     /// <summary>
     /// Executes the specified callback.
     /// </summary>
+    /// <typeparam name="T">The type of the result.</typeparam>
     /// <typeparam name="TState">The type of state associated with the callback.</typeparam>
     /// <param name="callback">The user-provided callback.</param>
     /// <param name="context">The context associated with the callback.</param>
     /// <param name="state">The state associated with the callback.</param>
     /// <returns>An instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> or <paramref name="context"/> is <see langword="null"/>.</exception>
-    public TResult Execute<TState>(
-        Func<ResilienceContext, TState, TResult> callback,
+    public T Execute<T, TState>(
+        Func<ResilienceContext, TState, T> callback,
         ResilienceContext context,
         TState state)
+        where T : TResult
     {
         Guard.NotNull(callback);
         Guard.NotNull(context);
@@ -27,13 +29,15 @@ public partial class ResilienceStrategy<TResult>
     /// <summary>
     /// Executes the specified callback.
     /// </summary>
+    /// <typeparam name="T">The type of the result.</typeparam>
     /// <param name="callback">The user-provided callback.</param>
     /// <param name="context">The context associated with the callback.</param>
     /// <returns>An instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> or <paramref name="context"/> is <see langword="null"/>.</exception>
-    public TResult Execute(
-        Func<ResilienceContext, TResult> callback,
+    public T Execute<T>(
+        Func<ResilienceContext, T> callback,
         ResilienceContext context)
+        where T : TResult
     {
         Guard.NotNull(callback);
         Guard.NotNull(context);
@@ -44,13 +48,15 @@ public partial class ResilienceStrategy<TResult>
     /// <summary>
     /// Executes the specified callback.
     /// </summary>
+    /// <typeparam name="T">The type of the result.</typeparam>
     /// <param name="callback">The user-provided callback.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> associated with the callback.</param>
     /// <returns>An instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> is <see langword="null"/>.</exception>
-    public TResult Execute(
-        Func<CancellationToken, TResult> callback,
+    public T Execute<T>(
+        Func<CancellationToken, T> callback,
         CancellationToken cancellationToken = default)
+        where T : TResult
     {
         Guard.NotNull(callback);
 
@@ -60,10 +66,12 @@ public partial class ResilienceStrategy<TResult>
     /// <summary>
     /// Executes the specified callback.
     /// </summary>
+    /// <typeparam name="T">The type of the result.</typeparam>
     /// <param name="callback">The user-provided callback.</param>
     /// <returns>An instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> is <see langword="null"/>.</exception>
-    public TResult Execute(Func<TResult> callback)
+    public T Execute<T>(Func<T> callback)
+        where T : TResult
     {
         Guard.NotNull(callback);
 
@@ -73,12 +81,14 @@ public partial class ResilienceStrategy<TResult>
     /// <summary>
     /// Executes the specified callback.
     /// </summary>
+    /// <typeparam name="T">The type of the result.</typeparam>
     /// <typeparam name="TState">The type of state associated with the callback.</typeparam>
     /// <param name="callback">The user-provided callback.</param>
     /// <param name="state">The state associated with the callback.</param>
     /// <returns>An instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> is <see langword="null"/>.</exception>
-    public TResult Execute<TState>(Func<TState, TResult> callback, TState state)
+    public T Execute<T, TState>(Func<TState, T> callback, TState state)
+        where T : TResult
     {
         Guard.NotNull(callback);
 
@@ -88,16 +98,18 @@ public partial class ResilienceStrategy<TResult>
     /// <summary>
     /// Executes the specified callback.
     /// </summary>
+    /// <typeparam name="T">The type of the result.</typeparam>
     /// <typeparam name="TState">The type of state associated with the callback.</typeparam>
     /// <param name="callback">The user-provided callback.</param>
     /// <param name="state">The state associated with the callback.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> associated with the callback.</param>
     /// <returns>An instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> is <see langword="null"/>.</exception>
-    public TResult Execute<TState>(
-        Func<TState, CancellationToken, TResult> callback,
+    public T Execute<T, TState>(
+        Func<TState, CancellationToken, T> callback,
         TState state,
         CancellationToken cancellationToken = default)
+        where T : TResult
     {
         Guard.NotNull(callback);
 

--- a/src/Polly.Core/ResilienceStrategy.TResult.Sync.cs
+++ b/src/Polly.Core/ResilienceStrategy.TResult.Sync.cs
@@ -2,23 +2,23 @@ namespace Polly;
 
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
 
-public partial class ResilienceStrategy<TResult>
+public partial class ResilienceStrategy<T>
 {
     /// <summary>
     /// Executes the specified callback.
     /// </summary>
-    /// <typeparam name="T">The type of the result.</typeparam>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <typeparam name="TState">The type of state associated with the callback.</typeparam>
     /// <param name="callback">The user-provided callback.</param>
     /// <param name="context">The context associated with the callback.</param>
     /// <param name="state">The state associated with the callback.</param>
     /// <returns>An instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> or <paramref name="context"/> is <see langword="null"/>.</exception>
-    public T Execute<T, TState>(
-        Func<ResilienceContext, TState, T> callback,
+    public TResult Execute<TResult, TState>(
+        Func<ResilienceContext, TState, TResult> callback,
         ResilienceContext context,
         TState state)
-        where T : TResult
+        where TResult : T
     {
         Guard.NotNull(callback);
         Guard.NotNull(context);
@@ -29,15 +29,15 @@ public partial class ResilienceStrategy<TResult>
     /// <summary>
     /// Executes the specified callback.
     /// </summary>
-    /// <typeparam name="T">The type of the result.</typeparam>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="callback">The user-provided callback.</param>
     /// <param name="context">The context associated with the callback.</param>
     /// <returns>An instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> or <paramref name="context"/> is <see langword="null"/>.</exception>
-    public T Execute<T>(
-        Func<ResilienceContext, T> callback,
+    public TResult Execute<TResult>(
+        Func<ResilienceContext, TResult> callback,
         ResilienceContext context)
-        where T : TResult
+        where TResult : T
     {
         Guard.NotNull(callback);
         Guard.NotNull(context);
@@ -48,15 +48,15 @@ public partial class ResilienceStrategy<TResult>
     /// <summary>
     /// Executes the specified callback.
     /// </summary>
-    /// <typeparam name="T">The type of the result.</typeparam>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="callback">The user-provided callback.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> associated with the callback.</param>
     /// <returns>An instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> is <see langword="null"/>.</exception>
-    public T Execute<T>(
-        Func<CancellationToken, T> callback,
+    public TResult Execute<TResult>(
+        Func<CancellationToken, TResult> callback,
         CancellationToken cancellationToken = default)
-        where T : TResult
+        where TResult : T
     {
         Guard.NotNull(callback);
 
@@ -66,12 +66,12 @@ public partial class ResilienceStrategy<TResult>
     /// <summary>
     /// Executes the specified callback.
     /// </summary>
-    /// <typeparam name="T">The type of the result.</typeparam>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="callback">The user-provided callback.</param>
     /// <returns>An instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> is <see langword="null"/>.</exception>
-    public T Execute<T>(Func<T> callback)
-        where T : TResult
+    public TResult Execute<TResult>(Func<TResult> callback)
+        where TResult : T
     {
         Guard.NotNull(callback);
 
@@ -81,14 +81,14 @@ public partial class ResilienceStrategy<TResult>
     /// <summary>
     /// Executes the specified callback.
     /// </summary>
-    /// <typeparam name="T">The type of the result.</typeparam>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <typeparam name="TState">The type of state associated with the callback.</typeparam>
     /// <param name="callback">The user-provided callback.</param>
     /// <param name="state">The state associated with the callback.</param>
     /// <returns>An instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> is <see langword="null"/>.</exception>
-    public T Execute<T, TState>(Func<TState, T> callback, TState state)
-        where T : TResult
+    public TResult Execute<TResult, TState>(Func<TState, TResult> callback, TState state)
+        where TResult : T
     {
         Guard.NotNull(callback);
 
@@ -98,18 +98,18 @@ public partial class ResilienceStrategy<TResult>
     /// <summary>
     /// Executes the specified callback.
     /// </summary>
-    /// <typeparam name="T">The type of the result.</typeparam>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <typeparam name="TState">The type of state associated with the callback.</typeparam>
     /// <param name="callback">The user-provided callback.</param>
     /// <param name="state">The state associated with the callback.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> associated with the callback.</param>
     /// <returns>An instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> is <see langword="null"/>.</exception>
-    public T Execute<T, TState>(
-        Func<TState, CancellationToken, T> callback,
+    public TResult Execute<TResult, TState>(
+        Func<TState, CancellationToken, TResult> callback,
         TState state,
         CancellationToken cancellationToken = default)
-        where T : TResult
+        where TResult : T
     {
         Guard.NotNull(callback);
 


### PR DESCRIPTION
### Details on the issue fix or feature implementation

These changes  enable flowing the type used in the callback back to the result:

``` csharp
ResilienceStrategy<object> strategy = NullResilienceStrategy<object>.Instance;

int v1 = strategy.Execute(() => 10);
string v2 = strategy.Execute(() => "val");
bool v3 = strategy.Execute(() => true);
```

Previously, these all would be object:

``` csharp
ResilienceStrategy<object> strategy = NullResilienceStrategy<object>.Instance;

object v1 = strategy.Execute(() => 10);
object v2 = strategy.Execute(() => "val");
object v3 = strategy.Execute(() => true);
```

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
