### PR TITLE
Make the `ReactiveResilienceStrategy` type-safe

### DIFF
--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerResilienceStrategy.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerResilienceStrategy.cs
@@ -21,7 +21,7 @@ internal sealed class CircuitBreakerResilienceStrategy<T> : ReactiveResilienceSt
             _controller.Dispose);
     }
 
-    protected override async ValueTask<Outcome<T>> ExecuteCore<TState>(Func<ResilienceContext, TState, ValueTask<Outcome<T>>> callback, ResilienceContext context, TState state)
+    protected internal override async ValueTask<Outcome<T>> ExecuteCore<TState>(Func<ResilienceContext, TState, ValueTask<Outcome<T>>> callback, ResilienceContext context, TState state)
     {
         if (await _controller.OnActionPreExecuteAsync(context).ConfigureAwait(context.ContinueOnCapturedContext) is Outcome<T> outcome)
         {

--- a/src/Polly.Core/CompositeStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/CompositeStrategyBuilderExtensions.cs
@@ -70,6 +70,53 @@ public static class CompositeStrategyBuilderExtensions
         return builder;
     }
 
+    /// <summary>
+    /// Adds a reactive strategy to the builder.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="factory">The factory that creates a resilience strategy.</param>
+    /// <param name="options">The options associated with the strategy. If none are provided the default instance of <see cref="ResilienceStrategyOptions"/> is created.</param>
+    /// <returns>The same builder instance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/>, <paramref name="factory"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when this builder was already used to create a strategy. The builder cannot be modified after it has been used.</exception>
+    /// <exception cref="ValidationException">Thrown when <paramref name="options"/> is invalid.</exception>
+    [RequiresUnreferencedCode(Constants.OptionsValidation)]
+    public static CompositeStrategyBuilder AddStrategy(
+        this CompositeStrategyBuilder builder, Func<StrategyBuilderContext, ReactiveResilienceStrategy<object>> factory,
+        ResilienceStrategyOptions options)
+    {
+        Guard.NotNull(builder);
+        Guard.NotNull(factory);
+        Guard.NotNull(options);
+
+        builder.AddStrategyCore(context => new ReactiveResilienceStrategyBridge<object>(factory(context)), options);
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a reactive strategy to the builder.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="factory">The factory that creates a resilience strategy.</param>
+    /// <param name="options">The options associated with the strategy. If none are provided the default instance of <see cref="ResilienceStrategyOptions"/> is created.</param>
+    /// <returns>The same builder instance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/>, <paramref name="factory"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when this builder was already used to create a strategy. The builder cannot be modified after it has been used.</exception>
+    /// <exception cref="ValidationException">Thrown when <paramref name="options"/> is invalid.</exception>
+    [RequiresUnreferencedCode(Constants.OptionsValidation)]
+    public static CompositeStrategyBuilder<TResult> AddStrategy<TResult>(
+        this CompositeStrategyBuilder<TResult> builder, Func<StrategyBuilderContext, ReactiveResilienceStrategy<TResult>> factory,
+        ResilienceStrategyOptions options)
+    {
+        Guard.NotNull(builder);
+        Guard.NotNull(factory);
+        Guard.NotNull(options);
+
+        builder.AddStrategyCore(context => new ReactiveResilienceStrategyBridge<TResult>(factory(context)), options);
+        return builder;
+    }
+
     internal sealed class EmptyOptions : ResilienceStrategyOptions
     {
         public static readonly EmptyOptions Instance = new();

--- a/src/Polly.Core/Fallback/FallbackResilienceStrategy.cs
+++ b/src/Polly.Core/Fallback/FallbackResilienceStrategy.cs
@@ -17,7 +17,7 @@ internal sealed class FallbackResilienceStrategy<T> : ReactiveResilienceStrategy
         _telemetry = telemetry;
     }
 
-    protected override async ValueTask<Outcome<T>> ExecuteCore<TState>(Func<ResilienceContext, TState, ValueTask<Outcome<T>>> callback, ResilienceContext context, TState state)
+    protected internal override async ValueTask<Outcome<T>> ExecuteCore<TState>(Func<ResilienceContext, TState, ValueTask<Outcome<T>>> callback, ResilienceContext context, TState state)
     {
         var outcome = await ExecuteCallbackSafeAsync(callback, context, state).ConfigureAwait(context.ContinueOnCapturedContext);
         var handleFallbackArgs = new OutcomeArguments<T, FallbackPredicateArguments>(context, outcome, default);

--- a/src/Polly.Core/Hedging/HedgingResilienceStrategy.cs
+++ b/src/Polly.Core/Hedging/HedgingResilienceStrategy.cs
@@ -41,7 +41,7 @@ internal sealed class HedgingResilienceStrategy<T> : ReactiveResilienceStrategy<
     public Func<OutcomeArguments<T, OnHedgingArguments>, ValueTask>? OnHedging { get; }
 
     [ExcludeFromCodeCoverage] // coverlet issue
-    protected override async ValueTask<Outcome<T>> ExecuteCore<TState>(
+    protected internal override async ValueTask<Outcome<T>> ExecuteCore<TState>(
         Func<ResilienceContext, TState, ValueTask<Outcome<T>>> callback,
         ResilienceContext context,
         TState state)

--- a/src/Polly.Core/PublicAPI.Unshipped.txt
+++ b/src/Polly.Core/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
-﻿abstract Polly.ReactiveResilienceStrategy<T>.ExecuteCore<TState>(System.Func<Polly.ResilienceContext!, TState, System.Threading.Tasks.ValueTask<Polly.Outcome<T>>>! callback, Polly.ResilienceContext! context, TState state) -> System.Threading.Tasks.ValueTask<Polly.Outcome<T>>
+﻿abstract Polly.ReactiveResilienceStrategy<TResult>.ExecuteCore<TState>(System.Func<Polly.ResilienceContext!, TState, System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>>! callback, Polly.ResilienceContext! context, TState state) -> System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>
 abstract Polly.Registry.ResilienceStrategyProvider<TKey>.TryGetStrategy(TKey key, out Polly.ResilienceStrategy? strategy) -> bool
 abstract Polly.Registry.ResilienceStrategyProvider<TKey>.TryGetStrategy<TResult>(TKey key, out Polly.ResilienceStrategy<TResult>? strategy) -> bool
 abstract Polly.ResilienceContextPool.Get(string? operationKey, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Polly.ResilienceContext!
@@ -178,8 +178,8 @@ Polly.PredicateBuilder<TResult>.HandleResult(System.Func<TResult, bool>! predica
 Polly.PredicateBuilder<TResult>.HandleResult(TResult result, System.Collections.Generic.IEqualityComparer<TResult>? comparer = null) -> Polly.PredicateBuilder<TResult>!
 Polly.PredicateBuilder<TResult>.PredicateBuilder() -> void
 Polly.PredicateResult
-Polly.ReactiveResilienceStrategy<T>
-Polly.ReactiveResilienceStrategy<T>.ReactiveResilienceStrategy() -> void
+Polly.ReactiveResilienceStrategy<TResult>
+Polly.ReactiveResilienceStrategy<TResult>.ReactiveResilienceStrategy() -> void
 Polly.Registry.ConfigureBuilderContext<TKey>
 Polly.Registry.ConfigureBuilderContext<TKey>.BuilderInstanceName.get -> string?
 Polly.Registry.ConfigureBuilderContext<TKey>.BuilderName.get -> string!

--- a/src/Polly.Core/PublicAPI.Unshipped.txt
+++ b/src/Polly.Core/PublicAPI.Unshipped.txt
@@ -11,7 +11,6 @@ override Polly.ResiliencePropertyKey<TValue>.Equals(object? obj) -> bool
 override Polly.ResiliencePropertyKey<TValue>.GetHashCode() -> int
 override Polly.ResiliencePropertyKey<TValue>.ToString() -> string!
 override Polly.Telemetry.ResilienceEvent.ToString() -> string!
-override sealed Polly.ReactiveResilienceStrategy<T>.ExecuteCore<TResult, TState>(System.Func<Polly.ResilienceContext!, TState, System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>>! callback, Polly.ResilienceContext! context, TState state) -> System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>
 Polly.CircuitBreaker.BrokenCircuitException
 Polly.CircuitBreaker.BrokenCircuitException.BrokenCircuitException() -> void
 Polly.CircuitBreaker.BrokenCircuitException.BrokenCircuitException(string! message) -> void
@@ -388,9 +387,11 @@ Polly.TimeoutCompositeStrategyBuilderExtensions
 Polly.Utils.LegacySupport
 static Polly.CircuitBreakerCompositeStrategyBuilderExtensions.AddCircuitBreaker(this Polly.CompositeStrategyBuilder! builder, Polly.CircuitBreaker.CircuitBreakerStrategyOptions! options) -> Polly.CompositeStrategyBuilder!
 static Polly.CircuitBreakerCompositeStrategyBuilderExtensions.AddCircuitBreaker<TResult>(this Polly.CompositeStrategyBuilder<TResult>! builder, Polly.CircuitBreaker.CircuitBreakerStrategyOptions<TResult>! options) -> Polly.CompositeStrategyBuilder<TResult>!
+static Polly.CompositeStrategyBuilderExtensions.AddStrategy(this Polly.CompositeStrategyBuilder! builder, System.Func<Polly.StrategyBuilderContext!, Polly.ReactiveResilienceStrategy<object!>!>! factory, Polly.ResilienceStrategyOptions! options) -> Polly.CompositeStrategyBuilder!
 static Polly.CompositeStrategyBuilderExtensions.AddStrategy<TBuilder>(this TBuilder! builder, Polly.ResilienceStrategy! strategy) -> TBuilder!
 static Polly.CompositeStrategyBuilderExtensions.AddStrategy<TBuilder>(this TBuilder! builder, System.Func<Polly.StrategyBuilderContext!, Polly.ResilienceStrategy!>! factory, Polly.ResilienceStrategyOptions! options) -> TBuilder!
 static Polly.CompositeStrategyBuilderExtensions.AddStrategy<TResult>(this Polly.CompositeStrategyBuilder<TResult>! builder, Polly.ResilienceStrategy<TResult>! strategy) -> Polly.CompositeStrategyBuilder<TResult>!
+static Polly.CompositeStrategyBuilderExtensions.AddStrategy<TResult>(this Polly.CompositeStrategyBuilder<TResult>! builder, System.Func<Polly.StrategyBuilderContext!, Polly.ReactiveResilienceStrategy<TResult>!>! factory, Polly.ResilienceStrategyOptions! options) -> Polly.CompositeStrategyBuilder<TResult>!
 static Polly.FallbackCompositeStrategyBuilderExtensions.AddFallback<TResult>(this Polly.CompositeStrategyBuilder<TResult>! builder, Polly.Fallback.FallbackStrategyOptions<TResult>! options) -> Polly.CompositeStrategyBuilder<TResult>!
 static Polly.HedgingCompositeStrategyBuilderExtensions.AddHedging<TResult>(this Polly.CompositeStrategyBuilder<TResult>! builder, Polly.Hedging.HedgingStrategyOptions<TResult>! options) -> Polly.CompositeStrategyBuilder<TResult>!
 static Polly.Outcome.FromException<TResult>(System.Exception! exception) -> Polly.Outcome<TResult>

--- a/src/Polly.Core/ReactiveResilienceStrategy.cs
+++ b/src/Polly.Core/ReactiveResilienceStrategy.cs
@@ -4,11 +4,11 @@
 /// This base strategy class is used to simplify the implementation of generic (reactive)
 /// strategies by limiting the number of generic types the execute method receives.
 /// </summary>
-/// <typeparam name="T">The type of result this strategy handles.</typeparam>
+/// <typeparam name="TResult">The type of result this strategy handles.</typeparam>
 /// <remarks>
 /// For strategies that handle all result types the generic parameter must be of type <see cref="object"/>.
 /// </remarks>
-public abstract class ReactiveResilienceStrategy<T>
+public abstract class ReactiveResilienceStrategy<TResult>
 {
     /// <summary>
     /// An implementation of resilience strategy that executes the specified <paramref name="callback"/>.
@@ -33,13 +33,13 @@ public abstract class ReactiveResilienceStrategy<T>
     /// Similarly, do not throw exceptions from your strategy implementation. Instead, return an exception instance as <see cref="Outcome{TResult}"/>.
     /// </para>
     /// </remarks>
-    protected internal abstract ValueTask<Outcome<T>> ExecuteCore<TState>(
-        Func<ResilienceContext, TState, ValueTask<Outcome<T>>> callback,
+    protected internal abstract ValueTask<Outcome<TResult>> ExecuteCore<TState>(
+        Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
         ResilienceContext context,
         TState state);
 
-    internal static ValueTask<Outcome<TResult>> ExecuteCallbackSafeAsync<TResult, TState>(
-        Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
+    internal static ValueTask<Outcome<T>> ExecuteCallbackSafeAsync<T, TState>(
+        Func<ResilienceContext, TState, ValueTask<Outcome<T>>> callback,
         ResilienceContext context,
         TState state) => StrategyHelper.ExecuteCallbackSafeAsync(callback, context, state);
 }

--- a/src/Polly.Core/ResilienceStrategy.cs
+++ b/src/Polly.Core/ResilienceStrategy.cs
@@ -63,38 +63,5 @@ public abstract partial class ResilienceStrategy
     internal static ValueTask<Outcome<TResult>> ExecuteCallbackSafeAsync<TResult, TState>(
         Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
         ResilienceContext context,
-        TState state)
-    {
-        if (context.CancellationToken.IsCancellationRequested)
-        {
-            return new ValueTask<Outcome<TResult>>(Outcome.FromException<TResult>(new OperationCanceledException(context.CancellationToken)));
-        }
-
-        try
-        {
-            var callbackTask = callback(context, state);
-            if (callbackTask.IsCompleted)
-            {
-                return new ValueTask<Outcome<TResult>>(callbackTask.GetResult());
-            }
-
-            return AwaitTask(callbackTask, context.ContinueOnCapturedContext);
-        }
-        catch (Exception e)
-        {
-            return new ValueTask<Outcome<TResult>>(Outcome.FromException<TResult>(e));
-        }
-
-        static async ValueTask<Outcome<T>> AwaitTask<T>(ValueTask<Outcome<T>> task, bool continueOnCapturedContext)
-        {
-            try
-            {
-                return await task.ConfigureAwait(continueOnCapturedContext);
-            }
-            catch (Exception e)
-            {
-                return Outcome.FromException<T>(e);
-            }
-        }
-    }
+        TState state) => StrategyHelper.ExecuteCallbackSafeAsync(callback, context, state);
 }

--- a/src/Polly.Core/Retry/RetryCompositeStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/Retry/RetryCompositeStrategyBuilderExtensions.cs
@@ -17,13 +17,19 @@ public static class RetryCompositeStrategyBuilderExtensions
     /// <returns>The builder instance with the retry strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code",
+        Justification = "All options members preserved.")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(RetryStrategyOptions))]
     public static CompositeStrategyBuilder AddRetry(this CompositeStrategyBuilder builder, RetryStrategyOptions options)
     {
         Guard.NotNull(builder);
         Guard.NotNull(options);
 
-        builder.AddRetryCore<object, RetryStrategyOptions>(options);
-        return builder;
+        return builder.AddStrategy(
+            context => new RetryResilienceStrategy<object>(options, context.TimeProvider, context.Telemetry, context.Randomizer),
+            options);
     }
 
     /// <summary>
@@ -35,29 +41,19 @@ public static class RetryCompositeStrategyBuilderExtensions
     /// <returns>The builder instance with the retry strategy added.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
     /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
-    public static CompositeStrategyBuilder<TResult> AddRetry<TResult>(this CompositeStrategyBuilder<TResult> builder, RetryStrategyOptions<TResult> options)
-    {
-        Guard.NotNull(builder);
-        Guard.NotNull(options);
-
-        builder.AddRetryCore<TResult, RetryStrategyOptions<TResult>>(options);
-        return builder;
-    }
-
     [UnconditionalSuppressMessage(
         "Trimming",
         "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code",
         Justification = "All options members preserved.")]
-    private static void AddRetryCore<TResult, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TOptions>(
-        this CompositeStrategyBuilderBase builder,
+    public static CompositeStrategyBuilder<TResult> AddRetry<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TResult>(
+        this CompositeStrategyBuilder<TResult> builder,
         RetryStrategyOptions<TResult> options)
     {
-        builder.AddStrategy(context =>
-            new RetryResilienceStrategy<TResult>(
-                options,
-                context.TimeProvider,
-                context.Telemetry,
-                context.Randomizer),
+        Guard.NotNull(builder);
+        Guard.NotNull(options);
+
+        return builder.AddStrategy(
+            context => new RetryResilienceStrategy<TResult>(options, context.TimeProvider, context.Telemetry, context.Randomizer),
             options);
     }
 }

--- a/src/Polly.Core/Retry/RetryResilienceStrategy.cs
+++ b/src/Polly.Core/Retry/RetryResilienceStrategy.cs
@@ -42,7 +42,7 @@ internal sealed class RetryResilienceStrategy<T> : ReactiveResilienceStrategy<T>
 
     public Func<OutcomeArguments<T, OnRetryArguments>, ValueTask>? OnRetry { get; }
 
-    protected override async ValueTask<Outcome<T>> ExecuteCore<TState>(Func<ResilienceContext, TState, ValueTask<Outcome<T>>> callback, ResilienceContext context, TState state)
+    protected internal override async ValueTask<Outcome<T>> ExecuteCore<TState>(Func<ResilienceContext, TState, ValueTask<Outcome<T>>> callback, ResilienceContext context, TState state)
     {
         double retryState = 0;
 

--- a/src/Polly.Core/Utils/ReactiveResilienceStrategyBridge.cs
+++ b/src/Polly.Core/Utils/ReactiveResilienceStrategyBridge.cs
@@ -1,0 +1,35 @@
+﻿namespace Polly.Utils;
+
+internal sealed class ReactiveResilienceStrategyBridge<T> : ResilienceStrategy
+{
+    public ReactiveResilienceStrategyBridge(ReactiveResilienceStrategy<T> strategy) => Strategy = strategy;
+
+    public ReactiveResilienceStrategy<T> Strategy { get; }
+
+    protected internal override ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
+        Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
+        ResilienceContext context,
+        TState state)
+    {
+        // Check if we can cast directly, thus saving some cycles and improving the performance
+        if (callback is Func<ResilienceContext, TState, ValueTask<Outcome<T>>> casted)
+        {
+            return TaskHelper.ConvertValueTask<T, TResult>(
+                Strategy.ExecuteCore(casted, context, state),
+                context);
+        }
+        else
+        {
+            var valueTask = Strategy.ExecuteCore(
+                static async (context, state) =>
+                {
+                    var outcome = await state.callback(context, state.state).ConfigureAwait(context.ContinueOnCapturedContext);
+                    return outcome.AsOutcome<T>();
+                },
+                context,
+                (callback, state));
+
+            return TaskHelper.ConvertValueTask<T, TResult>(valueTask, context);
+        }
+    }
+}

--- a/src/Polly.Core/Utils/StrategyHelper.cs
+++ b/src/Polly.Core/Utils/StrategyHelper.cs
@@ -1,0 +1,44 @@
+﻿namespace Polly.Utils;
+
+#pragma warning disable CA1031 // Do not catch general exception types
+
+internal static class StrategyHelper
+{
+    public static ValueTask<Outcome<TResult>> ExecuteCallbackSafeAsync<TResult, TState>(
+        Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
+        ResilienceContext context,
+        TState state)
+    {
+        if (context.CancellationToken.IsCancellationRequested)
+        {
+            return new ValueTask<Outcome<TResult>>(Outcome.FromException<TResult>(new OperationCanceledException(context.CancellationToken)));
+        }
+
+        try
+        {
+            var callbackTask = callback(context, state);
+            if (callbackTask.IsCompleted)
+            {
+                return new ValueTask<Outcome<TResult>>(callbackTask.GetResult());
+            }
+
+            return AwaitTask(callbackTask, context.ContinueOnCapturedContext);
+        }
+        catch (Exception e)
+        {
+            return new ValueTask<Outcome<TResult>>(Outcome.FromException<TResult>(e));
+        }
+
+        static async ValueTask<Outcome<T>> AwaitTask<T>(ValueTask<Outcome<T>> task, bool continueOnCapturedContext)
+        {
+            try
+            {
+                return await task.ConfigureAwait(continueOnCapturedContext);
+            }
+            catch (Exception e)
+            {
+                return Outcome.FromException<T>(e);
+            }
+        }
+    }
+}

--- a/src/Polly.Testing/ResilienceStrategyExtensions.cs
+++ b/src/Polly.Testing/ResilienceStrategyExtensions.cs
@@ -20,7 +20,7 @@ public static class ResilienceStrategyExtensions
     {
         Guard.NotNull(strategy);
 
-        return strategy.Strategy.GetInnerStrategies();
+        return GetInnerStrategiesCore<TResult>(strategy.Strategy);
     }
 
     /// <summary>
@@ -33,15 +33,30 @@ public static class ResilienceStrategyExtensions
     {
         Guard.NotNull(strategy);
 
+        return GetInnerStrategiesCore<object>(strategy);
+    }
+
+    private static InnerStrategiesDescriptor GetInnerStrategiesCore<T>(ResilienceStrategy strategy)
+    {
         var strategies = new List<ResilienceStrategy>();
         strategy.ExpandStrategies(strategies);
 
-        var innerStrategies = strategies.Select(s => new ResilienceStrategyDescriptor(s.Options, s.GetType())).ToList();
+        var innerStrategies = strategies.Select(s => new ResilienceStrategyDescriptor(s.Options, GetStrategyType<T>(s))).ToList();
 
         return new InnerStrategiesDescriptor(
             innerStrategies.Where(s => !ShouldSkip(s.StrategyType)).ToList().AsReadOnly(),
             hasTelemetry: innerStrategies.Exists(s => s.StrategyType.FullName == TelemetryResilienceStrategy),
             isReloadable: innerStrategies.Exists(s => s.StrategyType == typeof(ReloadableResilienceStrategy)));
+    }
+
+    private static Type GetStrategyType<T>(ResilienceStrategy strategy)
+    {
+        if (strategy is ReactiveResilienceStrategyBridge<T> bridge)
+        {
+            return bridge.Strategy.GetType();
+        }
+
+        return strategy.GetType();
     }
 
     private static bool ShouldSkip(Type type) => type == typeof(ReloadableResilienceStrategy) || type.FullName == TelemetryResilienceStrategy;

--- a/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerCompositeStrategyBuilderTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerCompositeStrategyBuilderTests.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.Extensions.Time.Testing;
 using Polly.CircuitBreaker;
+using Polly.Utils;
 
 namespace Polly.Core.Tests.CircuitBreaker;
 
@@ -32,7 +33,10 @@ public class CircuitBreakerCompositeStrategyBuilderTests
 
         var strategy = builder.Build();
 
-        strategy.Should().BeOfType<CircuitBreakerResilienceStrategy<object>>();
+        strategy
+            .Should().BeOfType<ReactiveResilienceStrategyBridge<object>>().Subject
+            .Strategy
+            .Should().BeOfType<CircuitBreakerResilienceStrategy<object>>();
     }
 
     [MemberData(nameof(ConfigureDataGeneric))]
@@ -45,7 +49,10 @@ public class CircuitBreakerCompositeStrategyBuilderTests
 
         var strategy = builder.Build().Strategy;
 
-        strategy.Should().BeOfType<CircuitBreakerResilienceStrategy<int>>();
+        strategy
+            .Should().BeOfType<ReactiveResilienceStrategyBridge<int>>().Subject
+            .Strategy
+            .Should().BeOfType<CircuitBreakerResilienceStrategy<int>>();
     }
 
     [Fact]

--- a/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerResilienceStrategyTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Polly.CircuitBreaker;
 using Polly.Telemetry;
+using Polly.Utils;
 
 namespace Polly.Core.Tests.CircuitBreaker;
 
@@ -130,5 +131,5 @@ public class CircuitBreakerResilienceStrategyTests : IDisposable
         Create().Invoking(s => s.Execute(_ => 0)).Should().NotThrow();
     }
 
-    private CircuitBreakerResilienceStrategy<int> Create() => new(_options.ShouldHandle!, _controller, _options.StateProvider, _options.ManualControl);
+    private ReactiveResilienceStrategyBridge<int> Create() => new(new CircuitBreakerResilienceStrategy<int>(_options.ShouldHandle!, _controller, _options.StateProvider, _options.ManualControl));
 }

