### PR TITLE
API Review Feedback

### DIFF
--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerPredicateArguments.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerPredicateArguments.cs
@@ -23,7 +23,7 @@ public readonly struct CircuitBreakerPredicateArguments<TResult> : IOutcomeArgum
     }
 
     /// <summary>
-    /// Gets the outcome of user-callback.
+    /// Gets the outcome of the user-specified callback.
     /// </summary>
     public Outcome<TResult> Outcome { get; }
 

--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerPredicateArguments.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerPredicateArguments.cs
@@ -23,12 +23,12 @@ public readonly struct CircuitBreakerPredicateArguments<TResult> : IOutcomeArgum
     }
 
     /// <summary>
-    /// Gets the outcome of the resilience operation or event.
+    /// Gets the outcome of user-callback.
     /// </summary>
     public Outcome<TResult> Outcome { get; }
 
     /// <summary>
-    /// Gets the context in which the resilience operation or event occurred.
+    /// Gets the context of this event.
     /// </summary>
     public ResilienceContext Context { get; }
 }

--- a/src/Polly.Core/CircuitBreaker/OnCircuitClosedArguments.cs
+++ b/src/Polly.Core/CircuitBreaker/OnCircuitClosedArguments.cs
@@ -25,12 +25,12 @@ public readonly struct OnCircuitClosedArguments<TResult> : IOutcomeArguments<TRe
     }
 
     /// <summary>
-    /// Gets the outcome of the resilience operation or event.
+    /// Gets the outcome that caused the circuit breaker to be closed.
     /// </summary>
     public Outcome<TResult> Outcome { get; }
 
     /// <summary>
-    /// Gets the context in which the resilience operation or event occurred.
+    /// Gets the context of this event.
     /// </summary>
     public ResilienceContext Context { get; }
 

--- a/src/Polly.Core/CircuitBreaker/OnCircuitOpenedArguments.cs
+++ b/src/Polly.Core/CircuitBreaker/OnCircuitOpenedArguments.cs
@@ -27,12 +27,12 @@ public readonly struct OnCircuitOpenedArguments<TResult> : IOutcomeArguments<TRe
     }
 
     /// <summary>
-    /// Gets the outcome of the resilience operation or event.
+    /// Gets the outcome that caused the circuit to open.
     /// </summary>
     public Outcome<TResult> Outcome { get; }
 
     /// <summary>
-    /// Gets the context in which the resilience operation or event occurred.
+    /// Gets the context of this event.
     /// </summary>
     public ResilienceContext Context { get; }
 

--- a/src/Polly.Core/Fallback/FallbackActionArguments.cs
+++ b/src/Polly.Core/Fallback/FallbackActionArguments.cs
@@ -1,29 +1,29 @@
-namespace Polly.Hedging;
+﻿namespace Polly.Fallback;
 
 #pragma warning disable CA1815 // Override equals and operator equals on value types
 
 /// <summary>
-/// Represents arguments used in hedging handling scenarios.
+/// Arguments used by <see cref="FallbackStrategyOptions{TResult}.FallbackAction"/>.
 /// </summary>
 /// <typeparam name="TResult">The type of result.</typeparam>
 /// <remarks>
 /// Always use the constructor when creating this struct, otherwise we do not guarantee binary compatibility.
 /// </remarks>
-public readonly struct HedgingPredicateArguments<TResult> : IOutcomeArguments<TResult>
+public readonly struct FallbackActionArguments<TResult> : IOutcomeArguments<TResult>
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="HedgingPredicateArguments{TResult}"/> struct.
+    /// Initializes a new instance of the <see cref="FallbackActionArguments{TResult}"/> struct.
     /// </summary>
     /// <param name="outcome">The context in which the resilience operation or event occurred.</param>
     /// <param name="context">The outcome of the resilience operation or event.</param>
-    public HedgingPredicateArguments(ResilienceContext context, Outcome<TResult> outcome)
+    public FallbackActionArguments(ResilienceContext context, Outcome<TResult> outcome)
     {
         Context = context;
         Outcome = outcome;
     }
 
     /// <summary>
-    /// Gets the outcome of user-callback.
+    /// Gets the outcome that should be handled by the fallback.
     /// </summary>
     public Outcome<TResult> Outcome { get; }
 

--- a/src/Polly.Core/Fallback/FallbackHandler.cs
+++ b/src/Polly.Core/Fallback/FallbackHandler.cs
@@ -2,11 +2,11 @@ namespace Polly.Fallback;
 
 internal sealed record class FallbackHandler<T>(
     Func<FallbackPredicateArguments<T>, ValueTask<bool>> ShouldHandle,
-    Func<FallbackPredicateArguments<T>, ValueTask<Outcome<T>>> ActionGenerator)
+    Func<FallbackActionArguments<T>, ValueTask<Outcome<T>>> ActionGenerator)
 {
-    public async ValueTask<Outcome<TResult>> GetFallbackOutcomeAsync<TResult>(FallbackPredicateArguments<T> args)
+    public async ValueTask<Outcome<TResult>> GetFallbackOutcomeAsync<TResult>(FallbackActionArguments<T> args)
     {
-        var copiedArgs = new FallbackPredicateArguments<T>(
+        var copiedArgs = new FallbackActionArguments<T>(
             args.Context,
             args.Outcome.AsOutcome<T>());
 

--- a/src/Polly.Core/Fallback/FallbackPredicateArguments.cs
+++ b/src/Polly.Core/Fallback/FallbackPredicateArguments.cs
@@ -23,7 +23,7 @@ public readonly struct FallbackPredicateArguments<TResult> : IOutcomeArguments<T
     }
 
     /// <summary>
-    /// Gets the outcome of user-callback.
+    /// Gets the outcome of the user-specified callback.
     /// </summary>
     public Outcome<TResult> Outcome { get; }
 

--- a/src/Polly.Core/Fallback/FallbackPredicateArguments.cs
+++ b/src/Polly.Core/Fallback/FallbackPredicateArguments.cs
@@ -23,12 +23,12 @@ public readonly struct FallbackPredicateArguments<TResult> : IOutcomeArguments<T
     }
 
     /// <summary>
-    /// Gets the outcome of the resilience operation or event.
+    /// Gets the outcome of user-callback.
     /// </summary>
     public Outcome<TResult> Outcome { get; }
 
     /// <summary>
-    /// Gets the context in which the resilience operation or event occurred.
+    /// Gets the context of this event.
     /// </summary>
     public ResilienceContext Context { get; }
 }

