### PR TITLE
[Docs] Add diagram to action generator hedging

### DIFF
--- a/docs/strategies/circuit-breaker.md
+++ b/docs/strategies/circuit-breaker.md
@@ -185,7 +185,7 @@ sequenceDiagram
 
     C->>P: Calls ExecuteAsync
     P->>CB: Calls ExecuteCore
-    CB->>CB: Rejects request
+    CB-->>CB: Rejects request
     CB->>P: Throws <br/>BrokenCircuitException
     P->>C: Propagates exception
     deactivate CB
@@ -203,6 +203,8 @@ Let's suppose we have a circuit breaker strategy with the following configuratio
 
 #### Complex: happy path sequence diagram
 
+The circuit will break and later it will transition into `HalfOpen` state. The probe will succeed so, the circuit breaker will go back to normal (`Closed`) state.
+
 ```mermaid
 sequenceDiagram
     autonumber
@@ -230,7 +232,7 @@ sequenceDiagram
 
     C->>P: Calls ExecuteAsync
     P->>CB: Calls ExecuteCore
-    CB->>CB: Rejects request
+    CB-->>CB: Rejects request
     CB->>P: Throws <br/>BrokenCircuitException
     P->>C: Propagates exception
 
@@ -247,6 +249,8 @@ sequenceDiagram
 
 #### Complex: unhappy path sequence diagram
 
+The circuit will break and later it will transition into `HalfOpen` state. The probe will fail so, the circuit breaker will become broken again (`Open` state).
+
 ```mermaid
 sequenceDiagram
     autonumber
@@ -274,7 +278,7 @@ sequenceDiagram
 
     C->>P: Calls ExecuteAsync
     P->>CB: Calls ExecuteCore
-    CB->>CB: Rejects request
+    CB-->>CB: Rejects request
     CB->>P: Throws <br/>BrokenCircuitException
     P->>C: Propagates exception
 

--- a/docs/strategies/circuit-breaker.md
+++ b/docs/strategies/circuit-breaker.md
@@ -203,7 +203,7 @@ Let's suppose we have a circuit breaker strategy with the following configuratio
 
 #### Complex: happy path sequence diagram
 
-The circuit will break and later it will transition into `HalfOpen` state. The probe will succeed so, the circuit breaker will go back to normal (`Closed`) state.
+The circuit will break and later it will transition into the `HalfOpen` state. The probe will then succeed, so the circuit breaker will go back to the normal (`Closed`) state.
 
 ```mermaid
 sequenceDiagram
@@ -249,7 +249,7 @@ sequenceDiagram
 
 #### Complex: unhappy path sequence diagram
 
-The circuit will break and later it will transition into `HalfOpen` state. The probe will fail so, the circuit breaker will become broken again (`Open` state).
+The circuit will break and later it will transition into the `HalfOpen` state. The probe will then fail, so the circuit breaker will become broken again (the `Open` state).
 
 ```mermaid
 sequenceDiagram

--- a/docs/strategies/fallback.md
+++ b/docs/strategies/fallback.md
@@ -97,7 +97,9 @@ sequenceDiagram
     P->>F: Calls ExecuteCore
     F->>+D: Invokes
     D->>-F: Fails
-    F->>F: Falls back to<br/>substitute result
+    activate F
+    F-->>F: Falls back to<br/>substitute result
+    deactivate F
     F->>P: Returns <br/>substituted result
     P->>C: Returns <br/>substituted result
 ```

--- a/docs/strategies/fallback.md
+++ b/docs/strategies/fallback.md
@@ -91,15 +91,16 @@ sequenceDiagram
     actor C as Caller
     participant P as Pipeline
     participant F as Fallback
+    participant FA as FallbackAction
     participant D as DecoratedUserCallback
 
     C->>P: Calls ExecuteAsync
     P->>F: Calls ExecuteCore
     F->>+D: Invokes
     D->>-F: Fails
-    activate F
-    F-->>F: Falls back to<br/>substitute result
-    deactivate F
+    F->>+FA: Invokes
+    FA-->>FA: Calculates substitute result
+    FA->>-F: Returns <br/>substituted result
     F->>P: Returns <br/>substituted result
     P->>C: Returns <br/>substituted result
 ```

--- a/docs/strategies/hedging.md
+++ b/docs/strategies/hedging.md
@@ -265,7 +265,7 @@ sequenceDiagram
 
 #### Parallel: unhappy path sequence diagram
 
