### PR TITLE
Fix the link to v8 docs (second attempt)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 > :rotating_light::rotating_light: **Polly v8 feature-complete!** :rotating_light::rotating_light:
 > - Polly v8 Beta 1 is now available on [NuGet.org](https://www.nuget.org/packages/Polly/8.0.0-beta.1).
 > - The Beta 1 version is considered feature-complete and the public API surface is stable.
-> - Explore the [v8 documentation](./README_V8.md).
+> - Explore the [v8 documentation](https://github.com/App-vNext/Polly/blob/main/README_V8.md).
 
 # Polly
 


### PR DESCRIPTION
### Details on the issue fix or feature implementation

#1557 did not work, so we have to set absolute URL.

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