--- a/src/Polly.Core/Fallback/FallbackResilienceStrategy.cs
+++ b/src/Polly.Core/Fallback/FallbackResilienceStrategy.cs
@@ -37,7 +37,7 @@ internal sealed class FallbackResilienceStrategy<T> : ResilienceStrategy<T>
 
         try
         {
-            return await _handler.GetFallbackOutcomeAsync<T>(handleFallbackArgs).ConfigureAwait(context.ContinueOnCapturedContext);
+            return await _handler.GetFallbackOutcomeAsync<T>(new FallbackActionArguments<T>(context, outcome)).ConfigureAwait(context.ContinueOnCapturedContext);
         }
         catch (Exception e)
         {

--- a/src/Polly.Core/Fallback/FallbackStrategyOptions.TResult.cs
+++ b/src/Polly.Core/Fallback/FallbackStrategyOptions.TResult.cs
@@ -29,7 +29,7 @@ public class FallbackStrategyOptions<TResult> : ResilienceStrategyOptions
     /// The default value is <see langword="null"/>. This property is required.
     /// </value>
     [Required]
-    public Func<FallbackPredicateArguments<TResult>, ValueTask<Outcome<TResult>>>? FallbackAction { get; set; }
+    public Func<FallbackActionArguments<TResult>, ValueTask<Outcome<TResult>>>? FallbackAction { get; set; }
 
     /// <summary>
     /// Gets or sets event delegate that is raised when fallback happens.

--- a/src/Polly.Core/Fallback/OnFallbackArguments.cs
+++ b/src/Polly.Core/Fallback/OnFallbackArguments.cs
@@ -23,12 +23,12 @@ public readonly struct OnFallbackArguments<TResult> : IOutcomeArguments<TResult>
     }
 
     /// <summary>
-    /// Gets the outcome of the resilience operation or event.
+    /// Gets the outcome that caused the fallback to be executed.
     /// </summary>
     public Outcome<TResult> Outcome { get; }
 
     /// <summary>
-    /// Gets the context in which the resilience operation or event occurred.
+    /// Gets the context of this event.
     /// </summary>
     public ResilienceContext Context { get; }
 }

--- a/src/Polly.Core/Hedging/Controller/HedgingHandler.cs
+++ b/src/Polly.Core/Hedging/Controller/HedgingHandler.cs
@@ -13,9 +13,9 @@ internal sealed record class HedgingHandler<T>(
                 args.PrimaryContext,
                 args.ActionContext,
                 args.AttemptNumber,
-                (Func<ResilienceContext, ValueTask<Outcome<T>>>)(object)args.Callback);
+                args.Callback);
 
-            return (Func<ValueTask<Outcome<T>>>?)(object)ActionGenerator(copiedArgs)!;
+            return ActionGenerator(copiedArgs);
         }
 
         return CreateNonGenericAction(args);

--- a/src/Polly.Core/Hedging/HedgingDelayGeneratorArguments.cs
+++ b/src/Polly.Core/Hedging/HedgingDelayGeneratorArguments.cs
@@ -8,14 +8,14 @@ namespace Polly.Hedging;
 /// <remarks>
 /// Always use the constructor when creating this struct, otherwise we do not guarantee binary compatibility.
 /// </remarks>
-public readonly struct HedgingDelayArguments
+public readonly struct HedgingDelayGeneratorArguments
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="HedgingDelayArguments"/> struct.
+    /// Initializes a new instance of the <see cref="HedgingDelayGeneratorArguments"/> struct.
     /// </summary>
     /// <param name="context">The context associated with the execution of a user-provided callback.</param>
     /// <param name="attemptNumber">The zero-based hedging attempt number.</param>
-    public HedgingDelayArguments(ResilienceContext context, int attemptNumber)
+    public HedgingDelayGeneratorArguments(ResilienceContext context, int attemptNumber)
     {
         Context = context;
         AttemptNumber = attemptNumber;

--- a/src/Polly.Core/Hedging/HedgingPredicateArguments.cs
+++ b/src/Polly.Core/Hedging/HedgingPredicateArguments.cs
@@ -23,7 +23,7 @@ public readonly struct HedgingPredicateArguments<TResult> : IOutcomeArguments<TR
     }
 
     /// <summary>
-    /// Gets the outcome of user-callback.
+    /// Gets the outcome of the user-specified callback.
     /// </summary>
     public Outcome<TResult> Outcome { get; }
 

--- a/src/Polly.Core/Hedging/HedgingResilienceStrategy.cs
+++ b/src/Polly.Core/Hedging/HedgingResilienceStrategy.cs
@@ -95,7 +95,7 @@ internal sealed class HedgingResilienceStrategy<T> : ResilienceStrategy<T>
                 // If completedHedgedTask is null it indicates that we still do not have any finished hedged task within the hedging delay.
                 // We will create additional hedged task in the next iteration.
                 await HandleOnHedgingAsync(
-                    new OnHedgingArguments<T>(context, Outcome.FromResult<T>(default), attempt, hasOutcome: false, duration: delay)).ConfigureAwait(context.ContinueOnCapturedContext);
+                    new OnHedgingArguments<T>(context, null, attempt, duration: delay)).ConfigureAwait(context.ContinueOnCapturedContext);
                 continue;
             }
 
