### PR TITLE
Improve the docs and behavior around infinite retries

### DIFF
--- a/README_V8.md
+++ b/README_V8.md
@@ -193,7 +193,7 @@ new ResiliencePipelineBuilder().AddRetry(new RetryStrategyOptions
     }
 });
 
-// To keep retrying indefinitely until successful
+// To keep retrying indefinitely or until success use int.MaxValue.
 new ResiliencePipelineBuilder().AddRetry(new RetryStrategyOptions
 {
     MaxRetryAttempts = int.MaxValue,

--- a/docs/strategies/retry.md
+++ b/docs/strategies/retry.md
@@ -86,7 +86,7 @@ new ResiliencePipelineBuilder().AddRetry(new RetryStrategyOptions
     }
 });
 
-// To keep retrying indefinitely until successful
+// To keep retrying indefinitely or until success use int.MaxValue.
 new ResiliencePipelineBuilder().AddRetry(new RetryStrategyOptions
 {
     MaxRetryAttempts = int.MaxValue,

--- a/src/Polly.Core/Retry/RetryResilienceStrategy.cs
+++ b/src/Polly.Core/Retry/RetryResilienceStrategy.cs
@@ -56,7 +56,7 @@ internal sealed class RetryResilienceStrategy<T> : ResilienceStrategy<T>
 
             TelemetryUtil.ReportExecutionAttempt(_telemetry, context, outcome, attempt, executionTime, handle);
 
-            if (context.CancellationToken.IsCancellationRequested || IsLastAttempt(attempt) || !handle)
+            if (context.CancellationToken.IsCancellationRequested || IsLastAttempt(attempt, out bool incrementAttempts) || !handle)
             {
                 return outcome;
             }
@@ -98,9 +98,22 @@ internal sealed class RetryResilienceStrategy<T> : ResilienceStrategy<T>
                 }
             }
 
-            attempt++;
+            if (incrementAttempts)
+            {
+                attempt++;
+            }
         }
     }
 
-    private bool IsLastAttempt(int attempt) => attempt >= RetryCount;
+    internal bool IsLastAttempt(int attempt, out bool incrementAttempts)
+    {
+        if (attempt == int.MaxValue)
+        {
+            incrementAttempts = false;
+            return false;
+        }
+
+        incrementAttempts = true;
+        return attempt >= RetryCount;
+    }
 }

--- a/src/Polly.Core/Retry/RetryStrategyOptions.TResult.cs
+++ b/src/Polly.Core/Retry/RetryStrategyOptions.TResult.cs
@@ -20,6 +20,9 @@ public class RetryStrategyOptions<TResult> : ResilienceStrategyOptions
     /// <value>
     /// The default value is 3 retries.
     /// </value>
+    /// <remarks>
+    /// To retry indefinitely use <see cref="int.MaxValue"/>. Note that the reported attempt number is capped at <see cref="int.MaxValue"/>.
+    /// </remarks>
     [Range(1, RetryConstants.MaxRetryCount)]
     public int MaxRetryAttempts { get; set; } = RetryConstants.DefaultRetryCount;
 

--- a/src/Snippets/Docs/Retry.cs
+++ b/src/Snippets/Docs/Retry.cs
@@ -81,7 +81,7 @@ internal static class Retry
             }
         });
 
-        // To keep retrying indefinitely until successful
+        // To keep retrying indefinitely or until success use int.MaxValue.
         new ResiliencePipelineBuilder().AddRetry(new RetryStrategyOptions
         {
             MaxRetryAttempts = int.MaxValue,

--- a/test/Polly.Core.Tests/Retry/RetryResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Retry/RetryResilienceStrategyTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions.Execution;
 using Microsoft.Extensions.Time.Testing;
 using Polly.Retry;
 using Polly.Telemetry;
+using Polly.Testing;
 
 namespace Polly.Core.Tests.Retry;
 
@@ -188,6 +189,15 @@ public class RetryResilienceStrategyTests
 
         retries.Should().Be(3);
         generatedValues.Should().Be(3);
+    }
+
+    [Fact]
+    public void IsLastAttempt_Ok()
+    {
+        var sut = (RetryResilienceStrategy<object>)CreateSut().GetPipelineDescriptor().FirstStrategy.StrategyInstance;
+
+        sut.IsLastAttempt(int.MaxValue, out var increment).Should().BeFalse();
+        increment.Should().BeFalse();
     }
 
     private sealed class ThrowingFakeTimeProvider : FakeTimeProvider


### PR DESCRIPTION
### Details on the issue fix or feature implementation

- Using `int.MaxValue` will indicate infinite retries to retry strategy. 
- Docs improvements.

Closes #944

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
