### PR TITLE
Remove Moq

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="MinVer" Version="4.3.0" />
-    <PackageVersion Include="Moq" Version="4.18.4" />
+    <PackageVersion Include="NSubstitute" Version="5.0.0" />
     <PackageVersion Include="Polly" Version="$(PollyVersion)" />
     <PackageVersion Include="Polly.Core" Version="$(PollyVersion)" />
     <PackageVersion Include="Polly.Extensions" Version="$(PollyVersion)" />

--- a/eng/Test.targets
+++ b/eng/Test.targets
@@ -15,7 +15,7 @@
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="GitHubActionsTestLogger" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Moq" />
+    <PackageReference Include="NSubstitute" />
     <PackageReference Include="ReportGenerator" PrivateAssets="all" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />

--- a/test/Polly.Core.Tests/CompositeStrategyBuilderContextTests.cs
+++ b/test/Polly.Core.Tests/CompositeStrategyBuilderContextTests.cs
@@ -1,5 +1,5 @@
 using Microsoft.Extensions.Time.Testing;
-using Moq;
+using NSubstitute;
 
 namespace Polly.Core.Tests;
 
@@ -10,7 +10,7 @@ public class CompositeStrategyBuilderContextTests
     {
         var properties = new ResilienceProperties();
         var timeProvider = new FakeTimeProvider();
-        var context = new StrategyBuilderContext("builder-name", "instance", properties, "strategy-name", timeProvider, Mock.Of<DiagnosticSource>(), () => 1.0);
+        var context = new StrategyBuilderContext("builder-name", "instance", properties, "strategy-name", timeProvider, Substitute.For<DiagnosticSource>(), () => 1.0);
 
         context.BuilderName.Should().Be("builder-name");
         context.BuilderInstanceName.Should().Be("instance");

--- a/test/Polly.Core.Tests/CompositeStrategyBuilderTests.cs
+++ b/test/Polly.Core.Tests/CompositeStrategyBuilderTests.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.Extensions.Time.Testing;
-using Moq;
+using NSubstitute;
 using Polly.Retry;
 using Polly.Utils;
 
@@ -24,10 +24,10 @@ public class CompositeStrategyBuilderTests
     {
         var builder = new CompositeStrategyBuilder
         {
-            TimeProvider = Mock.Of<TimeProvider>(),
+            TimeProvider = Substitute.For<TimeProvider>(),
             Name = "dummy",
             Randomizer = () => 0.0,
-            DiagnosticSource = Mock.Of<DiagnosticSource>(),
+            DiagnosticSource = Substitute.For<DiagnosticSource>(),
             OnCreatingStrategy = _ => { },
         };
 

--- a/test/Polly.Core.Tests/Telemetry/TelemetryUtilTests.cs
+++ b/test/Polly.Core.Tests/Telemetry/TelemetryUtilTests.cs
@@ -1,4 +1,4 @@
-using Moq;
+using NSubstitute;
 using Polly.Telemetry;
 
 namespace Polly.Core.Tests.Telemetry;
@@ -20,7 +20,7 @@ public class TelemetryUtilTests
     public void CreateResilienceTelemetry_DiagnosticSourceFromProperties_Ok()
     {
         var props = new ResilienceProperties();
-        var source = Mock.Of<DiagnosticSource>();
+        var source = Substitute.For<DiagnosticSource>();
 
         var telemetry = TelemetryUtil.CreateTelemetry(source, "builder", "instance", props, "strategy-name");
 

--- a/test/Polly.Core.Tests/Timeout/TimeoutResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Timeout/TimeoutResilienceStrategyTests.cs
@@ -1,5 +1,5 @@
 using Microsoft.Extensions.Time.Testing;
-using Moq;
+using NSubstitute;
 using Polly.Telemetry;
 using Polly.Timeout;
 
@@ -13,11 +13,11 @@ public class TimeoutResilienceStrategyTests : IDisposable
     private readonly CancellationTokenSource _cancellationSource;
     private readonly TimeSpan _delay = TimeSpan.FromSeconds(12);
 
-    private readonly Mock<DiagnosticSource> _diagnosticSource = new();
+    private readonly DiagnosticSource _diagnosticSource = Substitute.For<DiagnosticSource>();
 
     public TimeoutResilienceStrategyTests()
     {
-        _telemetry = TestUtilities.CreateResilienceTelemetry(_diagnosticSource.Object);
+        _telemetry = TestUtilities.CreateResilienceTelemetry(_diagnosticSource);
         _options = new TimeoutStrategyOptions();
         _cancellationSource = new CancellationTokenSource();
     }
@@ -52,7 +52,7 @@ public class TimeoutResilienceStrategyTests : IDisposable
     [Fact]
     public async Task Execute_EnsureOnTimeoutCalled()
     {
-        _diagnosticSource.Setup(v => v.IsEnabled("OnTimeout")).Returns(true);
+        _diagnosticSource.IsEnabled("OnTimeout").Returns(true);
 
         var called = false;
         SetTimeout(_delay);
@@ -78,7 +78,7 @@ public class TimeoutResilienceStrategyTests : IDisposable
         .AsTask()).Should().ThrowAsync<TimeoutRejectedException>();
 
         called.Should().BeTrue();
-        _diagnosticSource.VerifyAll();
+        _diagnosticSource.Received().IsEnabled("OnTimeout");
     }
 
     [MemberData(nameof(Execute_NoTimeout_Data))]
@@ -164,7 +164,7 @@ public class TimeoutResilienceStrategyTests : IDisposable
 
         onTimeoutCalled.Should().BeFalse();
 
-        _diagnosticSource.Verify(v => v.IsEnabled("OnTimeout"), Times.Never());
+        _diagnosticSource.DidNotReceive().IsEnabled("OnTimeout");
     }
 
     [Fact]
@@ -202,16 +202,15 @@ public class TimeoutResilienceStrategyTests : IDisposable
 
         var sut = CreateSut();
 
-        var mockSynchronizationContext = new Mock<SynchronizationContext>(MockBehavior.Strict);
+        var mockSynchronizationContext = Substitute.For<SynchronizationContext>();
         mockSynchronizationContext
-            .Setup(x => x.Post(It.IsAny<SendOrPostCallback>(), It.IsAny<object>()))
-            .Callback<SendOrPostCallback, object>((callback, state) => callback(state));
+            .When(x => x.Post(Arg.Any<SendOrPostCallback>(), Arg.Any<object>()))
+            .Do((p) => ((SendOrPostCallback)p[1])(p[2]));
 
-        mockSynchronizationContext
-            .Setup(x => x.CreateCopy())
-            .Returns(mockSynchronizationContext.Object);
+        mockSynchronizationContext.CreateCopy()
+            .Returns(mockSynchronizationContext);
 
-        SynchronizationContext.SetSynchronizationContext(mockSynchronizationContext.Object);
+        SynchronizationContext.SetSynchronizationContext(mockSynchronizationContext);
 
         // Act
         try
@@ -230,7 +229,7 @@ public class TimeoutResilienceStrategyTests : IDisposable
         }
 
         // Assert
