### PR TITLE
Allow jitter for all backoff types

### DIFF
--- a/src/Polly.Core/PublicAPI.Unshipped.txt
+++ b/src/Polly.Core/PublicAPI.Unshipped.txt
@@ -319,9 +319,8 @@ Polly.Retry.OnRetryArguments.RetryDelay.get -> System.TimeSpan
 Polly.Retry.OnRetryArguments.RetryDelay.init -> void
 Polly.Retry.RetryBackoffType
 Polly.Retry.RetryBackoffType.Constant = 0 -> Polly.Retry.RetryBackoffType
-Polly.Retry.RetryBackoffType.Exponential = 2 -> Polly.Retry.RetryBackoffType
-Polly.Retry.RetryBackoffType.ExponentialWithJitter = 3 -> Polly.Retry.RetryBackoffType
 Polly.Retry.RetryBackoffType.Linear = 1 -> Polly.Retry.RetryBackoffType
+Polly.Retry.RetryBackoffType.Exponential = 2 -> Polly.Retry.RetryBackoffType
 Polly.Retry.RetryDelayArguments
 Polly.Retry.RetryDelayArguments.Attempt.get -> int
 Polly.Retry.RetryDelayArguments.Attempt.init -> void
@@ -350,6 +349,8 @@ Polly.Retry.RetryStrategyOptions<TResult>.RetryDelayGenerator.set -> void
 Polly.Retry.RetryStrategyOptions<TResult>.RetryStrategyOptions() -> void
 Polly.Retry.RetryStrategyOptions<TResult>.ShouldHandle.get -> System.Func<Polly.OutcomeArguments<TResult, Polly.Retry.RetryPredicateArguments>, System.Threading.Tasks.ValueTask<bool>>!
 Polly.Retry.RetryStrategyOptions<TResult>.ShouldHandle.set -> void
+Polly.Retry.RetryStrategyOptions<TResult>.UseJitter.get -> bool
+Polly.Retry.RetryStrategyOptions<TResult>.UseJitter.set -> void
 Polly.RetryResilienceStrategyBuilderExtensions
 Polly.Telemetry.ExecutionAttemptArguments
 Polly.Telemetry.ExecutionAttemptArguments.Attempt.get -> int

--- a/src/Polly.Core/Retry/RetryBackoffType.cs
+++ b/src/Polly.Core/Retry/RetryBackoffType.cs
@@ -38,17 +38,4 @@ public enum RetryBackoffType
     /// 200ms, 400ms, 800ms.
     /// </example>
     Exponential,
-
-    /// <summary>
-    /// Exponential delay with randomization retry type,
-    /// making sure to mitigate any correlations.
-    /// </summary>
-    /// <example>
-    /// 850ms, 1455ms, 3060ms.
-    /// </example>
-    /// <remarks>
-    /// In transient failures handling scenarios, this is the
-    /// <see href=" https://github.com/Polly-Contrib/Polly.Contrib.WaitAndRetry#new-jitter-recommendation"> recommended retry type</see>.
-    /// </remarks>
-    ExponentialWithJitter,
 }

--- a/src/Polly.Core/Retry/RetryResilienceStrategy.cs
+++ b/src/Polly.Core/Retry/RetryResilienceStrategy.cs
@@ -23,6 +23,7 @@ internal sealed class RetryResilienceStrategy<T> : OutcomeResilienceStrategy<T>
         RetryCount = options.RetryCount;
         OnRetry = options.OnRetry;
         DelayGenerator = options.RetryDelayGenerator;
+        UseJitter = options.UseJitter;
 
         _timeProvider = timeProvider;
         _telemetry = telemetry;
@@ -38,6 +39,8 @@ internal sealed class RetryResilienceStrategy<T> : OutcomeResilienceStrategy<T>
     public Func<OutcomeArguments<T, RetryPredicateArguments>, ValueTask<bool>> ShouldHandle { get; }
 
     public Func<OutcomeArguments<T, RetryDelayArguments>, ValueTask<TimeSpan>>? DelayGenerator { get; }
+
+    public bool UseJitter { get; }
 
     public Func<OutcomeArguments<T, OnRetryArguments>, ValueTask>? OnRetry { get; }
 
@@ -62,7 +65,7 @@ internal sealed class RetryResilienceStrategy<T> : OutcomeResilienceStrategy<T>
                 return outcome;
             }
 
