### PR TITLE
[Docs] Add circuit breaker to the migration guide

### DIFF
--- a/docs/migration-v8.md
+++ b/docs/migration-v8.md
@@ -142,7 +142,7 @@ await pipelineT.ExecuteAsync(static async token =>
 ```
 <!-- endSnippet -->
 
-> [!IMPORTANT]
+> [!TIP]
 >
 > Things to remember:
 >
@@ -195,7 +195,7 @@ ResiliencePipeline pipeline = new ResiliencePipelineBuilder()
 
 See [fallback after retries](strategies/fallback.md#fallback-after-retries) for an example on how the strategies are executed.
 
-> [!IMPORTANT]
+> [!TIP]
 >
 > Things to remember:
 >
@@ -404,7 +404,7 @@ new ResiliencePipelineBuilder<HttpResponseMessage>().AddRetry(new RetryStrategyO
 ```
 <!-- endSnippet -->
 
-> [!IMPORTANT]
+> [!TIP]
 >
 > Things to remember:
 >
@@ -475,7 +475,7 @@ ResiliencePipeline<HttpResponseMessage> pipelineT = new ResiliencePipelineBuilde
 ```
 <!-- endSnippet -->
 
-> [!IMPORTANT]
+> [!TIP]
 >
 > Things to remember:
 >
@@ -538,7 +538,7 @@ ResiliencePipeline<HttpResponseMessage> pipelineT = new ResiliencePipelineBuilde
 ```
 <!-- endSnippet -->
 
-> [!IMPORTANT]
+> [!TIP]
 >
 > Things to remember:
 >
@@ -588,7 +588,7 @@ ResiliencePipeline<HttpResponseMessage> pipelineT = new ResiliencePipelineBuilde
 ```
 <!-- endSnippet -->
 
-> [!IMPORTANT]
+> [!TIP]
 >
 > Things to remember:
 >
@@ -758,7 +758,7 @@ await manualControl.CloseAsync(); // transitions into Closed state
 
 ____
 
-> [!IMPORTANT]
+> [!TIP]
 >
 > Things to remember:
 >

--- a/docs/migration-v8.md
+++ b/docs/migration-v8.md
@@ -682,8 +682,8 @@ ICircuitBreakerPolicy cbPolicy = (ICircuitBreakerPolicy)asyncPolicy;
 bool isOpen = cbPolicy.CircuitState == CircuitState.Open || cbPolicy.CircuitState == CircuitState.Isolated;
 
 // Manually control state
-cbPolicy.Isolate(); // transitions into Isolated state
-cbPolicy.Reset(); // transitions into Closed state
+cbPolicy.Isolate(); // Transitions into the Isolated state
+cbPolicy.Reset(); // Transitions into the Closed state
 ```
 <!-- endSnippet -->
 
@@ -711,7 +711,7 @@ ResiliencePipeline pipeline = new ResiliencePipelineBuilder()
     .Build();
 
 // Create a generic pipeline with circuit breaker. Because ResiliencePipeline<T> supports both sync and async
-// callbacks, there is no need to define it twice.
+// callbacks, there is also no need to define it twice.
 ResiliencePipeline<HttpResponseMessage> pipelineT = new ResiliencePipelineBuilder<HttpResponseMessage>()
     .AddCircuitBreaker(new CircuitBreakerStrategyOptions<HttpResponseMessage>
     {
@@ -745,8 +745,8 @@ ResiliencePipeline pipelineState = new ResiliencePipelineBuilder()
 bool isOpen = stateProvider.CircuitState == CircuitState.Open || stateProvider.CircuitState == CircuitState.Isolated;
 
 // Manually control state
-await manualControl.IsolateAsync(); // transitions into Isolated state
-await manualControl.CloseAsync(); // transitions into Closed state
+await manualControl.IsolateAsync(); // Transitions into the Isolated state
+await manualControl.CloseAsync(); // Transitions into the Closed state
 ```
 <!-- endSnippet -->
 

--- a/docs/migration-v8.md
+++ b/docs/migration-v8.md
@@ -750,6 +750,14 @@ await manualControl.CloseAsync(); // transitions into Closed state
 ```
 <!-- endSnippet -->
 
+> [!NOTE]
+>
+> On the [V7's wiki page](https://github.com/App-vNext/Polly/wiki/Circuit-Breaker#reducing-thrown-exceptions-when-the-circuit-is-broken) you can find a tip how to reduce thrown exceptions. The described technique does **not** work with V8.
+>
+> Under the [circuit breaker's anti-patterns](strategies/circuit-breaker.md#4---reducing-thrown-exceptions) you can find the suggested way for V8.
+
+____
+
 > [!IMPORTANT]
 >
 > Things to remember:

--- a/docs/migration-v8.md
+++ b/docs/migration-v8.md
@@ -752,7 +752,9 @@ await manualControl.CloseAsync(); // Transitions into the Closed state
 
 > [!NOTE]
 >
-> On the [V7's wiki page](https://github.com/App-vNext/Polly/wiki/Circuit-Breaker#reducing-thrown-exceptions-when-the-circuit-is-broken) you can find a tip how to reduce thrown exceptions. The described technique does **not** work with V8.
+> In case of V7 you could do an optimization to reduce the thrown exceptions.
+>
+> You could guard the `Execute{Async}` call with a condition that the circuit is not broken. This technique does **not** work with V8.
 >
 > Under the [circuit breaker's anti-patterns](strategies/circuit-breaker.md#4---reducing-thrown-exceptions) you can find the suggested way for V8.
 

--- a/docs/migration-v8.md
+++ b/docs/migration-v8.md
@@ -603,7 +603,7 @@ This section describes how to migrate v7 circuit breaker policies to V8 circuit 
 
 ### Circuit breaker in v7
 
-V7's "Standard" Circuit Breaker policy could be defined like bellow:
+V7's "Standard" Circuit Breaker policy could be defined like below:
 
 <!-- snippet: migration-circuit-breaker-v7 -->
 ```cs
@@ -637,7 +637,7 @@ IAsyncPolicy<HttpResponseMessage> asyncPolicyT = Policy<HttpResponseMessage>
 ```
 <!-- endSnippet -->
 
-V7's Advanced Circuit Breaker policy could be defined like bellow:
+V7's Advanced Circuit Breaker policy could be defined like below:
 
 <!-- snippet: migration-advanced-circuit-breaker-v7 -->
 ```cs
@@ -691,7 +691,7 @@ cbPolicy.Reset(); // transitions into Closed state
 
 > [!IMPORTANT]
 >
-> Polly V8 does not support the standard ("classic") circuit breaker with consecutive failure counting.
+> Polly V8 does not support the standard (_"classic"_) circuit breaker with consecutive failure counting.
 >
 > In case of V8 you can define a Circuit Breaker strategy which works like the advanced circuit breaker in V7.
 

--- a/docs/migration-v8.md
+++ b/docs/migration-v8.md
@@ -687,8 +687,7 @@ cbPolicy.Reset(); // transitions into Closed state
 ```
 <!-- endSnippet -->
 
-
-### Timeout in v8
+### Circuit breaker in v8
 
 > [!IMPORTANT]
 >
@@ -759,7 +758,6 @@ await manualControl.CloseAsync(); // transitions into Closed state
 > - Use the `CircuitBreakerStrategyOptions{<TResult>}` to customize your circuit breaker behavior to meet your requirements
 >
 > For further information please check out the [Circuit Breaker resilience strategy documentation](strategies/circuit-breaker.md).
-
 
 ## Migrating other policies
 

--- a/docs/migration-v8.md
+++ b/docs/migration-v8.md
@@ -142,7 +142,7 @@ await pipelineT.ExecuteAsync(static async token =>
 ```
 <!-- endSnippet -->
 
-> [!TIP]
+> [!IMPORTANT]
 >
 > Things to remember:
 >
@@ -195,7 +195,7 @@ ResiliencePipeline pipeline = new ResiliencePipelineBuilder()
 
 See [fallback after retries](strategies/fallback.md#fallback-after-retries) for an example on how the strategies are executed.
 
-> [!TIP]
+> [!IMPORTANT]
 >
 > Things to remember:
 >
@@ -404,7 +404,7 @@ new ResiliencePipelineBuilder<HttpResponseMessage>().AddRetry(new RetryStrategyO
 ```
 <!-- endSnippet -->
 
-> [!TIP]
+> [!IMPORTANT]
 >
 > Things to remember:
 >
@@ -475,7 +475,7 @@ ResiliencePipeline<HttpResponseMessage> pipelineT = new ResiliencePipelineBuilde
 ```
 <!-- endSnippet -->
 
-> [!TIP]
+> [!IMPORTANT]
 >
 > Things to remember:
 >
@@ -538,7 +538,7 @@ ResiliencePipeline<HttpResponseMessage> pipelineT = new ResiliencePipelineBuilde
 ```
 <!-- endSnippet -->
 
-> [!TIP]
+> [!IMPORTANT]
 >
 > Things to remember:
 >
@@ -588,7 +588,7 @@ ResiliencePipeline<HttpResponseMessage> pipelineT = new ResiliencePipelineBuilde
 ```
 <!-- endSnippet -->
 
-> [!TIP]
+> [!IMPORTANT]
 >
 > Things to remember:
 >
@@ -758,7 +758,7 @@ await manualControl.CloseAsync(); // transitions into Closed state
 
 ____
 
-> [!TIP]
+> [!IMPORTANT]
 >
 > Things to remember:
 >

--- a/docs/migration-v8.md
+++ b/docs/migration-v8.md
@@ -597,6 +597,170 @@ ResiliencePipeline<HttpResponseMessage> pipelineT = new ResiliencePipelineBuilde
 >
 > For further information please check out the [Timeout resilience strategy documentation](strategies/timeout.md).
 
+## Migrating circuit breaker policies
+
+This section describes how to migrate v7 circuit breaker policies to V8 circuit breaker strategies.
+
+### Circuit breaker in v7
+
+V7's "Standard" Circuit Breaker policy could be defined like bellow:
+
+<!-- snippet: migration-circuit-breaker-v7 -->
+```cs
+// Create sync circuit breaker
+ISyncPolicy syncPolicy = Policy
+    .Handle<SomeExceptionType>()
+    .CircuitBreaker(
+        exceptionsAllowedBeforeBreaking: 2,
+        durationOfBreak: TimeSpan.FromSeconds(1));
+
+// Create async circuit breaker
+IAsyncPolicy asyncPolicy = Policy
+    .Handle<SomeExceptionType>()
+    .CircuitBreakerAsync(
+        exceptionsAllowedBeforeBreaking: 2,
+        durationOfBreak: TimeSpan.FromSeconds(1));
+
+// Create generic sync circuit breaker
+ISyncPolicy<HttpResponseMessage> syncPolicyT = Policy<HttpResponseMessage>
+    .Handle<SomeExceptionType>()
+    .CircuitBreaker(
+        handledEventsAllowedBeforeBreaking: 2,
+        durationOfBreak: TimeSpan.FromSeconds(1));
+
+// Create generic async circuit breaker
+IAsyncPolicy<HttpResponseMessage> asyncPolicyT = Policy<HttpResponseMessage>
+    .Handle<SomeExceptionType>()
+    .CircuitBreakerAsync(
+        handledEventsAllowedBeforeBreaking: 2,
+        durationOfBreak: TimeSpan.FromSeconds(1));
+```
+<!-- endSnippet -->
+
+V7's Advanced Circuit Breaker policy could be defined like bellow:
+
+<!-- snippet: migration-advanced-circuit-breaker-v7 -->
+```cs
+// Create sync advanced circuit breaker
+ISyncPolicy syncPolicy = Policy
+    .Handle<SomeExceptionType>()
+    .AdvancedCircuitBreaker(
+        failureThreshold: 0.5d,
+        samplingDuration: TimeSpan.FromSeconds(5),
+        minimumThroughput: 2,
+        durationOfBreak: TimeSpan.FromSeconds(1));
+
+// Create async advanced circuit breaker
+IAsyncPolicy asyncPolicy = Policy
+    .Handle<SomeExceptionType>()
+    .AdvancedCircuitBreakerAsync(
+        failureThreshold: 0.5d,
+        samplingDuration: TimeSpan.FromSeconds(5),
+        minimumThroughput: 2,
+        durationOfBreak: TimeSpan.FromSeconds(1));
+
+// Create generic sync advanced circuit breaker
+ISyncPolicy<HttpResponseMessage> syncPolicyT = Policy<HttpResponseMessage>
+    .Handle<SomeExceptionType>()
+    .AdvancedCircuitBreaker(
+        failureThreshold: 0.5d,
+        samplingDuration: TimeSpan.FromSeconds(5),
+        minimumThroughput: 2,
+        durationOfBreak: TimeSpan.FromSeconds(1));
+
+// Create generic async advanced circuit breaker
+IAsyncPolicy<HttpResponseMessage> asyncPolicyT = Policy<HttpResponseMessage>
+    .Handle<SomeExceptionType>()
+    .AdvancedCircuitBreakerAsync(
+        failureThreshold: 0.5d,
+        samplingDuration: TimeSpan.FromSeconds(5),
+        minimumThroughput: 2,
+        durationOfBreak: TimeSpan.FromSeconds(1));
+
+// Check circuit state
+ICircuitBreakerPolicy cbPolicy = (ICircuitBreakerPolicy)asyncPolicy;
+bool isOpen = cbPolicy.CircuitState == CircuitState.Open || cbPolicy.CircuitState == CircuitState.Isolated;
+
+// Manually control state
+cbPolicy.Isolate(); // transitions into Isolated state
+cbPolicy.Reset(); // transitions into Closed state
+```
+<!-- endSnippet -->
+
+
+### Timeout in v8
+
+> [!IMPORTANT]
+>
+> Polly V8 does not support the standard ("classic") circuit breaker with consecutive failure counting.
+>
+> In case of V8 you can define a Circuit Breaker strategy which works like the advanced circuit breaker in V7.
+
+<!-- snippet: migration-circuit-breaker-v8 -->
+```cs
+// Create pipeline with circuit breaker. Because ResiliencePipeline supports both sync and async
+// callbacks, there is no need to define it twice.
+ResiliencePipeline pipeline = new ResiliencePipelineBuilder()
+    .AddCircuitBreaker(new CircuitBreakerStrategyOptions
+    {
+        ShouldHandle = new PredicateBuilder().Handle<SomeExceptionType>(),
+        FailureRatio = 0.5d,
+        SamplingDuration = TimeSpan.FromSeconds(5),
+        MinimumThroughput = 2,
+        BreakDuration = TimeSpan.FromSeconds(1)
+    })
+    .Build();
+
+// Create a generic pipeline with circuit breaker. Because ResiliencePipeline<T> supports both sync and async
+// callbacks, there is no need to define it twice.
+ResiliencePipeline<HttpResponseMessage> pipelineT = new ResiliencePipelineBuilder<HttpResponseMessage>()
+    .AddCircuitBreaker(new CircuitBreakerStrategyOptions<HttpResponseMessage>
+    {
+        ShouldHandle = new PredicateBuilder<HttpResponseMessage>().Handle<SomeExceptionType>(),
+        FailureRatio = 0.5d,
+        SamplingDuration = TimeSpan.FromSeconds(5),
+        MinimumThroughput = 2,
+        BreakDuration = TimeSpan.FromSeconds(1)
+    })
+    .Build();
+
+// Check circuit state
+CircuitBreakerStateProvider stateProvider = new();
+// Manually control state
+CircuitBreakerManualControl manualControl = new();
+
+ResiliencePipeline pipelineState = new ResiliencePipelineBuilder()
+    .AddCircuitBreaker(new CircuitBreakerStrategyOptions
+    {
+        ShouldHandle = new PredicateBuilder().Handle<SomeExceptionType>(),
+        FailureRatio = 0.5d,
+        SamplingDuration = TimeSpan.FromSeconds(5),
+        MinimumThroughput = 2,
+        BreakDuration = TimeSpan.FromSeconds(1),
+        StateProvider = stateProvider,
+        ManualControl = manualControl
+    })
+    .Build();
+
+// Check circuit state
+bool isOpen = stateProvider.CircuitState == CircuitState.Open || stateProvider.CircuitState == CircuitState.Isolated;
+
+// Manually control state
+await manualControl.IsolateAsync(); // transitions into Isolated state
+await manualControl.CloseAsync(); // transitions into Closed state
+```
+<!-- endSnippet -->
+
+> [!IMPORTANT]
+>
+> Things to remember:
+>
+> - Use `AddCircuitBreaker` to add a circuit breaker strategy to your resiliency pipeline
+> - Use the `CircuitBreakerStrategyOptions{<TResult>}` to customize your circuit breaker behavior to meet your requirements
+>
+> For further information please check out the [Circuit Breaker resilience strategy documentation](strategies/circuit-breaker.md).
+
+
 ## Migrating other policies
 
 Migrating is a process similar to the ones described in the previous sections. Keep in mind that:

--- a/docs/migration-v8.md
+++ b/docs/migration-v8.md
@@ -691,7 +691,7 @@ cbPolicy.Reset(); // Transitions into the Closed state
 
 > [!IMPORTANT]
 >
-> Polly V8 does not support the standard (_"classic"_) circuit breaker with consecutive failure counting.
+> Polly V8 does not support the standard (*"classic"*) circuit breaker with consecutive failure counting.
 >
 > In case of V8 you can define a Circuit Breaker strategy which works like the advanced circuit breaker in V7.
 

--- a/docs/strategies/circuit-breaker.md
+++ b/docs/strategies/circuit-breaker.md
@@ -603,11 +603,12 @@ ResilienceContextPool.Shared.Return(context);
 
 if (outcome.Exception is BrokenCircuitException)
 {
-    // the execution was stopped by CB
+    // The execution was stopped by the circuit breaker
 }
 else
 {
-    // Your code goes here to process response (outcome.Result)
+    HttpResponseMessage response = outcome.Result!;
+    // Your code goes here to process the response
 }
 ```
 <!-- endSnippet -->

--- a/docs/strategies/circuit-breaker.md
+++ b/docs/strategies/circuit-breaker.md
@@ -615,5 +615,5 @@ else
 
 **Reasoning**:
 
-- The `ExecuteOutcomeAsync` is a low-allocation API which does not throw exception rather captures it inside the `Exception` property of the `Outcome` data structure.
+- The `ExecuteOutcomeAsync` is a low-allocation API which does not throw exceptions; rather it captures them inside an `Outcome` data structure.
 - Since you are calling one of the `Execute` methods, that's why the circuit breaker can transition into the `HalfOpen` state.

--- a/docs/strategies/circuit-breaker.md
+++ b/docs/strategies/circuit-breaker.md
@@ -538,7 +538,7 @@ public Downstream1Client(
 
 ### 4 - Reducing thrown exceptions
 
-In case of Circuit Breaker when it is either in `Open` or in `Isolated` state new requests are rejected immediately.
+In case of Circuit Breaker when it is either in the `Open` or `Isolated` state new requests are rejected immediately.
 
 That means the strategy will throw either a `BrokenCircuitException` or an `IsolatedCircuitException` respectively.
 
@@ -574,9 +574,9 @@ if (stateProvider.CircuitState
 
 **Reasoning**:
 
-- The problem with this approach is that the circuit breaker will never transition into `HalfOpen` state.
+- The problem with this approach is that the circuit breaker will never transition into the `HalfOpen` state.
 - The circuit breaker does not act as an active object. In other words the state transition does not happen automatically in the background.
-- The circuit transition into `HalfOpen` state when the `Execute{Async}` is called and the `BreakDuration` elapsed.
+- The circuit transition into the `HalfOpen` state when the `Execute{Async}` method is called and the `BreakDuration` elapsed.
 
 ✅ DO
 
@@ -615,4 +615,4 @@ else
 **Reasoning**:
 
 - The `ExecuteOutcomeAsync` is a low-allocation API which does not throw exception rather captures it inside the `Exception` property of the `Outcome` data structure.
-- Since your are calling one of the `Execute` methods that's why the circuit breaker can transition into `HalfOpen` state.
+- Since you are calling one of the `Execute` methods, that's why the circuit breaker can transition into the `HalfOpen` state.

--- a/docs/strategies/circuit-breaker.md
+++ b/docs/strategies/circuit-breaker.md
@@ -612,7 +612,6 @@ else
 ```
 <!-- endSnippet -->
 
-
 **Reasoning**:
 
 - The `ExecuteOutcomeAsync` is a low-allocation API which does not throw exception rather captures it inside the `Exception` property of the `Outcome` data structure.

--- a/src/Snippets/Docs/CircuitBreaker.cs
+++ b/src/Snippets/Docs/CircuitBreaker.cs
@@ -273,7 +273,8 @@ internal static class CircuitBreaker
         }
         else
         {
-            // Your code goes here to process the response (outcome.Result)
+            HttpResponseMessage response = outcome.Result!;
+            // Your code goes here to process the response
         }
 
         #endregion

--- a/src/Snippets/Docs/CircuitBreaker.cs
+++ b/src/Snippets/Docs/CircuitBreaker.cs
@@ -269,11 +269,11 @@ internal static class CircuitBreaker
 
         if (outcome.Exception is BrokenCircuitException)
         {
-            // the execution was stopped by CB
+            // The execution was stopped by the circuit breaker
         }
         else
         {
-            // Your code goes here to process response (outcome.Result)
+            // Your code goes here to process the response (outcome.Result)
         }
 
         #endregion

--- a/src/Snippets/Docs/CircuitBreaker.cs
+++ b/src/Snippets/Docs/CircuitBreaker.cs
@@ -214,4 +214,68 @@ internal static class CircuitBreaker
         await uriToCbMappings[downstream1Uri].ExecuteAsync(CallXYZOnDownstream1, CancellationToken.None);
         #endregion
     }
+
+    public static async ValueTask AntiPattern_4()
+    {
+        #region circuit-breaker-anti-pattern-4
+
+        var stateProvider = new CircuitBreakerStateProvider();
+        var circuitBreaker = new ResiliencePipelineBuilder()
+            .AddCircuitBreaker(new()
+            {
+                ShouldHandle = new PredicateBuilder().Handle<HttpRequestException>(),
+                BreakDuration = TimeSpan.FromSeconds(0.5),
+                StateProvider = stateProvider
+            })
+            .Build();
+
+        if (stateProvider.CircuitState
+            is not CircuitState.Open
+            and not CircuitState.Isolated)
+        {
+            var response = await circuitBreaker.ExecuteAsync(static async ct =>
+            {
+                return await IssueRequest();
+            }, CancellationToken.None);
+
+            // Your code goes here to process response
+        }
+
+        #endregion
+    }
+
+    private static ValueTask<HttpResponseMessage> IssueRequest() => ValueTask.FromResult(new HttpResponseMessage());
+
+    public static async ValueTask Pattern_4()
+    {
+        #region circuit-breaker-pattern-4
+
+        var context = ResilienceContextPool.Shared.Get();
+        var circuitBreaker = new ResiliencePipelineBuilder()
+            .AddCircuitBreaker(new()
+            {
+                ShouldHandle = new PredicateBuilder().Handle<HttpRequestException>(),
+                BreakDuration = TimeSpan.FromSeconds(0.5),
+            })
+            .Build();
+
+        Outcome<HttpResponseMessage> outcome = await circuitBreaker.ExecuteOutcomeAsync(static async (ctx, state) =>
+        {
+            var response = await IssueRequest();
+            return Outcome.FromResult(response);
+        }, context, "state");
+
+        ResilienceContextPool.Shared.Return(context);
+
+        if (outcome.Exception is BrokenCircuitException)
+        {
+            // the execution was stopped by CB
+        }
+        else
+        {
+            // Your code goes here to process response (outcome.Result)
+        }
+
+        #endregion
+    }
 }

--- a/src/Snippets/Docs/Migration.CircuitBreaker.cs
+++ b/src/Snippets/Docs/Migration.CircuitBreaker.cs
@@ -1,5 +1,4 @@
 using System.Net.Http;
-using System.Runtime.Versioning;
 using Polly.CircuitBreaker;
 using Snippets.Docs.Utils;
 
@@ -7,7 +6,6 @@ namespace Snippets.Docs;
 
 internal static partial class Migration
 {
-    [RequiresPreviewFeatures]
     public static void CircuitBreaker_V7()
     {
         #region migration-circuit-breaker-v7

--- a/src/Snippets/Docs/Migration.CircuitBreaker.cs
+++ b/src/Snippets/Docs/Migration.CircuitBreaker.cs
@@ -86,8 +86,8 @@ internal static partial class Migration
         bool isOpen = cbPolicy.CircuitState == CircuitState.Open || cbPolicy.CircuitState == CircuitState.Isolated;
 
         // Manually control state
-        cbPolicy.Isolate(); // transitions into Isolated state
-        cbPolicy.Reset(); // transitions into Closed state
+        cbPolicy.Isolate(); // Transitions into the Isolated state
+        cbPolicy.Reset(); // Transitions into the Closed state
 
         #endregion
     }
@@ -110,7 +110,7 @@ internal static partial class Migration
             .Build();
 
         // Create a generic pipeline with circuit breaker. Because ResiliencePipeline<T> supports both sync and async
-        // callbacks, there is no need to define it twice.
+        // callbacks, there is also no need to define it twice.
         ResiliencePipeline<HttpResponseMessage> pipelineT = new ResiliencePipelineBuilder<HttpResponseMessage>()
             .AddCircuitBreaker(new CircuitBreakerStrategyOptions<HttpResponseMessage>
             {
@@ -144,8 +144,8 @@ internal static partial class Migration
         bool isOpen = stateProvider.CircuitState == CircuitState.Open || stateProvider.CircuitState == CircuitState.Isolated;
 
         // Manually control state
-        await manualControl.IsolateAsync(); // transitions into Isolated state
-        await manualControl.CloseAsync(); // transitions into Closed state
+        await manualControl.IsolateAsync(); // Transitions into the Isolated state
+        await manualControl.CloseAsync(); // Transitions into the Closed state
 
         #endregion
     }

--- a/src/Snippets/Docs/Migration.CircuitBreaker.cs
+++ b/src/Snippets/Docs/Migration.CircuitBreaker.cs
@@ -1,0 +1,158 @@
+using System.Net.Http;
+using System.Runtime.Versioning;
+using Polly.CircuitBreaker;
+using Snippets.Docs.Utils;
+
+namespace Snippets.Docs;
+
+internal static partial class Migration
+{
+    [RequiresPreviewFeatures]
+    public static void CircuitBreaker_V7()
+    {
+        #region migration-circuit-breaker-v7
+
+        // Create sync circuit breaker
+        ISyncPolicy syncPolicy = Policy
+            .Handle<SomeExceptionType>()
+            .CircuitBreaker(
+                exceptionsAllowedBeforeBreaking: 2,
+                durationOfBreak: TimeSpan.FromSeconds(1));
+
+        // Create async circuit breaker
+        IAsyncPolicy asyncPolicy = Policy
+            .Handle<SomeExceptionType>()
+            .CircuitBreakerAsync(
+                exceptionsAllowedBeforeBreaking: 2,
+                durationOfBreak: TimeSpan.FromSeconds(1));
+
+        // Create generic sync circuit breaker
+        ISyncPolicy<HttpResponseMessage> syncPolicyT = Policy<HttpResponseMessage>
+            .Handle<SomeExceptionType>()
+            .CircuitBreaker(
+                handledEventsAllowedBeforeBreaking: 2,
+                durationOfBreak: TimeSpan.FromSeconds(1));
+
+        // Create generic async circuit breaker
+        IAsyncPolicy<HttpResponseMessage> asyncPolicyT = Policy<HttpResponseMessage>
+            .Handle<SomeExceptionType>()
+            .CircuitBreakerAsync(
+                handledEventsAllowedBeforeBreaking: 2,
+                durationOfBreak: TimeSpan.FromSeconds(1));
+
+        #endregion
+    }
+
+    public static void AdvancedCircuitBreaker_V7()
+    {
+        #region migration-advanced-circuit-breaker-v7
+
+        // Create sync advanced circuit breaker
+        ISyncPolicy syncPolicy = Policy
+            .Handle<SomeExceptionType>()
+            .AdvancedCircuitBreaker(
+                failureThreshold: 0.5d,
+                samplingDuration: TimeSpan.FromSeconds(5),
+                minimumThroughput: 2,
+                durationOfBreak: TimeSpan.FromSeconds(1));
+
+        // Create async advanced circuit breaker
+        IAsyncPolicy asyncPolicy = Policy
+            .Handle<SomeExceptionType>()
+            .AdvancedCircuitBreakerAsync(
+                failureThreshold: 0.5d,
+                samplingDuration: TimeSpan.FromSeconds(5),
+                minimumThroughput: 2,
+                durationOfBreak: TimeSpan.FromSeconds(1));
+
+        // Create generic sync advanced circuit breaker
+        ISyncPolicy<HttpResponseMessage> syncPolicyT = Policy<HttpResponseMessage>
+            .Handle<SomeExceptionType>()
+            .AdvancedCircuitBreaker(
+                failureThreshold: 0.5d,
+                samplingDuration: TimeSpan.FromSeconds(5),
+                minimumThroughput: 2,
+                durationOfBreak: TimeSpan.FromSeconds(1));
+
+        // Create generic async advanced circuit breaker
+        IAsyncPolicy<HttpResponseMessage> asyncPolicyT = Policy<HttpResponseMessage>
+            .Handle<SomeExceptionType>()
+            .AdvancedCircuitBreakerAsync(
+                failureThreshold: 0.5d,
+                samplingDuration: TimeSpan.FromSeconds(5),
+                minimumThroughput: 2,
+                durationOfBreak: TimeSpan.FromSeconds(1));
+
+        // Check circuit state
+        ICircuitBreakerPolicy cbPolicy = (ICircuitBreakerPolicy)asyncPolicy;
+        bool isOpen = cbPolicy.CircuitState == CircuitState.Open || cbPolicy.CircuitState == CircuitState.Isolated;
+
+        // Manually control state
+        cbPolicy.Isolate(); // transitions into Isolated state
+        cbPolicy.Reset(); // transitions into Closed state
+
+        #endregion
+    }
+
+    public static async Task CircuitBreaker_V8()
+    {
+        #region migration-circuit-breaker-v8
+
+        // Create pipeline with circuit breaker. Because ResiliencePipeline supports both sync and async
+        // callbacks, there is no need to define it twice.
+        ResiliencePipeline pipeline = new ResiliencePipelineBuilder()
+            .AddCircuitBreaker(new CircuitBreakerStrategyOptions
+            {
+                FailureRatio = 0.5d,
+                SamplingDuration = TimeSpan.FromSeconds(5),
+                MinimumThroughput = 2,
+                BreakDuration = TimeSpan.FromSeconds(1)
+            })
+            .Build();
+
+        // Create a generic pipeline with circuit breaker. Because ResiliencePipeline<T> supports both sync and async
+        // callbacks, there is no need to define it twice.
+        ResiliencePipeline<HttpResponseMessage> pipelineT = new ResiliencePipelineBuilder<HttpResponseMessage>()
+            .AddCircuitBreaker(new CircuitBreakerStrategyOptions<HttpResponseMessage>
+            {
+                FailureRatio = 0.5d,
+                SamplingDuration = TimeSpan.FromSeconds(5),
+                MinimumThroughput = 2,
+                BreakDuration = TimeSpan.FromSeconds(1)
+            })
+            .Build();
+
+        // Check circuit state
+        CircuitBreakerStateProvider stateProvider = new();
+        ResiliencePipeline<HttpResponseMessage> pipelineState = new ResiliencePipelineBuilder<HttpResponseMessage>()
+            .AddCircuitBreaker(new CircuitBreakerStrategyOptions<HttpResponseMessage>
+            {
+                FailureRatio = 0.5d,
+                SamplingDuration = TimeSpan.FromSeconds(5),
+                MinimumThroughput = 2,
+                BreakDuration = TimeSpan.FromSeconds(1),
+                StateProvider = stateProvider
+            })
+            .Build();
+
+        bool isOpen = stateProvider.CircuitState == CircuitState.Open || stateProvider.CircuitState == CircuitState.Isolated;
+
+        // Manually control state
+        CircuitBreakerManualControl manualControl = new();
+        ResiliencePipeline<HttpResponseMessage> pipelineControl = new ResiliencePipelineBuilder<HttpResponseMessage>()
+            .AddCircuitBreaker(new CircuitBreakerStrategyOptions<HttpResponseMessage>
+            {
+                FailureRatio = 0.5d,
+                SamplingDuration = TimeSpan.FromSeconds(5),
+                MinimumThroughput = 2,
+                BreakDuration = TimeSpan.FromSeconds(1),
+                ManualControl = manualControl
+            })
+            .Build();
+
+        await manualControl.IsolateAsync(); // transitions into Isolated state
+        await manualControl.CloseAsync(); // transitions into Closed state
+
+        #endregion
+    }
+}

--- a/src/Snippets/Docs/Migration.Retry.cs
+++ b/src/Snippets/Docs/Migration.Retry.cs
@@ -1,6 +1,5 @@
 ﻿using System.Net;
 using System.Net.Http;
-using System.Runtime.Versioning;
 using Polly.Retry;
 using Snippets.Docs.Utils;
 
@@ -8,7 +7,6 @@ namespace Snippets.Docs;
 
 internal static partial class Migration
 {
-    [RequiresPreviewFeatures]
     public static void Retry_V7()
     {
         #region migration-retry-v7


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed

- #1763  
  - As I've pointed in the previous PR the migration guide did not have a circuit breaker section 

## Details on the issue fix or feature implementation
- Created a `Migration.CircuitBreaker.cs` file with V7 and V8 samples
- Added a _Migrating circuit breaker policies_ section to the `migration-v8.md` files

## Open questions
- Does it make sense to have a "standard"/"classic" section under the V7 paragraph?
  - Or shall I delete it since it is not supported in V8?
  - Personally I would vote to keep it to make it explicit that the "classic" version support is discontinued

**Answer: keep it under the V7 paragraph**

-  In the github wiki under the Circuit breaker we have a "suggest" which does not work for V8
   - [Wiki link](https://github.com/App-vNext/Polly/wiki/Circuit-Breaker#reducing-thrown-exceptions-when-the-circuit-is-broken)
   - Several weeks ago [I've detailed the problem](https://stackoverflow.com/questions/77203937/polly-v8-circuitbreaker-behavior-is-different-the-circuit-gets-stuck-open/77214137#77214137) from V8 perspective on StackOverflow
   - What do want to do with this?
      - Shall I add a new anti-pattern under the Circuit Breaker page?
      - Shall I add a note at the end of this circuit breaker migration paragraph?
      - Other? 

**Answer: add it to the anti-patterns section and add reference to that from the migration guide**

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
