### PR TITLE
Hedging strategy also deep-copies context for primary execution

### DIFF
--- a/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.HedgingBenchmark-report-github.md
+++ b/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.HedgingBenchmark-report-github.md
@@ -1,17 +1,17 @@
 ```
 
-BenchmarkDotNet v0.13.7, Windows 11 (10.0.22621.2283/22H2/2022Update/SunValley2) (Hyper-V)
+BenchmarkDotNet v0.13.9+228a464e8be6c580ad9408e98f18813f6407fb5a, Windows 11 (10.0.22621.2428/22H2/2022Update/SunValley2) (Hyper-V)
 Intel Xeon Platinum 8370C CPU 2.80GHz, 1 CPU, 16 logical and 8 physical cores
-.NET SDK 7.0.401
-  [Host] : .NET 7.0.11 (7.0.1123.42427), X64 RyuJIT AVX2
+.NET SDK 7.0.403
+  [Host] : .NET 7.0.13 (7.0.1323.51816), X64 RyuJIT AVX2
 
 Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
 LaunchCount=2  WarmupCount=10  
 
 ```
-|                      Method |     Mean |     Error |    StdDev | Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
-|---------------------------- |---------:|----------:|----------:|------:|--------:|-------:|----------:|------------:|
-|             Hedging_Primary | 1.432 μs | 0.0042 μs | 0.0061 μs |  1.00 |    0.00 |      - |      40 B |        1.00 |
-|           Hedging_Secondary | 2.253 μs | 0.0051 μs | 0.0075 μs |  1.57 |    0.01 | 0.0038 |     184 B |        4.60 |
-|   Hedging_Primary_AsyncWork | 3.903 μs | 0.0260 μs | 0.0381 μs |  2.73 |    0.03 | 0.0610 |    1636 B |       40.90 |
-| Hedging_Secondary_AsyncWork | 4.936 μs | 0.0424 μs | 0.0595 μs |  3.45 |    0.05 | 0.0687 |    1838 B |       45.95 |
+| Method                      | Mean      | Error     | StdDev    | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
+|---------------------------- |----------:|----------:|----------:|------:|--------:|-------:|----------:|------------:|
+| Hedging_Primary             |  1.284 μs | 0.0047 μs | 0.0066 μs |  1.00 |    0.00 |      - |      40 B |        1.00 |
+| Hedging_Secondary           |  2.007 μs | 0.0043 μs | 0.0064 μs |  1.56 |    0.01 | 0.0038 |     184 B |        4.60 |
+| Hedging_Primary_AsyncWork   | 33.379 μs | 1.9491 μs | 2.9173 μs | 26.43 |    1.90 | 0.6104 |   15299 B |      382.48 |
+| Hedging_Secondary_AsyncWork | 33.735 μs | 0.2915 μs | 0.4273 μs | 26.28 |    0.43 | 0.6104 |   15431 B |      385.77 |

--- a/docs/strategies/hedging.md
+++ b/docs/strategies/hedging.md
@@ -449,8 +449,7 @@ The hedging strategy supports the concurrent execution and cancellation of multi
 
 Here's the flow:
 
-- The strategy gets the primary context and creates a snapshot for deep cloning.
-- For each hedged action execution, the hedging strategy makes a deep copy of the original context. The deep copy has its own cancellation token designated for that execution. Note that the first execution (primary) uses the original resilience context, albeit with a cloned set of resilience properties.
+- The strategy gets the primary context and preserves it for deep-cloning.
 - After the strategy has an accepted result from a hedged action, the resilience context from the action is merged back into the primary context.
 - All ongoing hedged actions are cancelled and discarded. The hedging strategy awaits the propagation of cancellation.
 

--- a/src/Polly.Core/Hedging/Controller/ContextSnapshot.cs
+++ b/src/Polly.Core/Hedging/Controller/ContextSnapshot.cs
@@ -1,3 +1,0 @@
-﻿namespace Polly.Hedging.Utils;
-
-internal readonly record struct ContextSnapshot(ResilienceContext Context, ResilienceProperties OriginalProperties, CancellationToken OriginalCancellationToken);

