### PR TITLE
Reduced nesting levels through block-scoped `using`s and the inversion of an `if` block.

### DIFF
--- a/src/Polly/CircuitBreaker/ConsecutiveCountCircuitController.cs
+++ b/src/Polly/CircuitBreaker/ConsecutiveCountCircuitController.cs
@@ -16,65 +16,60 @@ internal class ConsecutiveCountCircuitController<TResult> : CircuitStateControll
 
     public override void OnCircuitReset(Context context)
     {
-        using (TimedLock.Lock(_lock))
-        {
-            _consecutiveFailureCount = 0;
-
-            ResetInternal_NeedsLock(context);
-        }
+        using var _ = TimedLock.Lock(_lock);
+        _consecutiveFailureCount = 0;
+        ResetInternal_NeedsLock(context);
     }
 
     public override void OnActionSuccess(Context context)
     {
-        using (TimedLock.Lock(_lock))
+        using var _ = TimedLock.Lock(_lock);
+
+        switch (_circuitState)
         {
-            switch (_circuitState)
-            {
-                case CircuitState.HalfOpen:
-                    OnCircuitReset(context);
-                    break;
+            case CircuitState.HalfOpen:
+                OnCircuitReset(context);
+                break;
 
-                case CircuitState.Closed:
-                    _consecutiveFailureCount = 0;
-                    break;
+            case CircuitState.Closed:
+                _consecutiveFailureCount = 0;
+                break;
 
-                case CircuitState.Open:
-                case CircuitState.Isolated:
-                    break; // A successful call result may arrive when the circuit is open, if it was placed before the circuit broke.  We take no action; only time passing governs transitioning from Open to HalfOpen state.
+            case CircuitState.Open:
+            case CircuitState.Isolated:
+                break; // A successful call result may arrive when the circuit is open, if it was placed before the circuit broke.  We take no action; only time passing governs transitioning from Open to HalfOpen state.
 
-                default:
-                    throw new InvalidOperationException("Unhandled CircuitState.");
-            }
+            default:
+                throw new InvalidOperationException("Unhandled CircuitState.");
         }
     }
 
     public override void OnActionFailure(DelegateResult<TResult> outcome, Context context)
     {
-        using (TimedLock.Lock(_lock))
+        using var _ = TimedLock.Lock(_lock);
+
+        _lastOutcome = outcome;
+
+        switch (_circuitState)
         {
-            _lastOutcome = outcome;
+            case CircuitState.HalfOpen:
+                Break_NeedsLock(context);
+                return;
 
-            switch (_circuitState)
-            {
-                case CircuitState.HalfOpen:
+            case CircuitState.Closed:
+                _consecutiveFailureCount += 1;
+                if (_consecutiveFailureCount >= _exceptionsAllowedBeforeBreaking)
+                {
                     Break_NeedsLock(context);
-                    return;
+                }
+                break;
 
-                case CircuitState.Closed:
-                    _consecutiveFailureCount += 1;
-                    if (_consecutiveFailureCount >= _exceptionsAllowedBeforeBreaking)
-                    {
-                        Break_NeedsLock(context);
-                    }
-                    break;
+            case CircuitState.Open:
+            case CircuitState.Isolated:
+                break; // A failure call result may arrive when the circuit is open, if it was placed before the circuit broke.  We take no action; we do not want to duplicate-signal onBreak; we do not want to extend time for which the circuit is broken.  We do not want to mask the fact that the call executed (as replacing its result with a Broken/IsolatedCircuitException would do).
 
-                case CircuitState.Open:
-                case CircuitState.Isolated:
-                    break; // A failure call result may arrive when the circuit is open, if it was placed before the circuit broke.  We take no action; we do not want to duplicate-signal onBreak; we do not want to extend time for which the circuit is broken.  We do not want to mask the fact that the call executed (as replacing its result with a Broken/IsolatedCircuitException would do).
-
-                default:
-                    throw new InvalidOperationException("Unhandled CircuitState.");
-            }
+            default:
+                throw new InvalidOperationException("Unhandled CircuitState.");
         }
     }
 }

--- a/src/Polly/Timeout/TimeoutEngine.cs
+++ b/src/Polly/Timeout/TimeoutEngine.cs
@@ -15,52 +15,49 @@ internal static class TimeoutEngine
         cancellationToken.ThrowIfCancellationRequested();
         TimeSpan timeout = timeoutProvider(context);
 
