### PR TITLE
Clean duplications around disposing the pipelines

### DIFF
--- a/src/Polly.Core/Registry/ResiliencePipelineRegistry.TResult.cs
+++ b/src/Polly.Core/Registry/ResiliencePipelineRegistry.TResult.cs
@@ -5,7 +5,7 @@ namespace Polly.Registry;
 public sealed partial class ResiliencePipelineRegistry<TKey> : ResiliencePipelineProvider<TKey>
     where TKey : notnull
 {
-    private sealed class GenericRegistry<TResult> : IDisposable, IAsyncDisposable
+    private sealed class GenericRegistry<TResult> : IAsyncDisposable
     {
         private readonly Func<ResiliencePipelineBuilder<TResult>> _activator;
         private readonly ConcurrentDictionary<TKey, Action<ResiliencePipelineBuilder<TResult>, ConfigureBuilderContext<TKey>>> _builders;
@@ -63,16 +63,6 @@ public sealed partial class ResiliencePipelineRegistry<TKey> : ResiliencePipelin
         }
 
         public bool TryAddBuilder(TKey key, Action<ResiliencePipelineBuilder<TResult>, ConfigureBuilderContext<TKey>> configure) => _builders.TryAdd(key, configure);
-
-        public void Dispose()
-        {
-            foreach (var strategy in _pipelines.Values)
-            {
-                strategy.DisposeHelper.ForceDispose();
-            }
-
-            _pipelines.Clear();
-        }
 
         public async ValueTask DisposeAsync()
         {

--- a/src/Polly.Core/Registry/ResiliencePipelineRegistry.cs
+++ b/src/Polly.Core/Registry/ResiliencePipelineRegistry.cs
@@ -218,19 +218,7 @@ public sealed partial class ResiliencePipelineRegistry<TKey> : ResiliencePipelin
     /// After the disposal, all resilience pipelines still used outside of the builder are disposed
     /// and cannot be used anymore.
     /// </remarks>
-    public void Dispose()
-    {
-        _disposed = true;
-
-        var pipelines = _pipelines.Values.ToList();
-        _pipelines.Clear();
-
-        var registries = _genericRegistry.Values.Cast<IDisposable>().ToList();
-        _genericRegistry.Clear();
-
-        pipelines.ForEach(p => p.DisposeHelper.ForceDispose());
-        registries.ForEach(p => p.Dispose());
-    }
+    public void Dispose() => DisposeAsync().AsTask().GetAwaiter().GetResult();
 
     /// <summary>
     /// Disposes all resources that are held by the resilience pipelines created by this builder.

--- a/src/Polly.Core/Utils/Pipeline/BridgeComponentBase.cs
+++ b/src/Polly.Core/Utils/Pipeline/BridgeComponentBase.cs
@@ -6,28 +6,17 @@ internal abstract class BridgeComponentBase : PipelineComponent
 
     protected BridgeComponentBase(object strategy) => _strategy = strategy;
 
-    public override void Dispose()
-    {
-        if (_strategy is IDisposable disposable)
-        {
-            disposable.Dispose();
-        }
-        else if (_strategy is IAsyncDisposable asyncDisposable)
-        {
-            asyncDisposable.DisposeAsync().AsTask().GetAwaiter().GetResult();
-        }
-    }
-
     public override ValueTask DisposeAsync()
     {
         if (_strategy is IAsyncDisposable asyncDisposable)
         {
             return asyncDisposable.DisposeAsync();
         }
-        else
+        else if (_strategy is IDisposable disposable)
         {
-            Dispose();
-            return default;
+            disposable.Dispose();
         }
+
+        return default;
     }
 }

--- a/src/Polly.Core/Utils/Pipeline/ComponentDisposeHelper.cs
+++ b/src/Polly.Core/Utils/Pipeline/ComponentDisposeHelper.cs
@@ -1,6 +1,6 @@
 ﻿namespace Polly.Utils.Pipeline;
 
-internal sealed class ComponentDisposeHelper : IDisposable, IAsyncDisposable
+internal sealed class ComponentDisposeHelper : IAsyncDisposable
 {
     private readonly PipelineComponent _component;
     private readonly DisposeBehavior _disposeBehavior;
@@ -10,14 +10,6 @@ internal sealed class ComponentDisposeHelper : IDisposable, IAsyncDisposable
     {
         _component = component;
         _disposeBehavior = disposeBehavior;
-    }
-
-    public void Dispose()
-    {
-        if (EnsureDisposable())
-        {
-            ForceDispose();
-        }
     }
 
     public ValueTask DisposeAsync()
@@ -36,14 +28,6 @@ internal sealed class ComponentDisposeHelper : IDisposable, IAsyncDisposable
         {
             throw new ObjectDisposedException("ResiliencePipeline", "This resilience pipeline has been disposed and cannot be used anymore.");
         }
-    }
-
-    public void ForceDispose()
-    {
-        _disposed = true;
-#pragma warning disable S2952 // Classes should "Dispose" of members from the classes' own "Dispose" methods
-        _component.Dispose();
-#pragma warning restore S2952 // Classes should "Dispose" of members from the classes' own "Dispose" methods
     }
 
     public ValueTask ForceDisposeAsync()

--- a/src/Polly.Core/Utils/Pipeline/ComponentWithDisposeCallbacks.cs
+++ b/src/Polly.Core/Utils/Pipeline/ComponentWithDisposeCallbacks.cs
@@ -12,13 +12,6 @@ internal class ComponentWithDisposeCallbacks : PipelineComponent
 
     internal PipelineComponent Component { get; }
 
-    public override void Dispose()
-    {
-        ExecuteCallbacks();
-
-        Component.Dispose();
-    }
-
     public override ValueTask DisposeAsync()
     {
         ExecuteCallbacks();

--- a/src/Polly.Core/Utils/Pipeline/CompositeComponent.cs
+++ b/src/Polly.Core/Utils/Pipeline/CompositeComponent.cs
@@ -61,14 +61,6 @@ internal sealed class CompositeComponent : PipelineComponent
 
     public IReadOnlyList<PipelineComponent> Components { get; }
 
-    public override void Dispose()
-    {
-        foreach (var component in Components)
-        {
-            component.Dispose();
-        }
-    }
-
     public override async ValueTask DisposeAsync()
     {
         foreach (var component in Components)
@@ -153,10 +145,6 @@ internal sealed class CompositeComponent : PipelineComponent
                 },
                 context,
                 (Next, callback, state));
-        }
-
-        public override void Dispose()
-        {
         }
 
         public override ValueTask DisposeAsync() => default;