--- a/src/Polly.Core/ResilienceContext.cs
+++ b/src/Polly.Core/ResilienceContext.cs
@@ -61,15 +61,17 @@ public sealed class ResilienceContext
     /// <summary>
     /// Gets the custom properties attached to the context.
     /// </summary>
-    public ResilienceProperties Properties { get; internal set; } = new();
+    public ResilienceProperties Properties { get; } = new();
 
-    internal void InitializeFrom(ResilienceContext context)
+    internal void InitializeFrom(ResilienceContext context, CancellationToken cancellationToken)
     {
         OperationKey = context.OperationKey;
         ResultType = context.ResultType;
         IsSynchronous = context.IsSynchronous;
         CancellationToken = context.CancellationToken;
         ContinueOnCapturedContext = context.ContinueOnCapturedContext;
+        CancellationToken = cancellationToken;
+        Properties.AddOrReplaceProperties(context.Properties);
     }
 
     [ExcludeFromCodeCoverage]

--- a/src/Polly.Core/ResilienceProperties.cs
+++ b/src/Polly.Core/ResilienceProperties.cs
@@ -58,10 +58,8 @@ public sealed class ResilienceProperties
         Options[key.Key] = value;
     }
 
-    internal void Replace(ResilienceProperties other)
+    internal void AddOrReplaceProperties(ResilienceProperties other)
     {
-        Clear();
-
         // try to avoid enumerator allocation
         if (other.Options is Dictionary<string, object?> otherOptions)
         {
@@ -78,7 +76,5 @@ public sealed class ResilienceProperties
             }
         }
     }
-
-    internal void Clear() => Options.Clear();
 }
 

--- a/test/Polly.Core.Tests/Hedging/Controller/HedgingExecutionContextTests.cs
+++ b/test/Polly.Core.Tests/Hedging/Controller/HedgingExecutionContextTests.cs
@@ -54,7 +54,7 @@ public class HedgingExecutionContextTests : IDisposable
         var context = Create();
 
         context.LoadedTasks.Should().Be(0);
-        context.Snapshot.Context.Should().BeNull();
+        context.PrimaryContext.Should().BeNull();
 
         context.Should().NotBeNull();
     }
@@ -67,11 +67,7 @@ public class HedgingExecutionContextTests : IDisposable
 
         context.Initialize(_resilienceContext);
 
-        context.Snapshot.Context.Should().Be(_resilienceContext);
-        context.Snapshot.Context.Properties.Should().NotBeSameAs(props);
-        context.Snapshot.OriginalProperties.Should().BeSameAs(props);
-        context.Snapshot.OriginalCancellationToken.Should().Be(_cts.Token);
-        context.Snapshot.Context.Properties.Options.Should().HaveCount(1);
+        context.PrimaryContext.Should().Be(_resilienceContext);
         context.IsInitialized.Should().BeTrue();
     }
 
@@ -409,7 +405,7 @@ public class HedgingExecutionContextTests : IDisposable
         await context.DisposeAsync();
 
         context.LoadedTasks.Should().Be(0);
-        context.Snapshot.Context.Should().BeNull();
+        context.PrimaryContext!.Should().BeNull();
 
         _onReset.WaitOne(AssertTimeout);
         _resets.Count.Should().Be(1);

--- a/test/Polly.Core.Tests/Hedging/Controller/TaskExecutionTests.cs
+++ b/test/Polly.Core.Tests/Hedging/Controller/TaskExecutionTests.cs
@@ -223,6 +223,7 @@ public class TaskExecutionTests : IDisposable
         var token = default(CancellationToken);
         await InitializePrimaryAsync(execution, result, context => token = context.CancellationToken);
         await execution.ExecutionTaskSafe!;
