### PR TITLE
Demonstrate synchronous API in ResilienceStrategy

### DIFF
--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerResilienceStrategy.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerResilienceStrategy.cs
@@ -42,5 +42,15 @@ internal sealed class CircuitBreakerResilienceStrategy<T> : OutcomeResilienceStr
 
         return outcome;
     }
+
+    protected override Outcome<T> ExecuteCoreSync<TState>(Func<ResilienceContext, TState, Outcome<T>> callback, ResilienceContext context, TState state)
+    {
+        return ExecuteCore(static (c, s) =>
+        {
+            return new ValueTask<Outcome<T>>(s.callback(c, s.state));
+        },
+        context,
+        (callback, state)).GetAwaiter().GetResult();
+    }
 }
 

--- a/src/Polly.Core/Fallback/FallbackResilienceStrategy.cs
+++ b/src/Polly.Core/Fallback/FallbackResilienceStrategy.cs
@@ -44,4 +44,14 @@ internal sealed class FallbackResilienceStrategy<T> : OutcomeResilienceStrategy<
             return Outcome.FromException<T>(e);
         }
     }
+
+    protected override Outcome<T> ExecuteCoreSync<TState>(Func<ResilienceContext, TState, Outcome<T>> callback, ResilienceContext context, TState state)
+    {
+        return ExecuteCore(static (c, s) =>
+        {
+            return new ValueTask<Outcome<T>>(s.callback(c, s.state));
+        },
+        context,
+        (callback, state)).GetAwaiter().GetResult();
+    }
 }

--- a/src/Polly.Core/Hedging/HedgingResilienceStrategy.cs
+++ b/src/Polly.Core/Hedging/HedgingResilienceStrategy.cs
@@ -59,6 +59,16 @@ internal sealed class HedgingResilienceStrategy<T> : OutcomeResilienceStrategy<T
         }
     }
 
+    protected override Outcome<T> ExecuteCoreSync<TState>(Func<ResilienceContext, TState, Outcome<T>> callback, ResilienceContext context, TState state)
+    {
+        return ExecuteCore(static (c, s) =>
+        {
+            return new ValueTask<Outcome<T>>(s.callback(c, s.state));
+        },
+        context,
+        (callback, state)).GetAwaiter().GetResult();
+    }
+
     private async ValueTask<Outcome<T>> ExecuteCoreAsync<TState>(
         HedgingExecutionContext<T> hedgingContext,
         Func<ResilienceContext, TState, ValueTask<Outcome<T>>> callback,

--- a/src/Polly.Core/NullResilienceStrategy.cs
+++ b/src/Polly.Core/NullResilienceStrategy.cs
@@ -27,4 +27,17 @@ public sealed class NullResilienceStrategy : ResilienceStrategy
 
         return callback(context, state);
     }
+
+    protected internal override Outcome<TResult> ExecuteCoreSync<TResult, TState>(
+        Func<ResilienceContext, TState, Outcome<TResult>> callback,
+        ResilienceContext context,
+        TState state)
+    {
+        Guard.NotNull(callback);
+        Guard.NotNull(context);
+
+        context.AssertInitialized();
+
+        return callback(context, state);
+    }
 }

--- a/src/Polly.Core/ResilienceStrategy.cs
+++ b/src/Polly.Core/ResilienceStrategy.cs
@@ -43,21 +43,10 @@ public abstract partial class ResilienceStrategy
         ResilienceContext context,
         TState state);
 
-    private Outcome<TResult> ExecuteCoreSync<TResult, TState>(
+    protected internal abstract Outcome<TResult> ExecuteCoreSync<TResult, TState>(
         Func<ResilienceContext, TState, Outcome<TResult>> callback,
         ResilienceContext context,
-        TState state)
-    {
-        return ExecuteCore(
-            static (context, state) =>
-            {
-                var result = state.callback(context, state.state);
-
-                return new ValueTask<Outcome<TResult>>(result);
-            },
-            context,
-            (callback, state)).GetResult();
-    }
+        TState state);
 
     internal static ValueTask<Outcome<TResult>> ExecuteCallbackSafeAsync<TResult, TState>(
         Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,

--- a/src/Polly.Core/Retry/RetryResilienceStrategy.cs
+++ b/src/Polly.Core/Retry/RetryResilienceStrategy.cs
@@ -101,5 +101,15 @@ internal sealed class RetryResilienceStrategy<T> : OutcomeResilienceStrategy<T>
         }
     }
 
+    protected override Outcome<T> ExecuteCoreSync<TState>(Func<ResilienceContext, TState, Outcome<T>> callback, ResilienceContext context, TState state)
+    {
+        return ExecuteCore(static (c, s) =>
+        {
+            return new ValueTask<Outcome<T>>(s.callback(c, s.state));
+        },
+        context,
+        (callback, state)).GetAwaiter().GetResult();
+    }
+
     private bool IsLastAttempt(int attempt) => attempt >= RetryCount;
 }

--- a/src/Polly.Core/Timeout/TimeoutResilienceStrategy.cs
+++ b/src/Polly.Core/Timeout/TimeoutResilienceStrategy.cs
@@ -78,6 +78,16 @@ internal sealed class TimeoutResilienceStrategy : ResilienceStrategy
         return outcome;
     }
 
+    protected internal override Outcome<TResult> ExecuteCoreSync<TResult, TState>(Func<ResilienceContext, TState, Outcome<TResult>> callback, ResilienceContext context, TState state)
+    {
+        return ExecuteCore(static (c, s) =>
+        {
+            return new ValueTask<Outcome<TResult>>(s.callback(c, s.state));
+        },
+        context,
+        (callback, state)).GetAwaiter().GetResult();
+    }
+
     private static CancellationTokenRegistration CreateRegistration(CancellationTokenSource cancellationSource, CancellationToken previousToken)
     {
         if (previousToken.CanBeCanceled)

--- a/src/Polly.Core/Utils/ReloadableResilienceStrategy.cs
+++ b/src/Polly.Core/Utils/ReloadableResilienceStrategy.cs
@@ -38,6 +38,11 @@ internal sealed class ReloadableResilienceStrategy : ResilienceStrategy
         return Strategy.ExecuteCore(callback, context, state);
     }
 
+    protected internal override Outcome<TResult> ExecuteCoreSync<TResult, TState>(Func<ResilienceContext, TState, Outcome<TResult>> callback, ResilienceContext context, TState state)
+    {
+        return Strategy.ExecuteCoreSync(callback, context, state);
+    }
+
     private void RegisterOnReload(CancellationToken previousToken)
     {
         var token = _onReload();


### PR DESCRIPTION
### Details on the issue fix or feature implementation

This PR demonstrate the necessary changes to have explicit support for sync executions in resilience strategies.
To avoid duplications these sync methods just call the async counter-parts.


For context:
https://github.com/App-vNext/Polly/pull/1233#discussion_r1269760039

### Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build