--- a/test/Polly.Core.Tests/CompositeStrategyBuilderTests.cs
+++ b/test/Polly.Core.Tests/CompositeStrategyBuilderTests.cs
@@ -236,7 +236,15 @@ The RequiredProperty field is required.
         var builder = new CompositeStrategyBuilder();
 
         builder
-            .Invoking(b => b.AddStrategy(null!, new TestResilienceStrategyOptions()))
+            .Invoking(b => b.AddStrategy((Func<StrategyBuilderContext, ResilienceStrategy>)null!, new TestResilienceStrategyOptions()))
+            .Should()
+            .Throw<ArgumentNullException>()
+            .And.ParamName
+            .Should()
+            .Be("factory");
+
+        builder
+            .Invoking(b => b.AddStrategy((Func<StrategyBuilderContext, ReactiveResilienceStrategy<object>>)null!, new TestResilienceStrategyOptions()))
             .Should()
             .Throw<ArgumentNullException>()
             .And.ParamName

--- a/test/Polly.Core.Tests/Fallback/FallbackCompositeStrategyBuilderExtensionsTests.cs
+++ b/test/Polly.Core.Tests/Fallback/FallbackCompositeStrategyBuilderExtensionsTests.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Polly.Fallback;
+using Polly.Utils;
 
 namespace Polly.Core.Tests.Fallback;
 
