### PR TITLE
Pre-allocate list size in tests

### DIFF
--- a/test/Polly.Extensions.Tests/Issues/IssuesTests.StrategiesPerEndpoint_1365.cs
+++ b/test/Polly.Extensions.Tests/Issues/IssuesTests.StrategiesPerEndpoint_1365.cs
@@ -13,7 +13,7 @@ public partial class IssuesTests
     [Fact]
     public void StrategiesPerEndpoint_1365()
     {
-        var events = new List<MeteringEvent>();
+        var events = new List<MeteringEvent>(1024);
         using var listener = TestUtilities.EnablePollyMetering(events);
         var services = new ServiceCollection();
 

--- a/test/Polly.Extensions.Tests/Telemetry/TelemetryListenerImplTests.cs
+++ b/test/Polly.Extensions.Tests/Telemetry/TelemetryListenerImplTests.cs
@@ -12,7 +12,7 @@ public class TelemetryListenerImplTests : IDisposable
 {
     private readonly FakeLogger _logger;
     private readonly ILoggerFactory _loggerFactory;
-    private readonly List<MeteringEvent> _events = [];
+    private readonly List<MeteringEvent> _events = new(1024);
     private Action<TelemetryEventArguments<object, object>>? _onEvent;
 
     public TelemetryListenerImplTests() => _loggerFactory = TestUtilities.CreateLoggerFactory(out _logger);


### PR DESCRIPTION
Try to avoid test flakiness from concurrent adds on a `List<T>` by pre-allocating what is hopefully enough capacity to avoid a re-size.

See https://github.com/App-vNext/Polly/issues/980#issuecomment-1814675215.
