### PR TITLE
[Docs] Make quick start samples consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,43 +366,41 @@ The timeout resilience strategy assumes delegates you execute support [co-operat
 ```cs
 // Add timeout using the default options.
 // See https://www.pollydocs.org/strategies/timeout#defaults for defaults.
-new ResiliencePipelineBuilder()
-    .AddTimeout(new TimeoutStrategyOptions());
+new ResiliencePipelineBuilder().AddTimeout(new TimeoutStrategyOptions());
 
 // To add a timeout with a custom TimeSpan duration
-new ResiliencePipelineBuilder()
-    .AddTimeout(TimeSpan.FromSeconds(3));
+new ResiliencePipelineBuilder().AddTimeout(TimeSpan.FromSeconds(3));
 
 // To add a timeout using a custom timeout generator function
-new ResiliencePipelineBuilder()
-    .AddTimeout(new TimeoutStrategyOptions
+new ResiliencePipelineBuilder().AddTimeout(new TimeoutStrategyOptions
+{
+    TimeoutGenerator = static args =>
     {
-        TimeoutGenerator = args =>
-        {
-            // Note: the timeout generator supports asynchronous operations
-            return new ValueTask<TimeSpan>(TimeSpan.FromSeconds(123));
-        }
-    });
+        // Note: the timeout generator supports asynchronous operations
+        return new ValueTask<TimeSpan>(TimeSpan.FromSeconds(123));
+    }
+});
 
 // To add a timeout and listen for timeout events
-new ResiliencePipelineBuilder()
-    .AddTimeout(new TimeoutStrategyOptions
+new ResiliencePipelineBuilder().AddTimeout(new TimeoutStrategyOptions
+{
+    TimeoutGenerator = static args =>
     {
-        TimeoutGenerator = args =>
-        {
-            // Note: the timeout generator supports asynchronous operations
-            return new ValueTask<TimeSpan>(TimeSpan.FromSeconds(123));
-        },
-        OnTimeout = args =>
-        {
-            Console.WriteLine($"{args.Context.OperationKey}: Execution timed out after {args.Timeout.TotalSeconds} seconds.");
-            return default;
-        }
-    });
+        // Note: the timeout generator supports asynchronous operations
+        return new ValueTask<TimeSpan>(TimeSpan.FromSeconds(123));
+    },
+    OnTimeout = static args =>
+    {
+        Console.WriteLine($"{args.Context.OperationKey}: Execution timed out after {args.Timeout.TotalSeconds} seconds.");
+        return default;
+    }
+});
 ```
 <!-- endSnippet -->
 
-Timeout strategies throw `TimeoutRejectedException` when a timeout occurs. For more details, visit the [timeout strategy](https://www.pollydocs.org/strategies/timeout) documentation.
+Timeout strategies throw `TimeoutRejectedException` when a timeout occurs.
+
+For more details, visit the [timeout strategy](https://www.pollydocs.org/strategies/timeout) documentation.
 
 ### Rate Limiter
 
@@ -410,24 +408,23 @@ Timeout strategies throw `TimeoutRejectedException` when a timeout occurs. For m
 ```cs
 // Add rate limiter with default options.
 // See https://www.pollydocs.org/strategies/rate-limiter#defaults for defaults.
-new ResiliencePipelineBuilder()
-    .AddRateLimiter(new RateLimiterStrategyOptions());
+new ResiliencePipelineBuilder().AddRateLimiter(new RateLimiterStrategyOptions());
 
 // Create a rate limiter to allow a maximum of 100 concurrent executions and a queue of 50.
-new ResiliencePipelineBuilder()
-    .AddConcurrencyLimiter(100, 50);
+new ResiliencePipelineBuilder().AddConcurrencyLimiter(100, 50);
 
 // Create a rate limiter that allows 100 executions per minute.
-new ResiliencePipelineBuilder()
-    .AddRateLimiter(new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions
-    {
-        PermitLimit = 100,
-        Window = TimeSpan.FromMinutes(1)
-    }));
+new ResiliencePipelineBuilder().AddRateLimiter(new SlidingWindowRateLimiter(new()
+{
+    PermitLimit = 100,
+    Window = TimeSpan.FromMinutes(1)
+}));
 ```
 <!-- endSnippet -->
 
-Rate limiter strategy throws `RateLimiterRejectedException` if execution is rejected. For more details, visit the [rate limiter strategy](https://www.pollydocs.org/strategies/rate-limiter) documentation.
+Rate limiter strategy throws `RateLimiterRejectedException` if execution is rejected.
+
+For more details, visit the [rate limiter strategy](https://www.pollydocs.org/strategies/rate-limiter) documentation.
 
 ## Next steps
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Polly categorizes resilience strategies into two main groups:
 These strategies handle specific exceptions that are thrown, or results that are returned, by the callbacks executed through the strategy.
 
 | Strategy | Premise | AKA | Mitigation |
-| ------------- | ------------- |:-------------: |------------- |
+| ------------- | ------------- | -------------- | ------------ |
 |[**Retry** family](#retry) |Many faults are transient and may self-correct after a short delay.| *Maybe it's just a blip* |  Allows configuring automatic retries. |
 |[**Circuit-breaker** family](#circuit-breaker)|When a system is seriously struggling, failing fast is better than making users/callers wait.  <br/><br/>Protecting a faulting system from overload can help it recover. | *Stop doing it if it hurts* <br/><br/>*Give that system a break* | Breaks the circuit (blocks executions) for a period, when faults exceed some pre-configured threshold. |
 |[**Fallback**](#fallback)|Things will still fail - plan what you will do when that happens.| *Degrade gracefully*  |Defines an alternative value to be returned (or action to be executed) on failure. |
@@ -114,7 +114,7 @@ These strategies handle specific exceptions that are thrown, or results that are
 Unlike reactive strategies, proactive strategies do not focus on handling errors by the callbacks might throw or return. They can make pro-active decisions to cancel or reject the execution of callbacks.
 
 | Strategy | Premise | AKA | Prevention |
-|-------------| ------------- |:-------------: |------------- |
+| ----------- | ------------- | -------------- | ------------ |
 |[**Timeout**](#timeout)|Beyond a certain wait, a success result is unlikely.| *Don't wait forever*  |Guarantees the caller won't have to wait beyond the timeout. |
 |[**Rate Limiter**](#rate-limiter)|Limiting the rate a system handles requests is another way to control load. <br/> <br/> This can apply to the way your system accepts incoming calls, and/or to the way you call downstream services. | *Slow down a bit, will you?*  |Constrains executions to not exceed a certain rate. |
 

--- a/README.md
+++ b/README.md
@@ -124,29 +124,29 @@ Visit [resilience strategies](https://www.pollydocs.org/strategies) docs to expl
 
 <!-- snippet: retry -->
 ```cs
-// Add retry using the default options.
+// Retry using the default options.
 // See https://www.pollydocs.org/strategies/retry#defaults for defaults.
-new ResiliencePipelineBuilder().AddRetry(new RetryStrategyOptions());
+var optionsDefaults = new RetryStrategyOptions();
 
 // For instant retries with no delay
-new ResiliencePipelineBuilder().AddRetry(new()
+var optionsNoDelay = new RetryStrategyOptions
 {
     Delay = TimeSpan.Zero
-});
+};
 
 // For advanced control over the retry behavior, including the number of attempts,
 // delay between retries, and the types of exceptions to handle.
-new ResiliencePipelineBuilder().AddRetry(new()
+var optionsComplex = new RetryStrategyOptions
 {
     ShouldHandle = new PredicateBuilder().Handle<SomeExceptionType>(),
     BackoffType = DelayBackoffType.Exponential,
     UseJitter = true,  // Adds a random factor to the delay
     MaxRetryAttempts = 4,
     Delay = TimeSpan.FromSeconds(3),
-});
+};
 
 // To use a custom function to generate the delay for retries
-new ResiliencePipelineBuilder().AddRetry(new()
+var optionsDelayGenerator = new RetryStrategyOptions
 {
     MaxRetryAttempts = 2,
     DelayGenerator = static args =>
@@ -162,10 +162,10 @@ new ResiliencePipelineBuilder().AddRetry(new()
         // but the API also supports asynchronous implementations.
         return new ValueTask<TimeSpan?>(delay);
     }
-});
+};
 
 // To extract the delay from the result object
-new ResiliencePipelineBuilder<HttpResponseMessage>().AddRetry(new()
+var optionsExtractDelay = new RetryStrategyOptions<HttpResponseMessage>
 {
     DelayGenerator = static args =>
     {
@@ -178,10 +178,10 @@ new ResiliencePipelineBuilder<HttpResponseMessage>().AddRetry(new()
         // Returning null means the retry strategy will use its internal delay for this attempt.
         return new ValueTask<TimeSpan?>((TimeSpan?)null);
     }
-});
+};
 
 // To get notifications when a retry is performed
-new ResiliencePipelineBuilder().AddRetry(new()
+var optionsOnRetry = new RetryStrategyOptions
 {
     MaxRetryAttempts = 2,
     OnRetry = static args =>
@@ -191,13 +191,17 @@ new ResiliencePipelineBuilder().AddRetry(new()
         // Event handlers can be asynchronous; here, we return an empty ValueTask.
         return default;
     }
-});
+};
 
 // To keep retrying indefinitely or until success use int.MaxValue.
-new ResiliencePipelineBuilder().AddRetry(new()
+var optionsIndefiniteRetry = new RetryStrategyOptions
 {
     MaxRetryAttempts = int.MaxValue,
-});
+};
+
+// Add a retry strategy with a RetryStrategyOptions{<TResult>} instance to the pipeline
+new ResiliencePipelineBuilder().AddRetry(optionsDefaults);
+new ResiliencePipelineBuilder<HttpResponseMessage>().AddRetry(optionsExtractDelay);
 ```
 <!-- endSnippet -->
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,7 +19,7 @@ ResiliencePipeline pipeline = new ResiliencePipelineBuilder()
     .Build(); // Builds the resilience pipeline
 
 // Execute the pipeline asynchronously
-await pipeline.ExecuteAsync(static async cancellationToken => { /*Your custom logic here */ }, cancellationToken);
+await pipeline.ExecuteAsync(static async token => { /*Your custom logic goes here */ }, cancellationToken);
 ```
 <!-- endSnippet -->
 
@@ -46,7 +46,7 @@ services.AddResiliencePipeline("my-pipeline", builder =>
 });
 
 // Build the service provider
-IServiceProvider serviceProvider = services.BuildServiceProvider();
+var serviceProvider = services.BuildServiceProvider();
 
 // Retrieve ResiliencePipelineProvider that caches and dynamically creates the resilience pipelines
 var pipelineProvider = serviceProvider.GetRequiredService<ResiliencePipelineProvider<string>>();
@@ -57,7 +57,7 @@ ResiliencePipeline pipeline = pipelineProvider.GetPipeline("my-pipeline");
 // Execute the pipeline
 await pipeline.ExecuteAsync(static async token =>
 {
-    // Your custom logic here
+    // Your custom logic goes here
 });
 ```
 <!-- endSnippet -->

--- a/docs/strategies/circuit-breaker.md
+++ b/docs/strategies/circuit-breaker.md
@@ -25,10 +25,9 @@
 new ResiliencePipelineBuilder().AddCircuitBreaker(new CircuitBreakerStrategyOptions());
 
 // Add circuit breaker with customized options:
-//
 // The circuit will break if more than 50% of actions result in handled exceptions,
 // within any 10-second sampling duration, and at least 8 actions are processed.
-new ResiliencePipelineBuilder().AddCircuitBreaker(new CircuitBreakerStrategyOptions
+new ResiliencePipelineBuilder().AddCircuitBreaker(new()
 {
     FailureRatio = 0.5,
     SamplingDuration = TimeSpan.FromSeconds(10),
@@ -38,20 +37,20 @@ new ResiliencePipelineBuilder().AddCircuitBreaker(new CircuitBreakerStrategyOpti
 });
 
 // Handle specific failed results for HttpResponseMessage:
-new ResiliencePipelineBuilder<HttpResponseMessage>()
-    .AddCircuitBreaker(new CircuitBreakerStrategyOptions<HttpResponseMessage>
-    {
-        ShouldHandle = new PredicateBuilder<HttpResponseMessage>()
-            .Handle<SomeExceptionType>()
-            .HandleResult(response => response.StatusCode == HttpStatusCode.InternalServerError)
-    });
+new ResiliencePipelineBuilder<HttpResponseMessage>().AddCircuitBreaker(new()
+{
+    ShouldHandle = new PredicateBuilder<HttpResponseMessage>()
+        .Handle<SomeExceptionType>()
+        .HandleResult(response => response.StatusCode == HttpStatusCode.InternalServerError)
+});
 
 // Monitor the circuit state, useful for health reporting:
 var stateProvider = new CircuitBreakerStateProvider();
 
-new ResiliencePipelineBuilder<HttpResponseMessage>()
-    .AddCircuitBreaker(new() { StateProvider = stateProvider })
-    .Build();
+new ResiliencePipelineBuilder<HttpResponseMessage>().AddCircuitBreaker(new()
+{
+    StateProvider = stateProvider
+});
 
 /*
 CircuitState.Closed - Normal operation; actions are executed.
@@ -63,9 +62,10 @@ CircuitState.Isolated - Circuit is manually held open; actions are blocked.
 // Manually control the Circuit Breaker state:
 var manualControl = new CircuitBreakerManualControl();
 
-new ResiliencePipelineBuilder()
-    .AddCircuitBreaker(new() { ManualControl = manualControl })
-    .Build();
+new ResiliencePipelineBuilder().AddCircuitBreaker(new()
+{
+    ManualControl = manualControl
+});
 
 // Manually isolate a circuit, e.g., to isolate a downstream service.
 await manualControl.IsolateAsync();

--- a/docs/strategies/circuit-breaker.md
+++ b/docs/strategies/circuit-breaker.md
@@ -20,37 +20,38 @@
 
 <!-- snippet: circuit-breaker -->
 ```cs
-// Add circuit breaker with default options.
+// Circuit breaker with default options.
 // See https://www.pollydocs.org/strategies/circuit-breaker#defaults for defaults.
-new ResiliencePipelineBuilder().AddCircuitBreaker(new CircuitBreakerStrategyOptions());
+var optionsDefaults = new CircuitBreakerStrategyOptions();
 
-// Add circuit breaker with customized options:
+// Circuit breaker with customized options:
 // The circuit will break if more than 50% of actions result in handled exceptions,
 // within any 10-second sampling duration, and at least 8 actions are processed.
-new ResiliencePipelineBuilder().AddCircuitBreaker(new()
+var optionsComplex = new CircuitBreakerStrategyOptions
 {
     FailureRatio = 0.5,
     SamplingDuration = TimeSpan.FromSeconds(10),
     MinimumThroughput = 8,
     BreakDuration = TimeSpan.FromSeconds(30),
     ShouldHandle = new PredicateBuilder().Handle<SomeExceptionType>()
-});
+};
 
 // Handle specific failed results for HttpResponseMessage:
-new ResiliencePipelineBuilder<HttpResponseMessage>().AddCircuitBreaker(new()
+var optionsShouldHandle = new CircuitBreakerStrategyOptions<HttpResponseMessage>
 {
     ShouldHandle = new PredicateBuilder<HttpResponseMessage>()
         .Handle<SomeExceptionType>()
         .HandleResult(response => response.StatusCode == HttpStatusCode.InternalServerError)
-});
+};
 
 // Monitor the circuit state, useful for health reporting:
 var stateProvider = new CircuitBreakerStateProvider();
-
-new ResiliencePipelineBuilder<HttpResponseMessage>().AddCircuitBreaker(new()
+var optionsStateProvider = new CircuitBreakerStrategyOptions<HttpResponseMessage>
 {
     StateProvider = stateProvider
-});
+};
+
+var circuitState = stateProvider.CircuitState;
 
 /*
 CircuitState.Closed - Normal operation; actions are executed.
@@ -61,17 +62,20 @@ CircuitState.Isolated - Circuit is manually held open; actions are blocked.
 
 // Manually control the Circuit Breaker state:
 var manualControl = new CircuitBreakerManualControl();
-
-new ResiliencePipelineBuilder().AddCircuitBreaker(new()
+var optionsManualControl = new CircuitBreakerStrategyOptions
 {
     ManualControl = manualControl
-});
+};
 
 // Manually isolate a circuit, e.g., to isolate a downstream service.
 await manualControl.IsolateAsync();
 
 // Manually close the circuit to allow actions to be executed again.
 await manualControl.CloseAsync();
+
+// Add a circuit breaker strategy with a CircuitBreakerStrategyOptions{<TResult>} instance to the pipeline
+new ResiliencePipelineBuilder().AddCircuitBreaker(optionsDefaults);
+new ResiliencePipelineBuilder<HttpResponseMessage>().AddCircuitBreaker(optionsStateProvider);
 ```
 <!-- endSnippet -->
 

--- a/docs/strategies/fallback.md
+++ b/docs/strategies/fallback.md
@@ -13,47 +13,44 @@
 <!-- snippet: fallback -->
 ```cs
 // Add a fallback/substitute value if an operation fails.
-new ResiliencePipelineBuilder<UserAvatar>()
-    .AddFallback(new FallbackStrategyOptions<UserAvatar>
-    {
-        ShouldHandle = new PredicateBuilder<UserAvatar>()
-            .Handle<SomeExceptionType>()
-            .HandleResult(r => r is null),
-        FallbackAction = args => Outcome.FromResultAsValueTask(UserAvatar.Blank)
-    });
+new ResiliencePipelineBuilder<UserAvatar>().AddFallback(new FallbackStrategyOptions<UserAvatar>
+{
+    ShouldHandle = new PredicateBuilder<UserAvatar>()
+        .Handle<SomeExceptionType>()
+        .HandleResult(r => r is null),
+    FallbackAction = static args => Outcome.FromResultAsValueTask(UserAvatar.Blank)
+});
 
 // Use a dynamically generated value if an operation fails.
-new ResiliencePipelineBuilder<UserAvatar>()
-    .AddFallback(new FallbackStrategyOptions<UserAvatar>
+new ResiliencePipelineBuilder<UserAvatar>().AddFallback(new()
+{
+    ShouldHandle = new PredicateBuilder<UserAvatar>()
+        .Handle<SomeExceptionType>()
+        .HandleResult(r => r is null),
+    FallbackAction = static args =>
     {
-        ShouldHandle = new PredicateBuilder<UserAvatar>()
-            .Handle<SomeExceptionType>()
-            .HandleResult(r => r is null),
-        FallbackAction = args =>
-        {
-            var avatar = UserAvatar.GetRandomAvatar();
-            return Outcome.FromResultAsValueTask(avatar);
-        }
-    });
+        var avatar = UserAvatar.GetRandomAvatar();
+        return Outcome.FromResultAsValueTask(avatar);
+    }
+});
 
 // Use a default or dynamically generated value, and execute an additional action if the fallback is triggered.
-new ResiliencePipelineBuilder<UserAvatar>()
-    .AddFallback(new FallbackStrategyOptions<UserAvatar>
+new ResiliencePipelineBuilder<UserAvatar>().AddFallback(new()
+{
+    ShouldHandle = new PredicateBuilder<UserAvatar>()
+        .Handle<SomeExceptionType>()
+        .HandleResult(r => r is null),
+    FallbackAction = static args =>
     {
-        ShouldHandle = new PredicateBuilder<UserAvatar>()
-            .Handle<SomeExceptionType>()
-            .HandleResult(r => r is null),
-        FallbackAction = args =>
-        {
-            var avatar = UserAvatar.GetRandomAvatar();
-            return Outcome.FromResultAsValueTask(UserAvatar.Blank);
-        },
-        OnFallback = args =>
-        {
-            // Add extra logic to be executed when the fallback is triggered, such as logging.
-            return default; // Returns an empty ValueTask
-        }
-    });
+        var avatar = UserAvatar.GetRandomAvatar();
+        return Outcome.FromResultAsValueTask(UserAvatar.Blank);
+    },
+    OnFallback = static args =>
+    {
+        // Add extra logic to be executed when the fallback is triggered, such as logging.
+        return default; // Returns an empty ValueTask
+    }
+});
 ```
 <!-- endSnippet -->
 

--- a/docs/strategies/fallback.md
+++ b/docs/strategies/fallback.md
@@ -12,17 +12,17 @@
 
 <!-- snippet: fallback -->
 ```cs
-// Add a fallback/substitute value if an operation fails.
-new ResiliencePipelineBuilder<UserAvatar>().AddFallback(new FallbackStrategyOptions<UserAvatar>
+// A fallback/substitute value if an operation fails.
+var optionsSubstitute = new FallbackStrategyOptions<UserAvatar>
 {
     ShouldHandle = new PredicateBuilder<UserAvatar>()
         .Handle<SomeExceptionType>()
         .HandleResult(r => r is null),
     FallbackAction = static args => Outcome.FromResultAsValueTask(UserAvatar.Blank)
-});
+};
 
 // Use a dynamically generated value if an operation fails.
-new ResiliencePipelineBuilder<UserAvatar>().AddFallback(new()
+var optionsFallbackAction = new FallbackStrategyOptions<UserAvatar>
 {
     ShouldHandle = new PredicateBuilder<UserAvatar>()
         .Handle<SomeExceptionType>()
@@ -32,10 +32,10 @@ new ResiliencePipelineBuilder<UserAvatar>().AddFallback(new()
         var avatar = UserAvatar.GetRandomAvatar();
         return Outcome.FromResultAsValueTask(avatar);
     }
-});
+};
 
 // Use a default or dynamically generated value, and execute an additional action if the fallback is triggered.
-new ResiliencePipelineBuilder<UserAvatar>().AddFallback(new()
+var optionsOnFallback = new FallbackStrategyOptions<UserAvatar>
 {
     ShouldHandle = new PredicateBuilder<UserAvatar>()
         .Handle<SomeExceptionType>()
@@ -50,7 +50,10 @@ new ResiliencePipelineBuilder<UserAvatar>().AddFallback(new()
         // Add extra logic to be executed when the fallback is triggered, such as logging.
         return default; // Returns an empty ValueTask
     }
-});
+};
+
+// Add a fallback strategy with a FallbackStrategyOptions<TResult> instance to the pipeline
+new ResiliencePipelineBuilder<UserAvatar>().AddFallback(optionsOnFallback);
 ```
 <!-- endSnippet -->
 

--- a/docs/strategies/hedging.md
+++ b/docs/strategies/hedging.md
@@ -26,34 +26,32 @@ new ResiliencePipelineBuilder<HttpResponseMessage>()
 
 // Add a customized hedging strategy that retries up to 3 times if the execution
 // takes longer than 1 second or if it fails due to an exception or returns an HTTP 500 Internal Server Error.
-new ResiliencePipelineBuilder<HttpResponseMessage>()
-    .AddHedging(new HedgingStrategyOptions<HttpResponseMessage>
+new ResiliencePipelineBuilder<HttpResponseMessage>().AddHedging(new()
+{
+    ShouldHandle = new PredicateBuilder<HttpResponseMessage>()
+        .Handle<SomeExceptionType>()
+        .HandleResult(response => response.StatusCode == HttpStatusCode.InternalServerError),
+    MaxHedgedAttempts = 3,
+    Delay = TimeSpan.FromSeconds(1),
+    ActionGenerator = static args =>
     {
-        ShouldHandle = new PredicateBuilder<HttpResponseMessage>()
-            .Handle<SomeExceptionType>()
-            .HandleResult(response => response.StatusCode == HttpStatusCode.InternalServerError),
-        MaxHedgedAttempts = 3,
-        Delay = TimeSpan.FromSeconds(1),
-        ActionGenerator = args =>
-        {
-            Console.WriteLine("Preparing to execute hedged action.");
+        Console.WriteLine("Preparing to execute hedged action.");
 
-            // Return a delegate function to invoke the original action with the action context.
-            // Optionally, you can also create a completely new action to be executed.
-            return () => args.Callback(args.ActionContext);
-        }
-    });
+        // Return a delegate function to invoke the original action with the action context.
+        // Optionally, you can also create a completely new action to be executed.
+        return () => args.Callback(args.ActionContext);
+    }
+});
 
 // Subscribe to hedging events.
-new ResiliencePipelineBuilder<HttpResponseMessage>()
-    .AddHedging(new HedgingStrategyOptions<HttpResponseMessage>
+new ResiliencePipelineBuilder<HttpResponseMessage>().AddHedging(new()
+{
+    OnHedging = static args =>
     {
-        OnHedging = args =>
-        {
-            Console.WriteLine($"OnHedging: Attempt number {args.AttemptNumber}");
-            return default;
-        }
-    });
+        Console.WriteLine($"OnHedging: Attempt number {args.AttemptNumber}");
+        return default;
+    }
+});
 ```
 <!-- endSnippet -->
 

--- a/docs/strategies/hedging.md
+++ b/docs/strategies/hedging.md
@@ -19,14 +19,13 @@ This strategy also supports multiple [concurrency modes](#concurrency-modes) for
 
 <!-- snippet: hedging -->
 ```cs
-// Add hedging with default options.
+// Hedging with default options.
 // See https://www.pollydocs.org/strategies/hedging#defaults for defaults.
-new ResiliencePipelineBuilder<HttpResponseMessage>()
-    .AddHedging(new HedgingStrategyOptions<HttpResponseMessage>());
+var optionsDefaults = new HedgingStrategyOptions<HttpResponseMessage>();
 
-// Add a customized hedging strategy that retries up to 3 times if the execution
+// A customized hedging strategy that retries up to 3 times if the execution
 // takes longer than 1 second or if it fails due to an exception or returns an HTTP 500 Internal Server Error.
-new ResiliencePipelineBuilder<HttpResponseMessage>().AddHedging(new()
+var optionsComplex = new HedgingStrategyOptions<HttpResponseMessage>
 {
     ShouldHandle = new PredicateBuilder<HttpResponseMessage>()
         .Handle<SomeExceptionType>()
@@ -41,17 +40,20 @@ new ResiliencePipelineBuilder<HttpResponseMessage>().AddHedging(new()
         // Optionally, you can also create a completely new action to be executed.
         return () => args.Callback(args.ActionContext);
     }
-});
+};
 
 // Subscribe to hedging events.
-new ResiliencePipelineBuilder<HttpResponseMessage>().AddHedging(new()
+var optionsOnHedging = new HedgingStrategyOptions<HttpResponseMessage>
 {
     OnHedging = static args =>
     {
         Console.WriteLine($"OnHedging: Attempt number {args.AttemptNumber}");
         return default;
     }
-});
+};
+
+// Add a hedging strategy with a HedgingStrategyOptions<TResult> instance to the pipeline
+new ResiliencePipelineBuilder<HttpResponseMessage>().AddHedging(optionsDefaults);
 ```
 <!-- endSnippet -->
 

--- a/docs/strategies/rate-limiter.md
+++ b/docs/strategies/rate-limiter.md
@@ -24,20 +24,17 @@ Further reading:
 ```cs
 // Add rate limiter with default options.
 // See https://www.pollydocs.org/strategies/rate-limiter#defaults for defaults.
-new ResiliencePipelineBuilder()
-    .AddRateLimiter(new RateLimiterStrategyOptions());
+new ResiliencePipelineBuilder().AddRateLimiter(new RateLimiterStrategyOptions());
 
 // Create a rate limiter to allow a maximum of 100 concurrent executions and a queue of 50.
-new ResiliencePipelineBuilder()
-    .AddConcurrencyLimiter(100, 50);
+new ResiliencePipelineBuilder().AddConcurrencyLimiter(100, 50);
 
 // Create a rate limiter that allows 100 executions per minute.
-new ResiliencePipelineBuilder()
-    .AddRateLimiter(new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions
-    {
-        PermitLimit = 100,
-        Window = TimeSpan.FromMinutes(1)
-    }));
+new ResiliencePipelineBuilder().AddRateLimiter(new SlidingWindowRateLimiter(new()
+{
+    PermitLimit = 100,
+    Window = TimeSpan.FromMinutes(1)
+}));
 ```
 <!-- endSnippet -->
 

--- a/docs/strategies/rate-limiter.md
+++ b/docs/strategies/rate-limiter.md
@@ -24,17 +24,21 @@ Further reading:
 ```cs
 // Add rate limiter with default options.
 // See https://www.pollydocs.org/strategies/rate-limiter#defaults for defaults.
-new ResiliencePipelineBuilder().AddRateLimiter(new RateLimiterStrategyOptions());
+new ResiliencePipelineBuilder()
+    .AddRateLimiter(new RateLimiterStrategyOptions());
 
 // Create a rate limiter to allow a maximum of 100 concurrent executions and a queue of 50.
-new ResiliencePipelineBuilder().AddConcurrencyLimiter(100, 50);
+new ResiliencePipelineBuilder()
+    .AddConcurrencyLimiter(100, 50);
 
 // Create a rate limiter that allows 100 executions per minute.
-new ResiliencePipelineBuilder().AddRateLimiter(new SlidingWindowRateLimiter(new()
-{
-    PermitLimit = 100,
-    Window = TimeSpan.FromMinutes(1)
-}));
+new ResiliencePipelineBuilder()
+    .AddRateLimiter(new SlidingWindowRateLimiter(
+        new SlidingWindowRateLimiterOptions
+        {
+            PermitLimit = 100,
+            Window = TimeSpan.FromMinutes(1)
+        }));
 ```
 <!-- endSnippet -->
 

--- a/docs/strategies/retry.md
+++ b/docs/strategies/retry.md
@@ -19,14 +19,14 @@
 new ResiliencePipelineBuilder().AddRetry(new RetryStrategyOptions());
 
 // For instant retries with no delay
-new ResiliencePipelineBuilder().AddRetry(new RetryStrategyOptions
+new ResiliencePipelineBuilder().AddRetry(new()
 {
     Delay = TimeSpan.Zero
 });
 
 // For advanced control over the retry behavior, including the number of attempts,
 // delay between retries, and the types of exceptions to handle.
-new ResiliencePipelineBuilder().AddRetry(new RetryStrategyOptions
+new ResiliencePipelineBuilder().AddRetry(new()
 {
     ShouldHandle = new PredicateBuilder().Handle<SomeExceptionType>(),
     BackoffType = DelayBackoffType.Exponential,
@@ -36,10 +36,10 @@ new ResiliencePipelineBuilder().AddRetry(new RetryStrategyOptions
 });
 
 // To use a custom function to generate the delay for retries
-new ResiliencePipelineBuilder().AddRetry(new RetryStrategyOptions
+new ResiliencePipelineBuilder().AddRetry(new()
 {
     MaxRetryAttempts = 2,
-    DelayGenerator = args =>
+    DelayGenerator = static args =>
     {
         var delay = args.AttemptNumber switch
         {
@@ -55,9 +55,9 @@ new ResiliencePipelineBuilder().AddRetry(new RetryStrategyOptions
 });
 
 // To extract the delay from the result object
-new ResiliencePipelineBuilder<HttpResponseMessage>().AddRetry(new RetryStrategyOptions<HttpResponseMessage>
+new ResiliencePipelineBuilder<HttpResponseMessage>().AddRetry(new()
 {
-    DelayGenerator = args =>
+    DelayGenerator = static args =>
     {
         if (args.Outcome.Result is HttpResponseMessage responseMessage &&
             TryGetDelay(responseMessage, out TimeSpan delay))
@@ -71,10 +71,10 @@ new ResiliencePipelineBuilder<HttpResponseMessage>().AddRetry(new RetryStrategyO
 });
 
 // To get notifications when a retry is performed
-new ResiliencePipelineBuilder().AddRetry(new RetryStrategyOptions
+new ResiliencePipelineBuilder().AddRetry(new()
 {
     MaxRetryAttempts = 2,
-    OnRetry = args =>
+    OnRetry = static args =>
     {
         Console.WriteLine("OnRetry, Attempt: {0}", args.AttemptNumber);
 
@@ -84,7 +84,7 @@ new ResiliencePipelineBuilder().AddRetry(new RetryStrategyOptions
 });
 
 // To keep retrying indefinitely or until success use int.MaxValue.
-new ResiliencePipelineBuilder().AddRetry(new RetryStrategyOptions
+new ResiliencePipelineBuilder().AddRetry(new()
 {
     MaxRetryAttempts = int.MaxValue,
 });

--- a/docs/strategies/retry.md
+++ b/docs/strategies/retry.md
@@ -14,29 +14,29 @@
 
 <!-- snippet: Retry -->
 ```cs
-// Add retry using the default options.
+// Retry using the default options.
 // See https://www.pollydocs.org/strategies/retry#defaults for defaults.
-new ResiliencePipelineBuilder().AddRetry(new RetryStrategyOptions());
+var optionsDefaults = new RetryStrategyOptions();
 
 // For instant retries with no delay
-new ResiliencePipelineBuilder().AddRetry(new()
+var optionsNoDelay = new RetryStrategyOptions
 {
     Delay = TimeSpan.Zero
-});
+};
 
 // For advanced control over the retry behavior, including the number of attempts,
 // delay between retries, and the types of exceptions to handle.
-new ResiliencePipelineBuilder().AddRetry(new()
+var optionsComplex = new RetryStrategyOptions
 {
     ShouldHandle = new PredicateBuilder().Handle<SomeExceptionType>(),
     BackoffType = DelayBackoffType.Exponential,
     UseJitter = true,  // Adds a random factor to the delay
     MaxRetryAttempts = 4,
     Delay = TimeSpan.FromSeconds(3),
-});
+};
 
 // To use a custom function to generate the delay for retries
-new ResiliencePipelineBuilder().AddRetry(new()
+var optionsDelayGenerator = new RetryStrategyOptions
 {
     MaxRetryAttempts = 2,
     DelayGenerator = static args =>
@@ -52,10 +52,10 @@ new ResiliencePipelineBuilder().AddRetry(new()
         // but the API also supports asynchronous implementations.
         return new ValueTask<TimeSpan?>(delay);
     }
-});
+};
 
 // To extract the delay from the result object
-new ResiliencePipelineBuilder<HttpResponseMessage>().AddRetry(new()
+var optionsExtractDelay = new RetryStrategyOptions<HttpResponseMessage>
 {
     DelayGenerator = static args =>
     {
@@ -68,10 +68,10 @@ new ResiliencePipelineBuilder<HttpResponseMessage>().AddRetry(new()
         // Returning null means the retry strategy will use its internal delay for this attempt.
         return new ValueTask<TimeSpan?>((TimeSpan?)null);
     }
-});
+};
 
 // To get notifications when a retry is performed
-new ResiliencePipelineBuilder().AddRetry(new()
+var optionsOnRetry = new RetryStrategyOptions
 {
     MaxRetryAttempts = 2,
     OnRetry = static args =>
@@ -81,13 +81,17 @@ new ResiliencePipelineBuilder().AddRetry(new()
         // Event handlers can be asynchronous; here, we return an empty ValueTask.
         return default;
     }
-});
+};
 
 // To keep retrying indefinitely or until success use int.MaxValue.
-new ResiliencePipelineBuilder().AddRetry(new()
+var optionsIndefiniteRetry = new RetryStrategyOptions
 {
     MaxRetryAttempts = int.MaxValue,
-});
+};
+
+// Add a retry strategy with a RetryStrategyOptions{<TResult>} instance to the pipeline
+new ResiliencePipelineBuilder().AddRetry(optionsDefaults);
+new ResiliencePipelineBuilder<HttpResponseMessage>().AddRetry(optionsExtractDelay);
 ```
 <!-- endSnippet -->
 

--- a/docs/strategies/timeout.md
+++ b/docs/strategies/timeout.md
@@ -14,25 +14,25 @@
 
 <!-- snippet: timeout -->
 ```cs
-// Add timeout using the default options.
-// See https://www.pollydocs.org/strategies/timeout#defaults for defaults.
-new ResiliencePipelineBuilder().AddTimeout(new TimeoutStrategyOptions());
-
 // To add a timeout with a custom TimeSpan duration
 new ResiliencePipelineBuilder().AddTimeout(TimeSpan.FromSeconds(3));
 
+// Timeout using the default options.
+// See https://www.pollydocs.org/strategies/timeout#defaults for defaults.
+var optionsDefaults = new TimeoutStrategyOptions();
+
 // To add a timeout using a custom timeout generator function
-new ResiliencePipelineBuilder().AddTimeout(new TimeoutStrategyOptions
+var optionsTimeoutGenerator = new TimeoutStrategyOptions
 {
     TimeoutGenerator = static args =>
     {
         // Note: the timeout generator supports asynchronous operations
         return new ValueTask<TimeSpan>(TimeSpan.FromSeconds(123));
     }
-});
+};
 
 // To add a timeout and listen for timeout events
-new ResiliencePipelineBuilder().AddTimeout(new TimeoutStrategyOptions
+var optionsOnTimeout = new TimeoutStrategyOptions
 {
     TimeoutGenerator = static args =>
     {
@@ -44,7 +44,10 @@ new ResiliencePipelineBuilder().AddTimeout(new TimeoutStrategyOptions
         Console.WriteLine($"{args.Context.OperationKey}: Execution timed out after {args.Timeout.TotalSeconds} seconds.");
         return default;
     }
-});
+};
+
+// Add a timeout strategy with a TimeoutStrategyOptions instance to the pipeline
+new ResiliencePipelineBuilder().AddTimeout(optionsDefaults);
 ```
 <!-- endSnippet -->
 

--- a/docs/strategies/timeout.md
+++ b/docs/strategies/timeout.md
@@ -16,39 +16,35 @@
 ```cs
 // Add timeout using the default options.
 // See https://www.pollydocs.org/strategies/timeout#defaults for defaults.
-new ResiliencePipelineBuilder()
-    .AddTimeout(new TimeoutStrategyOptions());
+new ResiliencePipelineBuilder().AddTimeout(new TimeoutStrategyOptions());
 
 // To add a timeout with a custom TimeSpan duration
-new ResiliencePipelineBuilder()
-    .AddTimeout(TimeSpan.FromSeconds(3));
+new ResiliencePipelineBuilder().AddTimeout(TimeSpan.FromSeconds(3));
 
 // To add a timeout using a custom timeout generator function
-new ResiliencePipelineBuilder()
-    .AddTimeout(new TimeoutStrategyOptions
+new ResiliencePipelineBuilder().AddTimeout(new TimeoutStrategyOptions
+{
+    TimeoutGenerator = static args =>
     {
-        TimeoutGenerator = args =>
-        {
-            // Note: the timeout generator supports asynchronous operations
-            return new ValueTask<TimeSpan>(TimeSpan.FromSeconds(123));
-        }
-    });
+        // Note: the timeout generator supports asynchronous operations
+        return new ValueTask<TimeSpan>(TimeSpan.FromSeconds(123));
+    }
+});
 
 // To add a timeout and listen for timeout events
-new ResiliencePipelineBuilder()
-    .AddTimeout(new TimeoutStrategyOptions
+new ResiliencePipelineBuilder().AddTimeout(new TimeoutStrategyOptions
+{
+    TimeoutGenerator = static args =>
     {
-        TimeoutGenerator = args =>
-        {
-            // Note: the timeout generator supports asynchronous operations
-            return new ValueTask<TimeSpan>(TimeSpan.FromSeconds(123));
-        },
-        OnTimeout = args =>
-        {
-            Console.WriteLine($"{args.Context.OperationKey}: Execution timed out after {args.Timeout.TotalSeconds} seconds.");
-            return default;
-        }
-    });
+        // Note: the timeout generator supports asynchronous operations
+        return new ValueTask<TimeSpan>(TimeSpan.FromSeconds(123));
+    },
+    OnTimeout = static args =>
+    {
+        Console.WriteLine($"{args.Context.OperationKey}: Execution timed out after {args.Timeout.TotalSeconds} seconds.");
+        return default;
+    }
+});
 ```
 <!-- endSnippet -->
 

--- a/src/Polly.RateLimiting/README.md
+++ b/src/Polly.RateLimiting/README.md
@@ -14,19 +14,16 @@ See [the documentation](https://www.pollydocs.org/strategies/rate-limiter) for m
 ```cs
 // Add rate limiter with default options.
 // See https://www.pollydocs.org/strategies/rate-limiter#defaults for defaults.
-new ResiliencePipelineBuilder()
-    .AddRateLimiter(new RateLimiterStrategyOptions());
+new ResiliencePipelineBuilder().AddRateLimiter(new RateLimiterStrategyOptions());
 
 // Create a rate limiter to allow a maximum of 100 concurrent executions and a queue of 50.
-new ResiliencePipelineBuilder()
-    .AddConcurrencyLimiter(100, 50);
+new ResiliencePipelineBuilder().AddConcurrencyLimiter(100, 50);
 
 // Create a rate limiter that allows 100 executions per minute.
-new ResiliencePipelineBuilder()
-    .AddRateLimiter(new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions
-    {
-        PermitLimit = 100,
-        Window = TimeSpan.FromMinutes(1)
-    }));
+new ResiliencePipelineBuilder().AddRateLimiter(new SlidingWindowRateLimiter(new()
+{
+    PermitLimit = 100,
+    Window = TimeSpan.FromMinutes(1)
+}));
 ```
 <!-- endSnippet -->

--- a/src/Polly.RateLimiting/README.md
+++ b/src/Polly.RateLimiting/README.md
@@ -14,16 +14,20 @@ See [the documentation](https://www.pollydocs.org/strategies/rate-limiter) for m
 ```cs
 // Add rate limiter with default options.
 // See https://www.pollydocs.org/strategies/rate-limiter#defaults for defaults.
-new ResiliencePipelineBuilder().AddRateLimiter(new RateLimiterStrategyOptions());
+new ResiliencePipelineBuilder()
+    .AddRateLimiter(new RateLimiterStrategyOptions());
 
 // Create a rate limiter to allow a maximum of 100 concurrent executions and a queue of 50.
-new ResiliencePipelineBuilder().AddConcurrencyLimiter(100, 50);
+new ResiliencePipelineBuilder()
+    .AddConcurrencyLimiter(100, 50);
 
 // Create a rate limiter that allows 100 executions per minute.
-new ResiliencePipelineBuilder().AddRateLimiter(new SlidingWindowRateLimiter(new()
-{
-    PermitLimit = 100,
-    Window = TimeSpan.FromMinutes(1)
-}));
+new ResiliencePipelineBuilder()
+    .AddRateLimiter(new SlidingWindowRateLimiter(
+        new SlidingWindowRateLimiterOptions
+        {
+            PermitLimit = 100,
+            Window = TimeSpan.FromMinutes(1)
+        }));
 ```
 <!-- endSnippet -->

--- a/src/Snippets/Docs/CircuitBreaker.cs
+++ b/src/Snippets/Docs/CircuitBreaker.cs
@@ -11,37 +11,38 @@ internal static class CircuitBreaker
     {
         #region circuit-breaker
 
-        // Add circuit breaker with default options.
+        // Circuit breaker with default options.
         // See https://www.pollydocs.org/strategies/circuit-breaker#defaults for defaults.
-        new ResiliencePipelineBuilder().AddCircuitBreaker(new CircuitBreakerStrategyOptions());
+        var optionsDefaults = new CircuitBreakerStrategyOptions();
 
-        // Add circuit breaker with customized options:
+        // Circuit breaker with customized options:
         // The circuit will break if more than 50% of actions result in handled exceptions,
         // within any 10-second sampling duration, and at least 8 actions are processed.
-        new ResiliencePipelineBuilder().AddCircuitBreaker(new()
+        var optionsComplex = new CircuitBreakerStrategyOptions
         {
             FailureRatio = 0.5,
             SamplingDuration = TimeSpan.FromSeconds(10),
             MinimumThroughput = 8,
             BreakDuration = TimeSpan.FromSeconds(30),
             ShouldHandle = new PredicateBuilder().Handle<SomeExceptionType>()
-        });
+        };
 
         // Handle specific failed results for HttpResponseMessage:
-        new ResiliencePipelineBuilder<HttpResponseMessage>().AddCircuitBreaker(new()
+        var optionsShouldHandle = new CircuitBreakerStrategyOptions<HttpResponseMessage>
         {
             ShouldHandle = new PredicateBuilder<HttpResponseMessage>()
                 .Handle<SomeExceptionType>()
                 .HandleResult(response => response.StatusCode == HttpStatusCode.InternalServerError)
-        });
+        };
 
         // Monitor the circuit state, useful for health reporting:
         var stateProvider = new CircuitBreakerStateProvider();
-
-        new ResiliencePipelineBuilder<HttpResponseMessage>().AddCircuitBreaker(new()
+        var optionsStateProvider = new CircuitBreakerStrategyOptions<HttpResponseMessage>
         {
             StateProvider = stateProvider
-        });
+        };
+
+        var circuitState = stateProvider.CircuitState;
 
         /*
         CircuitState.Closed - Normal operation; actions are executed.
@@ -52,17 +53,20 @@ internal static class CircuitBreaker
 
         // Manually control the Circuit Breaker state:
         var manualControl = new CircuitBreakerManualControl();
-
-        new ResiliencePipelineBuilder().AddCircuitBreaker(new()
+        var optionsManualControl = new CircuitBreakerStrategyOptions
         {
             ManualControl = manualControl
-        });
+        };
 
         // Manually isolate a circuit, e.g., to isolate a downstream service.
         await manualControl.IsolateAsync();
 
         // Manually close the circuit to allow actions to be executed again.
         await manualControl.CloseAsync();
+
+        // Add a circuit breaker strategy with a CircuitBreakerStrategyOptions{<TResult>} instance to the pipeline
+        new ResiliencePipelineBuilder().AddCircuitBreaker(optionsDefaults);
+        new ResiliencePipelineBuilder<HttpResponseMessage>().AddCircuitBreaker(optionsStateProvider);
 
         #endregion
     }

--- a/src/Snippets/Docs/CircuitBreaker.cs
+++ b/src/Snippets/Docs/CircuitBreaker.cs
@@ -16,10 +16,9 @@ internal static class CircuitBreaker
         new ResiliencePipelineBuilder().AddCircuitBreaker(new CircuitBreakerStrategyOptions());
 
         // Add circuit breaker with customized options:
-        //
         // The circuit will break if more than 50% of actions result in handled exceptions,
         // within any 10-second sampling duration, and at least 8 actions are processed.
-        new ResiliencePipelineBuilder().AddCircuitBreaker(new CircuitBreakerStrategyOptions
+        new ResiliencePipelineBuilder().AddCircuitBreaker(new()
         {
             FailureRatio = 0.5,
             SamplingDuration = TimeSpan.FromSeconds(10),
@@ -29,20 +28,20 @@ internal static class CircuitBreaker
         });
 
         // Handle specific failed results for HttpResponseMessage:
-        new ResiliencePipelineBuilder<HttpResponseMessage>()
-            .AddCircuitBreaker(new CircuitBreakerStrategyOptions<HttpResponseMessage>
-            {
-                ShouldHandle = new PredicateBuilder<HttpResponseMessage>()
-                    .Handle<SomeExceptionType>()
-                    .HandleResult(response => response.StatusCode == HttpStatusCode.InternalServerError)
-            });
+        new ResiliencePipelineBuilder<HttpResponseMessage>().AddCircuitBreaker(new()
+        {
+            ShouldHandle = new PredicateBuilder<HttpResponseMessage>()
+                .Handle<SomeExceptionType>()
+                .HandleResult(response => response.StatusCode == HttpStatusCode.InternalServerError)
+        });
 
         // Monitor the circuit state, useful for health reporting:
         var stateProvider = new CircuitBreakerStateProvider();
 
-        new ResiliencePipelineBuilder<HttpResponseMessage>()
-            .AddCircuitBreaker(new() { StateProvider = stateProvider })
-            .Build();
+        new ResiliencePipelineBuilder<HttpResponseMessage>().AddCircuitBreaker(new()
+        {
+            StateProvider = stateProvider
+        });
 
         /*
         CircuitState.Closed - Normal operation; actions are executed.
@@ -54,9 +53,10 @@ internal static class CircuitBreaker
         // Manually control the Circuit Breaker state:
         var manualControl = new CircuitBreakerManualControl();
 
-        new ResiliencePipelineBuilder()
-            .AddCircuitBreaker(new() { ManualControl = manualControl })
-            .Build();
+        new ResiliencePipelineBuilder().AddCircuitBreaker(new()
+        {
+            ManualControl = manualControl
+        });
 
         // Manually isolate a circuit, e.g., to isolate a downstream service.
         await manualControl.IsolateAsync();

--- a/src/Snippets/Docs/Fallback.cs
+++ b/src/Snippets/Docs/Fallback.cs
@@ -11,17 +11,17 @@ internal static class Fallback
     {
         #region fallback
 
-        // Add a fallback/substitute value if an operation fails.
-        new ResiliencePipelineBuilder<UserAvatar>().AddFallback(new FallbackStrategyOptions<UserAvatar>
+        // A fallback/substitute value if an operation fails.
+        var optionsSubstitute = new FallbackStrategyOptions<UserAvatar>
         {
             ShouldHandle = new PredicateBuilder<UserAvatar>()
                 .Handle<SomeExceptionType>()
                 .HandleResult(r => r is null),
             FallbackAction = static args => Outcome.FromResultAsValueTask(UserAvatar.Blank)
-        });
+        };
 
         // Use a dynamically generated value if an operation fails.
-        new ResiliencePipelineBuilder<UserAvatar>().AddFallback(new()
+        var optionsFallbackAction = new FallbackStrategyOptions<UserAvatar>
         {
             ShouldHandle = new PredicateBuilder<UserAvatar>()
                 .Handle<SomeExceptionType>()
@@ -31,10 +31,10 @@ internal static class Fallback
                 var avatar = UserAvatar.GetRandomAvatar();
                 return Outcome.FromResultAsValueTask(avatar);
             }
-        });
+        };
 
         // Use a default or dynamically generated value, and execute an additional action if the fallback is triggered.
-        new ResiliencePipelineBuilder<UserAvatar>().AddFallback(new()
+        var optionsOnFallback = new FallbackStrategyOptions<UserAvatar>
         {
             ShouldHandle = new PredicateBuilder<UserAvatar>()
                 .Handle<SomeExceptionType>()
@@ -49,7 +49,10 @@ internal static class Fallback
                 // Add extra logic to be executed when the fallback is triggered, such as logging.
                 return default; // Returns an empty ValueTask
             }
-        });
+        };
+
+        // Add a fallback strategy with a FallbackStrategyOptions<TResult> instance to the pipeline
+        new ResiliencePipelineBuilder<UserAvatar>().AddFallback(optionsOnFallback);
 
         #endregion
     }

--- a/src/Snippets/Docs/Fallback.cs
+++ b/src/Snippets/Docs/Fallback.cs
@@ -12,47 +12,44 @@ internal static class Fallback
         #region fallback
 
         // Add a fallback/substitute value if an operation fails.
-        new ResiliencePipelineBuilder<UserAvatar>()
-            .AddFallback(new FallbackStrategyOptions<UserAvatar>
-            {
-                ShouldHandle = new PredicateBuilder<UserAvatar>()
-                    .Handle<SomeExceptionType>()
-                    .HandleResult(r => r is null),
-                FallbackAction = args => Outcome.FromResultAsValueTask(UserAvatar.Blank)
-            });
+        new ResiliencePipelineBuilder<UserAvatar>().AddFallback(new FallbackStrategyOptions<UserAvatar>
+        {
+            ShouldHandle = new PredicateBuilder<UserAvatar>()
+                .Handle<SomeExceptionType>()
+                .HandleResult(r => r is null),
+            FallbackAction = static args => Outcome.FromResultAsValueTask(UserAvatar.Blank)
+        });
 
         // Use a dynamically generated value if an operation fails.
-        new ResiliencePipelineBuilder<UserAvatar>()
-            .AddFallback(new FallbackStrategyOptions<UserAvatar>
+        new ResiliencePipelineBuilder<UserAvatar>().AddFallback(new()
+        {
+            ShouldHandle = new PredicateBuilder<UserAvatar>()
+                .Handle<SomeExceptionType>()
+                .HandleResult(r => r is null),
+            FallbackAction = static args =>
             {
-                ShouldHandle = new PredicateBuilder<UserAvatar>()
-                    .Handle<SomeExceptionType>()
-                    .HandleResult(r => r is null),
-                FallbackAction = args =>
-                {
-                    var avatar = UserAvatar.GetRandomAvatar();
-                    return Outcome.FromResultAsValueTask(avatar);
-                }
-            });
+                var avatar = UserAvatar.GetRandomAvatar();
+                return Outcome.FromResultAsValueTask(avatar);
+            }
+        });
 
         // Use a default or dynamically generated value, and execute an additional action if the fallback is triggered.
-        new ResiliencePipelineBuilder<UserAvatar>()
-            .AddFallback(new FallbackStrategyOptions<UserAvatar>
+        new ResiliencePipelineBuilder<UserAvatar>().AddFallback(new()
+        {
+            ShouldHandle = new PredicateBuilder<UserAvatar>()
+                .Handle<SomeExceptionType>()
+                .HandleResult(r => r is null),
+            FallbackAction = static args =>
             {
-                ShouldHandle = new PredicateBuilder<UserAvatar>()
-                    .Handle<SomeExceptionType>()
-                    .HandleResult(r => r is null),
-                FallbackAction = args =>
-                {
-                    var avatar = UserAvatar.GetRandomAvatar();
-                    return Outcome.FromResultAsValueTask(UserAvatar.Blank);
-                },
-                OnFallback = args =>
-                {
-                    // Add extra logic to be executed when the fallback is triggered, such as logging.
-                    return default; // Returns an empty ValueTask
-                }
-            });
+                var avatar = UserAvatar.GetRandomAvatar();
+                return Outcome.FromResultAsValueTask(UserAvatar.Blank);
+            },
+            OnFallback = static args =>
+            {
+                // Add extra logic to be executed when the fallback is triggered, such as logging.
+                return default; // Returns an empty ValueTask
+            }
+        });
 
         #endregion
     }

--- a/src/Snippets/Docs/Hedging.cs
+++ b/src/Snippets/Docs/Hedging.cs
@@ -13,14 +13,13 @@ internal static class Hedging
     {
         #region hedging
 
-        // Add hedging with default options.
+        // Hedging with default options.
         // See https://www.pollydocs.org/strategies/hedging#defaults for defaults.
-        new ResiliencePipelineBuilder<HttpResponseMessage>()
-            .AddHedging(new HedgingStrategyOptions<HttpResponseMessage>());
+        var optionsDefaults = new HedgingStrategyOptions<HttpResponseMessage>();
 
-        // Add a customized hedging strategy that retries up to 3 times if the execution
+        // A customized hedging strategy that retries up to 3 times if the execution
         // takes longer than 1 second or if it fails due to an exception or returns an HTTP 500 Internal Server Error.
-        new ResiliencePipelineBuilder<HttpResponseMessage>().AddHedging(new()
+        var optionsComplex = new HedgingStrategyOptions<HttpResponseMessage>
         {
             ShouldHandle = new PredicateBuilder<HttpResponseMessage>()
                 .Handle<SomeExceptionType>()
@@ -35,17 +34,20 @@ internal static class Hedging
                 // Optionally, you can also create a completely new action to be executed.
                 return () => args.Callback(args.ActionContext);
             }
-        });
+        };
 
         // Subscribe to hedging events.
-        new ResiliencePipelineBuilder<HttpResponseMessage>().AddHedging(new()
+        var optionsOnHedging = new HedgingStrategyOptions<HttpResponseMessage>
         {
             OnHedging = static args =>
             {
                 Console.WriteLine($"OnHedging: Attempt number {args.AttemptNumber}");
                 return default;
             }
-        });
+        };
+
+        // Add a hedging strategy with a HedgingStrategyOptions<TResult> instance to the pipeline
+        new ResiliencePipelineBuilder<HttpResponseMessage>().AddHedging(optionsDefaults);
 
         #endregion
     }

--- a/src/Snippets/Docs/Hedging.cs
+++ b/src/Snippets/Docs/Hedging.cs
@@ -20,34 +20,32 @@ internal static class Hedging
 
         // Add a customized hedging strategy that retries up to 3 times if the execution
         // takes longer than 1 second or if it fails due to an exception or returns an HTTP 500 Internal Server Error.
-        new ResiliencePipelineBuilder<HttpResponseMessage>()
-            .AddHedging(new HedgingStrategyOptions<HttpResponseMessage>
+        new ResiliencePipelineBuilder<HttpResponseMessage>().AddHedging(new()
+        {
+            ShouldHandle = new PredicateBuilder<HttpResponseMessage>()
+                .Handle<SomeExceptionType>()
+                .HandleResult(response => response.StatusCode == HttpStatusCode.InternalServerError),
+            MaxHedgedAttempts = 3,
+            Delay = TimeSpan.FromSeconds(1),
+            ActionGenerator = static args =>
             {
-                ShouldHandle = new PredicateBuilder<HttpResponseMessage>()
-                    .Handle<SomeExceptionType>()
-                    .HandleResult(response => response.StatusCode == HttpStatusCode.InternalServerError),
-                MaxHedgedAttempts = 3,
-                Delay = TimeSpan.FromSeconds(1),
-                ActionGenerator = args =>
-                {
-                    Console.WriteLine("Preparing to execute hedged action.");
+                Console.WriteLine("Preparing to execute hedged action.");
 
-                    // Return a delegate function to invoke the original action with the action context.
-                    // Optionally, you can also create a completely new action to be executed.
-                    return () => args.Callback(args.ActionContext);
-                }
-            });
+                // Return a delegate function to invoke the original action with the action context.
+                // Optionally, you can also create a completely new action to be executed.
+                return () => args.Callback(args.ActionContext);
+            }
+        });
 
         // Subscribe to hedging events.
-        new ResiliencePipelineBuilder<HttpResponseMessage>()
-            .AddHedging(new HedgingStrategyOptions<HttpResponseMessage>
+        new ResiliencePipelineBuilder<HttpResponseMessage>().AddHedging(new()
+        {
+            OnHedging = static args =>
             {
-                OnHedging = args =>
-                {
-                    Console.WriteLine($"OnHedging: Attempt number {args.AttemptNumber}");
-                    return default;
-                }
-            });
+                Console.WriteLine($"OnHedging: Attempt number {args.AttemptNumber}");
+                return default;
+            }
+        });
 
         #endregion
     }

--- a/src/Snippets/Docs/RateLimiter.cs
+++ b/src/Snippets/Docs/RateLimiter.cs
@@ -12,17 +12,21 @@ internal static class RateLimiter
 
         // Add rate limiter with default options.
         // See https://www.pollydocs.org/strategies/rate-limiter#defaults for defaults.
-        new ResiliencePipelineBuilder().AddRateLimiter(new RateLimiterStrategyOptions());
+        new ResiliencePipelineBuilder()
+            .AddRateLimiter(new RateLimiterStrategyOptions());
 
         // Create a rate limiter to allow a maximum of 100 concurrent executions and a queue of 50.
-        new ResiliencePipelineBuilder().AddConcurrencyLimiter(100, 50);
+        new ResiliencePipelineBuilder()
+            .AddConcurrencyLimiter(100, 50);
 
         // Create a rate limiter that allows 100 executions per minute.
-        new ResiliencePipelineBuilder().AddRateLimiter(new SlidingWindowRateLimiter(new()
-        {
-            PermitLimit = 100,
-            Window = TimeSpan.FromMinutes(1)
-        }));
+        new ResiliencePipelineBuilder()
+            .AddRateLimiter(new SlidingWindowRateLimiter(
+                new SlidingWindowRateLimiterOptions
+                {
+                    PermitLimit = 100,
+                    Window = TimeSpan.FromMinutes(1)
+                }));
 
         #endregion
 

--- a/src/Snippets/Docs/RateLimiter.cs
+++ b/src/Snippets/Docs/RateLimiter.cs
@@ -12,20 +12,17 @@ internal static class RateLimiter
 
         // Add rate limiter with default options.
         // See https://www.pollydocs.org/strategies/rate-limiter#defaults for defaults.
-        new ResiliencePipelineBuilder()
-            .AddRateLimiter(new RateLimiterStrategyOptions());
+        new ResiliencePipelineBuilder().AddRateLimiter(new RateLimiterStrategyOptions());
 
         // Create a rate limiter to allow a maximum of 100 concurrent executions and a queue of 50.
-        new ResiliencePipelineBuilder()
-            .AddConcurrencyLimiter(100, 50);
+        new ResiliencePipelineBuilder().AddConcurrencyLimiter(100, 50);
 
         // Create a rate limiter that allows 100 executions per minute.
-        new ResiliencePipelineBuilder()
-            .AddRateLimiter(new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions
-            {
-                PermitLimit = 100,
-                Window = TimeSpan.FromMinutes(1)
-            }));
+        new ResiliencePipelineBuilder().AddRateLimiter(new SlidingWindowRateLimiter(new()
+        {
+            PermitLimit = 100,
+            Window = TimeSpan.FromMinutes(1)
+        }));
 
         #endregion
 

--- a/src/Snippets/Docs/Readme.cs
+++ b/src/Snippets/Docs/Readme.cs
@@ -19,7 +19,7 @@ internal static class Readme
             .Build(); // Builds the resilience pipeline
 
         // Execute the pipeline asynchronously
-        await pipeline.ExecuteAsync(static async cancellationToken => { /*Your custom logic here */ }, cancellationToken);
+        await pipeline.ExecuteAsync(static async token => { /*Your custom logic goes here */ }, cancellationToken);
 
         #endregion
     }
@@ -39,7 +39,7 @@ internal static class Readme
         });
 
         // Build the service provider
-        IServiceProvider serviceProvider = services.BuildServiceProvider();
+        var serviceProvider = services.BuildServiceProvider();
 
         // Retrieve ResiliencePipelineProvider that caches and dynamically creates the resilience pipelines
         var pipelineProvider = serviceProvider.GetRequiredService<ResiliencePipelineProvider<string>>();
@@ -50,7 +50,7 @@ internal static class Readme
         // Execute the pipeline
         await pipeline.ExecuteAsync(static async token =>
         {
-            // Your custom logic here
+            // Your custom logic goes here
         });
 
         #endregion

--- a/src/Snippets/Docs/Retry.cs
+++ b/src/Snippets/Docs/Retry.cs
@@ -17,29 +17,29 @@ internal static class Retry
     {
         #region retry
 
-        // Add retry using the default options.
+        // Retry using the default options.
         // See https://www.pollydocs.org/strategies/retry#defaults for defaults.
-        new ResiliencePipelineBuilder().AddRetry(new RetryStrategyOptions());
+        var optionsDefaults = new RetryStrategyOptions();
 
         // For instant retries with no delay
-        new ResiliencePipelineBuilder().AddRetry(new()
+        var optionsNoDelay = new RetryStrategyOptions
         {
             Delay = TimeSpan.Zero
-        });
+        };
 
         // For advanced control over the retry behavior, including the number of attempts,
         // delay between retries, and the types of exceptions to handle.
-        new ResiliencePipelineBuilder().AddRetry(new()
+        var optionsComplex = new RetryStrategyOptions
         {
             ShouldHandle = new PredicateBuilder().Handle<SomeExceptionType>(),
             BackoffType = DelayBackoffType.Exponential,
             UseJitter = true,  // Adds a random factor to the delay
             MaxRetryAttempts = 4,
             Delay = TimeSpan.FromSeconds(3),
-        });
+        };
 
         // To use a custom function to generate the delay for retries
-        new ResiliencePipelineBuilder().AddRetry(new()
+        var optionsDelayGenerator = new RetryStrategyOptions
         {
             MaxRetryAttempts = 2,
             DelayGenerator = static args =>
@@ -55,10 +55,10 @@ internal static class Retry
                 // but the API also supports asynchronous implementations.
                 return new ValueTask<TimeSpan?>(delay);
             }
-        });
+        };
 
         // To extract the delay from the result object
-        new ResiliencePipelineBuilder<HttpResponseMessage>().AddRetry(new()
+        var optionsExtractDelay = new RetryStrategyOptions<HttpResponseMessage>
         {
             DelayGenerator = static args =>
             {
@@ -71,10 +71,10 @@ internal static class Retry
                 // Returning null means the retry strategy will use its internal delay for this attempt.
                 return new ValueTask<TimeSpan?>((TimeSpan?)null);
             }
-        });
+        };
 
         // To get notifications when a retry is performed
-        new ResiliencePipelineBuilder().AddRetry(new()
+        var optionsOnRetry = new RetryStrategyOptions
         {
             MaxRetryAttempts = 2,
             OnRetry = static args =>
@@ -84,13 +84,17 @@ internal static class Retry
                 // Event handlers can be asynchronous; here, we return an empty ValueTask.
                 return default;
             }
-        });
+        };
 
         // To keep retrying indefinitely or until success use int.MaxValue.
-        new ResiliencePipelineBuilder().AddRetry(new()
+        var optionsIndefiniteRetry = new RetryStrategyOptions
         {
             MaxRetryAttempts = int.MaxValue,
-        });
+        };
+
+        // Add a retry strategy with a RetryStrategyOptions{<TResult>} instance to the pipeline
+        new ResiliencePipelineBuilder().AddRetry(optionsDefaults);
+        new ResiliencePipelineBuilder<HttpResponseMessage>().AddRetry(optionsExtractDelay);
 
         #endregion
     }

