### PR TITLE
Docs: Include info about numerical type used in metrics in telemetry.md

### DIFF
--- a/docs/advanced/telemetry.md
+++ b/docs/advanced/telemetry.md
@@ -104,6 +104,7 @@ These values are subsequently reflected in the following metering instruments ex
 ### Instrument: `resilience.polly.strategy.events`
 
 - Type: *Counter*
+- Numerical type of measurement: *int*
 - Description: Emitted upon the occurrence of a resilience event.
 
 Tags:
@@ -122,6 +123,7 @@ Tags:
 
 - Type: *Histogram*
 - Unit: *milliseconds*
+- Numerical type of measurement: *double*
 - Description: Tracks the duration of execution attempts, produced by `Retry` and `Hedging` resilience strategies.
 
 Tags:

--- a/docs/advanced/telemetry.md
+++ b/docs/advanced/telemetry.md
@@ -144,6 +144,7 @@ Tags:
 
 - Type: *Histogram*
 - Unit: *milliseconds*
+- Numerical type of measurement: *double*
 - Description: Measures the duration of resilience pipelines.
 
 Tags:


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request
This PR adds info about the numerical type used for the three metrics. This is useful to know if you use the `MeterListener` class which requires you to specify the measurement type when calling `SetMeasurementEventCallback<T>()`.

## The issue or feature being addressed
Improve documentation of metrics.

<!-- Please include the existing GitHub issue number where relevant -->

## Details on the issue fix or feature implementation

## Confirm the following

- [X]  I started this PR by branching from the head of the default branch
- [X]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build