@@ -23,7 +24,11 @@ public class FallbackCompositeStrategyBuilderExtensionsTests
     {
         var builder = new CompositeStrategyBuilder<int>();
         configure(builder);
-        builder.Build().Strategy.Should().BeOfType<FallbackResilienceStrategy<int>>();
+
+        builder.Build().Strategy
+            .Should().BeOfType<ReactiveResilienceStrategyBridge<int>>().Subject
+            .Strategy
+            .Should().BeOfType<FallbackResilienceStrategy<int>>();
     }
 
     [Fact]

--- a/test/Polly.Core.Tests/Fallback/FallbackResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Fallback/FallbackResilienceStrategyTests.cs
@@ -1,5 +1,6 @@
 using Polly.Fallback;
 using Polly.Telemetry;
+using Polly.Utils;
 
 namespace Polly.Core.Tests.Fallback;
 
@@ -89,8 +90,8 @@ public class FallbackResilienceStrategyTests
         _handler = FallbackHelper.CreateHandler(shouldHandle, fallback);
     }
 
-    private FallbackResilienceStrategy<string> Create() => new(
+    private ReactiveResilienceStrategyBridge<string> Create() => new(new FallbackResilienceStrategy<string>(
         _handler!,
         _options.OnFallback,
-        _telemetry);
+        _telemetry));
 }

