### PR TITLE
Drop the `Extensions` from `Polly.Extensions` namespace

### DIFF
--- a/bench/Polly.Core.Benchmarks/ResilienceStrategyProviderBenchmark.cs
+++ b/bench/Polly.Core.Benchmarks/ResilienceStrategyProviderBenchmark.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Polly.DependencyInjection;
 
 namespace Polly.Core.Benchmarks;
 

--- a/bench/Polly.Core.Benchmarks/ResilienceStrategyProviderBenchmark.cs
+++ b/bench/Polly.Core.Benchmarks/ResilienceStrategyProviderBenchmark.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.DependencyInjection;
-using Polly.DependencyInjection;
 
 namespace Polly.Core.Benchmarks;
 

--- a/bench/Polly.Core.Benchmarks/TelemetryBenchmark.cs
+++ b/bench/Polly.Core.Benchmarks/TelemetryBenchmark.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.Metrics;
 using Microsoft.Extensions.Logging.Abstractions;
-using Polly.Extensions.Telemetry;
 using Polly.Telemetry;
 
 namespace Polly.Core.Benchmarks;

--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerManualControl.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerManualControl.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Polly.CircuitBreaker;
 
 /// <summary>

--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerResilienceStrategy.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerResilienceStrategy.cs
@@ -1,5 +1,3 @@
-using Polly.Utils;
-
 namespace Polly.CircuitBreaker;
 
 internal sealed class CircuitBreakerResilienceStrategy<T> : ReactiveResilienceStrategy<T>

--- a/src/Polly.Core/LegacySupport.cs
+++ b/src/Polly.Core/LegacySupport.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel;
 
-namespace Polly.Utils;
+namespace Polly;
 
 /// <summary>
 /// Legacy support for older versions of Polly.

--- a/src/Polly.Core/PublicAPI.Unshipped.txt
+++ b/src/Polly.Core/PublicAPI.Unshipped.txt
@@ -146,6 +146,7 @@ Polly.Hedging.OnHedgingArguments.ExecutionTime.get -> System.TimeSpan
 Polly.Hedging.OnHedgingArguments.HasOutcome.get -> bool
 Polly.Hedging.OnHedgingArguments.OnHedgingArguments(int attemptNumber, bool hasOutcome, System.TimeSpan executionTime) -> void
 Polly.HedgingCompositeStrategyBuilderExtensions
+Polly.LegacySupport
 Polly.NullResilienceStrategy
 Polly.NullResilienceStrategy<TResult>
 Polly.Outcome
@@ -384,7 +385,6 @@ Polly.Timeout.TimeoutStrategyOptions.TimeoutGenerator.get -> System.Func<Polly.T
 Polly.Timeout.TimeoutStrategyOptions.TimeoutGenerator.set -> void
 Polly.Timeout.TimeoutStrategyOptions.TimeoutStrategyOptions() -> void
 Polly.TimeoutCompositeStrategyBuilderExtensions
-Polly.Utils.LegacySupport
 static Polly.CircuitBreakerCompositeStrategyBuilderExtensions.AddCircuitBreaker(this Polly.CompositeStrategyBuilder! builder, Polly.CircuitBreaker.CircuitBreakerStrategyOptions! options) -> Polly.CompositeStrategyBuilder!
 static Polly.CircuitBreakerCompositeStrategyBuilderExtensions.AddCircuitBreaker<TResult>(this Polly.CompositeStrategyBuilder<TResult>! builder, Polly.CircuitBreaker.CircuitBreakerStrategyOptions<TResult>! options) -> Polly.CompositeStrategyBuilder<TResult>!
 static Polly.CompositeStrategyBuilderExtensions.AddStrategy(this Polly.CompositeStrategyBuilder! builder, System.Func<Polly.StrategyBuilderContext!, Polly.ReactiveResilienceStrategy<object!>!>! factory, Polly.ResilienceStrategyOptions! options) -> Polly.CompositeStrategyBuilder!
