### PR TITLE
Fix documentation comment for CB's MinimumThroughput

### DIFF
--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerStrategyOptions.TResult.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerStrategyOptions.TResult.cs
@@ -42,7 +42,7 @@ public class CircuitBreakerStrategyOptions<TResult> : ResilienceStrategyOptions
     /// for statistics to be considered significant and the circuit-breaker to come into action.
     /// </summary>
     /// <value>
-    /// The default value is 0.1 (i.e. 10%). The value must be 2 or greater.
+    /// The default value 100. The value must be 2 or greater.
     /// </value>
     [Range(CircuitBreakerConstants.MinimumValidThroughput, int.MaxValue)]
     public int MinimumThroughput { get; set; } = CircuitBreakerConstants.DefaultMinimumThroughput;

--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerStrategyOptions.TResult.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerStrategyOptions.TResult.cs
@@ -42,7 +42,7 @@ public class CircuitBreakerStrategyOptions<TResult> : ResilienceStrategyOptions
     /// for statistics to be considered significant and the circuit-breaker to come into action.
     /// </summary>
     /// <value>
-    /// The default value 100. The value must be 2 or greater.
+    /// The default value is 100. The value must be 2 or greater.
     /// </value>
     [Range(CircuitBreakerConstants.MinimumValidThroughput, int.MaxValue)]
     public int MinimumThroughput { get; set; } = CircuitBreakerConstants.DefaultMinimumThroughput;


### PR DESCRIPTION
### The issue or feature being addressed
- NO ISSUE

### Details on the issue fix or feature implementation
- The documentation comment of `MinimumThroughput` contained wrong default value.

### Confirm the following
- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