@@ -109,13 +109,13 @@ internal sealed class HedgingResilienceStrategy<T> : ResilienceStrategy<T>
 
             var executionTime = _timeProvider.GetElapsedTime(start);
             await HandleOnHedgingAsync(
-                new OnHedgingArguments<T>(context, outcome, attempt, hasOutcome: true, executionTime)).ConfigureAwait(context.ContinueOnCapturedContext);
+                new OnHedgingArguments<T>(context, outcome, attempt, executionTime)).ConfigureAwait(context.ContinueOnCapturedContext);
         }
     }
 
     private async ValueTask HandleOnHedgingAsync(OnHedgingArguments<T> args)
     {
-        _telemetry.Report<OnHedgingArguments<T>, T>(new(ResilienceEventSeverity.Warning, HedgingConstants.OnHedgingEventName), args);
+        _telemetry.Report<OnHedgingArguments<T>, T>(new(ResilienceEventSeverity.Warning, HedgingConstants.OnHedgingEventName), args.Context, default, args);
 
         if (OnHedging is not null)
         {

--- a/src/Polly.Core/Hedging/HedgingResilienceStrategy.cs
+++ b/src/Polly.Core/Hedging/HedgingResilienceStrategy.cs
@@ -15,7 +15,7 @@ internal sealed class HedgingResilienceStrategy<T> : ResilienceStrategy<T>
         int maxHedgedAttempts,
         HedgingHandler<T> hedgingHandler,
         Func<OnHedgingArguments<T>, ValueTask>? onHedging,
-        Func<HedgingDelayArguments, ValueTask<TimeSpan>>? hedgingDelayGenerator,
+        Func<HedgingDelayGeneratorArguments, ValueTask<TimeSpan>>? hedgingDelayGenerator,
         TimeProvider timeProvider,
         ResilienceStrategyTelemetry telemetry)
     {
@@ -34,7 +34,7 @@ internal sealed class HedgingResilienceStrategy<T> : ResilienceStrategy<T>
 
     public int MaxHedgedAttempts { get; }
 
-    public Func<HedgingDelayArguments, ValueTask<TimeSpan>>? HedgingDelayGenerator { get; }
+    public Func<HedgingDelayGeneratorArguments, ValueTask<TimeSpan>>? HedgingDelayGenerator { get; }
 
     public HedgingHandler<T> HedgingHandler { get; }
 
@@ -133,6 +133,6 @@ internal sealed class HedgingResilienceStrategy<T> : ResilienceStrategy<T>
             return new ValueTask<TimeSpan>(HedgingDelay);
         }
 
-        return HedgingDelayGenerator(new HedgingDelayArguments(context, attempt));
+        return HedgingDelayGenerator(new HedgingDelayGeneratorArguments(context, attempt));
     }
 }

--- a/src/Polly.Core/Hedging/HedgingStrategyOptions.TResult.cs
+++ b/src/Polly.Core/Hedging/HedgingStrategyOptions.TResult.cs
@@ -79,7 +79,7 @@ public class HedgingStrategyOptions<TResult> : ResilienceStrategyOptions
     /// <value>
     /// The default value is <see langword="null"/>.
     /// </value>
-    public Func<HedgingDelayArguments, ValueTask<TimeSpan>>? HedgingDelayGenerator { get; set; }
+    public Func<HedgingDelayGeneratorArguments, ValueTask<TimeSpan>>? HedgingDelayGenerator { get; set; }
 
     /// <summary>
     /// Gets or sets the event that is raised when a hedging is performed.

--- a/src/Polly.Core/Hedging/OnHedgingArguments.cs
+++ b/src/Polly.Core/Hedging/OnHedgingArguments.cs
@@ -9,7 +9,7 @@ namespace Polly.Hedging;
 /// <remarks>
 /// Always use the constructor when creating this struct, otherwise we do not guarantee binary compatibility.
 /// </remarks>
-public readonly struct OnHedgingArguments<TResult> : IOutcomeArguments<TResult>
+public readonly struct OnHedgingArguments<TResult>
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="OnHedgingArguments{TResult}"/> struct.
@@ -17,24 +17,23 @@ public readonly struct OnHedgingArguments<TResult> : IOutcomeArguments<TResult>
     /// <param name="outcome">The context in which the resilience operation or event occurred.</param>
     /// <param name="context">The outcome of the resilience operation or event.</param>
     /// <param name="attemptNumber">The zero-based hedging attempt number.</param>
-    /// <param name="hasOutcome">Indicates whether outcome is available.</param>
     /// <param name="duration">The execution duration of hedging attempt or the hedging delay in case the attempt was not finished in time.</param>
-    public OnHedgingArguments(ResilienceContext context, Outcome<TResult> outcome, int attemptNumber, bool hasOutcome, TimeSpan duration)
+    public OnHedgingArguments(ResilienceContext context, Outcome<TResult>? outcome, int attemptNumber, TimeSpan duration)
     {
         Context = context;
         Outcome = outcome;
         AttemptNumber = attemptNumber;
-        HasOutcome = hasOutcome;
         Duration = duration;
     }
 
     /// <summary>
-    /// Gets the outcome of the resilience operation or event.
+    /// Gets the outcome that needs to be hedged, if any.
     /// </summary>
-    public Outcome<TResult> Outcome { get; }
+    /// <remarks>If this property is <see langword="null"/>, it's an indication that user-callback or hedged operation did not complete within the hedging delay.</remarks>
+    public Outcome<TResult>? Outcome { get; }
 
     /// <summary>
-    /// Gets the context in which the resilience operation or event occurred.
+    /// Gets the context of this event.
     /// </summary>
     public ResilienceContext Context { get; }
 
