### PR TITLE
[Docs] Revise migration guide 3/3

### DIFF
--- a/docs/migration-v8.md
+++ b/docs/migration-v8.md
@@ -913,7 +913,7 @@ string? ctxValue = asyncPolicyResult.Context.GetValueOrDefault(Key) as string;
 >
 > Polly V8 does not provide an API to synchronously execute and capture the outcome of a pipeline.
 >
-> On the other hand it introduced a type-safe `state`: TBD.
+> On the other hand it introduced a type-safe `state`: to-be-defined.
 
 <!-- snippet: migration-execute-v8 -->
 ```cs
@@ -975,7 +975,7 @@ ResilienceContextPool.Shared.Return(context);
 > Things to remember:
 >
 > - Use `ExecuteOutcomeAsync` to execute your callback in a safe way
-> - TBD: when to use context and when to use state
+> - To-Be-Defined: when to use context and when to use state
 
 ## Migrating no-op policies
 

--- a/docs/migration-v8.md
+++ b/docs/migration-v8.md
@@ -1060,7 +1060,7 @@ registry.GetOrAddPipeline(PipelineKey, builder => builder.AddTimeout(TimeSpan.Fr
 > Things to remember:
 >
 > - Use `ResiliencePipelineRegistry<TResult>` to add or get a pipelines to the registry
-> - Prefer the safe methods (for example: `TryGetPipeline{<TResult>}`) over their counterpart (for example: `GetPipeline{<TResult>}`)
+> - Prefer the safer methods (for example: `TryGetPipeline{<TResult>}`) over their counterpart (for example: `GetPipeline{<TResult>}`)
 >
 > For further information please check out the [Resilience pipeline registry documentation](pipelines/resilience-pipeline-registry.md).
 

--- a/docs/migration-v8.md
+++ b/docs/migration-v8.md
@@ -912,8 +912,6 @@ string? ctxValue = asyncPolicyResult.Context.GetValueOrDefault(Key) as string;
 > [!NOTE]
 >
 > Polly V8 does not provide an API to synchronously execute and capture the outcome of a pipeline.
->
-> On the other hand it introduced a type-safe `state`: to-be-defined.
 
 <!-- snippet: migration-execute-v8 -->
 ```cs
@@ -975,7 +973,6 @@ ResilienceContextPool.Shared.Return(context);
 > Things to remember:
 >
 > - Use `ExecuteOutcomeAsync` to execute your callback in a safe way
-> - To-Be-Defined: when to use context and when to use state
 
 ## Migrating no-op policies
 
