### PR TITLE
Avoid capturing where possible.

### DIFF
--- a/README_V8.md
+++ b/README_V8.md
@@ -48,7 +48,7 @@ ResiliencePipeline pipeline = new ResiliencePipelineBuilder()
     .Build(); // Builds the resilience pipeline
 
 // Execute the pipeline asynchronously
-await pipeline.ExecuteAsync(async cancellationToken => { /*Your custom logic here */ }, cancellationToken);
+await pipeline.ExecuteAsync(static async cancellationToken => { /*Your custom logic here */ }, cancellationToken);
 ```
 <!-- endSnippet -->
 
@@ -84,7 +84,7 @@ var pipelineProvider = serviceProvider.GetRequiredService<ResiliencePipelineProv
 ResiliencePipeline pipeline = pipelineProvider.GetPipeline("my-pipeline");
 
 // Execute the pipeline
-await pipeline.ExecuteAsync(async token =>
+await pipeline.ExecuteAsync(static async token =>
 {
     // Your custom logic here
 });

--- a/docs/advanced/dependency-injection.md
+++ b/docs/advanced/dependency-injection.md
@@ -39,7 +39,8 @@ ResiliencePipelineProvider<string> pipelineProvider = serviceProvider.GetRequire
 ResiliencePipeline pipeline = pipelineProvider.GetPipeline("my-key");
 
 // Use it
-await pipeline.ExecuteAsync(async cancellation => await Task.Delay(100, cancellation));
+await pipeline.ExecuteAsync(
+    static async cancellation => await Task.Delay(100, cancellation));
 ```
 <!-- endSnippet -->
 

