### PR TITLE
Cleanup Outcome internals and drop unused hedging and fallbacks APIs

### DIFF
--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerResiliencePipelineBuilderExtensions.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerResiliencePipelineBuilderExtensions.cs
@@ -77,6 +77,7 @@ public static class CircuitBreakerResiliencePipelineBuilderExtensions
             options.MinimumThroughput,
             HealthMetrics.Create(options.SamplingDuration, context.TimeProvider));
 
+#pragma warning disable CA2000 // Dispose objects before losing scope
         var controller = new CircuitStateController<TResult>(
             options.BreakDuration,
             options.OnOpened,
@@ -85,6 +86,7 @@ public static class CircuitBreakerResiliencePipelineBuilderExtensions
             behavior,
             context.TimeProvider,
             context.Telemetry);
+#pragma warning restore CA2000 // Dispose objects before losing scope
 
         return new CircuitBreakerResilienceStrategy<TResult>(
             options.ShouldHandle!,

--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerResilienceStrategy.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerResilienceStrategy.cs
@@ -15,7 +15,7 @@ internal sealed class CircuitBreakerResilienceStrategy<T> : ResilienceStrategy<T
         _handler = handler;
         _controller = controller;
 
-        stateProvider?.Initialize(() => _controller.CircuitState, () => _controller.LastHandledOutcome);
+        stateProvider?.Initialize(() => _controller.CircuitState);
         _manualControlRegistration = manualControl?.Initialize(
             async c => await _controller.IsolateCircuitAsync(c).ConfigureAwait(c.ContinueOnCapturedContext),
             async c => await _controller.CloseCircuitAsync(c).ConfigureAwait(c.ContinueOnCapturedContext));

--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerStateProvider.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerStateProvider.cs
@@ -6,9 +6,8 @@ namespace Polly.CircuitBreaker;
 public sealed class CircuitBreakerStateProvider
 {
     private Func<CircuitState>? _circuitStateProvider;
-    private Func<Outcome<object>?>? _lastHandledOutcomeProvider;
 
-    internal void Initialize(Func<CircuitState> circuitStateProvider, Func<Outcome<object>?> lastHandledOutcomeProvider)
+    internal void Initialize(Func<CircuitState> circuitStateProvider)
     {
         if (_circuitStateProvider != null)
         {
@@ -16,7 +15,6 @@ public sealed class CircuitBreakerStateProvider
         }
 
         _circuitStateProvider = circuitStateProvider;
-        _lastHandledOutcomeProvider = lastHandledOutcomeProvider;
     }
 
     /// <summary>
@@ -32,11 +30,4 @@ public sealed class CircuitBreakerStateProvider
     /// Gets the state of the underlying circuit.
     /// </summary>
     public CircuitState CircuitState => _circuitStateProvider?.Invoke() ?? CircuitState.Closed;
-
-    /// <summary>
-    /// Gets the last outcome handled by the circuit-breaker.
-    /// <remarks>
-    /// This will be null if no exceptions or results have been handled by the circuit-breaker since the circuit last closed.</remarks>
-    /// </summary>
-    internal Outcome<object>? LastHandledOutcome => _lastHandledOutcomeProvider?.Invoke();
 }

--- a/src/Polly.Core/CircuitBreaker/Controller/CircuitStateController.cs
+++ b/src/Polly.Core/CircuitBreaker/Controller/CircuitStateController.cs
@@ -18,7 +18,7 @@ internal sealed class CircuitStateController<T> : IDisposable
     private readonly TimeSpan _breakDuration;
     private DateTimeOffset _blockedUntil;
     private CircuitState _circuitState = CircuitState.Closed;
-    private Outcome<object>? _lastOutcome;
+    private Outcome<T>? _lastOutcome;
     private BrokenCircuitException _breakingException = new();
     private bool _disposed;
 
@@ -66,7 +66,7 @@ internal sealed class CircuitStateController<T> : IDisposable
         }
     }
 
