### PR TITLE
Fix package signing verification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,6 +107,9 @@ jobs:
       with:
         name: packages-windows
 
+    - name: Checkout code
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
 
@@ -142,6 +145,9 @@ jobs:
       with:
         name: packages-windows
 
+    - name: Checkout code
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
 
@@ -168,6 +174,9 @@ jobs:
       with:
         name: signing-config
         path: signing-config
+
+    - name: Checkout code
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
@@ -209,8 +218,15 @@ jobs:
       with:
         name: signed-packages
 
+    - name: Checkout code
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        path: Polly
+
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
+      with:
+        global-json-file: Polly/global.json
 
     - name: Validate NuGet packages
       shell: pwsh
@@ -307,6 +323,9 @@ jobs:
       uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
         name: signed-packages
+
+    - name: Checkout code
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,9 +109,13 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        path: Polly
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
+      with:
+        global-json-file: Polly/global.json
 
     - name: Validate NuGet packages
       shell: pwsh
@@ -147,9 +151,13 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        path: Polly
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
+      with:
+        global-json-file: Polly/global.json
 
     - name: Publish NuGet packages to GitHub Packages
       run: dotnet nuget push "*.nupkg" --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate --no-symbols --source https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
@@ -177,9 +185,13 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        path: Polly
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
+      with:
+        global-json-file: Polly/global.json
 
     - name: Install Sign CLI tool
       run: dotnet tool install --tool-path . sign --version 0.9.1-beta.23530.1
@@ -327,9 +339,13 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        path: Polly
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
+      with:
+        global-json-file: Polly/global.json
 
     - name: Push signed NuGet packages to NuGet.org
       run: dotnet nuget push "*.nupkg" --api-key ${{ secrets.NUGET_TOKEN }} --skip-duplicate --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,6 +200,7 @@ jobs:
         --azure-key-vault-client-secret "${{ secrets.SIGN_CLI_SECRET }}"
         --azure-key-vault-tenant-id "${{ secrets.SIGN_CLI_TENANT_ID }}"
         --azure-key-vault-url "${{ secrets.SIGN_CLI_VAULT_URI }}"
+        --verbosity "${{ runner.debug == '1' && 'Debug' || 'Warning' }}"
 
     - name: Upload signed packages
       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,8 +245,14 @@ jobs:
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         path: AuthenticodeLint
-        ref: ccfaec53ee5c1b14f029cb8156e0653c530f8b65
-        repository: vcsjones/AuthenticodeLint
+        ref: ae44826fdcebaa671b06591ea0b3b47fc946b79c
+        repository: martincostello/AuthenticodeLint
+        submodules: recursive
+
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
+      with:
+        global-json-file: AuthenticodeLint/global.json
 
     - name: Validate signatures
       shell: pwsh
@@ -256,7 +262,12 @@ jobs:
         $artifacts = Join-Path $authlintSource "artifacts"
         $authlint = Join-Path $artifacts "authlint.exe"
 