--- a/src/Polly.Core/Utils/Pipeline/ExternalComponent.cs
+++ b/src/Polly.Core/Utils/Pipeline/ExternalComponent.cs
@@ -15,11 +15,6 @@ internal class ExternalComponent : PipelineComponent
         ResilienceContext context,
         TState state) => Component.ExecuteCore(callback, context, state);
 
-    public override void Dispose()
-    {
-        // don't dispose component that is external
-    }
-
     public override ValueTask DisposeAsync()
     {
         // don't dispose component that is external

--- a/src/Polly.Core/Utils/Pipeline/PipelineComponent.cs
+++ b/src/Polly.Core/Utils/Pipeline/PipelineComponent.cs
@@ -6,7 +6,7 @@
 /// <remarks>
 /// The component of the pipeline can be either a strategy, a generic strategy or a whole pipeline.
 /// </remarks>
-internal abstract class PipelineComponent : IDisposable, IAsyncDisposable
+internal abstract class PipelineComponent : IAsyncDisposable
 {
     public static PipelineComponent Empty { get; } = new NullComponent();
 
@@ -33,18 +33,12 @@ internal abstract class PipelineComponent : IDisposable, IAsyncDisposable
             (callback, state)).GetResult();
     }
 
-    public abstract void Dispose();
-
     public abstract ValueTask DisposeAsync();
 
     private class NullComponent : PipelineComponent
     {
         internal override ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback, ResilienceContext context, TState state)
             => callback(context, state);
-
-        public override void Dispose()
-        {
-        }
 
         public override ValueTask DisposeAsync() => default;
     }

--- a/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerResiliencePipelineBuilderTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerResiliencePipelineBuilderTests.cs
@@ -131,12 +131,10 @@ public class CircuitBreakerResiliencePipelineBuilderTests
         strategy2.Execute(() => { });
     }
 
