### PR TITLE
[Docs] Couple of minor corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ You can create a `ResiliencePipeline` using the `ResiliencePipelineBuilder` clas
 
 <!-- snippet: quick-start -->
 ```cs
-// Create a instance of builder that exposes various extensions for adding resilience strategies
+// Create an instance of builder that exposes various extensions for adding resilience strategies
 ResiliencePipeline pipeline = new ResiliencePipelineBuilder()
     .AddRetry(new RetryStrategyOptions()) // Add retry using the default options
-    .AddTimeout(TimeSpan.FromSeconds(10)) // Add 10 second timeout
+    .AddTimeout(TimeSpan.FromSeconds(10)) // Add 10 seconds timeout
     .Build(); // Builds the resilience pipeline
 
 // Execute the pipeline asynchronously
@@ -78,10 +78,10 @@ services.AddResiliencePipeline("my-pipeline", builder =>
 // Build the service provider
 var serviceProvider = services.BuildServiceProvider();
 
-// Retrieve ResiliencePipelineProvider that caches and dynamically creates the resilience pipelines
+// Retrieve a ResiliencePipelineProvider that dynamically creates and caches the resilience pipelines
 var pipelineProvider = serviceProvider.GetRequiredService<ResiliencePipelineProvider<string>>();
 
-// Retrieve resilience pipeline using the name it was registered with
+// Retrieve your resilience pipeline using the name it was registered with
 ResiliencePipeline pipeline = pipelineProvider.GetPipeline("my-pipeline");
 
 // Execute the pipeline

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,10 +12,10 @@ You can create a `ResiliencePipeline` using the `ResiliencePipelineBuilder` clas
 
 <!-- snippet: quick-start -->
 ```cs
-// Create a instance of builder that exposes various extensions for adding resilience strategies
+// Create an instance of builder that exposes various extensions for adding resilience strategies
 ResiliencePipeline pipeline = new ResiliencePipelineBuilder()
     .AddRetry(new RetryStrategyOptions()) // Add retry using the default options
-    .AddTimeout(TimeSpan.FromSeconds(10)) // Add 10 second timeout
+    .AddTimeout(TimeSpan.FromSeconds(10)) // Add 10 seconds timeout
     .Build(); // Builds the resilience pipeline
 
 // Execute the pipeline asynchronously