-    public Outcome<object>? LastHandledOutcome
+    public Outcome<T>? LastHandledOutcome
     {
         get
         {
@@ -290,9 +290,9 @@ internal sealed class CircuitStateController<T> : IDisposable
         return false;
     }
 
-    private void SetLastHandledOutcome_NeedsLock<TResult>(Outcome<TResult> outcome)
+    private void SetLastHandledOutcome_NeedsLock(Outcome<T> outcome)
     {
-        _lastOutcome = Outcome.ToObjectOutcome(outcome);
+        _lastOutcome = outcome;
 
         if (outcome.Exception is Exception exception)
         {
@@ -300,7 +300,7 @@ internal sealed class CircuitStateController<T> : IDisposable
         }
         else if (outcome.TryGetResult(out var result))
         {
-            _breakingException = new BrokenCircuitException<TResult>(BrokenCircuitException.DefaultMessage, result!);
+            _breakingException = new BrokenCircuitException<T>(BrokenCircuitException.DefaultMessage, result!);
         }
     }
 

--- a/src/Polly.Core/CircuitBreaker/Controller/CircuitStateController.cs
+++ b/src/Polly.Core/CircuitBreaker/Controller/CircuitStateController.cs
@@ -292,7 +292,7 @@ internal sealed class CircuitStateController<T> : IDisposable
 
     private void SetLastHandledOutcome_NeedsLock<TResult>(Outcome<TResult> outcome)
     {
-        _lastOutcome = outcome.AsOutcome();
+        _lastOutcome = Outcome.ToObjectOutcome(outcome);
 
         if (outcome.Exception is Exception exception)
         {

--- a/src/Polly.Core/Fallback/FallbackHandler.cs
+++ b/src/Polly.Core/Fallback/FallbackHandler.cs
@@ -4,13 +4,6 @@ internal sealed record class FallbackHandler<T>(
     Func<FallbackPredicateArguments<T>, ValueTask<bool>> ShouldHandle,
     Func<FallbackActionArguments<T>, ValueTask<Outcome<T>>> ActionGenerator)
 {
-    public async ValueTask<Outcome<TResult>> GetFallbackOutcomeAsync<TResult>(FallbackActionArguments<T> args)
-    {
-        var copiedArgs = new FallbackActionArguments<T>(
-            args.Context,
-            args.Outcome.AsOutcome<T>());
-
-        return (await ActionGenerator(copiedArgs).ConfigureAwait(args.Context.ContinueOnCapturedContext)).AsOutcome<TResult>();
-    }
+    public ValueTask<Outcome<T>> GetFallbackOutcomeAsync(FallbackActionArguments<T> args) => ActionGenerator(args);
 }
 

--- a/src/Polly.Core/Fallback/FallbackResiliencePipelineBuilderExtensions.cs
+++ b/src/Polly.Core/Fallback/FallbackResiliencePipelineBuilderExtensions.cs
@@ -32,27 +32,6 @@ public static class FallbackResiliencePipelineBuilderExtensions
         return builder.AddStrategy(context => CreateFallback(context, options), options);
     }
 
-    /// <summary>
-    /// Adds a fallback resilience strategy with the provided options to the builder.
-    /// </summary>
-    /// <param name="builder">The resilience pipeline builder.</param>
-    /// <param name="options">The options to configure the fallback resilience strategy.</param>
-    /// <returns>The builder instance with the fallback strategy added.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
-    [UnconditionalSuppressMessage(
-        "Trimming",
-        "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code",
-        Justification = "All options members preserved.")]
-    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(FallbackStrategyOptions))]
-    internal static ResiliencePipelineBuilder AddFallback(this ResiliencePipelineBuilder builder, FallbackStrategyOptions options)
-    {
-        Guard.NotNull(builder);
-        Guard.NotNull(options);
-
-        return builder.AddStrategy(context => CreateFallback(context, options), options);
-    }
-
     private static ResilienceStrategy<TResult> CreateFallback<TResult>(
         StrategyBuilderContext context,
         FallbackStrategyOptions<TResult> options)

--- a/src/Polly.Core/Fallback/FallbackResilienceStrategy.cs
+++ b/src/Polly.Core/Fallback/FallbackResilienceStrategy.cs
@@ -37,7 +37,7 @@ internal sealed class FallbackResilienceStrategy<T> : ResilienceStrategy<T>
 
         try
         {
-            return await _handler.GetFallbackOutcomeAsync<T>(new FallbackActionArguments<T>(context, outcome)).ConfigureAwait(context.ContinueOnCapturedContext);
+            return await _handler.GetFallbackOutcomeAsync(new FallbackActionArguments<T>(context, outcome)).ConfigureAwait(context.ContinueOnCapturedContext);
         }
         catch (Exception e)
         {

--- a/src/Polly.Core/Fallback/FallbackStrategyOptions.cs
+++ b/src/Polly.Core/Fallback/FallbackStrategyOptions.cs
@@ -1,9 +1,0 @@
-namespace Polly.Fallback;
-
-/// <summary>
-/// Represents the options for configuring a fallback resilience strategy.
-/// </summary>
-internal class FallbackStrategyOptions : FallbackStrategyOptions<object>
-{
-}
-

--- a/src/Polly.Core/Hedging/Controller/HedgingExecutionContext.cs
+++ b/src/Polly.Core/Hedging/Controller/HedgingExecutionContext.cs
@@ -156,9 +156,7 @@ internal sealed class HedgingExecutionContext<T> : IAsyncDisposable
             var finishedExecution = _tasks.First(static t => t.ExecutionTaskSafe!.IsCompleted);
             finishedExecution.AcceptOutcome();
 
-            var outcome = Outcome.FromObjectOutcome<T>(finishedExecution.Outcome);
-
-            return new ExecutionInfo<T>(null, false, outcome);
+            return new ExecutionInfo<T>(null, false, finishedExecution.Outcome);
         }
 
         return new ExecutionInfo<T>(null, false, null);

--- a/src/Polly.Core/Hedging/Controller/HedgingExecutionContext.cs
+++ b/src/Polly.Core/Hedging/Controller/HedgingExecutionContext.cs
@@ -55,7 +55,7 @@ internal sealed class HedgingExecutionContext<T> : IAsyncDisposable
     {
         if (LoadedTasks >= _maxAttempts)
         {
-            return CreateExecutionInfoWhenNoExecution<T>();
+            return CreateExecutionInfoWhenNoExecution();
         }
 
         // determine what type of task we are creating
@@ -77,7 +77,7 @@ internal sealed class HedgingExecutionContext<T> : IAsyncDisposable
         else
         {
             _executionPool.Return(execution);
-            return CreateExecutionInfoWhenNoExecution<T>();
+            return CreateExecutionInfoWhenNoExecution();
         }
     }
 
@@ -148,17 +148,20 @@ internal sealed class HedgingExecutionContext<T> : IAsyncDisposable
         return TryRemoveExecutedTask();
     }
 
-    private ExecutionInfo<TResult> CreateExecutionInfoWhenNoExecution<TResult>()
+    private ExecutionInfo<T> CreateExecutionInfoWhenNoExecution()
     {
         // if there are no more executing tasks we need to check finished ones
         if (_executingTasks.Count == 0)
         {
             var finishedExecution = _tasks.First(static t => t.ExecutionTaskSafe!.IsCompleted);
             finishedExecution.AcceptOutcome();
-            return new ExecutionInfo<TResult>(null, false, finishedExecution.Outcome.AsOutcome<TResult>());
+
+            var outcome = Outcome.FromObjectOutcome<T>(finishedExecution.Outcome);
+
+            return new ExecutionInfo<T>(null, false, outcome);
         }
 
-        return new ExecutionInfo<TResult>(null, false, null);
+        return new ExecutionInfo<T>(null, false, null);
     }
 
     private Task<Task> WaitForTaskCompetitionAsync()

