### PR TITLE
[Docs] Failure handling in case of proactive strategies

### DIFF
--- a/docs/strategies/rate-limiter.md
+++ b/docs/strategies/rate-limiter.md
@@ -67,6 +67,55 @@ catch (RateLimiterRejectedException ex)
 ```
 <!-- endSnippet -->
 
+### Failure handling
+
+It might not be obvious at the first glance what is the difference between these two techniques:
+
+<!-- snippet: rate-limiter-handling-failure -->
+```cs
+var withOnRejected = new ResiliencePipelineBuilder()
+    .AddRateLimiter(new RateLimiterStrategyOptions
+    {
+        DefaultRateLimiterOptions = new ConcurrencyLimiterOptions
+        {
+            PermitLimit = 10
+        },
+        OnRejected = args =>
+        {
+            Console.WriteLine("Rate limit has been exceeded");
+            return default;
+        }
+    }).Build();
+
+var withoutOnRejected = new ResiliencePipelineBuilder()
+    .AddRateLimiter(new RateLimiterStrategyOptions
+    {
+        DefaultRateLimiterOptions = new ConcurrencyLimiterOptions
+        {
+            PermitLimit = 10
+        }
+    }).Build();
+
+try
+{
+    await withoutOnRejected.ExecuteAsync(async ct => await TextSearchAsync(query, ct), CancellationToken.None);
+}
+catch (RateLimiterRejectedException)
+{
+    Console.WriteLine("Rate limit has been exceeded");
+}
+```
+<!-- endSnippet -->
+
+The `OnRejected` user provided delegate is called just before the strategy throws the `RateLimiterRejectedException`. This delegate receives a parameter which allows you to access the `Context` object as well as the `Lease`:
+
+- Accessing the `Context` is also possible via a different `Execute{Async}` overload.
+- Accessing the rejected `Lease` can be useful in really special scenarios.
+
+So, what is the purpose of the `OnRejected`?
+
+The `OnRejected` can be useful when you define a resilience pipeline which consists of multiple strategies. Like you have a rate limiter as the inner and a retry as the outer strategy. If the retry is defined to trigger for `RateLimiterRejectedException` that means the `Execute{Async}` may or may not throw that exception depending on future attempts. So, if you want to get notify about the fact that the rate limit has been exceeded your have to provide a delegate to the `OnRejected` property.
+
 ## Defaults
 
 | Property                    | Default Value                                        | Description                                                                                     |

--- a/docs/strategies/timeout.md
+++ b/docs/strategies/timeout.md
@@ -74,6 +74,49 @@ HttpResponseMessage httpResponse = await pipeline.ExecuteAsync(
 ```
 <!-- endSnippet -->
 
+### Failure handling
+
+It might not be obvious at the first glance what is the difference between these two techniques:
+
+<!-- snippet: timeout-handling-failure -->
+```cs
+var withOnTimeout = new ResiliencePipelineBuilder()
+    .AddTimeout(new TimeoutStrategyOptions
+    {
+        Timeout = TimeSpan.FromSeconds(2),
+        OnTimeout = args =>
+        {
+            Console.WriteLine("Timeout limit has been exceeded");
+            return default;
+        }
+    }).Build();
+
+var withoutOnTimeout = new ResiliencePipelineBuilder()
+    .AddTimeout(new TimeoutStrategyOptions
+    {
+        Timeout = TimeSpan.FromSeconds(2)
+    }).Build();
+
+try
+{
+    await withoutOnTimeout.ExecuteAsync(UserDelegate, CancellationToken.None);
+}
+catch (TimeoutRejectedException)
+{
+    Console.WriteLine("Timeout limit has been exceeded");
+}
+```
+<!-- endSnippet -->
+
+The `OnTimeout` user provided delegate is called just before the strategy throws the `TimeoutRejectedException`. This delegate receives a parameter which allows you to access the `Context` object as well as the `Timeout`:
+
+- Accessing the `Context` is also possible via a different `Execute{Async}` overload.
+- Accessing the `Timeout` can be useful if you were using the `TimeoutGenerator` property rather than the `Timeout`.
+
+So, what is the purpose of the `OnTimeout` in case of static timeout settings?
+
+The `OnTimeout` can be useful when you define a resilience pipeline which consists of multiple strategies. Like you have a timeout as the inner and a retry as the outer strategy. If the retry is defined to trigger for `TimeoutRejectedException` that means the `Execute{Async}` may or may not throw that exception depending on future attempts. So, if you want to get notified about the fact that a timeout has occurred your have to provide a delegate to the `OnTimeout` property.
+
 ## Defaults
 
 | Property           | Default Value | Description                                  |

--- a/src/Snippets/Docs/Timeout.cs
+++ b/src/Snippets/Docs/Timeout.cs
@@ -67,6 +67,38 @@ internal static class Timeout
         #endregion
     }
 
+    public static async Task HandleTimeout()
+    {
+        static ValueTask UserDelegate(CancellationToken ct) => ValueTask.CompletedTask;
+        #region timeout-handling-failure
+        var withOnTimeout = new ResiliencePipelineBuilder()
+            .AddTimeout(new TimeoutStrategyOptions
+            {
+                Timeout = TimeSpan.FromSeconds(2),
+                OnTimeout = args =>
+                {
+                    Console.WriteLine("Timeout limit has been exceeded");
+                    return default;
+                }
+            }).Build();
+
+        var withoutOnTimeout = new ResiliencePipelineBuilder()
+            .AddTimeout(new TimeoutStrategyOptions
+            {
+                Timeout = TimeSpan.FromSeconds(2)
+            }).Build();
+
+        try
+        {
+            await withoutOnTimeout.ExecuteAsync(UserDelegate, CancellationToken.None);
+        }
+        catch (TimeoutRejectedException)
+        {
+            Console.WriteLine("Timeout limit has been exceeded");
+        }
+        #endregion
+    }
+
     public static async Task AntiPattern_CancellationToken()
     {
         var outerToken = CancellationToken.None;


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed
- The documentation did not explicitly state what's the point of `OnXYZ` delegates in case of proactive strategies

## Details on the issue fix or feature implementation
- Extended the timeout strategy's documentation with a failure handling subsection
- Extended the rate limiter strategy's documentation with a failure handling subsection

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