@@ -42,14 +41,6 @@ public readonly struct OnHedgingArguments<TResult> : IOutcomeArguments<TResult>
     /// Gets the zero-based hedging attempt number.
     /// </summary>
     public int AttemptNumber { get; }
-
-    /// <summary>
-    /// Gets a value indicating whether the outcome is available before loading the next hedged task.
-    /// </summary>
-    /// <remarks>
-    /// No outcome indicates that the previous action did not finish within the hedging delay.
-    /// </remarks>
-    public bool HasOutcome { get; }
 
     /// <summary>
     /// Gets the execution duration of hedging attempt or the hedging delay in case the attempt was not finished in time.

--- a/src/Polly.Core/PublicAPI.Unshipped.txt
+++ b/src/Polly.Core/PublicAPI.Unshipped.txt
@@ -119,11 +119,11 @@ Polly.Hedging.HedgingActionGeneratorArguments<TResult>.Callback.get -> System.Fu
 Polly.Hedging.HedgingActionGeneratorArguments<TResult>.HedgingActionGeneratorArguments() -> void
 Polly.Hedging.HedgingActionGeneratorArguments<TResult>.HedgingActionGeneratorArguments(Polly.ResilienceContext! primaryContext, Polly.ResilienceContext! actionContext, int attemptNumber, System.Func<Polly.ResilienceContext!, System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>>! callback) -> void
 Polly.Hedging.HedgingActionGeneratorArguments<TResult>.PrimaryContext.get -> Polly.ResilienceContext!
-Polly.Hedging.HedgingDelayArguments
-Polly.Hedging.HedgingDelayArguments.AttemptNumber.get -> int
-Polly.Hedging.HedgingDelayArguments.Context.get -> Polly.ResilienceContext!
-Polly.Hedging.HedgingDelayArguments.HedgingDelayArguments() -> void
-Polly.Hedging.HedgingDelayArguments.HedgingDelayArguments(Polly.ResilienceContext! context, int attemptNumber) -> void
+Polly.Hedging.HedgingDelayGeneratorArguments
+Polly.Hedging.HedgingDelayGeneratorArguments.AttemptNumber.get -> int
+Polly.Hedging.HedgingDelayGeneratorArguments.Context.get -> Polly.ResilienceContext!
+Polly.Hedging.HedgingDelayGeneratorArguments.HedgingDelayGeneratorArguments() -> void
+Polly.Hedging.HedgingDelayGeneratorArguments.HedgingDelayGeneratorArguments(Polly.ResilienceContext! context, int attemptNumber) -> void
 Polly.Hedging.HedgingPredicateArguments<TResult>
 Polly.Hedging.HedgingPredicateArguments<TResult>.Context.get -> Polly.ResilienceContext!
 Polly.Hedging.HedgingPredicateArguments<TResult>.HedgingPredicateArguments() -> void
@@ -134,7 +134,7 @@ Polly.Hedging.HedgingStrategyOptions<TResult>.HedgingActionGenerator.get -> Syst
 Polly.Hedging.HedgingStrategyOptions<TResult>.HedgingActionGenerator.set -> void
 Polly.Hedging.HedgingStrategyOptions<TResult>.HedgingDelay.get -> System.TimeSpan
 Polly.Hedging.HedgingStrategyOptions<TResult>.HedgingDelay.set -> void
-Polly.Hedging.HedgingStrategyOptions<TResult>.HedgingDelayGenerator.get -> System.Func<Polly.Hedging.HedgingDelayArguments, System.Threading.Tasks.ValueTask<System.TimeSpan>>?
+Polly.Hedging.HedgingStrategyOptions<TResult>.HedgingDelayGenerator.get -> System.Func<Polly.Hedging.HedgingDelayGeneratorArguments, System.Threading.Tasks.ValueTask<System.TimeSpan>>?
 Polly.Hedging.HedgingStrategyOptions<TResult>.HedgingDelayGenerator.set -> void
 Polly.Hedging.HedgingStrategyOptions<TResult>.HedgingStrategyOptions() -> void
 Polly.Hedging.HedgingStrategyOptions<TResult>.MaxHedgedAttempts.get -> int
@@ -293,13 +293,13 @@ Polly.Retry.RetryBackoffType
 Polly.Retry.RetryBackoffType.Constant = 0 -> Polly.Retry.RetryBackoffType
 Polly.Retry.RetryBackoffType.Exponential = 2 -> Polly.Retry.RetryBackoffType
 Polly.Retry.RetryBackoffType.Linear = 1 -> Polly.Retry.RetryBackoffType
-Polly.Retry.RetryDelayArguments<TResult>
-Polly.Retry.RetryDelayArguments<TResult>.AttemptNumber.get -> int
-Polly.Retry.RetryDelayArguments<TResult>.Context.get -> Polly.ResilienceContext!
-Polly.Retry.RetryDelayArguments<TResult>.DelayHint.get -> System.TimeSpan
-Polly.Retry.RetryDelayArguments<TResult>.Outcome.get -> Polly.Outcome<TResult>
-Polly.Retry.RetryDelayArguments<TResult>.RetryDelayArguments() -> void
-Polly.Retry.RetryDelayArguments<TResult>.RetryDelayArguments(Polly.ResilienceContext! context, Polly.Outcome<TResult> outcome, int attemptNumber, System.TimeSpan delayHint) -> void
+Polly.Retry.RetryDelayGeneratorArguments<TResult>
+Polly.Retry.RetryDelayGeneratorArguments<TResult>.AttemptNumber.get -> int
+Polly.Retry.RetryDelayGeneratorArguments<TResult>.Context.get -> Polly.ResilienceContext!
+Polly.Retry.RetryDelayGeneratorArguments<TResult>.DelayHint.get -> System.TimeSpan
+Polly.Retry.RetryDelayGeneratorArguments<TResult>.Outcome.get -> Polly.Outcome<TResult>
+Polly.Retry.RetryDelayGeneratorArguments<TResult>.RetryDelayGeneratorArguments() -> void
+Polly.Retry.RetryDelayGeneratorArguments<TResult>.RetryDelayGeneratorArguments(Polly.ResilienceContext! context, Polly.Outcome<TResult> outcome, int attemptNumber, System.TimeSpan delayHint) -> void
 Polly.Retry.RetryPredicateArguments<TResult>
 Polly.Retry.RetryPredicateArguments<TResult>.AttemptNumber.get -> int
 Polly.Retry.RetryPredicateArguments<TResult>.Context.get -> Polly.ResilienceContext!