--- a/src/Polly.Core/Hedging/Controller/HedgingHandler.cs
+++ b/src/Polly.Core/Hedging/Controller/HedgingHandler.cs
@@ -2,44 +2,17 @@ namespace Polly.Hedging.Utils;
 
 internal sealed record class HedgingHandler<T>(
     Func<HedgingPredicateArguments<T>, ValueTask<bool>> ShouldHandle,
-    Func<HedgingActionGeneratorArguments<T>, Func<ValueTask<Outcome<T>>>?> ActionGenerator,
-    bool IsGeneric)
+    Func<HedgingActionGeneratorArguments<T>, Func<ValueTask<Outcome<T>>>?> ActionGenerator)
 {
     public Func<ValueTask<Outcome<T>>>? GenerateAction(HedgingActionGeneratorArguments<T> args)
     {
-        if (IsGeneric)
-        {
-            var copiedArgs = new HedgingActionGeneratorArguments<T>(
-                args.PrimaryContext,
-                args.ActionContext,
-                args.AttemptNumber,
-                args.Callback);
+        var copiedArgs = new HedgingActionGeneratorArguments<T>(
+            args.PrimaryContext,
+            args.ActionContext,
+            args.AttemptNumber,
+            args.Callback);
 
-            return ActionGenerator(copiedArgs);
-        }
-
-        return CreateNonGenericAction(args);
-    }
-
-    private Func<ValueTask<Outcome<T>>>? CreateNonGenericAction(HedgingActionGeneratorArguments<T> args)
-    {
-        var generator = (Func<HedgingActionGeneratorArguments<object>, Func<ValueTask<Outcome<object>>>?>)(object)ActionGenerator;
-        var action = generator(new HedgingActionGeneratorArguments<object>(args.PrimaryContext, args.ActionContext, args.AttemptNumber, async context =>
-        {
-            var outcome = await args.Callback(context).ConfigureAwait(context.ContinueOnCapturedContext);
-            return outcome.AsOutcome();
-        }));
-
-        if (action is null)
-        {
-            return null;
-        }
-
-        return async () =>
-        {
-            var outcome = await action().ConfigureAwait(args.ActionContext.ContinueOnCapturedContext);
-            return outcome.AsOutcome<T>();
-        };
+        return ActionGenerator(copiedArgs);
     }
 }
 

--- a/src/Polly.Core/Hedging/Controller/TaskExecution.cs
+++ b/src/Polly.Core/Hedging/Controller/TaskExecution.cs
@@ -225,7 +225,7 @@ internal sealed class TaskExecution<T>
     private async Task UpdateOutcomeAsync(Outcome<T> outcome)
     {
         var args = new HedgingPredicateArguments<T>(Context, outcome);
-        Outcome = outcome.AsOutcome();
+        Outcome = Polly.Outcome.ToObjectOutcome(outcome);
         IsHandled = await _handler.ShouldHandle(args).ConfigureAwait(Context.ContinueOnCapturedContext);
         TelemetryUtil.ReportExecutionAttempt(_telemetry, Context, outcome, AttemptNumber, ExecutionTime, IsHandled);
     }

--- a/src/Polly.Core/Hedging/Controller/TaskExecution.cs
+++ b/src/Polly.Core/Hedging/Controller/TaskExecution.cs
@@ -49,7 +49,7 @@ internal sealed class TaskExecution<T>
     /// </remarks>
     public Task? ExecutionTaskSafe { get; private set; }
 
-    public Outcome<object> Outcome { get; private set; }
+    public Outcome<T> Outcome { get; private set; }
 
     public bool IsHandled { get; private set; }
 
@@ -225,7 +225,7 @@ internal sealed class TaskExecution<T>
     private async Task UpdateOutcomeAsync(Outcome<T> outcome)
     {
         var args = new HedgingPredicateArguments<T>(Context, outcome);
-        Outcome = Polly.Outcome.ToObjectOutcome(outcome);
+        Outcome = outcome;
         IsHandled = await _handler.ShouldHandle(args).ConfigureAwait(Context.ContinueOnCapturedContext);
         TelemetryUtil.ReportExecutionAttempt(_telemetry, Context, outcome, AttemptNumber, ExecutionTime, IsHandled);
     }

--- a/src/Polly.Core/Hedging/HedgingResiliencePipelineBuilderExtensions.cs
+++ b/src/Polly.Core/Hedging/HedgingResiliencePipelineBuilderExtensions.cs
@@ -30,39 +30,12 @@ public static class HedgingResiliencePipelineBuilderExtensions
         Guard.NotNull(builder);
         Guard.NotNull(options);
 
-        return builder.AddStrategy(context => CreateHedgingStrategy(context, options, isGeneric: true), options);
+        return builder.AddStrategy(context => CreateHedgingStrategy(context, options), options);
     }
 
