### PR TITLE
Update to cancel downstream operation in TimeoutStrategy.Pessimistic

### DIFF
--- a/src/Polly/Timeout/AsyncTimeoutEngine.cs
+++ b/src/Polly/Timeout/AsyncTimeoutEngine.cs
@@ -52,8 +52,9 @@ internal static class AsyncTimeoutEngine
         }
         finally
         {
-            // If the timeoutCancellation was canceled & our combined token hasn't been signaled, cancel it.
+            // If timeoutCancellationTokenSource was canceled & our combined token hasn't been signaled, cancel it.
             // This avoids the exception propagating before the linked token can signal the downstream to cancel.
+            // See https://github.com/App-vNext/Polly/issues/722.
             if (!combinedTokenSource.IsCancellationRequested && timeoutCancellationTokenSource.IsCancellationRequested)
             {
                 combinedTokenSource.Cancel();

--- a/src/Polly/Timeout/AsyncTimeoutEngine.cs
+++ b/src/Polly/Timeout/AsyncTimeoutEngine.cs
@@ -15,8 +15,6 @@ internal static class AsyncTimeoutEngine
         TimeSpan timeout = timeoutProvider(context);
 
         using var timeoutCancellationTokenSource = new CancellationTokenSource();
-        // Do not use a using here, the exception will exit the scope before we have time to
-        // notify the downstream of the cancellation.
         using var combinedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCancellationTokenSource.Token);
 
         Task<TResult> actionTask = null;
@@ -54,7 +52,7 @@ internal static class AsyncTimeoutEngine
         }
         finally
         {
-            // If the timeoutCancellation was canceled & our combined token hasn't been signaled, signal it.
+            // If the timeoutCancellation was canceled & our combined token hasn't been signaled, cancel it.
             // This avoids the exception propagating before the linked token can signal the downstream to cancel.
             if (!combinedTokenSource.IsCancellationRequested && timeoutCancellationTokenSource.IsCancellationRequested)
             {

--- a/test/Polly.Specs/Timeout/TimeoutAsyncSpecs.cs
+++ b/test/Polly.Specs/Timeout/TimeoutAsyncSpecs.cs
@@ -1,4 +1,6 @@
-﻿namespace Polly.Specs.Timeout;
+﻿using System;
+
+namespace Polly.Specs.Timeout;
 
 [Collection(Constants.SystemClockDependentTestCollection)]
 public class TimeoutAsyncSpecs : TimeoutSpecsBase
@@ -246,6 +248,31 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
         var policy = Policy.TimeoutAsync(TimeSpan.FromSeconds(10), TimeoutStrategy.Pessimistic);
 
         await policy.Awaiting(p => p.ExecuteAsync(() => throw new NotImplementedException())).Should().ThrowAsync<NotImplementedException>();
+    }
+
+    [Fact]
+    public async Task Should_cancel_downstream_token_on_timeout__pessimistic()
+    {
+        // It seems that there's a difference in the mocked clock vs. the real time clock.
+        // This test does not fail when using the mocked timer.
+        // In the TimeoutSpecsBase we actually cancel the combined token. Which hides
+        // the fact that it doesn't actually cancel irl.
+        SystemClock.Reset();
+
+        var policy = Policy.TimeoutAsync(TimeSpan.FromMilliseconds(200), TimeoutStrategy.Pessimistic);
+        var upstreamToken = new CancellationToken();
+        bool isCancelled = false;
+
+        var act = () => policy.ExecuteAsync(async (combinedToken) =>
+        {
+            combinedToken.Register(() => isCancelled = true);
+            await SystemClock.SleepAsync(TimeSpan.FromMilliseconds(300), combinedToken);
+        }, upstreamToken);
+
+        await act.Should().ThrowAsync<TimeoutRejectedException>();
+
+        await SystemClock.SleepAsync(TimeSpan.FromMilliseconds(400), default);
+        isCancelled.Should().BeTrue();
     }
 
     #endregion

--- a/test/Polly.Specs/Timeout/TimeoutAsyncSpecs.cs
+++ b/test/Polly.Specs/Timeout/TimeoutAsyncSpecs.cs
@@ -260,18 +260,16 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
         SystemClock.Reset();
 
         var policy = Policy.TimeoutAsync(TimeSpan.FromMilliseconds(200), TimeoutStrategy.Pessimistic);
-        var upstreamToken = new CancellationToken();
         bool isCancelled = false;
 
         var act = () => policy.ExecuteAsync(async (combinedToken) =>
         {
             combinedToken.Register(() => isCancelled = true);
-            await SystemClock.SleepAsync(TimeSpan.FromMilliseconds(300), combinedToken);
-        }, upstreamToken);
+            await SystemClock.SleepAsync(TimeSpan.FromMilliseconds(1000), combinedToken);
+        }, CancellationToken.None);
 
         await act.Should().ThrowAsync<TimeoutRejectedException>();
 
-        await SystemClock.SleepAsync(TimeSpan.FromMilliseconds(400), default);
         isCancelled.Should().BeTrue();
     }
 


### PR DESCRIPTION
This PR has changes to extend the life of the `combinedTokenSource` in the `AsyncTimeoutEngine`, so that the cancellation will get propegated downstream in the case of a `TimeoutRejectedException`.

<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

We noticed that the downstream cancellation token was never signaled in `TimeoutStrategy.Pessimistic`. The root cause seems to be the `TimeoutRejectionException` escaping the scope of the `ImplementationAsync` function on `AsyncTimeoutEngine.cs:5`. This causes the `CancellationTokenSource` to be disposed and the downstream token to never get canceled. 


This is related to this issue: https://github.com/App-vNext/Polly/issues/722

## Details on the issue fix or feature implementation
In this fix we explicitly cancel the `combinedTokenSource` as the function leaves scope, because without the exception will propagate and cause the source to be disposed before the downstream token can be canceled. This issue was demonstrated in a UT. However, that UT requires that we use "real time" as the `TimeSpecBase.cs` `SystemClock` overrides actually cancel the downstream token themselves on a timeout. 


## Confirm the following

- [X]  I started this PR by branching from the head of the default branch
- [X]  I have targeted the PR to merge into the default branch
- [X]  I have included unit tests for the issue/feature
- [X]  I have successfully run a local build
