### PR TITLE
Allow isolate CircuitBreakerManualControl using constructor

### DIFF
--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerManualControl.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerManualControl.cs
@@ -15,6 +15,19 @@ public sealed class CircuitBreakerManualControl : IDisposable
     private readonly HashSet<Func<ResilienceContext, Task>> _onReset = new();
     private bool _isolated;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CircuitBreakerManualControl"/> class.
+    /// </summary>
+    public CircuitBreakerManualControl()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CircuitBreakerManualControl"/> class.
+    /// </summary>
+    /// <param name="isIsolated">Determines whether the circit breaker is isolated immediately after construction.</param>
+    public CircuitBreakerManualControl(bool isIsolated) => _isolated = isIsolated;
+
     internal void Initialize(Func<ResilienceContext, Task> onIsolate, Func<ResilienceContext, Task> onReset, Action onDispose)
     {
         _onDispose.Add(onDispose);

--- a/src/Polly.Core/PublicAPI.Unshipped.txt
+++ b/src/Polly.Core/PublicAPI.Unshipped.txt
@@ -32,6 +32,7 @@ Polly.CircuitBreaker.BrokenCircuitException<TResult>.BrokenCircuitException(TRes
 Polly.CircuitBreaker.BrokenCircuitException<TResult>.Result.get -> TResult
 Polly.CircuitBreaker.CircuitBreakerManualControl
 Polly.CircuitBreaker.CircuitBreakerManualControl.CircuitBreakerManualControl() -> void
+Polly.CircuitBreaker.CircuitBreakerManualControl.CircuitBreakerManualControl(bool isIsolated) -> void
 Polly.CircuitBreaker.CircuitBreakerManualControl.CloseAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 Polly.CircuitBreaker.CircuitBreakerManualControl.Dispose() -> void
 Polly.CircuitBreaker.CircuitBreakerManualControl.IsolateAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!

--- a/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerManualControlTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerManualControlTests.cs
@@ -7,6 +7,27 @@ public class CircuitBreakerManualControlTests
     [InlineData(true)]
     [InlineData(false)]
     [Theory]
+    public void Ctor_Isolated(bool isolated)
+    {
+        using var control = new CircuitBreakerManualControl(isolated);
+        var isolateCalled = false;
+
+        control.Initialize(
+            c =>
+            {
+                c.IsSynchronous.Should().BeTrue();
+                isolateCalled = true;
+                return Task.CompletedTask;
+            },
+            _ => Task.CompletedTask,
+            () => { });
+
+        isolateCalled.Should().Be(isolated);
+    }
+
+    [InlineData(true)]
+    [InlineData(false)]
+    [Theory]
     public async Task IsolateAsync_NotInitialized_Ok(bool closedAfter)
     {
         using var control = new CircuitBreakerManualControl();


### PR DESCRIPTION
### Details on the issue fix or feature implementation

https://github.com/App-vNext/Polly/pull/1233#discussion_r1257979321

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