-    /// <summary>
-    /// Adds a hedging with the provided options to the builder.
-    /// </summary>
-    /// <param name="builder">The resilience pipeline builder.</param>
-    /// <param name="options">The options to configure the hedging.</param>
-    /// <returns>The builder instance with the hedging added.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ValidationException">Thrown when <paramref name="options"/> are invalid.</exception>
-    [UnconditionalSuppressMessage(
-        "Trimming",
-        "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code",
-        Justification = "All options members preserved.")]
-    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(HedgingStrategyOptions))]
-    internal static ResiliencePipelineBuilder AddHedging(this ResiliencePipelineBuilder builder, HedgingStrategyOptions options)
+    private static HedgingResilienceStrategy<TResult> CreateHedgingStrategy<TResult>(StrategyBuilderContext context, HedgingStrategyOptions<TResult> options)
     {
-        Guard.NotNull(builder);
-        Guard.NotNull(options);
-
-        return builder.AddStrategy(context => CreateHedgingStrategy(context, options, isGeneric: false), options);
-    }
-
-    private static HedgingResilienceStrategy<TResult> CreateHedgingStrategy<TResult>(
-        StrategyBuilderContext context,
-        HedgingStrategyOptions<TResult> options,
-        bool isGeneric)
-    {
-        var handler = new HedgingHandler<TResult>(
-                        options.ShouldHandle!,
-                        options.ActionGenerator,
-                        IsGeneric: isGeneric);
+        var handler = new HedgingHandler<TResult>(options.ShouldHandle!, options.ActionGenerator);
 
         return new HedgingResilienceStrategy<TResult>(
             options.Delay,

--- a/src/Polly.Core/Hedging/HedgingResilienceStrategy.cs
+++ b/src/Polly.Core/Hedging/HedgingResilienceStrategy.cs
@@ -99,7 +99,7 @@ internal sealed class HedgingResilienceStrategy<T> : ResilienceStrategy<T>
                 continue;
             }
 
-            outcome = execution.Outcome.AsOutcome<T>();
+            outcome = Outcome.FromObjectOutcome<T>(execution.Outcome);
 
             if (!execution.IsHandled)
             {

--- a/src/Polly.Core/Hedging/HedgingResilienceStrategy.cs
+++ b/src/Polly.Core/Hedging/HedgingResilienceStrategy.cs
@@ -99,7 +99,7 @@ internal sealed class HedgingResilienceStrategy<T> : ResilienceStrategy<T>
                 continue;
             }
 
-            outcome = Outcome.FromObjectOutcome<T>(execution.Outcome);
+            outcome = execution.Outcome;
 
             if (!execution.IsHandled)
             {

--- a/src/Polly.Core/Hedging/HedgingStrategyOptions.cs
+++ b/src/Polly.Core/Hedging/HedgingStrategyOptions.cs
@@ -1,9 +1,0 @@
-namespace Polly.Hedging;
-
-/// <summary>
-/// Hedging strategy options.
-/// </summary>
-internal class HedgingStrategyOptions : HedgingStrategyOptions<object>
-{
-}
-

--- a/src/Polly.Core/Outcome.TResult.cs
+++ b/src/Polly.Core/Outcome.TResult.cs
@@ -1,6 +1,5 @@
 #pragma warning disable CA1815 // Override equals and operator equals on value types
 
-using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 
 namespace Polly;
@@ -20,7 +19,7 @@ public readonly struct Outcome<TResult>
     internal Outcome(TResult? result)
         : this() => Result = result;
 
-    private Outcome(ExceptionDispatchInfo exceptionDispatchInfo)
+    internal Outcome(ExceptionDispatchInfo exceptionDispatchInfo)
         : this() => ExceptionDispatchInfo = Guard.NotNull(exceptionDispatchInfo);
 
     /// <summary>
@@ -92,29 +91,4 @@ public readonly struct Outcome<TResult>
         return Result!;
     }
 
-    internal Outcome<object> AsOutcome() => AsOutcome<object>();
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal Outcome<T> AsOutcome<T>()
-    {
-        if (ExceptionDispatchInfo is not null)
-        {
-            return new Outcome<T>(ExceptionDispatchInfo);
-        }
-
-        if (Result is null)
-        {
-            return new Outcome<T>(default(T));
-        }
-
-        if (typeof(T) == typeof(TResult))
-        {
-            var result = Result;
-
-            // We can use the unsafe cast here because we know for sure these two types are the same
-            return new Outcome<T>(Unsafe.As<TResult, T>(ref result));
-        }
-
-        return new Outcome<T>((T)(object)Result);
-    }
 }

--- a/src/Polly.Core/Outcome.cs
+++ b/src/Polly.Core/Outcome.cs
@@ -53,4 +53,23 @@ public static class Outcome
 
     internal static Outcome<VoidResult> FromException(Exception exception) => FromException<VoidResult>(exception);
 
+    internal static Outcome<object> ToObjectOutcome<T>(Outcome<T> outcome)
+    {
+        if (outcome.ExceptionDispatchInfo is null)
+        {
+            return FromResult((object?)outcome.Result);
+        }
+
+        return new Outcome<object>(outcome.ExceptionDispatchInfo);
+    }
+
+    internal static Outcome<T> FromObjectOutcome<T>(Outcome<object> outcome)
+    {
+        if (outcome.ExceptionDispatchInfo is null)
+        {
+            return FromResult((T)outcome.Result!);
+        }
+
+        return new Outcome<T>(outcome.ExceptionDispatchInfo);
+    }
 }

--- a/src/Polly.Core/Outcome.cs
+++ b/src/Polly.Core/Outcome.cs
@@ -52,24 +52,4 @@ public static class Outcome
     internal static Outcome<VoidResult> Void => FromResult(VoidResult.Instance);
 
     internal static Outcome<VoidResult> FromException(Exception exception) => FromException<VoidResult>(exception);
-
-    internal static Outcome<object> ToObjectOutcome<T>(Outcome<T> outcome)
-    {
-        if (outcome.ExceptionDispatchInfo is null)
-        {
-            return FromResult((object?)outcome.Result);
-        }
-
-        return new Outcome<object>(outcome.ExceptionDispatchInfo);
-    }
-
-    internal static Outcome<T> FromObjectOutcome<T>(Outcome<object> outcome)
-    {
-        if (outcome.ExceptionDispatchInfo is null)
-        {
-            return FromResult((T)outcome.Result!);
-        }
-
-        return new Outcome<T>(outcome.ExceptionDispatchInfo);
-    }
 }

--- a/src/Polly.Core/Utils/Pipeline/BridgeComponent.TResult.cs
+++ b/src/Polly.Core/Utils/Pipeline/BridgeComponent.TResult.cs
@@ -28,7 +28,7 @@ internal sealed class BridgeComponent<T> : BridgeComponentBase
                 static async (context, state) =>
                 {
                     var outcome = await state.callback(context, state.state).ConfigureAwait(context.ContinueOnCapturedContext);
-                    return AsOutcome<TResult, T>(outcome);
+                    return ConvertOutcome<TResult, T>(outcome);
                 },
                 context,
                 (callback, state));