@@ -319,7 +319,7 @@ Polly.Retry.RetryStrategyOptions<TResult>.Randomizer.get -> System.Func<double>!
 Polly.Retry.RetryStrategyOptions<TResult>.Randomizer.set -> void
 Polly.Retry.RetryStrategyOptions<TResult>.RetryCount.get -> int
 Polly.Retry.RetryStrategyOptions<TResult>.RetryCount.set -> void
-Polly.Retry.RetryStrategyOptions<TResult>.RetryDelayGenerator.get -> System.Func<Polly.Retry.RetryDelayArguments<TResult>, System.Threading.Tasks.ValueTask<System.TimeSpan>>?
+Polly.Retry.RetryStrategyOptions<TResult>.RetryDelayGenerator.get -> System.Func<Polly.Retry.RetryDelayGeneratorArguments<TResult>, System.Threading.Tasks.ValueTask<System.TimeSpan>>?
 Polly.Retry.RetryStrategyOptions<TResult>.RetryDelayGenerator.set -> void
 Polly.Retry.RetryStrategyOptions<TResult>.RetryStrategyOptions() -> void
 Polly.Retry.RetryStrategyOptions<TResult>.ShouldHandle.get -> System.Func<Polly.Retry.RetryPredicateArguments<TResult>, System.Threading.Tasks.ValueTask<bool>>!

--- a/src/Polly.Core/PublicAPI.Unshipped.txt
+++ b/src/Polly.Core/PublicAPI.Unshipped.txt
@@ -88,13 +88,18 @@ Polly.ExecutionRejectedException
 Polly.ExecutionRejectedException.ExecutionRejectedException() -> void
 Polly.ExecutionRejectedException.ExecutionRejectedException(string! message) -> void
 Polly.ExecutionRejectedException.ExecutionRejectedException(string! message, System.Exception! inner) -> void
+Polly.Fallback.FallbackActionArguments<TResult>
+Polly.Fallback.FallbackActionArguments<TResult>.Context.get -> Polly.ResilienceContext!
+Polly.Fallback.FallbackActionArguments<TResult>.FallbackActionArguments() -> void
+Polly.Fallback.FallbackActionArguments<TResult>.FallbackActionArguments(Polly.ResilienceContext! context, Polly.Outcome<TResult> outcome) -> void
+Polly.Fallback.FallbackActionArguments<TResult>.Outcome.get -> Polly.Outcome<TResult>
 Polly.Fallback.FallbackPredicateArguments<TResult>
 Polly.Fallback.FallbackPredicateArguments<TResult>.Context.get -> Polly.ResilienceContext!
 Polly.Fallback.FallbackPredicateArguments<TResult>.FallbackPredicateArguments() -> void
 Polly.Fallback.FallbackPredicateArguments<TResult>.FallbackPredicateArguments(Polly.ResilienceContext! context, Polly.Outcome<TResult> outcome) -> void
 Polly.Fallback.FallbackPredicateArguments<TResult>.Outcome.get -> Polly.Outcome<TResult>
 Polly.Fallback.FallbackStrategyOptions<TResult>
-Polly.Fallback.FallbackStrategyOptions<TResult>.FallbackAction.get -> System.Func<Polly.Fallback.FallbackPredicateArguments<TResult>, System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>>?
+Polly.Fallback.FallbackStrategyOptions<TResult>.FallbackAction.get -> System.Func<Polly.Fallback.FallbackActionArguments<TResult>, System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>>?
 Polly.Fallback.FallbackStrategyOptions<TResult>.FallbackAction.set -> void
 Polly.Fallback.FallbackStrategyOptions<TResult>.FallbackStrategyOptions() -> void
 Polly.Fallback.FallbackStrategyOptions<TResult>.OnFallback.get -> System.Func<Polly.Fallback.OnFallbackArguments<TResult>, System.Threading.Tasks.ValueTask>?
@@ -142,10 +147,9 @@ Polly.Hedging.OnHedgingArguments<TResult>
 Polly.Hedging.OnHedgingArguments<TResult>.AttemptNumber.get -> int
 Polly.Hedging.OnHedgingArguments<TResult>.Context.get -> Polly.ResilienceContext!
 Polly.Hedging.OnHedgingArguments<TResult>.Duration.get -> System.TimeSpan
-Polly.Hedging.OnHedgingArguments<TResult>.HasOutcome.get -> bool
 Polly.Hedging.OnHedgingArguments<TResult>.OnHedgingArguments() -> void
-Polly.Hedging.OnHedgingArguments<TResult>.OnHedgingArguments(Polly.ResilienceContext! context, Polly.Outcome<TResult> outcome, int attemptNumber, bool hasOutcome, System.TimeSpan duration) -> void
-Polly.Hedging.OnHedgingArguments<TResult>.Outcome.get -> Polly.Outcome<TResult>
+Polly.Hedging.OnHedgingArguments<TResult>.OnHedgingArguments(Polly.ResilienceContext! context, Polly.Outcome<TResult>? outcome, int attemptNumber, System.TimeSpan duration) -> void
+Polly.Hedging.OnHedgingArguments<TResult>.Outcome.get -> Polly.Outcome<TResult>?
 Polly.HedgingResiliencePipelineBuilderExtensions
 Polly.LegacySupport
 Polly.Outcome