+        var context = execution.Context;
 
         if (accept)
         {
@@ -235,7 +236,7 @@ public class TaskExecutionTests : IDisposable
         // assert
         execution.IsAccepted.Should().BeFalse();
         execution.IsHandled.Should().BeFalse();
-        execution.Context.Properties.Options.Should().HaveCount(0);
+        context.Properties.Options.Should().HaveCount(0);
         execution.Invoking(e => e.Context).Should().Throw<InvalidOperationException>();
 #if !NETCOREAPP
         token.Invoking(t => t.WaitHandle).Should().Throw<InvalidOperationException>();
@@ -261,7 +262,6 @@ public class TaskExecutionTests : IDisposable
 
     private void AssertContext(ResilienceContext context)
     {
-        context.IsInitialized.Should().BeTrue();
         context.Should().NotBeSameAs(_primaryContext);
         context.Properties.Should().NotBeSameAs(_primaryContext.Properties);
         context.CancellationToken.Should().NotBeSameAs(_primaryContext.CancellationToken);

--- a/test/Polly.Core.Tests/ResilienceContextTests.cs
+++ b/test/Polly.Core.Tests/ResilienceContextTests.cs
@@ -25,9 +25,10 @@ public class ResilienceContextTests
         var context = ResilienceContextPool.Shared.Get("some-key");
         context.Initialize<bool>(synchronous);
         context.ContinueOnCapturedContext = true;
-
+        context.Properties.Set(new ResiliencePropertyKey<string>("A"), "B");
+        using var cancellation = new CancellationTokenSource();
         var other = ResilienceContextPool.Shared.Get();
-        other.InitializeFrom(context);
+        other.InitializeFrom(context, cancellation.Token);
 
         other.ResultType.Should().Be(typeof(bool));
         other.IsVoid.Should().BeFalse();
@@ -35,6 +36,8 @@ public class ResilienceContextTests
         other.IsSynchronous.Should().Be(synchronous);
         other.ContinueOnCapturedContext.Should().BeTrue();
         other.OperationKey.Should().Be("some-key");
+        other.CancellationToken.Should().Be(cancellation.Token);
+        other.Properties.GetValue(new ResiliencePropertyKey<string>("A"), string.Empty).Should().Be("B");
     }
 
     [InlineData(true)]

--- a/test/Polly.Core.Tests/ResiliencePropertiesTests.cs
+++ b/test/Polly.Core.Tests/ResiliencePropertiesTests.cs
@@ -59,7 +59,7 @@ public class ResiliencePropertiesTests
     [InlineData(true)]
     [InlineData(false)]
     [Theory]
-    public void Replace_Ok(bool isRawDictionary)
+    public void AddOrReplaceProperties_Ok(bool isRawDictionary)
     {
         var key1 = new ResiliencePropertyKey<string>("A");
         var key2 = new ResiliencePropertyKey<string>("B");
@@ -76,7 +76,8 @@ public class ResiliencePropertiesTests
         otherProps.Set(key2, "B");
 
         props.AddOrReplaceProperties(otherProps);
-        props.Options.Should().HaveCount(1);
+        props.Options.Should().HaveCount(2);
+        props.GetValue(key1, "").Should().Be("A");
         props.GetValue(key2, "").Should().Be("B");
     }
 }

--- a/test/Polly.Core.Tests/ResiliencePropertiesTests.cs
+++ b/test/Polly.Core.Tests/ResiliencePropertiesTests.cs
@@ -56,19 +56,6 @@ public class ResiliencePropertiesTests
         props.TryGetValue(key2, out var val).Should().Be(false);
     }
 
-    [Fact]
-    public void Clear_Ok()
-    {
-        var key1 = new ResiliencePropertyKey<long>("dummy");
-        var key2 = new ResiliencePropertyKey<string>("dummy");
-
-        var props = new ResilienceProperties();
-        props.Set(key1, 12345);
-        props.Clear();
-
-        props.Options.Should().HaveCount(0);
-    }
-
     [InlineData(true)]
     [InlineData(false)]
     [Theory]
@@ -88,7 +75,7 @@ public class ResiliencePropertiesTests
 
         otherProps.Set(key2, "B");
 
-        props.Replace(otherProps);
+        props.AddOrReplaceProperties(otherProps);
         props.Options.Should().HaveCount(1);
         props.GetValue(key2, "").Should().Be("B");
     }


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

#1727

## Details on the issue fix or feature implementation

As per #1727 there was inconsistency on how the hedging contexts for primary executions are handled. Instead of creating deep-clone, the hedging strategy re-used the original context. 

With this change, the handling is the same for both primary and hedged actions. Hedging strategy always creates a deep clone in all scenarios.

This also simplifies the implementation and handling of contexts. 
## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