@@ -41,7 +41,7 @@ internal sealed class BridgeComponent<T> : BridgeComponentBase
     {
         if (valueTask.IsCompletedSuccessfully)
         {
-            return new ValueTask<Outcome<TTo>>(AsOutcome<T, TTo>(valueTask.Result));
+            return new ValueTask<Outcome<TTo>>(ConvertOutcome<T, TTo>(valueTask.Result));
         }
 
         return ConvertValueTaskAsync(valueTask, resilienceContext);
@@ -49,11 +49,11 @@ internal sealed class BridgeComponent<T> : BridgeComponentBase
         static async ValueTask<Outcome<TTo>> ConvertValueTaskAsync(ValueTask<Outcome<T>> valueTask, ResilienceContext resilienceContext)
         {
             var outcome = await valueTask.ConfigureAwait(resilienceContext.ContinueOnCapturedContext);
-            return AsOutcome<T, TTo>(outcome);
+            return ConvertOutcome<T, TTo>(outcome);
         }
     }
 
-    internal static Outcome<TTo> AsOutcome<TFrom, TTo>(Outcome<TFrom> outcome)
+    private static Outcome<TTo> ConvertOutcome<TFrom, TTo>(Outcome<TFrom> outcome)
     {
         if (outcome.ExceptionDispatchInfo is not null)
         {

--- a/src/Polly.Core/Utils/Pipeline/BridgeComponent.TResult.cs
+++ b/src/Polly.Core/Utils/Pipeline/BridgeComponent.TResult.cs
@@ -1,4 +1,6 @@
-﻿namespace Polly.Utils.Pipeline;
+﻿using System.Runtime.CompilerServices;
+
+namespace Polly.Utils.Pipeline;
 
 [DebuggerDisplay("{Strategy}")]
 internal sealed class BridgeComponent<T> : BridgeComponentBase
@@ -16,7 +18,7 @@ internal sealed class BridgeComponent<T> : BridgeComponentBase
         // Check if we can cast directly, thus saving some cycles and improving the performance
         if (callback is Func<ResilienceContext, TState, ValueTask<Outcome<T>>> casted)
         {
-            return TaskHelper.ConvertValueTask<T, TResult>(
+            return ConvertValueTask<TResult>(
                 Strategy.ExecuteCore(casted, context, state),
                 context);
         }
@@ -26,12 +28,51 @@ internal sealed class BridgeComponent<T> : BridgeComponentBase
                 static async (context, state) =>
                 {
                     var outcome = await state.callback(context, state.state).ConfigureAwait(context.ContinueOnCapturedContext);
-                    return outcome.AsOutcome<T>();
+                    return AsOutcome<TResult, T>(outcome);
                 },
                 context,
                 (callback, state));
 
-            return TaskHelper.ConvertValueTask<T, TResult>(valueTask, context);
+            return ConvertValueTask<TResult>(valueTask, context);
         }
+    }
+
+    private static ValueTask<Outcome<TTo>> ConvertValueTask<TTo>(ValueTask<Outcome<T>> valueTask, ResilienceContext resilienceContext)
+    {
+        if (valueTask.IsCompletedSuccessfully)
+        {
+            return new ValueTask<Outcome<TTo>>(AsOutcome<T, TTo>(valueTask.Result));
+        }
+
+        return ConvertValueTaskAsync(valueTask, resilienceContext);
+
+        static async ValueTask<Outcome<TTo>> ConvertValueTaskAsync(ValueTask<Outcome<T>> valueTask, ResilienceContext resilienceContext)
+        {
+            var outcome = await valueTask.ConfigureAwait(resilienceContext.ContinueOnCapturedContext);
+            return AsOutcome<T, TTo>(outcome);
+        }
+    }
+
+    internal static Outcome<TTo> AsOutcome<TFrom, TTo>(Outcome<TFrom> outcome)
+    {
+        if (outcome.ExceptionDispatchInfo is not null)
+        {
+            return new Outcome<TTo>(outcome.ExceptionDispatchInfo);
+        }
+
+        if (outcome.Result is null)
+        {
+            return new Outcome<TTo>(default(TTo));
+        }
+
+        if (typeof(TTo) == typeof(TFrom))
+        {
+            var result = outcome.Result;
+
+            // We can use the unsafe cast here because we know for sure these two types are the same
+            return new Outcome<TTo>(Unsafe.As<TFrom, TTo>(ref result));
+        }
+
+        return new Outcome<TTo>((TTo)(object)outcome.Result);
     }
 }

--- a/src/Polly.Core/Utils/TaskHelper.cs
+++ b/src/Polly.Core/Utils/TaskHelper.cs
@@ -34,20 +34,4 @@ internal static class TaskHelper
 
         return task.Preserve().GetAwaiter().GetResult();
     }
-
-    public static ValueTask<Outcome<TTo>> ConvertValueTask<TFrom, TTo>(ValueTask<Outcome<TFrom>> valueTask, ResilienceContext resilienceContext)
-    {
-        if (valueTask.IsCompletedSuccessfully)
-        {
-            return new ValueTask<Outcome<TTo>>(valueTask.Result.AsOutcome<TTo>());
-        }
-
-        return ConvertValueTaskAsync(valueTask, resilienceContext);
-
-        static async ValueTask<Outcome<TTo>> ConvertValueTaskAsync(ValueTask<Outcome<TFrom>> valueTask, ResilienceContext resilienceContext)
-        {
-            var outcome = await valueTask.ConfigureAwait(resilienceContext.ContinueOnCapturedContext);
-            return outcome.AsOutcome<TTo>();
-        }
-    }
 }

