### PR TITLE
Cleanup ResiliencePipelineRegistry internals

### DIFF
--- a/src/Polly.Core/Registry/ConfigureBuilderContext.cs
+++ b/src/Polly.Core/Registry/ConfigureBuilderContext.cs
@@ -31,7 +31,7 @@ public class ConfigureBuilderContext<TKey>
     /// </summary>
     internal string? BuilderInstanceName { get; }
 
-    internal Func<Func<CancellationToken>>? ReloadTokenProducer { get; set; }
+    internal Func<Func<CancellationToken>>? ReloadTokenProducer { get; private set; }
 
     /// <summary>
     /// Enables dynamic reloading of the strategy retrieved from <see cref="ResiliencePipelineRegistry{TKey}"/>.

--- a/src/Polly.Core/Registry/ConfigureBuilderContext.cs
+++ b/src/Polly.Core/Registry/ConfigureBuilderContext.cs
@@ -31,7 +31,7 @@ public class ConfigureBuilderContext<TKey>
     /// </summary>
     internal string? BuilderInstanceName { get; }
 
-    internal Func<Func<CancellationToken>>? ReloadTokenProducer { get; private set; }
+    internal Func<Func<CancellationToken>>? ReloadTokenProducer { get; set; }
 
     /// <summary>
     /// Enables dynamic reloading of the strategy retrieved from <see cref="ResiliencePipelineRegistry{TKey}"/>.

--- a/src/Polly.Core/Registry/RegistryPipelineComponentBuilder.cs
+++ b/src/Polly.Core/Registry/RegistryPipelineComponentBuilder.cs
@@ -1,0 +1,72 @@
+﻿using Polly.Telemetry;
+using Polly.Utils.Pipeline;
+
+namespace Polly.Registry;
+
+/// <summary>
+/// Builds a <see cref="PipelineComponent"/> used by the registry.
+/// </summary>
+internal class RegistryPipelineComponentBuilder<TBuilder, TKey>
+    where TBuilder : ResiliencePipelineBuilderBase
+    where TKey : notnull
+{
+    private readonly Func<TBuilder> _activator;
+    private readonly TKey _key;
+    private readonly string _builderName;
+    private readonly string? _instanceName;
+    private readonly Action<TBuilder, ConfigureBuilderContext<TKey>> _configure;
+
+    public RegistryPipelineComponentBuilder(
+        Func<TBuilder> activator,
+        TKey key,
+        string builderName,
+        string? instanceName,
+        Action<TBuilder, ConfigureBuilderContext<TKey>> configure)
+    {
+        _activator = activator;
+        _key = key;
+        _builderName = builderName;
+        _instanceName = instanceName;
+        _configure = configure;
+    }
+
+    internal PipelineComponent CreateComponent()
+    {
+        var builder = CreateBuilder();
+        var telemetry = new ResilienceStrategyTelemetry(
+            new ResilienceTelemetrySource(_builderName, _instanceName, null),
+            builder.Listener);
+
+        var initialPipeline = builder.ComponentFactory();
+
+        if (builder.ReloadTokenProducer is null)
+        {
+            return initialPipeline;
+        }
+
+        return PipelineComponentFactory.CreateReloadable(
+            initialPipeline,
+            builder.ReloadTokenProducer(),
+            () => CreateBuilder().ComponentFactory(),
+            telemetry);
+    }
+
+    private Builder CreateBuilder()
+    {
+        var context = new ConfigureBuilderContext<TKey>(_key, _builderName, _instanceName);
+        var builder = _activator();
+        builder.Name = _builderName;
+        builder.InstanceName = _instanceName;
+        _configure(builder, context);
+
+        return new(
+            builder.BuildPipelineComponent,
+            context.ReloadTokenProducer,
+            builder.TelemetryListener);
+    }
+
+    private record Builder(
+        Func<PipelineComponent> ComponentFactory,
+        Func<Func<CancellationToken>>? ReloadTokenProducer,
+        TelemetryListener? Listener);
+}

--- a/src/Polly.Core/Registry/ResiliencePipelineRegistry.cs
+++ b/src/Polly.Core/Registry/ResiliencePipelineRegistry.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
-using Polly.Telemetry;
 using Polly.Utils.Pipeline;
 
 namespace Polly.Registry;
@@ -124,15 +123,17 @@ public sealed partial class ResiliencePipelineRegistry<TKey> : ResiliencePipelin
             return pipeline;
         }
 
-        var context = new ConfigureBuilderContext<TKey>(key, _builderNameFormatter(key), _instanceNameFormatter?.Invoke(key));
-
-        return _pipelines.GetOrAdd(key, static (_, factory) =>
+        return _pipelines.GetOrAdd(key, k =>
         {
-            var component = CreatePipelineComponent(factory.instance._activator, factory.context, factory.configure);
+            var component = new RegistryPipelineComponentBuilder<ResiliencePipelineBuilder, TKey>(
+                _activator,
+                k,
+                _builderNameFormatter(k),
+                _instanceNameFormatter?.Invoke(k),
+                configure).CreateComponent();
 
             return new ResiliencePipeline(component, DisposeBehavior.Reject);
-        },
-        (instance: this, context, configure));
+        });
     }
 
     /// <summary>
@@ -258,36 +259,6 @@ public sealed partial class ResiliencePipelineRegistry<TKey> : ResiliencePipelin
         {
             await disposable.DisposeAsync().ConfigureAwait(false);
         }
-    }
-
-    private static PipelineComponent CreatePipelineComponent<TBuilder>(
-        Func<TBuilder> activator,
-        ConfigureBuilderContext<TKey> context,
-        Action<TBuilder, ConfigureBuilderContext<TKey>> configure)
-        where TBuilder : ResiliencePipelineBuilderBase
-    {
-        Func<TBuilder> factory = () =>
-        {
-            var builder = activator();
-            builder.Name = context.BuilderName;
-            builder.InstanceName = context.BuilderInstanceName;
-            configure(builder, context);
-
-            return builder;
-        };
-
-        var builder = factory();
-        var pipeline = builder.BuildPipelineComponent();
-        var telemetry = new ResilienceStrategyTelemetry(
-            new ResilienceTelemetrySource(context.BuilderName, context.BuilderInstanceName, null),
-            builder.TelemetryListener);
-
-        if (context.ReloadTokenProducer is null)
-        {
-            return pipeline;
-        }
-
-        return PipelineComponentFactory.CreateReloadable(pipeline, context.ReloadTokenProducer(), () => factory().BuildPipelineComponent(), telemetry);
     }
 
     private GenericRegistry<TResult> GetGenericRegistry<TResult>()


### PR DESCRIPTION
### Details on the issue fix or feature implementation

- `ConfigureBuilderContext` should not be cached, instead re-created per each call.
- Moved `PipelineComponent` construction to a separate class.

No public changes.

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
