### PR TITLE
Add component benchmark

### DIFF
--- a/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.CompositeComponentBenchmark-report-github.md
+++ b/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.CompositeComponentBenchmark-report-github.md
@@ -1,0 +1,14 @@
+```
+
+BenchmarkDotNet v0.13.9+228a464e8be6c580ad9408e98f18813f6407fb5a, Windows 11 (10.0.22621.2428/22H2/2022Update/SunValley2)
+12th Gen Intel Core i7-1270P, 1 CPU, 16 logical and 12 physical cores
+.NET SDK 7.0.403
+  [Host] : .NET 7.0.13 (7.0.1323.51816), X64 RyuJIT AVX2
+
+Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
+LaunchCount=2  WarmupCount=10  
+
+```
+| Method                         | Mean     | Error    | StdDev   | Allocated |
+|------------------------------- |---------:|---------:|---------:|----------:|
+| CompositeComponent_ExecuteCore | 44.37 ns | 1.994 ns | 2.923 ns |         - |

--- a/bench/Polly.Core.Benchmarks/CompositeComponentBenchmark.cs
+++ b/bench/Polly.Core.Benchmarks/CompositeComponentBenchmark.cs
@@ -1,0 +1,27 @@
+﻿using Polly.Telemetry;
+using Polly.Utils.Pipeline;
+
+namespace Polly.Core.Benchmarks;
+
+public class CompositeComponentBenchmark
+{
+    private ResilienceContext? _context;
+    private PipelineComponent? _component;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var first = PipelineComponent.Empty;
+        var second = PipelineComponent.Empty;
+        var source = new ResilienceTelemetrySource("pipeline", "instance", "strategy");
+        var telemetry = new ResilienceStrategyTelemetry(source, null);
+        var components = new[] { first, second };
+
+        _component = CompositeComponent.Create(components, telemetry, TimeProvider.System);
+        _context = ResilienceContextPool.Shared.Get();
+    }
+
+    [Benchmark]
+    public ValueTask<Outcome<int>> CompositeComponent_ExecuteCore()
+        => _component!.ExecuteCore((_, state) => Outcome.FromResultAsValueTask(state), _context!, 42);
+}

--- a/bench/Polly.Core.Benchmarks/TelemetryBenchmark.cs
+++ b/bench/Polly.Core.Benchmarks/TelemetryBenchmark.cs
@@ -77,7 +77,7 @@ public class TelemetryBenchmark
 
         public TelemetryEventStrategy(ResilienceStrategyTelemetry telemetry) => _telemetry = telemetry;
 
-        protected override ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
+        protected internal override ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
             Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
             ResilienceContext context,
             TState state)

--- a/bench/Polly.Core.Benchmarks/Utils/EmptyResilienceStrategy.cs
+++ b/bench/Polly.Core.Benchmarks/Utils/EmptyResilienceStrategy.cs
@@ -2,7 +2,7 @@ namespace Polly.Core.Benchmarks.Utils;
 
 internal class EmptyResilienceStrategy : ResilienceStrategy
 {
-    protected override ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
+    protected internal override ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
         Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
         ResilienceContext context,
         TState state)

--- a/bench/Polly.Core.Benchmarks/Utils/Helper.CircuitBreaker.cs
+++ b/bench/Polly.Core.Benchmarks/Utils/Helper.CircuitBreaker.cs
@@ -66,7 +66,7 @@ internal static partial class Helper
 
     private class OutcomeHandlingStrategy : ResilienceStrategy
     {
-        protected override async ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
+        protected internal override async ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
             Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
             ResilienceContext context,
             TState state)

--- a/eng/Common.targets
+++ b/eng/Common.targets
@@ -1,10 +1,11 @@
 <Project>
   <PropertyGroup>
-    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\Polly.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
-    <LangVersion>latest</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
+    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\Polly.snk</AssemblyOriginatorKeyFile>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+    <SignAssembly>true</SignAssembly>
+    <PollyStrongNamePublicKey Condition=" '$(SignAssembly)' == 'true' ">0024000004800000940000000602000000240000525341310004000001000100150819e3494f97263a3abdd18e5e0c47b04e6c0ede44a6c51d50b545d403ceeb7cbb32d18dbbbcdd1d88a87d7b73206b126be134b0609c36aa3cb31dd2e47e393293102809b8d77f192f3188618a42e651c14ebf05f8f5b76aa91b431642b23497ed82b65d63791cdaa31d4282a2d6cbabc3fe0745b6b6690c417cabf6a1349c</PollyStrongNamePublicKey>
   </PropertyGroup>
 
   <Import Project="$(MsBuildThisFileDirectory)Analyzers.targets" />

--- a/eng/Library.targets
+++ b/eng/Library.targets
@@ -9,7 +9,6 @@
     <Authors>Michael Wolfenden, App vNext</Authors>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <EmbedUntrackedSources>true</EmbedUntrackedSources> <!-- EmbedUntrackedSources for deterministic build -->
