### PR TITLE
Allow to dispose linked resources on pipeline disposal

### DIFF
--- a/src/Polly.Core/PublicAPI.Unshipped.txt
+++ b/src/Polly.Core/PublicAPI.Unshipped.txt
@@ -159,6 +159,7 @@ Polly.PredicateBuilder<TResult>.PredicateBuilder() -> void
 Polly.PredicateResult
 Polly.Registry.ConfigureBuilderContext<TKey>
 Polly.Registry.ConfigureBuilderContext<TKey>.EnableReloads(System.Func<System.Func<System.Threading.CancellationToken>!>! tokenProducerFactory) -> void
+Polly.Registry.ConfigureBuilderContext<TKey>.OnPipelineDisposed(System.Action! callback) -> void
 Polly.Registry.ConfigureBuilderContext<TKey>.PipelineKey.get -> TKey
 Polly.Registry.ResiliencePipelineProvider<TKey>
 Polly.Registry.ResiliencePipelineProvider<TKey>.ResiliencePipelineProvider() -> void

--- a/src/Polly.Core/Registry/ConfigureBuilderContext.cs
+++ b/src/Polly.Core/Registry/ConfigureBuilderContext.cs
@@ -33,6 +33,8 @@ public class ConfigureBuilderContext<TKey>
 
     internal Func<Func<CancellationToken>>? ReloadTokenProducer { get; private set; }
 
+    internal List<Action> DisposeCallbacks { get; } = new();
+
     /// <summary>
     /// Enables dynamic reloading of the strategy retrieved from <see cref="ResiliencePipelineRegistry{TKey}"/>.
     /// </summary>
@@ -47,5 +49,16 @@ public class ConfigureBuilderContext<TKey>
         Guard.NotNull(tokenProducerFactory);
 
         ReloadTokenProducer = tokenProducerFactory;
+    }
+
+    /// <summary>
+    /// Registers a callback that is called when the pipeline instance being configured is disposed.
+    /// </summary>
+    /// <param name="callback">The callback delegate.</param>
+    public void OnPipelineDisposed(Action callback)
+    {
+        Guard.NotNull(callback);
+
+        DisposeCallbacks.Add(callback);
     }
 }

--- a/src/Polly.Core/Registry/RegistryPipelineComponentBuilder.cs
+++ b/src/Polly.Core/Registry/RegistryPipelineComponentBuilder.cs
@@ -60,13 +60,17 @@ internal class RegistryPipelineComponentBuilder<TBuilder, TKey>
         _configure(builder, context);
 
         return new(
-            builder.BuildPipelineComponent,
+            () => PipelineComponentFactory.WithDisposableCallbacks(
+                    builder.BuildPipelineComponent(),
+                    context.DisposeCallbacks),
             context.ReloadTokenProducer,
+            context.DisposeCallbacks,
             builder.TelemetryListener);
     }
 
     private record Builder(
         Func<PipelineComponent> ComponentFactory,
         Func<Func<CancellationToken>>? ReloadTokenProducer,
+        List<Action> DisposeCallbacks,
         TelemetryListener? Listener);
 }

--- a/src/Polly.Core/Utils/Pipeline/ComponentWithDisposeCallbacks.cs
+++ b/src/Polly.Core/Utils/Pipeline/ComponentWithDisposeCallbacks.cs
@@ -7,7 +7,7 @@ internal class ComponentWithDisposeCallbacks : PipelineComponent
     public ComponentWithDisposeCallbacks(PipelineComponent component, List<Action> callbacks)
     {
         Component = component;
-        _callbacks = callbacks.ToList();
+        _callbacks = callbacks;
     }
 
     internal PipelineComponent Component { get; }

--- a/src/Polly.Core/Utils/Pipeline/ComponentWithDisposeCallbacks.cs
+++ b/src/Polly.Core/Utils/Pipeline/ComponentWithDisposeCallbacks.cs
@@ -1,0 +1,43 @@
+﻿namespace Polly.Utils.Pipeline;
+
+internal class ComponentWithDisposeCallbacks : PipelineComponent
+{
+    private readonly List<Action> _callbacks;
+
+    public ComponentWithDisposeCallbacks(PipelineComponent component, List<Action> callbacks)
+    {
+        Component = component;
+        _callbacks = callbacks.ToList();
+    }
+
+    internal PipelineComponent Component { get; }
+
+    public override void Dispose()
+    {
+        ExecuteCallbacks();
+
+        Component.Dispose();
+    }
+
+    public override ValueTask DisposeAsync()
+    {
+        ExecuteCallbacks();
+
+        return Component.DisposeAsync();
+    }
+
+    internal override ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
+        Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
+        ResilienceContext context,
+        TState state) => Component.ExecuteCore(callback, context, state);
+
+    private void ExecuteCallbacks()
+    {
+        foreach (var callback in _callbacks)
+        {
+            callback();
+        }
+
+        _callbacks.Clear();
+    }
+}

