### PR TITLE
Introduce `NonReactiveResilienceStrategy`

### DIFF
--- a/bench/Polly.Core.Benchmarks/TelemetryBenchmark.cs
+++ b/bench/Polly.Core.Benchmarks/TelemetryBenchmark.cs
@@ -66,7 +66,7 @@ public class TelemetryBenchmark
         return builder.Build();
     }
 
-    private class TelemetryEventStrategy : ResilienceStrategy
+    private class TelemetryEventStrategy : NonReactiveResilienceStrategy
     {
         private readonly ResilienceStrategyTelemetry _telemetry;
 

--- a/bench/Polly.Core.Benchmarks/Utils/EmptyResilienceStrategy.cs
+++ b/bench/Polly.Core.Benchmarks/Utils/EmptyResilienceStrategy.cs
@@ -1,6 +1,6 @@
 namespace Polly.Core.Benchmarks.Utils;
 
-internal class EmptyResilienceStrategy : ResilienceStrategy
+internal class EmptyResilienceStrategy : NonReactiveResilienceStrategy
 {
     protected override ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
         Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,

--- a/bench/Polly.Core.Benchmarks/Utils/Helper.CircuitBreaker.cs
+++ b/bench/Polly.Core.Benchmarks/Utils/Helper.CircuitBreaker.cs
@@ -17,7 +17,7 @@ internal static partial class Helper
 
             if (handleOutcome)
             {
-                builder.AddStrategy(new OutcomeHandlingStrategy());
+                builder.AddStrategy(_ => new OutcomeHandlingStrategy(), new EmptyResilienceOptions());
             }
 
             var strategy = builder.AddCircuitBreaker(options).Build();
@@ -64,7 +64,7 @@ internal static partial class Helper
         };
     }
 
-    private class OutcomeHandlingStrategy : ResilienceStrategy
+    private class OutcomeHandlingStrategy : NonReactiveResilienceStrategy
     {
         protected override async ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
             Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,

--- a/bench/Polly.Core.Benchmarks/Utils/Helper.StrategyPipeline.cs
+++ b/bench/Polly.Core.Benchmarks/Utils/Helper.StrategyPipeline.cs
@@ -10,7 +10,7 @@ internal static partial class Helper
         {
             for (var i = 0; i < count; i++)
             {
-                builder.AddStrategy(new EmptyResilienceStrategy());
+                builder.AddStrategy(_ => new EmptyResilienceStrategy(), new EmptyResilienceOptions());
             }
         }),
         _ => throw new NotSupportedException()

--- a/src/Polly.Core/CompositeStrategyBuilderExtensions.cs
+++ b/src/Polly.Core/CompositeStrategyBuilderExtensions.cs
@@ -27,7 +27,8 @@ public static class CompositeStrategyBuilderExtensions
         Guard.NotNull(builder);
         Guard.NotNull(strategy);
 
-        return builder.AddStrategy(_ => strategy, EmptyOptions.Instance);
+        builder.AddStrategyCore(_ => strategy, EmptyOptions.Instance);
+        return builder;
     }
 
     /// <summary>
@@ -59,14 +60,14 @@ public static class CompositeStrategyBuilderExtensions
     /// <exception cref="InvalidOperationException">Thrown when this builder was already used to create a strategy. The builder cannot be modified after it has been used.</exception>
     /// <exception cref="ValidationException">Thrown when <paramref name="options"/> is invalid.</exception>
     [RequiresUnreferencedCode(Constants.OptionsValidation)]
-    public static TBuilder AddStrategy<TBuilder>(this TBuilder builder, Func<StrategyBuilderContext, ResilienceStrategy> factory, ResilienceStrategyOptions options)
+    public static TBuilder AddStrategy<TBuilder>(this TBuilder builder, Func<StrategyBuilderContext, NonReactiveResilienceStrategy> factory, ResilienceStrategyOptions options)
         where TBuilder : CompositeStrategyBuilderBase
     {
         Guard.NotNull(builder);
         Guard.NotNull(factory);
         Guard.NotNull(options);
 
-        builder.AddStrategyCore(factory, options);
+        builder.AddStrategyCore(context => new NonReactiveResilienceStrategyBridge(factory(context)), options);
         return builder;
     }
 

--- a/src/Polly.Core/NonReactiveResilienceStrategy.cs
+++ b/src/Polly.Core/NonReactiveResilienceStrategy.cs
@@ -6,7 +6,7 @@
 public abstract class NonReactiveResilienceStrategy
 {
     /// <summary>
-    /// An implementation of non-reactive resilience strategy that executes the specified <paramref name="callback"/>.
+    /// An implementation of a non-reactive resilience strategy that executes the specified <paramref name="callback"/>.
     /// </summary>
     /// <typeparam name="TResult">The type of result returned by the callback.</typeparam>
     /// <typeparam name="TState">The type of state associated with the callback.</typeparam>

--- a/src/Polly.Core/NonReactiveResilienceStrategy.cs
+++ b/src/Polly.Core/NonReactiveResilienceStrategy.cs
@@ -1,0 +1,36 @@
+﻿namespace Polly;
+
+/// <summary>
+/// This base class for all non-reactive resilience strategies.
+/// </summary>
+public abstract class NonReactiveResilienceStrategy
+{
+    /// <summary>
+    /// An implementation of resilience strategy that executes the specified <paramref name="callback"/>.
+    /// </summary>
+    /// <typeparam name="TResult">The type of result returned by the callback.</typeparam>
+    /// <typeparam name="TState">The type of state associated with the callback.</typeparam>
+    /// <param name="callback">The user-provided callback.</param>
+    /// <param name="context">The context associated with the callback.</param>
+    /// <param name="state">The state associated with the callback.</param>
+    /// <returns>
+    /// An instance of a pending <see cref="ValueTask"/> for asynchronous executions or a completed <see cref="ValueTask"/> task for synchronous executions.
+    /// </returns>
+    /// <remarks>
+    /// <strong>This method is called for both synchronous and asynchronous execution flows.</strong>
+    /// <para>
+    /// You can use <see cref="ResilienceContext.IsSynchronous"/> to determine whether <paramref name="callback"/> is synchronous or asynchronous.
+    /// This is useful when the custom strategy behaves differently in each execution flow. In general, for most strategies, the implementation
+    /// is the same for both execution flows.
+    /// See <seealso href="https://github.com/App-vNext/Polly/blob/main/src/Polly.Core/README.md#about-synchronous-and-asynchronous-executions"/> for more details.
+    /// </para>
+    /// <para>
+    /// The provided callback never throws an exception. Instead, the exception is captured and converted to an <see cref="Outcome{TResult}"/>.
+    /// Similarly, do not throw exceptions from your strategy implementation. Instead, return an exception instance as <see cref="Outcome{TResult}"/>.
+    /// </para>
+    /// </remarks>
+    protected internal abstract ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
+        Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
+        ResilienceContext context,
+        TState state);
+}