--- a/test/Polly.Core.Tests/Hedging/HedgingCompositeStrategyBuilderExtensionsTests.cs
+++ b/test/Polly.Core.Tests/Hedging/HedgingCompositeStrategyBuilderExtensionsTests.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Polly.Hedging;
+using Polly.Utils;
 
 namespace Polly.Core.Tests.Hedging;
 
@@ -12,9 +13,12 @@ public class HedgingCompositeStrategyBuilderExtensionsTests
     public void AddHedging_Ok()
     {
         _builder.AddHedging(new HedgingStrategyOptions { ShouldHandle = _ => PredicateResult.True });
-        var strategy = _builder.Build().Should().BeOfType<HedgingResilienceStrategy<object>>()
-            .Subject
-            .HedgingHandler.IsGeneric.Should().BeFalse();
+
+        _builder.Build()
+            .Should().BeOfType<ReactiveResilienceStrategyBridge<object>>().Subject
+            .Strategy
+            .Should().BeOfType<HedgingResilienceStrategy<object>>()
+            .Subject.HedgingHandler.IsGeneric.Should().BeFalse();
     }
 
     [Fact]
@@ -25,7 +29,10 @@ public class HedgingCompositeStrategyBuilderExtensionsTests
             HedgingActionGenerator = args => () => Outcome.FromResultAsTask("dummy"),
             ShouldHandle = _ => PredicateResult.True
         });