--- a/src/Polly.Core/Utils/Pipeline/PipelineComponentFactory.cs
+++ b/src/Polly.Core/Utils/Pipeline/PipelineComponentFactory.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Polly.Telemetry;
+
 namespace Polly.Utils.Pipeline;
 
 internal static class PipelineComponentFactory
@@ -12,6 +13,16 @@ internal static class PipelineComponentFactory
     public static PipelineComponent FromStrategy(ResilienceStrategy strategy) => new BridgeComponent(strategy);
 
     public static PipelineComponent FromStrategy<T>(ResilienceStrategy<T> strategy) => new BridgeComponent<T>(strategy);
+
+    public static PipelineComponent WithDisposableCallbacks(PipelineComponent component, List<Action> callbacks)
+    {
+        if (callbacks.Count == 0)
+        {
+            return component;
+        }
+
+        return new ComponentWithDisposeCallbacks(component, callbacks);
+    }
 
     public static PipelineComponent CreateComposite(
         IReadOnlyList<PipelineComponent> components,

--- a/src/Polly.Core/Utils/Pipeline/PipelineComponentFactory.cs
+++ b/src/Polly.Core/Utils/Pipeline/PipelineComponentFactory.cs
@@ -14,14 +14,14 @@ internal static class PipelineComponentFactory
 
     public static PipelineComponent FromStrategy<T>(ResilienceStrategy<T> strategy) => new BridgeComponent<T>(strategy);
 
-    public static PipelineComponent WithDisposableCallbacks(PipelineComponent component, List<Action> callbacks)
+    public static PipelineComponent WithDisposableCallbacks(PipelineComponent component, IEnumerable<Action> callbacks)
     {
-        if (callbacks.Count == 0)
+        if (!callbacks.Any())
         {
             return component;
         }
 
-        return new ComponentWithDisposeCallbacks(component, callbacks);
+        return new ComponentWithDisposeCallbacks(component, callbacks.ToList());
     }
 
     public static PipelineComponent CreateComposite(

--- a/src/Polly.Extensions/DependencyInjection/AddResiliencePipelineContext.cs
+++ b/src/Polly.Extensions/DependencyInjection/AddResiliencePipelineContext.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Polly.Registry;
+using Polly.Utils;
 
 namespace Polly.DependencyInjection;
 
@@ -62,5 +63,16 @@ public sealed class AddResiliencePipelineContext<TKey>
         var monitor = ServiceProvider.GetRequiredService<IOptionsMonitor<TOptions>>();
 
         return name == null ? monitor.CurrentValue : monitor.Get(name);
+    }
+
+    /// <summary>
+    /// Registers a callback that is called when the pipeline instance being configured is disposed.
+    /// </summary>
+    /// <param name="callback">The callback delegate.</param>
+    public void OnPipelineDisposed(Action callback)
+    {
+        Guard.NotNull(callback);
+
+        RegistryContext.OnPipelineDisposed(callback);
     }
 }

--- a/src/Polly.Extensions/PublicAPI.Unshipped.txt
+++ b/src/Polly.Extensions/PublicAPI.Unshipped.txt
@@ -3,6 +3,7 @@ abstract Polly.Telemetry.MeteringEnricher.Enrich<TResult, TArgs>(in Polly.Teleme
 Polly.DependencyInjection.AddResiliencePipelineContext<TKey>
 Polly.DependencyInjection.AddResiliencePipelineContext<TKey>.EnableReloads<TOptions>(string? name = null) -> void
 Polly.DependencyInjection.AddResiliencePipelineContext<TKey>.GetOptions<TOptions>(string? name = null) -> TOptions
+Polly.DependencyInjection.AddResiliencePipelineContext<TKey>.OnPipelineDisposed(System.Action! callback) -> void
 Polly.DependencyInjection.AddResiliencePipelineContext<TKey>.PipelineKey.get -> TKey
 Polly.DependencyInjection.AddResiliencePipelineContext<TKey>.ServiceProvider.get -> System.IServiceProvider!
 Polly.PollyServiceCollectionExtensions

--- a/src/Polly.Testing/ResiliencePipelineExtensions.cs
+++ b/src/Polly.Testing/ResiliencePipelineExtensions.cs
@@ -62,7 +62,7 @@ public static class ResiliencePipelineExtensions
         return component;
     }
 