--- a/src/Polly.Core/NonReactiveResilienceStrategy.cs
+++ b/src/Polly.Core/NonReactiveResilienceStrategy.cs
@@ -1,7 +1,7 @@
 ﻿namespace Polly;
 
 /// <summary>
-/// This base class for all non-reactive resilience strategies.
+/// Base class for all non-reactive resilience strategies.
 /// </summary>
 public abstract class NonReactiveResilienceStrategy
 {

--- a/src/Polly.Core/NonReactiveResilienceStrategy.cs
+++ b/src/Polly.Core/NonReactiveResilienceStrategy.cs
@@ -6,7 +6,7 @@
 public abstract class NonReactiveResilienceStrategy
 {
     /// <summary>
-    /// An implementation of resilience strategy that executes the specified <paramref name="callback"/>.
+    /// An implementation of non-reactive resilience strategy that executes the specified <paramref name="callback"/>.
     /// </summary>
     /// <typeparam name="TResult">The type of result returned by the callback.</typeparam>
     /// <typeparam name="TState">The type of state associated with the callback.</typeparam>

--- a/src/Polly.Core/NullResilienceStrategy.cs
+++ b/src/Polly.Core/NullResilienceStrategy.cs
@@ -15,7 +15,7 @@ public sealed class NullResilienceStrategy : ResilienceStrategy
     }
 
     /// <inheritdoc/>
-    protected internal override ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
+    internal override ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
         Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
         ResilienceContext context,
         TState state)

