### PR TITLE
Add test that verifies overriding by using `ConfigureTelemetry`

### DIFF
--- a/test/Polly.Extensions.Tests/Issues/IssuesTests.OverrideLoggerFactory_1783.cs
+++ b/test/Polly.Extensions.Tests/Issues/IssuesTests.OverrideLoggerFactory_1783.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Polly.Registry;
+
+namespace Polly.Extensions.Tests.Issues;
+
+public partial class IssuesTests
+{
+    [Fact]
+    public void OverrideLoggerFactory_ByExplicitConfigureTelemetryCall_1783()
+    {
+        // Arrange
+        using var loggerFactory1 = new FakeLoggerFactory();
+        using var loggerFactory2 = new FakeLoggerFactory();
+        var services = new ServiceCollection();
+        services.TryAddSingleton<ILoggerFactory>(loggerFactory1);
+
+        // Act
+        services.AddResiliencePipeline("dummy", builder =>
+        {
+            builder.AddTimeout(TimeSpan.FromSeconds(1));
+
+            // This call should override the base factory
+            builder.ConfigureTelemetry(loggerFactory2);
+        });
+
+        // Assert
+        var provider = services.BuildServiceProvider().GetRequiredService<ResiliencePipelineProvider<string>>();
+
+        provider.GetPipeline("dummy").Execute(() => { });
+
+        loggerFactory1.FakeLogger.GetRecords().Should().BeEmpty();
+        loggerFactory2.FakeLogger.GetRecords().Should().NotBeEmpty();
+    }
+}


### PR DESCRIPTION
## The issue or feature being addressed

Contributes to #1783 

## Details on the issue fix or feature implementation

In this test I try to to very that calling `ConfigureTelemetry` always wins even when using the `AddResiliencePipeline` extension to define a pipeline. 

The idea is that no matter what `ILoggerFactory` is defined in DI, calling `ConfigureTelemetry` explicitly always wins. 


## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build
