### PR TITLE
Hide validation APIs

### DIFF
--- a/src/Polly.Core/PublicAPI.Unshipped.txt
+++ b/src/Polly.Core/PublicAPI.Unshipped.txt
@@ -261,7 +261,6 @@ Polly.ResiliencePipelineBuilderBase.Name.get -> string?
 Polly.ResiliencePipelineBuilderBase.Name.set -> void
 Polly.ResiliencePipelineBuilderBase.TelemetryListener.get -> Polly.Telemetry.TelemetryListener?
 Polly.ResiliencePipelineBuilderBase.TelemetryListener.set -> void
-Polly.ResiliencePipelineBuilderBase.Validator.get -> System.Action<Polly.ResilienceValidationContext!>!
 Polly.ResiliencePipelineBuilderExtensions
 Polly.ResilienceProperties
 Polly.ResilienceProperties.GetValue<TValue>(Polly.ResiliencePropertyKey<TValue> key, TValue defaultValue) -> TValue
@@ -281,10 +280,6 @@ Polly.ResilienceStrategyOptions
 Polly.ResilienceStrategyOptions.Name.get -> string?
 Polly.ResilienceStrategyOptions.Name.set -> void
 Polly.ResilienceStrategyOptions.ResilienceStrategyOptions() -> void
-Polly.ResilienceValidationContext
-Polly.ResilienceValidationContext.Instance.get -> object!
-Polly.ResilienceValidationContext.PrimaryMessage.get -> string!
-Polly.ResilienceValidationContext.ResilienceValidationContext(object! instance, string! primaryMessage) -> void
 Polly.Retry.OnRetryArguments
 Polly.Retry.OnRetryArguments.AttemptNumber.get -> int
 Polly.Retry.OnRetryArguments.ExecutionTime.get -> System.TimeSpan

--- a/src/Polly.Core/ResiliencePipelineBuilderBase.cs
+++ b/src/Polly.Core/ResiliencePipelineBuilderBase.cs
@@ -85,8 +85,7 @@ public abstract class ResiliencePipelineBuilderBase
     /// The validator should throw <see cref="ValidationException"/> when the validated instance is invalid.
     /// </remarks>
     /// <exception cref="ArgumentNullException">Thrown when the attempting to assign <see langword="null"/> to this property.</exception>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public Action<ResilienceValidationContext> Validator { get; private protected set; } = ValidationHelper.ValidateObject;
+    internal Action<ResilienceValidationContext> Validator { get; private protected set; } = ValidationHelper.ValidateObject;
 
     [RequiresUnreferencedCode(Constants.OptionsValidation)]
     internal void AddStrategyCore(Func<StrategyBuilderContext, ResiliencePipeline> factory, ResilienceStrategyOptions options)

--- a/src/Polly.Core/ResilienceValidationContext.cs
+++ b/src/Polly.Core/ResilienceValidationContext.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// The validation context that encapsulates parameters for the validation.
 /// </summary>
-public sealed class ResilienceValidationContext
+internal sealed class ResilienceValidationContext
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="ResilienceValidationContext"/> class.
@@ -12,8 +12,8 @@ public sealed class ResilienceValidationContext
     /// <param name="primaryMessage">The primary validation message.</param>
     public ResilienceValidationContext(object instance, string primaryMessage)
     {
-        Instance = Guard.NotNull(instance);
-        PrimaryMessage = Guard.NotNull(primaryMessage);
+        Instance = Polly.Utils.Guard.NotNull(instance);
+        PrimaryMessage = Polly.Utils.Guard.NotNull(primaryMessage);
     }
 
     /// <summary>

--- a/src/Polly.Extensions/Polly.Extensions.csproj
+++ b/src/Polly.Extensions/Polly.Extensions.csproj
@@ -14,9 +14,11 @@
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\Polly.Core\ResilienceValidationContext.cs" Link="Utils\ResilienceValidationContext.cs" />
     <Compile Include="..\Polly.Core\Utils\Guard.cs" Link="Utils\Guard.cs" />
     <Compile Include="..\Polly.Core\Utils\ObjectPool.cs" Link="Utils\ObjectPool.cs" />
     <Compile Include="..\Polly.Core\ToBeRemoved\TimeProvider.cs" Link="ToBeRemoved\TimeProvider.cs" />
+    <Compile Include="..\Polly.Core\Utils\ValidationHelper.cs" Link="Utils\ValidationHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Polly.Extensions/Telemetry/TelemetryResiliencePipelineBuilderExtensions.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryResiliencePipelineBuilderExtensions.cs
@@ -50,7 +50,7 @@ public static class TelemetryResiliencePipelineBuilderExtensions
         Guard.NotNull(builder);
         Guard.NotNull(options);
 
-        builder.Validator(new(options, $"The '{nameof(TelemetryOptions)}' are invalid."));
+        ValidationHelper.ValidateObject(new(options, $"The '{nameof(TelemetryOptions)}' are invalid."));
         builder.TelemetryListener = new TelemetryListenerImpl(options);
 
         return builder;


### PR DESCRIPTION
### Details on the issue fix or feature implementation

Polly infra already validates all necessary options automatically. It was exposed only to validate `TelemetryOptions` but we can do it by linking internals.

If someone really needs it we can re-expose the API.

### Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build