-            var delay = RetryHelper.GetRetryDelay(BackoffType, attempt, BaseDelay, ref retryState, _randomizer);
+            var delay = RetryHelper.GetRetryDelay(BackoffType, UseJitter, attempt, BaseDelay, ref retryState, _randomizer);
             if (DelayGenerator is not null)
             {
                 var delayArgs = new OutcomeArguments<T, RetryDelayArguments>(context, outcome, new RetryDelayArguments(attempt, delay));

--- a/src/Polly.Core/Retry/RetryStrategyOptions.TResult.cs
+++ b/src/Polly.Core/Retry/RetryStrategyOptions.TResult.cs
@@ -35,7 +35,7 @@ public class RetryStrategyOptions<TResult> : ResilienceStrategyOptions
     public RetryBackoffType BackoffType { get; set; } = RetryConstants.DefaultBackoffType;
 
     /// <summary>
-    /// Gets or sets a value indicating whether the jitter should be used when calculating the backoff delay between retries.
+    /// Gets or sets a value indicating whether jitter should be used when calculating the backoff delay between retries.
     /// </summary>
     /// <remarks>
     /// See <see href="https://github.com/Polly-Contrib/Polly.Contrib.WaitAndRetry#new-jitter-recommendation"/> for more details

--- a/src/Polly.Core/Retry/RetryStrategyOptions.TResult.cs
+++ b/src/Polly.Core/Retry/RetryStrategyOptions.TResult.cs
@@ -34,6 +34,18 @@ public class RetryStrategyOptions<TResult> : ResilienceStrategyOptions
     /// </value>
     public RetryBackoffType BackoffType { get; set; } = RetryConstants.DefaultBackoffType;
 
+    /// <summary>
+    /// Gets or sets a value indicating whether the jitter should be used when calculating the backoff delay between retries.
+    /// </summary>
+    /// <remarks>
+    /// See <see href="https://github.com/Polly-Contrib/Polly.Contrib.WaitAndRetry#new-jitter-recommendation"/> for more details
+    /// on how jitter can improve the resilience when the retries are correlated.
+    /// </remarks>
+    /// <value>
+    /// The default value is <see langword="false"/>.
+    /// </value>
+    public bool UseJitter { get; set; }
+
 #pragma warning disable IL2026 // Addressed with DynamicDependency on ValidationHelper.Validate method
     /// <summary>
     /// Gets or sets the base delay between retries.
@@ -43,9 +55,6 @@ public class RetryStrategyOptions<TResult> : ResilienceStrategyOptions
     /// <list type="bullet">
     /// <item>
     /// <see cref="RetryBackoffType.Exponential"/>: Represents the median delay to target before the first retry.
-    /// </item>
-    /// <item>
-    /// <see cref="RetryBackoffType.ExponentialWithJitter"/>: Represents the median delay to target before the first retry.
     /// </item>
     /// <item>
     /// <see cref="RetryBackoffType.Linear"/>: Represents the initial delay, the following delays increasing linearly with this value.

--- a/test/Polly.Core.Tests/Retry/RetryResilienceStrategyBuilderExtensionsTests.cs
+++ b/test/Polly.Core.Tests/Retry/RetryResilienceStrategyBuilderExtensionsTests.cs
@@ -107,7 +107,7 @@ public class RetryResilienceStrategyBuilderExtensionsTests
     [Fact]
     public void GetAggregatedDelay_ShouldReturnTheSameValue()
     {
-        var options = new RetryStrategyOptions { BackoffType = RetryBackoffType.ExponentialWithJitter };
+        var options = new RetryStrategyOptions { BackoffType = RetryBackoffType.Exponential, UseJitter = true };
 
         var delay = GetAggregatedDelay(options);
         GetAggregatedDelay(options).Should().Be(delay);

--- a/test/Polly.Extensions.Tests/Issues/IssuesTests.StrategiesPerEndpoint_1365.cs
+++ b/test/Polly.Extensions.Tests/Issues/IssuesTests.StrategiesPerEndpoint_1365.cs
@@ -49,7 +49,8 @@ public partial class IssuesTests
             {
                 builder.AddRetry(new()
                 {
-                    BackoffType = RetryBackoffType.ExponentialWithJitter,
+                    BackoffType = RetryBackoffType.Exponential,
+                    UseJitter = true,
                     RetryCount = endpointOptions.Retries,
                     StrategyName = $"{context.StrategyKey.EndpointName}-Retry",
                 });


### PR DESCRIPTION
### Details on the issue fix or feature implementation

For context:
https://github.com/App-vNext/Polly/pull/1233/files#r1251595389

If jitter is used, then the final delay is randomized between the factor of `1` ... `1.5`. 

This applies for constant and linear delay, for exponential delay the formula is more complicated. (no changes)

Contributes to #1301 

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