--- a/src/Polly.Core/PublicAPI.Unshipped.txt
+++ b/src/Polly.Core/PublicAPI.Unshipped.txt
@@ -1,9 +1,9 @@
-﻿abstract Polly.ReactiveResilienceStrategy<TResult>.ExecuteCore<TState>(System.Func<Polly.ResilienceContext!, TState, System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>>! callback, Polly.ResilienceContext! context, TState state) -> System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>
+﻿abstract Polly.NonReactiveResilienceStrategy.ExecuteCore<TResult, TState>(System.Func<Polly.ResilienceContext!, TState, System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>>! callback, Polly.ResilienceContext! context, TState state) -> System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>
+abstract Polly.ReactiveResilienceStrategy<TResult>.ExecuteCore<TState>(System.Func<Polly.ResilienceContext!, TState, System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>>! callback, Polly.ResilienceContext! context, TState state) -> System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>
 abstract Polly.Registry.ResilienceStrategyProvider<TKey>.TryGetStrategy(TKey key, out Polly.ResilienceStrategy? strategy) -> bool
 abstract Polly.Registry.ResilienceStrategyProvider<TKey>.TryGetStrategy<TResult>(TKey key, out Polly.ResilienceStrategy<TResult>? strategy) -> bool
 abstract Polly.ResilienceContextPool.Get(string? operationKey, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Polly.ResilienceContext!
 abstract Polly.ResilienceContextPool.Return(Polly.ResilienceContext! context) -> void
-abstract Polly.ResilienceStrategy.ExecuteCore<TResult, TState>(System.Func<Polly.ResilienceContext!, TState, System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>>! callback, Polly.ResilienceContext! context, TState state) -> System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>
 override Polly.Outcome<TResult>.ToString() -> string!
 override Polly.Registry.ResilienceStrategyRegistry<TKey>.TryGetStrategy(TKey key, out Polly.ResilienceStrategy? strategy) -> bool
 override Polly.Registry.ResilienceStrategyRegistry<TKey>.TryGetStrategy<TResult>(TKey key, out Polly.ResilienceStrategy<TResult>? strategy) -> bool
@@ -147,6 +147,8 @@ Polly.Hedging.OnHedgingArguments.HasOutcome.get -> bool
 Polly.Hedging.OnHedgingArguments.OnHedgingArguments(int attemptNumber, bool hasOutcome, System.TimeSpan executionTime) -> void
 Polly.HedgingCompositeStrategyBuilderExtensions
 Polly.LegacySupport
+Polly.NonReactiveResilienceStrategy
+Polly.NonReactiveResilienceStrategy.NonReactiveResilienceStrategy() -> void
 Polly.NullResilienceStrategy
 Polly.NullResilienceStrategy<TResult>
 Polly.Outcome
@@ -262,7 +264,6 @@ Polly.ResilienceStrategy.ExecuteAsync<TResult>(System.Func<System.Threading.Canc
 Polly.ResilienceStrategy.ExecuteAsync<TState>(System.Func<Polly.ResilienceContext!, TState, System.Threading.Tasks.ValueTask>! callback, Polly.ResilienceContext! context, TState state) -> System.Threading.Tasks.ValueTask
 Polly.ResilienceStrategy.ExecuteAsync<TState>(System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! callback, TState state, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
 Polly.ResilienceStrategy.ExecuteOutcomeAsync<TResult, TState>(System.Func<Polly.ResilienceContext!, TState, System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>>! callback, Polly.ResilienceContext! context, TState state) -> System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>
-Polly.ResilienceStrategy.ResilienceStrategy() -> void
 Polly.ResilienceStrategy<T>
 Polly.ResilienceStrategy<T>.Execute<TResult, TState>(System.Func<Polly.ResilienceContext!, TState, TResult>! callback, Polly.ResilienceContext! context, TState state) -> TResult
 Polly.ResilienceStrategy<T>.Execute<TResult, TState>(System.Func<TState, System.Threading.CancellationToken, TResult>! callback, TState state, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> TResult
@@ -389,7 +390,7 @@ static Polly.CircuitBreakerCompositeStrategyBuilderExtensions.AddCircuitBreaker(
 static Polly.CircuitBreakerCompositeStrategyBuilderExtensions.AddCircuitBreaker<TResult>(this Polly.CompositeStrategyBuilder<TResult>! builder, Polly.CircuitBreaker.CircuitBreakerStrategyOptions<TResult>! options) -> Polly.CompositeStrategyBuilder<TResult>!
 static Polly.CompositeStrategyBuilderExtensions.AddStrategy(this Polly.CompositeStrategyBuilder! builder, System.Func<Polly.StrategyBuilderContext!, Polly.ReactiveResilienceStrategy<object!>!>! factory, Polly.ResilienceStrategyOptions! options) -> Polly.CompositeStrategyBuilder!
 static Polly.CompositeStrategyBuilderExtensions.AddStrategy<TBuilder>(this TBuilder! builder, Polly.ResilienceStrategy! strategy) -> TBuilder!
-static Polly.CompositeStrategyBuilderExtensions.AddStrategy<TBuilder>(this TBuilder! builder, System.Func<Polly.StrategyBuilderContext!, Polly.ResilienceStrategy!>! factory, Polly.ResilienceStrategyOptions! options) -> TBuilder!
+static Polly.CompositeStrategyBuilderExtensions.AddStrategy<TBuilder>(this TBuilder! builder, System.Func<Polly.StrategyBuilderContext!, Polly.NonReactiveResilienceStrategy!>! factory, Polly.ResilienceStrategyOptions! options) -> TBuilder!
 static Polly.CompositeStrategyBuilderExtensions.AddStrategy<TResult>(this Polly.CompositeStrategyBuilder<TResult>! builder, Polly.ResilienceStrategy<TResult>! strategy) -> Polly.CompositeStrategyBuilder<TResult>!
 static Polly.CompositeStrategyBuilderExtensions.AddStrategy<TResult>(this Polly.CompositeStrategyBuilder<TResult>! builder, System.Func<Polly.StrategyBuilderContext!, Polly.ReactiveResilienceStrategy<TResult>!>! factory, Polly.ResilienceStrategyOptions! options) -> Polly.CompositeStrategyBuilder<TResult>!
 static Polly.FallbackCompositeStrategyBuilderExtensions.AddFallback<TResult>(this Polly.CompositeStrategyBuilder<TResult>! builder, Polly.Fallback.FallbackStrategyOptions<TResult>! options) -> Polly.CompositeStrategyBuilder<TResult>!

--- a/src/Polly.Core/ReactiveResilienceStrategy.cs
+++ b/src/Polly.Core/ReactiveResilienceStrategy.cs
@@ -11,7 +11,7 @@
 public abstract class ReactiveResilienceStrategy<TResult>
 {
     /// <summary>
-    /// An implementation of resilience strategy that executes the specified <paramref name="callback"/>.
+    /// An implementation of a reactive resilience strategy that executes the specified <paramref name="callback"/>.
     /// </summary>
     /// <typeparam name="TState">The type of state associated with the callback.</typeparam>
     /// <param name="callback">The user-provided callback.</param>

--- a/src/Polly.Core/ResilienceStrategy.cs
+++ b/src/Polly.Core/ResilienceStrategy.cs
@@ -1,7 +1,5 @@
 namespace Polly;
 
-#pragma warning disable CA1031 // Do not catch general exception types
-
 /// <summary>
 /// Resilience strategy is used to execute the user-provided callbacks.
 /// </summary>
@@ -9,37 +7,17 @@ namespace Polly;
 /// Resilience strategy supports various types of callbacks and provides a unified way to execute them.
 /// This includes overloads for synchronous and asynchronous callbacks, generic and non-generic callbacks.
 /// </remarks>
-public abstract partial class ResilienceStrategy
+public partial class ResilienceStrategy
 {
     internal static ResilienceContextPool Pool => ResilienceContextPool.Shared;
 
     internal ResilienceStrategyOptions? Options { get; set; }
 
-    /// <summary>
-    /// An implementation of resilience strategy that executes the specified <paramref name="callback"/>.
-    /// </summary>
-    /// <typeparam name="TResult">The type of result returned by the callback.</typeparam>
-    /// <typeparam name="TState">The type of state associated with the callback.</typeparam>
-    /// <param name="callback">The user-provided callback.</param>
-    /// <param name="context">The context associated with the callback.</param>
-    /// <param name="state">The state associated with the callback.</param>
-    /// <returns>
-    /// An instance of a pending <see cref="ValueTask"/> for asynchronous executions or a completed <see cref="ValueTask"/> task for synchronous executions.
-    /// </returns>
-    /// <remarks>
-    /// <strong>This method is called for both synchronous and asynchronous execution flows.</strong>
-    /// <para>
-    /// You can use <see cref="ResilienceContext.IsSynchronous"/> to determine whether <paramref name="callback"/> is synchronous or asynchronous.
-    /// This is useful when the custom strategy behaves differently in each execution flow. In general, for most strategies, the implementation
-    /// is the same for both execution flows.
-    /// See <seealso href="https://github.com/App-vNext/Polly/blob/main/src/Polly.Core/README.md#about-synchronous-and-asynchronous-executions"/> for more details.
-    /// </para>
-    /// <para>
-    /// The provided callback never throws an exception. Instead, the exception is captured and converted to an <see cref="Outcome{TResult}"/>.
-    /// Similarly, do not throw exceptions from your strategy implementation. Instead, return an exception instance as <see cref="Outcome{TResult}"/>.
-    /// </para>
-    /// </remarks>
-    protected internal abstract ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
+    internal ResilienceStrategy()
+    {
+    }
+
+    internal abstract ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
         Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
         ResilienceContext context,
         TState state);

--- a/src/Polly.Core/Timeout/TimeoutResilienceStrategy.cs
+++ b/src/Polly.Core/Timeout/TimeoutResilienceStrategy.cs
@@ -2,7 +2,7 @@ using Polly.Telemetry;
 
 namespace Polly.Timeout;
 
-internal sealed class TimeoutResilienceStrategy : ResilienceStrategy
+internal sealed class TimeoutResilienceStrategy : NonReactiveResilienceStrategy
 {
     private readonly ResilienceStrategyTelemetry _telemetry;
     private readonly CancellationTokenSourcePool _cancellationTokenSourcePool;

--- a/src/Polly.Core/Utils/CompositeResilienceStrategy.cs
+++ b/src/Polly.Core/Utils/CompositeResilienceStrategy.cs
@@ -55,7 +55,7 @@ internal sealed partial class CompositeResilienceStrategy : ResilienceStrategy
 
     public IReadOnlyList<ResilienceStrategy> Strategies { get; }
 
-    protected internal override ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
+    internal override ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
         Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
         ResilienceContext context, TState state)
     {
@@ -78,7 +78,7 @@ internal sealed partial class CompositeResilienceStrategy : ResilienceStrategy
 
         public ResilienceStrategy? Next { get; set; }
 
-        protected internal override ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
+        internal override ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
             Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
             ResilienceContext context,
             TState state)

--- a/src/Polly.Core/Utils/NonReactiveResilienceStrategyBridge.cs
+++ b/src/Polly.Core/Utils/NonReactiveResilienceStrategyBridge.cs
@@ -1,0 +1,14 @@
+﻿namespace Polly.Utils;
+
+[DebuggerDisplay("{Strategy}")]
+internal sealed class NonReactiveResilienceStrategyBridge : ResilienceStrategy
+{
+    public NonReactiveResilienceStrategyBridge(NonReactiveResilienceStrategy strategy) => Strategy = strategy;
+
+    public NonReactiveResilienceStrategy Strategy { get; }
+
+    internal override ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
+        Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
+        ResilienceContext context,
+        TState state) => Strategy.ExecuteCore(callback, context, state);
+}

--- a/src/Polly.Core/Utils/ReactiveResilienceStrategyBridge.cs
+++ b/src/Polly.Core/Utils/ReactiveResilienceStrategyBridge.cs
@@ -7,7 +7,7 @@ internal sealed class ReactiveResilienceStrategyBridge<T> : ResilienceStrategy
 
     public ReactiveResilienceStrategy<T> Strategy { get; }
 
-    protected internal override ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
+    internal override ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
         Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
         ResilienceContext context,
         TState state)

--- a/src/Polly.Core/Utils/ReloadableResilienceStrategy.cs
+++ b/src/Polly.Core/Utils/ReloadableResilienceStrategy.cs
@@ -30,7 +30,7 @@ internal sealed class ReloadableResilienceStrategy : ResilienceStrategy
 
     public ResilienceStrategy Strategy { get; private set; }
 
-    protected internal override ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
+    internal override ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
         Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
         ResilienceContext context,
         TState state)

--- a/src/Polly.Extensions/Telemetry/TelemetryCompositeStrategyBuilderExtensions.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryCompositeStrategyBuilderExtensions.cs
@@ -44,6 +44,7 @@ public static class TelemetryCompositeStrategyBuilderExtensions
     /// </remarks>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
     [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(TelemetryOptions))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(TelemetryStrategyOptions))]
     public static TBuilder ConfigureTelemetry<TBuilder>(this TBuilder builder, TelemetryOptions options)
         where TBuilder : CompositeStrategyBuilderBase
     {
@@ -62,9 +63,15 @@ public static class TelemetryCompositeStrategyBuilderExtensions
                 options.ResultFormatter,
                 options.Enrichers.ToList());
 
-            strategies.Insert(0, telemetryStrategy);
+#pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+            strategies.Insert(0, new CompositeStrategyBuilder().AddStrategy(_ => telemetryStrategy, new TelemetryStrategyOptions()).Build());
+#pragma warning restore IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
         };
 
         return builder;
