### PR TITLE
Docs tweaks

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      with:
+        fetch-depth: 0
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0

--- a/docs/community/polly-contrib.md
+++ b/docs/community/polly-contrib.md
@@ -2,7 +2,7 @@
 
 Polly now has a [Polly-Contrib](https://github.com/Polly-Contrib) to allow the community to contribute policies or other enhancements around Polly with a low burden of ceremony.
 
-Have a contrib you'd like to publish under Polly-Contrib? Contact us with  an issue here or on [Polly's slack](http://pollytalk.slack.com), and we can set up a CI-ready Polly.Contrib repo to which you have full rights, to help you manage and deliver your awesomeness to the community!
+Have a contrib you'd like to publish under Polly-Contrib? Contact us with  an issue here or on [Polly's Slack](http://pollytalk.slack.com), and we can set up a CI-ready Polly.Contrib repo to which you have full rights, to help you manage and deliver your awesomeness to the community!
 
 We also provide:
 

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -29,8 +29,11 @@
   ],
   "build": {
     "globalMetadata": {
+      "_appName": "Polly",
+      "_appTitle": "Polly",
       "_appLogoPath": "icon.png",
-      "_appFaviconPath": "icon.png"
+      "_appFaviconPath": "icon.png",
+      "_lang": "en"
     },
     "content": [
       {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting started
 
-To use Polly, you must provide a callback and execute it using [**resilience pipeline**](pipelines/index.md). A resilience pipeline is a combination of one or more [**resilience strategies**](strategies/index.md) such as retry, timeout, and rate limiter. Polly uses **builders** to integrate these strategies into a pipeline.
+To use Polly, you must provide a callback and execute it using a [**resilience pipeline**](pipelines/index.md). A resilience pipeline is a combination of one or more [**resilience strategies**](strategies/index.md) such as retry, timeout, and rate limiter. Polly uses **builders** to integrate these strategies into a pipeline.
 
 To get started, first add the [Polly.Core](https://www.nuget.org/packages/Polly.Core/) package to your project by running the following command:
 

--- a/docs/strategies/circuit-breaker.md
+++ b/docs/strategies/circuit-breaker.md
@@ -14,9 +14,6 @@
 ---
 
 > [!NOTE]
-> Version 8 documentation for this strategy has not yet been migrated. For more information on circuit breaker concepts and behavior, refer to the [older documentation](https://github.com/App-vNext/Polly/wiki/Circuit-Breaker).
-
-> [!NOTE]
 > Be aware that the Circuit Breaker strategy [rethrows all exceptions](https://github.com/App-vNext/Polly/wiki/Circuit-Breaker#exception-handling), including those that are handled. A Circuit Breaker's role is to monitor faults and break the circuit when a certain threshold is reached; it does not manage retries. Combine the Circuit Breaker with a Retry strategy if needed.
 
 ## Usage

--- a/docs/strategies/fallback.md
+++ b/docs/strategies/fallback.md
@@ -8,9 +8,6 @@
 
 ---
 
-> [!NOTE]
-> Version 8 documentation for this strategy has not yet been migrated. For more information on fallback concepts and behavior, refer to the [older documentation](https://github.com/App-vNext/Polly/wiki/Fallback).
-
 ## Usage
 
 <!-- snippet: fallback -->

--- a/docs/strategies/retry.md
+++ b/docs/strategies/retry.md
@@ -10,9 +10,6 @@
 
 ---
 
-> [!NOTE]
-> Version 8 documentation for this strategy has not yet been migrated. For more information on retry concepts and behavior, refer to the [older documentation](https://github.com/App-vNext/Polly/wiki/Retry).
-
 ## Usage
 
 <!-- snippet: Retry -->

--- a/docs/strategies/timeout.md
+++ b/docs/strategies/timeout.md
@@ -10,9 +10,6 @@
 
 ---
 
-> [!NOTE]
-> Version 8 documentation for this strategy has not yet been migrated. For more information on timeout concepts and behavior, refer to the [older documentation](https://github.com/App-vNext/Polly/wiki/Timeout).
-
 ## Usage
 
 <!-- snippet: timeout -->

--- a/eng/Common.targets
+++ b/eng/Common.targets
@@ -23,7 +23,7 @@
 
   <Target Name="CustomizeVersions" AfterTargets="MinVer" Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <PropertyGroup>
-      <FileVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(GITHUB_RUN_NUMBER)</FileVersion>
+      <FileVersion>$([MSBuild]::ValueOrDefault('$(MinVerMajor)', '8')).$([MSBuild]::ValueOrDefault('$(MinVerMinor)', '0')).$([MSBuild]::ValueOrDefault('$(MinVerPatch)', '0')).$(GITHUB_RUN_NUMBER)</FileVersion>
     </PropertyGroup>
     <PropertyGroup Condition="$(GITHUB_REF.StartsWith(`refs/pull/`))">
       <PackageVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch)-pr.$(GITHUB_REF_NAME.Replace(`/merge`, ``)).$(GITHUB_RUN_NUMBER)</PackageVersion>

--- a/eng/Common.targets
+++ b/eng/Common.targets
@@ -12,4 +12,22 @@
   <ItemGroup Condition="'$(LegacySupport)' == 'true' AND !$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'netcoreapp3.1'))">
     <Compile Include="$(MSBuildThisFileDirectory)..\src\LegacySupport\*.cs" LinkBase="LegacySupport" />
   </ItemGroup>
+
+  <ItemGroup Label="MinVer">
+    <PackageReference Include="MinVer" PrivateAssets="All" />
+  </ItemGroup>
+
+  <PropertyGroup Label="MinVer">
+    <MinVerMinimumMajorMinor>8.0</MinVerMinimumMajorMinor>
+  </PropertyGroup>
+
+  <Target Name="CustomizeVersions" AfterTargets="MinVer" Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <PropertyGroup>
+      <FileVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(GITHUB_RUN_NUMBER)</FileVersion>
+    </PropertyGroup>
+    <PropertyGroup Condition="$(GITHUB_REF.StartsWith(`refs/pull/`))">
+      <PackageVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch)-pr.$(GITHUB_REF_NAME.Replace(`/merge`, ``)).$(GITHUB_RUN_NUMBER)</PackageVersion>
+    </PropertyGroup>
+  </Target>
+
 </Project>

--- a/eng/Library.targets
+++ b/eng/Library.targets
@@ -57,23 +57,6 @@
     </ItemGroup>
   </Target>
 
-  <ItemGroup Label="MinVer">
-    <PackageReference Include="MinVer" PrivateAssets="All" />
-  </ItemGroup>
-
-  <PropertyGroup Label="MinVer">
-    <MinVerMinimumMajorMinor>8.0</MinVerMinimumMajorMinor>
-  </PropertyGroup>
-
-  <Target Name="CustomizeVersions" AfterTargets="MinVer" Condition="'$(GITHUB_ACTIONS)' == 'true'">
-    <PropertyGroup>
-      <FileVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(GITHUB_RUN_NUMBER)</FileVersion>
-    </PropertyGroup>
-    <PropertyGroup Condition="$(GITHUB_REF.StartsWith(`refs/pull/`))">
-      <PackageVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch)-pr.$(GITHUB_REF_NAME.Replace(`/merge`, ``)).$(GITHUB_RUN_NUMBER)</PackageVersion>
-    </PropertyGroup>
-  </Target>
-
   <ItemGroup Condition="$(UsePublicApiAnalyzers) != 'false'">
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
- Fix CS7035 warning from docfx by cloning with the tags to compute the version number correctly.
- Fix two small typos.
- Remove outdated notes from content.
- Add Polly as the name and title for the site.
- Specify the language as English.
