### PR TITLE
[Docs] Revise proactive strategy doc

### DIFF
--- a/docs/extensibility/index.md
+++ b/docs/extensibility/index.md
@@ -11,8 +11,9 @@ This guide will help you create a new illustrative resilience strategy for each 
 
 Regardless of whether the strategy is reactive or proactive, every new resilience strategy should include the following components:
 
-- Options detailing the strategy's configuration. These should inherit from [`ResilienceStrategyOptions`](xref:Polly.ResilienceStrategyOptions).
-- Extensions for `ResiliencePipelineBuilder` or `ResiliencePipelineBuilder<T>`.
+- The strategy itself which should inherit from [`ResilienceStrategy`](xref:Polly.ResilienceStrategy)
+- Options detailing the strategy's configuration. This should inherit from [`ResilienceStrategyOptions`](xref:Polly.ResilienceStrategyOptions).
+- Extensions for `ResiliencePipelineBuilder` or `ResiliencePipelineBuilder<T>` to register the strategy into the pipeline.
 - Custom argument types for delegates that contain information about a specific event.
 
 The strategy options contain properties of following types:
@@ -20,6 +21,41 @@ The strategy options contain properties of following types:
 - **Common types**: Such as `int`, `bool`, `TimeSpan`, etc.
 - **Delegates**: For example when a strategy needs to raise an event, or generate a value. In general, the delegates should by asynchronous.
 - **Arguments**: Used by the delegates to pass the information to their consumers.
+
+### Component diagram
+
+This diagram depicts how the built-in types interact with the custom built types (with green border)
+
+```mermaid
+flowchart
+    options{{XYZStrategyOptions}}
+    style options stroke:#0f0
+
+    builder{{XYZResilienceStrategyBuilderExtensions}}
+    style builder stroke:#0f0
+
+    strategy{{XYZResilienceStrategy}}
+    style strategy stroke:#0f0
+
+    args{{XYZEventArguments}}
+    style args stroke:#0f0
+
+    telemetry{{ResilienceStrategyTelemetry}}
+    pipeline{{ResiliencePipeline}}
+
+    options -- is passed to AddXYZ  --> builder
+    builder -- registers a strategy --> pipeline
+    options -- configures behavior--> strategy
+
+    pipeline -- calls the execution --> strategy
+
+    strategy -- creates for notification --> args
+    strategy -- uses for reporting --> telemetry
+
+    %% a workaround to add note (currently only sequence diagram supports notes)
+    %% https://github.com/mermaid-js/mermaid/issues/821
+    args -.- note[The strategy calls<br/>the OnXYZ delegate of<br/> the options with this object.]
+```
 
 ## Delegates
 
@@ -93,9 +129,9 @@ Arguments are used by individual delegate types to flow information to the consu
 ```cs
 // Structs for arguments encapsulate details about specific events within the resilience strategy.
 // Relevant properties to the event can be exposed. In this event, the actual execution time and the exceeded threshold are included.
-public readonly struct ThresholdExceededArguments
+public readonly struct OnThresholdExceededArguments
 {
-    public ThresholdExceededArguments(ResilienceContext context, TimeSpan threshold, TimeSpan duration)
+    public OnThresholdExceededArguments(ResilienceContext context, TimeSpan threshold, TimeSpan duration)
     {
         Context = context;
         Threshold = threshold;

--- a/docs/extensibility/index.md
+++ b/docs/extensibility/index.md
@@ -24,21 +24,14 @@ The strategy options contain properties of following types:
 
 ### Component diagram
 
-This diagram depicts how the built-in types interact with custom built types (which have a green border)
+This diagram depicts how the built-in types (hexagon shaped) interact with custom built types (rectangle shaped):
 
 ```mermaid
 flowchart
-    options{{XYZStrategyOptions}}
-    style options stroke:#0f0
-
-    builder{{XYZResilienceStrategyBuilderExtensions}}
-    style builder stroke:#0f0
-
-    strategy{{XYZResilienceStrategy}}
-    style strategy stroke:#0f0
-
-    args{{XYZEventArguments}}
-    style args stroke:#0f0
+    options[XYZStrategyOptions]
+    builder[XYZResilienceStrategyBuilderExtensions]
+    strategy[XYZResilienceStrategy]
+    args[XYZEventArguments]
 
     telemetry{{ResilienceStrategyTelemetry}}
     pipeline{{ResiliencePipeline}}
@@ -54,7 +47,7 @@ flowchart
 
     %% a workaround to add note (currently only sequence diagram supports notes)
     %% https://github.com/mermaid-js/mermaid/issues/821
-    args -.- note[The strategy calls<br/>the OnXYZ delegate of<br/> the options with this object.]
+    args -.- note(The strategy calls<br/>the OnXYZ delegate of<br/> the options with this object.)
 ```
 
 ## Delegates

--- a/docs/extensibility/index.md
+++ b/docs/extensibility/index.md
@@ -24,7 +24,7 @@ The strategy options contain properties of following types:
 
 ### Component diagram
 
-This diagram depicts how the built-in types interact with the custom built types (with green border)
+This diagram depicts how the built-in types interact with custom built types (which have a green border)
 
 ```mermaid
 flowchart
@@ -45,11 +45,11 @@ flowchart
 
     options -- is passed to AddXYZ  --> builder
     builder -- registers a strategy --> pipeline
-    options -- configures behavior--> strategy
+    options -- configures behavior --> strategy
 
     pipeline -- calls the execution --> strategy
 
-    strategy -- creates for notification --> args
+    strategy -- creates for events --> args
     strategy -- uses for reporting --> telemetry
 
     %% a workaround to add note (currently only sequence diagram supports notes)