-        mockSynchronizationContext.Verify(x => x.Post(It.IsAny<SendOrPostCallback>(), It.IsAny<object>()), Times.Never());
+        mockSynchronizationContext.DidNotReceiveWithAnyArgs().Post(default!, default);
     }
 
     private void SetTimeout(TimeSpan timeout) => _options.TimeoutGenerator = args => new ValueTask<TimeSpan>(timeout);

--- a/test/Polly.Core.Tests/Utils/CancellationTokenSourcePoolTests.cs
+++ b/test/Polly.Core.Tests/Utils/CancellationTokenSourcePoolTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.Time.Testing;
-using Moq;
 using Polly.Utils;
 
 namespace Polly.Core.Tests.Utils;
@@ -93,9 +92,5 @@ public class CancellationTokenSourcePoolTests
         cts.IsCancellationRequested.Should().BeFalse();
     }
 
-    private static TimeProvider GetTimeProvider(object timeProvider) => timeProvider switch
-    {
-        Mock<TimeProvider> m => m.Object,
-        _ => (TimeProvider)timeProvider
-    };
+    private static TimeProvider GetTimeProvider(object timeProvider) => (TimeProvider)timeProvider;
 }

--- a/test/Polly.Extensions.Tests/Utils/OptionsReloadHelperTests.cs
+++ b/test/Polly.Extensions.Tests/Utils/OptionsReloadHelperTests.cs
@@ -1,5 +1,5 @@
 using Microsoft.Extensions.Options;
