### PR TITLE
Disposing pipeline should not dispose external inner pipeline

### DIFF
--- a/src/Polly.Core/ResiliencePipelineBuilderBase.cs
+++ b/src/Polly.Core/ResiliencePipelineBuilderBase.cs
@@ -119,11 +119,6 @@ public abstract class ResiliencePipelineBuilderBase
 
         var source = new ResilienceTelemetrySource(Name, InstanceName, null);
 
-        if (components.Distinct().Count() != components.Count)
-        {
-            throw new InvalidOperationException("The resilience pipeline must contain unique resilience strategies.");
-        }
-
         return PipelineComponentFactory.CreateComposite(components, new ResilienceStrategyTelemetry(source, TelemetryListener), TimeProvider);
     }
 

--- a/src/Polly.Core/Utils/Pipeline/ExternalComponent.cs
+++ b/src/Polly.Core/Utils/Pipeline/ExternalComponent.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Polly.Utils.Pipeline;
+
+[DebuggerDisplay("{Component}")]
+internal class ExternalComponent : PipelineComponent
+{
+    public ExternalComponent(PipelineComponent component) => Component = component;
+
+    internal PipelineComponent Component { get; }
+
+    internal override ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
+        Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
+        ResilienceContext context,
+        TState state) => Component.ExecuteCore(callback, context, state);
+
+    public override void Dispose()
+    {
+        // don't dispose component that is external
+    }
+
+    public override ValueTask DisposeAsync()
+    {
+        // don't dispose component that is external
+        return default;
+    }
+}

--- a/src/Polly.Core/Utils/Pipeline/PipelineComponentFactory.cs
+++ b/src/Polly.Core/Utils/Pipeline/PipelineComponentFactory.cs
@@ -6,9 +6,9 @@ namespace Polly.Utils.Pipeline;
 
 internal static class PipelineComponentFactory
 {
-    public static PipelineComponent FromPipeline(ResiliencePipeline pipeline) => pipeline.Component;
+    public static PipelineComponent FromPipeline(ResiliencePipeline pipeline) => new ExternalComponent(pipeline.Component);
 
-    public static PipelineComponent FromPipeline<T>(ResiliencePipeline<T> pipeline) => pipeline.Component;
+    public static PipelineComponent FromPipeline<T>(ResiliencePipeline<T> pipeline) => new ExternalComponent(pipeline.Component);
 
     public static PipelineComponent FromStrategy(ResilienceStrategy strategy) => new BridgeComponent(strategy);
 

--- a/src/Polly.Testing/ResiliencePipelineExtensions.cs
+++ b/src/Polly.Testing/ResiliencePipelineExtensions.cs
@@ -82,6 +82,10 @@ public static class ResiliencePipelineExtensions
         {
             ExpandComponents(callbacks.Component, components);
         }
+        else if (component is ExternalComponent nonDisposable)
+        {
+            ExpandComponents(nonDisposable.Component, components);
+        }
         else
         {
             components.Add(component);

--- a/test/Polly.Core.Tests/GenericResiliencePipelineBuilderTests.cs
+++ b/test/Polly.Core.Tests/GenericResiliencePipelineBuilderTests.cs
@@ -51,14 +51,18 @@ public class GenericResiliencePipelineBuilderTests
     public void AddGenericStrategy_Ok()
     {
         // arrange
-        var testStrategy = Substitute.For<ResilienceStrategy<string>>().AsPipeline();
-        _builder.AddPipeline(testStrategy);
+        var strategy = Substitute.For<ResilienceStrategy<string>>();
+        _builder.AddStrategy(strategy);
 
         // act
-        var strategy = _builder.Build();
+        var pipeline = _builder.Build();
 
         // assert
         strategy.Should().NotBeNull();
-        ((CompositeComponent)strategy.Component).Components[0].Should().Be(testStrategy.Component);
+        ((CompositeComponent)pipeline.Component).Components[0]
+            .Should()
+            .BeOfType<BridgeComponent<string>>().Subject.Strategy
+            .Should()
+            .Be(strategy);
     }
 }

--- a/test/Polly.Extensions.Tests/DisposablePipelineTests.cs
+++ b/test/Polly.Extensions.Tests/DisposablePipelineTests.cs
@@ -43,6 +43,31 @@ public class DisposablePipelineTests
         IsDisposed(limiters[0]).Should().BeTrue();
     }
 
+    [Fact]
+    public void DisposePipeline_EnsureExternalPipelineNotDisposed()
+    {
+        var registry1 = new ResiliencePipelineRegistry<string>();
+        var pipeline1 = registry1.GetOrAddPipeline("my-pipeline", builder => builder.AddConcurrencyLimiter(1));
+        var pipeline2 = registry1.GetOrAddPipeline<string>("my-pipeline", builder => builder.AddConcurrencyLimiter(1));
+
+        var registry2 = new ResiliencePipelineRegistry<string>();
+        var pipeline3 = registry2.GetOrAddPipeline<string>("my-pipeline", builder => builder
+            .AddPipeline(pipeline1)
+            .AddPipeline(pipeline2));
+
+        pipeline3.Execute(() => string.Empty);
+        registry2.Dispose();
+        pipeline3.Invoking(p => p.Execute(() => string.Empty)).Should().Throw<ObjectDisposedException>();
+
+        pipeline1.Execute(() => { });
+        pipeline2.Execute(() => string.Empty);
+
+        registry1.Dispose();
+
+        pipeline1.Invoking(p => p.Execute(() => { })).Should().Throw<ObjectDisposedException>();
+        pipeline2.Invoking(p => p.Execute(() => string.Empty)).Should().Throw<ObjectDisposedException>();
+    }
+
     private static bool IsDisposed(RateLimiter limiter)
     {
         try

--- a/test/Polly.Testing.Tests/ResiliencePipelineExtensionsTests.cs
+++ b/test/Polly.Testing.Tests/ResiliencePipelineExtensionsTests.cs
@@ -134,6 +134,18 @@ public class ResiliencePipelineExtensionsTests
         descriptor.Strategies[1].StrategyInstance.GetType().Should().Be(typeof(CustomStrategy));
     }
 
+    [Fact]
+    public void GetPipelineDescriptor_InnerPipeline_Ok()
+    {
+        var descriptor = new ResiliencePipelineBuilder()
+            .AddPipeline(new ResiliencePipelineBuilder().AddConcurrencyLimiter(1).Build())
+            .Build()
+            .GetPipelineDescriptor();
+
+        descriptor.Strategies.Should().HaveCount(1);
+        descriptor.Strategies[0].Options.Should().BeOfType<RateLimiterStrategyOptions>();
+    }
+
     private sealed class CustomStrategy : ResilienceStrategy
     {
         protected override ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback, ResilienceContext context, TState state)


### PR DESCRIPTION
### Details on the issue fix or feature implementation

If resilience pipeline uses other pipeline it should not own it. Therefore the pipeline is disposed, the "external' pipeline should still stay alive as it's lifetime is managed outside of current pipeline.
 
### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
