### PR TITLE
Protect against retry delay overflows

### DIFF
--- a/src/Polly.Core/Retry/RetryHelper.cs
+++ b/src/Polly.Core/Retry/RetryHelper.cs
@@ -10,6 +10,18 @@ internal static class RetryHelper
 
     public static TimeSpan GetRetryDelay(RetryBackoffType type, bool jitter, int attempt, TimeSpan baseDelay, ref double state, Func<double> randomizer)
     {
+        try
+        {
+            return GetRetryDelayCore(type, jitter, attempt, baseDelay, ref state, randomizer);
+        }
+        catch (OverflowException)
+        {
+            return TimeSpan.MaxValue;
+        }
+    }
+
+    private static TimeSpan GetRetryDelayCore(RetryBackoffType type, bool jitter, int attempt, TimeSpan baseDelay, ref double state, Func<double> randomizer)
+    {
         if (baseDelay == TimeSpan.Zero)
         {
             return baseDelay;

--- a/test/Polly.Core.Tests/Retry/RetryHelperTests.cs
+++ b/test/Polly.Core.Tests/Retry/RetryHelperTests.cs
@@ -95,6 +95,14 @@ public class RetryHelperTests
         RetryHelper.GetRetryDelay(RetryBackoffType.Exponential, false, 2, TimeSpan.FromSeconds(1), ref state, _randomizer).Should().Be(TimeSpan.FromSeconds(4));
     }
 
+    [Fact]
+    public void GetRetryDelay_Overflow_ReturnsMaxTimeSpan()
+    {
+        double state = 0;
+
+        RetryHelper.GetRetryDelay(RetryBackoffType.Exponential, false, 1000, TimeSpan.FromDays(1), ref state, _randomizer).Should().Be(TimeSpan.MaxValue);
+    }
+
     [InlineData(1)]
     [InlineData(2)]
     [InlineData(3)]


### PR DESCRIPTION
### Details on the issue fix or feature implementation

If the calculated delay overflows just return `TimeSpan.MaxValue`.

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
