### PR TITLE
Hide Simmy API for initial v8 release

### DIFF
--- a/src/Polly.Core/PublicAPI.Unshipped.txt
+++ b/src/Polly.Core/PublicAPI.Unshipped.txt
@@ -321,104 +321,6 @@ Polly.Retry.RetryStrategyOptions<TResult>.ShouldHandle.set -> void
 Polly.Retry.RetryStrategyOptions<TResult>.UseJitter.get -> bool
 Polly.Retry.RetryStrategyOptions<TResult>.UseJitter.set -> void
 Polly.RetryResiliencePipelineBuilderExtensions
-Polly.Simmy.Behavior.BehaviorActionArguments
-Polly.Simmy.Behavior.BehaviorActionArguments.BehaviorActionArguments() -> void
-Polly.Simmy.Behavior.BehaviorActionArguments.BehaviorActionArguments(Polly.ResilienceContext! context) -> void
-Polly.Simmy.Behavior.BehaviorActionArguments.Context.get -> Polly.ResilienceContext!
-Polly.Simmy.Behavior.BehaviorStrategyOptions
-Polly.Simmy.Behavior.BehaviorStrategyOptions.BehaviorAction.get -> System.Func<Polly.Simmy.Behavior.BehaviorActionArguments, System.Threading.Tasks.ValueTask>?
-Polly.Simmy.Behavior.BehaviorStrategyOptions.BehaviorAction.set -> void
-Polly.Simmy.Behavior.BehaviorStrategyOptions.BehaviorStrategyOptions() -> void
-Polly.Simmy.Behavior.BehaviorStrategyOptions.OnBehaviorInjected.get -> System.Func<Polly.Simmy.Behavior.OnBehaviorInjectedArguments, System.Threading.Tasks.ValueTask>?
-Polly.Simmy.Behavior.BehaviorStrategyOptions.OnBehaviorInjected.set -> void
-Polly.Simmy.Behavior.OnBehaviorInjectedArguments
-Polly.Simmy.Behavior.OnBehaviorInjectedArguments.Context.get -> Polly.ResilienceContext!
-Polly.Simmy.Behavior.OnBehaviorInjectedArguments.OnBehaviorInjectedArguments() -> void
-Polly.Simmy.Behavior.OnBehaviorInjectedArguments.OnBehaviorInjectedArguments(Polly.ResilienceContext! context) -> void
-Polly.Simmy.BehaviorPipelineBuilderExtensions
-Polly.Simmy.EnabledGeneratorArguments
-Polly.Simmy.EnabledGeneratorArguments.Context.get -> Polly.ResilienceContext!
-Polly.Simmy.EnabledGeneratorArguments.EnabledGeneratorArguments() -> void
-Polly.Simmy.EnabledGeneratorArguments.EnabledGeneratorArguments(Polly.ResilienceContext! context) -> void
-Polly.Simmy.InjectionRateGeneratorArguments
-Polly.Simmy.InjectionRateGeneratorArguments.Context.get -> Polly.ResilienceContext!
-Polly.Simmy.InjectionRateGeneratorArguments.InjectionRateGeneratorArguments() -> void
-Polly.Simmy.InjectionRateGeneratorArguments.InjectionRateGeneratorArguments(Polly.ResilienceContext! context) -> void
-Polly.Simmy.Latency.LatencyGeneratorArguments
-Polly.Simmy.Latency.LatencyGeneratorArguments.Context.get -> Polly.ResilienceContext!
-Polly.Simmy.Latency.LatencyGeneratorArguments.LatencyGeneratorArguments() -> void
-Polly.Simmy.Latency.LatencyGeneratorArguments.LatencyGeneratorArguments(Polly.ResilienceContext! context) -> void
-Polly.Simmy.Latency.LatencyStrategyOptions
-Polly.Simmy.Latency.LatencyStrategyOptions.Latency.get -> System.TimeSpan
-Polly.Simmy.Latency.LatencyStrategyOptions.Latency.set -> void
-Polly.Simmy.Latency.LatencyStrategyOptions.LatencyGenerator.get -> System.Func<Polly.Simmy.Latency.LatencyGeneratorArguments, System.Threading.Tasks.ValueTask<System.TimeSpan>>?
-Polly.Simmy.Latency.LatencyStrategyOptions.LatencyGenerator.set -> void
-Polly.Simmy.Latency.LatencyStrategyOptions.LatencyStrategyOptions() -> void
-Polly.Simmy.Latency.LatencyStrategyOptions.OnLatency.get -> System.Func<Polly.Simmy.Latency.OnLatencyArguments, System.Threading.Tasks.ValueTask>?
-Polly.Simmy.Latency.LatencyStrategyOptions.OnLatency.set -> void
-Polly.Simmy.Latency.OnLatencyArguments
-Polly.Simmy.Latency.OnLatencyArguments.Context.get -> Polly.ResilienceContext!
-Polly.Simmy.Latency.OnLatencyArguments.Latency.get -> System.TimeSpan
-Polly.Simmy.Latency.OnLatencyArguments.OnLatencyArguments() -> void
-Polly.Simmy.Latency.OnLatencyArguments.OnLatencyArguments(Polly.ResilienceContext! context, System.TimeSpan latency) -> void
-Polly.Simmy.LatencyPipelineBuilderExtensions
-Polly.Simmy.MonkeyStrategy
-Polly.Simmy.MonkeyStrategy.MonkeyStrategy(Polly.Simmy.MonkeyStrategyOptions! options) -> void
-Polly.Simmy.MonkeyStrategy.ShouldInjectAsync(Polly.ResilienceContext! context) -> System.Threading.Tasks.ValueTask<bool>
-Polly.Simmy.MonkeyStrategy<T>
-Polly.Simmy.MonkeyStrategy<T>.MonkeyStrategy(Polly.Simmy.MonkeyStrategyOptions! options) -> void
-Polly.Simmy.MonkeyStrategy<T>.ShouldInjectAsync(Polly.ResilienceContext! context) -> System.Threading.Tasks.ValueTask<bool>
-Polly.Simmy.MonkeyStrategyOptions
-Polly.Simmy.MonkeyStrategyOptions.MonkeyStrategyOptions() -> void
-Polly.Simmy.MonkeyStrategyOptions<TResult>
-Polly.Simmy.MonkeyStrategyOptions<TResult>.Enabled.get -> bool
-Polly.Simmy.MonkeyStrategyOptions<TResult>.Enabled.set -> void
-Polly.Simmy.MonkeyStrategyOptions<TResult>.EnabledGenerator.get -> System.Func<Polly.Simmy.EnabledGeneratorArguments, System.Threading.Tasks.ValueTask<bool>>?
-Polly.Simmy.MonkeyStrategyOptions<TResult>.EnabledGenerator.set -> void
-Polly.Simmy.MonkeyStrategyOptions<TResult>.InjectionRate.get -> double
-Polly.Simmy.MonkeyStrategyOptions<TResult>.InjectionRate.set -> void
-Polly.Simmy.MonkeyStrategyOptions<TResult>.InjectionRateGenerator.get -> System.Func<Polly.Simmy.InjectionRateGeneratorArguments, System.Threading.Tasks.ValueTask<double>>?
-Polly.Simmy.MonkeyStrategyOptions<TResult>.InjectionRateGenerator.set -> void
-Polly.Simmy.MonkeyStrategyOptions<TResult>.MonkeyStrategyOptions() -> void
-Polly.Simmy.MonkeyStrategyOptions<TResult>.Randomizer.get -> System.Func<double>!
-Polly.Simmy.MonkeyStrategyOptions<TResult>.Randomizer.set -> void
-Polly.Simmy.OutcomePipelineBuilderExtensions
-Polly.Simmy.Outcomes.FaultGeneratorArguments
-Polly.Simmy.Outcomes.FaultGeneratorArguments.Context.get -> Polly.ResilienceContext!
-Polly.Simmy.Outcomes.FaultGeneratorArguments.FaultGeneratorArguments() -> void
-Polly.Simmy.Outcomes.FaultGeneratorArguments.FaultGeneratorArguments(Polly.ResilienceContext! context) -> void
-Polly.Simmy.Outcomes.FaultStrategyOptions
-Polly.Simmy.Outcomes.FaultStrategyOptions.Fault.get -> System.Exception?
-Polly.Simmy.Outcomes.FaultStrategyOptions.Fault.set -> void
-Polly.Simmy.Outcomes.FaultStrategyOptions.FaultGenerator.get -> System.Func<Polly.Simmy.Outcomes.FaultGeneratorArguments, System.Threading.Tasks.ValueTask<System.Exception?>>?
-Polly.Simmy.Outcomes.FaultStrategyOptions.FaultGenerator.set -> void
-Polly.Simmy.Outcomes.FaultStrategyOptions.FaultStrategyOptions() -> void
-Polly.Simmy.Outcomes.FaultStrategyOptions.OnFaultInjected.get -> System.Func<Polly.Simmy.Outcomes.OnFaultInjectedArguments, System.Threading.Tasks.ValueTask>?
-Polly.Simmy.Outcomes.FaultStrategyOptions.OnFaultInjected.set -> void
-Polly.Simmy.Outcomes.OnFaultInjectedArguments
-Polly.Simmy.Outcomes.OnFaultInjectedArguments.Context.get -> Polly.ResilienceContext!
-Polly.Simmy.Outcomes.OnFaultInjectedArguments.Fault.get -> System.Exception!
-Polly.Simmy.Outcomes.OnFaultInjectedArguments.OnFaultInjectedArguments() -> void
-Polly.Simmy.Outcomes.OnFaultInjectedArguments.OnFaultInjectedArguments(Polly.ResilienceContext! context, System.Exception! fault) -> void
-Polly.Simmy.Outcomes.OnOutcomeInjectedArguments<TResult>
-Polly.Simmy.Outcomes.OnOutcomeInjectedArguments<TResult>.Context.get -> Polly.ResilienceContext!
-Polly.Simmy.Outcomes.OnOutcomeInjectedArguments<TResult>.OnOutcomeInjectedArguments() -> void
-Polly.Simmy.Outcomes.OnOutcomeInjectedArguments<TResult>.OnOutcomeInjectedArguments(Polly.ResilienceContext! context, Polly.Outcome<TResult> outcome) -> void
-Polly.Simmy.Outcomes.OnOutcomeInjectedArguments<TResult>.Outcome.get -> Polly.Outcome<TResult>
-Polly.Simmy.Outcomes.OutcomeGeneratorArguments
-Polly.Simmy.Outcomes.OutcomeGeneratorArguments.Context.get -> Polly.ResilienceContext!
-Polly.Simmy.Outcomes.OutcomeGeneratorArguments.OutcomeGeneratorArguments() -> void
-Polly.Simmy.Outcomes.OutcomeGeneratorArguments.OutcomeGeneratorArguments(Polly.ResilienceContext! context) -> void
-Polly.Simmy.Outcomes.OutcomeStrategyOptions
-Polly.Simmy.Outcomes.OutcomeStrategyOptions.OutcomeStrategyOptions() -> void
-Polly.Simmy.Outcomes.OutcomeStrategyOptions<TResult>
-Polly.Simmy.Outcomes.OutcomeStrategyOptions<TResult>.OnOutcomeInjected.get -> System.Func<Polly.Simmy.Outcomes.OnOutcomeInjectedArguments<TResult>, System.Threading.Tasks.ValueTask>?
-Polly.Simmy.Outcomes.OutcomeStrategyOptions<TResult>.OnOutcomeInjected.set -> void
-Polly.Simmy.Outcomes.OutcomeStrategyOptions<TResult>.Outcome.get -> Polly.Outcome<TResult>?
-Polly.Simmy.Outcomes.OutcomeStrategyOptions<TResult>.Outcome.set -> void
-Polly.Simmy.Outcomes.OutcomeStrategyOptions<TResult>.OutcomeGenerator.get -> System.Func<Polly.Simmy.Outcomes.OutcomeGeneratorArguments, System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>?>>?
-Polly.Simmy.Outcomes.OutcomeStrategyOptions<TResult>.OutcomeGenerator.set -> void
-Polly.Simmy.Outcomes.OutcomeStrategyOptions<TResult>.OutcomeStrategyOptions() -> void
 Polly.StrategyBuilderContext
 Polly.StrategyBuilderContext.Telemetry.get -> Polly.Telemetry.ResilienceStrategyTelemetry!
 Polly.Telemetry.ExecutionAttemptArguments
