### PR TITLE
Resolve AOT compilation issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 * Speed-up page builds by [@martincostello](https://github.com/martincostello) in https://github.com/App-vNext/Polly/pull/1753
 * Hedging strategy also deep-copies context for primary execution by [@martintmk](https://github.com/martintmk) in https://github.com/App-vNext/Polly/pull/1754
 * [Docs] Add diagram about hedging's context and callbacks by [@peter-csala](https://github.com/peter-csala) in https://github.com/App-vNext/Polly/pull/1751
+* Resolve AOT compilation issues by [@martincostello](https://github.com/martincostello) in https://github.com/App-vNext/Polly/pull/1737
 
 ## 8.0.0
 

--- a/Polly.sln
+++ b/Polly.sln
@@ -58,6 +58,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Polly.Testing.Tests", "test
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Snippets", "src\Snippets\Snippets.csproj", "{D812B941-79B0-4E1E-BB70-4FAE345B5234}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Polly.AotTest", "test\Polly.AotTest\Polly.AotTest.csproj", "{84091007-CFA5-4852-AC41-0171DF039C4E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -120,6 +122,10 @@ Global
 		{D812B941-79B0-4E1E-BB70-4FAE345B5234}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D812B941-79B0-4E1E-BB70-4FAE345B5234}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D812B941-79B0-4E1E-BB70-4FAE345B5234}.Release|Any CPU.Build.0 = Release|Any CPU
+		{84091007-CFA5-4852-AC41-0171DF039C4E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{84091007-CFA5-4852-AC41-0171DF039C4E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{84091007-CFA5-4852-AC41-0171DF039C4E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{84091007-CFA5-4852-AC41-0171DF039C4E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -140,6 +146,7 @@ Global
 		{9AD2D6AD-56E4-49D6-B6F1-EE975D5760B9} = {B7BF406B-B06F-4025-83E6-7219C53196A6}
 		{D333B5CE-982D-4C11-BDAF-4217AA02306E} = {A6CC41B9-E0B9-44F8-916B-3E4A78DA3BFB}
 		{D812B941-79B0-4E1E-BB70-4FAE345B5234} = {B7BF406B-B06F-4025-83E6-7219C53196A6}
+		{84091007-CFA5-4852-AC41-0171DF039C4E} = {A6CC41B9-E0B9-44F8-916B-3E4A78DA3BFB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2E5D54CD-770A-4345-B585-1848FC2EA6F4}

--- a/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.CompositeComponentBenchmark-report-github.md
+++ b/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.CompositeComponentBenchmark-report-github.md
@@ -11,4 +11,4 @@ LaunchCount=2  WarmupCount=10
 ```
 | Method                         | Mean     | Error    | StdDev   | Allocated |
 |------------------------------- |---------:|---------:|---------:|----------:|
-| CompositeComponent_ExecuteCore | 44.37 ns | 1.994 ns | 2.923 ns |         - |
+| CompositeComponent_ExecuteCore | 41.37 ns | 1.722 ns | 2.413 ns |         - |

--- a/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.CompositeComponentBenchmark-report-github.md
+++ b/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.CompositeComponentBenchmark-report-github.md
@@ -11,4 +11,4 @@ LaunchCount=2  WarmupCount=10
 ```
 | Method                         | Mean     | Error    | StdDev   | Allocated |
 |------------------------------- |---------:|---------:|---------:|----------:|
-| CompositeComponent_ExecuteCore | 41.37 ns | 1.722 ns | 2.413 ns |         - |
+| CompositeComponent_ExecuteCore | 37.44 ns | 0.713 ns | 0.952 ns |         - |

--- a/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.DelegatingComponentBenchmark-report-github.md
+++ b/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.DelegatingComponentBenchmark-report-github.md
@@ -1,0 +1,15 @@
+```
+
+BenchmarkDotNet v0.13.9+228a464e8be6c580ad9408e98f18813f6407fb5a, Windows 11 (10.0.22621.2428/22H2/2022Update/SunValley2)
+12th Gen Intel Core i7-1270P, 1 CPU, 16 logical and 12 physical cores
+.NET SDK 7.0.403
+  [Host] : .NET 7.0.13 (7.0.1323.51816), X64 RyuJIT AVX2
+
+Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
+LaunchCount=2  WarmupCount=10  
+
+```
+| Method                              | Mean     | Error    | StdDev   | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
+|------------------------------------ |---------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
+| DelegatingComponent_ExecuteCore_Jit | 29.40 ns | 0.699 ns | 1.025 ns |  1.00 |    0.00 |      - |         - |          NA |
+| DelegatingComponent_ExecuteCore_Aot | 34.65 ns | 0.627 ns | 0.919 ns |  1.18 |    0.05 | 0.0025 |      24 B |          NA |

--- a/bench/Polly.Core.Benchmarks/DelegatingComponentBenchmark.cs
+++ b/bench/Polly.Core.Benchmarks/DelegatingComponentBenchmark.cs
@@ -1,0 +1,38 @@
+﻿using Polly.Utils.Pipeline;
+
+namespace Polly.Core.Benchmarks;
+
+public class DelegatingComponentBenchmark : IAsyncDisposable
+{
+    private ResilienceContext? _context;
+    private DelegatingComponent? _component;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var first = PipelineComponent.Empty;
+        var second = PipelineComponent.Empty;
+
+        _component = new DelegatingComponent(first) { Next = second };
+        _context = ResilienceContextPool.Shared.Get();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_component is not null)
+        {
+            await _component.DisposeAsync().ConfigureAwait(false);
+            _component = null;
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    [Benchmark(Baseline = true)]
+    public ValueTask<Outcome<int>> DelegatingComponent_ExecuteCore_Jit()
+        => _component!.ExecuteComponent((_, state) => Outcome.FromResultAsValueTask(state), _context!, 42);
+
+    [Benchmark]
+    public ValueTask<Outcome<int>> DelegatingComponent_ExecuteCore_Aot()
+        => _component!.ExecuteComponentAot((_, state) => Outcome.FromResultAsValueTask(state), _context!, 42);
+}

--- a/build.cake
+++ b/build.cake
@@ -75,9 +75,9 @@ Task("__Clean")
 
     CleanDirectories(cleanDirectories);
 
-    foreach(var path in cleanDirectories) { EnsureDirectoryExists(path); }
+    foreach (var path in cleanDirectories) { EnsureDirectoryExists(path); }
 
-    foreach(var path in solutionPaths)
+    foreach (var path in solutionPaths)
     {
         Information("Cleaning {0}", path);
 
@@ -93,7 +93,7 @@ Task("__Clean")
 Task("__RestoreNuGetPackages")
     .Does(() =>
 {
-    foreach(var solution in solutions)
+    foreach (var solution in solutions)
     {
         Information("Restoring NuGet Packages for {0}", solution);
         DotNetRestore(solution.ToString());
@@ -103,7 +103,7 @@ Task("__RestoreNuGetPackages")
 Task("__BuildSolutions")
     .Does(() =>
 {
-    foreach(var solution in solutions)
+    foreach (var solution in solutions)
     {
         Information("Building {0}", solution);
 
@@ -125,6 +125,23 @@ Task("__BuildSolutions")
     }
 });
 
+Task("__ValidateAot")
+    .Does(() =>
+{
+    var aotProject = MakeAbsolute(File("./test/Polly.AotTest/Polly.AotTest.csproj"));
+    var settings = new DotNetPublishSettings
+    {
+        Configuration = configuration,
+        Verbosity = DotNetVerbosity.Minimal,
+        MSBuildSettings = new DotNetMSBuildSettings
+        {
+            TreatAllWarningsAs = MSBuildTreatAllWarningsAs.Error,
+        },
+    };
+
+    DotNetPublish(aotProject.ToString(), settings);
+});
+
 Task("__RunTests")
     .Does(() =>
 {
@@ -137,7 +154,7 @@ Task("__RunTests")
 
     var projects = GetFiles("./test/**/*.csproj");
 
-    foreach(var proj in projects)
+    foreach (var proj in projects)
     {
         DotNetTest(proj.FullPath, new DotNetTestSettings
         {
@@ -252,6 +269,7 @@ Task("Build")
     .IsDependentOn("__RestoreNuGetPackages")
     .IsDependentOn("__ValidateDocs")
     .IsDependentOn("__BuildSolutions")
+    .IsDependentOn("__ValidateAot")
     .IsDependentOn("__RunTests")
     .IsDependentOn("__RunMutationTests")
     .IsDependentOn("__CreateNuGetPackages");

--- a/src/Polly.Core/Polly.Core.csproj
+++ b/src/Polly.Core/Polly.Core.csproj
@@ -15,6 +15,7 @@
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <IsAotCompatible>true</IsAotCompatible>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 

--- a/src/Polly.Core/Polly.Core.csproj
+++ b/src/Polly.Core/Polly.Core.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <Using Include="Polly.Utils" />
+    <InternalsVisibleToProject Include="Polly.AotTest" />
     <InternalsVisibleToProject Include="Polly.Core.Benchmarks" />
     <InternalsVisibleToProject Include="Polly.Core.Tests" />
     <InternalsVisibleToProject Include="Polly.Testing" />

--- a/src/Polly.Core/Polly.Core.csproj
+++ b/src/Polly.Core/Polly.Core.csproj
@@ -21,7 +21,6 @@
 
   <ItemGroup>
     <Using Include="Polly.Utils" />
-    <InternalsVisibleToProject Include="Polly.AotTest" />
     <InternalsVisibleToProject Include="Polly.Core.Benchmarks" />
     <InternalsVisibleToProject Include="Polly.Core.Tests" />
     <InternalsVisibleToProject Include="Polly.Testing" />

--- a/src/Polly.Core/Utils/Pipeline/CompositeComponent.cs
+++ b/src/Polly.Core/Utils/Pipeline/CompositeComponent.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
-using Polly.Telemetry;
+﻿using Polly.Telemetry;
 
 namespace Polly.Utils.Pipeline;
 
@@ -117,95 +115,5 @@ internal sealed class CompositeComponent : PipelineComponent
             new PipelineExecutedArguments(_timeProvider.GetElapsedTime(timeStamp)));
 
         return outcome;
-    }
-
-    /// <summary>
-    /// A component that delegates the execution to the next component in the chain.
-    /// </summary>
-    internal sealed class DelegatingComponent : PipelineComponent
-    {
-        private readonly PipelineComponent _component;
-
-        public DelegatingComponent(PipelineComponent component) => _component = component;
-
-        public PipelineComponent? Next { get; set; }
-
-        public override ValueTask DisposeAsync() => default;
-
-        [ExcludeFromCodeCoverage]
-        internal override ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
-            Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
-            ResilienceContext context,
-            TState state)
-        {
-#if NET6_0_OR_GREATER
-            return RuntimeFeature.IsDynamicCodeSupported ? ExecuteComponent(callback, context, state) : ExecuteComponentAot(callback, context, state);
-#else
-            return ExecuteComponent(callback, context, state);
-#endif
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static ValueTask<Outcome<TResult>> ExecuteNext<TResult, TState>(
-            PipelineComponent next,
-            Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
-            ResilienceContext context,
-            TState state)
-        {
-            if (context.CancellationToken.IsCancellationRequested)
-            {
-                return Outcome.FromExceptionAsValueTask<TResult>(new OperationCanceledException(context.CancellationToken).TrySetStackTrace());
-            }
-
-            return next.ExecuteCore(callback, context, state);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal ValueTask<Outcome<TResult>> ExecuteComponent<TResult, TState>(
-            Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
-            ResilienceContext context,
-            TState state)
-        {
-            return _component.ExecuteCore(
-                static (context, state) => ExecuteNext(state.Next!, state.callback, context, state.state),
-                context,
-                (Next, callback, state));
-        }
-
-#if NET6_0_OR_GREATER
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal ValueTask<Outcome<TResult>> ExecuteComponentAot<TResult, TState>(
-            Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
-            ResilienceContext context,
-            TState state)
-        {
-            // Custom state object is used to cast the callback and state to prevent infinite
-            // generic type recursion warning IL3054 when referenced in a native AoT application.
-            // See https://github.com/App-vNext/Polly/issues/1732 for further context.
-            return _component.ExecuteCore(
-                static (context, wrapper) =>
-                {
-                    var callback = (Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>>)wrapper.Callback;
-                    var state = (TState)wrapper.State;
-                    return ExecuteNext(wrapper.Next, callback, context, state);
-                },
-                context,
-                new StateWrapper(Next!, callback, state!));
-        }
-
-        private struct StateWrapper
-        {
-            public StateWrapper(PipelineComponent next, object callback, object state)
-            {
-                Next = next;
-                Callback = callback;
-                State = state;
-            }
-
-            public PipelineComponent Next;
-            public object Callback;
-            public object State;
-        }
-#endif
     }
 }

--- a/src/Polly.Core/Utils/Pipeline/DelegatingComponent.cs
+++ b/src/Polly.Core/Utils/Pipeline/DelegatingComponent.cs
@@ -1,0 +1,94 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace Polly.Utils.Pipeline;
+
+/// <summary>
+/// A component that delegates the execution to the next component in the chain.
+/// </summary>
+internal sealed class DelegatingComponent : PipelineComponent
+{
+    private readonly PipelineComponent _component;
+
+    public DelegatingComponent(PipelineComponent component) => _component = component;
+
+    public PipelineComponent? Next { get; set; }
+
+    public override ValueTask DisposeAsync() => default;
+
+    [ExcludeFromCodeCoverage]
+    internal override ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
+        Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
+        ResilienceContext context,
+        TState state)
+    {
+#if NET6_0_OR_GREATER
+        return RuntimeFeature.IsDynamicCodeSupported ? ExecuteComponent(callback, context, state) : ExecuteComponentAot(callback, context, state);
+#else
+        return ExecuteComponent(callback, context, state);
+#endif
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static ValueTask<Outcome<TResult>> ExecuteNext<TResult, TState>(
+        PipelineComponent next,
+        Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
+        ResilienceContext context,
+        TState state)
+    {
+        if (context.CancellationToken.IsCancellationRequested)
+        {
+            return Outcome.FromExceptionAsValueTask<TResult>(new OperationCanceledException(context.CancellationToken).TrySetStackTrace());
+        }
+
+        return next.ExecuteCore(callback, context, state);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal ValueTask<Outcome<TResult>> ExecuteComponent<TResult, TState>(
+        Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
+        ResilienceContext context,
+        TState state)
+    {
+        return _component.ExecuteCore(
+            static (context, state) => ExecuteNext(state.Next!, state.callback, context, state.state),
+            context,
+            (Next, callback, state));
+    }
+
+#if NET6_0_OR_GREATER
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal ValueTask<Outcome<TResult>> ExecuteComponentAot<TResult, TState>(
+        Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
+        ResilienceContext context,
+        TState state)
+    {
+        // Custom state object is used to cast the callback and state to prevent infinite
+        // generic type recursion warning IL3054 when referenced in a native AoT application.
+        // See https://github.com/App-vNext/Polly/issues/1732 for further context.
+        return _component.ExecuteCore(
+            static (context, wrapper) =>
+            {
+                var callback = (Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>>)wrapper.Callback;
+                var state = (TState)wrapper.State;
+                return ExecuteNext(wrapper.Next, callback, context, state);
+            },
+            context,
+            new StateWrapper(Next!, callback, state!));
+    }
+
+    private struct StateWrapper
+    {
+        public StateWrapper(PipelineComponent next, object callback, object state)
+        {
+            Next = next;
+            Callback = callback;
+            State = state;
+        }
+
+        public PipelineComponent Next;
+        public object Callback;
+        public object State;
+    }
+#endif
+}

--- a/src/Polly.Core/Utils/Pipeline/DelegatingComponent.cs
+++ b/src/Polly.Core/Utils/Pipeline/DelegatingComponent.cs
@@ -77,18 +77,6 @@ internal sealed class DelegatingComponent : PipelineComponent
             new StateWrapper(Next!, callback, state!));
     }
 
-    private struct StateWrapper
-    {
-        public StateWrapper(PipelineComponent next, object callback, object state)
-        {
-            Next = next;
-            Callback = callback;
-            State = state;
-        }
-
-        public PipelineComponent Next;
-        public object Callback;
-        public object State;
-    }
+    private readonly record struct StateWrapper(PipelineComponent Next, object Callback, object State);
 #endif
 }

--- a/src/Polly.Core/Utils/Pipeline/PipelineComponent.cs
+++ b/src/Polly.Core/Utils/Pipeline/PipelineComponent.cs
@@ -35,7 +35,7 @@ internal abstract class PipelineComponent : IAsyncDisposable
 
     public abstract ValueTask DisposeAsync();
 
-    private class NullComponent : PipelineComponent
+    private sealed class NullComponent : PipelineComponent
     {
         internal override ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback, ResilienceContext context, TState state)
             => callback(context, state);

--- a/src/Polly.Extensions/Polly.Extensions.csproj
+++ b/src/Polly.Extensions/Polly.Extensions.csproj
@@ -13,6 +13,7 @@
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <IsAotCompatible>true</IsAotCompatible>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Polly.RateLimiting/Polly.RateLimiting.csproj
+++ b/src/Polly.RateLimiting/Polly.RateLimiting.csproj
@@ -13,6 +13,7 @@
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <IsAotCompatible>true</IsAotCompatible>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 

--- a/test/Polly.AotTest/Polly.AotTest.csproj
+++ b/test/Polly.AotTest/Polly.AotTest.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+    <PublishAot>true</PublishAot>
+    <SKIP_POLLY_ANALYZERS>true</SKIP_POLLY_ANALYZERS>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Polly.Core\Polly.Core.csproj" />
+    <ProjectReference Include="..\..\src\Polly.Extensions\Polly.Extensions.csproj" />
+    <ProjectReference Include="..\..\src\Polly.RateLimiting\Polly.RateLimiting.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <TrimmerRootAssembly Include="Polly.Core" />
+    <TrimmerRootAssembly Include="Polly.Extensions" />
+    <TrimmerRootAssembly Include="Polly.RateLimiting" />
+  </ItemGroup>
+</Project>

--- a/test/Polly.AotTest/Program.cs
+++ b/test/Polly.AotTest/Program.cs
@@ -1,8 +1,1 @@
-using Polly.Utils.Pipeline;
-
-// See https://github.com/App-vNext/Polly/issues/1732#issuecomment-1782466692.
-// This code is needed as a workaround until https://github.com/dotnet/runtime/issues/94131 is resolved.
-var pipeline = CompositeComponent.Create(new[] { PipelineComponent.Empty, PipelineComponent.Empty }, null!, null!);
-await pipeline.ExecuteCore<int, int>((state, context) => default, default!, default);
-
 Console.WriteLine("Hello Polly!");

--- a/test/Polly.AotTest/Program.cs
+++ b/test/Polly.AotTest/Program.cs
@@ -1,0 +1,8 @@
+using Polly.Utils.Pipeline;
+
+// See https://github.com/App-vNext/Polly/issues/1732#issuecomment-1782466692.
+// This code is needed as a workaround until https://github.com/dotnet/runtime/issues/94131 is resolved.
+var pipeline = CompositeComponent.Create(new[] { PipelineComponent.Empty, PipelineComponent.Empty }, null!, null!);
+await pipeline.ExecuteCore<int, int>((state, context) => default, default!, default);
+
+Console.WriteLine("Hello Polly!");

--- a/test/Polly.Core.Tests/Utils/Pipeline/CompositePipelineComponentTests.cs
+++ b/test/Polly.Core.Tests/Utils/Pipeline/CompositePipelineComponentTests.cs
@@ -140,62 +140,6 @@ public class CompositePipelineComponentTests
         await b.Received(1).DisposeAsync();
     }
 
-    [Fact]
-    public async Task ExecuteComponent_ReturnsCorrectResult()
-    {
-        var component = new CallbackComponent();
-        var next = new CallbackComponent();
-        var context = ResilienceContextPool.Shared.Get();
-        var state = 1;
-
-        var composite = new CompositeComponent.DelegatingComponent(component)
-        {
-            Next = next,
-        };
-
-        var actual = await composite.ExecuteComponent(
-            async static (_, state) => await Outcome.FromResultAsValueTask(state + 1),
-            context,
-            state);
-
-        actual.Should().NotBeNull();
-        actual.Result.Should().Be(2);
-    }
-
-#if NET6_0_OR_GREATER
-    [Fact]
-    public async Task ExecuteComponentAot_ReturnsCorrectResult()
-    {
-        var component = new CallbackComponent();
-        var next = new CallbackComponent();
-        var context = ResilienceContextPool.Shared.Get();
-        var state = 1;
-
-        var composite = new CompositeComponent.DelegatingComponent(component)
-        {
-            Next = next,
-        };
-
-        var actual = await composite.ExecuteComponentAot(
-            async static (_, state) => await Outcome.FromResultAsValueTask(state + 1),
-            context,
-            state);
-
-        actual.Should().NotBeNull();
-        actual.Result.Should().Be(2);
-    }
-#endif
-
-    private sealed class CallbackComponent : PipelineComponent
-    {
-        public override ValueTask DisposeAsync() => default;
-
-        internal override ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
-            Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
-            ResilienceContext context,
-            TState state) => callback(context, state);
-    }
-
     private CompositeComponent CreateSut(PipelineComponent[] components, TimeProvider? timeProvider = null)
     {
         return (CompositeComponent)PipelineComponentFactory.CreateComposite(components, _telemetry, timeProvider ?? Substitute.For<TimeProvider>());

--- a/test/Polly.Core.Tests/Utils/Pipeline/DelegatingComponentTests.cs
+++ b/test/Polly.Core.Tests/Utils/Pipeline/DelegatingComponentTests.cs
@@ -1,0 +1,56 @@
+using Polly.Utils.Pipeline;
+
+namespace Polly.Core.Tests.Utils.Pipeline;
+
+public static class DelegatingComponentTests
+{
+    [Fact]
+    public static async Task ExecuteComponent_ReturnsCorrectResult()
+    {
+        await using var component = new CallbackComponent();
+        var next = new CallbackComponent();
+        var context = ResilienceContextPool.Shared.Get();
+        var state = 1;
+
+        await using var delegating = new DelegatingComponent(component) { Next = next };
+
+        var actual = await delegating.ExecuteComponent(
+            async static (_, state) => await Outcome.FromResultAsValueTask(state + 1),
+            context,
+            state);
+
+        actual.Should().NotBeNull();
+        actual.Result.Should().Be(2);
+    }
+
+#if NET6_0_OR_GREATER
+    [Fact]
+    public static async Task ExecuteComponentAot_ReturnsCorrectResult()
+    {
+        await using var component = new CallbackComponent();
+        var next = new CallbackComponent();
+        var context = ResilienceContextPool.Shared.Get();
+        var state = 1;
+
+        await using var delegating = new DelegatingComponent(component) { Next = next };
+
+        var actual = await delegating.ExecuteComponentAot(
+            async static (_, state) => await Outcome.FromResultAsValueTask(state + 1),
+            context,
+            state);
+
+        actual.Should().NotBeNull();
+        actual.Result.Should().Be(2);
+    }
+#endif
+
+    private sealed class CallbackComponent : PipelineComponent
+    {
+        public override ValueTask DisposeAsync() => default;
+
+        internal override ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
+            Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
+            ResilienceContext context,
+            TState state) => callback(context, state);
+    }
+}


### PR DESCRIPTION
A _potential_ fix for #1732 using `RuntimeFeature.IsDynamicCodeSupported` to guard against an allocation regression while still avoiding the infinite generic recursion the current code in Polly 8.0.0 causes.

This is just a starting point for discussion on what the best fix and/or compromises are to support using Polly with AoT compiled applications.

I'm very much out of my comfort zone when it comes to AoT, so this was just something I came up with that resolves the issue at hand. It does trade-off against either increased code size by using the guard, or without the guard it introduces an allocation regression of 24 bytes per invocation ([original thread](https://github.com/martincostello/Polly/commit/393b2dbf422825db6c1ee0dd24c4ddc42d31f05c#r131079631)).

💯% open to suggestions for a better solution.

/cc @davidfowl @MichalStrehovsky @eerhardt @martintmk