@@ -394,6 +394,7 @@ static Polly.CompositeStrategyBuilderExtensions.AddStrategy<TResult>(this Polly.
 static Polly.CompositeStrategyBuilderExtensions.AddStrategy<TResult>(this Polly.CompositeStrategyBuilder<TResult>! builder, System.Func<Polly.StrategyBuilderContext!, Polly.ReactiveResilienceStrategy<TResult>!>! factory, Polly.ResilienceStrategyOptions! options) -> Polly.CompositeStrategyBuilder<TResult>!
 static Polly.FallbackCompositeStrategyBuilderExtensions.AddFallback<TResult>(this Polly.CompositeStrategyBuilder<TResult>! builder, Polly.Fallback.FallbackStrategyOptions<TResult>! options) -> Polly.CompositeStrategyBuilder<TResult>!
 static Polly.HedgingCompositeStrategyBuilderExtensions.AddHedging<TResult>(this Polly.CompositeStrategyBuilder<TResult>! builder, Polly.Hedging.HedgingStrategyOptions<TResult>! options) -> Polly.CompositeStrategyBuilder<TResult>!
+static Polly.LegacySupport.SetProperties(this Polly.ResilienceProperties! resilienceProperties, System.Collections.Generic.IDictionary<string!, object?>! properties, out System.Collections.Generic.IDictionary<string!, object?>! oldProperties) -> void
 static Polly.Outcome.FromException<TResult>(System.Exception! exception) -> Polly.Outcome<TResult>
 static Polly.Outcome.FromExceptionAsTask<TResult>(System.Exception! exception) -> System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>
 static Polly.Outcome.FromResult<TResult>(TResult? value) -> Polly.Outcome<TResult>
@@ -411,7 +412,6 @@ static Polly.RetryCompositeStrategyBuilderExtensions.AddRetry(this Polly.Composi
 static Polly.RetryCompositeStrategyBuilderExtensions.AddRetry<TResult>(this Polly.CompositeStrategyBuilder<TResult>! builder, Polly.Retry.RetryStrategyOptions<TResult>! options) -> Polly.CompositeStrategyBuilder<TResult>!
 static Polly.TimeoutCompositeStrategyBuilderExtensions.AddTimeout<TBuilder>(this TBuilder! builder, Polly.Timeout.TimeoutStrategyOptions! options) -> TBuilder!
 static Polly.TimeoutCompositeStrategyBuilderExtensions.AddTimeout<TBuilder>(this TBuilder! builder, System.TimeSpan timeout) -> TBuilder!
-static Polly.Utils.LegacySupport.SetProperties(this Polly.ResilienceProperties! resilienceProperties, System.Collections.Generic.IDictionary<string!, object?>! properties, out System.Collections.Generic.IDictionary<string!, object?>! oldProperties) -> void
 static readonly Polly.NullResilienceStrategy.Instance -> Polly.NullResilienceStrategy!
 static readonly Polly.NullResilienceStrategy<TResult>.Instance -> Polly.NullResilienceStrategy<TResult>!
 virtual Polly.Registry.ResilienceStrategyProvider<TKey>.GetStrategy(TKey key) -> Polly.ResilienceStrategy!

--- a/src/Polly.Core/ResilienceStrategyT.Async.cs
+++ b/src/Polly.Core/ResilienceStrategyT.Async.cs
@@ -1,5 +1,3 @@
-using Polly.Utils;
-
 namespace Polly;
 
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads

--- a/src/Polly.Core/Retry/RetryResilienceStrategy.cs
+++ b/src/Polly.Core/Retry/RetryResilienceStrategy.cs
@@ -1,4 +1,3 @@
-using System;
 using Polly.Telemetry;
 
 namespace Polly.Retry;

--- a/src/Polly.Core/Utils/CompositeResilienceStrategy.cs
+++ b/src/Polly.Core/Utils/CompositeResilienceStrategy.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics;
-
 namespace Polly.Utils;
 
 #pragma warning disable S2302 // "nameof" should be used

--- a/src/Polly.Core/Utils/TaskHelper.cs
+++ b/src/Polly.Core/Utils/TaskHelper.cs
@@ -1,6 +1,4 @@
-﻿using System.Threading.Tasks;
-
-namespace Polly.Utils;
+﻿namespace Polly.Utils;
 
 internal static class TaskHelper
 {

--- a/src/Polly.Extensions/DependencyInjection/AddResilienceStrategyContext.cs
+++ b/src/Polly.Extensions/DependencyInjection/AddResilienceStrategyContext.cs
@@ -2,7 +2,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Polly.Extensions.Registry;
 using Polly.Registry;
 
 namespace Polly.Extensions.DependencyInjection;

--- a/src/Polly.Extensions/DependencyInjection/AddResilienceStrategyContext.cs
+++ b/src/Polly.Extensions/DependencyInjection/AddResilienceStrategyContext.cs
@@ -1,10 +1,9 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Polly.Registry;
 
-namespace Polly.Extensions.DependencyInjection;
+namespace Polly.DependencyInjection;
 
 /// <summary>
 /// Represents the context for adding a resilience strategy with the specified key.

--- a/src/Polly.Extensions/DependencyInjection/ConfigureResilienceStrategyRegistryOptions.cs
+++ b/src/Polly.Extensions/DependencyInjection/ConfigureResilienceStrategyRegistryOptions.cs
@@ -1,6 +1,6 @@
 using Polly.Registry;
 
-namespace Polly.Extensions.DependencyInjection;
+namespace Polly.DependencyInjection;
 
 internal sealed class ConfigureResilienceStrategyRegistryOptions<TKey>
     where TKey : notnull

--- a/src/Polly.Extensions/DependencyInjection/PollyDependencyInjectionKeys.cs
+++ b/src/Polly.Extensions/DependencyInjection/PollyDependencyInjectionKeys.cs
@@ -1,4 +1,4 @@
-namespace Polly.Extensions.DependencyInjection;
+namespace Polly.DependencyInjection;
 
 /// <summary>
 /// The resilience keys used in the dependency injection scenarios.

--- a/src/Polly.Extensions/DependencyInjection/PollyServiceCollectionExtensions.cs
+++ b/src/Polly.Extensions/DependencyInjection/PollyServiceCollectionExtensions.cs
@@ -3,12 +3,11 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
-using Polly.Extensions.DependencyInjection;
-using Polly.Extensions.Telemetry;
 using Polly.Registry;
+using Polly.Telemetry;
 using Polly.Utils;
 
-namespace Polly;
+namespace Polly.DependencyInjection;
 
 /// <summary>
 /// Provides extension methods for registering resilience strategies using the <see cref="IServiceCollection"/>.
@@ -85,7 +84,7 @@ public static class PollyServiceCollectionExtensions
                 });
             });
 
-        return AddResilienceStrategyRegistry<TKey>(services);
+        return services.AddResilienceStrategyRegistry<TKey>();
     }
 
     /// <summary>
@@ -156,7 +155,7 @@ public static class PollyServiceCollectionExtensions
                 });
             });
 
-        return AddResilienceStrategyRegistry<TKey>(services);
+        return services.AddResilienceStrategyRegistry<TKey>();
     }
 
     /// <summary>

--- a/src/Polly.Extensions/DependencyInjection/PollyServiceCollectionExtensions.cs
+++ b/src/Polly.Extensions/DependencyInjection/PollyServiceCollectionExtensions.cs
@@ -3,11 +3,12 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Polly.DependencyInjection;
 using Polly.Registry;
 using Polly.Telemetry;
 using Polly.Utils;
 
-namespace Polly.DependencyInjection;
+namespace Polly;
 
 /// <summary>
 /// Provides extension methods for registering resilience strategies using the <see cref="IServiceCollection"/>.