--- a/samples/Extensibility/Proactive/OnThresholdExceededArguments.cs
+++ b/samples/Extensibility/Proactive/OnThresholdExceededArguments.cs
@@ -6,9 +6,9 @@ namespace Extensibility.Proactive;
 
 // Structs for arguments encapsulate details about specific events within the resilience strategy.
 // Relevant properties to the event can be exposed. In this event, the actual execution time and the exceeded threshold are included.
-public readonly struct ThresholdExceededArguments
+public readonly struct OnThresholdExceededArguments
 {
-    public ThresholdExceededArguments(ResilienceContext context, TimeSpan threshold, TimeSpan duration)
+    public OnThresholdExceededArguments(ResilienceContext context, TimeSpan threshold, TimeSpan duration)
     {
         Context = context;
         Threshold = threshold;

--- a/samples/Extensibility/Proactive/TimingResilienceStrategy.cs
+++ b/samples/Extensibility/Proactive/TimingResilienceStrategy.cs
@@ -11,17 +11,17 @@ namespace Extensibility.Proactive;
 internal sealed class TimingResilienceStrategy : ResilienceStrategy
 {
     private readonly TimeSpan _threshold;
-    private readonly Func<ThresholdExceededArguments, ValueTask>? _thresholdExceeded;
+    private readonly Func<OnThresholdExceededArguments, ValueTask>? _onThresholdExceeded;
     private readonly ResilienceStrategyTelemetry _telemetry;
 
     public TimingResilienceStrategy(
         TimeSpan threshold,
-        Func<ThresholdExceededArguments, ValueTask>? thresholdExceeded,
+        Func<OnThresholdExceededArguments, ValueTask>? onThresholdExceeded,
         ResilienceStrategyTelemetry telemetry)
     {
         _threshold = threshold;
         _telemetry = telemetry;
-        _thresholdExceeded = thresholdExceeded;
+        _onThresholdExceeded = onThresholdExceeded;
     }
 
     protected override async ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
@@ -37,7 +37,7 @@ internal sealed class TimingResilienceStrategy : ResilienceStrategy
         if (stopwatch.Elapsed > _threshold)
         {
             // Bundle information about the event into arguments.
-            var args = new ThresholdExceededArguments(context, _threshold, stopwatch.Elapsed);
+            var args = new OnThresholdExceededArguments(context, _threshold, stopwatch.Elapsed);
 
             // Report this as a resilience event if the execution took longer than the threshold.
             _telemetry.Report(
@@ -45,9 +45,9 @@ internal sealed class TimingResilienceStrategy : ResilienceStrategy
                 context,
                 args);
 
-            if (_thresholdExceeded is not null)
+            if (_onThresholdExceeded is not null)
             {
-                await _thresholdExceeded(args).ConfigureAwait(context.ContinueOnCapturedContext);
+                await _onThresholdExceeded(args).ConfigureAwait(context.ContinueOnCapturedContext);
             }
         }
 

--- a/samples/Extensibility/Proactive/TimingResilienceStrategyBuilderExtensions.cs
+++ b/samples/Extensibility/Proactive/TimingResilienceStrategyBuilderExtensions.cs
@@ -21,10 +21,10 @@ public static class TimingResilienceStrategyBuilderExtensions
             {
                 // The "context" provides various properties for the strategy's use.
                 // In this case, we simply use the "Telemetry" property and pass it to the strategy.
-                // The Threshold and ThresholdExceeded values are sourced from the options.
+                // The Threshold and OnThresholdExceeded values are sourced from the options.
                 var strategy = new TimingResilienceStrategy(
                     options.Threshold!.Value,
-                    options.ThresholdExceeded,
+                    options.OnThresholdExceeded,
                     context.Telemetry);
 
                 return strategy;

--- a/samples/Extensibility/Proactive/TimingStrategyOptions.cs
+++ b/samples/Extensibility/Proactive/TimingStrategyOptions.cs
@@ -21,7 +21,7 @@ public class TimingStrategyOptions : ResilienceStrategyOptions
 
     // Provide the delegate to be called when the threshold is surpassed.
     // Ideally, arguments should share the delegate's name, but with an "Arguments" suffix.
-    public Func<ThresholdExceededArguments, ValueTask>? ThresholdExceeded { get; set; }
+    public Func<OnThresholdExceededArguments, ValueTask>? OnThresholdExceeded { get; set; }
 }
 
 #endregion

--- a/samples/Extensibility/Program.cs
+++ b/samples/Extensibility/Program.cs
@@ -11,7 +11,7 @@ var pipeline = new ResiliencePipelineBuilder()
     .AddTiming(new TimingStrategyOptions
     {
         Threshold = TimeSpan.FromSeconds(1),
-        ThresholdExceeded = args =>
+        OnThresholdExceeded = args =>
         {
             Console.WriteLine("Execution threshold exceeded!");
             return default;


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed
1. On the `Proactive strategy` page the sample code did not follow the habit of prefixing each event with `On`
1. On the `Extensibility` page  I've missed a component diagram to see holistically the interactions between the different components

## Details on the issue fix or feature implementation
- Renamed all `ThresholdExceeded` staff to `OnThresholdExceeded`
- Added a new component diagram to describe the interactions between the components
  - Please note that mermaidjs does not support component diagram only flow diagram
<img width="863" alt="Screenshot 2023-12-19 at 12 52 25" src="https://github.com/App-vNext/Polly/assets/57183693/26d6eab3-8d91-4279-8e1c-2a307d0471e1">
<img width="871" alt="Screenshot 2023-12-19 at 12 52 36" src="https://github.com/App-vNext/Polly/assets/57183693/2bed42df-214a-46ec-8885-548ff37d9829">




## Note
In a separate PR I will update the `reactive strategy` documentation page.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