-    [InlineData(false, false)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(true, true)]
+    [InlineData(false)]
+    [InlineData(true)]
     [Theory]
-    public async Task DisposePipeline_EnsureCircuitBreakerDisposed(bool isAsync, bool attachManualControl)
+    public async Task DisposePipeline_EnsureCircuitBreakerDisposed(bool attachManualControl)
     {
         var manualControl = attachManualControl ? new CircuitBreakerManualControl() : null;
         var pipeline = new ResiliencePipelineBuilder()
@@ -153,14 +151,7 @@ public class CircuitBreakerResiliencePipelineBuilderTests
 
         var strategy = (ResilienceStrategy<object>)pipeline.GetPipelineDescriptor().FirstStrategy.StrategyInstance;
 
-        if (isAsync)
-        {
-            await pipeline.DisposeHelper.DisposeAsync();
-        }
-        else
-        {
-            pipeline.DisposeHelper.Dispose();
-        }
+        await pipeline.DisposeHelper.DisposeAsync();
 
         strategy.AsPipeline().Invoking(s => s.Execute(() => 1)).Should().Throw<ObjectDisposedException>();
 

--- a/test/Polly.Core.Tests/Registry/ResiliencePipelineRegistryTests.cs
+++ b/test/Polly.Core.Tests/Registry/ResiliencePipelineRegistryTests.cs
@@ -424,22 +424,14 @@ public class ResiliencePipelineRegistryTests
         pipeline4.Invoking(p => p.Execute(() => "dummy")).Should().Throw<ObjectDisposedException>();
     }
 
-    [InlineData(true)]
-    [InlineData(false)]
-    [Theory]
-    public async Task DisposePipeline_NotAllowed(bool isAsync)
+    [Fact]
+    public async Task DisposePipeline_NotAllowed()
     {
         using var registry = CreateRegistry();
         var pipeline = registry.GetOrAddPipeline(StrategyId.Create("A"), builder => { builder.AddTimeout(TimeSpan.FromSeconds(1)); });
 
-        if (isAsync)
-        {
-            await pipeline.Invoking(p => p.DisposeHelper.DisposeAsync().AsTask()).Should().ThrowAsync<InvalidOperationException>();
-        }
-        else
-        {
-            pipeline.Invoking(p => p.DisposeHelper.Dispose()).Should().Throw<InvalidOperationException>();
-        }
+        await pipeline.Invoking(p => p.DisposeHelper.DisposeAsync().AsTask()).Should().ThrowAsync<InvalidOperationException>();
+
     }
 
     [InlineData(true)]

--- a/test/Polly.Core.Tests/ResiliencePipelineBuilderTests.cs
+++ b/test/Polly.Core.Tests/ResiliencePipelineBuilderTests.cs
@@ -232,10 +232,8 @@ The RequiredProperty field is required.
             .Be("factory");
     }
 
-    [InlineData(true)]
-    [InlineData(false)]
-    [Theory]
-    public async Task AddPipeline_EnsureNotDisposed(bool isAsync)
+    [Fact]
+    public async Task AddPipeline_EnsureNotDisposed()
     {
         var externalComponent = Substitute.For<PipelineComponent>();
         var externalBuilder = new ResiliencePipelineBuilder();
@@ -249,24 +247,13 @@ The RequiredProperty field is required.
             .AddPipelineComponent(_ => internalComponent, new TestResilienceStrategyOptions());
         var pipeline = builder.Build();
 
-        if (isAsync)
-        {
-            await pipeline.DisposeHelper.DisposeAsync();
-            await externalComponent.Received(0).DisposeAsync();
-            await internalComponent.Received(1).DisposeAsync();
-        }
-        else
-        {
-            pipeline.DisposeHelper.Dispose();
-            externalComponent.Received(0).Dispose();
-            internalComponent.Received(1).Dispose();
-        }
+        await pipeline.DisposeHelper.DisposeAsync();
+        await externalComponent.Received(0).DisposeAsync();
+        await internalComponent.Received(1).DisposeAsync();
     }
 
