### PR TITLE
Default names for individual resilience strategies

### DIFF
--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerConstants.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerConstants.cs
@@ -2,6 +2,8 @@ namespace Polly.CircuitBreaker;
 
 internal static class CircuitBreakerConstants
 {
+    public const string DefaultName = "CircuitBreaker";
+
     public const string OnCircuitClosed = "OnCircuitClosed";
 
     public const string OnHalfOpenEvent = "OnCircuitHalfOpened";

--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerStrategyOptions.TResult.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerStrategyOptions.TResult.cs
@@ -23,6 +23,11 @@ namespace Polly.CircuitBreaker;
 public class CircuitBreakerStrategyOptions<TResult> : ResilienceStrategyOptions
 {
     /// <summary>
+    /// Initializes a new instance of the <see cref="CircuitBreakerStrategyOptions{TResult}"/> class.
+    /// </summary>
+    public CircuitBreakerStrategyOptions() => Name = CircuitBreakerConstants.DefaultName;
+
+    /// <summary>
     /// Gets or sets the failure-to-success ratio at which the circuit will break.
     /// </summary>
     /// <remarks>

--- a/src/Polly.Core/Fallback/FallbackConstants.cs
+++ b/src/Polly.Core/Fallback/FallbackConstants.cs
@@ -2,6 +2,8 @@ namespace Polly.Fallback;
 
 internal static class FallbackConstants
 {
+    public const string DefaultName = "Fallback";
+
     public const string OnFallback = "OnFallback";
 }
 

--- a/src/Polly.Core/Fallback/FallbackStrategyOptions.TResult.cs
+++ b/src/Polly.Core/Fallback/FallbackStrategyOptions.TResult.cs
@@ -9,6 +9,11 @@ namespace Polly.Fallback;
 public class FallbackStrategyOptions<TResult> : ResilienceStrategyOptions
 {
     /// <summary>
+    /// Initializes a new instance of the <see cref="FallbackStrategyOptions{TResult}"/> class.
+    /// </summary>
+    public FallbackStrategyOptions() => Name = FallbackConstants.DefaultName;
+
+    /// <summary>
     /// Gets or sets the outcome predicate for determining whether a fallback should be executed.
     /// </summary>
     /// <value>

--- a/src/Polly.Core/Hedging/HedgingConstants.cs
+++ b/src/Polly.Core/Hedging/HedgingConstants.cs
@@ -2,6 +2,8 @@ namespace Polly.Hedging;
 
 internal static class HedgingConstants
 {
+    public const string DefaultName = "Hedging";
+
     public const string OnHedgingEventName = "OnHedging";
 
     public const int DefaultMaxHedgedAttempts = 2;

--- a/src/Polly.Core/Hedging/HedgingStrategyOptions.TResult.cs
+++ b/src/Polly.Core/Hedging/HedgingStrategyOptions.TResult.cs
@@ -9,6 +9,11 @@ namespace Polly.Hedging;
 public class HedgingStrategyOptions<TResult> : ResilienceStrategyOptions
 {
     /// <summary>
+    /// Initializes a new instance of the <see cref="HedgingStrategyOptions{TResult}"/> class.
+    /// </summary>
+    public HedgingStrategyOptions() => Name = HedgingConstants.DefaultName;
+
+    /// <summary>
     /// Gets or sets the minimal time of waiting before spawning a new hedged call.
     /// </summary>
     /// <remarks>

--- a/src/Polly.Core/Retry/RetryConstants.cs
+++ b/src/Polly.Core/Retry/RetryConstants.cs
@@ -2,6 +2,8 @@ namespace Polly.Retry;
 
 internal static class RetryConstants
 {
+    public const string DefaultName = "Retry";
+
     public const string OnRetryEvent = "OnRetry";
 
     public const RetryBackoffType DefaultBackoffType = RetryBackoffType.Constant;

--- a/src/Polly.Core/Retry/RetryStrategyOptions.TResult.cs
+++ b/src/Polly.Core/Retry/RetryStrategyOptions.TResult.cs
@@ -9,6 +9,11 @@ namespace Polly.Retry;
 public class RetryStrategyOptions<TResult> : ResilienceStrategyOptions
 {
     /// <summary>
+    /// Initializes a new instance of the <see cref="RetryStrategyOptions{TResult}"/> class.
+    /// </summary>
+    public RetryStrategyOptions() => Name = RetryConstants.DefaultName;
+
+    /// <summary>
     /// Gets or sets the maximum number of retries to use, in addition to the original call.
     /// </summary>
     /// <value>

--- a/src/Polly.Core/Timeout/TimeoutConstants.cs
+++ b/src/Polly.Core/Timeout/TimeoutConstants.cs
@@ -2,5 +2,7 @@ namespace Polly.Timeout;
 
 internal static class TimeoutConstants
 {
+    public const string DefaultName = "Timeout";
+
     public const string OnTimeoutEvent = "OnTimeout";
 }

--- a/src/Polly.Core/Timeout/TimeoutStrategyOptions.cs
+++ b/src/Polly.Core/Timeout/TimeoutStrategyOptions.cs
@@ -7,6 +7,11 @@ namespace Polly.Timeout;
 /// </summary>
 public class TimeoutStrategyOptions : ResilienceStrategyOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TimeoutStrategyOptions"/> class.
+    /// </summary>
+    public TimeoutStrategyOptions() => Name = TimeoutConstants.DefaultName;
+
 #pragma warning disable IL2026 // Addressed with DynamicDependency on ValidationHelper.Validate method
     /// <summary>
     /// Gets or sets the default timeout.

--- a/src/Polly.RateLimiting/RateLimiterConstants.cs
+++ b/src/Polly.RateLimiting/RateLimiterConstants.cs
@@ -2,6 +2,8 @@ namespace Polly.RateLimiting;
 
 internal static class RateLimiterConstants
 {
+    public const string DefaultName = "RateLimiter";
+
     public const int DefaultPermitLimit = 1000;
 
     public const int DefaultQueueLimit = 0;

--- a/src/Polly.RateLimiting/RateLimiterStrategyOptions.cs
+++ b/src/Polly.RateLimiting/RateLimiterStrategyOptions.cs
@@ -9,6 +9,11 @@ namespace Polly.RateLimiting;
 public class RateLimiterStrategyOptions : ResilienceStrategyOptions
 {
     /// <summary>
+    /// Initializes a new instance of the <see cref="RateLimiterStrategyOptions"/> class.
+    /// </summary>
+    public RateLimiterStrategyOptions() => Name = RateLimiterConstants.DefaultName;
+
+    /// <summary>
     /// Gets or sets the default rate limiter options.
     /// </summary>
     /// <remarks>

--- a/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerOptionsTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerOptionsTests.cs
@@ -7,29 +7,6 @@ namespace Polly.Core.Tests.CircuitBreaker;
 public class CircuitBreakerOptionsTests
 {
     [Fact]
-    public void Ctor_Defaults()
-    {
-        var options = new CircuitBreakerStrategyOptions();
-        options.BreakDuration.Should().Be(TimeSpan.FromSeconds(5));
-        options.FailureRatio.Should().Be(0.1);
-        options.MinimumThroughput.Should().Be(100);
-        options.SamplingDuration.Should().Be(TimeSpan.FromSeconds(30));
-        options.OnOpened.Should().BeNull();
-        options.OnClosed.Should().BeNull();
-        options.OnHalfOpened.Should().BeNull();
-        options.ShouldHandle.Should().NotBeNull();
-        options.Name.Should().BeNull();
-
-        // now set to min values
-        options.FailureRatio = 0.001;
-        options.BreakDuration = TimeSpan.FromMilliseconds(500);
-        options.MinimumThroughput = 2;
-        options.SamplingDuration = TimeSpan.FromMilliseconds(500);
-
-        ValidationHelper.ValidateObject(new(options, "Dummy."));
-    }
-
-    [Fact]
     public async Task ShouldHandle_EnsureDefaults()
     {
         var options = new CircuitBreakerStrategyOptions();
@@ -42,7 +19,7 @@ public class CircuitBreakerOptionsTests
     }
 
     [Fact]
-    public void Ctor_Generic_Defaults()
+    public void Ctor_Defaults()
     {
         var options = new CircuitBreakerStrategyOptions<int>();
 
@@ -54,7 +31,7 @@ public class CircuitBreakerOptionsTests
         options.OnClosed.Should().BeNull();
         options.OnHalfOpened.Should().BeNull();
         options.ShouldHandle.Should().NotBeNull();
-        options.Name.Should().BeNull();
+        options.Name.Should().Be("CircuitBreaker");
 
         // now set to min values
         options.FailureRatio = 0.001;

--- a/test/Polly.Core.Tests/Fallback/FallbackStrategyOptionsTests.cs
+++ b/test/Polly.Core.Tests/Fallback/FallbackStrategyOptionsTests.cs
@@ -14,6 +14,7 @@ public class FallbackStrategyOptionsTests
         options.ShouldHandle.Should().NotBeNull();
         options.OnFallback.Should().BeNull();
         options.FallbackAction.Should().BeNull();
+        options.Name.Should().Be("Fallback");
     }
 
     [Fact]

--- a/test/Polly.Core.Tests/Hedging/HedgingStrategyOptionsTests.cs
+++ b/test/Polly.Core.Tests/Hedging/HedgingStrategyOptionsTests.cs
@@ -16,6 +16,7 @@ public class HedgingStrategyOptionsTests
         options.HedgingDelay.Should().Be(TimeSpan.FromSeconds(2));
         options.MaxHedgedAttempts.Should().Be(2);
         options.OnHedging.Should().BeNull();
+        options.Name.Should().Be("Hedging");
     }
 
     [InlineData(true)]

--- a/test/Polly.Core.Tests/Retry/RetryStrategyOptionsTests.cs
+++ b/test/Polly.Core.Tests/Retry/RetryStrategyOptionsTests.cs
@@ -20,6 +20,7 @@ public class RetryStrategyOptionsTests
         options.RetryCount.Should().Be(3);
         options.BackoffType.Should().Be(RetryBackoffType.Constant);
         options.BaseDelay.Should().Be(TimeSpan.FromSeconds(2));
+        options.Name.Should().Be("Retry");
     }
 
     [Fact]

--- a/test/Polly.Core.Tests/Timeout/TimeoutStrategyOptionsTests.cs
+++ b/test/Polly.Core.Tests/Timeout/TimeoutStrategyOptionsTests.cs
@@ -13,6 +13,7 @@ public class TimeoutStrategyOptionsTests
 
         options.TimeoutGenerator.Should().BeNull();
         options.OnTimeout.Should().BeNull();
+        options.Name.Should().Be("Timeout");
     }
 
     [MemberData(nameof(TimeoutTestUtils.InvalidTimeouts), MemberType = typeof(TimeoutTestUtils))]

--- a/test/Polly.RateLimiting.Tests/RateLimiterStrategyOptionsTests.cs
+++ b/test/Polly.RateLimiting.Tests/RateLimiterStrategyOptionsTests.cs
@@ -11,5 +11,6 @@ public class RateLimiterStrategyOptionsTests
         options.OnRejected.Should().BeNull();
         options.DefaultRateLimiterOptions.PermitLimit.Should().Be(1000);
         options.DefaultRateLimiterOptions.QueueLimit.Should().Be(0);
+        options.Name.Should().Be("RateLimiter");
     }
 }


### PR DESCRIPTION
### Details on the issue fix or feature implementation

This gives the consumer more details in telemetry in case they do not specify their own telemetry name.
Fixes https://github.com/App-vNext/Polly/pull/1233#discussion_r1276570737

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
