### PR TITLE
Drop the build target for net7.0

### DIFF
--- a/src/Polly.Core/Polly.Core.csproj
+++ b/src/Polly.Core/Polly.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;netstandard2.0;net472;net462</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0;net472;net462</TargetFrameworks>
     <AssemblyTitle>Polly.Core</AssemblyTitle>
     <RootNamespace>Polly</RootNamespace>
     <Nullable>enable</Nullable>

--- a/src/Polly.Extensions/Polly.Extensions.csproj
+++ b/src/Polly.Extensions/Polly.Extensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;netstandard2.0;net472;net462</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0;net472;net462</TargetFrameworks>
     <AssemblyTitle>Polly.Extensions</AssemblyTitle>
     <RootNamespace>Polly</RootNamespace>
     <Nullable>enable</Nullable>

--- a/src/Polly.RateLimiting/Polly.RateLimiting.csproj
+++ b/src/Polly.RateLimiting/Polly.RateLimiting.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;netstandard2.0;net472;net462</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0;net472;net462</TargetFrameworks>
     <AssemblyTitle>Polly.RateLimiting</AssemblyTitle>
     <RootNamespace>Polly.RateLimiting</RootNamespace>
     <Nullable>enable</Nullable>

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;netstandard2.0;net472;net462</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0;net472;net462</TargetFrameworks>
     <AssemblyTitle>Polly</AssemblyTitle>
     <ProjectType>Library</ProjectType>
     <MutationScore>70</MutationScore>


### PR DESCRIPTION
### Details on the issue fix or feature implementation

We are not using anything from `net7.0` so having `net6.0` is enough.

Closes #1534 

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