-        using (CancellationTokenSource timeoutCancellationTokenSource = new CancellationTokenSource())
+        using var timeoutCancellationTokenSource = new CancellationTokenSource();
+        using var combinedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCancellationTokenSource.Token);
+
+        CancellationToken combinedToken = combinedTokenSource.Token;
+
+        Task<TResult> actionTask = null;
+        try
         {
-            using (CancellationTokenSource combinedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCancellationTokenSource.Token))
+            if (timeoutStrategy == TimeoutStrategy.Optimistic)
             {
-                CancellationToken combinedToken = combinedTokenSource.Token;
-
-                Task<TResult> actionTask = null;
-                try
-                {
-                    if (timeoutStrategy == TimeoutStrategy.Optimistic)
-                    {
-                        SystemClock.CancelTokenAfter(timeoutCancellationTokenSource, timeout);
-                        return action(context, combinedToken);
-                    }
-
-                    // else: timeoutStrategy == TimeoutStrategy.Pessimistic
-
-                    SystemClock.CancelTokenAfter(timeoutCancellationTokenSource, timeout);
-
-                    actionTask = Task.Run(() =>
-                        action(context, combinedToken)       // cancellation token here allows the user delegate to react to cancellation: possibly clear up; then throw an OperationCanceledException.
-                        , combinedToken);           // cancellation token here only allows Task.Run() to not begin the passed delegate at all, if cancellation occurs prior to invoking the delegate.
-                    try
-                    {
-                        actionTask.Wait(timeoutCancellationTokenSource.Token); // cancellation token here cancels the Wait() and causes it to throw, but does not cancel actionTask.  We use only timeoutCancellationTokenSource.Token here, not combinedToken.  If we allowed the user's cancellation token to cancel the Wait(), in this pessimistic scenario where the user delegate may not observe that cancellation, that would create a no-longer-observed task.  That task could in turn later fault before completing, risking an UnobservedTaskException.
-                    }
-                    catch (AggregateException ex) when (ex.InnerExceptions.Count == 1) // Issue #270.  Unwrap extra AggregateException caused by the way pessimistic timeout policy for synchronous executions is necessarily constructed.
-                    {
-                        ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-                    }
-
-                    return actionTask.Result;
-                }
-                catch (Exception ex)
-                {
-                    // Note that we cannot rely on testing (operationCanceledException.CancellationToken == combinedToken || operationCanceledException.CancellationToken == timeoutCancellationTokenSource.Token)
-                    // as either of those tokens could have been onward combined with another token by executed code, and so may not be the token expressed on operationCanceledException.CancellationToken.
-                    if (ex is OperationCanceledException && timeoutCancellationTokenSource.IsCancellationRequested)
-                    {
-                        onTimeout(context, timeout, actionTask, ex);
-                        throw new TimeoutRejectedException("The delegate executed through TimeoutPolicy did not complete within the timeout.", ex);
-                    }
-
-                    throw;
-                }
+                SystemClock.CancelTokenAfter(timeoutCancellationTokenSource, timeout);
+                return action(context, combinedToken);
             }
+
+            // else: timeoutStrategy == TimeoutStrategy.Pessimistic
+
+            SystemClock.CancelTokenAfter(timeoutCancellationTokenSource, timeout);
+
+            actionTask = Task.Run(() =>
+                action(context, combinedToken)       // cancellation token here allows the user delegate to react to cancellation: possibly clear up; then throw an OperationCanceledException.
+                , combinedToken);           // cancellation token here only allows Task.Run() to not begin the passed delegate at all, if cancellation occurs prior to invoking the delegate.
+            try
+            {
+                actionTask.Wait(timeoutCancellationTokenSource.Token); // cancellation token here cancels the Wait() and causes it to throw, but does not cancel actionTask.  We use only timeoutCancellationTokenSource.Token here, not combinedToken.  If we allowed the user's cancellation token to cancel the Wait(), in this pessimistic scenario where the user delegate may not observe that cancellation, that would create a no-longer-observed task.  That task could in turn later fault before completing, risking an UnobservedTaskException.
+            }
+            catch (AggregateException ex) when (ex.InnerExceptions.Count == 1) // Issue #270.  Unwrap extra AggregateException caused by the way pessimistic timeout policy for synchronous executions is necessarily constructed.
+            {
+                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+            }
+
+            return actionTask.Result;
+        }
+        catch (Exception ex)
+        {
+            // Note that we cannot rely on testing (operationCanceledException.CancellationToken == combinedToken || operationCanceledException.CancellationToken == timeoutCancellationTokenSource.Token)
+            // as either of those tokens could have been onward combined with another token by executed code, and so may not be the token expressed on operationCanceledException.CancellationToken.
+            if (ex is OperationCanceledException && timeoutCancellationTokenSource.IsCancellationRequested)
+            {
+                onTimeout(context, timeout, actionTask, ex);
+                throw new TimeoutRejectedException("The delegate executed through TimeoutPolicy did not complete within the timeout.", ex);
+            }
+
+            throw;
         }
     }
 }


### PR DESCRIPTION
### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature (N/A)
- [x]  I have successfully run a local build