@@ -512,19 +414,6 @@ static Polly.ResiliencePipelineBuilderExtensions.AddStrategy<TBuilder>(this TBui
 static Polly.ResiliencePipelineBuilderExtensions.AddStrategy<TResult>(this Polly.ResiliencePipelineBuilder<TResult>! builder, System.Func<Polly.StrategyBuilderContext!, Polly.ResilienceStrategy<TResult>!>! factory, Polly.ResilienceStrategyOptions! options) -> Polly.ResiliencePipelineBuilder<TResult>!
 static Polly.RetryResiliencePipelineBuilderExtensions.AddRetry(this Polly.ResiliencePipelineBuilder! builder, Polly.Retry.RetryStrategyOptions! options) -> Polly.ResiliencePipelineBuilder!
 static Polly.RetryResiliencePipelineBuilderExtensions.AddRetry<TResult>(this Polly.ResiliencePipelineBuilder<TResult>! builder, Polly.Retry.RetryStrategyOptions<TResult>! options) -> Polly.ResiliencePipelineBuilder<TResult>!
-static Polly.Simmy.BehaviorPipelineBuilderExtensions.AddChaosBehavior<TBuilder>(this TBuilder! builder, bool enabled, double injectionRate, System.Func<System.Threading.Tasks.ValueTask>! behavior) -> TBuilder!
-static Polly.Simmy.BehaviorPipelineBuilderExtensions.AddChaosBehavior<TBuilder>(this TBuilder! builder, Polly.Simmy.Behavior.BehaviorStrategyOptions! options) -> TBuilder!
-static Polly.Simmy.LatencyPipelineBuilderExtensions.AddChaosLatency<TBuilder>(this TBuilder! builder, bool enabled, double injectionRate, System.TimeSpan latency) -> TBuilder!
-static Polly.Simmy.LatencyPipelineBuilderExtensions.AddChaosLatency<TBuilder>(this TBuilder! builder, Polly.Simmy.Latency.LatencyStrategyOptions! options) -> TBuilder!
-static Polly.Simmy.OutcomePipelineBuilderExtensions.AddChaosFault(this Polly.ResiliencePipelineBuilder! builder, bool enabled, double injectionRate, System.Exception! fault) -> Polly.ResiliencePipelineBuilder!
-static Polly.Simmy.OutcomePipelineBuilderExtensions.AddChaosFault(this Polly.ResiliencePipelineBuilder! builder, bool enabled, double injectionRate, System.Func<System.Exception?>! faultGenerator) -> Polly.ResiliencePipelineBuilder!
-static Polly.Simmy.OutcomePipelineBuilderExtensions.AddChaosFault(this Polly.ResiliencePipelineBuilder! builder, Polly.Simmy.Outcomes.FaultStrategyOptions! options) -> Polly.ResiliencePipelineBuilder!
-static Polly.Simmy.OutcomePipelineBuilderExtensions.AddChaosFault<TResult>(this Polly.ResiliencePipelineBuilder<TResult>! builder, bool enabled, double injectionRate, System.Exception! fault) -> Polly.ResiliencePipelineBuilder<TResult>!
-static Polly.Simmy.OutcomePipelineBuilderExtensions.AddChaosFault<TResult>(this Polly.ResiliencePipelineBuilder<TResult>! builder, bool enabled, double injectionRate, System.Func<System.Exception?>! faultGenerator) -> Polly.ResiliencePipelineBuilder<TResult>!
-static Polly.Simmy.OutcomePipelineBuilderExtensions.AddChaosFault<TResult>(this Polly.ResiliencePipelineBuilder<TResult>! builder, Polly.Simmy.Outcomes.FaultStrategyOptions! options) -> Polly.ResiliencePipelineBuilder<TResult>!
-static Polly.Simmy.OutcomePipelineBuilderExtensions.AddChaosResult<TResult>(this Polly.ResiliencePipelineBuilder<TResult>! builder, bool enabled, double injectionRate, System.Func<TResult?>! outcomeGenerator) -> Polly.ResiliencePipelineBuilder<TResult>!
-static Polly.Simmy.OutcomePipelineBuilderExtensions.AddChaosResult<TResult>(this Polly.ResiliencePipelineBuilder<TResult>! builder, bool enabled, double injectionRate, TResult result) -> Polly.ResiliencePipelineBuilder<TResult>!
-static Polly.Simmy.OutcomePipelineBuilderExtensions.AddChaosResult<TResult>(this Polly.ResiliencePipelineBuilder<TResult>! builder, Polly.Simmy.Outcomes.OutcomeStrategyOptions<TResult>! options) -> Polly.ResiliencePipelineBuilder<TResult>!
 static Polly.TimeoutResiliencePipelineBuilderExtensions.AddTimeout<TBuilder>(this TBuilder! builder, Polly.Timeout.TimeoutStrategyOptions! options) -> TBuilder!
 static Polly.TimeoutResiliencePipelineBuilderExtensions.AddTimeout<TBuilder>(this TBuilder! builder, System.TimeSpan timeout) -> TBuilder!
 static readonly Polly.ResiliencePipeline.Empty -> Polly.ResiliencePipeline!

--- a/src/Polly.Core/Simmy/Behavior/BehaviorActionArguments.cs
+++ b/src/Polly.Core/Simmy/Behavior/BehaviorActionArguments.cs
@@ -5,7 +5,7 @@
 /// <summary>
 /// Arguments used by the behavior chaos strategy to execute a user's delegate custom action.
 /// </summary>
-public readonly struct BehaviorActionArguments
+internal readonly struct BehaviorActionArguments
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="BehaviorActionArguments"/> struct.

--- a/src/Polly.Core/Simmy/Behavior/BehaviorPipelineBuilderExtensions.cs
+++ b/src/Polly.Core/Simmy/Behavior/BehaviorPipelineBuilderExtensions.cs
@@ -7,7 +7,7 @@ namespace Polly.Simmy;
 /// <summary>
 /// Extension methods for adding custom behaviors to a <see cref="ResiliencePipelineBuilder"/>.
 /// </summary>
-public static class BehaviorPipelineBuilderExtensions
+internal static class BehaviorPipelineBuilderExtensions
 {
     /// <summary>
     /// Adds a behavior chaos strategy to the builder.

--- a/src/Polly.Core/Simmy/Behavior/BehaviorStrategyOptions.cs
+++ b/src/Polly.Core/Simmy/Behavior/BehaviorStrategyOptions.cs
@@ -5,7 +5,7 @@ namespace Polly.Simmy.Behavior;
 /// <summary>
 /// Represents the options for the Behavior chaos strategy.
 /// </summary>
-public class BehaviorStrategyOptions : MonkeyStrategyOptions
+internal class BehaviorStrategyOptions : MonkeyStrategyOptions
 {
     /// <summary>
     /// Gets or sets the delegate that's raised when the custom behavior is injected.

--- a/src/Polly.Core/Simmy/Behavior/OnBehaviorInjectedArguments.cs
+++ b/src/Polly.Core/Simmy/Behavior/OnBehaviorInjectedArguments.cs
@@ -5,7 +5,7 @@
 /// <summary>
 /// Arguments used by the behavior chaos strategy to notify that a custom behavior was injected.
 /// </summary>
-public readonly struct OnBehaviorInjectedArguments
+internal readonly struct OnBehaviorInjectedArguments
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="OnBehaviorInjectedArguments"/> struct.

--- a/src/Polly.Core/Simmy/EnabledGeneratorArguments.cs
+++ b/src/Polly.Core/Simmy/EnabledGeneratorArguments.cs
@@ -5,7 +5,7 @@
 /// <summary>
 /// Defines the arguments for the <see cref="MonkeyStrategyOptions{TResult}.EnabledGenerator"/>.
 /// </summary>
-public readonly struct EnabledGeneratorArguments
+internal readonly struct EnabledGeneratorArguments
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="EnabledGeneratorArguments"/> struct.

--- a/src/Polly.Core/Simmy/InjectionRateGeneratorArguments.cs
+++ b/src/Polly.Core/Simmy/InjectionRateGeneratorArguments.cs
@@ -5,7 +5,7 @@
 /// <summary>
 /// Defines the arguments for the <see cref="MonkeyStrategyOptions{TResult}.InjectionRateGenerator"/>.
 /// </summary>
-public readonly struct InjectionRateGeneratorArguments
+internal readonly struct InjectionRateGeneratorArguments
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="InjectionRateGeneratorArguments"/> struct.

--- a/src/Polly.Core/Simmy/Latency/LatencyGeneratorArguments.cs
+++ b/src/Polly.Core/Simmy/Latency/LatencyGeneratorArguments.cs
@@ -5,7 +5,7 @@
 /// <summary>
 /// Arguments used by the latency chaos strategy to notify that a delayed occurred.
 /// </summary>
-public readonly struct LatencyGeneratorArguments
+internal readonly struct LatencyGeneratorArguments
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="LatencyGeneratorArguments"/> struct.

--- a/src/Polly.Core/Simmy/Latency/LatencyPipelineBuilderExtensions.cs
+++ b/src/Polly.Core/Simmy/Latency/LatencyPipelineBuilderExtensions.cs
@@ -7,7 +7,7 @@ namespace Polly.Simmy;
 /// <summary>
 /// Extension methods for adding latency to a <see cref="ResiliencePipelineBuilderBase"/>.
 /// </summary>
-public static class LatencyPipelineBuilderExtensions
+internal static class LatencyPipelineBuilderExtensions
 {
     /// <summary>
     /// Adds a latency chaos strategy to the builder.

--- a/src/Polly.Core/Simmy/Latency/LatencyStrategyOptions.cs
+++ b/src/Polly.Core/Simmy/Latency/LatencyStrategyOptions.cs
@@ -5,7 +5,7 @@
 /// <summary>
 /// Represents the options for the Latency chaos strategy.
 /// </summary>
-public class LatencyStrategyOptions : MonkeyStrategyOptions
+internal class LatencyStrategyOptions : MonkeyStrategyOptions
 {
     /// <summary>
     /// Gets or sets the delegate that's raised when a delay occurs.

--- a/src/Polly.Core/Simmy/Latency/OnLatencyArguments.cs
+++ b/src/Polly.Core/Simmy/Latency/OnLatencyArguments.cs
@@ -5,7 +5,7 @@
 /// <summary>
 /// Arguments used by the latency chaos strategy to notify that a delayed occurred.
 /// </summary>
-public readonly struct OnLatencyArguments
+internal readonly struct OnLatencyArguments
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="OnLatencyArguments"/> struct.

--- a/src/Polly.Core/Simmy/MonkeyStrategy.TResult.cs
+++ b/src/Polly.Core/Simmy/MonkeyStrategy.TResult.cs
@@ -10,7 +10,7 @@ namespace Polly.Simmy;
 /// <remarks>
 /// For strategies that handle all result types the generic parameter must be of type <see cref="object"/>.
 /// </remarks>
-public abstract class MonkeyStrategy<T> : ResilienceStrategy<T>
+internal abstract class MonkeyStrategy<T> : ResilienceStrategy<T>
 {
     private readonly Func<double> _randomizer;
 

--- a/src/Polly.Core/Simmy/MonkeyStrategy.cs
+++ b/src/Polly.Core/Simmy/MonkeyStrategy.cs
@@ -8,7 +8,7 @@ namespace Polly.Simmy;
 /// <summary>
 /// Contains common functionality for chaos strategies which intentionally disrupt executions - which monkey around with calls.
 /// </summary>
-public abstract class MonkeyStrategy : ResilienceStrategy
+internal abstract class MonkeyStrategy : ResilienceStrategy
 {
     private readonly Func<double> _randomizer;
 

--- a/src/Polly.Core/Simmy/MonkeyStrategyOptions.TResult.cs
+++ b/src/Polly.Core/Simmy/MonkeyStrategyOptions.TResult.cs
@@ -8,7 +8,7 @@ namespace Polly.Simmy;
 /// The options associated with the <see cref="MonkeyStrategy"/>.
 /// </summary>
 /// <typeparam name="TResult">The type of result the monkey strategy handles.</typeparam>
-public abstract class MonkeyStrategyOptions<TResult> : ResilienceStrategyOptions
+internal abstract class MonkeyStrategyOptions<TResult> : ResilienceStrategyOptions
 {
     /// <summary>
     /// Gets or sets the injection rate for a given execution, which the value should be between [0, 1] (inclusive).

--- a/src/Polly.Core/Simmy/MonkeyStrategyOptions.cs
+++ b/src/Polly.Core/Simmy/MonkeyStrategyOptions.cs
@@ -5,7 +5,7 @@
 /// <summary>
 /// The options associated with the <see cref="MonkeyStrategy"/>.
 /// </summary>
-public abstract class MonkeyStrategyOptions : MonkeyStrategyOptions<object>
+internal abstract class MonkeyStrategyOptions : MonkeyStrategyOptions<object>
 {
 }
 

--- a/src/Polly.Core/Simmy/Outcomes/FaultGeneratorArguments.cs
+++ b/src/Polly.Core/Simmy/Outcomes/FaultGeneratorArguments.cs
@@ -5,7 +5,7 @@
 /// <summary>
 /// Arguments used by the fault chaos strategy to ge the fault that is going to be injected.
 /// </summary>
-public readonly struct FaultGeneratorArguments
+internal readonly struct FaultGeneratorArguments
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="FaultGeneratorArguments"/> struct.

--- a/src/Polly.Core/Simmy/Outcomes/FaultStrategyOptions.cs
+++ b/src/Polly.Core/Simmy/Outcomes/FaultStrategyOptions.cs
@@ -5,7 +5,7 @@
 /// <summary>
 /// Represents the options for the Fault chaos strategy.
 /// </summary>
-public class FaultStrategyOptions : MonkeyStrategyOptions
+internal class FaultStrategyOptions : MonkeyStrategyOptions
 {
     /// <summary>
     /// Gets or sets the delegate that's raised when the outcome is injected.

--- a/src/Polly.Core/Simmy/Outcomes/OnFaultInjectedArguments.cs
+++ b/src/Polly.Core/Simmy/Outcomes/OnFaultInjectedArguments.cs
@@ -5,7 +5,7 @@
 /// <summary>
 /// Arguments used by the fault chaos strategy to notify that an fault was injected.
 /// </summary>
-public readonly struct OnFaultInjectedArguments
+internal readonly struct OnFaultInjectedArguments
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="OnFaultInjectedArguments"/> struct.

--- a/src/Polly.Core/Simmy/Outcomes/OnOutcomeInjectedArguments.cs
+++ b/src/Polly.Core/Simmy/Outcomes/OnOutcomeInjectedArguments.cs
@@ -6,7 +6,7 @@
 /// Arguments used by the outcome chaos strategy to notify that an outcome was injected.
 /// </summary>
 /// <typeparam name="TResult">The type of the outcome that was injected.</typeparam>
-public readonly struct OnOutcomeInjectedArguments<TResult>
+internal readonly struct OnOutcomeInjectedArguments<TResult>
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="OnOutcomeInjectedArguments{TResult}"/> struct.

--- a/src/Polly.Core/Simmy/Outcomes/OutcomeGeneratorArguments.cs
+++ b/src/Polly.Core/Simmy/Outcomes/OutcomeGeneratorArguments.cs
@@ -5,7 +5,7 @@
 /// <summary>
 /// Arguments used by the outcome chaos strategy to ge the outcome that is going to be injected.
 /// </summary>
-public readonly struct OutcomeGeneratorArguments
+internal readonly struct OutcomeGeneratorArguments
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="OutcomeGeneratorArguments"/> struct.

--- a/src/Polly.Core/Simmy/Outcomes/OutcomePipelineBuilderExtensions.TResult.cs
+++ b/src/Polly.Core/Simmy/Outcomes/OutcomePipelineBuilderExtensions.TResult.cs
@@ -6,7 +6,7 @@ namespace Polly.Simmy;
 /// <summary>
 /// Extension methods for adding outcome to a <see cref="ResiliencePipelineBuilder"/>.
 /// </summary>
-public static partial class OutcomePipelineBuilderExtensions
+internal static partial class OutcomePipelineBuilderExtensions
 {
     /// <summary>
     /// Adds a fault chaos strategy to the builder.

--- a/src/Polly.Core/Simmy/Outcomes/OutcomePipelineBuilderExtensions.cs
+++ b/src/Polly.Core/Simmy/Outcomes/OutcomePipelineBuilderExtensions.cs
@@ -6,7 +6,7 @@ namespace Polly.Simmy;
 /// <summary>
 /// Extension methods for adding outcome to a <see cref="ResiliencePipelineBuilder"/>.
 /// </summary>
-public static partial class OutcomePipelineBuilderExtensions
+internal static partial class OutcomePipelineBuilderExtensions
 {
     /// <summary>
     /// Adds a fault chaos strategy to the builder.

--- a/src/Polly.Core/Simmy/Outcomes/OutcomeStrategyOptions.TResult.cs
+++ b/src/Polly.Core/Simmy/Outcomes/OutcomeStrategyOptions.TResult.cs
@@ -6,7 +6,7 @@
 /// Represents the options for the Outcome chaos strategy.
 /// </summary>
 /// <typeparam name="TResult">The type of the outcome that was injected.</typeparam>
-public class OutcomeStrategyOptions<TResult> : MonkeyStrategyOptions
+internal class OutcomeStrategyOptions<TResult> : MonkeyStrategyOptions
 {
     /// <summary>
     /// Gets or sets the delegate that's raised when the outcome is injected.

--- a/src/Polly.Core/Simmy/Outcomes/OutcomeStrategyOptions.cs
+++ b/src/Polly.Core/Simmy/Outcomes/OutcomeStrategyOptions.cs
@@ -1,6 +1,6 @@
 ﻿namespace Polly.Simmy.Outcomes;
 
 /// <inheritdoc/>
-public class OutcomeStrategyOptions : OutcomeStrategyOptions<object>
+internal class OutcomeStrategyOptions : OutcomeStrategyOptions<object>
 {
 }

--- a/test/Polly.Core.Tests/Simmy/Outcomes/OutcomeChaosStrategyTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Outcomes/OutcomeChaosStrategyTests.cs
@@ -46,13 +46,13 @@ public class OutcomeChaosStrategyTests
     [Theory]
     [MemberData(nameof(FaultCtorTestCases))]
 #pragma warning disable xUnit1026 // Theory methods should use all of their parameters
-    public void FaultInvalidCtor(FaultStrategyOptions options, string expectedMessage, Type expectedException)
+    public void FaultInvalidCtor(object options, string expectedMessage, Type expectedException)
 #pragma warning restore xUnit1026 // Theory methods should use all of their parameters
     {
 #pragma warning disable CA1031 // Do not catch general exception types
         try
         {
-            var _ = new OutcomeChaosStrategy<object>(options, _telemetry);
+            var _ = new OutcomeChaosStrategy<object>((FaultStrategyOptions)options, _telemetry);
         }
         catch (Exception ex)
         {
@@ -67,13 +67,13 @@ public class OutcomeChaosStrategyTests
     [Theory]
     [MemberData(nameof(ResultCtorTestCases))]
 #pragma warning disable xUnit1026 // Theory methods should use all of their parameters
-    public void ResultInvalidCtor(OutcomeStrategyOptions<int> options, string expectedMessage, Type expectedException)
+    public void ResultInvalidCtor(object options, string expectedMessage, Type expectedException)
 #pragma warning restore xUnit1026 // Theory methods should use all of their parameters
     {
 #pragma warning disable CA1031 // Do not catch general exception types
         try
         {
-            var _ = new OutcomeChaosStrategy<int>(options, _telemetry);
+            var _ = new OutcomeChaosStrategy<int>((OutcomeStrategyOptions<int>)options, _telemetry);
         }
         catch (Exception ex)
         {

--- a/test/Polly.Core.Tests/Simmy/TestChaosStrategy.TResult.cs
+++ b/test/Polly.Core.Tests/Simmy/TestChaosStrategy.TResult.cs
@@ -1,7 +1,8 @@
 ﻿using Polly.Simmy;
 
 namespace Polly.Core.Tests.Simmy;
-public sealed class TestChaosStrategy<T> : MonkeyStrategy<T>
+
+internal sealed class TestChaosStrategy<T> : MonkeyStrategy<T>
 {
     public TestChaosStrategy(TestChaosStrategyOptions<T> options)
         : base(options)

--- a/test/Polly.Core.Tests/Simmy/TestChaosStrategy.cs
+++ b/test/Polly.Core.Tests/Simmy/TestChaosStrategy.cs
@@ -1,7 +1,8 @@
 ﻿using Polly.Simmy;
 
 namespace Polly.Core.Tests.Simmy;
-public sealed class TestChaosStrategy : MonkeyStrategy
+
+internal sealed class TestChaosStrategy : MonkeyStrategy
 {
     public TestChaosStrategy(TestChaosStrategyOptions options)
         : base(options)

--- a/test/Polly.Core.Tests/Simmy/TestChaosStrategyOptions.TResult.cs
+++ b/test/Polly.Core.Tests/Simmy/TestChaosStrategyOptions.TResult.cs
@@ -2,6 +2,6 @@
 
 namespace Polly.Core.Tests.Simmy;
 
-public sealed class TestChaosStrategyOptions<T> : MonkeyStrategyOptions
+internal sealed class TestChaosStrategyOptions<T> : MonkeyStrategyOptions
 {
 }

--- a/test/Polly.Core.Tests/Simmy/TestChaosStrategyOptions.cs
+++ b/test/Polly.Core.Tests/Simmy/TestChaosStrategyOptions.cs
@@ -2,6 +2,6 @@
 
 namespace Polly.Core.Tests.Simmy;
 
-public sealed class TestChaosStrategyOptions : MonkeyStrategyOptions
+internal sealed class TestChaosStrategyOptions : MonkeyStrategyOptions
 {
 }


### PR DESCRIPTION
### Details on the issue fix or feature implementation

This PR hides API introduced by #1459. 

The reason for this is that current API is already reviewed and Polly v8 is to be released soon after #1091 is done.
Once #1571 is approved we can unhide the API and release it in 8.1

### Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build
