### PR TITLE
Turn off var preferences

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -43,3 +43,7 @@ dotnet_naming_symbols.static_fields.required_modifiers = static
 dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
 dotnet_naming_style.static_prefix_style.required_prefix = 
 dotnet_naming_style.static_prefix_style.capitalization = pascal_case
+
+# don't have var preferences
+dotnet_diagnostic.IDE0007.severity = none
+dotnet_diagnostic.IDE0008.severity = none

--- a/src/Polly.Core/Hedging/HedgingResilienceStrategy.cs
+++ b/src/Polly.Core/Hedging/HedgingResilienceStrategy.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using Polly.Hedging.Controller;
 using Polly.Hedging.Utils;
 using Polly.Telemetry;
 

--- a/src/Polly.Core/Registry/ResiliencePipelineRegistry.cs
+++ b/src/Polly.Core/Registry/ResiliencePipelineRegistry.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
-using Polly.Utils.Pipeline;
 
 namespace Polly.Registry;
 

--- a/src/Polly.Core/Retry/RetryHelper.cs
+++ b/src/Polly.Core/Retry/RetryHelper.cs
@@ -121,5 +121,5 @@ internal static class RetryHelper
 
         return TimeSpan.FromMilliseconds(newDelay);
     }
-}
 #pragma warning restore IDE0047 // Remove unnecessary parentheses which offer less mental gymnastics
+}

--- a/src/Polly.Core/Retry/RetryHelper.cs
+++ b/src/Polly.Core/Retry/RetryHelper.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Polly.Retry;
 
 internal static class RetryHelper
@@ -112,9 +114,10 @@ internal static class RetryHelper
         return TimeSpan.FromTicks((long)Math.Min(formulaIntrinsicValue * RpScalingFactor * targetTicksFirstDelay, maxTimeSpanDouble));
     }
 
+    [SuppressMessage("Style", "IDE0047", Justification = "Parentheses offer less mental gymnastics")]
     private static TimeSpan ApplyJitter(TimeSpan delay, Func<double> randomizer)
     {
-        var offset = delay.TotalMilliseconds * JitterFactor / 2;
+        var offset = (delay.TotalMilliseconds * JitterFactor) / 2;
         var randomDelay = (delay.TotalMilliseconds * JitterFactor * randomizer()) - offset;
         var newDelay = delay.TotalMilliseconds + randomDelay;
 

--- a/src/Polly.Core/Retry/RetryHelper.cs
+++ b/src/Polly.Core/Retry/RetryHelper.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace Polly.Retry;
 
 internal static class RetryHelper
@@ -114,7 +112,7 @@ internal static class RetryHelper
         return TimeSpan.FromTicks((long)Math.Min(formulaIntrinsicValue * RpScalingFactor * targetTicksFirstDelay, maxTimeSpanDouble));
     }
 
-    [SuppressMessage("Style", "IDE0047", Justification = "Parentheses offer less mental gymnastics")]
+#pragma warning disable IDE0047 // Remove unnecessary parentheses which offer less mental gymnastics
     private static TimeSpan ApplyJitter(TimeSpan delay, Func<double> randomizer)
     {
         var offset = (delay.TotalMilliseconds * JitterFactor) / 2;
@@ -124,3 +122,4 @@ internal static class RetryHelper
         return TimeSpan.FromMilliseconds(newDelay);
     }
 }
+#pragma warning restore IDE0047 // Remove unnecessary parentheses which offer less mental gymnastics

--- a/src/Polly.Core/Retry/RetryHelper.cs
+++ b/src/Polly.Core/Retry/RetryHelper.cs
@@ -114,7 +114,7 @@ internal static class RetryHelper
 
     private static TimeSpan ApplyJitter(TimeSpan delay, Func<double> randomizer)
     {
-        var offset = (delay.TotalMilliseconds * JitterFactor) / 2;
+        var offset = delay.TotalMilliseconds * JitterFactor / 2;
         var randomDelay = (delay.TotalMilliseconds * JitterFactor * randomizer()) - offset;
         var newDelay = delay.TotalMilliseconds + randomDelay;
 

--- a/src/Polly.Core/Utils/Pipeline/ExternalComponent.cs
+++ b/src/Polly.Core/Utils/Pipeline/ExternalComponent.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-
-namespace Polly.Utils.Pipeline;
+﻿namespace Polly.Utils.Pipeline;
 
 [DebuggerDisplay("{Component}")]
 internal class ExternalComponent : PipelineComponent

--- a/src/Polly.Core/Utils/Pipeline/PipelineComponentFactory.cs
+++ b/src/Polly.Core/Utils/Pipeline/PipelineComponentFactory.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Polly.Telemetry;
+﻿using Polly.Telemetry;
 
 namespace Polly.Utils.Pipeline;
 


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
Contributors leverage code cleanup add superfluous changes to files when executing code clean up due to `var` preferences

<!-- Please include the existing GitHub issue number where relevant -->
Link to PR & comment: https://github.com/App-vNext/Polly/pull/1693#discussion_r1357891345

## Details on the issue fix or feature implementation
Running code cleanup on Polly.Core results for the following editorconfig scenarios results in:

1. no changes: 15 files
1. toggle [built-in](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0007-ide0008#csharp_style_var_for_built_in_types) to `false`: 16 files
1. turn off suggestions / cleanup for this rule: 6 files (cleaning up unnecessary usings)

After looking through the changes for options 1 & 2, it appears we are intentionally adding explicit context that is valuable in scenarios on both sides.  This PR implements option 3 as the codebase does a pretty good job of being consistent while allowing for a few one-off exceptions in places where context is important.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
