### PR TITLE
Fix BreakDurationGenerator not being used

### DIFF
--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerResiliencePipelineBuilderExtensions.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerResiliencePipelineBuilderExtensions.cs
@@ -85,7 +85,8 @@ public static class CircuitBreakerResiliencePipelineBuilderExtensions
             options.OnHalfOpened,
             behavior,
             context.TimeProvider,
-            context.Telemetry);
+            context.Telemetry,
+            options.BreakDurationGenerator);
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
         return new CircuitBreakerResilienceStrategy<TResult>(

--- a/src/Polly.Core/CircuitBreaker/Controller/CircuitStateController.cs
+++ b/src/Polly.Core/CircuitBreaker/Controller/CircuitStateController.cs
@@ -32,7 +32,7 @@ internal sealed class CircuitStateController<T> : IDisposable
         CircuitBehavior behavior,
         TimeProvider timeProvider,
         ResilienceStrategyTelemetry telemetry,
-        Func<BreakDurationGeneratorArguments, ValueTask<TimeSpan>>? breakDurationGenerator = null)
+        Func<BreakDurationGeneratorArguments, ValueTask<TimeSpan>>? breakDurationGenerator)
 #pragma warning restore S107
     {
         _breakDuration = breakDuration;

--- a/src/Snippets/Snippets.csproj
+++ b/src/Snippets/Snippets.csproj
@@ -8,6 +8,7 @@
     <ProjectType>Library</ProjectType>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <IsPackable>false</IsPackable>
+    <IsTestProject>false</IsTestProject>
     <NoWarn>$(NoWarn);SA1123;SA1515;CA2000;CA2007;CA1303;IDE0021;IDE0017;IDE0060;CS1998;CA1064;S3257;IDE0028;CA1031;CA1848</NoWarn>
     <NoWarn>$(NoWarn);RS0016;SA1402;SA1600;RS0037;CA1062;SA1204</NoWarn>
     <RootNamespace>Snippets</RootNamespace>

--- a/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerResilienceStrategyTests.cs
@@ -26,7 +26,8 @@ public class CircuitBreakerResilienceStrategyTests : IDisposable
             null,
             _behavior,
             _timeProvider,
-            _telemetry);
+            _telemetry,
+            null);
     }
 
     [Fact]

--- a/test/Polly.Core.Tests/CircuitBreaker/Controller/CircuitStateControllerTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/Controller/CircuitStateControllerTests.cs
@@ -309,26 +309,22 @@ public class CircuitStateControllerTests
     public async Task OnActionFailureAsync_EnsureBreakDurationGeneration()
     {
         // arrange
-        using var controller = CreateController(new()
+        _options.BreakDurationGenerator = static args =>
         {
-            FailureRatio = 0,
-            MinimumThroughput = 0,
-            SamplingDuration = default,
-            BreakDuration = TimeSpan.FromMinutes(1),
-            BreakDurationGenerator = static args => new ValueTask<TimeSpan>(TimeSpan.FromMinutes(args.FailureCount)),
-            OnClosed = null,
-            OnOpened = null,
-            OnHalfOpened = null,
-            ManualControl = null,
-            StateProvider = null
-        });
+            args.FailureCount.Should().Be(1);
+            args.FailureRate.Should().Be(0.5);
+            return new ValueTask<TimeSpan>(TimeSpan.FromMinutes(42));
+        };
+
+        using var controller = CreateController();
 
         await TransitionToState(controller, CircuitState.Closed);
 
-        var utcNow = DateTimeOffset.MaxValue;
-
+        var utcNow = new DateTimeOffset(2023, 12, 12, 12, 34, 56, TimeSpan.Zero);
         _timeProvider.SetUtcNow(utcNow);
+
         _circuitBehavior.FailureCount.Returns(1);
+        _circuitBehavior.FailureRate.Returns(0.5);
         _circuitBehavior.When(v => v.OnActionFailure(CircuitState.Closed, out Arg.Any<bool>()))
             .Do(x => x[1] = true);
 
@@ -337,7 +333,7 @@ public class CircuitStateControllerTests
 
         // assert
         var blockedTill = GetBlockedTill(controller);
-        blockedTill.Should().Be(utcNow);
+        blockedTill.Should().Be(utcNow + TimeSpan.FromMinutes(42));
     }
 
     [InlineData(true)]
@@ -504,15 +500,6 @@ public class CircuitStateControllerTests
         _options.OnHalfOpened,
         _circuitBehavior,
         _timeProvider,
-        TestUtilities.CreateResilienceTelemetry(_telemetryListener));
-
-    private CircuitStateController<int> CreateController(CircuitBreakerStrategyOptions<int> options) => new(
-        options.BreakDuration,
-        options.OnOpened,
-        options.OnClosed,
-        options.OnHalfOpened,
-        _circuitBehavior,
-        _timeProvider,
         TestUtilities.CreateResilienceTelemetry(_telemetryListener),
-        options.BreakDurationGenerator);
+        _options.BreakDurationGenerator);
 }


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed

Resolves #1850.

## Details on the issue fix or feature implementation

- Always pass `BreakDurationGenerator` to the controller.
- Fix assertion so if `BreakDurationGenerator` isn't configured, the test fails.
- Make the `breakDurationGenerator` parameter required so that no code forgets to pass it through.
- Add an integration test for when `BreakDurationGenerator` is specified to guard against the issue reported by https://github.com/App-vNext/Polly/issues/1850.
- Running `dotnet test` in the root of the repo would generate an error from trying to run tests in the Snippets project. As this project doesn't actually have any tests in it, mark it as not a test project.
