### PR TITLE
Allow concurrent PR docs builds

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     concurrency:
-      group: ${{ github.workflow }}
+      group: ${{ github.event_name == 'pull_request' && github.event.ref || github.workflow }}
       cancel-in-progress: false
 
     permissions:


### PR DESCRIPTION
Allow pull requests to run the github-pages workflow simultaneously, as deployments won't actually happen so they do not need to be protected from concurrent deployments.
