### PR TITLE
Disable GitHub publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,10 +137,11 @@ jobs:
     permissions:
       packages: write
     runs-on: ubuntu-latest
-    if: |
-      github.event.repository.fork == false &&
-      (github.ref_name == github.event.repository.default_branch ||
-       startsWith(github.ref, 'refs/tags/'))
+    if: false # Temporarily disabled
+    #if: |
+    #  github.event.repository.fork == false &&
+    #  (github.ref_name == github.event.repository.default_branch ||
+    #   startsWith(github.ref, 'refs/tags/'))
     steps:
 
     - name: Download packages


### PR DESCRIPTION
It appears we've used up a quota for GitHub packages.

Disable for now to fix CI. I’ll do a more complete fix-up (if we have to turn it off permanently) next week, which will also be needed to unblock NuGet.org publishing.