-    private static bool ShouldSkip(object instance) => instance is ReloadableComponent;
+    private static bool ShouldSkip(object instance) => instance is ReloadableComponent || instance is ComponentWithDisposeCallbacks;
 
     private static void ExpandComponents(this PipelineComponent component, List<PipelineComponent> components)
     {
@@ -77,6 +77,10 @@ public static class ResiliencePipelineExtensions
         {
             components.Add(reloadable);
             ExpandComponents(reloadable.Component, components);
+        }
+        else if (component is ComponentWithDisposeCallbacks callbacks)
+        {
+            ExpandComponents(callbacks.Component, components);
         }
         else
         {

--- a/test/Polly.Core.Tests/Utils/Pipeline/ComponentWithDisposeCallbacksTests.cs
+++ b/test/Polly.Core.Tests/Utils/Pipeline/ComponentWithDisposeCallbacksTests.cs
@@ -39,7 +39,7 @@ public class ComponentWithDisposeCallbacksTests
         }
 
         // Assert
-        callbacks.Should().HaveCount(2);
+        callbacks.Should().BeEmpty();
         called1.Should().Be(1);
         called2.Should().Be(1);
     }

--- a/test/Polly.Core.Tests/Utils/Pipeline/ComponentWithDisposeCallbacksTests.cs
+++ b/test/Polly.Core.Tests/Utils/Pipeline/ComponentWithDisposeCallbacksTests.cs
@@ -1,0 +1,46 @@
+﻿using NSubstitute;
+using Polly.Utils.Pipeline;
+
+namespace Polly.Core.Tests.Utils.Pipeline;
+
+public class ComponentWithDisposeCallbacksTests
+{
+    [InlineData(true)]
+    [InlineData(false)]
+    [Theory]
+    public async Task Dispose_Ok(bool isAsync)
+    {
+        // Arrange
+        var called1 = 0;
+        var called2 = 0;
+
+        var callbacks = new List<Action>
+        {
+            () => called1++,
+            () => called2++
+        };
+        var component = Substitute.For<PipelineComponent>();
+        var sut = new ComponentWithDisposeCallbacks(component, callbacks);
+
+        // Act
+        if (isAsync)
+        {
+            await sut.DisposeAsync();
+            await sut.DisposeAsync();
+            await component.Received(2).DisposeAsync();
+        }
+        else
+        {
+            sut.Dispose();
+#pragma warning disable S3966 // Objects should not be disposed more than once
+            sut.Dispose();
+#pragma warning restore S3966 // Objects should not be disposed more than once
+            component.Received(2).Dispose();
+        }
+
+        // Assert
+        callbacks.Should().HaveCount(2);
+        called1.Should().Be(1);
+        called2.Should().Be(1);
+    }
+}

--- a/test/Polly.Core.Tests/Utils/Pipeline/PipelineComponentFactoryTests.cs
+++ b/test/Polly.Core.Tests/Utils/Pipeline/PipelineComponentFactoryTests.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NSubstitute;
+using Polly.Utils.Pipeline;
+
+namespace Polly.Core.Tests.Utils.Pipeline;
+
+public class PipelineComponentFactoryTests
+{
+    [Fact]
+    public void WithDisposableCallbacks_NoCallbacks_ReturnsOriginalComponent()
+    {
+        var component = Substitute.For<PipelineComponent>();
+        var result = PipelineComponentFactory.WithDisposableCallbacks(component, new List<Action>());
+        result.Should().BeSameAs(component);
+    }
+
+    [Fact]
+    public void PipelineComponentFactory_Should_Return_WrapperComponent_With_Callbacks()
+    {
+        var component = Substitute.For<PipelineComponent>();
+        List<Action> callbacks = new List<Action> { () => { } };
+
+        var result = PipelineComponentFactory.WithDisposableCallbacks(component, callbacks);
+
+        result.Should().BeOfType<ComponentWithDisposeCallbacks>();
+    }
+}

--- a/test/Polly.Core.Tests/Utils/Pipeline/PipelineComponentFactoryTests.cs
+++ b/test/Polly.Core.Tests/Utils/Pipeline/PipelineComponentFactoryTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using NSubstitute;
+﻿using NSubstitute;
 using Polly.Utils.Pipeline;
 
 namespace Polly.Core.Tests.Utils.Pipeline;

