### PR TITLE
Fix issue I was experiencing in my time zone

### DIFF
--- a/src/Polly.Core/CircuitBreaker/Controller/CircuitStateController.cs
+++ b/src/Polly.Core/CircuitBreaker/Controller/CircuitStateController.cs
@@ -241,7 +241,7 @@ internal sealed class CircuitStateController<T> : IDisposable
 
     private static bool IsDateTimeOverflow(DateTimeOffset utcNow, TimeSpan breakDuration)
     {
-        TimeSpan maxDifference = DateTime.MaxValue - utcNow;
+        TimeSpan maxDifference = DateTimeOffset.MaxValue - utcNow;
 
         // stryker disable once equality : no means to test this
         return breakDuration > maxDifference;

--- a/test/Polly.Core.Tests/CircuitBreaker/Controller/CircuitStateControllerTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/Controller/CircuitStateControllerTests.cs
@@ -312,7 +312,7 @@ public class CircuitStateControllerTests
         using var controller = CreateController();
         var shouldBreak = true;
         await TransitionToState(controller, CircuitState.HalfOpen);
-        var utcNow = DateTime.MaxValue - _options.BreakDuration;
+        var utcNow = DateTimeOffset.MaxValue - _options.BreakDuration;
         if (overflow)
         {
             utcNow += TimeSpan.FromMilliseconds(10);


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors.  All non-trivial contributions get a public credit in the readme! -->

### The issue or feature being addressed

When comparing `DateTime` and `DateTimeOffset` exceptions can be thrown during implicit conversion. When I was testing the circuit breaker strategy within my .NET 8 rtm pipeline, I was seeing the following exception:

<details>
<summary><b>Exception Details</b></summary>

> System.ArgumentOutOfRangeException: 'The UTC time represented when the offset is applied must be between year 0 and 10,000. (Parameter 'offset')'
> at System.DateTimeOffset.ValidateDate(DateTime dateTime, TimeSpan offset)
   at System.DateTimeOffset..ctor(DateTime dateTime)
   at System.DateTimeOffset.op_Implicit(DateTime dateTime)
   at Polly.CircuitBreaker.CircuitStateController`1.IsDateTimeOverflow(DateTimeOffset utcNow, TimeSpan breakDuration)
   at Polly.CircuitBreaker.CircuitStateController`1.OpenCircuitFor_NeedsLock(Outcome`1 outcome, TimeSpan breakDuration, Boolean manual, ResilienceContext context, Task& scheduledTask)
   at Polly.CircuitBreaker.CircuitStateController`1.OpenCircuit_NeedsLock(Outcome`1 outcome, Boolean manual, ResilienceContext context, Task& scheduledTask)
   at Polly.CircuitBreaker.CircuitStateController`1.OnActionFailureAsync(Outcome`1 outcome, ResilienceContext context)
   at Polly.CircuitBreaker.CircuitBreakerResilienceStrategy`1.<ExecuteCore>d__5`1.MoveNext()
   at System.Threading.Tasks.ValueTask`1.get_Result()
   at System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1.ConfiguredValueTaskAwaiter.GetResult()
   at Polly.Utils.Pipeline.BridgeComponent`1.<<ConvertValueTask>g__ConvertValueTaskAsync|5_0>d`1.MoveNext()
   at System.Threading.Tasks.ValueTask`1.get_Result()
   at System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1.ConfiguredValueTaskAwaiter.GetResult()
   at Polly.Utils.Pipeline.CompositeComponent.<ExecuteCoreWithTelemetry>d__13`2.MoveNext()
   at System.Threading.Tasks.ValueTask`1.get_Result()
   at System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1.ConfiguredValueTaskAwaiter.GetResult()
   at Polly.ResiliencePipeline.<ExecuteAsync>d__2`1.MoveNext()
   at Program.<<Main>$>d__0.MoveNext() in C:\Users\dapine\source\repos\dotnet-docs\docs\core\resilience\snippets\resilience\Program.cs:line 70
   at Program.<Main>(String[] args)

</details>

This PR includes fixes to a failing unit test and addresses the issue in the source as well.

![image](https://github.com/App-vNext/Polly/assets/7679720/e5ad290f-fe0e-4f9e-98fa-0d667a5f2302)

Special shoutout to @stephentoub for his help with this bug fix.

<!-- Please include the existing GitHub issue number where relevant -->

### Details on the issue fix or feature implementation

### Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build

I'm target the `dotnet-8` branch, and that's what I started from.
