### PR TITLE
Run mutation tests on Windows instead of Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,10 @@ jobs:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
+    env:
+      # HACK Running on Windows instead of Linux due to https://github.com/stryker-mutator/stryker-net/issues/2741
+      RUN_MUTATION_TESTS: ${{ matrix.os_name == 'windows' && !startsWith(github.ref, 'refs/tags/') && 'true' || 'false' }}
+
     strategy:
       fail-fast: false
       matrix:
@@ -57,8 +61,6 @@ jobs:
     - name: Build, Test and Package
       shell: pwsh
       run: ./build.ps1
-      env:
-        RUN_MUTATION_TESTS: ${{ matrix.os_name == 'linux' && !startsWith(github.ref, 'refs/tags/') && 'true' || 'false' }}
 
     - name: Upload Coverage Reports
       if: always()
@@ -75,7 +77,7 @@ jobs:
         flags: ${{ matrix.os_name }}
 
     - name: Upload Mutation Report
-      if: always() && matrix.os_name == 'linux' && !startsWith(github.ref, 'refs/tags/')
+      if: always() && env.RUN_MUTATION_TESTS == 'true'
       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         name: mutation-report


### PR DESCRIPTION
As discovered in #1738, there's an issue with Stryker with .NET 8 that breaks it on Linux and macOS, so run on Windows until that's resolved.

Doing this as a separate PR to reduce the scope of the changes needed ahead of our actual support for .NET 8.