--- a/src/Snippets/Docs/Retry.cs
+++ b/src/Snippets/Docs/Retry.cs
@@ -22,14 +22,14 @@ internal static class Retry
         new ResiliencePipelineBuilder().AddRetry(new RetryStrategyOptions());
 
         // For instant retries with no delay
-        new ResiliencePipelineBuilder().AddRetry(new RetryStrategyOptions
+        new ResiliencePipelineBuilder().AddRetry(new()
         {
             Delay = TimeSpan.Zero
         });
 
         // For advanced control over the retry behavior, including the number of attempts,
         // delay between retries, and the types of exceptions to handle.
-        new ResiliencePipelineBuilder().AddRetry(new RetryStrategyOptions
+        new ResiliencePipelineBuilder().AddRetry(new()
         {
             ShouldHandle = new PredicateBuilder().Handle<SomeExceptionType>(),
             BackoffType = DelayBackoffType.Exponential,
@@ -39,10 +39,10 @@ internal static class Retry
         });
 
         // To use a custom function to generate the delay for retries
-        new ResiliencePipelineBuilder().AddRetry(new RetryStrategyOptions
+        new ResiliencePipelineBuilder().AddRetry(new()
         {
             MaxRetryAttempts = 2,
-            DelayGenerator = args =>
+            DelayGenerator = static args =>
             {
                 var delay = args.AttemptNumber switch
                 {
@@ -58,9 +58,9 @@ internal static class Retry
         });
 
         // To extract the delay from the result object
-        new ResiliencePipelineBuilder<HttpResponseMessage>().AddRetry(new RetryStrategyOptions<HttpResponseMessage>
+        new ResiliencePipelineBuilder<HttpResponseMessage>().AddRetry(new()
         {
-            DelayGenerator = args =>
+            DelayGenerator = static args =>
             {
                 if (args.Outcome.Result is HttpResponseMessage responseMessage &&
                     TryGetDelay(responseMessage, out TimeSpan delay))
@@ -74,10 +74,10 @@ internal static class Retry
         });
 
         // To get notifications when a retry is performed
-        new ResiliencePipelineBuilder().AddRetry(new RetryStrategyOptions
+        new ResiliencePipelineBuilder().AddRetry(new()
         {
             MaxRetryAttempts = 2,
-            OnRetry = args =>
+            OnRetry = static args =>
             {
                 Console.WriteLine("OnRetry, Attempt: {0}", args.AttemptNumber);
 
@@ -87,7 +87,7 @@ internal static class Retry
         });
 
         // To keep retrying indefinitely or until success use int.MaxValue.
-        new ResiliencePipelineBuilder().AddRetry(new RetryStrategyOptions
+        new ResiliencePipelineBuilder().AddRetry(new()
         {
             MaxRetryAttempts = int.MaxValue,
         });

--- a/src/Snippets/Docs/Timeout.cs
+++ b/src/Snippets/Docs/Timeout.cs
@@ -9,25 +9,25 @@ internal static class Timeout
     {
         #region timeout
 
-        // Add timeout using the default options.
-        // See https://www.pollydocs.org/strategies/timeout#defaults for defaults.
-        new ResiliencePipelineBuilder().AddTimeout(new TimeoutStrategyOptions());
-
         // To add a timeout with a custom TimeSpan duration
         new ResiliencePipelineBuilder().AddTimeout(TimeSpan.FromSeconds(3));
 
+        // Timeout using the default options.
+        // See https://www.pollydocs.org/strategies/timeout#defaults for defaults.
+        var optionsDefaults = new TimeoutStrategyOptions();
+
         // To add a timeout using a custom timeout generator function
-        new ResiliencePipelineBuilder().AddTimeout(new TimeoutStrategyOptions
+        var optionsTimeoutGenerator = new TimeoutStrategyOptions
         {
             TimeoutGenerator = static args =>
             {
                 // Note: the timeout generator supports asynchronous operations
                 return new ValueTask<TimeSpan>(TimeSpan.FromSeconds(123));
             }
-        });
+        };
 
         // To add a timeout and listen for timeout events
-        new ResiliencePipelineBuilder().AddTimeout(new TimeoutStrategyOptions
+        var optionsOnTimeout = new TimeoutStrategyOptions
         {
             TimeoutGenerator = static args =>
             {
@@ -39,7 +39,10 @@ internal static class Timeout
                 Console.WriteLine($"{args.Context.OperationKey}: Execution timed out after {args.Timeout.TotalSeconds} seconds.");
                 return default;
             }
-        });
+        };
+
+        // Add a timeout strategy with a TimeoutStrategyOptions instance to the pipeline
+        new ResiliencePipelineBuilder().AddTimeout(optionsDefaults);
 
         #endregion
 

--- a/src/Snippets/Docs/Timeout.cs
+++ b/src/Snippets/Docs/Timeout.cs
@@ -11,39 +11,35 @@ internal static class Timeout
 
         // Add timeout using the default options.
         // See https://www.pollydocs.org/strategies/timeout#defaults for defaults.
-        new ResiliencePipelineBuilder()
-            .AddTimeout(new TimeoutStrategyOptions());
+        new ResiliencePipelineBuilder().AddTimeout(new TimeoutStrategyOptions());
 
         // To add a timeout with a custom TimeSpan duration
-        new ResiliencePipelineBuilder()
-            .AddTimeout(TimeSpan.FromSeconds(3));
+        new ResiliencePipelineBuilder().AddTimeout(TimeSpan.FromSeconds(3));
 
         // To add a timeout using a custom timeout generator function
-        new ResiliencePipelineBuilder()
-            .AddTimeout(new TimeoutStrategyOptions
+        new ResiliencePipelineBuilder().AddTimeout(new TimeoutStrategyOptions
+        {
+            TimeoutGenerator = static args =>
             {
-                TimeoutGenerator = args =>
-                {
-                    // Note: the timeout generator supports asynchronous operations
-                    return new ValueTask<TimeSpan>(TimeSpan.FromSeconds(123));
-                }
-            });
+                // Note: the timeout generator supports asynchronous operations
+                return new ValueTask<TimeSpan>(TimeSpan.FromSeconds(123));
+            }
+        });
 
         // To add a timeout and listen for timeout events
-        new ResiliencePipelineBuilder()
-            .AddTimeout(new TimeoutStrategyOptions
+        new ResiliencePipelineBuilder().AddTimeout(new TimeoutStrategyOptions
+        {
+            TimeoutGenerator = static args =>
             {
-                TimeoutGenerator = args =>
-                {
-                    // Note: the timeout generator supports asynchronous operations
-                    return new ValueTask<TimeSpan>(TimeSpan.FromSeconds(123));
-                },
-                OnTimeout = args =>
-                {
-                    Console.WriteLine($"{args.Context.OperationKey}: Execution timed out after {args.Timeout.TotalSeconds} seconds.");
-                    return default;
-                }
-            });
+                // Note: the timeout generator supports asynchronous operations
+                return new ValueTask<TimeSpan>(TimeSpan.FromSeconds(123));
+            },
+            OnTimeout = static args =>
+            {
+                Console.WriteLine($"{args.Context.OperationKey}: Execution timed out after {args.Timeout.TotalSeconds} seconds.");
+                return default;
+            }
+        });
 
         #endregion
 


### PR DESCRIPTION
# Pull Request
## The issue or feature being addressed

- The quick start samples were not consistent
- The strategy summary table was too crowded

## Details on the issue fix or feature implementation

- Split the strategy summary table into two: reactive and proactive
  - Minus one column
  - Also deleted the links "section" from the first column
    - Made the strategy name a relative link to the related quick start 
    - The _deep_ links are available at the end of each quick start section
  - Renamed the last column to `Mitigation` and `Prevention` respectively
- Sample codes should embrace best practices IMHO
  - Used `static` anonymous function where it was possible
  - Used `new()` instead of the full name of the `XYZStrategyOptions`
  - Tried to use the same indention everywhere
  - Removed `.Build()` calls for the sake of consistency 

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