-using Moq;
+using NSubstitute;
 using Polly.Utils;
 
 namespace Polly.Extensions.Tests.Utils;
@@ -9,14 +9,14 @@ public class OptionsReloadHelperTests
     [Fact]
     public void Ctor_NamedOptions()
     {
-        var monitor = new Mock<IOptionsMonitor<string>>();
+        var disposable = Substitute.For<IDisposable>();
+        var monitor = Substitute.For<IOptionsMonitor<string>>();
 
-        monitor
-            .Setup(m => m.OnChange(It.IsAny<Action<string, string?>>()))
-            .Returns(() => Mock.Of<IDisposable>());
+        monitor.OnChange(Arg.Any<Action<string, string?>>())
+               .Returns(disposable);
 
-        var helper = new OptionsReloadHelper<string>(monitor.Object, "name");
+        var helper = new OptionsReloadHelper<string>(monitor, "name");
 
-        monitor.VerifyAll();
+        monitor.Received().OnChange(Arg.Any<Action<string, string?>>());
     }
 }

--- a/test/Polly.RateLimiting.Tests/OnRateLimiterRejectedArgumentsTests.cs
+++ b/test/Polly.RateLimiting.Tests/OnRateLimiterRejectedArgumentsTests.cs
@@ -1,5 +1,5 @@
 using System.Threading.RateLimiting;
-using Moq;
+using NSubstitute;
 
 namespace Polly.RateLimiting.Tests;
 
@@ -8,7 +8,7 @@ public class OnRateLimiterRejectedArgumentsTests
     [Fact]
     public void Ctor_Ok()
     {
-        var args = new OnRateLimiterRejectedArguments(ResilienceContextPool.Shared.Get(), Mock.Of<RateLimitLease>(), TimeSpan.FromSeconds(1));
+        var args = new OnRateLimiterRejectedArguments(ResilienceContextPool.Shared.Get(), Substitute.For<RateLimitLease>(), TimeSpan.FromSeconds(1));
 
         args.Context.Should().NotBeNull();
         args.Lease.Should().NotBeNull();

--- a/test/Polly.RateLimiting.Tests/RateLimiterCompositeStrategyBuilderExtensionsTests.cs
+++ b/test/Polly.RateLimiting.Tests/RateLimiterCompositeStrategyBuilderExtensionsTests.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Threading.RateLimiting;
-using Moq;
+using NSubstitute;
 
 namespace Polly.RateLimiting.Tests;
 
@@ -26,7 +26,7 @@ public class RateLimiterCompositeStrategyBuilderExtensionsTests
         },
         builder =>
         {
-            var expected = Mock.Of<RateLimiter>();
+            var expected = Substitute.For<RateLimiter>();
             builder.AddRateLimiter(expected);
             AssertRateLimiter(builder, hasEvents: false, limiter => limiter.Should().Be(expected));
         }
@@ -123,7 +123,7 @@ public class RateLimiterCompositeStrategyBuilderExtensionsTests
         var strategy = new CompositeStrategyBuilder()
             .AddRateLimiter(new RateLimiterStrategyOptions
             {
-                RateLimiter = ResilienceRateLimiter.Create(Mock.Of<RateLimiter>())
+                RateLimiter = ResilienceRateLimiter.Create(Substitute.For<RateLimiter>())
             })
             .Build();
 
@@ -139,7 +139,7 @@ public class RateLimiterCompositeStrategyBuilderExtensionsTests
         {
             strategy.OnLeaseRejected.Should().NotBeNull();
             strategy
-                .OnLeaseRejected!(new OnRateLimiterRejectedArguments(ResilienceContextPool.Shared.Get(), Mock.Of<RateLimitLease>(), null))
+                .OnLeaseRejected!(new OnRateLimiterRejectedArguments(ResilienceContextPool.Shared.Get(), Substitute.For<RateLimitLease>(), null))
                 .Preserve().GetAwaiter().GetResult();
         }
         else
@@ -159,7 +159,7 @@ public class RateLimiterCompositeStrategyBuilderExtensionsTests
         {
             strategy.OnLeaseRejected.Should().NotBeNull();
             strategy
-                .OnLeaseRejected!(new OnRateLimiterRejectedArguments(ResilienceContextPool.Shared.Get(), Mock.Of<RateLimitLease>(), null))
+                .OnLeaseRejected!(new OnRateLimiterRejectedArguments(ResilienceContextPool.Shared.Get(), Substitute.For<RateLimitLease>(), null))
                 .Preserve().GetAwaiter().GetResult();
         }
         else

