### PR TITLE
Prepare for 8.2.0 release

### DIFF
--- a/eng/Common.targets
+++ b/eng/Common.targets
@@ -19,12 +19,12 @@
   </ItemGroup>
 
   <PropertyGroup Label="MinVer">
-    <MinVerMinimumMajorMinor>8.1</MinVerMinimumMajorMinor>
+    <MinVerMinimumMajorMinor>8.2</MinVerMinimumMajorMinor>
   </PropertyGroup>
 
   <Target Name="CustomizeVersions" AfterTargets="MinVer" Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <PropertyGroup>
-      <FileVersion>$([MSBuild]::ValueOrDefault('$(MinVerMajor)', '8')).$([MSBuild]::ValueOrDefault('$(MinVerMinor)', '1')).$([MSBuild]::ValueOrDefault('$(MinVerPatch)', '0')).$(GITHUB_RUN_NUMBER)</FileVersion>
+      <FileVersion>$([MSBuild]::ValueOrDefault('$(MinVerMajor)', '8')).$([MSBuild]::ValueOrDefault('$(MinVerMinor)', '2')).$([MSBuild]::ValueOrDefault('$(MinVerPatch)', '0')).$(GITHUB_RUN_NUMBER)</FileVersion>
     </PropertyGroup>
     <PropertyGroup Condition="$(GITHUB_REF.StartsWith(`refs/pull/`))">
       <PackageVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch)-pr.$(GITHUB_REF_NAME.Replace(`/merge`, ``)).$(GITHUB_RUN_NUMBER)</PackageVersion>

--- a/eng/Library.targets
+++ b/eng/Library.targets
@@ -14,8 +14,7 @@
 
   <PropertyGroup Label="NuGet package validation">
     <EnablePackageValidation Condition="'$(EnablePackageValidation)' == ''">true</EnablePackageValidation>
-    <!-- TODO Bump to 8.1.0 once published to NuGet.org -->
-    <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == ''">8.0.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == ''">8.1.0</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="SourceLink">

--- a/src/Polly.Core/PublicAPI.Shipped.txt
+++ b/src/Polly.Core/PublicAPI.Shipped.txt
@@ -255,6 +255,8 @@ Polly.ResiliencePipelineBuilder<TResult>
 Polly.ResiliencePipelineBuilder<TResult>.Build() -> Polly.ResiliencePipeline<TResult>!
 Polly.ResiliencePipelineBuilder<TResult>.ResiliencePipelineBuilder() -> void
 Polly.ResiliencePipelineBuilderBase
+Polly.ResiliencePipelineBuilderBase.ContextPool.get -> Polly.ResilienceContextPool?
+Polly.ResiliencePipelineBuilderBase.ContextPool.set -> void
 Polly.ResiliencePipelineBuilderBase.InstanceName.get -> string?
 Polly.ResiliencePipelineBuilderBase.InstanceName.set -> void
 Polly.ResiliencePipelineBuilderBase.Name.get -> string?

--- a/src/Polly.Core/PublicAPI.Unshipped.txt
+++ b/src/Polly.Core/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 ﻿#nullable enable
-Polly.ResiliencePipelineBuilderBase.ContextPool.get -> Polly.ResilienceContextPool?
-Polly.ResiliencePipelineBuilderBase.ContextPool.set -> void


### PR DESCRIPTION
- Bump Polly version to 8.2.0.
- Update API/NuGet package baselines for 8.1.0.
