### PR TITLE
Drop unused ResiliencePipelineRegistry APIs

### DIFF
--- a/src/Polly.Core/PublicAPI.Unshipped.txt
+++ b/src/Polly.Core/PublicAPI.Unshipped.txt
@@ -167,22 +167,14 @@ Polly.Registry.ConfigureBuilderContext<TKey>.PipelineKey.get -> TKey
 Polly.Registry.ResiliencePipelineProvider<TKey>
 Polly.Registry.ResiliencePipelineProvider<TKey>.ResiliencePipelineProvider() -> void
 Polly.Registry.ResiliencePipelineRegistry<TKey>
-Polly.Registry.ResiliencePipelineRegistry<TKey>.ClearPipelines() -> void
-Polly.Registry.ResiliencePipelineRegistry<TKey>.ClearPipelines<TResult>() -> void
 Polly.Registry.ResiliencePipelineRegistry<TKey>.GetOrAddPipeline(TKey key, System.Action<Polly.ResiliencePipelineBuilder!, Polly.Registry.ConfigureBuilderContext<TKey>!>! configure) -> Polly.ResiliencePipeline!
 Polly.Registry.ResiliencePipelineRegistry<TKey>.GetOrAddPipeline(TKey key, System.Action<Polly.ResiliencePipelineBuilder!>! configure) -> Polly.ResiliencePipeline!
 Polly.Registry.ResiliencePipelineRegistry<TKey>.GetOrAddPipeline<TResult>(TKey key, System.Action<Polly.ResiliencePipelineBuilder<TResult>!, Polly.Registry.ConfigureBuilderContext<TKey>!>! configure) -> Polly.ResiliencePipeline<TResult>!
 Polly.Registry.ResiliencePipelineRegistry<TKey>.GetOrAddPipeline<TResult>(TKey key, System.Action<Polly.ResiliencePipelineBuilder<TResult>!>! configure) -> Polly.ResiliencePipeline<TResult>!
-Polly.Registry.ResiliencePipelineRegistry<TKey>.RemoveBuilder(TKey key) -> bool
-Polly.Registry.ResiliencePipelineRegistry<TKey>.RemoveBuilder<TResult>(TKey key) -> bool
-Polly.Registry.ResiliencePipelineRegistry<TKey>.RemovePipeline(TKey key) -> bool
-Polly.Registry.ResiliencePipelineRegistry<TKey>.RemovePipeline<TResult>(TKey key) -> bool
 Polly.Registry.ResiliencePipelineRegistry<TKey>.ResiliencePipelineRegistry() -> void
 Polly.Registry.ResiliencePipelineRegistry<TKey>.ResiliencePipelineRegistry(Polly.Registry.ResiliencePipelineRegistryOptions<TKey>! options) -> void
 Polly.Registry.ResiliencePipelineRegistry<TKey>.TryAddBuilder(TKey key, System.Action<Polly.ResiliencePipelineBuilder!, Polly.Registry.ConfigureBuilderContext<TKey>!>! configure) -> bool
 Polly.Registry.ResiliencePipelineRegistry<TKey>.TryAddBuilder<TResult>(TKey key, System.Action<Polly.ResiliencePipelineBuilder<TResult>!, Polly.Registry.ConfigureBuilderContext<TKey>!>! configure) -> bool
-Polly.Registry.ResiliencePipelineRegistry<TKey>.TryAddPipeline(TKey key, Polly.ResiliencePipeline! pipeline) -> bool
-Polly.Registry.ResiliencePipelineRegistry<TKey>.TryAddPipeline<TResult>(TKey key, Polly.ResiliencePipeline<TResult>! pipeline) -> bool
 Polly.Registry.ResiliencePipelineRegistryOptions<TKey>
 Polly.Registry.ResiliencePipelineRegistryOptions<TKey>.BuilderComparer.get -> System.Collections.Generic.IEqualityComparer<TKey>!
 Polly.Registry.ResiliencePipelineRegistryOptions<TKey>.BuilderComparer.set -> void

--- a/src/Polly.Core/Registry/ResiliencePipelineRegistry.TResult.cs
+++ b/src/Polly.Core/Registry/ResiliencePipelineRegistry.TResult.cs
@@ -28,10 +28,6 @@ public sealed partial class ResiliencePipelineRegistry<TKey> : ResiliencePipelin
             _instanceNameFormatter = instanceNameFormatter;
         }
 