-The hedging strategy triggers because the `Delay` is set to zero. It succeeds because one of the requests succeeds.
+The hedging strategy triggers because the `Delay` is set to zero. It fails because all requests fail.
 
 ```mermaid
 sequenceDiagram
@@ -323,7 +323,7 @@ new ResiliencePipelineBuilder<HttpResponseMessage>()
             {
                 0 => TimeSpan.FromSeconds(1),
                 1 => TimeSpan.FromSeconds(2),
-                _ => System.Threading.Timeout.InfiniteTimeSpan
+                _ => TimeSpan.FromSeconds(-1)
             };
 
             return new ValueTask<TimeSpan>(delay);
@@ -339,7 +339,7 @@ With this configuration, the hedging strategy:
 
 #### Dynamic: happy path sequence diagram
 
-The hedging strategy triggers and switches between modes due to the usage of `DelayGenerator`. It succeeds because the last request succeeds.
+The hedging strategy triggers and switches between modes due to our `DelayGenerator`. It succeeds because the last request succeeds.
 
 ```mermaid
 sequenceDiagram
@@ -373,13 +373,13 @@ sequenceDiagram
     Note over H: Fallback mode
 
     H->>DG: Gets delay
-    DG->>H: Infinite
+    DG->>H: -1 second
     H->>+HUC: Invokes (R3)
     HUC-->>HUC: Processes R3
     HUC->>-H: Fails (R3)
 
     H->>DG: Gets delay
-    DG->>H: Infinite
+    DG->>H: -1 second
     H->>+HUC: Invokes (R4)
     HUC-->>HUC: Processes R4
     HUC->>-H: Returns result (R4)
@@ -391,7 +391,7 @@ sequenceDiagram
 
 #### Dynamic: unhappy path sequence diagram
 
-The hedging strategy triggers and switches between modes due to the usage of `DelayGenerator`. It fails because all requests fail.
+The hedging strategy triggers and switches between modes due our `DelayGenerator`. It fails because all requests fail.
 
 ```mermaid
 sequenceDiagram
@@ -425,13 +425,13 @@ sequenceDiagram
     Note over H: Fallback mode
 
     H->>DG: Gets delay
-    DG->>H: Infinite
+    DG->>H: -1 second
     H->>+HUC: Invokes (R3)
     HUC-->>HUC: Processes R3
     HUC->>-H: Fails (R3)
 
     H -> DG: Gets delay
-    DG->>H: Infinite
+    DG->>H: -1 second
     H->>+HUC: Invokes (R4)
     HUC-->>HUC: Processes R4
     HUC->>-H: Fails (R4)
@@ -485,6 +485,43 @@ new ResiliencePipelineBuilder<HttpResponseMessage>()
     });
 ```
 <!-- endSnippet -->