+
         _genericBuilder.Build().Strategy
+            .Should().BeOfType<ReactiveResilienceStrategyBridge<string>>().Subject
+            .Strategy
             .Should().BeOfType<HedgingResilienceStrategy<string>>()
             .Subject.HedgingHandler.IsGeneric.Should().BeTrue();
     }

--- a/test/Polly.Core.Tests/Retry/RetryCompositeStrategyBuilderExtensionsTests.cs
+++ b/test/Polly.Core.Tests/Retry/RetryCompositeStrategyBuilderExtensionsTests.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Polly.Retry;
+using Polly.Utils;
 
 namespace Polly.Core.Tests.Retry;
 
@@ -70,7 +71,7 @@ public class RetryCompositeStrategyBuilderExtensionsTests
 
     private static void AssertStrategy(CompositeStrategyBuilder builder, RetryBackoffType type, int retries, TimeSpan delay, Action<RetryResilienceStrategy<object>>? assert = null)
     {
-        var strategy = (RetryResilienceStrategy<object>)builder.Build();
+        var strategy = (RetryResilienceStrategy<object>)((ReactiveResilienceStrategyBridge<object>)builder.Build()).Strategy;
 
         strategy.BackoffType.Should().Be(type);
         strategy.RetryCount.Should().Be(retries);
@@ -81,7 +82,7 @@ public class RetryCompositeStrategyBuilderExtensionsTests
 
     private static void AssertStrategy<T>(CompositeStrategyBuilder<T> builder, RetryBackoffType type, int retries, TimeSpan delay, Action<RetryResilienceStrategy<T>>? assert = null)
     {
-        var strategy = (RetryResilienceStrategy<T>)builder.Build().Strategy;
+        var strategy = (RetryResilienceStrategy<T>)((ReactiveResilienceStrategyBridge<T>)builder.Build().Strategy).Strategy;
 
         strategy.BackoffType.Should().Be(type);
         strategy.RetryCount.Should().Be(retries);

--- a/test/Polly.Core.Tests/Retry/RetryResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Retry/RetryResilienceStrategyTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Polly.Retry;
 using Polly.Telemetry;
+using Polly.Utils;
 
 namespace Polly.Core.Tests.Retry;
 
@@ -338,7 +339,7 @@ public class RetryResilienceStrategyTests
 
     private void SetupNoDelay() => _options.RetryDelayGenerator = _ => new ValueTask<TimeSpan>(TimeSpan.Zero);
 
-    private async ValueTask<int> ExecuteAndAdvance(RetryResilienceStrategy<object> sut)
+    private async ValueTask<int> ExecuteAndAdvance(ReactiveResilienceStrategyBridge<object> sut)
     {
         var executing = sut.ExecuteAsync(_ => new ValueTask<int>(0)).AsTask();
 
@@ -350,9 +351,9 @@ public class RetryResilienceStrategyTests
         return await executing;
     }
 
-    private RetryResilienceStrategy<object> CreateSut(TimeProvider? timeProvider = null) =>
-        new(_options,
+    private ReactiveResilienceStrategyBridge<object> CreateSut(TimeProvider? timeProvider = null) =>
+        new(new RetryResilienceStrategy<object>(_options,
             timeProvider ?? _timeProvider,
             _telemetry,
-            () => 1.0);
+            () => 1.0));
 }

--- a/test/Polly.Core.Tests/Utils/ReactiveResilienceStrategyBridgeTests.cs
+++ b/test/Polly.Core.Tests/Utils/ReactiveResilienceStrategyBridgeTests.cs
@@ -1,6 +1,8 @@
-﻿namespace Polly.Core.Tests.Utils;
+﻿using Polly.Utils;
 
-public class ReactiveResilienceStrategyTests
+namespace Polly.Core.Tests.Utils;
+
+public class ReactiveResilienceStrategyBridgeTests
 {
     [Fact]
     public void Ctor_Ok()
@@ -13,10 +15,10 @@ public class ReactiveResilienceStrategyTests
     {
         var values = new List<object?>();
 
-        var strategy = new Strategy<object>(outcome =>
+        var strategy = new ReactiveResilienceStrategyBridge<object>(new Strategy<object>(outcome =>
         {
             values.Add(outcome.Result);
-        });
+        }));
 
         strategy.Execute(args => "dummy");
         strategy.Execute(args => 0);
@@ -34,10 +36,10 @@ public class ReactiveResilienceStrategyTests
     {
         var values = new List<object?>();
 
-        var strategy = new Strategy<string>(outcome =>
+        var strategy = new ReactiveResilienceStrategyBridge<string>(new Strategy<string>(outcome =>
         {
             values.Add(outcome.Result);
-        });
+        }));
 
         strategy.Execute(args => "dummy");
 
@@ -49,11 +51,11 @@ public class ReactiveResilienceStrategyTests
     public void Pipeline_TypeCheck_Ok()
     {
         var called = false;
-        var strategy = new Strategy<object>(o =>
+        var strategy = new ReactiveResilienceStrategyBridge<object>(new Strategy<object>(o =>
         {
             o.Result.Should().Be(-1);
             called = true;
-        });
+        }));
 
         strategy.Execute(() => -1);
 
@@ -66,7 +68,7 @@ public class ReactiveResilienceStrategyTests
 
         public Strategy(Action<Outcome<T>> onOutcome) => _onOutcome = onOutcome;
 
-        protected override async ValueTask<Outcome<T>> ExecuteCore<TState>(Func<ResilienceContext, TState, ValueTask<Outcome<T>>> callback, ResilienceContext context, TState state)
+        protected internal override async ValueTask<Outcome<T>> ExecuteCore<TState>(Func<ResilienceContext, TState, ValueTask<Outcome<T>>> callback, ResilienceContext context, TState state)
         {
             var outcome = await callback(context, state);
             _onOutcome(outcome);


### PR DESCRIPTION
### Details on the issue fix or feature implementation

One reoccurring complaint about the current non-generic core was the possibility of combining incompatible reactive strategies. This PR improves the API and makes the above not possible.

This was ensured with the following changes:

- `ReactiveResilienceStrategy<T>` no longer derives from `ResilienceStrategy`.
- Added two new `AddStrategy` extensions for both `CompositeStrategyBuilder` and `CompositeStrategyBuilder<T>` that require factory returning `ReactiveResilienceStrategy<T>`.
- Reimplemented all extensions for reactive strategies to use the new API

Going forward the author of custom resilience strategies can use:

- `ResilienceStrategy` as a base class for non-reactive strategies
- `ReactiveResilienceStrategy<T>` as a base class for reactive strategies

Contributes to #1454

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