+    }
+
+    private sealed class TelemetryStrategyOptions : ResilienceStrategyOptions
+    {
     }
 }

--- a/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategy.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryResilienceStrategy.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Polly.Telemetry;
 
-internal sealed class TelemetryResilienceStrategy : ResilienceStrategy
+internal sealed class TelemetryResilienceStrategy : NonReactiveResilienceStrategy
 {
     private readonly TimeProvider _timeProvider;
     private readonly string? _builderName;

--- a/src/Polly.RateLimiting/RateLimiterResilienceStrategy.cs
+++ b/src/Polly.RateLimiting/RateLimiterResilienceStrategy.cs
@@ -3,7 +3,7 @@ using Polly.Telemetry;
 
 namespace Polly.RateLimiting;
 
-internal sealed class RateLimiterResilienceStrategy : ResilienceStrategy
+internal sealed class RateLimiterResilienceStrategy : NonReactiveResilienceStrategy
 {
     private readonly ResilienceStrategyTelemetry _telemetry;
 

--- a/src/Polly.Testing/ResilienceStrategyExtensions.cs
+++ b/src/Polly.Testing/ResilienceStrategyExtensions.cs
@@ -56,6 +56,11 @@ public static class ResilienceStrategyExtensions
             return bridge.Strategy.GetType();
         }
 
+        if (strategy is NonReactiveResilienceStrategyBridge bridge2)
+        {
+            return bridge2.Strategy.GetType();
+        }
+
         return strategy.GetType();
     }
 

