### PR TITLE
Publicize DefaultContinueOnCapturedContext

### DIFF
--- a/src/Polly/AsyncPolicy.ExecuteOverloads.cs
+++ b/src/Polly/AsyncPolicy.ExecuteOverloads.cs
@@ -344,6 +344,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
 
         try
         {
+            continueOnCapturedContext ??= DefaultContinueOnCapturedContext;
             await ExecuteAsync(action, context, cancellationToken, continueOnCapturedContext.Value).ConfigureAwait(continueOnCapturedContext.Value);
             return PolicyResult.Successful(context);
         }
@@ -470,6 +471,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
 
         try
         {
+            continueOnCapturedContext ??= DefaultContinueOnCapturedContext;
             return PolicyResult<TResult>.Successful(
                 await ExecuteAsync(action, context, cancellationToken, continueOnCapturedContext.Value).ConfigureAwait(continueOnCapturedContext.Value), context);
         }

--- a/src/Polly/PolicyBase.cs
+++ b/src/Polly/PolicyBase.cs
@@ -18,7 +18,7 @@ public abstract partial class PolicyBase
     /// <summary>
     /// Defines a value to use for continueOnCaptureContext, when none is supplied.
     /// </summary>
-    internal const bool DefaultContinueOnCapturedContext = false;
+    public static bool DefaultContinueOnCapturedContext = false;
 
     internal static ExceptionType GetExceptionType(ExceptionPredicates exceptionPredicates, Exception exception)
     {

--- a/src/Polly/PublicAPI.Unshipped.txt
+++ b/src/Polly/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-﻿
+﻿static Polly.PolicyBase.DefaultContinueOnCapturedContext -> bool


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed
#1687

## Details on the issue fix or feature implementation
The issue describes the PR pretty well.  This PR **does not** introduce any binary breaking changes and should be safe to release via a minor release.  

To avoid overload confusion, I put the method with the actual logic into its own `xxxInternalAsync` submethod to differentiate between the `bool?` and `bool` overloads.  This has the added benefit of making the decompiled source easier to navigate as Visual Studio tends to get confused w/ heavily overloaded methods in these kinds of files.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature - _I don't think any new tests are needed here?_
- [x]  I have successfully run a local build
- [x] Still need to do the `Result` overloads

^^ Still working on tests