--- a/test/Polly.RateLimiting.Tests/RateLimiterResilienceStrategyTests.cs
+++ b/test/Polly.RateLimiting.Tests/RateLimiterResilienceStrategyTests.cs
@@ -1,14 +1,13 @@
 using System.Threading.RateLimiting;
-using Moq;
-using Moq.Protected;
+using NSubstitute;
 
 namespace Polly.RateLimiting.Tests;
 
 public class RateLimiterResilienceStrategyTests
 {
-    private readonly Mock<RateLimiter> _limiter = new(MockBehavior.Strict);
-    private readonly Mock<RateLimitLease> _lease = new(MockBehavior.Strict);
-    private readonly Mock<DiagnosticSource> _diagnosticSource = new();
+    private readonly RateLimiter _limiter = Substitute.For<RateLimiter>();
+    private readonly RateLimitLease _lease = Substitute.For<RateLimitLease>();
+    private readonly DiagnosticSource _diagnosticSource = Substitute.For<DiagnosticSource>();
     private Func<OnRateLimiterRejectedArguments, ValueTask>? _event;
 
     [Fact]
@@ -18,14 +17,13 @@ public class RateLimiterResilienceStrategyTests
     }
 
     [Fact]
-    public void Execute_HappyPath()
+    public async Task Execute_HappyPath()
     {
         using var cts = new CancellationTokenSource();
 
         SetupLimiter(cts.Token);
 
-        _lease.Setup(v => v.IsAcquired).Returns(true);
-        _lease.Protected().Setup("Dispose", exactParameterMatch: true, true);
+        _lease.IsAcquired.Returns(true);
 
         Create().Should().NotBeNull();
 
@@ -33,8 +31,8 @@ public class RateLimiterResilienceStrategyTests
 
         strategy.Execute(_ => { }, cts.Token);
 
-        _limiter.VerifyAll();
-        _lease.VerifyAll();
+        await _limiter.ReceivedWithAnyArgs().AcquireAsync(default, default);
+        _lease.Received().Dispose();
     }
 
     [InlineData(false, true)]