--- a/src/Polly.Testing/ResilienceStrategyExtensions.cs
+++ b/src/Polly.Testing/ResilienceStrategyExtensions.cs
@@ -51,14 +51,14 @@ public static class ResilienceStrategyExtensions
 
     private static Type GetStrategyType<T>(ResilienceStrategy strategy)
     {
-        if (strategy is ReactiveResilienceStrategyBridge<T> bridge)
+        if (strategy is ReactiveResilienceStrategyBridge<T> reactiveBridge)
         {
-            return bridge.Strategy.GetType();
+            return reactiveBridge.Strategy.GetType();
         }
 
-        if (strategy is NonReactiveResilienceStrategyBridge bridge2)
+        if (strategy is NonReactiveResilienceStrategyBridge nonReactiveBridge)
         {
-            return bridge2.Strategy.GetType();
+            return nonReactiveBridge.Strategy.GetType();
         }
 
         return strategy.GetType();

--- a/test/Polly.Core.Tests/GenericCompositeStrategyBuilderTests.cs
+++ b/test/Polly.Core.Tests/GenericCompositeStrategyBuilderTests.cs
@@ -55,7 +55,7 @@ public class GenericCompositeStrategyBuilderTests
     public void AddGenericStrategy_Ok()
     {
         // arrange
-        var testStrategy = new ResilienceStrategy<string>(new TestResilienceStrategy());
+        var testStrategy = new ResilienceStrategy<string>(new TestResilienceStrategy().AsStrategy());
         _builder.AddStrategy(testStrategy);
 
         // act

--- a/test/Polly.Core.Tests/Registry/ResilienceStrategyProviderTests.cs
+++ b/test/Polly.Core.Tests/Registry/ResilienceStrategyProviderTests.cs
@@ -29,7 +29,7 @@ public class ResilienceStrategyProviderTests
     [Fact]
     public void Get_Exist_Ok()
     {
-        var provider = new Provider { Strategy = new TestResilienceStrategy() };
+        var provider = new Provider { Strategy = new TestResilienceStrategy().AsStrategy() };
 
         provider.GetStrategy("exists").Should().Be(provider.Strategy);
     }

--- a/test/Polly.Core.Tests/ResilienceStrategyTTests.Async.cs
+++ b/test/Polly.Core.Tests/ResilienceStrategyTTests.Async.cs
@@ -71,7 +71,7 @@ public partial class ResilienceStrategyTests
                 c.ResultType.Should().Be(typeof(string));
                 c.CancellationToken.CanBeCanceled.Should().BeTrue();
             },
-        });
+        }.AsStrategy());
 
         await execute(strategy);
     }

--- a/test/Polly.Core.Tests/ResilienceStrategyTTests.Sync.cs
+++ b/test/Polly.Core.Tests/ResilienceStrategyTTests.Sync.cs
@@ -84,7 +84,7 @@ public partial class ResilienceStrategyTests
                 c.IsSynchronous.Should().BeTrue();
                 c.ResultType.Should().Be(typeof(string));
             },
-        });
+        }.AsStrategy());
 
         execute(strategy);
     }

--- a/test/Polly.Core.Tests/ResilienceStrategyTests.Async.cs
+++ b/test/Polly.Core.Tests/ResilienceStrategyTests.Async.cs
@@ -78,7 +78,7 @@ public partial class ResilienceStrategyTests
                 context = c;
                 parameters.AssertContext(c);
             },
-        };
+        }.AsStrategy();
 
         var result = await parameters.Execute(strategy);
 
@@ -96,7 +96,7 @@ public partial class ResilienceStrategyTests
 
         static async ValueTask AssertStackTrace(Func<ResilienceStrategy, ValueTask> execute)
         {
-            var strategy = new TestResilienceStrategy();
+            var strategy = new TestResilienceStrategy().AsStrategy();
 
             var error = await strategy
                 .Invoking(s =>

--- a/test/Polly.Core.Tests/ResilienceStrategyTests.AsyncT.cs
+++ b/test/Polly.Core.Tests/ResilienceStrategyTests.AsyncT.cs
@@ -82,7 +82,7 @@ public partial class ResilienceStrategyTests
             },
         };
 
-        var result = await parameters.Execute(strategy);
+        var result = await parameters.Execute(strategy.AsStrategy());
 
         parameters.AssertContextAfter(context!);
         parameters.AssertResult(result);
@@ -98,7 +98,7 @@ public partial class ResilienceStrategyTests
 
         static async ValueTask AssertStackTrace(Func<ResilienceStrategy, ValueTask<string>> execute)
         {
-            var strategy = new TestResilienceStrategy();
+            var strategy = new TestResilienceStrategy().AsStrategy();
 
             var error = await strategy
                 .Invoking(s =>

--- a/test/Polly.Core.Tests/ResilienceStrategyTests.Sync.cs
+++ b/test/Polly.Core.Tests/ResilienceStrategyTests.Sync.cs
@@ -82,7 +82,7 @@ public partial class ResilienceStrategyTests
                 context = c;
                 parameters.AssertContext(c);
             },
-        };
+        }.AsStrategy();
 
         var result = await parameters.Execute(strategy);
 
@@ -103,7 +103,7 @@ public partial class ResilienceStrategyTests
 
         static void AssertStackTrace(Action<ResilienceStrategy> execute)
         {
-            var strategy = new TestResilienceStrategy();
+            var strategy = new TestResilienceStrategy().AsStrategy();
 
             var error = strategy
                 .Invoking(s => execute(s))

--- a/test/Polly.Core.Tests/ResilienceStrategyTests.SyncT.cs
+++ b/test/Polly.Core.Tests/ResilienceStrategyTests.SyncT.cs
@@ -84,7 +84,7 @@ public partial class ResilienceStrategyTests
                 context = c;
                 parameters.AssertContext(c);
             },
-        };
+        }.AsStrategy();
 
         var result = await parameters.Execute(strategy);
 