-        dotnet publish $authLintProject --configuration Release --output $artifacts --runtime win-x64 --self-contained false /p:NoWarn=CS8604
+        dotnet publish $authLintProject `
+          --configuration Release `
+          --output $artifacts `
+          --runtime win-x64 `
+          --self-contained false `
+          /p:NoWarn=NU1902
 
         if ($LASTEXITCODE -ne 0) {
           throw "Failed to publish AuthenticodeLint."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,7 +173,7 @@ jobs:
       uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
 
     - name: Install Sign CLI tool
-      run: dotnet tool install --tool-path . sign --version 0.9.1-beta.23274.1
+      run: dotnet tool install --tool-path . sign --version 0.9.1-beta.23530.1
 
     - name: Sign artifacts
       shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,9 @@ jobs:
       # HACK Running on Windows instead of Linux due to https://github.com/stryker-mutator/stryker-net/issues/2741
       RUN_MUTATION_TESTS: ${{ matrix.os_name == 'windows' && !startsWith(github.ref, 'refs/tags/') && 'true' || 'false' }}
 
+    outputs:
+      dotnet-sdk-version: ${{ steps.setup-dotnet.outputs.dotnet-version }}
+
     strategy:
       fail-fast: false
       matrix:
@@ -50,6 +53,7 @@ jobs:
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
+      id: setup-dotnet
 
     - name: Setup NuGet cache
       uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
@@ -107,15 +111,10 @@ jobs:
       with:
         name: packages-windows
 
-    - name: Checkout code
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      with:
-        path: Polly
-
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
       with:
-        global-json-file: Polly/global.json
+        dotnet-version: ${{ needs.build.outputs.dotnet-sdk-version }}
 
     - name: Validate NuGet packages
       shell: pwsh
@@ -134,7 +133,7 @@ jobs:
         }
 
   publish-github:
-    needs: validate-packages
+    needs: [ build, validate-packages ]
     permissions:
       packages: write
     runs-on: ubuntu-latest
@@ -149,21 +148,16 @@ jobs:
       with:
         name: packages-windows
 
-    - name: Checkout code
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      with:
-        path: Polly
-
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
       with:
-        global-json-file: Polly/global.json
+        dotnet-version: ${{ needs.build.outputs.dotnet-sdk-version }}
 
     - name: Publish NuGet packages to GitHub Packages
       run: dotnet nuget push "*.nupkg" --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate --no-symbols --source https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
 
   sign:
-    needs: publish-github
+    needs: [ build, publish-github ]
     runs-on: windows-latest
     if: |
       github.event.repository.fork == false &&
@@ -183,15 +177,10 @@ jobs:
         name: signing-config
         path: signing-config
 
-    - name: Checkout code
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      with:
-        path: Polly
-
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
       with:
-        global-json-file: Polly/global.json
+        dotnet-version: ${{ needs.build.outputs.dotnet-sdk-version }}
 
     - name: Install Sign CLI tool
       run: dotnet tool install --tool-path . sign --version 0.9.1-beta.23530.1
@@ -222,7 +211,7 @@ jobs:
         if-no-files-found: error
 
   validate-signed-packages:
-    needs: sign
+    needs: [ build, sign ]
     runs-on: windows-latest
     steps:
 
@@ -231,15 +220,10 @@ jobs:
       with:
         name: signed-packages
 
-    - name: Checkout code
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      with:
-        path: Polly
-
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
       with:
-        global-json-file: Polly/global.json
+        dotnet-version: ${{ needs.build.outputs.dotnet-sdk-version }}
 
     - name: Validate NuGet packages
       shell: pwsh
@@ -328,7 +312,7 @@ jobs:
         }
 
   publish-nuget:
-    needs: validate-signed-packages
+    needs: [ build, validate-signed-packages ]
     runs-on: ubuntu-latest
     steps:
 
@@ -337,15 +321,10 @@ jobs:
       with:
         name: signed-packages
 
-    - name: Checkout code
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      with:
-        path: Polly
-
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
       with:
-        global-json-file: Polly/global.json
+        dotnet-version: ${{ needs.build.outputs.dotnet-sdk-version }}
 
     - name: Push signed NuGet packages to NuGet.org
       run: dotnet nuget push "*.nupkg" --api-key ${{ secrets.NUGET_TOKEN }} --skip-duplicate --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,7 +195,7 @@ jobs:
         --application-name "Polly"
         --publisher-name "App vNext"
         --description "Polly"
-        --description-url "https://github.com/App-vNext/Polly"
+        --description-url "https://github.com/${{ github.repository }}"
         --azure-key-vault-certificate "${{ secrets.SIGN_CLI_CERT_NAME }}"
         --azure-key-vault-client-id "${{ secrets.SIGN_CLI_APPLICATION_ID }}"
         --azure-key-vault-client-secret "${{ secrets.SIGN_CLI_SECRET }}"


### PR DESCRIPTION
- Build [vcsjones/AuthenticodeLint](https://github.com/vcsjones/AuthenticodeLint) from https://github.com/martincostello/AuthenticodeLint/commit/ae44826fdcebaa671b06591ea0b3b47fc946b79c that contains fixes that resolve failure to validate Authenticode signatures of our assemblies ([diff](https://github.com/vcsjones/AuthenticodeLint/compare/main...martincostello:AuthenticodeLint:Bump-AuthenticodeExaminer)).
- Bump sign to [0.9.1-beta.23530.1](https://www.nuget.org/packages/sign/0.9.1-beta.23530.1).
- Ensure that the .NET SDK versions used to validate, sign and publish the NuGet packages are deterministic.
- Remove hard-coded repository URL passed to the sign tool.
- Support running the sign tool with Debug logging.

Changes verified using #1762: [successful valid signing](https://github.com/App-vNext/Polly/actions/runs/6708015664/job/18228246088#step:7:146)

~~Once 8.1.0 has been successfully published to NuGet.org, I'll create follow-up issues with the relevant tools/repos to hopefully resolve the underlying issue without us having to build the linter from a custom fork/branch.~~

Reported issues:
- https://github.com/vcsjones/AuthenticodeExaminer/issues/19
- https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/issues/1633
