### PR TITLE
Prevent concurrent page builds

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,6 +14,10 @@ jobs:
   publish-docs:
     runs-on: ubuntu-latest
 
+    concurrency:
+      group: ${{ github.workflow }}
+      cancel-in-progress: false
+
     permissions:
       contents: write
       pages: write


### PR DESCRIPTION
If multiple PRs are merged in succession, don't try and try and update GitHub Pages from multiple workflow runs at the same time.