--- a/src/Polly.Extensions/Polly.Extensions.csproj
+++ b/src/Polly.Extensions/Polly.Extensions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net7.0;net6.0;netstandard2.0;net472;net462</TargetFrameworks>
     <AssemblyTitle>Polly.Extensions</AssemblyTitle>
-    <RootNamespace>Polly.Extensions</RootNamespace>
+    <RootNamespace>Polly</RootNamespace>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ProjectType>Library</ProjectType>

--- a/src/Polly.Extensions/PublicAPI.Unshipped.txt
+++ b/src/Polly.Extensions/PublicAPI.Unshipped.txt
@@ -1,33 +1,33 @@
 ﻿#nullable enable
-Polly.Extensions.DependencyInjection.AddResilienceStrategyContext<TKey>
-Polly.Extensions.DependencyInjection.AddResilienceStrategyContext<TKey>.BuilderName.get -> string!
-Polly.Extensions.DependencyInjection.AddResilienceStrategyContext<TKey>.EnableReloads<TOptions>(string? name = null) -> void
-Polly.Extensions.DependencyInjection.AddResilienceStrategyContext<TKey>.GetOptions<TOptions>(string? name = null) -> TOptions
-Polly.Extensions.DependencyInjection.AddResilienceStrategyContext<TKey>.ServiceProvider.get -> System.IServiceProvider!
-Polly.Extensions.DependencyInjection.AddResilienceStrategyContext<TKey>.StrategyKey.get -> TKey
-Polly.Extensions.Telemetry.EnrichmentContext
-Polly.Extensions.Telemetry.EnrichmentContext.Arguments.get -> object?
-Polly.Extensions.Telemetry.EnrichmentContext.Context.get -> Polly.ResilienceContext!
-Polly.Extensions.Telemetry.EnrichmentContext.Outcome.get -> Polly.Outcome<object!>?
-Polly.Extensions.Telemetry.EnrichmentContext.Tags.get -> System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string!, object?>>!
-Polly.Extensions.Telemetry.TelemetryOptions
-Polly.Extensions.Telemetry.TelemetryOptions.Enrichers.get -> System.Collections.Generic.ICollection<System.Action<Polly.Extensions.Telemetry.EnrichmentContext!>!>!
-Polly.Extensions.Telemetry.TelemetryOptions.LoggerFactory.get -> Microsoft.Extensions.Logging.ILoggerFactory!
-Polly.Extensions.Telemetry.TelemetryOptions.LoggerFactory.set -> void
-Polly.Extensions.Telemetry.TelemetryOptions.OnTelemetryEvent.get -> System.Action<Polly.Telemetry.TelemetryEventArguments!>?
-Polly.Extensions.Telemetry.TelemetryOptions.OnTelemetryEvent.set -> void
-Polly.Extensions.Telemetry.TelemetryOptions.ResultFormatter.get -> System.Func<Polly.ResilienceContext!, object?, object?>!
-Polly.Extensions.Telemetry.TelemetryOptions.ResultFormatter.set -> void
-Polly.Extensions.Telemetry.TelemetryOptions.TelemetryOptions() -> void
-Polly.PollyServiceCollectionExtensions
+Polly.DependencyInjection.AddResilienceStrategyContext<TKey>
+Polly.DependencyInjection.AddResilienceStrategyContext<TKey>.BuilderName.get -> string!
+Polly.DependencyInjection.AddResilienceStrategyContext<TKey>.EnableReloads<TOptions>(string? name = null) -> void
+Polly.DependencyInjection.AddResilienceStrategyContext<TKey>.GetOptions<TOptions>(string? name = null) -> TOptions
+Polly.DependencyInjection.AddResilienceStrategyContext<TKey>.ServiceProvider.get -> System.IServiceProvider!
+Polly.DependencyInjection.AddResilienceStrategyContext<TKey>.StrategyKey.get -> TKey
+Polly.DependencyInjection.PollyServiceCollectionExtensions
 Polly.Registry.ConfigureBuilderContextExtensions
+Polly.Telemetry.EnrichmentContext
+Polly.Telemetry.EnrichmentContext.Arguments.get -> object?
+Polly.Telemetry.EnrichmentContext.Context.get -> Polly.ResilienceContext!
+Polly.Telemetry.EnrichmentContext.Outcome.get -> Polly.Outcome<object!>?
+Polly.Telemetry.EnrichmentContext.Tags.get -> System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string!, object?>>!
+Polly.Telemetry.TelemetryOptions
+Polly.Telemetry.TelemetryOptions.Enrichers.get -> System.Collections.Generic.ICollection<System.Action<Polly.Telemetry.EnrichmentContext!>!>!
+Polly.Telemetry.TelemetryOptions.LoggerFactory.get -> Microsoft.Extensions.Logging.ILoggerFactory!
+Polly.Telemetry.TelemetryOptions.LoggerFactory.set -> void
+Polly.Telemetry.TelemetryOptions.OnTelemetryEvent.get -> System.Action<Polly.Telemetry.TelemetryEventArguments!>?
+Polly.Telemetry.TelemetryOptions.OnTelemetryEvent.set -> void
+Polly.Telemetry.TelemetryOptions.ResultFormatter.get -> System.Func<Polly.ResilienceContext!, object?, object?>!
+Polly.Telemetry.TelemetryOptions.ResultFormatter.set -> void
+Polly.Telemetry.TelemetryOptions.TelemetryOptions() -> void
 Polly.TelemetryCompositeStrategyBuilderExtensions