--- a/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerResilienceStrategyTests.cs
@@ -44,7 +44,6 @@ public class CircuitBreakerResilienceStrategyTests : IDisposable
         _options.StateProvider.IsInitialized.Should().BeTrue();
 
         _options.StateProvider.CircuitState.Should().Be(CircuitState.Closed);
-        _options.StateProvider.LastHandledOutcome.Should().Be(null);
     }
 
     [Fact]

--- a/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerStateProviderTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerStateProviderTests.cs
@@ -18,7 +18,6 @@ public class CircuitBreakerStateProviderTests
         var provider = new CircuitBreakerStateProvider();
 
         provider.CircuitState.Should().Be(CircuitState.Closed);
-        provider.LastHandledOutcome.Should().Be(null);
     }
 
     [Fact]
@@ -36,10 +35,10 @@ public class CircuitBreakerStateProviderTests
     public void Initialize_Twice_Throws()
     {
         var provider = new CircuitBreakerStateProvider();
-        provider.Initialize(() => CircuitState.Closed, () => null);
+        provider.Initialize(() => CircuitState.Closed);
 
         provider
-            .Invoking(c => c.Initialize(() => CircuitState.Closed, () => null))
+            .Invoking(c => c.Initialize(() => CircuitState.Closed))
             .Should()
             .Throw<InvalidOperationException>();
     }
@@ -49,24 +48,16 @@ public class CircuitBreakerStateProviderTests
     {
         var provider = new CircuitBreakerStateProvider();
         var stateCalled = false;
-        var exceptionCalled = false;
 
         provider.Initialize(
             () =>
             {
                 stateCalled = true;
                 return CircuitState.HalfOpen;
-            },
-            () =>
-            {
-                exceptionCalled = true;
-                return Outcome.FromException<object>(new InvalidOperationException());
             });
 
         provider.CircuitState.Should().Be(CircuitState.HalfOpen);
-        provider.LastHandledOutcome!.Value.Exception.Should().BeOfType<InvalidOperationException>();
 
         stateCalled.Should().BeTrue();
-        exceptionCalled.Should().BeTrue();
     }
 }

--- a/test/Polly.Core.Tests/Fallback/FallbackHandlerTests.cs
+++ b/test/Polly.Core.Tests/Fallback/FallbackHandlerTests.cs
@@ -8,17 +8,7 @@ public class FallbackHandlerTests
     {
         var handler = FallbackHelper.CreateHandler(_ => true, () => Outcome.FromResult("secondary"));
         var context = ResilienceContextPool.Shared.Get();
-        var outcome = await handler.GetFallbackOutcomeAsync<string>(new FallbackActionArguments<string>(context, Outcome.FromResult("primary")))!;
-
-        outcome.Result.Should().Be("secondary");
-    }
-
-    [Fact]
-    public async Task GenerateAction_NonGeneric_Ok()
-    {
-        var handler = FallbackHelper.CreateHandler(_ => true, () => Outcome.FromResult((object)"secondary"));
-        var context = ResilienceContextPool.Shared.Get();
-        var outcome = await handler.GetFallbackOutcomeAsync<object>(new FallbackActionArguments<object>(context, Outcome.FromResult((object)"primary")))!;
+        var outcome = await handler.GetFallbackOutcomeAsync(new FallbackActionArguments<string>(context, Outcome.FromResult("primary")))!;
 
         outcome.Result.Should().Be("secondary");
     }

--- a/test/Polly.Core.Tests/Fallback/FallbackResiliencePipelineBuilderExtensionsTests.cs
+++ b/test/Polly.Core.Tests/Fallback/FallbackResiliencePipelineBuilderExtensionsTests.cs
@@ -29,35 +29,6 @@ public class FallbackResiliencePipelineBuilderExtensionsTests
     }
 
     [Fact]
-    public void AddFallback_Ok()
-    {
-        var options = new FallbackStrategyOptions
-        {
-            ShouldHandle = args => args.Outcome switch
-            {
-                { Exception: InvalidOperationException } => PredicateResult.True,
-                { Result: -1 } => PredicateResult.True,
-                _ => PredicateResult.False
-            },
-            FallbackAction = _ => Outcome.FromResultAsTask((object)1)
-        };
-
-        var strategy = new ResiliencePipelineBuilder().AddFallback(options).Build();
-
-        strategy.Execute<int>(_ => -1).Should().Be(1);
-        strategy.Execute<int>(_ => throw new InvalidOperationException()).Should().Be(1);
-    }
-
-    [Fact]
-    public void AddFallback_InvalidOptions_Throws()
-    {
-        new ResiliencePipelineBuilder()
-            .Invoking(b => b.AddFallback(new FallbackStrategyOptions()))
-            .Should()
-            .Throw<ValidationException>();
-    }
-
-    [Fact]
     public void AddFallbackT_InvalidOptions_Throws()
     {
         new ResiliencePipelineBuilder<double>()

--- a/test/Polly.Core.Tests/Fallback/FallbackResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Fallback/FallbackResilienceStrategyTests.cs
@@ -1,4 +1,3 @@
-using System.Runtime.CompilerServices;
 using Polly.Fallback;
 using Polly.Telemetry;
 

--- a/test/Polly.Core.Tests/Hedging/Controller/HedgingExecutionContextTests.cs
+++ b/test/Polly.Core.Tests/Hedging/Controller/HedgingExecutionContextTests.cs
@@ -104,7 +104,7 @@ public class HedgingExecutionContextTests : IDisposable
         task.Should().NotBeNull();
         task!.ExecutionTaskSafe!.IsCompleted.Should().BeTrue();
 
-        Outcome.FromObjectOutcome<DisposableResult>(task.Outcome).Result!.Name.Should().Be("dummy");
+        task.Outcome.Result!.Name.Should().Be("dummy");
         task.AcceptOutcome();
         context.LoadedTasks.Should().Be(1);
     }

