### PR TITLE
Add .NET Blog resilience blog post

### DIFF
--- a/docs/community/resources.md
+++ b/docs/community/resources.md
@@ -28,6 +28,7 @@ This includes Blogs, podcasts, courses, e-books, architecture samples and videos
 - [Using Polly and Flurl to improve your website](https://jeremylindsayni.wordpress.com/2019/01/01/using-polly-and-flurl-to-improve-your-website/) - by Jeremy Lindsay.
 - [Exploring the Polly.Contrib.WaitAndRetry helpers](https://hyr.mn/Polly-wait-and-retry/) - by [Ben Hyrman](https://twitter.com/hyrmn), who also wrote most of the Polly.Contrib.WaitAndRetry documentation.
 - [Retries - An interactive study of common retry methods](https://encore.dev/blog/retries) - by [Sam Rose](https://twitter.com/samwhoo)
+- [Building resilient cloud services with .NET 8](https://devblogs.microsoft.com/dotnet/building-resilient-cloud-services-with-dotnet-8/) by [Martin Tomka](https://github.com/martintmk)
 
 ## Podcasts
 


### PR DESCRIPTION
Add the Building resilient cloud services with .NET 8 blog post to the resources in the docs.