@@ -1037,7 +1034,7 @@ registry.AddOrUpdate(
 >
 > Polly V8 does not provide an explicit API to directly update a strategy in the registry.
 >
-> On the other hand it does provide a mechanism to reload pipelines.
+> On the other hand it does provide a mechanism to [reload pipelines](pipelines/resilience-pipeline-registry.md#dynamic-reloads).
 
 <!-- snippet: migration-registry-v8 -->
 ```cs

--- a/docs/pipelines/resilience-pipeline-registry.md
+++ b/docs/pipelines/resilience-pipeline-registry.md
@@ -95,7 +95,7 @@ The constructor for `ResiliencePipelineRegistry<TKey>` accepts a parameter of ty
 | `InstanceNameFormatter` | `null`                                                          | Delegate formatting `TKey` to instance name.                      |
 | `BuilderNameFormatter`  | Function returning the `key.ToString()` value.                  | Delegate formatting `TKey` to builder name.                       |
 
-> [>NOTE]
+> [!NOTE]
 > The `BuilderName` and `InstanceName` are used in [telemetry](../advanced/telemetry.md#metrics).
 
 Usage example:

--- a/src/Snippets/Docs/Migration.Context.cs
+++ b/src/Snippets/Docs/Migration.Context.cs
@@ -2,6 +2,8 @@
 
 internal static partial class Migration
 {
+    private const string Key1 = nameof(Key1);
+    private const string Key2 = nameof(Key2);
     public static void Context_V7()
     {
         #region migration-context-v7
@@ -13,12 +15,19 @@ internal static partial class Migration
         context = new Context("my-operation-key");
 
         // Attach custom properties
-        context["prop-1"] = "value-1";
-        context["prop-2"] = 100;
+        context[Key1] = "value-1";
+        context[Key2] = 100;
 
         // Retrieve custom properties
-        string value1 = (string)context["prop-1"];
-        int value2 = (int)context["prop-2"];
+        string value1 = (string)context[Key1];
+        int value2 = (int)context[Key2];
+
+        // Bulk attach
+        context = new Context("my-operation-key", new Dictionary<string, object>
+        {
+            { Key1 , "value-1" },
+            { Key2 , 100 }
+        });
 
         #endregion
     }
@@ -34,12 +43,22 @@ internal static partial class Migration
         context = ResilienceContextPool.Shared.Get("my-operation-key");
 
         // Attach custom properties
-        context.Properties.Set(new ResiliencePropertyKey<string>("prop-1"), "value-1");
-        context.Properties.Set(new ResiliencePropertyKey<int>("prop-2"), 100);
+        ResiliencePropertyKey<string> propertyKey1 = new(Key1);
+        context.Properties.Set(propertyKey1, "value-1");
+
+        ResiliencePropertyKey<int> propertyKey2 = new(Key2);
+        context.Properties.Set(propertyKey2, 100);
+
+        // Bulk attach
+        context.Properties.SetProperties(new Dictionary<string, object?>
+        {
+            { Key1 , "value-1" },
+            { Key2 , 100 }
+        }, out var oldProperties);
 
         // Retrieve custom properties
-        string value1 = context.Properties.GetValue(new ResiliencePropertyKey<string>("prop-1"), "default");
-        int value2 = context.Properties.GetValue(new ResiliencePropertyKey<int>("prop-2"), 0);
+        string value1 = context.Properties.GetValue(propertyKey1, "default");
+        int value2 = context.Properties.GetValue(propertyKey2, 0);
 
         // Return the context to the pool
         ResilienceContextPool.Shared.Return(context);

--- a/src/Snippets/Docs/Migration.Execute.cs
+++ b/src/Snippets/Docs/Migration.Execute.cs
@@ -27,22 +27,23 @@ internal static partial class Migration
         else
         {
             Exception exception = policyResult.FinalException;
-            FaultType failtType = policyResult.FaultType!.Value;
+            FaultType faultType = policyResult.FaultType!.Value;
             ExceptionType exceptionType = policyResult.ExceptionType!.Value;
 
             // Process failure
         }
 
         // Access context
+        const string Key = "context_key";
         IAsyncPolicy<int> asyncPolicyWithContext = Policy.TimeoutAsync<int>(TimeSpan.FromSeconds(10),
             onTimeoutAsync: (ctx, ts, task) =>
             {
-                ctx["context_key"] = "context_value";
+                ctx[Key] = "context_value";
                 return Task.CompletedTask;
             });
 
         asyncPolicyResult = await asyncPolicyWithContext.ExecuteAndCaptureAsync((ctx, token) => MethodAsync(token), new Context(), CancellationToken.None);
-        string? ctxValue = asyncPolicyResult.Context.GetValueOrDefault("context_key") as string;
+        string? ctxValue = asyncPolicyResult.Context.GetValueOrDefault(Key) as string;
         #endregion
     }
 
@@ -54,7 +55,7 @@ internal static partial class Migration
             .Build();
 
         // Synchronous execution
-        // Polly v8 does not provide an API to synchronously execute and capture the outcome of a pipeline
+        // Polly v8 does not support
 
         // Asynchronous execution
         var context = ResilienceContextPool.Shared.Get();

--- a/src/Snippets/Docs/Migration.Registry.cs
+++ b/src/Snippets/Docs/Migration.Registry.cs
@@ -4,6 +4,7 @@ namespace Snippets.Docs;
 
 internal static partial class Migration
 {
+    private const string PolicyKey = nameof(PolicyKey);
     public static void Registry_V7()
     {
         #region migration-registry-v7
@@ -11,24 +12,25 @@ internal static partial class Migration
         // Create a registry
         var registry = new PolicyRegistry();
 
+        // Add a policy
+        registry.Add(PolicyKey, Policy.Timeout(TimeSpan.FromSeconds(10)));
+
         // Try get a policy
-        registry.TryGet<IAsyncPolicy>("my-key", out IAsyncPolicy? policy);
+        registry.TryGet<IAsyncPolicy>(PolicyKey, out IAsyncPolicy? policy);
 
         // Try get a generic policy
-        registry.TryGet<IAsyncPolicy<string>>("my-key", out IAsyncPolicy<string>? genericPolicy);
-
-        // Add a policy
-        registry.Add("my-key", Policy.Timeout(TimeSpan.FromSeconds(10)));
+        registry.TryGet<IAsyncPolicy<string>>(PolicyKey, out IAsyncPolicy<string>? genericPolicy);
 
         // Update a policy
         registry.AddOrUpdate(
-            "my-key",
+            PolicyKey,
             Policy.Timeout(TimeSpan.FromSeconds(10)),
             (key, previous) => Policy.Timeout(TimeSpan.FromSeconds(10)));
 
         #endregion
     }
 
+    private const string PipelineKey = nameof(PipelineKey);
     public static void Registry_V8()
     {
         #region migration-registry-v8
@@ -36,17 +38,17 @@ internal static partial class Migration
         // Create a registry
         var registry = new ResiliencePipelineRegistry<string>();
 
+        // Add a pipeline using a builder, when the pipeline is retrieved it will be dynamically built and cached
+        registry.TryAddBuilder(PipelineKey, (builder, context) => builder.AddTimeout(TimeSpan.FromSeconds(10)));
+
         // Try get a pipeline
-        registry.TryGetPipeline("my-key", out ResiliencePipeline? pipeline);
+        registry.TryGetPipeline(PipelineKey, out ResiliencePipeline? pipeline);
 
         // Try get a generic pipeline
-        registry.TryGetPipeline<string>("my-key", out ResiliencePipeline<string>? genericPipeline);
-
-        // Add a pipeline using a builder, when "my-key" pipeline is retrieved it will be dynamically built and cached
-        registry.TryAddBuilder("my-key", (builder, context) => builder.AddTimeout(TimeSpan.FromSeconds(10)));
+        registry.TryGetPipeline<string>(PipelineKey, out ResiliencePipeline<string>? genericPipeline);
 
         // Get or add pipeline
-        registry.GetOrAddPipeline("my-key", builder => builder.AddTimeout(TimeSpan.FromSeconds(10)));
+        registry.GetOrAddPipeline(PipelineKey, builder => builder.AddTimeout(TimeSpan.FromSeconds(10)));
 
         #endregion
     }


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed

- #1763
- #1764

## Details on the issue fix or feature implementation
- Fixed a typo in `resilience-pipeline-registry.md`
- Fixed the tip of the _migration of retry policies_
- Fixed circuit breaker V8's warning about discontinued support for classic CB  
- Get rid of the _Migrating other policies_ section because it just echoed previous statements 

- _Migrating `Polly.Context_
   - Replaced the bullet listed predefined key mapping with a tabular fashion one
   - Added a new list item about `ResiliencePropertyKey`
   - Extended the samples with the *Bulk attach* scenario
   - Introduced constants for the context keys
   - Added a tip section to the end

- _Migrating safe execution_
   - Fixed a typo
   - Introduced constants for the context keys
   - Added a note about the discontinued support for sync safe method
   - Added a tip section to the end
    
- _Migrating no-op policies_
   - Replaced bullet listed format to a tabular one
   - Replaced `T` to `TResult` for clarity

- _Migrating policy registries_
   - Reordered the interfaces to follow alphabetical order 
   - Replaced `T` to `TKey` for clarity
   - Introduced constants for the registry keys 
   - Moved the add samples before the retrieval samples
   - Added a note about no direct update support   
   - Added a tip section to the end

- _Interoperability between policies and resilience pipeline_
   - Rephrased the paragraph 

## Open question(s)
- When I deleted the _Migrating other policies_ section then I was thinking: 
   - "Shall we add here a statement about the cache policy?"
   - What do you guys think?

**Answer: Do not mention**
   
- Regarding to the `Migrating safe execution`
   - I did not found any documentation about the `state`
   - I think we should capture _somewhere_ how does it differ from the context?; when to use which?
   - Shall we create a dedicated page with samples?
   - Or is it enough to answer the above questions with two sentences?

**Answer: Extend the resilience pipelines page**

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
