### PR TITLE
[Docs] Context versus state

### DIFF
--- a/docs/pipelines/index.md
+++ b/docs/pipelines/index.md
@@ -135,6 +135,31 @@ else
 
 Use `ExecuteOutcomeAsync(...)` in high-performance scenarios where you wish to avoid re-throwing exceptions. Keep in mind that Polly's resilience strategies also make use of the `Outcome` struct to prevent unnecessary exception throwing.
 
+### Context vs State
+
+In the previous example the `ExecuteOutcomeAsync` was called with `"my-state"` state object. You might wonder what's the point of the `state`, or can't we just use the `context`?
+
+The `state` object was introduced to be able to pass a parameter to the user callback without the usage of closure.
+
+- It allows you to access any object of the `ExecuteOutcomeAsync`'s caller method without extra memory allocation
+- It also enables you to use static anonymous functions
+
+So, it is a performance optimization tool. Of course you can pass more complex object than just a simple string like `(instance: this, request)`.
+
+While the `state` object is accessible only inside the user callback, you can use the `context` in many places.
+For example in case of Retry the `context` is accessible:
+
+- Inside the `ShouldHandle` delegate
+- Inside the `OnRetry` delegate
+- Inside the `DelayGenerator` delegate
+- and through the `Outcome` property
+
+As a rule of thumb:
+
+- Use the `state` object to pass a parameter to your decorated method
+- Use the `context` object to exchange information between delegates of the `XYZOptions`
+  - or between invocation attempts (in case of retry or hedging strategies)
+
 ## Diagrams
 
 ### Sequence diagram for a pipeline with retry and timeout

--- a/src/Polly.Core/Utils/Pipeline/PipelineComponent.cs
+++ b/src/Polly.Core/Utils/Pipeline/PipelineComponent.cs
@@ -21,17 +21,11 @@ internal abstract class PipelineComponent : IAsyncDisposable
         Func<ResilienceContext, TState, Outcome<TResult>> callback,
         ResilienceContext context,
         TState state)
-    {
-        return ExecuteCore(
-            static (context, state) =>
-            {
-                var result = state.callback(context, state.state);
-
-                return new ValueTask<Outcome<TResult>>(result);
-            },
+        => ExecuteCore(
+            static (context, state) => new ValueTask<Outcome<TResult>>(state.callbackMethod(context, state.stateObject)),
             context,
-            (callback, state)).GetResult();
-    }
+            (callbackMethod: callback, stateObject: state))
+        .GetResult();
 
     public abstract ValueTask DisposeAsync();
 


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
 - https://github.com/App-vNext/Polly/pull/1775#issuecomment-1792154192
 - Several documentation pages use a dummy `state` object without explaining the difference between that and the `context`

## Details on the issue fix or feature implementation
- Added a subsection to the pipeline doc to clarify the difference between `state` and `context` objects
  - [Preview](https://github.com/peter-csala/Polly/blob/document-context-versus-state/docs/pipelines/index.md#context-vs-state) 
- Refactored the `ExecuteCoreSync` for better legibility
  - I had to read this line many times to understand what's happening here: 
  - `var result = state.callback(context, state.state);` 

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