-        public bool TryAdd(TKey key, ResiliencePipeline<TResult> strategy) => _strategies.TryAdd(key, strategy);
-
-        public bool Remove(TKey key) => _strategies.TryRemove(key, out _);
-
         public bool TryGet(TKey key, [NotNullWhen(true)] out ResiliencePipeline<TResult>? strategy)
         {
             if (_strategies.TryGetValue(key, out strategy))
@@ -65,9 +61,5 @@ public sealed partial class ResiliencePipelineRegistry<TKey> : ResiliencePipelin
         }
 
         public bool TryAddBuilder(TKey key, Action<ResiliencePipelineBuilder<TResult>, ConfigureBuilderContext<TKey>> configure) => _builders.TryAdd(key, configure);
-
-        public bool RemoveBuilder(TKey key) => _builders.TryRemove(key, out _);
-
-        public void Clear() => _strategies.Clear();
     }
 }

--- a/src/Polly.Core/Registry/ResiliencePipelineRegistry.cs
+++ b/src/Polly.Core/Registry/ResiliencePipelineRegistry.cs
@@ -60,50 +60,6 @@ public sealed partial class ResiliencePipelineRegistry<TKey> : ResiliencePipelin
         _pipelineComparer = options.PipelineComparer;
     }
 
-    /// <summary>
-    /// Tries to add an existing resilience pipeline to the registry.
-    /// </summary>
-    /// <param name="key">The key used to identify the resilience pipeline.</param>
-    /// <param name="pipeline">The resilience pipeline instance.</param>
-    /// <returns><see langword="true"/> if the pipeline was added successfully, <see langword="false"/> otherwise.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="pipeline"/> is <see langword="null"/>.</exception>
-    public bool TryAddPipeline(TKey key, ResiliencePipeline pipeline)
-    {
-        Guard.NotNull(pipeline);
-
-        return _pipelines.TryAdd(key, pipeline);
-    }
-
-    /// <summary>
-    /// Tries to add an existing generic resilience pipeline to the registry.
-    /// </summary>
-    /// <typeparam name="TResult">The type of result that the resilience pipeline handles.</typeparam>
-    /// <param name="key">The key used to identify the resilience pipeline.</param>
-    /// <param name="pipeline">The resilience pipeline instance.</param>
-    /// <returns><see langword="true"/> if the pipeline was added successfully, <see langword="false"/> otherwise.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="pipeline"/> is <see langword="null"/>.</exception>
-    public bool TryAddPipeline<TResult>(TKey key, ResiliencePipeline<TResult> pipeline)
-    {
-        Guard.NotNull(pipeline);
-
-        return GetGenericRegistry<TResult>().TryAdd(key, pipeline);
-    }
-
-    /// <summary>
-    /// Removes a resilience pipeline from the registry.
-    /// </summary>
-    /// <param name="key">The key used to identify the resilience pipeline.</param>
-    /// <returns><see langword="true"/> if the pipeline was removed successfully, <see langword="false"/> otherwise.</returns>
-    public bool RemovePipeline(TKey key) => _pipelines.TryRemove(key, out _);
-
-    /// <summary>
-    /// Removes a generic resilience pipeline from the registry.
-    /// </summary>
-    /// <typeparam name="TResult">The type of result that the resilience pipeline handles.</typeparam>
-    /// <param name="key">The key used to identify the resilience pipeline.</param>
-    /// <returns><see langword="true"/> if the pipeline was removed successfully, <see langword="false"/> otherwise.</returns>
-    public bool RemovePipeline<TResult>(TKey key) => GetGenericRegistry<TResult>().Remove(key);
-
     /// <inheritdoc/>
     public override bool TryGetPipeline<TResult>(TKey key, [NotNullWhen(true)] out ResiliencePipeline<TResult>? pipeline)
     {
@@ -231,38 +187,6 @@ public sealed partial class ResiliencePipelineRegistry<TKey> : ResiliencePipelin
 
         return GetGenericRegistry<TResult>().TryAddBuilder(key, configure);
     }