+
+### Action generator: sequence diagram
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor C as Caller
+    participant P as Pipeline
+    participant H as Hedging
+    participant AG as ActionGenerator
+    participant UC as UserCallback
+    participant HUC as HedgedUserCallback
+
+    C->>P: Calls ExecuteAsync
+    P->>H: Calls ExecuteCore
+
+    activate H
+    H->>+UC: Invokes (R1)
+    UC-->>UC: Processes R1
+    UC->>-H: Fails (R1)
+    H->>+AG: Invokes
+    AG->>-H: Returns factory
+    H-->>H: Invokes factory
+
+    H->>+HUC: Invokes (R2)
+    HUC-->>HUC: Processes R2
+    HUC->>-H: Fails (R2)
+
+    H-->>H: Invokes factory
+    H->>+HUC: Invokes (R3)
+    HUC-->>HUC: Processes R3
+    HUC->>-H: Returns result (R3)
+    deactivate H
+
+    H->>P: Returns result (R3)
+    P->>C: Returns result (R3)
+```
 
 ### Parameterized callbacks and action generator
 

--- a/docs/strategies/hedging.md
+++ b/docs/strategies/hedging.md
@@ -321,8 +321,7 @@ new ResiliencePipelineBuilder<HttpResponseMessage>()
         {
             var delay = args.AttemptNumber switch
             {
-                0 => TimeSpan.Zero, // Parallel mode
-                1 => TimeSpan.Zero, // Parallel mode
+                0 or 1 => TimeSpan.Zero, // Parallel mode
                 _ => TimeSpan.FromSeconds(-1) // switch to Fallback mode
             };
 

--- a/docs/strategies/hedging.md
+++ b/docs/strategies/hedging.md
@@ -323,7 +323,7 @@ new ResiliencePipelineBuilder<HttpResponseMessage>()
             {
                 0 => TimeSpan.FromSeconds(1),
                 1 => TimeSpan.FromSeconds(2),
-                _ => TimeSpan.FromSeconds(-1)
+                _ => TimeSpan.FromSeconds(-1) // switch to Fallback mode from Parallel
             };
 
             return new ValueTask<TimeSpan>(delay);

--- a/docs/strategies/hedging.md
+++ b/docs/strategies/hedging.md
@@ -321,9 +321,9 @@ new ResiliencePipelineBuilder<HttpResponseMessage>()
         {
             var delay = args.AttemptNumber switch
             {
-                0 => TimeSpan.FromSeconds(1),
-                1 => TimeSpan.FromSeconds(2),
-                _ => TimeSpan.FromSeconds(-1) // switch to Fallback mode from Parallel
+                0 => TimeSpan.Zero, // Parallel mode
+                1 => TimeSpan.Zero, // Parallel mode
+                _ => TimeSpan.FromSeconds(-1) // switch to Fallback mode
             };
 
             return new ValueTask<TimeSpan>(delay);
@@ -356,12 +356,12 @@ sequenceDiagram
     Note over H: Parallel mode
     par
     H->>DG: Gets delay
-    DG->>H: 1 second
+    DG->>H: 0 second
     H->>HUC: Invokes (R1)
     activate HUC
     and
     H ->> DG: Gets delay
-    DG ->> H: 2 seconds
+    DG ->> H: 0 second
     H->>+HUC: Invokes (R2)
     end
 
@@ -408,12 +408,12 @@ sequenceDiagram
     Note over H: Parallel mode
     par
     H->>DG: Gets delay
-    DG->>H: 1 second
+    DG->>H: 0 second
     H->>HUC: Invokes (R1)
     activate HUC
     and
     H->>DG: Gets delay
-    DG->>H: 2 seconds
+    DG->>H: 0 second
     H->>+HUC: Invokes (R2)
     end
 

--- a/docs/strategies/rate-limiter.md
+++ b/docs/strategies/rate-limiter.md
@@ -84,6 +84,7 @@ Let's suppose we have a rate limiter strategy with `PermitLimit` : `1` and `Wind
 
 ```mermaid
 sequenceDiagram
+    autonumber
     actor C as Caller
     participant P as Pipeline
     participant RL as RateLimiter
@@ -112,6 +113,7 @@ sequenceDiagram
 
 ```mermaid
 sequenceDiagram
+    autonumber
     actor C as Caller
     participant P as Pipeline
     participant RL as RateLimiter
@@ -127,7 +129,7 @@ sequenceDiagram
     Note over C: Few seconds later...
     C->>P: Calls ExecuteAsync
     P->>RL: Calls ExecuteCore
-    RL->>RL: Rejects request
+    RL-->>RL: Rejects request
     RL->>P: Throws <br/>RateLimiterRejectedException
     P->>C: Propagates exception
     Note over RL,D: Window end
@@ -156,7 +158,7 @@ sequenceDiagram
     P->>CL: Calls ExecuteCore
     CL->>+D: Invokes (C1)
     P->>CL: Calls ExecuteCore
-    CL->>CL: Queues request
+    CL-->>CL: Queues request
 
     D->>-CL: Returns result (C1)
     CL->>P: Returns result (C1)
@@ -189,9 +191,9 @@ sequenceDiagram
     P->>CL: Calls ExecuteCore
     CL->>+D: Invokes (C1)
     P->>CL: Calls ExecuteCore
-    CL->>CL: Queues request (C2)
+    CL-->>CL: Queues request (C2)
     P->>CL: Calls ExecuteCore
-    CL->>CL: Rejects request (C3)
+    CL-->>CL: Rejects request (C3)
     CL->>P: Throws <br/>RateLimiterRejectedException
     P->>C3: Propagates exception
 

--- a/docs/strategies/retry.md
+++ b/docs/strategies/retry.md
@@ -122,7 +122,7 @@ sequenceDiagram
     Note over R,D: Initial attempt
     R->>+D: Invokes
     D->>-R: Fails
