### PR TITLE
[Docs] Add notes to use Polly.RateLimiting package

### DIFF
--- a/docs/migration-v8.md
+++ b/docs/migration-v8.md
@@ -423,7 +423,7 @@ IAsyncPolicy<HttpResponseMessage> asyncPolicyT = Policy.RateLimitAsync<HttpRespo
 ### Rate limit in v8
 
 > [!NOTE]
-> In v8, you have to add the `Polly.RateLimiting` package to your application otherwise you won't see the `AddRateLimiter` extension.
+> In v8, you have to add the [`Polly.RateLimiting`](https://www.nuget.org/packages/Polly.RateLimiting) package to your application otherwise you won't see the `AddRateLimiter` extension.
 
 <!-- snippet: migration-rate-limit-v8 -->
 ```cs
@@ -480,7 +480,7 @@ IAsyncPolicy<HttpResponseMessage> asyncPolicyT = Policy.BulkheadAsync<HttpRespon
 ### Bulkhead in v8
 
 > [!NOTE]
-> In v8, you have to add the `Polly.RateLimiting` package to your application otherwise you won't see the `AddConcurrencyLimiter` extension.
+> In v8, you have to add the [`Polly.RateLimiting`](https://www.nuget.org/packages/Polly.RateLimiting) package to your application otherwise you won't see the `AddConcurrencyLimiter` extension.
 
 <!-- snippet: migration-bulkhead-v8 -->
 ```cs
@@ -786,7 +786,7 @@ registry.GetOrAddPipeline("my-key", builder => builder.AddTimeout(TimeSpan.FromS
 In certain scenarios, you might not want to migrate your code to the v8 API. Instead, you may prefer to use strategies from v8 and apply them to v7 APIs. Polly provides a set of extension methods to support easy conversion from v8 to v7 APIs, as shown in the example below:
 
 > [!NOTE]
-> In v8, you have to add the `Polly.RateLimiting` package to your application otherwise you won't see the `AddRateLimiter` extension.
+> In v8, you have to add the [`Polly.RateLimiting`](https://www.nuget.org/packages/Polly.RateLimiting) package to your application otherwise you won't see the `AddRateLimiter` extension.
 
 <!-- snippet: migration-interoperability -->
 ```cs

--- a/docs/migration-v8.md
+++ b/docs/migration-v8.md
@@ -422,6 +422,9 @@ IAsyncPolicy<HttpResponseMessage> asyncPolicyT = Policy.RateLimitAsync<HttpRespo
 
 ### Rate limit in v8
 
+> [!NOTE]
+> In v8, you have to add the `Polly.RateLimiting` package to your application otherwise you won't see the `AddRateLimiter` extension.
+
 <!-- snippet: migration-rate-limit-v8 -->
 ```cs
 // The equivalent to Polly v7's RateLimit is the SlidingWindowRateLimiter.
@@ -475,6 +478,9 @@ IAsyncPolicy<HttpResponseMessage> asyncPolicyT = Policy.BulkheadAsync<HttpRespon
 <!-- endSnippet -->
 
 ### Bulkhead in v8
+
+> [!NOTE]
+> In v8, you have to add the `Polly.RateLimiting` package to your application otherwise you won't see the `AddConcurrencyLimiter` extension.
 
 <!-- snippet: migration-bulkhead-v8 -->
 ```cs
@@ -778,6 +784,9 @@ registry.GetOrAddPipeline("my-key", builder => builder.AddTimeout(TimeSpan.FromS
 ## Interoperability between policies and resilience pipelines
 
 In certain scenarios, you might not want to migrate your code to the v8 API. Instead, you may prefer to use strategies from v8 and apply them to v7 APIs. Polly provides a set of extension methods to support easy conversion from v8 to v7 APIs, as shown in the example below:
+
+> [!NOTE]
+> In v8, you have to add the `Polly.RateLimiting` package to your application otherwise you won't see the `AddRateLimiter` extension.
 
 <!-- snippet: migration-interoperability -->
 ```cs


### PR DESCRIPTION
## Details on the issue fix or feature implementation
- The migration document does not mention explicitly that the new rate limiting strategies reside in a different package than the rest of the strategies.
- I've added notes to doc to help people with the migration process.


## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
