### PR TITLE
Bump docfx

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "docfx": {
-      "version": "2.72.0",
+      "version": "2.72.1",
       "commands": [
         "docfx"
       ]


### PR DESCRIPTION
Update docfx to [v2.72.1](https://github.com/dotnet/docfx/releases/tag/v2.72.1).