-    [InlineData(true)]
-    [InlineData(false)]
-    [Theory]
-    public async Task AddPipeline_Generic_EnsureNotDisposed(bool isAsync)
+    [Fact]
+    public async Task AddPipeline_Generic_EnsureNotDisposed()
     {
         var externalComponent = Substitute.For<PipelineComponent>();
         var externalBuilder = new ResiliencePipelineBuilder<string>();
@@ -282,18 +269,9 @@ The RequiredProperty field is required.
 
         pipeline.Execute(_ => string.Empty);
 
-        if (isAsync)
-        {
-            await pipeline.DisposeHelper.DisposeAsync();
-            await externalComponent.Received(0).DisposeAsync();
-            await internalComponent.Received(1).DisposeAsync();
-        }
-        else
-        {
-            pipeline.DisposeHelper.Dispose();
-            externalComponent.Received(0).Dispose();
-            internalComponent.Received(1).Dispose();
-        }
+        await pipeline.DisposeHelper.DisposeAsync();
+        await externalComponent.Received(0).DisposeAsync();
+        await internalComponent.Received(1).DisposeAsync();
     }
 
     [Fact]

--- a/test/Polly.Core.Tests/ResiliencePipelineTests.cs
+++ b/test/Polly.Core.Tests/ResiliencePipelineTests.cs
@@ -11,10 +11,8 @@ public partial class ResiliencePipelineTests
     public static readonly CancellationToken CancellationToken = new CancellationTokenSource().Token;
 
     [Fact]
-    public async Task Dispose_NullPipeline_OK()
+    public async Task DisposeAsync_NullPipeline_OK()
     {
-        ResiliencePipeline.Empty.DisposeHelper.Dispose();
-        ResiliencePipeline.Empty.DisposeHelper.Dispose();
         await ResiliencePipeline.Empty.DisposeHelper.DisposeAsync();
         await ResiliencePipeline.Empty.DisposeHelper.DisposeAsync();
 
@@ -22,10 +20,8 @@ public partial class ResiliencePipelineTests
     }
 
     [Fact]
-    public async Task Dispose_NullGenericPipeline_OK()
+    public async Task DisposeAsync_NullGenericPipeline_OK()
     {
-        ResiliencePipeline<int>.Empty.DisposeHelper.Dispose();
-        ResiliencePipeline<int>.Empty.DisposeHelper.Dispose();
         await ResiliencePipeline<int>.Empty.DisposeHelper.DisposeAsync();
         await ResiliencePipeline<int>.Empty.DisposeHelper.DisposeAsync();
 
@@ -33,33 +29,15 @@ public partial class ResiliencePipelineTests
     }
 
     [Fact]
-    public async Task Dispose_Reject_Throws()
+    public async Task DisposeAsync_Reject_Throws()
     {
         var component = Substitute.For<PipelineComponent>();
         var pipeline = new ResiliencePipeline(component, DisposeBehavior.Reject);
-
-        pipeline.Invoking(p => p.DisposeHelper.Dispose())
-            .Should()
-            .Throw<InvalidOperationException>()
-            .WithMessage("Disposing this resilience pipeline is not allowed because it is owned by the pipeline registry.");
 
         (await pipeline.Invoking(p => p.DisposeHelper.DisposeAsync().AsTask())
             .Should()
             .ThrowAsync<InvalidOperationException>())
             .WithMessage("Disposing this resilience pipeline is not allowed because it is owned by the pipeline registry.");
-    }
-
-    [Fact]
-    public void Dispose_Allowed_Disposed()
-    {
-        var component = Substitute.For<PipelineComponent>();
-        var pipeline = new ResiliencePipeline(component, DisposeBehavior.Allow);
-        pipeline.DisposeHelper.Dispose();
-        pipeline.DisposeHelper.Dispose();
-
-        pipeline.Invoking(p => p.Execute(() => { })).Should().Throw<ObjectDisposedException>();
-
-        component.Received(1).Dispose();
     }
 
     [Fact]
@@ -83,9 +61,9 @@ public partial class ResiliencePipelineTests
     }
 
     [Fact]
