### PR TITLE
Fix test

### DIFF
--- a/test/Polly.Specs/Caching/AbsoluteTtlSpecs.cs
+++ b/test/Polly.Specs/Caching/AbsoluteTtlSpecs.cs
@@ -38,7 +38,7 @@ public class AbsoluteTtlSpecs : IDisposable
     [Fact]
     public void Should_return_timespan_reflecting_time_until_expiry()
     {
-        DateTime today = DateTime.Today;
+        DateTime today = DateTime.UtcNow.Date;
         DateTime tomorrow = today.AddDays(1);
 
         AbsoluteTtl ttlStrategy = new AbsoluteTtl(tomorrow);

--- a/test/Polly.Specs/Caching/AbsoluteTtlSpecs.cs
+++ b/test/Polly.Specs/Caching/AbsoluteTtlSpecs.cs
@@ -6,7 +6,7 @@ public class AbsoluteTtlSpecs : IDisposable
     [Fact]
     public void Should_be_able_to_configure_for_near_future_time()
     {
-        Action configure = () => new AbsoluteTtl(DateTime.Today.AddDays(1));
+        Action configure = () => new AbsoluteTtl(DateTimeOffset.UtcNow.Date.AddDays(1));
 
         configure.Should().NotThrow();
     }
@@ -38,8 +38,8 @@ public class AbsoluteTtlSpecs : IDisposable
     [Fact]
     public void Should_return_timespan_reflecting_time_until_expiry()
     {
-        DateTime today = DateTime.UtcNow.Date;
-        DateTime tomorrow = today.AddDays(1);
+        DateTimeOffset today = DateTimeOffset.UtcNow.Date;
+        DateTimeOffset tomorrow = today.AddDays(1);
 
         AbsoluteTtl ttlStrategy = new AbsoluteTtl(tomorrow);
 


### PR DESCRIPTION
Fix test that fails in GMT (rather than BST).

Before this change, I get this on my laptop since the clocks changed overnight:

```
[xUnit.net 00:00:26.10]     Polly.Specs.Caching.AbsoluteTtlSpecs.Should_return_timespan_reflecting_time_until_expiry [FAIL]
  Failed Polly.Specs.Caching.AbsoluteTtlSpecs.Should_return_timespan_reflecting_time_until_expiry [5 ms]
  Error Message:
   Expected 1d, but found 1d and 1h.
  Stack Trace:
     at FluentAssertions.Execution.XUnit2TestFramework.Throw(String message)
   at FluentAssertions.Execution.TestFrameworkProvider.Throw(String message)
   at FluentAssertions.Execution.DefaultAssertionStrategy.HandleFailure(String message)
   at FluentAssertions.Execution.AssertionScope.FailWith(Func`1 failReasonFunc)
   at FluentAssertions.Primitives.SimpleTimeSpanAssertions`1.Be(TimeSpan expected, String because, Object[] becauseArgs)
   at Polly.Specs.Caching.AbsoluteTtlSpecs.Should_return_timespan_reflecting_time_until_expiry() in C:\Coding\App-vNext\Polly\test\Polly.Specs\Caching\AbsoluteTtlSpecs.cs:line 47
```

Also does some other refactoring to remove implicit `DateTime` -> `DateTimeOffset` conversions.
