### PR TITLE
[Docs] Fix hedging documentation about unhappy paths

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -42,6 +42,7 @@ jobs:
     - name: Generate documentation
       run: |
         dotnet tool restore
+        dotnet build --configuration Release
         dotnet docfx docs/docfx.json
 
     - name: Deploy

--- a/docs/strategies/hedging.md
+++ b/docs/strategies/hedging.md
@@ -84,8 +84,8 @@ When the `Delay` property is set to a value greater than zero, the hedging strat
 - The primary execution is initiated.
 - If the initial execution either fails or takes longer than the `Delay` to complete, a new execution is initiated.
 - If the first two executions fail or exceed the `Delay` (calculated from the last initiated execution), another execution is triggered.
-- The final result is the result of fastest successful execution.
-- If all executions fail, the final result will be the first failure encountered.
+- **Happy path**: The final result is the result of fastest successful execution.
+- **Unhappy path**: If all executions fail, the final result will be the primary execution's failure.
 
 #### Latency: happy path sequence diagram
 
@@ -155,8 +155,8 @@ In fallback mode, the `Delay` value should be less than `TimeSpan.Zero`. This mo
 
 - An execution is initiated, and the strategy waits for its completion.
 - If the initial execution fails, new one is initiated.
-- The final result will be the first successful execution.
-- If all executions fail, the final result will be the first failure encountered.
+- **Happy path**: The final result will be the first successful execution.
+- **Unhappy path**: If all executions fail, the final result will be the primary execution's failure.
 
 #### Fallback: happy path sequence diagram
 
@@ -224,8 +224,8 @@ The hedging strategy operates in parallel mode when the `Delay` property is set 
 > Use this mode only when absolutely necessary, as it consumes the most resources, particularly when the hedging strategy uses remote resources such as remote HTTP services.
 
 - All executions are initiated simultaneously, adhering to the `MaxHedgedAttempts` limit.
-- The final result will be the fastest successful execution.
-- If all executions fail, the final result will be the first failure encountered.
+- **Happy path**: The final result will be the fastest successful execution.
+- **Unhappy path**: If all executions fail, the final result will be the primary execution's failure
 
 #### Parallel: happy path sequence diagram
 
@@ -293,8 +293,8 @@ sequenceDiagram
     HUC->>-H: Fails (R1)
 
     deactivate H
-    H->>P: Propagates failure (R2)
-    P->>C: Propagates failure (R2)
+    H->>P: Propagates failure (R1)
+    P->>C: Propagates failure (R1)
 ```
 
 ### Dynamic mode

--- a/test/Polly.Core.Tests/Hedging/HedgingResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Hedging/HedgingResilienceStrategyTests.cs
@@ -556,7 +556,10 @@ public class HedgingResilienceStrategyTests : IDisposable
         ConfigureHedging(async context => Outcome.FromResult(await Execute(context.CancellationToken)));
 
         // act
-        (await Create().ExecuteAsync(Execute, _cts.Token)).Should().Be("1st");
+        var actual = await Create().ExecuteAsync(Execute, _cts.Token);
+        
+        // assert
+        actual.Should().Be("1st");
     }
 
     [Fact]

--- a/test/Polly.Core.Tests/Hedging/HedgingResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Hedging/HedgingResilienceStrategyTests.cs
@@ -557,7 +557,7 @@ public class HedgingResilienceStrategyTests : IDisposable
 
         // act
         var actual = await Create().ExecuteAsync(Execute, _cts.Token);
-        
+
         // assert
         actual.Should().Be("1st");
     }


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed

- In all concurrency modes the hedging strategy returns the primary execution's failure if all attempts fail
- The documentation used the the following wording: `first failure encountered`
  - This is misleading since it can be interpreted as `fastest execution's failure` 

## Details on the issue fix or feature implementation

- Rephrased the documentation to clarify which result would be the final result
- Updated parallel mode's unhappy path's sequence diagram
- Added a parameterized unit test to the `HedgingResilienceStrategyTests`

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