@@ -105,7 +105,7 @@ public partial class ResilienceStrategyTests
 
         static void AssertStackTrace(Func<ResilienceStrategy, string> execute)
         {
-            var strategy = new TestResilienceStrategy();
+            var strategy = new TestResilienceStrategy().AsStrategy();
 
             var error = strategy
                 .Invoking(s => execute(s))

--- a/test/Polly.Core.Tests/ResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/ResilienceStrategyTests.cs
@@ -11,8 +11,8 @@ public partial class ResilienceStrategyTests
     {
         var pipeline = CompositeResilienceStrategy.Create(new[]
         {
-            new TestResilienceStrategy(),
-            new TestResilienceStrategy()
+            new TestResilienceStrategy().AsStrategy(),
+            new TestResilienceStrategy().AsStrategy()
         });
 
         new CompositeResilienceStrategy.DebuggerProxy(pipeline).Strategies.Should().HaveCount(2);

--- a/test/Polly.Core.Tests/Timeout/TimeoutCompositeStrategyBuilderExtensionsTests.cs
+++ b/test/Polly.Core.Tests/Timeout/TimeoutCompositeStrategyBuilderExtensionsTests.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Polly.Timeout;
+using Polly.Utils;
 
 namespace Polly.Core.Tests.Timeout;
 
@@ -31,7 +32,8 @@ public class TimeoutCompositeStrategyBuilderExtensionsTests
     {
         var builder = new CompositeStrategyBuilder<int>();
         configure(builder);
-        var strategy = builder.Build().Strategy.Should().BeOfType<TimeoutResilienceStrategy>().Subject;
+
+        var strategy = ((NonReactiveResilienceStrategyBridge)builder.Build().Strategy).Strategy.Should().BeOfType<TimeoutResilienceStrategy>().Subject;
         assert(strategy);
 
         GetTimeout(strategy).Should().Be(timeout);
@@ -42,7 +44,7 @@ public class TimeoutCompositeStrategyBuilderExtensionsTests
     {
         var strategy = new CompositeStrategyBuilder().AddTimeout(new TimeoutStrategyOptions()).Build();
 
-        strategy.Should().BeOfType<TimeoutResilienceStrategy>();
+        ((NonReactiveResilienceStrategyBridge)strategy).Strategy.Should().BeOfType<TimeoutResilienceStrategy>();
     }
 
     [Fact]

--- a/test/Polly.Core.Tests/Timeout/TimeoutResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Timeout/TimeoutResilienceStrategyTests.cs
@@ -234,5 +234,5 @@ public class TimeoutResilienceStrategyTests : IDisposable
 
     private void SetTimeout(TimeSpan timeout) => _options.TimeoutGenerator = args => new ValueTask<TimeSpan>(timeout);
 
-    private TimeoutResilienceStrategy CreateSut() => new(_options, _timeProvider, _telemetry);
+    private ResilienceStrategy CreateSut() => new TimeoutResilienceStrategy(_options, _timeProvider, _telemetry).AsStrategy();
 }

--- a/test/Polly.Core.Tests/Utils/CompositeResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Utils/CompositeResilienceStrategyTests.cs
@@ -9,7 +9,7 @@ public class CompositeResilienceStrategyTests
     {
         Assert.Throws<ArgumentNullException>(() => CompositeResilienceStrategy.Create(null!));
         Assert.Throws<InvalidOperationException>(() => CompositeResilienceStrategy.Create(Array.Empty<ResilienceStrategy>()));
-        Assert.Throws<InvalidOperationException>(() => CompositeResilienceStrategy.Create(new ResilienceStrategy[] { new TestResilienceStrategy() }));
+        Assert.Throws<InvalidOperationException>(() => CompositeResilienceStrategy.Create(new[] { new TestResilienceStrategy().AsStrategy() }));
         Assert.Throws<InvalidOperationException>(() => CompositeResilienceStrategy.Create(new ResilienceStrategy[]
         {
             NullResilienceStrategy.Instance,
@@ -20,11 +20,11 @@ public class CompositeResilienceStrategyTests
     [Fact]
     public void Create_EnsureOriginalStrategiesPreserved()
     {
-        var strategies = new ResilienceStrategy[]
+        var strategies = new[]
         {
-            new TestResilienceStrategy(),
-            new Strategy(),
-            new TestResilienceStrategy(),
+            new TestResilienceStrategy().AsStrategy(),
+            new Strategy().AsStrategy(),
+            new TestResilienceStrategy().AsStrategy(),
         };
 
         var pipeline = CompositeResilienceStrategy.Create(strategies);
@@ -40,10 +40,10 @@ public class CompositeResilienceStrategyTests
     [Fact]
     public async Task Create_EnsureExceptionsNotWrapped()
     {
-        var strategies = new ResilienceStrategy[]
+        var strategies = new[]
         {
-            new Strategy(),
-            new Strategy(),
+            new Strategy().AsStrategy(),
+            new Strategy().AsStrategy(),
         };
 
         var pipeline = CompositeResilienceStrategy.Create(strategies);
@@ -56,11 +56,11 @@ public class CompositeResilienceStrategyTests
     [Fact]
     public void Create_EnsurePipelineReusableAcrossDifferentPipelines()
     {
-        var strategies = new ResilienceStrategy[]
+        var strategies = new[]
         {
-            new TestResilienceStrategy(),
-            new Strategy(),
-            new TestResilienceStrategy(),
+            new TestResilienceStrategy().AsStrategy(),
+            new Strategy().AsStrategy(),
+            new TestResilienceStrategy().AsStrategy(),
         };
 
         var pipeline = CompositeResilienceStrategy.Create(strategies);
@@ -77,10 +77,10 @@ public class CompositeResilienceStrategyTests
     {
         using var cancellation = new CancellationTokenSource();
         cancellation.Cancel();
-        var strategies = new ResilienceStrategy[]
+        var strategies = new[]
         {
-            new TestResilienceStrategy(),
-            new TestResilienceStrategy(),
+            new TestResilienceStrategy().AsStrategy(),
+            new TestResilienceStrategy().AsStrategy(),
         };
 
         var pipeline = CompositeResilienceStrategy.Create(strategies);
@@ -96,10 +96,10 @@ public class CompositeResilienceStrategyTests
     {
         var executed = false;
         using var cancellation = new CancellationTokenSource();
-        var strategies = new ResilienceStrategy[]
+        var strategies = new[]
         {
-            new TestResilienceStrategy { Before = (_, _) => { executed = true; cancellation.Cancel(); } },
-            new TestResilienceStrategy(),
+            new TestResilienceStrategy { Before = (_, _) => { executed = true; cancellation.Cancel(); } }.AsStrategy(),
+            new TestResilienceStrategy().AsStrategy(),
         };
 
         var pipeline = CompositeResilienceStrategy.Create(strategies);
@@ -111,7 +111,7 @@ public class CompositeResilienceStrategyTests
         executed.Should().BeTrue();
     }
 
-    private class Strategy : ResilienceStrategy
+    private class Strategy : NonReactiveResilienceStrategy
     {
         protected internal override async ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
             Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,

--- a/test/Polly.Core.Tests/Utils/ReloadableResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Utils/ReloadableResilienceStrategyTests.cs
@@ -24,7 +24,7 @@ public class ReloadableResilienceStrategyTests : IDisposable
     [Fact]
     public void Ctor_Ok()
     {
-        var strategy = new TestResilienceStrategy();
+        var strategy = new TestResilienceStrategy().AsStrategy();
         var sut = CreateSut(strategy);
 
         sut.Strategy.Should().Be(strategy);
@@ -35,7 +35,7 @@ public class ReloadableResilienceStrategyTests : IDisposable
     [Fact]
     public void ChangeTriggered_StrategyReloaded()
     {
-        var strategy = new TestResilienceStrategy();
+        var strategy = new TestResilienceStrategy().AsStrategy();
         var sut = CreateSut(strategy);
 
         for (var i = 0; i < 10; i++)
@@ -54,7 +54,7 @@ public class ReloadableResilienceStrategyTests : IDisposable
     [Fact]
     public void ChangeTriggered_FactoryError_LastStrategyUsedAndErrorReported()
     {
-        var strategy = new TestResilienceStrategy();
+        var strategy = new TestResilienceStrategy().AsStrategy();
         var sut = CreateSut(strategy, () => throw new InvalidOperationException());
 
         _cancellationTokenSource.Cancel();
@@ -78,10 +78,10 @@ public class ReloadableResilienceStrategyTests : IDisposable
 
     private ReloadableResilienceStrategy CreateSut(ResilienceStrategy? initial = null, Func<ResilienceStrategy>? factory = null)
     {
-        factory ??= () => new TestResilienceStrategy();
+        factory ??= () => new TestResilienceStrategy().AsStrategy();
 
         return new(
-            initial ?? new TestResilienceStrategy(),
+            initial ?? new TestResilienceStrategy().AsStrategy(),
             () => _cancellationTokenSource.Token,
             factory,
             _telemetry);

--- a/test/Polly.Extensions.Tests/DependencyInjection/PollyServiceCollectionExtensionTests.cs
+++ b/test/Polly.Extensions.Tests/DependencyInjection/PollyServiceCollectionExtensionTests.cs
@@ -304,7 +304,7 @@ public class PollyServiceCollectionExtensionTests
         return _services.BuildServiceProvider().GetRequiredService<ResilienceStrategyProvider<string>>();
     }
 
-    private class TestStrategy : ResilienceStrategy
+    private class TestStrategy : NonReactiveResilienceStrategy
     {
         protected override ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
             Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,

--- a/test/Polly.Extensions.Tests/Issues/IssuesTests.OnCircuitBreakWithServiceProvider_796.cs
+++ b/test/Polly.Extensions.Tests/Issues/IssuesTests.OnCircuitBreakWithServiceProvider_796.cs
@@ -54,7 +54,7 @@ public partial class IssuesTests
         contextChecked.Should().BeTrue();
     }
 
-    private class ServiceProviderStrategy : ResilienceStrategy
+    private class ServiceProviderStrategy : NonReactiveResilienceStrategy
     {
         private readonly IServiceProvider _serviceProvider;
 

--- a/test/Polly.Extensions.Tests/ReloadableResilienceStrategyTests.cs
+++ b/test/Polly.Extensions.Tests/ReloadableResilienceStrategyTests.cs
@@ -55,7 +55,7 @@ public class ReloadableResilienceStrategyTests
         }
     }
 
-    public class ReloadableStrategy : ResilienceStrategy
+    public class ReloadableStrategy : NonReactiveResilienceStrategy
     {
         public ReloadableStrategy(string tag) => Tag = tag;
 

--- a/test/Polly.RateLimiting.Tests/Polly.RateLimiting.Tests.csproj
+++ b/test/Polly.RateLimiting.Tests/Polly.RateLimiting.Tests.csproj
@@ -14,5 +14,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Polly.RateLimiting\Polly.RateLimiting.csproj" />
+    <ProjectReference Include="..\..\src\Polly.Testing\Polly.Testing.csproj" />
   </ItemGroup>
 </Project>

--- a/test/Polly.RateLimiting.Tests/RateLimiterResilienceStrategyTests.cs
+++ b/test/Polly.RateLimiting.Tests/RateLimiterResilienceStrategyTests.cs
@@ -99,19 +99,18 @@ public class RateLimiterResilienceStrategyTests
             .Returns(result);
     }
 
-    private RateLimiterResilienceStrategy Create()
+    private ResilienceStrategy Create()
     {
         var builder = new CompositeStrategyBuilder
         {
             DiagnosticSource = _diagnosticSource
         };
 
-        return (RateLimiterResilienceStrategy)builder
-            .AddRateLimiter(new RateLimiterStrategyOptions
-            {
-                RateLimiter = ResilienceRateLimiter.Create(_limiter),
-                OnRejected = _event
-            })
-            .Build();
+        return builder.AddRateLimiter(new RateLimiterStrategyOptions
+        {
+            RateLimiter = ResilienceRateLimiter.Create(_limiter),
+            OnRejected = _event
+        })
+        .Build();
     }
 }

--- a/test/Polly.Specs/ResilienceStrategyConversionExtensionsTests.cs
+++ b/test/Polly.Specs/ResilienceStrategyConversionExtensionsTests.cs
@@ -50,7 +50,7 @@ public class ResilienceStrategyConversionExtensionsTests
             [Incoming.Key] = "incoming-value"
         };
 
-        _strategy.AsSyncPolicy().Execute(_ =>
+        _strategy.AsStrategy().AsSyncPolicy().Execute(_ =>
         {
             context[Executing.Key] = "executing-value";
         },
@@ -86,7 +86,7 @@ public class ResilienceStrategyConversionExtensionsTests
             [Incoming.Key] = "incoming-value"
         };
 
-        var result = _strategy.AsSyncPolicy().Execute(_ => { context[Executing.Key] = "executing-value"; return "dummy"; }, context);
+        var result = _strategy.AsStrategy().AsSyncPolicy().Execute(_ => { context[Executing.Key] = "executing-value"; return "dummy"; }, context);
 
         AssertContext(context);
         result.Should().Be("dummy");
@@ -102,7 +102,7 @@ public class ResilienceStrategyConversionExtensionsTests
             [Incoming.Key] = "incoming-value"
         };
 
-        await _strategy.AsAsyncPolicy().ExecuteAsync(_ =>
+        await _strategy.AsStrategy().AsAsyncPolicy().ExecuteAsync(_ =>
         {
             context[Executing.Key] = "executing-value";
             return Task.CompletedTask;
@@ -144,7 +144,7 @@ public class ResilienceStrategyConversionExtensionsTests
             [Incoming.Key] = "incoming-value"
         };
 
-        var result = await _strategy.AsAsyncPolicy().ExecuteAsync(_ =>
+        var result = await _strategy.AsStrategy().AsAsyncPolicy().ExecuteAsync(_ =>
         {
             context[Executing.Key] = "executing-value";
             return Task.FromResult("dummy");

--- a/test/Polly.TestUtils/NonReactiveStrategyExtensions.cs
+++ b/test/Polly.TestUtils/NonReactiveStrategyExtensions.cs
@@ -1,0 +1,14 @@
+﻿using Polly.Utils;
+
+namespace Polly.TestUtils;
+
+public static class NonReactiveStrategyExtensions
+{
+    public static ResilienceStrategy AsStrategy(this NonReactiveResilienceStrategy strategy) => new NonReactiveResilienceStrategyBridge(strategy);
+
+    public static TBuilder AddStrategy<TBuilder>(this TBuilder builder, NonReactiveResilienceStrategy strategy)
+        where TBuilder : CompositeStrategyBuilderBase
+    {
+        return builder.AddStrategy(strategy.AsStrategy());
+    }
+}

--- a/test/Polly.TestUtils/TestResilienceStrategy.TResult.cs
+++ b/test/Polly.TestUtils/TestResilienceStrategy.TResult.cs
@@ -3,7 +3,7 @@ namespace Polly.TestUtils;
 public class TestResilienceStrategy<T> : ResilienceStrategy<T>
 {
     public TestResilienceStrategy()
-        : base(new TestResilienceStrategy())
+        : base(new TestResilienceStrategy().AsStrategy())
     {
     }
 }

--- a/test/Polly.TestUtils/TestResilienceStrategy.cs
+++ b/test/Polly.TestUtils/TestResilienceStrategy.cs
@@ -1,6 +1,6 @@
 namespace Polly.TestUtils;
 
-public class TestResilienceStrategy : ResilienceStrategy
+public class TestResilienceStrategy : NonReactiveResilienceStrategy
 {
     public Action<ResilienceContext, object?>? Before { get; set; }
 

--- a/test/Polly.Testing.Tests/ResilienceStrategyExtensionsTests.cs
+++ b/test/Polly.Testing.Tests/ResilienceStrategyExtensionsTests.cs
@@ -25,7 +25,7 @@ public class ResilienceStrategyExtensionsTests
             .AddTimeout(TimeSpan.FromSeconds(1))
             .AddHedging(new())
             .AddConcurrencyLimiter(10)
-            .AddStrategy(new CustomStrategy())
+            .AddStrategy(_ => new CustomStrategy(), new TestOptions())
             .ConfigureTelemetry(NullLoggerFactory.Instance)
             .Build();
 
@@ -65,7 +65,7 @@ public class ResilienceStrategyExtensionsTests
             .AddCircuitBreaker(new())
             .AddTimeout(TimeSpan.FromSeconds(1))
             .AddConcurrencyLimiter(10)
-            .AddStrategy(new CustomStrategy())
+            .AddStrategy(_ => new CustomStrategy(), new TestOptions())
             .ConfigureTelemetry(NullLoggerFactory.Instance)
             .Build();
 
@@ -120,7 +120,7 @@ public class ResilienceStrategyExtensionsTests
 
             builder
                 .AddConcurrencyLimiter(10)
-                .AddStrategy(new CustomStrategy());
+                .AddStrategy(_ => new CustomStrategy(), new TestOptions());
         });
 
         // act
@@ -134,9 +134,13 @@ public class ResilienceStrategyExtensionsTests
         descriptor.Strategies[1].StrategyType.Should().Be(typeof(CustomStrategy));
     }
 
-    private sealed class CustomStrategy : ResilienceStrategy
+    private sealed class CustomStrategy : NonReactiveResilienceStrategy
     {
         protected override ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback, ResilienceContext context, TState state)
             => throw new NotSupportedException();
+    }
+
+    private class TestOptions : ResilienceStrategyOptions
+    {
     }
 }


### PR DESCRIPTION
### Details on the issue fix or feature implementation

The follow-up of #1462 that introduces the base class for non-reactive resilience strategies. 

Additional changes:

- Make the construction of `ResilienceStrategy` internal (similar to `ResilienceStrategy<T>`). We now have full control over these top-level types.

This change make the decision when implementing a new resilience strategy straightforward:

- Pick `NonReactiveResilienceStrategy` when you want to implement non-reactive strategy.
- Pick `ReactiveResilienceStrategy<T>` when you want to implement reactive strategy.

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