-    R->>R: Sleeps
+    R-->>R: Sleeps
     Note over R,D: 1st retry attempt
     R->>+D: Invokes
     D->>-R: Returns result
@@ -144,11 +144,11 @@ sequenceDiagram
     Note over R,D: Initial attempt
     R->>+D: Invokes
     D->>-R: Fails
-    R->>R: Sleeps
+    R-->>R: Sleeps
     Note over R,D: 1st retry attempt
     R->>+D: Invokes
     D->>-R: Fails
-    R->>R: Sleeps
+    R-->>R: Sleeps
     Note over R,D: 2nd retry attempt
     R->>+D: Invokes
     D->>-R: Fails

--- a/docs/strategies/timeout.md
+++ b/docs/strategies/timeout.md
@@ -92,7 +92,7 @@ sequenceDiagram
     C->>P: Calls ExecuteAsync
     P->>T: Calls ExecuteCore
     T->>+D: Invokes
-    D->>D: Performs <br/>long-running <br/>operation
+    D-->>D: Performs <br/>long-running <br/>operation
     D->>-T: Returns result
     T->>P: Returns result
     P->>C: Returns result
@@ -112,8 +112,8 @@ sequenceDiagram
     T->>+D: Invokes
     activate T
     activate D
-    D->>D: Performs <br/>long-running <br/>operation
-    T->T: Times out
+    D-->>D: Performs <br/>long-running <br/>operation
+    T-->>T: Times out
     deactivate T
     T->>D: Propagates cancellation
     deactivate D

--- a/src/Snippets/Docs/Hedging.cs
+++ b/src/Snippets/Docs/Hedging.cs
@@ -66,7 +66,7 @@ internal static class Hedging
                     {
                         0 => TimeSpan.FromSeconds(1),
                         1 => TimeSpan.FromSeconds(2),
-                        _ => TimeSpan.FromSeconds(-1)
+                        _ => TimeSpan.FromSeconds(-1) // switch to Fallback mode from Parallel
                     };
 
                     return new ValueTask<TimeSpan>(delay);

--- a/src/Snippets/Docs/Hedging.cs
+++ b/src/Snippets/Docs/Hedging.cs
@@ -66,7 +66,7 @@ internal static class Hedging
                     {
                         0 => TimeSpan.FromSeconds(1),
                         1 => TimeSpan.FromSeconds(2),
-                        _ => System.Threading.Timeout.InfiniteTimeSpan
+                        _ => TimeSpan.FromSeconds(-1)
                     };
 
                     return new ValueTask<TimeSpan>(delay);

--- a/src/Snippets/Docs/Hedging.cs
+++ b/src/Snippets/Docs/Hedging.cs
@@ -64,8 +64,7 @@ internal static class Hedging
                 {
                     var delay = args.AttemptNumber switch
                     {
-                        0 => TimeSpan.Zero, // Parallel mode
-                        1 => TimeSpan.Zero, // Parallel mode
+                        0 or 1 => TimeSpan.Zero, // Parallel mode
                         _ => TimeSpan.FromSeconds(-1) // switch to Fallback mode
                     };
 

--- a/src/Snippets/Docs/Hedging.cs
+++ b/src/Snippets/Docs/Hedging.cs
@@ -64,9 +64,9 @@ internal static class Hedging
                 {
                     var delay = args.AttemptNumber switch
                     {
-                        0 => TimeSpan.FromSeconds(1),
-                        1 => TimeSpan.FromSeconds(2),
-                        _ => TimeSpan.FromSeconds(-1) // switch to Fallback mode from Parallel
+                        0 => TimeSpan.Zero, // Parallel mode
+                        1 => TimeSpan.Zero, // Parallel mode
+                        _ => TimeSpan.FromSeconds(-1) // switch to Fallback mode
                     };
 
                     return new ValueTask<TimeSpan>(delay);


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed

- Add sequence diagrams to the documentation to ease the understanding of the strategies

## Details on the issue fix or feature implementation
- Replaced `InfiniteTimespan` to `TimeSpan.FromSeconds(-1)`
- Fixed inconsistencies between diagrams
- Fixed `Parallel: unhappy path sequence diagram` section's description
- Added description to complex circuit breaker scenarios
- Added [`Action generator: sequence diagram` section](https://github.com/peter-csala/Polly/blob/add-diagrams-part-5/docs/strategies/hedging.md#action-generator-sequence-diagram)

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