--- a/test/Polly.Core.Tests/Utils/Pipeline/PipelineComponentFactoryTests.cs
+++ b/test/Polly.Core.Tests/Utils/Pipeline/PipelineComponentFactoryTests.cs
@@ -17,7 +17,7 @@ public class PipelineComponentFactoryTests
     public void PipelineComponentFactory_Should_Return_WrapperComponent_With_Callbacks()
     {
         var component = Substitute.For<PipelineComponent>();
-        List<Action> callbacks = new List<Action> { () => { } };
+        var callbacks = new List<Action> { () => { } };
 
         var result = PipelineComponentFactory.WithDisposableCallbacks(component, callbacks);
 

--- a/test/Polly.Extensions.Tests/DisposablePipelineTests.cs
+++ b/test/Polly.Extensions.Tests/DisposablePipelineTests.cs
@@ -1,0 +1,58 @@
+﻿using System.Threading.RateLimiting;
+using Microsoft.Extensions.DependencyInjection;
+using Polly.RateLimiting;
+using Polly.Registry;
+
+namespace Polly.Extensions.Tests;
+
+public class DisposablePipelineTests
+{
+    [Fact]
+    public void DisposePipeline_EnsureLinkedResourcesDisposedToo()
+    {
+        var limiters = new List<RateLimiter>();
+
+        var provider = new ServiceCollection()
+            .AddResiliencePipeline("my-pipeline", (builder, context) =>
+            {
+                var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
+                {
+                    PermitLimit = 1,
+                    QueueLimit = 1
+                });
+                limiters.Add(limiter);
+
+                builder.AddRateLimiter(new RateLimiterStrategyOptions
+                {
+                    RateLimiter = args => limiter.AcquireAsync(1, args.Context.CancellationToken)
+                });
+
+                // when the pipeline instance is disposed, limiter is disposed too
+                context.OnPipelineDisposed(() => limiter.Dispose());
+            })
+            .BuildServiceProvider();
+
+        limiters.Should().HaveCount(0);
+        provider.GetRequiredService<ResiliencePipelineProvider<string>>().GetPipeline("my-pipeline");
+        provider.GetRequiredService<ResiliencePipelineProvider<string>>().GetPipeline("my-pipeline");
+        limiters.Should().HaveCount(1);
+        IsDisposed(limiters[0]).Should().BeFalse();
+
+        provider.Dispose();
+        limiters.Should().HaveCount(1);
+        IsDisposed(limiters[0]).Should().BeTrue();
+    }
+
+    private static bool IsDisposed(RateLimiter limiter)
+    {
+        try
+        {
+            limiter.AcquireAsync(1).AsTask().GetAwaiter().GetResult();
+            return false;
+        }
+        catch (ObjectDisposedException)
+        {
+            return true;
+        }
+    }
+}

--- a/test/Polly.Testing.Tests/ResiliencePipelineExtensionsTests.cs
+++ b/test/Polly.Testing.Tests/ResiliencePipelineExtensionsTests.cs
@@ -116,7 +116,7 @@ public class ResiliencePipelineExtensionsTests
         var strategy = registry.GetOrAddPipeline("dummy", (builder, context) =>
         {
             context.EnableReloads(() => () => CancellationToken.None);
-
+            context.OnPipelineDisposed(() => { });
             builder
                 .AddConcurrencyLimiter(10)
                 .AddStrategy(_ => new CustomStrategy(), new TestOptions());


### PR DESCRIPTION
### Details on the issue fix or feature implementation

Allows disposal of resources attached to the pipeline or to attach any cleanup actions:

``` csharp
var provider = new ServiceCollection()
    .AddResiliencePipeline("my-pipeline", (builder, context) =>
    {
        var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
        {
            PermitLimit = 1,
            QueueLimit = 1
        });

        builder.AddRateLimiter(new RateLimiterStrategyOptions
        {
            RateLimiter = args => limiter.AcquireAsync(1, args.Context.CancellationToken)
        });

        // when the pipeline instance is disposed, limiter is disposed too
        context.OnPipelineDisposed(() => limiter.Dispose());
    });
```

This is not inclusive to rate limiters as any disposable resource created when configuring the pipeline can be now freed after the pipeline is disposed. This prevents memory leaks and improves the performance.

Contributes to https://github.com/App-vNext/Polly/pull/1507#discussion_r1302499181

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