-    <PollyPublicKeySuffix>, PublicKey=0024000004800000940000000602000000240000525341310004000001000100150819e3494f97263a3abdd18e5e0c47b04e6c0ede44a6c51d50b545d403ceeb7cbb32d18dbbbcdd1d88a87d7b73206b126be134b0609c36aa3cb31dd2e47e393293102809b8d77f192f3188618a42e651c14ebf05f8f5b76aa91b431642b23497ed82b65d63791cdaa31d4282a2d6cbabc3fe0745b6b6690c417cabf6a1349c</PollyPublicKeySuffix>
     <ChecksumAlgorithm>SHA256</ChecksumAlgorithm>
   </PropertyGroup>
 
@@ -43,21 +42,17 @@
     <None Include="$(MsBuildThisFileDirectory)..\$(PackageReadmeFile)" Pack="true" PackagePath="" />
   </ItemGroup>
 
-  <Target Name="AddInternalsVisibleToDynamicProxyGenAssembly2" BeforeTargets="BeforeCompile">
+  <ItemGroup>
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" PublicKey="0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7" />
+  </ItemGroup>
+
+  <Target Name="AddInternalsVisibleToProject" BeforeTargets="BeforeCompile" Condition=" '@(InternalsVisibleToProject)' != '' ">
     <ItemGroup>
-      <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-        <_Parameter1>DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7</_Parameter1>
-      </AssemblyAttribute>
+      <InternalsVisibleTo Include="%(InternalsVisibleToProject.Identity)" PublicKey="$(PollyStrongNamePublicKey)" />
     </ItemGroup>
   </Target>
 
-  <Target Name="AddInternalsVisibleToTest" BeforeTargets="BeforeCompile" Condition="'@(InternalsVisibleToTest)' != ''">
-    <ItemGroup>
-      <InternalsVisibleTo Include="%(InternalsVisibleToTest.Identity)$(PollyPublicKeySuffix)" />
-    </ItemGroup>
-  </Target>
-
-  <ItemGroup Condition="$(UsePublicApiAnalyzers) != 'false'">
+  <ItemGroup Condition=" '$(UsePublicApiAnalyzers)' != 'false' ">
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Polly.Core/Polly.Core.csproj
+++ b/src/Polly.Core/Polly.Core.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <Using Include="Polly.Utils" />
+    <InternalsVisibleToProject Include="Polly.Core.Benchmarks" />
     <InternalsVisibleToProject Include="Polly.Core.Tests" />
     <InternalsVisibleToProject Include="Polly.Testing" />
     <InternalsVisibleToProject Include="Polly.TestUtils" />

--- a/src/Polly.Core/Polly.Core.csproj
+++ b/src/Polly.Core/Polly.Core.csproj
@@ -20,9 +20,9 @@
 
   <ItemGroup>
     <Using Include="Polly.Utils" />
-    <InternalsVisibleToTest Include="Polly.Core.Tests" />
-    <InternalsVisibleToTest Include="Polly.Testing" />
-    <InternalsVisibleToTest Include="Polly.TestUtils" />
+    <InternalsVisibleToProject Include="Polly.Core.Tests" />
+    <InternalsVisibleToProject Include="Polly.Testing" />
+    <InternalsVisibleToProject Include="Polly.TestUtils" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Polly.Extensions/Polly.Extensions.csproj
+++ b/src/Polly.Extensions/Polly.Extensions.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <Using Remove="System.Net.Http" />
-    <InternalsVisibleToTest Include="Polly.Extensions.Tests" />
+    <InternalsVisibleToProject Include="Polly.Extensions.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Polly.RateLimiting/Polly.RateLimiting.csproj
+++ b/src/Polly.RateLimiting/Polly.RateLimiting.csproj
@@ -20,7 +20,7 @@
     <Using Include="Polly.Utils" />
     <Compile Include="..\Polly.Core\Utils\ExceptionUtilities.cs" Link="utils\ExceptionUtilities.cs" />
     <Compile Include="..\Polly.Core\Utils\Guard.cs" Link="Utils\Guard.cs" />
-    <InternalsVisibleToTest Include="Polly.RateLimiting.Tests" />
+    <InternalsVisibleToProject Include="Polly.RateLimiting.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <InternalsVisibleToTest Include="Polly.Specs" />
+    <InternalsVisibleToProject Include="Polly.Specs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Add a benchmark for `CompositeComponent` to aid with https://github.com/App-vNext/Polly/issues/1732.
- Use MSBuild built-in support for `[InternalsVisibleTo]` public key.
- Rename item so it can be used in projects that aren't tests (i.e. the benchmarks) without an incorrect name.
- Make it easier to build without strong naming if needed.
- Make conditions a bit more readable.
- Sort properties.
