### PR TITLE
[Docs] Add sequence diagrams to fallback, retry, and rate limiter

### DIFF
--- a/docs/strategies/fallback.md
+++ b/docs/strategies/fallback.md
@@ -65,6 +65,45 @@ new ResiliencePipelineBuilder<UserAvatar>()
 | `FallbackAction` | `Null`, **Required**                                                       | Fallback action to be executed.                                                             |
 | `OnFallback`     | `null`                                                                     | Event that is raised when fallback happens.                                                 |
 
+## Diagrams
+
+### Happy path sequence diagram
+
+```mermaid
+%%{init: {'theme':'dark'}}%%
+sequenceDiagram
+    actor C as Caller
+    participant P as Pipeline
+    participant F as Fallback
+    participant DM as DecoratedMethod
+
+    C->>P: Calls ExecuteAsync
+    P->>F: Calls ExecuteCore
+    F->>+DM: Invokes
+    DM->>-F: Returns result
+    F->>P: Returns result
+    P->>C: Returns result
+```
+
+### Unhappy path sequence diagram
+
+```mermaid
+%%{init: {'theme':'dark'}}%%
+sequenceDiagram
+    actor C as Caller
+    participant P as Pipeline
+    participant F as Fallback
+    participant DM as DecoratedMethod
+
+    C->>P: Calls ExecuteAsync
+    P->>F: Calls ExecuteCore
+    F->>+DM: Invokes
+    DM->>-F: Fails transiently
+    F->>F: Falls back to<br/>substitute result
+    F->>P: Returns <br/>substituted result
+    P->>C: Returns <br/>substituted result
+```
+
 ## Patterns
 
 ### Fallback after retries


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed
- Add sequence diagrams to the documentation to ease the understanding of the strategies
 
## Details on the issue fix or feature implementation
- Added diagrams to fallback
  - [Happy path preview](https://github.com/peter-csala/Polly/blob/add-sequence-diagrams-part-2/docs/strategies/fallback.md#happy-path-sequence-diagram)
  - [Unhappy path preview](https://github.com/peter-csala/Polly/blob/add-sequence-diagrams-part-2/docs/strategies/fallback.md#unhappy-path-sequence-diagram) 
- Added diagrams to retry
  - [Happy path preview](https://github.com/peter-csala/Polly/blob/add-sequence-diagrams-part-2/docs/strategies/retry.md#happy-path-sequence-diagram)
  - [Unhappy path preview](https://github.com/peter-csala/Polly/blob/add-sequence-diagrams-part-2/docs/strategies/retry.md#unhappy-path-sequence-diagram)
- Added diagrams to rate limiter
  - [Happy path preview](https://github.com/peter-csala/Polly/blob/add-sequence-diagrams-part-2/docs/strategies/rate-limiter.md#happy-path-sequence-diagram)
  - [Unhappy path preview](https://github.com/peter-csala/Polly/blob/add-sequence-diagrams-part-2/docs/strategies/rate-limiter.md#unhappy-path-sequence-diagram)   
- Added diagrams to concurrency limiter
  - [Happy path preview](https://github.com/peter-csala/Polly/blob/add-sequence-diagrams-part-2/docs/strategies/rate-limiter.md#happy-path-sequence-diagram-1)
  - [Unhappy path preview](https://github.com/peter-csala/Polly/blob/add-sequence-diagrams-part-2/docs/strategies/rate-limiter.md#unhappy-path-sequence-diagram-1)    

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
