### PR TITLE
Rename `BuilderName` to `Name`

### DIFF
--- a/src/Polly.Core/PublicAPI.Unshipped.txt
+++ b/src/Polly.Core/PublicAPI.Unshipped.txt
@@ -268,12 +268,12 @@ Polly.ResilienceStrategyBuilder<TResult>
 Polly.ResilienceStrategyBuilder<TResult>.Build() -> Polly.ResilienceStrategy<TResult>!
 Polly.ResilienceStrategyBuilder<TResult>.ResilienceStrategyBuilder() -> void
 Polly.ResilienceStrategyBuilderBase
-Polly.ResilienceStrategyBuilderBase.BuilderName.get -> string?
-Polly.ResilienceStrategyBuilderBase.BuilderName.set -> void
 Polly.ResilienceStrategyBuilderBase.DiagnosticSource.get -> System.Diagnostics.DiagnosticSource?
 Polly.ResilienceStrategyBuilderBase.DiagnosticSource.set -> void
 Polly.ResilienceStrategyBuilderBase.InstanceName.get -> string?
 Polly.ResilienceStrategyBuilderBase.InstanceName.set -> void
+Polly.ResilienceStrategyBuilderBase.Name.get -> string?
+Polly.ResilienceStrategyBuilderBase.Name.set -> void
 Polly.ResilienceStrategyBuilderBase.OnCreatingStrategy.get -> System.Action<System.Collections.Generic.IList<Polly.ResilienceStrategy!>!>?
 Polly.ResilienceStrategyBuilderBase.OnCreatingStrategy.set -> void
 Polly.ResilienceStrategyBuilderBase.Properties.get -> Polly.ResilienceProperties!

