### PR TITLE
Add banned API analyzers and fix time zone issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * Update docs source by [@martincostello](https://github.com/martincostello) in https://github.com/App-vNext/Polly/pull/1641
 * Stabilize `AddHedging_IntegrationTest` test by [@martintmk](https://github.com/martintmk) in https://github.com/App-vNext/Polly/pull/1644
 * Release v8 docs by [@martintmk](https://github.com/martintmk) in https://github.com/App-vNext/Polly/pull/1599
+* Add banned API analyzers and fix time zone issue by [@martincostello](https://github.com/martincostello) and [@IEvangelist](https://github.com/IEvangelist) in https://github.com/App-vNext/Polly/pull/1651
 
 ## 8.0.0-beta.2
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,6 +10,7 @@
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsVersion)" />

--- a/eng/Analyzers.targets
+++ b/eng/Analyzers.targets
@@ -1,7 +1,9 @@
 <Project>
   <ItemGroup Label="Analyzers">
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" PrivateAssets="All" />
     <PackageReference Include="SonarAnalyzer.CSharp" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)analyzers\BannedSymbols.txt" Condition=" '$(IsTestProject)' != 'true' " Visible="false" />
     <AdditionalFiles Include="$(MsBuildThisFileDirectory)analyzers\Stylecop.json" Visible="false" />
     <EditorConfigFiles Include="$(MsBuildThisFileDirectory)analyzers\Stylecop.globalconfig" />
     <EditorConfigFiles Include="$(MsBuildThisFileDirectory)analyzers\$(ProjectType).globalconfig" />

--- a/eng/analyzers/BannedSymbols.txt
+++ b/eng/analyzers/BannedSymbols.txt
@@ -1,0 +1,5 @@
+P:System.DateTime.Now; Use TimeProvider.GetLocalNow().DateTime instead.
+P:System.DateTime.Today; Use TimeProvider.GetLocalNow().DateTime.Date instead.
+P:System.DateTimeOffset.Now; Use TimeProvider.GetLocalNow() instead.
+P:System.DateTimeOffset.Today; Use TimeProvider.GetLocalNow().Date instead.
+M:System.DateTimeOffset.op_Implicit(System.DateTime); Do not implicitly cast DateTime to DateTimeOffset.

--- a/src/Polly.Core/CircuitBreaker/Controller/CircuitStateController.cs
+++ b/src/Polly.Core/CircuitBreaker/Controller/CircuitStateController.cs
@@ -241,7 +241,7 @@ internal sealed class CircuitStateController<T> : IDisposable
 
     private static bool IsDateTimeOverflow(DateTimeOffset utcNow, TimeSpan breakDuration)
     {
-        TimeSpan maxDifference = DateTime.MaxValue - utcNow;
+        TimeSpan maxDifference = DateTimeOffset.MaxValue - utcNow;
 
         // stryker disable once equality : no means to test this
         return breakDuration > maxDifference;

--- a/src/Polly/RateLimit/LockFreeTokenBucketRateLimiter.cs
+++ b/src/Polly/RateLimit/LockFreeTokenBucketRateLimiter.cs
@@ -19,7 +19,7 @@ internal sealed class LockFreeTokenBucketRateLimiter : IRateLimiter
 #endif
 
     /// <summary>
-    /// Creates an instance of <see cref="LockFreeTokenBucketRateLimiter"/>
+    /// Initializes a new instance of the <see cref="LockFreeTokenBucketRateLimiter"/> class.
     /// </summary>
     /// <param name="onePer">How often one execution is permitted.</param>
     /// <param name="bucketCapacity">The capacity of the token bucket.

--- a/test/Polly.Core.Tests/CircuitBreaker/Controller/CircuitStateControllerTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/Controller/CircuitStateControllerTests.cs
@@ -312,7 +312,7 @@ public class CircuitStateControllerTests
         using var controller = CreateController();
         var shouldBreak = true;
         await TransitionToState(controller, CircuitState.HalfOpen);
-        var utcNow = DateTime.MaxValue - _options.BreakDuration;
+        var utcNow = DateTimeOffset.MaxValue - _options.BreakDuration;
         if (overflow)
         {
             utcNow += TimeSpan.FromMilliseconds(10);


### PR DESCRIPTION
- Add Microsoft.CodeAnalysis.BannedApiAnalyzers to detect usage of problematic code patterns.
- Cherry-pick fix from #1650.
- Fix StyleCop warning by updating constructor documentation (found while testing the analyzers).