--- a/test/Polly.Core.Tests/Hedging/Controller/HedgingExecutionContextTests.cs
+++ b/test/Polly.Core.Tests/Hedging/Controller/HedgingExecutionContextTests.cs
@@ -103,7 +103,8 @@ public class HedgingExecutionContextTests : IDisposable
 
         task.Should().NotBeNull();
         task!.ExecutionTaskSafe!.IsCompleted.Should().BeTrue();
-        task.Outcome.AsOutcome<DisposableResult>().Result!.Name.Should().Be("dummy");
+
+        Outcome.FromObjectOutcome<DisposableResult>(task.Outcome).Result!.Name.Should().Be("dummy");
         task.AcceptOutcome();
         context.LoadedTasks.Should().Be(1);
     }

--- a/test/Polly.Core.Tests/Hedging/Controller/TaskExecutionTests.cs
+++ b/test/Polly.Core.Tests/Hedging/Controller/TaskExecutionTests.cs
@@ -58,7 +58,7 @@ public class TaskExecutionTests : IDisposable
             99);
 
         await execution.ExecutionTaskSafe!;
-        ((DisposableResult)execution.Outcome.Result!).Name.Should().Be(value);
+        execution.Outcome.Result!.Name.Should().Be(value);
         execution.IsHandled.Should().Be(handled);
         AssertPrimaryContext(execution.Context, execution);
 
@@ -98,7 +98,7 @@ public class TaskExecutionTests : IDisposable
 
         await execution.ExecutionTaskSafe!;
 
-        ((DisposableResult)execution.Outcome.Result!).Name.Should().Be(value);
+        execution.Outcome.Result!.Name.Should().Be(value);
         execution.IsHandled.Should().Be(handled);
         AssertSecondaryContext(execution.Context, execution);
     }

--- a/test/Polly.Core.Tests/Hedging/HedgingHandlerTests.cs
+++ b/test/Polly.Core.Tests/Hedging/HedgingHandlerTests.cs
@@ -10,8 +10,7 @@ public class HedgingHandlerTests
     {
         var handler = new HedgingHandler<string>(
             args => PredicateResult.True,
-            args => () => Outcome.FromResultAsTask("ok"),
-            true);
+            args => () => Outcome.FromResultAsTask("ok"));
 
         var action = handler.GenerateAction(new HedgingActionGeneratorArguments<string>(
             ResilienceContextPool.Shared.Get(),
@@ -21,57 +20,5 @@ public class HedgingHandlerTests
         var res = await action();
 
         res.Result.Should().Be("ok");
-    }
-
-    [InlineData(true)]
-    [InlineData(false)]
-    [Theory]
-    public async Task GenerateAction_NonGeneric_Ok(bool nullAction)
-    {
-        var handler = new HedgingHandler<object>(
-            args => PredicateResult.True,
-            args =>
-            {
-                if (nullAction)
-                {
-                    return null;
-                }
-
-                return () => Outcome.FromResultAsTask((object)"ok");
-            },
-            false);
-
-        var action = handler.GenerateAction(new HedgingActionGeneratorArguments<object>(
-            ResilienceContextPool.Shared.Get(),
-            ResilienceContextPool.Shared.Get(),
-            0,
-            _ => Outcome.FromResultAsTask((object)"primary")))!;
-        if (nullAction)
-        {
-            action.Should().BeNull();
-        }
-        else
-        {
-            var res = await action();
-            res.Result.Should().Be("ok");
-        }
-    }
-
-    [Fact]
-    public async Task GenerateAction_NonGeneric_FromCallback()
-    {
-        var handler = new HedgingHandler<object>(
-            args => PredicateResult.True,
-            args => () => args.Callback(args.ActionContext),
-            false);
-
-        var action = handler.GenerateAction(
-            new HedgingActionGeneratorArguments<object>(
-                ResilienceContextPool.Shared.Get(),
-                ResilienceContextPool.Shared.Get(),
-                0,
-                _ => Outcome.FromResultAsTask((object)"callback")))!;
-        var res = await action();
-        res.Result.Should().Be("callback");
     }
 }

--- a/test/Polly.Core.Tests/Hedging/HedgingHelper.cs
+++ b/test/Polly.Core.Tests/Hedging/HedgingHelper.cs
@@ -9,10 +9,7 @@ internal static class HedgingHelper
         Func<Outcome<T>, bool> shouldHandle,
         Func<HedgingActionGeneratorArguments<T>, Func<ValueTask<Outcome<T>>>?> generator)
     {
-        return new HedgingHandler<T>(
-            args => new ValueTask<bool>(shouldHandle(args.Outcome!))!,
-            generator,
-            true);
+        return new HedgingHandler<T>(args => new ValueTask<bool>(shouldHandle(args.Outcome!))!, generator);
     }
 }
 

--- a/test/Polly.Core.Tests/OutcomeTests.cs
+++ b/test/Polly.Core.Tests/OutcomeTests.cs
@@ -13,10 +13,11 @@ public class OutcomeTests
         result.Should().Be(10);
         outcome.ToString().Should().Be("10");
 
-        outcome.AsOutcome().HasResult.Should().BeTrue();
-        outcome.AsOutcome().Exception.Should().BeNull();
-        outcome.AsOutcome().IsVoidResult.Should().BeFalse();
-        outcome.AsOutcome().TryGetResult(out var resultObj).Should().BeTrue();
+        var objectOutcome = Outcome.ToObjectOutcome(outcome);
+        objectOutcome.HasResult.Should().BeTrue();
+        objectOutcome.Exception.Should().BeNull();
+        objectOutcome.IsVoidResult.Should().BeFalse();
+        objectOutcome.TryGetResult(out var resultObj).Should().BeTrue();
         resultObj.Should().Be(10);
     }
 
@@ -31,11 +32,12 @@ public class OutcomeTests
         outcome.Result.Should().Be(VoidResult.Instance);
         outcome.ToString().Should().Be("void");
 