-static Polly.PollyServiceCollectionExtensions.AddResilienceStrategy<TKey, TResult>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, TKey key, System.Action<Polly.CompositeStrategyBuilder<TResult>!, Polly.Extensions.DependencyInjection.AddResilienceStrategyContext<TKey>!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static Polly.PollyServiceCollectionExtensions.AddResilienceStrategy<TKey, TResult>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, TKey key, System.Action<Polly.CompositeStrategyBuilder<TResult>!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static Polly.PollyServiceCollectionExtensions.AddResilienceStrategy<TKey>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, TKey key, System.Action<Polly.CompositeStrategyBuilder!, Polly.Extensions.DependencyInjection.AddResilienceStrategyContext<TKey>!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static Polly.PollyServiceCollectionExtensions.AddResilienceStrategy<TKey>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, TKey key, System.Action<Polly.CompositeStrategyBuilder!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static Polly.PollyServiceCollectionExtensions.AddResilienceStrategyRegistry<TKey>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static Polly.PollyServiceCollectionExtensions.AddResilienceStrategyRegistry<TKey>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<Polly.Registry.ResilienceStrategyRegistryOptions<TKey>!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Polly.DependencyInjection.PollyServiceCollectionExtensions.AddResilienceStrategy<TKey, TResult>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, TKey key, System.Action<Polly.CompositeStrategyBuilder<TResult>!, Polly.DependencyInjection.AddResilienceStrategyContext<TKey>!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Polly.DependencyInjection.PollyServiceCollectionExtensions.AddResilienceStrategy<TKey, TResult>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, TKey key, System.Action<Polly.CompositeStrategyBuilder<TResult>!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Polly.DependencyInjection.PollyServiceCollectionExtensions.AddResilienceStrategy<TKey>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, TKey key, System.Action<Polly.CompositeStrategyBuilder!, Polly.DependencyInjection.AddResilienceStrategyContext<TKey>!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Polly.DependencyInjection.PollyServiceCollectionExtensions.AddResilienceStrategy<TKey>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, TKey key, System.Action<Polly.CompositeStrategyBuilder!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Polly.DependencyInjection.PollyServiceCollectionExtensions.AddResilienceStrategyRegistry<TKey>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Polly.DependencyInjection.PollyServiceCollectionExtensions.AddResilienceStrategyRegistry<TKey>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<Polly.Registry.ResilienceStrategyRegistryOptions<TKey>!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Polly.Registry.ConfigureBuilderContextExtensions.EnableReloads<TKey, TOptions>(this Polly.Registry.ConfigureBuilderContext<TKey>! context, Microsoft.Extensions.Options.IOptionsMonitor<TOptions>! optionsMonitor, string? name = null) -> void
 static Polly.TelemetryCompositeStrategyBuilderExtensions.ConfigureTelemetry<TBuilder>(this TBuilder! builder, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> TBuilder!
-static Polly.TelemetryCompositeStrategyBuilderExtensions.ConfigureTelemetry<TBuilder>(this TBuilder! builder, Polly.Extensions.Telemetry.TelemetryOptions! options) -> TBuilder!
+static Polly.TelemetryCompositeStrategyBuilderExtensions.ConfigureTelemetry<TBuilder>(this TBuilder! builder, Polly.Telemetry.TelemetryOptions! options) -> TBuilder!

--- a/src/Polly.Extensions/PublicAPI.Unshipped.txt
+++ b/src/Polly.Extensions/PublicAPI.Unshipped.txt
@@ -5,7 +5,7 @@ Polly.DependencyInjection.AddResilienceStrategyContext<TKey>.EnableReloads<TOpti
 Polly.DependencyInjection.AddResilienceStrategyContext<TKey>.GetOptions<TOptions>(string? name = null) -> TOptions
 Polly.DependencyInjection.AddResilienceStrategyContext<TKey>.ServiceProvider.get -> System.IServiceProvider!
 Polly.DependencyInjection.AddResilienceStrategyContext<TKey>.StrategyKey.get -> TKey
-Polly.DependencyInjection.PollyServiceCollectionExtensions
+Polly.PollyServiceCollectionExtensions
 Polly.Registry.ConfigureBuilderContextExtensions
 Polly.Telemetry.EnrichmentContext
 Polly.Telemetry.EnrichmentContext.Arguments.get -> object?
@@ -22,12 +22,12 @@ Polly.Telemetry.TelemetryOptions.ResultFormatter.get -> System.Func<Polly.Resili
 Polly.Telemetry.TelemetryOptions.ResultFormatter.set -> void
 Polly.Telemetry.TelemetryOptions.TelemetryOptions() -> void
 Polly.TelemetryCompositeStrategyBuilderExtensions
-static Polly.DependencyInjection.PollyServiceCollectionExtensions.AddResilienceStrategy<TKey, TResult>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, TKey key, System.Action<Polly.CompositeStrategyBuilder<TResult>!, Polly.DependencyInjection.AddResilienceStrategyContext<TKey>!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static Polly.DependencyInjection.PollyServiceCollectionExtensions.AddResilienceStrategy<TKey, TResult>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, TKey key, System.Action<Polly.CompositeStrategyBuilder<TResult>!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static Polly.DependencyInjection.PollyServiceCollectionExtensions.AddResilienceStrategy<TKey>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, TKey key, System.Action<Polly.CompositeStrategyBuilder!, Polly.DependencyInjection.AddResilienceStrategyContext<TKey>!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static Polly.DependencyInjection.PollyServiceCollectionExtensions.AddResilienceStrategy<TKey>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, TKey key, System.Action<Polly.CompositeStrategyBuilder!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static Polly.DependencyInjection.PollyServiceCollectionExtensions.AddResilienceStrategyRegistry<TKey>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static Polly.DependencyInjection.PollyServiceCollectionExtensions.AddResilienceStrategyRegistry<TKey>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<Polly.Registry.ResilienceStrategyRegistryOptions<TKey>!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Polly.PollyServiceCollectionExtensions.AddResilienceStrategy<TKey, TResult>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, TKey key, System.Action<Polly.CompositeStrategyBuilder<TResult>!, Polly.DependencyInjection.AddResilienceStrategyContext<TKey>!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Polly.PollyServiceCollectionExtensions.AddResilienceStrategy<TKey, TResult>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, TKey key, System.Action<Polly.CompositeStrategyBuilder<TResult>!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Polly.PollyServiceCollectionExtensions.AddResilienceStrategy<TKey>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, TKey key, System.Action<Polly.CompositeStrategyBuilder!, Polly.DependencyInjection.AddResilienceStrategyContext<TKey>!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Polly.PollyServiceCollectionExtensions.AddResilienceStrategy<TKey>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, TKey key, System.Action<Polly.CompositeStrategyBuilder!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Polly.PollyServiceCollectionExtensions.AddResilienceStrategyRegistry<TKey>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Polly.PollyServiceCollectionExtensions.AddResilienceStrategyRegistry<TKey>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<Polly.Registry.ResilienceStrategyRegistryOptions<TKey>!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Polly.Registry.ConfigureBuilderContextExtensions.EnableReloads<TKey, TOptions>(this Polly.Registry.ConfigureBuilderContext<TKey>! context, Microsoft.Extensions.Options.IOptionsMonitor<TOptions>! optionsMonitor, string? name = null) -> void
 static Polly.TelemetryCompositeStrategyBuilderExtensions.ConfigureTelemetry<TBuilder>(this TBuilder! builder, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> TBuilder!
 static Polly.TelemetryCompositeStrategyBuilderExtensions.ConfigureTelemetry<TBuilder>(this TBuilder! builder, Polly.Telemetry.TelemetryOptions! options) -> TBuilder!

--- a/src/Polly.Extensions/PublicAPI.Unshipped.txt
+++ b/src/Polly.Extensions/PublicAPI.Unshipped.txt
@@ -5,7 +5,6 @@ Polly.Extensions.DependencyInjection.AddResilienceStrategyContext<TKey>.EnableRe
 Polly.Extensions.DependencyInjection.AddResilienceStrategyContext<TKey>.GetOptions<TOptions>(string? name = null) -> TOptions
 Polly.Extensions.DependencyInjection.AddResilienceStrategyContext<TKey>.ServiceProvider.get -> System.IServiceProvider!
 Polly.Extensions.DependencyInjection.AddResilienceStrategyContext<TKey>.StrategyKey.get -> TKey
-Polly.Extensions.Registry.ConfigureBuilderContextExtensions
 Polly.Extensions.Telemetry.EnrichmentContext
 Polly.Extensions.Telemetry.EnrichmentContext.Arguments.get -> object?
 Polly.Extensions.Telemetry.EnrichmentContext.Context.get -> Polly.ResilienceContext!
@@ -21,13 +20,14 @@ Polly.Extensions.Telemetry.TelemetryOptions.ResultFormatter.get -> System.Func<P
 Polly.Extensions.Telemetry.TelemetryOptions.ResultFormatter.set -> void
 Polly.Extensions.Telemetry.TelemetryOptions.TelemetryOptions() -> void
 Polly.PollyServiceCollectionExtensions
+Polly.Registry.ConfigureBuilderContextExtensions
 Polly.TelemetryCompositeStrategyBuilderExtensions
-static Polly.Extensions.Registry.ConfigureBuilderContextExtensions.EnableReloads<TKey, TOptions>(this Polly.Registry.ConfigureBuilderContext<TKey>! context, Microsoft.Extensions.Options.IOptionsMonitor<TOptions>! optionsMonitor, string? name = null) -> void
 static Polly.PollyServiceCollectionExtensions.AddResilienceStrategy<TKey, TResult>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, TKey key, System.Action<Polly.CompositeStrategyBuilder<TResult>!, Polly.Extensions.DependencyInjection.AddResilienceStrategyContext<TKey>!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Polly.PollyServiceCollectionExtensions.AddResilienceStrategy<TKey, TResult>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, TKey key, System.Action<Polly.CompositeStrategyBuilder<TResult>!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Polly.PollyServiceCollectionExtensions.AddResilienceStrategy<TKey>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, TKey key, System.Action<Polly.CompositeStrategyBuilder!, Polly.Extensions.DependencyInjection.AddResilienceStrategyContext<TKey>!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Polly.PollyServiceCollectionExtensions.AddResilienceStrategy<TKey>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, TKey key, System.Action<Polly.CompositeStrategyBuilder!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Polly.PollyServiceCollectionExtensions.AddResilienceStrategyRegistry<TKey>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Polly.PollyServiceCollectionExtensions.AddResilienceStrategyRegistry<TKey>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<Polly.Registry.ResilienceStrategyRegistryOptions<TKey>!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Polly.Registry.ConfigureBuilderContextExtensions.EnableReloads<TKey, TOptions>(this Polly.Registry.ConfigureBuilderContext<TKey>! context, Microsoft.Extensions.Options.IOptionsMonitor<TOptions>! optionsMonitor, string? name = null) -> void
 static Polly.TelemetryCompositeStrategyBuilderExtensions.ConfigureTelemetry<TBuilder>(this TBuilder! builder, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> TBuilder!
 static Polly.TelemetryCompositeStrategyBuilderExtensions.ConfigureTelemetry<TBuilder>(this TBuilder! builder, Polly.Extensions.Telemetry.TelemetryOptions! options) -> TBuilder!

--- a/src/Polly.Extensions/Registry/ConfigureBuilderContextExtensions.cs
+++ b/src/Polly.Extensions/Registry/ConfigureBuilderContextExtensions.cs
@@ -4,7 +4,7 @@ using Polly.Extensions.Utils;
 using Polly.Registry;
 using Polly.Utils;
 
-namespace Polly.Extensions.Registry;
+namespace Polly.Registry;
 
 /// <summary>
 /// Extensions for <see cref="ConfigureBuilderContext{TKey}"/>.

--- a/src/Polly.Extensions/Registry/ConfigureBuilderContextExtensions.cs
+++ b/src/Polly.Extensions/Registry/ConfigureBuilderContextExtensions.cs
@@ -1,7 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Options;
-using Polly.Extensions.Utils;
-using Polly.Registry;
 using Polly.Utils;
 
 namespace Polly.Registry;

--- a/src/Polly.Extensions/Telemetry/EnrichmentContext.Pool.cs
+++ b/src/Polly.Extensions/Telemetry/EnrichmentContext.Pool.cs
@@ -1,6 +1,6 @@
 using Polly.Utils;
 
-namespace Polly.Extensions.Telemetry;
+namespace Polly.Telemetry;
 
 public partial class EnrichmentContext
 {

--- a/src/Polly.Extensions/Telemetry/EnrichmentContext.cs
+++ b/src/Polly.Extensions/Telemetry/EnrichmentContext.cs
@@ -1,4 +1,4 @@
-namespace Polly.Extensions.Telemetry;
+namespace Polly.Telemetry;
 
 /// <summary>
 /// Enrichment context used when reporting resilience telemetry. This context is passed to the registered enrichers in <see cref="TelemetryOptions.Enrichers"/>.

--- a/src/Polly.Extensions/Telemetry/EnrichmentUtil.cs
+++ b/src/Polly.Extensions/Telemetry/EnrichmentUtil.cs
@@ -1,4 +1,4 @@
-namespace Polly.Extensions.Telemetry;
+namespace Polly.Telemetry;
 
 internal static class EnrichmentUtil
 {

--- a/src/Polly.Extensions/Telemetry/Log.cs
+++ b/src/Polly.Extensions/Telemetry/Log.cs
@@ -1,7 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 
-namespace Polly.Extensions.Telemetry;
+namespace Polly.Telemetry;
 
 #pragma warning disable S107 // Methods should not have too many parameters
 

--- a/src/Polly.Extensions/Telemetry/ResilienceContextExtensions.cs
+++ b/src/Polly.Extensions/Telemetry/ResilienceContextExtensions.cs
@@ -1,6 +1,6 @@
 using System.Globalization;
 
-namespace Polly.Extensions.Telemetry;
+namespace Polly.Telemetry;
 
 internal static class ResilienceContextExtensions
 {
@@ -12,7 +12,7 @@ internal static class ResilienceContextExtensions
     {
         for (int i = 0; i < context.ResilienceEvents.Count; i++)
         {
-            if (context.ResilienceEvents[i].Severity > Polly.Telemetry.ResilienceEventSeverity.Information)
+            if (context.ResilienceEvents[i].Severity > ResilienceEventSeverity.Information)
             {
                 return false;
             }

--- a/src/Polly.Extensions/Telemetry/ResilienceTelemetryDiagnosticSource.cs
+++ b/src/Polly.Extensions/Telemetry/ResilienceTelemetryDiagnosticSource.cs
@@ -1,8 +1,7 @@
 using System.Diagnostics.Metrics;
 using Microsoft.Extensions.Logging;
-using Polly.Telemetry;
 
-namespace Polly.Extensions.Telemetry;
+namespace Polly.Telemetry;
 
 internal sealed class ResilienceTelemetryDiagnosticSource : DiagnosticSource
 {
@@ -133,8 +132,7 @@ internal sealed class ResilienceTelemetryDiagnosticSource : DiagnosticSource
         {
             if (_logger.IsEnabled(level))
             {
-                Log.ExecutionAttempt(
-                    _logger,
+                _logger.ExecutionAttempt(
                     level,
                     args.Source.BuilderName.GetValueOrPlaceholder(),
                     args.Source.BuilderInstanceName.GetValueOrPlaceholder(),
@@ -149,8 +147,7 @@ internal sealed class ResilienceTelemetryDiagnosticSource : DiagnosticSource
         }
         else
         {
-            Log.ResilienceEvent(
-                _logger,
+            _logger.ResilienceEvent(
                 level,
                 args.Event.EventName,
                 args.Source.BuilderName.GetValueOrPlaceholder(),

--- a/src/Polly.Extensions/Telemetry/ResilienceTelemetryTags.cs
+++ b/src/Polly.Extensions/Telemetry/ResilienceTelemetryTags.cs
@@ -1,4 +1,4 @@
-namespace Polly.Extensions.Telemetry;
+namespace Polly.Telemetry;
 
 internal class ResilienceTelemetryTags
 {

--- a/src/Polly.Extensions/Telemetry/TelemetryCompositeStrategyBuilderExtensions.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryCompositeStrategyBuilderExtensions.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
-using Polly.Extensions.Telemetry;
+using Polly.Telemetry;
 using Polly.Utils;
 
 namespace Polly;

--- a/src/Polly.Extensions/Telemetry/TelemetryOptions.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryOptions.cs
@@ -2,9 +2,8 @@ using System.ComponentModel.DataAnnotations;
 using System.Net.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Polly.Telemetry;
 
-namespace Polly.Extensions.Telemetry;
+namespace Polly.Telemetry;
 
 /// <summary>
 /// The options that are used to configure the telemetry that is produced by the resilience strategies.

--- a/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategy.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategy.cs
@@ -1,7 +1,7 @@
 using System.Diagnostics.Metrics;
 using Microsoft.Extensions.Logging;
 
-namespace Polly.Extensions.Telemetry;
+namespace Polly.Telemetry;
 
 internal sealed class TelemetryResilienceStrategy : ResilienceStrategy
 {
@@ -51,15 +51,14 @@ internal sealed class TelemetryResilienceStrategy : ResilienceStrategy
         TState state)
     {
         var stamp = _timeProvider.GetTimestamp();
-        Log.ExecutingStrategy(_logger, _builderName.GetValueOrPlaceholder(), _builderInstance.GetValueOrPlaceholder(), context.OperationKey, context.GetResultType());
+        _logger.ExecutingStrategy(_builderName.GetValueOrPlaceholder(), _builderInstance.GetValueOrPlaceholder(), context.OperationKey, context.GetResultType());
 
         var outcome = await callback(context, state).ConfigureAwait(context.ContinueOnCapturedContext);
 
         var duration = _timeProvider.GetElapsedTime(stamp);
         var logLevel = context.IsExecutionHealthy() ? LogLevel.Debug : LogLevel.Warning;
 
-        Log.StrategyExecuted(
-            _logger,
+        _logger.StrategyExecuted(
             logLevel,
             _builderName.GetValueOrPlaceholder(),
             _builderInstance.GetValueOrPlaceholder(),

--- a/src/Polly.Extensions/Telemetry/TelemetryUtil.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryUtil.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.Logging;
-using Polly.Telemetry;
 
-namespace Polly.Extensions.Telemetry;
+namespace Polly.Telemetry;
 
 internal static class TelemetryUtil
 {

--- a/src/Polly.Extensions/Utils/OptionsReloadHelper.cs
+++ b/src/Polly.Extensions/Utils/OptionsReloadHelper.cs
@@ -1,7 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Options;
 
-namespace Polly.Extensions.Utils;
+namespace Polly.Utils;
 
 #pragma warning disable CA1001 // we can get away of not disposing this class because it's active for a lifetime of app
 #pragma warning disable S2931

--- a/src/Polly.Testing/ResilienceStrategyExtensions.cs
+++ b/src/Polly.Testing/ResilienceStrategyExtensions.cs
@@ -7,7 +7,7 @@ namespace Polly.Testing;
 /// </summary>
 public static class ResilienceStrategyExtensions
 {
-    private const string TelemetryResilienceStrategy = "Polly.Extensions.Telemetry.TelemetryResilienceStrategy";
+    private const string TelemetryResilienceStrategy = "Polly.Telemetry.TelemetryResilienceStrategy";
 
     /// <summary>
     /// Gets the inner strategies the <paramref name="strategy"/> is composed of.

--- a/src/Polly/Utilities/Wrappers/ResilienceContextFactory.cs
+++ b/src/Polly/Utilities/Wrappers/ResilienceContextFactory.cs
@@ -1,5 +1,3 @@
-using Polly.Utils;
-
 namespace Polly.Utilities.Wrappers;
 
 internal static class ResilienceContextFactory

--- a/test/Polly.Core.Tests/CircuitBreaker/OnCircuitHalfOpenedArgumentsTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/OnCircuitHalfOpenedArgumentsTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using Polly.CircuitBreaker;
 
 namespace Polly.Core.Tests.CircuitBreaker;

--- a/test/Polly.Core.Tests/Utils/LegacySupportTests.cs
+++ b/test/Polly.Core.Tests/Utils/LegacySupportTests.cs
@@ -1,5 +1,3 @@
-using Polly.Utils;
-
 namespace Polly.Core.Tests.Utils;
 
 public class LegacySupportTests

--- a/test/Polly.Extensions.Tests/DependencyInjection/PollyDependencyInjectionKeysTests.cs
+++ b/test/Polly.Extensions.Tests/DependencyInjection/PollyDependencyInjectionKeysTests.cs
@@ -1,4 +1,4 @@
-using Polly.Extensions.DependencyInjection;
+using Polly.DependencyInjection;
 
 namespace Polly.Extensions.Tests.DependencyInjection;
 

--- a/test/Polly.Extensions.Tests/DependencyInjection/PollyServiceCollectionExtensionTests.cs
+++ b/test/Polly.Extensions.Tests/DependencyInjection/PollyServiceCollectionExtensionTests.cs
@@ -2,8 +2,7 @@ using System.Globalization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
-using Polly.Extensions.DependencyInjection;
-using Polly.Extensions.Telemetry;
+using Polly.DependencyInjection;
 using Polly.Registry;
 using Polly.Telemetry;
 

--- a/test/Polly.Extensions.Tests/Issues/IssuesTests.OnCircuitBreakWithServiceProvider_796.cs
+++ b/test/Polly.Extensions.Tests/Issues/IssuesTests.OnCircuitBreakWithServiceProvider_796.cs
@@ -1,6 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Polly.CircuitBreaker;
-using Polly.Extensions.DependencyInjection;
+using Polly.DependencyInjection;
 using Polly.Registry;
 
 namespace Polly.Extensions.Tests.Issues;

--- a/test/Polly.Extensions.Tests/Issues/IssuesTests.OverrideLibraryStrategies_1072.cs
+++ b/test/Polly.Extensions.Tests/Issues/IssuesTests.OverrideLibraryStrategies_1072.cs
@@ -1,6 +1,7 @@
 using System.Net.Sockets;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Polly.DependencyInjection;
 using Polly.Registry;
 
 namespace Polly.Extensions.Tests.Issues;

--- a/test/Polly.Extensions.Tests/Issues/IssuesTests.OverrideLibraryStrategies_1072.cs
+++ b/test/Polly.Extensions.Tests/Issues/IssuesTests.OverrideLibraryStrategies_1072.cs
@@ -1,7 +1,6 @@
 using System.Net.Sockets;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Polly.DependencyInjection;
 using Polly.Registry;
 
 namespace Polly.Extensions.Tests.Issues;

--- a/test/Polly.Extensions.Tests/Issues/IssuesTests.PartitionedRateLimiter_1365.cs
+++ b/test/Polly.Extensions.Tests/Issues/IssuesTests.PartitionedRateLimiter_1365.cs
@@ -1,6 +1,5 @@
 using System.Threading.RateLimiting;
 using Microsoft.Extensions.DependencyInjection;
-using Polly.DependencyInjection;
 using Polly.RateLimiting;
 using Polly.Registry;
 

--- a/test/Polly.Extensions.Tests/Issues/IssuesTests.PartitionedRateLimiter_1365.cs
+++ b/test/Polly.Extensions.Tests/Issues/IssuesTests.PartitionedRateLimiter_1365.cs
@@ -1,5 +1,6 @@
 using System.Threading.RateLimiting;
 using Microsoft.Extensions.DependencyInjection;
+using Polly.DependencyInjection;
 using Polly.RateLimiting;
 using Polly.Registry;
 

--- a/test/Polly.Extensions.Tests/Issues/IssuesTests.StrategiesPerEndpoint_1365.cs
+++ b/test/Polly.Extensions.Tests/Issues/IssuesTests.StrategiesPerEndpoint_1365.cs
@@ -3,7 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.RateLimiting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Polly.Extensions.Registry;
 using Polly.Registry;
 using Polly.Retry;
 using Polly.Timeout;

--- a/test/Polly.Extensions.Tests/Issues/IssuesTests.StrategiesPerEndpoint_1365.cs
+++ b/test/Polly.Extensions.Tests/Issues/IssuesTests.StrategiesPerEndpoint_1365.cs
@@ -1,8 +1,8 @@
-﻿using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Threading.RateLimiting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Polly.DependencyInjection;
 using Polly.Registry;
 using Polly.Retry;
 using Polly.Timeout;

--- a/test/Polly.Extensions.Tests/ReloadableResilienceStrategyTests.cs
+++ b/test/Polly.Extensions.Tests/ReloadableResilienceStrategyTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Polly.DependencyInjection;
 using Polly.Registry;
 
 namespace Polly.Extensions.Tests;

--- a/test/Polly.Extensions.Tests/Telemetry/EnrichmentContextTests.cs
+++ b/test/Polly.Extensions.Tests/Telemetry/EnrichmentContextTests.cs
@@ -1,4 +1,4 @@
-using Polly.Extensions.Telemetry;
+using Polly.Telemetry;
 
 namespace Polly.Extensions.Tests.Telemetry;
 

--- a/test/Polly.Extensions.Tests/Telemetry/ResilienceTelemetryDiagnosticSourceTests.cs
+++ b/test/Polly.Extensions.Tests/Telemetry/ResilienceTelemetryDiagnosticSourceTests.cs
@@ -1,6 +1,5 @@
 using System.Net.Http;
 using Microsoft.Extensions.Logging;
-using Polly.Extensions.Telemetry;
 using Polly.Telemetry;
 
 namespace Polly.Extensions.Tests.Telemetry;

--- a/test/Polly.Extensions.Tests/Telemetry/TelemetryCompositeStrategyBuilderExtensionsTests.cs
+++ b/test/Polly.Extensions.Tests/Telemetry/TelemetryCompositeStrategyBuilderExtensionsTests.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.Extensions.Logging.Abstractions;
-using Polly.Extensions.Telemetry;
+using Polly.Telemetry;
 
 namespace Polly.Extensions.Tests.Telemetry;
 

--- a/test/Polly.Extensions.Tests/Telemetry/TelemetryOptionsTests.cs
+++ b/test/Polly.Extensions.Tests/Telemetry/TelemetryOptionsTests.cs
@@ -1,7 +1,7 @@
 using System.Net;
 using System.Net.Http;
 using Microsoft.Extensions.Logging.Abstractions;
-using Polly.Extensions.Telemetry;
+using Polly.Telemetry;
 
 namespace Polly.Extensions.Tests.Telemetry;
 

--- a/test/Polly.Extensions.Tests/Telemetry/TelemetryResilienceStrategyTests.cs
+++ b/test/Polly.Extensions.Tests/Telemetry/TelemetryResilienceStrategyTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.Logging;
-using Polly.Extensions.Telemetry;
 using Polly.Telemetry;
 
 namespace Polly.Extensions.Tests.Telemetry;

--- a/test/Polly.Extensions.Tests/Utils/OptionsReloadHelperTests.cs
+++ b/test/Polly.Extensions.Tests/Utils/OptionsReloadHelperTests.cs
@@ -1,6 +1,6 @@
 using Microsoft.Extensions.Options;
 using Moq;
-using Polly.Extensions.Utils;
+using Polly.Utils;
 
 namespace Polly.Extensions.Tests.Utils;
 

--- a/test/Polly.Extensions.Tests/Utils/TelemetryUtilTests.cs
+++ b/test/Polly.Extensions.Tests/Utils/TelemetryUtilTests.cs
@@ -1,4 +1,4 @@
-﻿using Polly.Extensions.Telemetry;
+﻿using Polly.Telemetry;
 
 namespace Polly.Extensions.Tests.Utils;
 

--- a/test/Polly.RateLimiting.Tests/ResilienceRateLimiterTests.cs
+++ b/test/Polly.RateLimiting.Tests/ResilienceRateLimiterTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Threading.RateLimiting;
-using System.Threading.Tasks;
 using Moq;
 using Moq.Protected;
 

--- a/test/Polly.Testing.Tests/ResilienceStrategyExtensionsTests.cs
+++ b/test/Polly.Testing.Tests/ResilienceStrategyExtensionsTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using FluentAssertions;
-using Microsoft.Extensions.Logging.Abstractions;
+﻿using Microsoft.Extensions.Logging.Abstractions;
 using Polly.CircuitBreaker;
 using Polly.Fallback;
 using Polly.Hedging;


### PR DESCRIPTION
### Details on the issue fix or feature implementation


Having `Extensions` in the namespace feels unnecessary. New namespaces:

- `Polly.Extensions.Telemetry` -> `Polly.Telemetry`
- `Polly.Extensions.DependencyInjection` -> `Polly.DependencyInjection`

Additionally, I have also moved `Polly.Utils.LegacySupport` to `Polly.LegacySupport` so the `Utils` namespace is not exposed.

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