--- a/src/Polly.Core/Registry/ResilienceStrategyRegistry.cs
+++ b/src/Polly.Core/Registry/ResilienceStrategyRegistry.cs
@@ -273,7 +273,7 @@ public sealed partial class ResilienceStrategyRegistry<TKey> : ResilienceStrateg
         Func<TBuilder> factory = () =>
         {
             var builder = activator();
-            builder.BuilderName = context.BuilderName;
+            builder.Name = context.BuilderName;
             builder.InstanceName = context.BuilderInstanceName;
             configure(builder, context);
 

--- a/src/Polly.Core/ResilienceStrategyBuilderBase.cs
+++ b/src/Polly.Core/ResilienceStrategyBuilderBase.cs
@@ -24,7 +24,7 @@ public abstract class ResilienceStrategyBuilderBase
 
     private protected ResilienceStrategyBuilderBase(ResilienceStrategyBuilderBase other)
     {
-        BuilderName = other.BuilderName;
+        Name = other.Name;
         Properties = other.Properties;
         TimeProvider = other.TimeProvider;
         OnCreatingStrategy = other.OnCreatingStrategy;
@@ -41,14 +41,14 @@ public abstract class ResilienceStrategyBuilderBase
     /// <value>
     /// The default value is <see langword="null"/>.
     /// </value>
-    public string? BuilderName { get; set; }
+    public string? Name { get; set; }
 
     /// <summary>
     /// Gets or sets the instance name of the builder.
     /// </summary>
     /// <remarks>
     /// This property is also included in the telemetry that is produced by the individual resilience strategies.
-    /// The instance name can be used to differentiate between multiple builder instances with the same <see cref="BuilderName"/>.
+    /// The instance name can be used to differentiate between multiple builder instances with the same <see cref="Name"/>.
     /// </remarks>
     /// <value>
     /// The default value is <see langword="null"/>.
@@ -161,7 +161,7 @@ public abstract class ResilienceStrategyBuilderBase
     private ResilienceStrategy CreateResilienceStrategy(Entry entry)
     {
         var context = new ResilienceStrategyBuilderContext(
-            builderName: BuilderName,
+            builderName: Name,
             builderInstanceName: InstanceName,
             builderProperties: Properties,
             strategyName: entry.Options.Name,

--- a/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategyBuilderExtensions.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategyBuilderExtensions.cs
@@ -56,7 +56,7 @@ public static class TelemetryResilienceStrategyBuilderExtensions
         {
             var telemetryStrategy = new TelemetryResilienceStrategy(
                 TimeProvider.System,
-                builder.BuilderName,
+                builder.Name,
                 builder.InstanceName,
                 options.LoggerFactory,
                 options.ResultFormatter,

--- a/test/Polly.Core.Tests/GenericResilienceStrategyBuilderTests.cs
+++ b/test/Polly.Core.Tests/GenericResilienceStrategyBuilderTests.cs
@@ -10,7 +10,7 @@ public class GenericResilienceStrategyBuilderTests
     [Fact]
     public void Ctor_EnsureDefaults()
     {
-        _builder.BuilderName.Should().BeNull();
+        _builder.Name.Should().BeNull();
         _builder.Properties.Should().NotBeNull();
         _builder.TimeProvider.Should().Be(TimeProvider.System);
         _builder.OnCreatingStrategy.Should().BeNull();
@@ -25,8 +25,8 @@ public class GenericResilienceStrategyBuilderTests
     [Fact]
     public void Properties_GetSet_Ok()
     {
-        _builder.BuilderName = "dummy";
-        _builder.BuilderName.Should().Be("dummy");
+        _builder.Name = "dummy";
+        _builder.Name.Should().Be("dummy");
 
         var timeProvider = new FakeTimeProvider();
         _builder.TimeProvider = timeProvider;

--- a/test/Polly.Core.Tests/Registry/ResilienceStrategyRegistryTests.cs
+++ b/test/Polly.Core.Tests/Registry/ResilienceStrategyRegistryTests.cs
@@ -240,7 +240,7 @@ public class ResilienceStrategyRegistryTests
             context.BuilderName.Should().Be("A");
             context.BuilderInstanceName.Should().Be("Instance1");
             builder.AddStrategy(new TestResilienceStrategy());
-            builder.BuilderName.Should().Be("A");
+            builder.Name.Should().Be("A");
             called = true;
         });
 
@@ -270,7 +270,7 @@ public class ResilienceStrategyRegistryTests
         registry.TryAddBuilder<string>(StrategyId.Create("A"), (builder, _) =>
         {
             builder.AddStrategy(new TestResilienceStrategy());
-            builder.BuilderName.Should().Be("A");
+            builder.Name.Should().Be("A");
             builder.InstanceName.Should().Be("Instance1");
             called = true;
         });

--- a/test/Polly.Core.Tests/ResilienceStrategyBuilderTests.cs
+++ b/test/Polly.Core.Tests/ResilienceStrategyBuilderTests.cs
@@ -13,7 +13,7 @@ public class ResilienceStrategyBuilderTests
     {
         var builder = new ResilienceStrategyBuilder();
 
-        builder.BuilderName.Should().BeNull();
+        builder.Name.Should().BeNull();
         builder.Properties.Should().NotBeNull();
         builder.TimeProvider.Should().Be(TimeProvider.System);
         builder.Randomizer.Should().NotBeNull();
@@ -25,7 +25,7 @@ public class ResilienceStrategyBuilderTests
         var builder = new ResilienceStrategyBuilder
         {
             TimeProvider = Mock.Of<TimeProvider>(),
-            BuilderName = "dummy",
+            Name = "dummy",
             Randomizer = () => 0.0,
             DiagnosticSource = Mock.Of<DiagnosticSource>(),
             OnCreatingStrategy = _ => { },
@@ -34,7 +34,7 @@ public class ResilienceStrategyBuilderTests
         builder.Properties.Set(new ResiliencePropertyKey<string>("dummy"), "dummy");
 
         var other = new ResilienceStrategyBuilder<double>(builder);
-        other.BuilderName.Should().Be(builder.BuilderName);
+        other.Name.Should().Be(builder.Name);
         other.TimeProvider.Should().Be(builder.TimeProvider);
         other.Randomizer.Should().BeSameAs(builder.Randomizer);
         other.DiagnosticSource.Should().BeSameAs(builder.DiagnosticSource);
@@ -288,7 +288,7 @@ The RequiredProperty field is required.
 
         var builder = new ResilienceStrategyBuilder
         {
-            BuilderName = "builder-name",
+            Name = "builder-name",
             TimeProvider = new FakeTimeProvider(),
         };
 


### PR DESCRIPTION
### Details on the issue fix or feature implementation

The `Builder` is redundant as it's clear because we are in ResilienceStrategyBuilder class.

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