-
-    /// <summary>
-    /// Removes a resilience pipeline builder from the registry.
-    /// </summary>
-    /// <param name="key">The key used to identify the resilience pipeline builder.</param>
-    /// <returns><see langword="true"/> if the builder was removed successfully, <see langword="false"/> otherwise.</returns>
-    public bool RemoveBuilder(TKey key) => _builders.TryRemove(key, out _);
-
-    /// <summary>
-    /// Removes a generic resilience pipeline builder from the registry.
-    /// </summary>
-    /// <typeparam name="TResult">The type of result that the resilience pipeline handles.</typeparam>
-    /// <param name="key">The key used to identify the resilience pipeline builder.</param>
-    /// <returns><see langword="true"/> if the builder was removed successfully, <see langword="false"/> otherwise.</returns>
-    public bool RemoveBuilder<TResult>(TKey key) => GetGenericRegistry<TResult>().RemoveBuilder(key);
-
-    /// <summary>
-    /// Clears all cached pipelines.
-    /// </summary>
-    /// <remarks>
-    /// This method only clears the cached pipelines, the registered builders are kept unchanged.
-    /// </remarks>
-    public void ClearPipelines() => _pipelines.Clear();
-
-    /// <summary>
-    /// Clears all cached generic pipelines.
-    /// </summary>
-    /// <typeparam name="TResult">The type of result that the resilience pipeline handles.</typeparam>
-    /// <remarks>
-    /// This method only clears the cached pipelines, the registered builders are kept unchanged.
-    /// </remarks>
-    public void ClearPipelines<TResult>() => GetGenericRegistry<TResult>().Clear();
 
     private static PipelineComponent CreatePipelineComponent<TBuilder>(
         Func<TBuilder> activator,

--- a/src/Polly.Extensions/DependencyInjection/PollyServiceCollectionExtensions.cs
+++ b/src/Polly.Extensions/DependencyInjection/PollyServiceCollectionExtensions.cs
@@ -76,8 +76,6 @@ public static class PollyServiceCollectionExtensions
             {
                 options.Actions.Add((registry) =>
                 {
-                    // the last added builder with the same key wins, this allows overriding the builders
-                    registry.RemoveBuilder<TResult>(key);
                     registry.TryAddBuilder<TResult>(key, (builder, context) =>
                     {
                         configure(builder, new AddResiliencePipelineContext<TKey>(context, serviceProvider));
@@ -148,7 +146,6 @@ public static class PollyServiceCollectionExtensions
                 options.Actions.Add((registry) =>
                 {
                     // the last added builder with the same key wins, this allows overriding the builders
-                    registry.RemoveBuilder(key);
                     registry.TryAddBuilder(key, (builder, context) =>
                     {
                         configure(builder, new AddResiliencePipelineContext<TKey>(context, serviceProvider));

--- a/test/Polly.Extensions.Tests/DependencyInjection/PollyServiceCollectionExtensionTests.cs
+++ b/test/Polly.Extensions.Tests/DependencyInjection/PollyServiceCollectionExtensionTests.cs
@@ -197,7 +197,7 @@ public class PollyServiceCollectionExtensionTests
     [InlineData(true)]
     [InlineData(false)]
     [Theory]
-    public void AddResiliencePipeline_Twice_LastOneWins(bool generic)
+    public void AddResiliencePipeline_Twice_FirstOneWins(bool generic)
     {
         var firstCalled = false;
         var secondCalled = false;
@@ -215,8 +215,8 @@ public class PollyServiceCollectionExtensionTests
             CreateProvider().GetPipeline(Key);
         }
 
-        firstCalled.Should().BeFalse();
-        secondCalled.Should().BeTrue();
+        firstCalled.Should().BeTrue();
+        secondCalled.Should().BeFalse();
     }
 
     [Fact]

--- a/test/Polly.Extensions.Tests/Issues/IssuesTests.OverrideLibraryStrategies_1072.cs
+++ b/test/Polly.Extensions.Tests/Issues/IssuesTests.OverrideLibraryStrategies_1072.cs
@@ -15,7 +15,6 @@ public partial class IssuesTests
         // arrange
         var services = new ServiceCollection();
         var failFirstCall = true;
-        AddLibraryServices(services);
 
         if (overrideStrategy)
         {
@@ -31,6 +30,8 @@ public partial class IssuesTests
                 BaseDelay = TimeSpan.Zero
             }));
         }
+
+        AddLibraryServices(services);
 
         var serviceProvider = services.BuildServiceProvider();
         var api = serviceProvider.GetRequiredService<LibraryApi>();


### PR DESCRIPTION
### Details on the issue fix or feature implementation

This makes the registry append-only.

One reason the removals might not be required is the built-in dynamic reload support. Instead of removing, re-creating and adding the pipeline back, it's cleaner and safer to just tell the registry to reload the pipeline.

 If there is a feature request for it, we can add these APIs easily back.

Contributes to #1233

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