-    public void DebuggerProxy_Ok()
+    public async Task DebuggerProxy_Ok()
     {
-        using var pipeline = (CompositeComponent)PipelineComponentFactory.CreateComposite(new[]
+        await using var pipeline = (CompositeComponent)PipelineComponentFactory.CreateComposite(new[]
         {
             Substitute.For<PipelineComponent>(),
             Substitute.For<PipelineComponent>(),

--- a/test/Polly.Core.Tests/Utils/Pipeline/BridgePipelineComponentTests.cs
+++ b/test/Polly.Core.Tests/Utils/Pipeline/BridgePipelineComponentTests.cs
@@ -66,45 +66,34 @@ public class BridgePipelineComponentTests
     }
 
 #pragma warning disable S1944 // Invalid casts should be avoided
-    [InlineData(true)]
-    [InlineData(false)]
-    [Theory]
-    public async Task Dispose_EnsureStrategyDisposed(bool isAsync)
+    [Fact]
+    public async Task Dispose_EnsureStrategyDisposed()
     {
         var strategy = Substitute.For<ResilienceStrategy, IDisposable>();
-        await Dispose(PipelineComponentFactory.FromStrategy(strategy), isAsync);
+        await Dispose(PipelineComponentFactory.FromStrategy(strategy));
         ((IDisposable)strategy).Received(1).Dispose();
 
         strategy = Substitute.For<ResilienceStrategy, IAsyncDisposable>();
-        await Dispose(PipelineComponentFactory.FromStrategy(strategy), isAsync);
+        await Dispose(PipelineComponentFactory.FromStrategy(strategy));
         await ((IAsyncDisposable)strategy).Received(1).DisposeAsync();
     }
 
-    [InlineData(true)]
-    [InlineData(false)]
-    [Theory]
-    public async Task Dispose_Generic_EnsureStrategyDisposed(bool isAsync)
+    [Fact]
+    public async Task Dispose_Generic_EnsureStrategyDisposed()
     {
         var strategy = Substitute.For<ResilienceStrategy<string>, IDisposable>();
-        await Dispose(PipelineComponentFactory.FromStrategy(strategy), isAsync);
+        await Dispose(PipelineComponentFactory.FromStrategy(strategy));
         ((IDisposable)strategy).Received(1).Dispose();
 
         strategy = Substitute.For<ResilienceStrategy<string>, IAsyncDisposable>();
-        await Dispose(PipelineComponentFactory.FromStrategy(strategy), isAsync);
+        await Dispose(PipelineComponentFactory.FromStrategy(strategy));
         await ((IAsyncDisposable)strategy).Received(1).DisposeAsync();
     }
 #pragma warning restore S1944 // Invalid casts should be avoided
 
-    private static async Task Dispose(PipelineComponent component, bool isAsync)
+    private static async Task Dispose(PipelineComponent component)
     {
-        if (isAsync)
-        {
-            await component.DisposeAsync();
-        }
-        else
-        {
-            component.Dispose();
-        }
+        await component.DisposeAsync();
     }
 
     private class Strategy<T> : ResilienceStrategy<T>

--- a/test/Polly.Core.Tests/Utils/Pipeline/ComponentWithDisposeCallbacksTests.cs
+++ b/test/Polly.Core.Tests/Utils/Pipeline/ComponentWithDisposeCallbacksTests.cs
@@ -5,10 +5,8 @@ namespace Polly.Core.Tests.Utils.Pipeline;
 
 public class ComponentWithDisposeCallbacksTests
 {
-    [InlineData(true)]
-    [InlineData(false)]
-    [Theory]
-    public async Task Dispose_Ok(bool isAsync)
+    [Fact]
+    public async Task Dispose_Ok()
     {
         // Arrange
         var called1 = 0;
@@ -23,20 +21,9 @@ public class ComponentWithDisposeCallbacksTests
         var sut = new ComponentWithDisposeCallbacks(component, callbacks);
 
         // Act
-        if (isAsync)
-        {
-            await sut.DisposeAsync();
-            await sut.DisposeAsync();
-            await component.Received(2).DisposeAsync();
-        }
-        else
-        {
-            sut.Dispose();
-#pragma warning disable S3966 // Objects should not be disposed more than once
-            sut.Dispose();
-#pragma warning restore S3966 // Objects should not be disposed more than once
-            component.Received(2).Dispose();
-        }
+        await sut.DisposeAsync();
+        await sut.DisposeAsync();
+        await component.Received(2).DisposeAsync();
 
         // Assert
         callbacks.Should().BeEmpty();

--- a/test/Polly.Core.Tests/Utils/Pipeline/CompositePipelineComponentTests.cs
+++ b/test/Polly.Core.Tests/Utils/Pipeline/CompositePipelineComponentTests.cs
@@ -127,21 +127,6 @@ public class CompositePipelineComponentTests
     }
 
     [Fact]
-    public void Dispose_EnsureInnerComponentsDisposed()
-    {
-        var a = Substitute.For<PipelineComponent>();
-        var b = Substitute.For<PipelineComponent>();
-
-        var composite = CreateSut(new[] { a, b });
-
-        composite.FirstComponent.Dispose();
-        composite.Dispose();
-
-        a.Received(1).Dispose();
-        b.Received(1).Dispose();
-    }
-
-    [Fact]
     public async Task DisposeAsync_EnsureInnerComponentsDisposed()
     {
         var a = Substitute.For<PipelineComponent>();

--- a/test/Polly.Core.Tests/Utils/Pipeline/PipelineComponentTests.cs
+++ b/test/Polly.Core.Tests/Utils/Pipeline/PipelineComponentTests.cs
@@ -9,7 +9,6 @@ public class PipelineComponentTests
     public async Task Dispose_Ok()
     {
         PipelineComponent.Empty.Should().NotBeNull();
-        PipelineComponent.Empty.Dispose();
         await PipelineComponent.Empty.DisposeAsync();
     }
 }

--- a/test/Polly.Core.Tests/Utils/Pipeline/ReloadablePipelineComponentTests.cs
+++ b/test/Polly.Core.Tests/Utils/Pipeline/ReloadablePipelineComponentTests.cs
@@ -6,39 +6,27 @@ namespace Polly.Core.Tests.Utils.Pipeline;
 
 public class ReloadablePipelineComponentTests : IDisposable
 {
-    private readonly List<TelemetryEventArguments<object, object>> _events = new();
+    private readonly FakeTelemetryListener _listener;
     private readonly ResilienceStrategyTelemetry _telemetry;
+    private readonly List<bool> _synchronousFlags = new();
     private CancellationTokenSource _cancellationTokenSource;
 
     public ReloadablePipelineComponentTests()
     {
-        _telemetry = TestUtilities.CreateResilienceTelemetry(args =>
-        {
-            args.Context.IsSynchronous.Should().BeTrue();
-            args.Context.IsVoid.Should().BeTrue();
-            _events.Add(args);
-        });
-
+        _listener = new FakeTelemetryListener(args => _synchronousFlags.Add(args.Context.IsSynchronous));
+        _telemetry = TestUtilities.CreateResilienceTelemetry(_listener);
         _cancellationTokenSource = new CancellationTokenSource();
     }
 
     [Fact]
-    public void Ctor_Ok()
+    public async Task Ctor_Ok()
     {
         var component = Substitute.For<PipelineComponent>();
-        using var sut = CreateSut(component);
+        await using var sut = CreateSut(component);
 
         sut.Component.Should().Be(component);
 
         ReloadableComponent.ReloadFailedEvent.Should().Be("ReloadFailed");
-    }
-
-    [Fact]
-    public void Dispose_ComponentDisposed()
-    {
-        var component = Substitute.For<PipelineComponent>();
-        CreateSut(component).Dispose();
-        component.Received(1).Dispose();
     }
 
     [Fact]
@@ -50,58 +38,94 @@ public class ReloadablePipelineComponentTests : IDisposable
     }
 
     [Fact]
-    public void ChangeTriggered_StrategyReloaded()
+    public async Task ChangeTriggered_StrategyReloaded()
     {
         var component = Substitute.For<PipelineComponent>();
-        using var sut = CreateSut(component);
+        await using var sut = CreateSut(component);
 
         sut.Component.Should().Be(component);
         _cancellationTokenSource.Cancel();
         sut.Component.Should().NotBe(component);
 
-        _events.Where(e => e.Event.EventName == "ReloadFailed").Should().HaveCount(0);
-        _events.Where(e => e.Event.EventName == "OnReload").Should().HaveCount(1);
+        _listener.Events.Where(e => e.Event.EventName == "ReloadFailed").Should().HaveCount(0);
+        _listener.Events.Where(e => e.Event.EventName == "OnReload").Should().HaveCount(1);
     }
 
     [Fact]
-    public void ChangeTriggered_EnsureOldStrategyDisposed()
+    public async Task ChangeTriggered_EnsureOldStrategyDisposed()
     {
         var component = Substitute.For<PipelineComponent>();
-        using var sut = CreateSut(component, () => new(Substitute.For<PipelineComponent>(), new List<CancellationToken>()));
+        await using var sut = CreateSut(component, () => new(Substitute.For<PipelineComponent>(), new List<CancellationToken>()));
 
         for (var i = 0; i < 10; i++)
         {
             var src = _cancellationTokenSource;
             _cancellationTokenSource = new CancellationTokenSource();
             src.Cancel();
-            component.Received(1).Dispose();
-            sut.Component.Received(0).Dispose();
+            await component.Received(1).DisposeAsync();
+            await sut.Component.Received(0).DisposeAsync();
         }
     }
 
     [Fact]
-    public void ChangeTriggered_FactoryError_LastStrategyUsedAndErrorReported()
+    public async Task ChangeTriggered_FactoryError_LastStrategyUsedAndErrorReported()
     {
         var component = Substitute.For<PipelineComponent>();
-        using var sut = CreateSut(component, () => throw new InvalidOperationException());
+        await using var sut = CreateSut(component, () => throw new InvalidOperationException());
 
         _cancellationTokenSource.Cancel();
 
         sut.Component.Should().Be(component);
-        _events.Should().HaveCount(2);
+        _listener.Events.Should().HaveCount(2);
 
-        _events[0]
+        _listener.Events[0]
             .Arguments
             .Should()
             .BeOfType<ReloadableComponent.OnReloadArguments>();
 
-        var args = _events[1]
+        var args = _listener.Events[1]
             .Arguments
             .Should()
             .BeOfType<ReloadableComponent.ReloadFailedArguments>()
             .Subject;
 
         args.Exception.Should().BeOfType<InvalidOperationException>();
+
+        _synchronousFlags.Should().AllSatisfy(f => f.Should().BeTrue());
+    }
+
+    [Fact]
+    public async Task DisposeError_EnsureReported()
+    {
+        var component = Substitute.For<PipelineComponent>();
+#pragma warning disable CA2012 // Use ValueTasks correctly
+        component
+            .When(c => c.DisposeAsync())
+            .Do(_ => throw new InvalidOperationException());
+#pragma warning restore CA2012 // Use ValueTasks correctly
+
+        await using var sut = CreateSut(component);
+
+        _cancellationTokenSource.Cancel();
+
+        _listener.Events.Should().HaveCount(2);
+
+        _listener.Events[0]
+            .Arguments
+            .Should()
+            .BeOfType<ReloadableComponent.OnReloadArguments>();
+
+        var args = _listener.Events[1]
+            .Arguments
+            .Should()
+            .BeOfType<ReloadableComponent.DisposedFailedArguments>()
+            .Subject;
+
+        args.Exception.Should().BeOfType<InvalidOperationException>();
+
+        _synchronousFlags.Should().HaveCount(2);
+        _synchronousFlags[0].Should().BeTrue();
+        _synchronousFlags[1].Should().BeFalse();
     }
 
     private ReloadableComponent CreateSut(PipelineComponent? initial = null, Func<ReloadableComponent.Entry>? factory = null)

--- a/test/Polly.Extensions.Tests/DisposablePipelineTests.cs
+++ b/test/Polly.Extensions.Tests/DisposablePipelineTests.cs
@@ -44,7 +44,7 @@ public class DisposablePipelineTests
     }
 
     [Fact]
-    public void DisposePipeline_EnsureExternalPipelineNotDisposed()
+    public async Task DisposePipeline_EnsureExternalPipelineNotDisposed()
     {
         var registry1 = new ResiliencePipelineRegistry<string>();
         var pipeline1 = registry1.GetOrAddPipeline("my-pipeline", builder => builder.AddConcurrencyLimiter(1));
@@ -56,13 +56,13 @@ public class DisposablePipelineTests
             .AddPipeline(pipeline2));
 
         pipeline3.Execute(() => string.Empty);
-        registry2.Dispose();
+        await registry2.DisposeAsync();
         pipeline3.Invoking(p => p.Execute(() => string.Empty)).Should().Throw<ObjectDisposedException>();
 
         pipeline1.Execute(() => { });
         pipeline2.Execute(() => string.Empty);
 
-        registry1.Dispose();
+        await registry1.DisposeAsync();
 
         pipeline1.Invoking(p => p.Execute(() => { })).Should().Throw<ObjectDisposedException>();
         pipeline2.Invoking(p => p.Execute(() => string.Empty)).Should().Throw<ObjectDisposedException>();

--- a/test/Polly.Extensions.Tests/Registry/ConfigureBuilderContextExtensionsTEsts.cs
+++ b/test/Polly.Extensions.Tests/Registry/ConfigureBuilderContextExtensionsTEsts.cs
@@ -8,7 +8,7 @@ namespace Polly.Extensions.Tests.Registry;
 public class ConfigureBuilderContextExtensionsTests
 {
     [Fact]
-    public void ConfigureReloads_MonitorRegistrationReturnsNull_DoesNotThrow()
+    public async Task ConfigureReloads_MonitorRegistrationReturnsNull_DoesNotThrow()
     {
         var monitor = Substitute.For<IOptionsMonitor<Options>>();
         monitor.OnChange(default!).ReturnsNullForAnyArgs();
@@ -22,7 +22,7 @@ public class ConfigureBuilderContextExtensionsTests
             context.EnableReloads(monitor);
         });
 
-        registry.Dispose();
+        await registry.DisposeAsync();
 
         listener.Events.Should().BeEmpty();
     }

--- a/test/Polly.RateLimiting.Tests/RateLimiterResiliencePipelineBuilderExtensionsTests.cs
+++ b/test/Polly.RateLimiting.Tests/RateLimiterResiliencePipelineBuilderExtensionsTests.cs
@@ -146,24 +146,15 @@ public class RateLimiterResiliencePipelineBuilderExtensionsTests
             .BeOfType<RateLimiterResilienceStrategy>();
     }
 
-    [InlineData(true)]
-    [InlineData(false)]
-    [Theory]
-    public async Task DisposeRegistry_EnsureRateLimiterDisposed(bool isAsync)
+    [Fact]
+    public async Task DisposeRegistry_EnsureRateLimiterDisposed()
     {
         var registry = new ResiliencePipelineRegistry<string>();
         var pipeline = registry.GetOrAddPipeline("limiter", p => p.AddRateLimiter(new RateLimiterStrategyOptions()));
 
         var strategy = (RateLimiterResilienceStrategy)pipeline.GetPipelineDescriptor().FirstStrategy.StrategyInstance;
 
-        if (isAsync)
-        {
-            await registry.DisposeAsync();
-        }
-        else
-        {
-            registry.Dispose();
-        }
+        await registry.DisposeAsync();
 
         strategy.AsPipeline().Invoking(p => p.Execute(() => { })).Should().Throw<ObjectDisposedException>();
     }

--- a/test/Polly.Testing.Tests/ResiliencePipelineExtensionsTests.cs
+++ b/test/Polly.Testing.Tests/ResiliencePipelineExtensionsTests.cs
@@ -109,11 +109,11 @@ public class ResiliencePipelineExtensionsTests
     }
 
     [Fact]
-    public void GetPipelineDescriptor_Reloadable_Ok()
+    public async Task GetPipelineDescriptor_Reloadable_Ok()
     {
         // arrange
         using var source = new CancellationTokenSource();
-        using var registry = new ResiliencePipelineRegistry<string>();
+        await using var registry = new ResiliencePipelineRegistry<string>();
         var strategy = registry.GetOrAddPipeline("dummy", (builder, context) =>
         {
             context.OnPipelineDisposed(() => { });


### PR DESCRIPTION
### Details on the issue fix or feature implementation

Internally, `PipelineComponent` implemented both `IDisposable` and `IAsyncDisposable` that caused some duplications. Now it only implements `IAsyncDisposable`.

The registry still implements `IDisposable` and `IAsyncDisposable` for ease of use. We can afford sync-over-async because in most scenarios `DisposeAsync` will have sync implementation anyway.

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