--- a/src/Polly.Core/Retry/OnRetryArguments.cs
+++ b/src/Polly.Core/Retry/OnRetryArguments.cs
@@ -29,12 +29,12 @@ public readonly struct OnRetryArguments<TResult> : IOutcomeArguments<TResult>
     }
 
     /// <summary>
-    /// Gets the outcome of the resilience operation or event.
+    /// Gets the outcome that will be retried.
     /// </summary>
     public Outcome<TResult> Outcome { get; }
 
     /// <summary>
-    /// Gets the context in which the resilience operation or event occurred.
+    /// Gets the context of this event.
     /// </summary>
     public ResilienceContext Context { get; }
 

--- a/src/Polly.Core/Retry/RetryDelayGeneratorArguments.cs
+++ b/src/Polly.Core/Retry/RetryDelayGeneratorArguments.cs
@@ -9,16 +9,16 @@ namespace Polly.Retry;
 /// <remarks>
 /// Always use the constructor when creating this struct, otherwise we do not guarantee binary compatibility.
 /// </remarks>
-public readonly struct RetryDelayArguments<TResult>
+public readonly struct RetryDelayGeneratorArguments<TResult>
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="RetryDelayArguments{TResult}"/> struct.
+    /// Initializes a new instance of the <see cref="RetryDelayGeneratorArguments{TResult}"/> struct.
     /// </summary>
     /// <param name="outcome">The context in which the resilience operation or event occurred.</param>
     /// <param name="context">The outcome of the resilience operation or event.</param>
     /// <param name="attemptNumber">The zero-based attempt number.</param>
     /// <param name="delayHint">The delay suggested by the retry strategy.</param>
-    public RetryDelayArguments(ResilienceContext context, Outcome<TResult> outcome, int attemptNumber, TimeSpan delayHint)
+    public RetryDelayGeneratorArguments(ResilienceContext context, Outcome<TResult> outcome, int attemptNumber, TimeSpan delayHint)
     {
         Context = context;
         Outcome = outcome;

--- a/src/Polly.Core/Retry/RetryPredicateArguments.cs
+++ b/src/Polly.Core/Retry/RetryPredicateArguments.cs
@@ -25,7 +25,7 @@ public readonly struct RetryPredicateArguments<TResult> : IOutcomeArguments<TRes
     }
 
     /// <summary>
-    /// Gets the outcome of user-callback.
+    /// Gets the outcome of the user-specified callback.
     /// </summary>
     public Outcome<TResult> Outcome { get; }
 

--- a/src/Polly.Core/Retry/RetryPredicateArguments.cs
+++ b/src/Polly.Core/Retry/RetryPredicateArguments.cs
@@ -25,12 +25,12 @@ public readonly struct RetryPredicateArguments<TResult> : IOutcomeArguments<TRes
     }
 
     /// <summary>
-    /// Gets the outcome of the resilience operation or event.
+    /// Gets the outcome of user-callback.
     /// </summary>
     public Outcome<TResult> Outcome { get; }
 
     /// <summary>
-    /// Gets the context in which the resilience operation or event occurred.
+    /// Gets the context of this event.
     /// </summary>
     public ResilienceContext Context { get; }
 

--- a/src/Polly.Core/Retry/RetryResilienceStrategy.cs
+++ b/src/Polly.Core/Retry/RetryResilienceStrategy.cs
@@ -34,7 +34,7 @@ internal sealed class RetryResilienceStrategy<T> : ResilienceStrategy<T>
 
     public Func<RetryPredicateArguments<T>, ValueTask<bool>> ShouldHandle { get; }
 
-    public Func<RetryDelayArguments<T>, ValueTask<TimeSpan>>? DelayGenerator { get; }
+    public Func<RetryDelayGeneratorArguments<T>, ValueTask<TimeSpan>>? DelayGenerator { get; }
 
     public bool UseJitter { get; }
 