--- a/docs/advanced/resilience-context.md
+++ b/docs/advanced/resilience-context.md
@@ -44,7 +44,7 @@ ResiliencePipeline pipeline = new ResiliencePipelineBuilder()
 
 // Execute the resilience pipeline asynchronously
 await pipeline.ExecuteAsync(
-    async context =>
+    static async context =>
     {
         // Insert your execution logic here
     },

--- a/docs/general.md
+++ b/docs/general.md
@@ -58,7 +58,7 @@ await pipeline.ExecuteAsync(
 ResilienceContext context = ResilienceContextPool.Shared.Get(cancellationToken: cancellationToken);
 
 await pipeline.ExecuteAsync(
-    async context => await MyMethodAsync(context.CancellationToken),
+    static async context => await MyMethodAsync(context.CancellationToken),
     context);
 ```
 <!-- endSnippet -->

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,7 +19,7 @@ ResiliencePipeline pipeline = new ResiliencePipelineBuilder()
     .Build(); // Builds the resilience pipeline
 
 // Execute the pipeline asynchronously
-await pipeline.ExecuteAsync(async cancellationToken => { /*Your custom logic here */ }, cancellationToken);
+await pipeline.ExecuteAsync(static async cancellationToken => { /*Your custom logic here */ }, cancellationToken);
 ```
 <!-- endSnippet -->
 
@@ -55,7 +55,7 @@ var pipelineProvider = serviceProvider.GetRequiredService<ResiliencePipelineProv
 ResiliencePipeline pipeline = pipelineProvider.GetPipeline("my-pipeline");
 
 // Execute the pipeline
-await pipeline.ExecuteAsync(async token =>
+await pipeline.ExecuteAsync(static async token =>
 {
     // Your custom logic here
 });

--- a/docs/migration-v8.md
+++ b/docs/migration-v8.md
@@ -104,7 +104,7 @@ pipeline.Execute(() =>
 });
 
 // Asynchronous execution is also supported with the same pipeline instance
-await pipeline.ExecuteAsync(async cancellationToken =>
+await pipeline.ExecuteAsync(static async cancellationToken =>
 {
     // your code here
 },
@@ -135,7 +135,7 @@ pipelineT.Execute(() =>
 });
 
 // Asynchronous execution
-await pipelineT.ExecuteAsync(async cancellationToken =>
+await pipelineT.ExecuteAsync(static async cancellationToken =>
 {
     // your code here
     return await GetResponseAsync(cancellationToken);

--- a/docs/strategies/fallback.md
+++ b/docs/strategies/fallback.md
@@ -228,7 +228,7 @@ Nest `ExecuteAsync` calls
 ```cs
 var result = await fallback.ExecuteAsync(async (CancellationToken outerCT) =>
 {
-    return await timeout.ExecuteAsync(async (CancellationToken innerCT) =>
+    return await timeout.ExecuteAsync(static async (CancellationToken innerCT) =>
     {
         return await CallExternalSystem(innerCT);
     }, outerCT);

--- a/docs/strategies/hedging.md
+++ b/docs/strategies/hedging.md
@@ -218,13 +218,13 @@ internal class HedgingHandler : DelegatingHandler
 
         try
         {
-            return await _pipeline.ExecuteAsync(async context =>
+            return await _pipeline.ExecuteAsync(async cxt =>
             {
                 // Allow the pipeline to use request message that was stored in the context.
                 // This allows replacing the request message with a new one in the resilience pipeline.
-                request = context.Properties.GetValue(ResilienceKeys.RequestMessage, request);
+                request = cxt.Properties.GetValue(ResilienceKeys.RequestMessage, request);
 
-                return await base.SendAsync(request, context.CancellationToken);
+                return await base.SendAsync(request, cxt.CancellationToken);
             },
             context);
         }

--- a/docs/strategies/retry.md
+++ b/docs/strategies/retry.md
@@ -382,11 +382,12 @@ var builder = new ResiliencePipelineBuilder()
 builder.AddTimeout(TimeSpan.FromMinutes(1));
 
 var pipeline = builder.Build();
-await pipeline.ExecuteAsync(async (ct) =>
+await pipeline.ExecuteAsync(static async (httpClient, ct) =>
 {
     var stream = await httpClient.GetStreamAsync(new Uri("endpoint"), ct);
     var foo = await JsonSerializer.DeserializeAsync<Foo>(stream, cancellationToken: ct);
-});
+},
+httpClient);
 ```
 <!-- endSnippet -->
 
@@ -409,7 +410,10 @@ var retry = new ResiliencePipelineBuilder()
     })
     .Build();
 
-var stream = await retry.ExecuteAsync(async (ct) => await httpClient.GetStreamAsync(new Uri("endpoint"), ct));
+var stream = await retry.ExecuteAsync(
+    static async (httpClient, ct) =>
+        await httpClient.GetStreamAsync(new Uri("endpoint"), ct),
+    httpClient);
 
 var timeout = new ResiliencePipelineBuilder<Foo>()
     .AddTimeout(TimeSpan.FromMinutes(1))

--- a/src/Snippets/Docs/DependencyInjection.cs
+++ b/src/Snippets/Docs/DependencyInjection.cs
@@ -41,7 +41,8 @@ internal static class DependencyInjection
         ResiliencePipeline pipeline = pipelineProvider.GetPipeline("my-key");
 
         // Use it
-        await pipeline.ExecuteAsync(async cancellation => await Task.Delay(100, cancellation));
+        await pipeline.ExecuteAsync(
+            static async cancellation => await Task.Delay(100, cancellation));
 
         #endregion
     }

--- a/src/Snippets/Docs/Fallback.cs
+++ b/src/Snippets/Docs/Fallback.cs
@@ -208,7 +208,7 @@ internal static class Fallback
         #region fallback-anti-pattern-3
         var result = await fallback.ExecuteAsync(async (CancellationToken outerCT) =>
         {
-            return await timeout.ExecuteAsync(async (CancellationToken innerCT) =>
+            return await timeout.ExecuteAsync(static async (CancellationToken innerCT) =>
             {
                 return await CallExternalSystem(innerCT);
             }, outerCT);

--- a/src/Snippets/Docs/General.cs
+++ b/src/Snippets/Docs/General.cs
@@ -45,7 +45,7 @@ internal static class General
         ResilienceContext context = ResilienceContextPool.Shared.Get(cancellationToken: cancellationToken);
 
         await pipeline.ExecuteAsync(
-            async context => await MyMethodAsync(context.CancellationToken),
+            static async context => await MyMethodAsync(context.CancellationToken),
             context);
 
         #endregion

--- a/src/Snippets/Docs/Hedging.cs
+++ b/src/Snippets/Docs/Hedging.cs
@@ -151,13 +151,13 @@ internal static class Hedging
 
             try
             {
-                return await _pipeline.ExecuteAsync(async context =>
+                return await _pipeline.ExecuteAsync(async cxt =>
                 {
                     // Allow the pipeline to use request message that was stored in the context.
                     // This allows replacing the request message with a new one in the resilience pipeline.
-                    request = context.Properties.GetValue(ResilienceKeys.RequestMessage, request);
+                    request = cxt.Properties.GetValue(ResilienceKeys.RequestMessage, request);
 
-                    return await base.SendAsync(request, context.CancellationToken);
+                    return await base.SendAsync(request, cxt.CancellationToken);
                 },
                 context);
             }

--- a/src/Snippets/Docs/Migration.Policies.cs
+++ b/src/Snippets/Docs/Migration.Policies.cs
@@ -80,7 +80,7 @@ internal static partial class Migration
         });
 
         // Asynchronous execution is also supported with the same pipeline instance
-        await pipeline.ExecuteAsync(async cancellationToken =>
+        await pipeline.ExecuteAsync(static async cancellationToken =>
         {
             // your code here
         },
@@ -111,7 +111,7 @@ internal static partial class Migration
         });
 
         // Asynchronous execution
-        await pipelineT.ExecuteAsync(async cancellationToken =>
+        await pipelineT.ExecuteAsync(static async cancellationToken =>
         {
             // your code here
             return await GetResponseAsync(cancellationToken);

--- a/src/Snippets/Docs/Readme.cs
+++ b/src/Snippets/Docs/Readme.cs
@@ -19,7 +19,7 @@ internal static class Readme
             .Build(); // Builds the resilience pipeline
 
         // Execute the pipeline asynchronously
-        await pipeline.ExecuteAsync(async cancellationToken => { /*Your custom logic here */ }, cancellationToken);
+        await pipeline.ExecuteAsync(static async cancellationToken => { /*Your custom logic here */ }, cancellationToken);
 
         #endregion
     }
@@ -48,7 +48,7 @@ internal static class Readme
         ResiliencePipeline pipeline = pipelineProvider.GetPipeline("my-pipeline");
 
         // Execute the pipeline
-        await pipeline.ExecuteAsync(async token =>
+        await pipeline.ExecuteAsync(static async token =>
         {
             // Your custom logic here
         });

--- a/src/Snippets/Docs/ResilienceContextUsage.cs
+++ b/src/Snippets/Docs/ResilienceContextUsage.cs
@@ -45,7 +45,7 @@ internal static class ResilienceContextUsage
 
         // Execute the resilience pipeline asynchronously
         await pipeline.ExecuteAsync(
-            async context =>
+            static async context =>
             {
                 // Insert your execution logic here
             },

--- a/src/Snippets/Docs/Retry.cs
+++ b/src/Snippets/Docs/Retry.cs
@@ -314,11 +314,12 @@ internal static class Retry
         builder.AddTimeout(TimeSpan.FromMinutes(1));
 
         var pipeline = builder.Build();
-        await pipeline.ExecuteAsync(async (ct) =>
+        await pipeline.ExecuteAsync(static async (httpClient, ct) =>
         {
             var stream = await httpClient.GetStreamAsync(new Uri("endpoint"), ct);
             var foo = await JsonSerializer.DeserializeAsync<Foo>(stream, cancellationToken: ct);
-        });
+        },
+        httpClient);
 
         #endregion
     }
@@ -337,7 +338,10 @@ internal static class Retry
             })
             .Build();
 
-        var stream = await retry.ExecuteAsync(async (ct) => await httpClient.GetStreamAsync(new Uri("endpoint"), ct));
+        var stream = await retry.ExecuteAsync(
+            static async (httpClient, ct) =>
+                await httpClient.GetStreamAsync(new Uri("endpoint"), ct),
+            httpClient);
 
         var timeout = new ResiliencePipelineBuilder<Foo>()
             .AddTimeout(TimeSpan.FromMinutes(1))


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors.  All non-trivial contributions get a public credit in the readme! -->

### The issue or feature being addressed

All of these changes are only within the `Docs/Snippets` content.

When reviewing docs, I noticed that some of the example snippets were _lifting_ (capturing outer scope variables) when it clearly wasn't intended as the `state` parameter was passed an argument with the same name. Ideally, we shouldn't be capturing outer scope variables when using the `state` parameter.

### Details on the issue fix or feature implementation

In this PR:

- Some cases are simply resolved by adding the `static` modifier.
- Other cases involved renaming the delegate parameter for the inner scope to isolate the variable usage.
- And a few cases required passing `state`.

### Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
