### PR TITLE
Drop the ResilienceStrategyBuilder.IsGenericBuilder property

### DIFF
--- a/src/Polly.Core/Fallback/FallbackHandler.cs
+++ b/src/Polly.Core/Fallback/FallbackHandler.cs
@@ -2,8 +2,7 @@ namespace Polly.Fallback;
 
 internal sealed record class FallbackHandler<T>(
     Func<OutcomeArguments<T, FallbackPredicateArguments>, ValueTask<bool>> ShouldHandle,
-    Func<OutcomeArguments<T, FallbackPredicateArguments>, ValueTask<Outcome<T>>> ActionGenerator,
-    bool IsGeneric)
+    Func<OutcomeArguments<T, FallbackPredicateArguments>, ValueTask<Outcome<T>>> ActionGenerator)
 {
     public async ValueTask<Outcome<TResult>> GetFallbackOutcomeAsync<TResult>(OutcomeArguments<TResult, FallbackPredicateArguments> args)
     {

--- a/src/Polly.Core/Fallback/FallbackResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/Fallback/FallbackResilienceStrategyBuilderExtensions.cs
@@ -56,8 +56,7 @@ public static class FallbackResilienceStrategyBuilderExtensions
         {
             var handler = new FallbackHandler<TResult>(
                 options.ShouldHandle!,
-                options.FallbackAction!,
-                IsGeneric: context.IsGenericBuilder);
+                options.FallbackAction!);
 
             return new FallbackResilienceStrategy<TResult>(
                 handler,

--- a/src/Polly.Core/Hedging/HedgingResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/Hedging/HedgingResilienceStrategyBuilderExtensions.cs
@@ -24,7 +24,7 @@ public static class HedgingResilienceStrategyBuilderExtensions
         Guard.NotNull(builder);
         Guard.NotNull(options);
 
-        builder.AddHedgingCore<TResult, HedgingStrategyOptions<TResult>>(options);
+        builder.AddHedgingCore<TResult, HedgingStrategyOptions<TResult>>(options, isGeneric: true);
         return builder;
     }
 
@@ -41,7 +41,7 @@ public static class HedgingResilienceStrategyBuilderExtensions
         Guard.NotNull(builder);
         Guard.NotNull(options);
 
-        builder.AddHedgingCore<object, HedgingStrategyOptions>(options);
+        builder.AddHedgingCore<object, HedgingStrategyOptions>(options, isGeneric: false);
         return builder;
     }
 
@@ -51,14 +51,15 @@ public static class HedgingResilienceStrategyBuilderExtensions
         Justification = "All options members preserved.")]
     internal static void AddHedgingCore<TResult, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TOptions>(
         this ResilienceStrategyBuilderBase builder,
-        HedgingStrategyOptions<TResult> options)
+        HedgingStrategyOptions<TResult> options,
+        bool isGeneric)
     {
         builder.AddStrategy(context =>
         {
             var handler = new HedgingHandler<TResult>(
                 options.ShouldHandle!,
                 options.HedgingActionGenerator,
-                context.IsGenericBuilder);
+                isGeneric);
 
             return new HedgingResilienceStrategy<TResult>(
                 options.HedgingDelay,

--- a/src/Polly.Core/Hedging/HedgingResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/Hedging/HedgingResilienceStrategyBuilderExtensions.cs
@@ -24,7 +24,7 @@ public static class HedgingResilienceStrategyBuilderExtensions
         Guard.NotNull(builder);
         Guard.NotNull(options);
 
-        builder.AddHedgingCore<TResult, HedgingStrategyOptions<TResult>>(options, isGeneric: true);
+        builder.AddHedgingCore<TResult, HedgingStrategyOptions<TResult>>(options);
         return builder;
     }
 
@@ -41,7 +41,7 @@ public static class HedgingResilienceStrategyBuilderExtensions
         Guard.NotNull(builder);
         Guard.NotNull(options);
 
-        builder.AddHedgingCore<object, HedgingStrategyOptions>(options, isGeneric: false);
+        builder.AddHedgingCore<object, HedgingStrategyOptions>(options);
         return builder;
     }
 
@@ -51,15 +51,14 @@ public static class HedgingResilienceStrategyBuilderExtensions
         Justification = "All options members preserved.")]
     internal static void AddHedgingCore<TResult, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TOptions>(
         this ResilienceStrategyBuilderBase builder,
-        HedgingStrategyOptions<TResult> options,
-        bool isGeneric)
+        HedgingStrategyOptions<TResult> options)
     {
         builder.AddStrategy(context =>
         {
             var handler = new HedgingHandler<TResult>(
                 options.ShouldHandle!,
                 options.HedgingActionGenerator,
-                isGeneric);
+                IsGeneric: builder is not ResilienceStrategyBuilder);
 
             return new HedgingResilienceStrategy<TResult>(
                 options.HedgingDelay,

--- a/src/Polly.Core/ResilienceStrategyBuilder.TResult.cs
+++ b/src/Polly.Core/ResilienceStrategyBuilder.TResult.cs
@@ -25,8 +25,6 @@ public sealed class ResilienceStrategyBuilder<TResult> : ResilienceStrategyBuild
     {
     }
 
-    internal override bool IsGenericBuilder => true;
-
     /// <summary>
     /// Builds the resilience strategy.
     /// </summary>

--- a/src/Polly.Core/ResilienceStrategyBuilder.cs
+++ b/src/Polly.Core/ResilienceStrategyBuilder.cs
@@ -12,8 +12,6 @@ namespace Polly;
 /// </remarks>
 public sealed class ResilienceStrategyBuilder : ResilienceStrategyBuilderBase
 {
-    internal override bool IsGenericBuilder => false;
-
     /// <summary>
     /// Builds the resilience strategy.
     /// </summary>

--- a/src/Polly.Core/ResilienceStrategyBuilderBase.cs
+++ b/src/Polly.Core/ResilienceStrategyBuilderBase.cs
@@ -120,8 +120,6 @@ public abstract class ResilienceStrategyBuilderBase
     [EditorBrowsable(EditorBrowsableState.Never)]
     public Action<ResilienceValidationContext> Validator { get; private protected set; } = ValidationHelper.ValidateObject;
 
-    internal abstract bool IsGenericBuilder { get; }
-
     [RequiresUnreferencedCode(Constants.OptionsValidation)]
     internal void AddStrategyCore(Func<ResilienceStrategyBuilderContext, ResilienceStrategy> factory, ResilienceStrategyOptions options)
     {
@@ -168,7 +166,6 @@ public abstract class ResilienceStrategyBuilderBase
             builderProperties: Properties,
             strategyName: entry.Options.Name,
             timeProvider: TimeProvider,
-            isGenericBuilder: IsGenericBuilder,
             diagnosticSource: DiagnosticSource,
             randomizer: Randomizer);
 

--- a/src/Polly.Core/ResilienceStrategyBuilderContext.cs
+++ b/src/Polly.Core/ResilienceStrategyBuilderContext.cs
@@ -15,7 +15,6 @@ public sealed class ResilienceStrategyBuilderContext
         ResilienceProperties builderProperties,
         string? strategyName,
         TimeProvider timeProvider,
-        bool isGenericBuilder,
         DiagnosticSource? diagnosticSource,
         Func<double> randomizer)
     {
@@ -24,7 +23,6 @@ public sealed class ResilienceStrategyBuilderContext
         BuilderProperties = builderProperties;
         StrategyName = strategyName;
         TimeProvider = timeProvider;
-        IsGenericBuilder = isGenericBuilder;
         Telemetry = TelemetryUtil.CreateTelemetry(diagnosticSource, builderName, builderInstanceName, builderProperties, strategyName);
         Randomizer = randomizer;
     }
@@ -60,6 +58,4 @@ public sealed class ResilienceStrategyBuilderContext
     internal TimeProvider TimeProvider { get; }
 
     internal Func<double> Randomizer { get; }
-
-    internal bool IsGenericBuilder { get; }
 }

--- a/test/Polly.Core.Tests/Fallback/FallbackHandlerTests.cs
+++ b/test/Polly.Core.Tests/Fallback/FallbackHandlerTests.cs
@@ -6,7 +6,7 @@ public class FallbackHandlerTests
     [Fact]
     public async Task GenerateAction_Generic_Ok()
     {
-        var handler = FallbackHelper.CreateHandler(_ => true, () => Outcome.FromResult("secondary"), true);
+        var handler = FallbackHelper.CreateHandler(_ => true, () => Outcome.FromResult("secondary"));
         var context = ResilienceContextPool.Shared.Get();
         var outcome = await handler.GetFallbackOutcomeAsync(new OutcomeArguments<string, FallbackPredicateArguments>(context, Outcome.FromResult("primary"), default))!;
 
@@ -16,7 +16,7 @@ public class FallbackHandlerTests
     [Fact]
     public async Task GenerateAction_NonGeneric_Ok()
     {
-        var handler = FallbackHelper.CreateHandler(_ => true, () => Outcome.FromResult((object)"secondary"), false);
+        var handler = FallbackHelper.CreateHandler(_ => true, () => Outcome.FromResult((object)"secondary"));
         var context = ResilienceContextPool.Shared.Get();
         var outcome = await handler.GetFallbackOutcomeAsync(new OutcomeArguments<string, FallbackPredicateArguments>(context, Outcome.FromResult("primary"), default))!;
 

--- a/test/Polly.Core.Tests/Fallback/FallbackHelper.cs
+++ b/test/Polly.Core.Tests/Fallback/FallbackHelper.cs
@@ -6,13 +6,11 @@ internal static class FallbackHelper
 {
     public static FallbackHandler<T> CreateHandler<T>(
         Func<Outcome<T>, bool> shouldHandle,
-        Func<Outcome<T>> fallback,
-        bool isGeneric = true)
+        Func<Outcome<T>> fallback)
     {
         return new FallbackHandler<T>(
             args => new ValueTask<bool>(shouldHandle(args.Outcome)),
-            _ => new ValueTask<Outcome<T>>(fallback()),
-            isGeneric);
+            _ => new ValueTask<Outcome<T>>(fallback()));
     }
 }
 

--- a/test/Polly.Core.Tests/Fallback/FallbackResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Fallback/FallbackResilienceStrategyTests.cs
@@ -84,10 +84,9 @@ public class FallbackResilienceStrategyTests
 
     private void SetHandler(
         Func<Outcome<string>, bool> shouldHandle,
-        Func<Outcome<string>> fallback,
-        bool isGeneric = true)
+        Func<Outcome<string>> fallback)
     {
-        _handler = FallbackHelper.CreateHandler(shouldHandle, fallback, isGeneric);
+        _handler = FallbackHelper.CreateHandler(shouldHandle, fallback);
     }
 
     private FallbackResilienceStrategy<string> Create() => new(

--- a/test/Polly.Core.Tests/GenericResilienceStrategyBuilderTests.cs
+++ b/test/Polly.Core.Tests/GenericResilienceStrategyBuilderTests.cs
@@ -14,13 +14,12 @@ public class GenericResilienceStrategyBuilderTests
         _builder.Properties.Should().NotBeNull();
         _builder.TimeProvider.Should().Be(TimeProvider.System);
         _builder.OnCreatingStrategy.Should().BeNull();
-        _builder.IsGenericBuilder.Should().BeTrue();
     }
 
     [Fact]
     public void CopyCtor_Ok()
     {
-        new ResilienceStrategyBuilder<string>(new ResilienceStrategyBuilder()).IsGenericBuilder.Should().BeTrue();
+        new ResilienceStrategyBuilder<string>(new ResilienceStrategyBuilder()).Should().NotBeNull();
     }
 
     [Fact]

--- a/test/Polly.Core.Tests/Hedging/HedgingResilienceStrategyBuilderExtensionsTests.cs
+++ b/test/Polly.Core.Tests/Hedging/HedgingResilienceStrategyBuilderExtensionsTests.cs
@@ -12,7 +12,9 @@ public class HedgingResilienceStrategyBuilderExtensionsTests
     public void AddHedging_Ok()
     {
         _builder.AddHedging(new HedgingStrategyOptions { ShouldHandle = _ => PredicateResult.True });
-        _builder.Build().Should().BeOfType<HedgingResilienceStrategy<object>>();
+        var strategy = _builder.Build().Should().BeOfType<HedgingResilienceStrategy<object>>()
+            .Subject
+            .HedgingHandler.IsGeneric.Should().BeFalse();
     }
 
     [Fact]
@@ -23,7 +25,9 @@ public class HedgingResilienceStrategyBuilderExtensionsTests
             HedgingActionGenerator = args => () => Outcome.FromResultAsTask("dummy"),
             ShouldHandle = _ => PredicateResult.True
         });