@@ -31,7 +31,7 @@ If you prefer to define resilience pipelines using [`IServiceCollection`](https:
 dotnet add package Polly.Extensions
 ```
 
-You can then define your resilience pipeline using the `AddResiliencePipeline(...)` extension method as shown:
+then you can define your resilience pipeline using the `AddResiliencePipeline(...)` extension method as shown:
 
 <!-- snippet: quick-start-di -->
 ```cs
@@ -48,10 +48,10 @@ services.AddResiliencePipeline("my-pipeline", builder =>
 // Build the service provider
 var serviceProvider = services.BuildServiceProvider();
 
-// Retrieve ResiliencePipelineProvider that caches and dynamically creates the resilience pipelines
+// Retrieve a ResiliencePipelineProvider that dynamically creates and caches the resilience pipelines
 var pipelineProvider = serviceProvider.GetRequiredService<ResiliencePipelineProvider<string>>();
 
-// Retrieve resilience pipeline using the name it was registered with
+// Retrieve your resilience pipeline using the name it was registered with
 ResiliencePipeline pipeline = pipelineProvider.GetPipeline("my-pipeline");
 
 // Execute the pipeline
@@ -61,3 +61,6 @@ await pipeline.ExecuteAsync(static async token =>
 });
 ```
 <!-- endSnippet -->
+
+> [!NOTE]
+> You don't need to call the `Build` method on the `builder` parameter inside the `AddResiliencePipeline`.

--- a/docs/migration-v8.md
+++ b/docs/migration-v8.md
@@ -27,7 +27,7 @@ When you do your migration process it is recommended to follow these steps:
   - Your previous policies should run smoothly without any change
 - Migrate your V7 policies to V8 strategies gradually, such as one at a time
   - Test your migrated code in a QA environment before publishing your changes into production
-- After you have migrated all your legacy Polly code then switch to [`Polly.Core`](https://www.nuget.org/packages/Polly.Core)
+- After you have successfully migrated all your legacy Polly code then change your package reference from `Polly` to [`Polly.Core`](https://www.nuget.org/packages/Polly.Core)
 
 ## Migrating execution policies
 

--- a/docs/migration-v8.md
+++ b/docs/migration-v8.md
@@ -25,7 +25,7 @@ When you do your migration process it is recommended to follow these steps:
 
 - Upgrade the `Polly` package version from 7.x to 8.x
   - Your previous policies should run smoothly without any change
-- Migrate your V7 policies to V8 strategies one-by-one gradually
+- Migrate your V7 policies to V8 strategies gradually, such as one at a time
   - Test your migrated code in a QA environment before publishing your changes into production
 - After you have migrated all your legacy Polly code then switch to [`Polly.Core`](https://www.nuget.org/packages/Polly.Core)
 

--- a/docs/migration-v8.md
+++ b/docs/migration-v8.md
@@ -26,7 +26,7 @@ When you do your migration process it is recommended to follow these steps:
 - Upgrade the `Polly` package version from 7.x to 8.x
   - Your previous policies should run smoothly without any change
 - Migrate your V7 policies to V8 strategies gradually, such as one at a time
-  - Test your migrated code in a QA environment before publishing your changes into production
+  - Test your migrated code thoroughly
 - After you have successfully migrated all your legacy Polly code then change your package reference from `Polly` to [`Polly.Core`](https://www.nuget.org/packages/Polly.Core)
 
 ## Migrating execution policies

--- a/docs/migration-v8.md
+++ b/docs/migration-v8.md
@@ -19,6 +19,16 @@ Welcome to the migration guide for Polly's v8 release. Version 8 of Polly brings
 > [!NOTE]
 > Please read the comments in the code carefully for additional context and explanations.
 
+## Polly or Polly.Core package
+
+When you do your migration process it is recommended to follow these steps:
+
+- Upgrade the `Polly` package version from 7.x to 8.x
+  - Your previous policies should run smoothly without any change
+- Migrate your V7 policies to V8 strategies one-by-one gradually
+  - Test your migrated code in a QA environment before publishing your changes into production
+- After you have migrated all your legacy Polly code then switch to [`Polly.Core`](https://www.nuget.org/packages/Polly.Core)
+
 ## Migrating execution policies
 
 This section describes how to migrate from execution policies (i.e. `IAsyncPolicy`, `ISyncPolicy`) to resilience pipelines (i.e. `ResiliencePipeline`, `ResiliencePipeline<T>`).

--- a/docs/strategies/index.md
+++ b/docs/strategies/index.md
@@ -98,7 +98,7 @@ Notes from the preceding example:
 
 > [!NOTE]
 > The `args` parameter of the `ShouldHandle` allows read-only access to strategy specific information.
-> For example in case of retry you can assess the `AttemptNumber`, as well as the `Outcome` and `Context`.
+> For example in case of retry you can access the `AttemptNumber`, as well as the `Outcome` and `Context`.
 
 ### Asynchronous predicates
 

--- a/docs/strategies/index.md
+++ b/docs/strategies/index.md
@@ -97,7 +97,7 @@ Notes from the preceding example:
 - Multiple exceptions can be handled using switch expressions.
 
 > [!NOTE]
-> The `args` parameter of the `ShouldHandle` allows readonly access to strategy specific information.
+> The `args` parameter of the `ShouldHandle` allows read-only access to strategy specific information.
 > For example in case of retry you can assess the `AttemptNumber`, as well as the `Outcome` and `Context`.
 
 ### Asynchronous predicates

--- a/docs/strategies/index.md
+++ b/docs/strategies/index.md
@@ -96,6 +96,10 @@ Notes from the preceding example:
   - The `Args<TResult>` acts as a placeholder, and each strategy defines its own arguments.
 - Multiple exceptions can be handled using switch expressions.
 
+> [!NOTE]
+> The `args` parameter of the `ShouldHandle` allows readonly access to strategy specific information.
+> For example in case of retry you can assess the `AttemptNumber`, as well as the `Outcome` and `Context`.
+
 ### Asynchronous predicates
 
 You can also use asynchronous delegates for more advanced scenarios, such as retrying based on the response body:

--- a/docs/strategies/index.md
+++ b/docs/strategies/index.md
@@ -79,9 +79,6 @@ var options = new RetryStrategyOptions<HttpResponseMessage>
     // For greater flexibility, you can directly use the ShouldHandle delegate with switch expressions.
     ShouldHandle = args => args.Outcome switch
     {
-        // Strategies may offer rich arguments for result handling.
-        // For instance, the retry strategy exposes the number of attempts made.
-        _ when args.AttemptNumber > 3 => PredicateResult.False(),
         { Exception: HttpRequestException } => PredicateResult.True(),
         { Exception: TimeoutRejectedException } => PredicateResult.True(), // You can handle multiple exceptions
         { Result: HttpResponseMessage response } when !response.IsSuccessStatusCode => PredicateResult.True(),

--- a/docs/strategies/index.md
+++ b/docs/strategies/index.md
@@ -9,18 +9,34 @@ Polly categorizes resilience strategies into two main groups:
 
 ## Built-in strategies
 
-| Strategy | Reactive | Premise | AKA | How does the strategy mitigate?|
-| ------------- | --- | ------------- |:-------------: |------------- |
-|[Retry](retry.md) |Yes|Many faults are transient and may self-correct after a short delay.| *Maybe it's just a blip* |  Allows configuring automatic retries. |
-|[Circuit-breaker](circuit-breaker.md) |Yes|When a system is seriously struggling, failing fast is better than making users/callers wait.  <br/><br/>Protecting a faulting system from overload can help it recover. | *Stop doing it if it hurts* <br/><br/>*Give that system a break* | Breaks the circuit (blocks executions) for a period, when faults exceed some pre-configured threshold. |
-|[Timeout](timeout.md)|No|Beyond a certain wait, a success result is unlikely.| *Don't wait forever*  |Guarantees the caller won't have to wait beyond the timeout. |
-|[Rate Limiter](rate-limiter.md)|No|Limiting the rate a system handles requests is another way to control load. <br/><br/> This can apply to the way your system accepts incoming calls, and/or to the way you call downstream services. | *Slow down a bit, will you?*  |Constrains executions to not exceed a certain rate. |
-|[Fallback](fallback.md)|Yes|Things will still fail - plan what you will do when that happens.| *Degrade gracefully*  |Defines an alternative value to be returned (or action to be executed) on failure. |
-|[Hedging](hedging.md)|Yes|Things can be slow sometimes, plan what you will do when that happens.| *Hedge your bets*  | Executes parallel actions when things are slow and waits for the fastest one.  |
+### Reactive
+
+| Strategy | Premise | AKA | How does the strategy mitigate?|
+| ------------- | ------------- |:-------------: |------------- |
+|[Retry](retry.md) |Many faults are transient and may self-correct after a short delay.| *Maybe it's just a blip* |  Allows configuring automatic retries. |
+|[Circuit-breaker](circuit-breaker.md) |When a system is seriously struggling, failing fast is better than making users/callers wait.  <br/><br/>Protecting a faulting system from overload can help it recover. | *Stop doing it if it hurts* <br/><br/>*Give that system a break* | Breaks the circuit (blocks executions) for a period, when faults exceed some pre-configured threshold. |
+|[Fallback](fallback.md)|Things will still fail - plan what you will do when that happens.| *Degrade gracefully*  |Defines an alternative value to be returned (or action to be executed) on failure. |
+|[Hedging](hedging.md)|Things can be slow sometimes, plan what you will do when that happens.| *Hedge your bets*  | Executes parallel actions when things are slow and waits for the fastest one.  |
+
+### Proactive
+
+| Strategy | Premise | AKA | How does the strategy prevent?|
+| ------------- | ------------- |:-------------: |------------- |
+|[Timeout](timeout.md)|Beyond a certain wait, a success result is unlikely.| *Don't wait forever*  |Guarantees the caller won't have to wait beyond the timeout. |
+|[Rate Limiter](rate-limiter.md)|Limiting the rate a system handles requests is another way to control load. <br/><br/> This can apply to the way your system accepts incoming calls, and/or to the way you call downstream services. | *Slow down a bit, will you?*  |Constrains executions to not exceed a certain rate. |
 
 ## Usage
 
-Extensions for adding resilience strategies to the builders are provided by each strategy. Depending on the type of strategy, these extensions may be available for both `ResiliencePipelineBuilder` and `ResiliencePipelineBuilder<T>` or just one of them. Proactive strategies like timeout or rate limiter are available for both types of builders, while specialized reactive strategies are only available for `ResiliencePipelineBuilder<T>`. Adding multiple resilience strategies is supported.
+Extensions for adding resilience strategies to the builders are provided by each strategy. Depending on the type of strategy, these extensions may be available for both `ResiliencePipelineBuilder` and `ResiliencePipelineBuilder<T>` or just for the latter one. Adding multiple resilience strategies is supported.
+
+| Strategy | `ResiliencePipelineBuilder` | `ResiliencePipelineBuilder<T>` |
+| ------------- | :-------------: | :-------------: |
+|Circuit Breaker| + | + |
+|Fallback| - | + |
+|Hedging| - | + |
+|Rate Limiter| + | + |
+|Retry| + | + |
+|Timeout| + | + |
 
 Each resilience strategy provides:
 
@@ -50,7 +66,7 @@ Each reactive strategy provides access to the `ShouldHandle` predicate property.
 Setting up the predicate can be accomplished in the following ways:
 
 - **Manually setting the predicate**: Directly configure the predicate. The advised approach involves using [switch expressions](https://learn.microsoft.com/dotnet/csharp/language-reference/operators/switch-expression) for maximum flexibility, and also allows the incorporation of asynchronous predicates.
-- **Employing `PredicateBuilder`**: The `PredicateBuilder` class provides a more straight-forward method to configure the predicates, akin to predicate setups in earlier Polly versions.
+- **Employing `PredicateBuilder`**: The `PredicateBuilder{<TResult>}` classes provide a more straight-forward method to configure the predicates, akin to predicate setups in earlier Polly versions.
 
 The examples below illustrate these:
 
@@ -77,9 +93,10 @@ var options = new RetryStrategyOptions<HttpResponseMessage>
 
 Notes from the preceding example:
 
-- Switch expressions are used to determine whether to retry on not.
+- Switch expressions are used to determine whether to retry or not.
 - `PredicateResult.True()` is a shorthand for `new ValueTask<bool>(true)`.
-- `ShouldHandle` predicates are asynchronous and use the type `Func<Args<TResult>, ValueTask<bool>>`. The `Args<TResult>` acts as a placeholder, and each strategy defines its own arguments.
+- `ShouldHandle` predicates are asynchronous and use the type `Func<Args<TResult>, ValueTask<bool>>`.
+  - The `Args<TResult>` acts as a placeholder, and each strategy defines its own arguments.
 - Multiple exceptions can be handled using switch expressions.
 
 ### Asynchronous predicates

--- a/docs/strategies/index.md
+++ b/docs/strategies/index.md
@@ -31,12 +31,12 @@ Extensions for adding resilience strategies to the builders are provided by each
 
 | Strategy | `ResiliencePipelineBuilder` | `ResiliencePipelineBuilder<T>` |
 | ------------- | :-------------: | :-------------: |
-|Circuit Breaker| ✅ | ✅ |
-|Fallback| ❌ | ✅ |
-|Hedging| ❌ | ✅ |
-|Rate Limiter| ✅ | ✅ |
-|Retry| ✅ | ✅ |
-|Timeout| ✅ | ✅ |
+| Circuit Breaker | ✅ | ✅ |
+| Fallback | ❌ | ✅ |
+| Hedging | ❌ | ✅ |
+| Rate Limiter | ✅ | ✅ |
+| Retry | ✅ | ✅ |
+| Timeout | ✅ | ✅ |
 
 Each resilience strategy provides:
 

--- a/docs/strategies/index.md
+++ b/docs/strategies/index.md
@@ -31,12 +31,12 @@ Extensions for adding resilience strategies to the builders are provided by each
 
 | Strategy | `ResiliencePipelineBuilder` | `ResiliencePipelineBuilder<T>` |
 | ------------- | :-------------: | :-------------: |
-|Circuit Breaker| + | + |
-|Fallback| - | + |
-|Hedging| - | + |
-|Rate Limiter| + | + |
-|Retry| + | + |
-|Timeout| + | + |
+|Circuit Breaker| ✅ | ✅ |
+|Fallback| ❌ | ✅ |
+|Hedging| ❌ | ✅ |
+|Rate Limiter| ✅ | ✅ |
+|Retry| ✅ | ✅ |
+|Timeout| ✅ | ✅ |
 
 Each resilience strategy provides:
 

--- a/src/Snippets/Docs/Readme.cs
+++ b/src/Snippets/Docs/Readme.cs
@@ -12,10 +12,10 @@ internal static class Readme
 
         #region quick-start
 
-        // Create a instance of builder that exposes various extensions for adding resilience strategies
+        // Create an instance of builder that exposes various extensions for adding resilience strategies
         ResiliencePipeline pipeline = new ResiliencePipelineBuilder()
             .AddRetry(new RetryStrategyOptions()) // Add retry using the default options
-            .AddTimeout(TimeSpan.FromSeconds(10)) // Add 10 second timeout
+            .AddTimeout(TimeSpan.FromSeconds(10)) // Add 10 seconds timeout
             .Build(); // Builds the resilience pipeline
 
         // Execute the pipeline asynchronously
@@ -41,10 +41,10 @@ internal static class Readme
         // Build the service provider
         var serviceProvider = services.BuildServiceProvider();
 
-        // Retrieve ResiliencePipelineProvider that caches and dynamically creates the resilience pipelines
+        // Retrieve a ResiliencePipelineProvider that dynamically creates and caches the resilience pipelines
         var pipelineProvider = serviceProvider.GetRequiredService<ResiliencePipelineProvider<string>>();
 
-        // Retrieve resilience pipeline using the name it was registered with
+        // Retrieve your resilience pipeline using the name it was registered with
         ResiliencePipeline pipeline = pipelineProvider.GetPipeline("my-pipeline");
 
         // Execute the pipeline

--- a/src/Snippets/Docs/ResilienceStrategies.cs
+++ b/src/Snippets/Docs/ResilienceStrategies.cs
@@ -29,9 +29,6 @@ internal static class ResilienceStrategies
             // For greater flexibility, you can directly use the ShouldHandle delegate with switch expressions.
             ShouldHandle = args => args.Outcome switch
             {
-                // Strategies may offer rich arguments for result handling.
-                // For instance, the retry strategy exposes the number of attempts made.
-                _ when args.AttemptNumber > 3 => PredicateResult.False(),
                 { Exception: HttpRequestException } => PredicateResult.True(),
                 { Exception: TimeoutRejectedException } => PredicateResult.True(), // You can handle multiple exceptions
                 { Result: HttpResponseMessage response } when !response.IsSuccessStatusCode => PredicateResult.True(),


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed

## Details on the issue fix or feature implementation

- `docs/readme.md`  + `readme.cs`
  - Fixed some typos in the comments

-  `docs/getting-started.md`
   - Fixed some typos in the comments
   - Added a note to the DI example

- `docs/migration-v8.md`
  - Added a new subsection about `Polly` vs `Polly.Core` 

- `docs/strategies/index.md`
  -  Split the _Built-in strategies_ table into to two just like on the [main readme page](https://github.com/App-vNext/Polly#resilience-strategies)
  - Added a new table under the _Usage_ to explicitly state where you can use which strategy 
  -  Fixed some typos

## Open questions
- [Here](https://www.pollydocs.org/strategies/index.html#predicates) the following line is bit misleading IMHO
   - Even though you can access the `AttemptNumber` you should not branch on it normally
   - Or if you do we should add a really good example and explanation
   - What do you guys think?
```cs
_ when args.AttemptNumber > 3 => PredicateResult.False(),
```
**Answer**: I've deleted this switch case. The reasoning can be found [here](https://github.com/App-vNext/Polly/pull/1819#issuecomment-1826095142).


- [Here](https://www.pollydocs.org/strategies/index.html#predicate-builder) I'm not sure I understand entirely this
   - Are you saying that a new `PredicateBuilder` is created at each retry attempt?
  - Or are you saying that the the predicate evaluates all registered `Handle` methors eagerly? (not until the first `true`result) 
```
Each method call on PredicateBuilder registers a new predicate, which must be invoked when evaluating the outcome.
```
**Answer**: After the clarification I can live with the current wording.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