@@ -64,7 +64,7 @@ internal sealed class RetryResilienceStrategy<T> : ResilienceStrategy<T>
             var delay = RetryHelper.GetRetryDelay(BackoffType, UseJitter, attempt, BaseDelay, ref retryState, _randomizer);
             if (DelayGenerator is not null)
             {
-                var delayArgs = new RetryDelayArguments<T>(context, outcome, attempt, delay);
+                var delayArgs = new RetryDelayGeneratorArguments<T>(context, outcome, attempt, delay);
                 var newDelay = await DelayGenerator(delayArgs).ConfigureAwait(false);
                 if (RetryHelper.IsValidDelay(newDelay))
                 {

--- a/src/Polly.Core/Retry/RetryStrategyOptions.TResult.cs
+++ b/src/Polly.Core/Retry/RetryStrategyOptions.TResult.cs
@@ -90,7 +90,7 @@ public class RetryStrategyOptions<TResult> : ResilienceStrategyOptions
     /// <value>
     /// The default value is <see langword="null"/>.
     /// </value>
-    public Func<RetryDelayArguments<TResult>, ValueTask<TimeSpan>>? RetryDelayGenerator { get; set; }
+    public Func<RetryDelayGeneratorArguments<TResult>, ValueTask<TimeSpan>>? RetryDelayGenerator { get; set; }
 
     /// <summary>
     /// Gets or sets an event delegate that is raised when the retry happens.

--- a/src/Polly.Extensions/PublicAPI.Unshipped.txt
+++ b/src/Polly.Extensions/PublicAPI.Unshipped.txt
@@ -21,8 +21,7 @@ Polly.Telemetry.TelemetryOptions.LoggerFactory.set -> void
 Polly.Telemetry.TelemetryOptions.MeteringEnrichers.get -> System.Collections.Generic.ICollection<Polly.Telemetry.MeteringEnricher!>!
 Polly.Telemetry.TelemetryOptions.ResultFormatter.get -> System.Func<Polly.ResilienceContext!, object?, object?>!
 Polly.Telemetry.TelemetryOptions.ResultFormatter.set -> void
-Polly.Telemetry.TelemetryOptions.TelemetryListener.get -> Polly.Telemetry.TelemetryListener?
-Polly.Telemetry.TelemetryOptions.TelemetryListener.set -> void
+Polly.Telemetry.TelemetryOptions.TelemetryListeners.get -> System.Collections.Generic.ICollection<Polly.Telemetry.TelemetryListener!>!
 Polly.Telemetry.TelemetryOptions.TelemetryOptions() -> void
 Polly.TelemetryResiliencePipelineBuilderExtensions
 static Polly.PollyServiceCollectionExtensions.AddResiliencePipeline<TKey, TResult>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, TKey key, System.Action<Polly.ResiliencePipelineBuilder<TResult>!, Polly.DependencyInjection.AddResiliencePipelineContext<TKey>!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Polly.Extensions/Telemetry/TelemetryListenerImpl.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryListenerImpl.cs
@@ -43,6 +43,7 @@ internal sealed class TelemetryListenerImpl : TelemetryListener
 
     public override void Write<TResult, TArgs>(in TelemetryEventArguments<TResult, TArgs> args)
     {
+        // stryker disable once equality : no means to test this
         if (_listeners.Count > 0)
         {
             foreach (var listener in _listeners)

--- a/src/Polly.Extensions/Telemetry/TelemetryOptions.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryOptions.cs
@@ -11,12 +11,12 @@ namespace Polly.Telemetry;
 public class TelemetryOptions
 {
     /// <summary>
-    /// Gets or sets the optional user-specified telemetry listener.
+    /// Gets the collection of telemetry listeners.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="null"/>.
+    /// The default value is an empty collection.
     /// </value>
-    public TelemetryListener? TelemetryListener { get; set; }
+    public ICollection<TelemetryListener> TelemetryListeners { get; } = new List<TelemetryListener>();
 
     /// <summary>
     /// Gets or sets the logger factory.
@@ -28,7 +28,7 @@ public class TelemetryOptions
     public ILoggerFactory LoggerFactory { get; set; } = NullLoggerFactory.Instance;
 
     /// <summary>
-    /// Gets the registered resilience telemetry enrichers.
+    /// Gets the collection of telemetry enrichers.
     /// </summary>
     /// <value>
     /// The default value is an empty collection.

--- a/test/Polly.Core.Tests/Fallback/FallbackHandlerTests.cs
+++ b/test/Polly.Core.Tests/Fallback/FallbackHandlerTests.cs
@@ -8,7 +8,7 @@ public class FallbackHandlerTests
     {
         var handler = FallbackHelper.CreateHandler(_ => true, () => Outcome.FromResult("secondary"));
         var context = ResilienceContextPool.Shared.Get();
-        var outcome = await handler.GetFallbackOutcomeAsync<string>(new FallbackPredicateArguments<string>(context, Outcome.FromResult("primary")))!;
+        var outcome = await handler.GetFallbackOutcomeAsync<string>(new FallbackActionArguments<string>(context, Outcome.FromResult("primary")))!;
 
         outcome.Result.Should().Be("secondary");
     }
@@ -18,7 +18,7 @@ public class FallbackHandlerTests
     {
         var handler = FallbackHelper.CreateHandler(_ => true, () => Outcome.FromResult((object)"secondary"));
         var context = ResilienceContextPool.Shared.Get();
-        var outcome = await handler.GetFallbackOutcomeAsync<object>(new FallbackPredicateArguments<object>(context, Outcome.FromResult((object)"primary")))!;
+        var outcome = await handler.GetFallbackOutcomeAsync<object>(new FallbackActionArguments<object>(context, Outcome.FromResult((object)"primary")))!;
 
         outcome.Result.Should().Be("secondary");
     }

--- a/test/Polly.Core.Tests/Fallback/FallbackResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Fallback/FallbackResilienceStrategyTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection.Metadata;
 using Polly.Fallback;
 using Polly.Telemetry;
 
@@ -28,6 +29,27 @@ public class FallbackResilienceStrategyTests
         Create().Execute(_ => "error").Should().Be("success");
 
         _args.Should().ContainSingle(v => v.Arguments is OnFallbackArguments<string>);
+        called.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldHandle_ArgumentsSetCorrectly()
+    {
+        var called = false;
+
+        _handler = new FallbackHandler<string>(
+            args =>
+            {
+                called = true;
+                args.Outcome.Result.Should().Be("ok");
+                args.Context.Should().NotBeNull();
+                called = true;
+
+                return PredicateResult.False;
+            },
+            args => Outcome.FromResultAsTask("fallback"));
+
+        Create().Execute(_ => "ok").Should().Be("ok");
         called.Should().BeTrue();
     }
 

--- a/test/Polly.Core.Tests/Fallback/FallbackResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Fallback/FallbackResilienceStrategyTests.cs
@@ -1,4 +1,3 @@
-using System.Reflection.Metadata;
 using Polly.Fallback;
 using Polly.Telemetry;
 

--- a/test/Polly.Core.Tests/Hedging/HedgingDelayGeneratorArgumentsTests.cs
+++ b/test/Polly.Core.Tests/Hedging/HedgingDelayGeneratorArgumentsTests.cs
@@ -2,12 +2,12 @@ using Polly.Hedging;
 
 namespace Polly.Core.Tests.Hedging;
 
-public class HedgingDelayArgumentsTests
+public class HedgingDelayGeneratorArgumentsTests
 {
     [Fact]
     public void Ctor_Ok()
     {
-        var args = new HedgingDelayArguments(ResilienceContextPool.Shared.Get(), 5);
+        var args = new HedgingDelayGeneratorArguments(ResilienceContextPool.Shared.Get(), 5);
 
         args.Context.Should().NotBeNull();
         args.AttemptNumber.Should().Be(5);

--- a/test/Polly.Core.Tests/Hedging/HedgingResiliencePipelineBuilderExtensionsTests.cs
+++ b/test/Polly.Core.Tests/Hedging/HedgingResiliencePipelineBuilderExtensionsTests.cs
@@ -88,9 +88,9 @@ public class HedgingResiliencePipelineBuilderExtensionsTests
                 },
                 OnHedging = args =>
                 {
-                    if (args.Outcome is not null)
+                    if (args.Outcome is { } outcome)
                     {
-                        results.Enqueue(args.Outcome!.Value.Result!.ToString()!);
+                        results.Enqueue(outcome.Result!.ToString()!);
                     }
                     else
                     {

--- a/test/Polly.Core.Tests/Hedging/HedgingResiliencePipelineBuilderExtensionsTests.cs
+++ b/test/Polly.Core.Tests/Hedging/HedgingResiliencePipelineBuilderExtensionsTests.cs
@@ -88,9 +88,9 @@ public class HedgingResiliencePipelineBuilderExtensionsTests
                 },
                 OnHedging = args =>
                 {
-                    if (args.HasOutcome)
+                    if (args.Outcome is not null)
                     {
-                        results.Enqueue(args.Outcome.Result!.ToString()!);
+                        results.Enqueue(args.Outcome!.Value.Result!.ToString()!);
                     }
                     else
                     {

--- a/test/Polly.Core.Tests/Hedging/HedgingResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Hedging/HedgingResilienceStrategyTests.cs
@@ -294,7 +294,7 @@ public class HedgingResilienceStrategyTests : IDisposable
         var hasOutcome = true;
         _options.OnHedging = args =>
         {
-            hasOutcome = args.HasOutcome;
+            hasOutcome = args.Outcome is not null;
             return default;
         };
 
@@ -886,8 +886,8 @@ public class HedgingResilienceStrategyTests : IDisposable
         var attempts = new List<int>();
         _options.OnHedging = args =>
         {
-            args.HasOutcome.Should().BeTrue();
-            args.Outcome.Result.Should().Be(Failure);
+            args.Outcome.Should().NotBeNull();
+            args.Outcome!.Value.Result.Should().Be(Failure);
             attempts.Add(args.AttemptNumber);
             return default;
         };
@@ -922,7 +922,10 @@ public class HedgingResilienceStrategyTests : IDisposable
         {
             lock (_results)
             {
-                _results.Add(args.Outcome.Result!);
+                if (args.Outcome.HasValue)
+                {
+                    _results.Add(args.Outcome.Value.Result!);
+                }
             }
 
             return default;

--- a/test/Polly.Core.Tests/Hedging/OnHedgingArgumentsTests.cs
+++ b/test/Polly.Core.Tests/Hedging/OnHedgingArgumentsTests.cs
@@ -7,12 +7,11 @@ public class OnHedgingArgumentsTests
     [Fact]
     public void Ctor_Ok()
     {
-        var args = new OnHedgingArguments<int>(ResilienceContextPool.Shared.Get(), Outcome.FromResult(1), 1, true, TimeSpan.FromSeconds(1));
+        var args = new OnHedgingArguments<int>(ResilienceContextPool.Shared.Get(), Outcome.FromResult(1), 1, TimeSpan.FromSeconds(1));
 
         args.Context.Should().NotBeNull();
-        args.Outcome.Result.Should().Be(1);
+        args.Outcome!.Value.Result.Should().Be(1);
         args.AttemptNumber.Should().Be(1);
-        args.HasOutcome.Should().BeTrue();
         args.Duration.Should().Be(TimeSpan.FromSeconds(1));
     }
 }

--- a/test/Polly.Core.Tests/Retry/RetryDelayGeneratorArgumentsTests.cs
+++ b/test/Polly.Core.Tests/Retry/RetryDelayGeneratorArgumentsTests.cs
@@ -2,12 +2,12 @@ using Polly.Retry;
 
 namespace Polly.Core.Tests.Retry;
 
-public class RetryDelayArgumentsTests
+public class RetryDelayGeneratorArgumentsTests
 {
     [Fact]
     public void Ctor_Ok()
     {
-        var args = new RetryDelayArguments<int>(ResilienceContextPool.Shared.Get(), Outcome.FromResult(1), 2, TimeSpan.FromSeconds(2));
+        var args = new RetryDelayGeneratorArguments<int>(ResilienceContextPool.Shared.Get(), Outcome.FromResult(1), 2, TimeSpan.FromSeconds(2));
 
         args.Context.Should().NotBeNull();
         args.Outcome.Result.Should().Be(1);

--- a/test/Polly.Extensions.Tests/Telemetry/TelemetryListenerImplTests.cs
+++ b/test/Polly.Extensions.Tests/Telemetry/TelemetryListenerImplTests.cs
@@ -464,7 +464,7 @@ public class TelemetryListenerImplTests : IDisposable
 
         if (_onEvent is not null)
         {
-            options.TelemetryListener = new FakeTelemetryListener(_onEvent);
+            options.TelemetryListeners.Add(new FakeTelemetryListener(_onEvent));
         }
 
         if (enrichers != null)


### PR DESCRIPTION
### Details on the issue fix or feature implementation

- Improved XML docs for arguments.
- Drop `OnHedgingArguments.HasOutcome` property
- Introduce `FallbackActionArguments` (instead of using `FallbackPredicateArguments` in `FallbackAction` delegate)
- Rename `RetryDelayArguments` to `RetryDelayGeneratorArguments` 
- Rename `HedgingDelayArguments` to `HedgingDelayGeneratorArguments` 
- Allow registering multiple listeners in `TelemetryOptions`

Contributes to #1507 

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