-        _genericBuilder.Build().Strategy.Should().BeOfType<HedgingResilienceStrategy<string>>();
+        _genericBuilder.Build().Strategy
+            .Should().BeOfType<HedgingResilienceStrategy<string>>()
+            .Subject.HedgingHandler.IsGeneric.Should().BeTrue();
     }
 
     [Fact]

--- a/test/Polly.Core.Tests/ResilienceStrategyBuilderContextTests.cs
+++ b/test/Polly.Core.Tests/ResilienceStrategyBuilderContextTests.cs
@@ -10,9 +10,8 @@ public class ResilienceStrategyBuilderContextTests
     {
         var properties = new ResilienceProperties();
         var timeProvider = new FakeTimeProvider();
-        var context = new ResilienceStrategyBuilderContext("builder-name", "instance", properties, "strategy-name", timeProvider, true, Mock.Of<DiagnosticSource>(), () => 1.0);
+        var context = new ResilienceStrategyBuilderContext("builder-name", "instance", properties, "strategy-name", timeProvider, Mock.Of<DiagnosticSource>(), () => 1.0);
 
-        context.IsGenericBuilder.Should().BeTrue();
         context.BuilderName.Should().Be("builder-name");
         context.BuilderInstanceName.Should().Be("instance");
         context.BuilderProperties.Should().BeSameAs(properties);

--- a/test/Polly.Core.Tests/ResilienceStrategyBuilderTests.cs
+++ b/test/Polly.Core.Tests/ResilienceStrategyBuilderTests.cs
@@ -16,7 +16,6 @@ public class ResilienceStrategyBuilderTests
         builder.BuilderName.Should().BeNull();
         builder.Properties.Should().NotBeNull();
         builder.TimeProvider.Should().Be(TimeProvider.System);
-        builder.IsGenericBuilder.Should().BeFalse();
         builder.Randomizer.Should().NotBeNull();
     }
 
@@ -296,7 +295,6 @@ The RequiredProperty field is required.
         builder.AddStrategy(
             context =>
             {
-                context.IsGenericBuilder.Should().BeFalse();
                 context.BuilderName.Should().Be("builder-name");
                 context.StrategyName.Should().Be("strategy-name");
                 context.BuilderProperties.Should().BeSameAs(builder.Properties);
@@ -460,7 +458,5 @@ The RequiredProperty field is required.
     {
         [Required]
         public string? RequiredProperty { get; set; }
-
-        internal override bool IsGenericBuilder => false;
     }
 }


### PR DESCRIPTION
### Details on the issue fix or feature implementation

Follow-up of #1430

It was internal API that's not required anymore.


### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