@@ -44,8 +42,8 @@ public class RateLimiterResilienceStrategyTests
     [Theory]
     public async Task Execute_LeaseRejected(bool hasEvents, bool hasRetryAfter)
     {
-        _diagnosticSource.Setup(v => v.IsEnabled("OnRateLimiterRejected")).Returns(true);
-        _diagnosticSource.Setup(v => v.Write("OnRateLimiterRejected", It.Is<object>(obj => obj != null)));
+        _diagnosticSource.IsEnabled("OnRateLimiterRejected").Returns(true);
+        _diagnosticSource.Write("OnRateLimiterRejected", Arg.Is<object>(obj => obj != null));
 
         object? metadata = hasRetryAfter ? TimeSpan.FromSeconds(123) : null;
 
@@ -53,16 +51,20 @@ public class RateLimiterResilienceStrategyTests
         var eventCalled = false;
         SetupLimiter(cts.Token);
 
-        _lease.Setup(v => v.IsAcquired).Returns(false);
-        _lease.Protected().Setup("Dispose", exactParameterMatch: true, true);
-        _lease.Setup(v => v.TryGetMetadata("RETRY_AFTER", out metadata)).Returns(hasRetryAfter);
+        _lease.IsAcquired.Returns(false);
+        _lease.TryGetMetadata("RETRY_AFTER", out Arg.Any<object?>())
+              .Returns(x =>
+              {
+                  x[1] = hasRetryAfter ? metadata : null;
+                  return hasRetryAfter;
+              });
 
         if (hasEvents)
         {
             _event = args =>
             {
                 args.Context.Should().NotBeNull();
-                args.Lease.Should().Be(_lease.Object);
+                args.Lease.Should().Be(_lease);
                 args.RetryAfter.Should().Be((TimeSpan?)metadata);
                 eventCalled = true;
                 return default;
@@ -81,29 +83,33 @@ public class RateLimiterResilienceStrategyTests
 
         outcome.Exception!.StackTrace.Should().Contain("Execute_LeaseRejected");
 
-        _limiter.VerifyAll();
-        _lease.VerifyAll();
         eventCalled.Should().Be(hasEvents);
 
-        _diagnosticSource.VerifyAll();
+        await _limiter.ReceivedWithAnyArgs().AcquireAsync(default, default);
+        _lease.Received().Dispose();
     }
 
-    private void SetupLimiter(CancellationToken token) => _limiter
-                .Protected()
-                .Setup<ValueTask<RateLimitLease>>("AcquireAsyncCore", 1, token)
-                .Returns(new ValueTask<RateLimitLease>(_lease.Object));
+    private void SetupLimiter(CancellationToken token)
+    {
+        var result = new ValueTask<RateLimitLease>(_lease);
+        _limiter
+            .GetType()
+            .GetMethod("AcquireAsyncCore", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(_limiter, new object[] { 1, token })
+            .Returns(result);
+    }
 
     private RateLimiterResilienceStrategy Create()
     {
         var builder = new CompositeStrategyBuilder
         {
-            DiagnosticSource = _diagnosticSource.Object
+            DiagnosticSource = _diagnosticSource
         };
 
         return (RateLimiterResilienceStrategy)builder
             .AddRateLimiter(new RateLimiterStrategyOptions
             {
-                RateLimiter = ResilienceRateLimiter.Create(_limiter.Object),
+                RateLimiter = ResilienceRateLimiter.Create(_limiter),
                 OnRejected = _event
             })
             .Build();

--- a/test/Polly.RateLimiting.Tests/ResilienceRateLimiterTests.cs
+++ b/test/Polly.RateLimiting.Tests/ResilienceRateLimiterTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Threading.RateLimiting;
-using Moq;
-using Moq.Protected;
+using NSubstitute;
 
 namespace Polly.RateLimiting.Tests;
 
@@ -9,29 +8,40 @@ public class ResilienceRateLimiterTests
     [Fact]
     public async Task Create_RateLimiter_Ok()
     {
-        var lease = Mock.Of<RateLimitLease>();
-        var limiterMock = new Mock<RateLimiter>(MockBehavior.Strict);
-        limiterMock.Protected().Setup<ValueTask<RateLimitLease>>("AcquireAsyncCore", 1, default(CancellationToken)).ReturnsAsync(lease);
+        var lease = Substitute.For<RateLimitLease>();
+        var leaseTask = new ValueTask<RateLimitLease>(lease);
 
-        var limiter = ResilienceRateLimiter.Create(limiterMock.Object);
+        var rateLimiter = Substitute.For<RateLimiter>();
+        rateLimiter
+            .GetType()
+            .GetMethod("AcquireAsyncCore", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(rateLimiter, new object[] { 1, default(CancellationToken) })
+            .Returns(leaseTask);
+
+        var limiter = ResilienceRateLimiter.Create(rateLimiter);
 
         (await limiter.AcquireAsync(ResilienceContextPool.Shared.Get())).Should().Be(lease);
         limiter.Limiter.Should().NotBeNull();
-        limiterMock.VerifyAll();
     }
 
     [Fact]
     public async Task Create_PartitionedRateLimiter_Ok()
     {
         var context = ResilienceContextPool.Shared.Get();
-        var lease = Mock.Of<RateLimitLease>();
-        var limiterMock = new Mock<PartitionedRateLimiter<ResilienceContext>>(MockBehavior.Strict);
-        limiterMock.Protected().Setup<ValueTask<RateLimitLease>>("AcquireAsyncCore", context, 1, default(CancellationToken)).ReturnsAsync(lease);
 
-        var limiter = ResilienceRateLimiter.Create(limiterMock.Object);
+        var lease = Substitute.For<RateLimitLease>();
+        var leaseTask = new ValueTask<RateLimitLease>(lease);
+
+        var rateLimiter = Substitute.For<PartitionedRateLimiter<ResilienceContext>>();
+        rateLimiter
+            .GetType()
+            .GetMethod("AcquireAsyncCore", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(rateLimiter, new object[] { context, 1, default(CancellationToken) })
+            .Returns(leaseTask);
+
+        var limiter = ResilienceRateLimiter.Create(rateLimiter);
 
         (await limiter.AcquireAsync(context)).Should().Be(lease);
         limiter.PartitionedLimiter.Should().NotBeNull();
-        limiterMock.VerifyAll();
     }
 }

--- a/test/Polly.Specs/Polly.Specs.csproj
+++ b/test/Polly.Specs/Polly.Specs.csproj
@@ -17,7 +17,7 @@
     <Using Include="FluentAssertions" />
     <Using Include="FluentAssertions.Execution" />
     <Using Include="FluentAssertions.Extensions" />
-    <Using Include="Moq" />
+    <Using Include="NSubstitute" />
     <Using Include="Polly.Specs.Helpers" />
     <Using Include="Polly.Specs.Helpers.Bulkhead" />
     <Using Include="Polly.Specs.Helpers.Caching" />

--- a/test/Polly.Specs/Registry/PolicyRegistrySpecs.cs
+++ b/test/Polly.Specs/Registry/PolicyRegistrySpecs.cs
@@ -442,13 +442,13 @@ public class PolicyRegistrySpecs
     [Fact]
     public void Constructor_Called_With_A_Registry_Parameter_Should_Assign_The_Passed_In_Registry_To_The_Registry_Field()
     {
-        var testDictionary = new Mock<IDictionary<string, IsPolicy>>();
-        var testRegistry = new PolicyRegistry(testDictionary.Object);
+        var testDictionary = Substitute.For<IDictionary<string, IsPolicy>>();
+        var testRegistry = new PolicyRegistry(testDictionary);
 
         // Generally, using reflection is a bad practice, but we are accepting it given we own the implementation.
         var registryField = typeof(PolicyRegistry).GetField("_registry", BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance)!;
         var registryFieldValue = registryField.GetValue(testRegistry);
-        registryFieldValue.Should().Be(testDictionary.Object);
+        registryFieldValue.Should().Be(testDictionary);
     }
 
     [Fact]

--- a/test/Polly.Specs/Registry/ReadOnlyPolicyRegistrySpecs.cs
+++ b/test/Polly.Specs/Registry/ReadOnlyPolicyRegistrySpecs.cs
@@ -256,12 +256,12 @@ public class ReadOnlyPolicyRegistrySpecs
     [Fact]
     public void Calling_The_GetEnumerator_Method_Returning_A_IEnumerator_Of_KeyValuePair_Of_String_And_IsPolicy_Calls_The_Registrys_GetEnumerator_Method()
     {
-        var testDictionary = new Mock<IDictionary<string, IsPolicy>>();
-        var testRegistry = new PolicyRegistry(testDictionary.Object);
+        var testDictionary = Substitute.For<IDictionary<string, IsPolicy>>();
+        var testRegistry = new PolicyRegistry(testDictionary);
 
         testRegistry.GetEnumerator();
 
-        testDictionary.Verify(x => x.GetEnumerator(), Times.Once);
+        testDictionary.Received(1).GetEnumerator();
     }
 
     #endregion

--- a/test/Polly.TestUtils/Polly.TestUtils.csproj
+++ b/test/Polly.TestUtils/Polly.TestUtils.csproj
@@ -13,6 +13,6 @@
     <Using Remove="System.Net.Http" />
     <ProjectReference Include="..\..\src\Polly.Core\Polly.Core.csproj" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
-    <PackageReference Include="Moq" />
+    <PackageReference Include="NSubstitute" />
   </ItemGroup>
 </Project>

--- a/test/Polly.TestUtils/TestUtilities.cs
+++ b/test/Polly.TestUtils/TestUtilities.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics.Metrics;
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 using Polly.Telemetry;
 
 namespace Polly.TestUtils;
@@ -46,11 +46,10 @@ public static class TestUtilities
     public static ILoggerFactory CreateLoggerFactory(out FakeLogger logger)
     {
         logger = new FakeLogger();
-        var loggerFactory = new Mock<ILoggerFactory>(MockBehavior.Strict);
-        loggerFactory.Setup(v => v.CreateLogger("Polly")).Returns(logger);
-        loggerFactory.Setup(v => v.Dispose());
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        loggerFactory.CreateLogger("Polly").Returns(logger);
 
-        return loggerFactory.Object;
+        return loggerFactory;
     }
 
     public static IDisposable EnablePollyMetering(ICollection<MeteringEvent> events)


### PR DESCRIPTION
Removes Moq and replaces it with NSubstitute.

~~May need some tweaks to mutations and/or coverage as the previous strict mock behaviour isn't available to use.~~

Resolves #1470.