-        outcome.AsOutcome().HasResult.Should().BeTrue();
-        outcome.AsOutcome().Exception.Should().BeNull();
-        outcome.AsOutcome().IsVoidResult.Should().BeTrue();
-        outcome.AsOutcome().TryGetResult(out _).Should().BeFalse();
-        outcome.AsOutcome().Result.Should().Be(VoidResult.Instance);
+        var objectOutcome = Outcome.ToObjectOutcome(outcome);
+        objectOutcome.HasResult.Should().BeTrue();
+        objectOutcome.Exception.Should().BeNull();
+        objectOutcome.IsVoidResult.Should().BeTrue();
+        objectOutcome.TryGetResult(out _).Should().BeFalse();
+        objectOutcome.Result.Should().Be(VoidResult.Instance);
     }
 
     [Fact]
@@ -49,11 +51,12 @@ public class OutcomeTests
         outcome.TryGetResult(out var result).Should().BeFalse();
         outcome.ToString().Should().Be("Dummy message.");
 
-        outcome.AsOutcome().HasResult.Should().BeFalse();
-        outcome.AsOutcome().Exception.Should().NotBeNull();
-        outcome.AsOutcome().IsVoidResult.Should().BeFalse();
-        outcome.AsOutcome().TryGetResult(out _).Should().BeFalse();
-        outcome.AsOutcome().ExceptionDispatchInfo.Should().Be(outcome.ExceptionDispatchInfo);
+        var objectOutcome = Outcome.ToObjectOutcome(outcome);
+        objectOutcome.HasResult.Should().BeFalse();
+        objectOutcome.Exception.Should().NotBeNull();
+        objectOutcome.IsVoidResult.Should().BeFalse();
+        objectOutcome.TryGetResult(out _).Should().BeFalse();
+        objectOutcome.ExceptionDispatchInfo.Should().Be(outcome.ExceptionDispatchInfo);
     }
 
     [Fact]

--- a/test/Polly.Core.Tests/OutcomeTests.cs
+++ b/test/Polly.Core.Tests/OutcomeTests.cs
@@ -12,13 +12,6 @@ public class OutcomeTests
         outcome.TryGetResult(out var result).Should().BeTrue();
         result.Should().Be(10);
         outcome.ToString().Should().Be("10");
-
-        var objectOutcome = Outcome.ToObjectOutcome(outcome);
-        objectOutcome.HasResult.Should().BeTrue();
-        objectOutcome.Exception.Should().BeNull();
-        objectOutcome.IsVoidResult.Should().BeFalse();
-        objectOutcome.TryGetResult(out var resultObj).Should().BeTrue();
-        resultObj.Should().Be(10);
     }
 
     [Fact]
@@ -31,13 +24,6 @@ public class OutcomeTests
         outcome.TryGetResult(out var result).Should().BeFalse();
         outcome.Result.Should().Be(VoidResult.Instance);
         outcome.ToString().Should().Be("void");
-
-        var objectOutcome = Outcome.ToObjectOutcome(outcome);
-        objectOutcome.HasResult.Should().BeTrue();
-        objectOutcome.Exception.Should().BeNull();
-        objectOutcome.IsVoidResult.Should().BeTrue();
-        objectOutcome.TryGetResult(out _).Should().BeFalse();
-        objectOutcome.Result.Should().Be(VoidResult.Instance);
     }
 
     [Fact]
@@ -50,13 +36,6 @@ public class OutcomeTests
         outcome.IsVoidResult.Should().BeFalse();
         outcome.TryGetResult(out var result).Should().BeFalse();
         outcome.ToString().Should().Be("Dummy message.");
-
-        var objectOutcome = Outcome.ToObjectOutcome(outcome);
-        objectOutcome.HasResult.Should().BeFalse();
-        objectOutcome.Exception.Should().NotBeNull();
-        objectOutcome.IsVoidResult.Should().BeFalse();
-        objectOutcome.TryGetResult(out _).Should().BeFalse();
-        objectOutcome.ExceptionDispatchInfo.Should().Be(outcome.ExceptionDispatchInfo);
     }
 
     [Fact]

--- a/test/Polly.TestUtils/TestUtilities.cs
+++ b/test/Polly.TestUtils/TestUtilities.cs
@@ -104,6 +104,6 @@ public static class TestUtilities
                 args.Event,
                 args.Context,
                 args.Arguments!,
-                args.Outcome.HasValue ? args.Outcome.Value.AsOutcome<object>() : null);
+                args.Outcome.HasValue ? Outcome.ToObjectOutcome(args.Outcome.Value) : null);
     }
 }

--- a/test/Polly.TestUtils/TestUtilities.cs
+++ b/test/Polly.TestUtils/TestUtilities.cs
@@ -99,11 +99,18 @@ public static class TestUtilities
 
     public static TelemetryEventArguments<object, object> AsObjectArguments<T, TArgs>(this TelemetryEventArguments<T, TArgs> args)
     {
+        Outcome<object>? outcome = args.Outcome switch
+        {
+            null => null,
+            { Exception: { } ex } => Outcome.FromException<object>(ex),
+            _ => Outcome.FromResult<object>(args.Outcome!.Value.Result),
+        };
+
         return new TelemetryEventArguments<object, object>(
                 args.Source,
                 args.Event,
                 args.Context,
                 args.Arguments!,
-                args.Outcome.HasValue ? Outcome.ToObjectOutcome(args.Outcome.Value) : null);
+                outcome);
     }
 }


### PR DESCRIPTION
### Details on the issue fix or feature implementation

Internal changes only.

- Drop non-generic APIs for fallback and hedging as there are not used nor exposed
- Simplify some hedging and fallback internals
- Cleanup `Outcome<>` struct. 
  - The unsafe conversion between types moved to `BridgeComponent` as it is the only consumer
  - Conversion to and from `Object`-based outcomes dropped as it's no longer necessaary.

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
