### PR TITLE
[Docs] Revise reactive strategy sample

### DIFF
--- a/docs/extensibility/reactive-strategy.md
+++ b/docs/extensibility/reactive-strategy.md
@@ -4,7 +4,7 @@ This document describes how to set up a **Result reporting resilience strategy**
 
 ## Implementation
 
-Reactive resilience strategies inherit from the [`ResilienceStrategy<T>`](xref:Polly.ResilienceStrategy`1) base class. The implementation for this specific strategy is as follows:
+Reactive resilience strategies inherit from the [`ResilienceStrategy<T>`](xref:Polly.ResilienceStrategy`1) base class. The implementation for this specific strategy:
 
 <!-- snippet: ext-reactive-strategy -->
 ```cs
@@ -31,15 +31,21 @@ internal sealed class ResultReportingResilienceStrategy<T> : ResilienceStrategy<
         ResilienceContext context,
         TState state)
     {
+        // Execute the given callback and adhere to the ContinueOnCapturedContext property value.
         Outcome<T> outcome = await callback(context, state).ConfigureAwait(context.ContinueOnCapturedContext);
 
         // Check if the outcome should be reported using the "ShouldHandle" predicate.
         if (await _shouldHandle(new ResultReportingPredicateArguments<T>(context, outcome)).ConfigureAwait(context.ContinueOnCapturedContext))
         {
+            // Bundle information about the event into arguments.
             var args = new OnReportResultArguments<T>(context, outcome);
 
-            // Report the event with an informational severity level to the telemetry infrastructure.
-            _telemetry.Report(new ResilienceEvent(ResilienceEventSeverity.Information, "ResultReported"), context, outcome, args);
+            // Report this as a resilience event with information severity level to the telemetry infrastructure.
+            _telemetry.Report(
+                new ResilienceEvent(ResilienceEventSeverity.Information, "ResultReported"),
+                context,
+                outcome,
+                args);
 
             // Call the "OnReportResult" callback.
             await _onReportResult(args).ConfigureAwait(context.ContinueOnCapturedContext);
@@ -55,7 +61,7 @@ Reactive strategies use the `ShouldHandle` predicate to decide whether to handle
 
 <!-- snippet: ext-reactive-predicate-args -->
 ```cs
-public struct ResultReportingPredicateArguments<TResult>
+public readonly struct ResultReportingPredicateArguments<TResult>
 {
     public ResultReportingPredicateArguments(ResilienceContext context, Outcome<TResult> outcome)
     {
@@ -72,13 +78,13 @@ public struct ResultReportingPredicateArguments<TResult>
 ```
 <!-- endSnippet -->
 
-Reactive arguments always contain the `Context` and `Outcome` properties.
+Reactive arguments should **always** contain the `Context` and `Outcome` properties.
 
 Additionally, to report the outcome, the strategy uses `OnReportResultArguments<TResult>`:
 
 <!-- snippet: ext-reactive-event-args -->
 ```cs
-public struct OnReportResultArguments<TResult>
+public readonly struct OnReportResultArguments<TResult>
 {
     public OnReportResultArguments(ResilienceContext context, Outcome<TResult> outcome)
     {
@@ -109,7 +115,7 @@ public class ResultReportingStrategyOptions<TResult> : ResilienceStrategyOptions
 {
     public ResultReportingStrategyOptions()
     {
-        // Set a default name for the options to enhance telemetry insights.
+        // Assign a default name to the options for more detailed telemetry insights.
         Name = "ResultReporting";
     }
 
@@ -159,16 +165,18 @@ public static class ResultReportingResilienceStrategyBuilderExtensions
 {
     // Add extensions for the generic builder.
     // Extensions should return the builder to support a fluent API.
-    public static ResiliencePipelineBuilder<TResult> AddResultReporting<TResult>(this ResiliencePipelineBuilder<TResult> builder, ResultReportingStrategyOptions<TResult> options)
+    public static ResiliencePipelineBuilder<TResult> AddResultReporting<TResult>(
+        this ResiliencePipelineBuilder<TResult> builder,
+        ResultReportingStrategyOptions<TResult> options)
     {
-        // Incorporate the strategy using the AddStrategy() method. This method receives a factory delegate
-        // and automatically checks the options.
+        // Add the strategy through the AddStrategy method. This method accepts a factory delegate
+        // and automatically validates the options.
         return builder.AddStrategy(
             context =>
             {
-                // The "context" offers various properties for the strategy to use.
-                // Here, we simply use the "Telemetry" property and hand it over to the strategy.
-                // The ShouldHandle and OnReportResult values come from the options.
+                // The "context" offers various properties for the strategy's use.
+                // In this case, we simply use the "Telemetry" property and pass it to the strategy.
+                // The ShouldHandle and OnReportResult values are sourced from the options.
                 var strategy = new ResultReportingResilienceStrategy<TResult>(
                     options.ShouldHandle,
                     options.OnReportResult!,
@@ -181,7 +189,9 @@ public static class ResultReportingResilienceStrategyBuilderExtensions
 
     // Optionally, if suitable for the strategy, add support for non-generic builders.
     // Observe the use of the non-generic ResultReportingStrategyOptions.
-    public static ResiliencePipelineBuilder AddResultReporting(this ResiliencePipelineBuilder builder, ResultReportingStrategyOptions options)
+    public static ResiliencePipelineBuilder AddResultReporting(
+        this ResiliencePipelineBuilder builder,
+        ResultReportingStrategyOptions options)
     {
         return builder.AddStrategy(
             context =>
@@ -211,7 +221,7 @@ new ResiliencePipelineBuilder<HttpResponseMessage>()
         ShouldHandle = args => args.Outcome switch
         {
             { Exception: { } } => PredicateResult.True(),
-            { Result: { StatusCode: HttpStatusCode.InternalServerError } } => PredicateResult.True(),
+            { Result.StatusCode: HttpStatusCode.InternalServerError } => PredicateResult.True(),
             _ => PredicateResult.False()
         },
         OnReportResult = args =>

--- a/samples/Extensibility/Extensibility.csproj
+++ b/samples/Extensibility/Extensibility.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/Extensibility/Program.cs
+++ b/samples/Extensibility/Program.cs
@@ -31,7 +31,7 @@ new ResiliencePipelineBuilder<HttpResponseMessage>()
         ShouldHandle = args => args.Outcome switch
         {
             { Exception: { } } => PredicateResult.True(),
-            { Result: { StatusCode: HttpStatusCode.InternalServerError } } => PredicateResult.True(),
+            { Result.StatusCode: HttpStatusCode.InternalServerError } => PredicateResult.True(),
             _ => PredicateResult.False()
         },
         OnReportResult = args =>
@@ -61,37 +61,3 @@ new ResiliencePipelineBuilder()
 
 #endregion
 
-// Execute the pipeline
-await pipeline.ExecuteAsync(async token => await Task.Delay(1500, token), CancellationToken.None);
-
-// ------------------------------------------------------------------------
-// SIMPLE EXTENSIBILITY MODEL (INLINE STRATEGY)
-// ------------------------------------------------------------------------
-pipeline = new ResiliencePipelineBuilder()
-    // Just add the strategy instance directly
-    .AddStrategy(_ => new MySimpleStrategy(), new MySimpleStrategyOptions())
-    .Build();
-
-// Execute the pipeline
-pipeline.Execute(() => { });
-
-internal class MySimpleStrategy : ResilienceStrategy
-{
-    protected override ValueTask<Outcome<TResult>> ExecuteCore<TResult, TState>(
-        Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
-        ResilienceContext context,
-        TState state)
-    {
-        Console.WriteLine("MySimpleStrategy executing!");
-
-        // The "state" is an ambient value passed by the caller that holds the state.
-        // Here, we do not do anything with it, just pass it to the callback.
-
-        // Execute the provided callback
-        return callback(context, state);
-    }
-}
-
-public class MySimpleStrategyOptions : ResilienceStrategyOptions
-{
-}

--- a/samples/Extensibility/Reactive/OnReportResultArguments.cs
+++ b/samples/Extensibility/Reactive/OnReportResultArguments.cs
@@ -4,7 +4,7 @@ namespace Extensibility.Reactive;
 
 #region ext-reactive-event-args
 
-public struct OnReportResultArguments<TResult>
+public readonly struct OnReportResultArguments<TResult>
 {
     public OnReportResultArguments(ResilienceContext context, Outcome<TResult> outcome)
     {

--- a/samples/Extensibility/Reactive/ResultReportingPredicateArguments.cs
+++ b/samples/Extensibility/Reactive/ResultReportingPredicateArguments.cs
@@ -4,7 +4,7 @@ namespace Extensibility.Reactive;
 
 #region ext-reactive-predicate-args
 
-public struct ResultReportingPredicateArguments<TResult>
+public readonly struct ResultReportingPredicateArguments<TResult>
 {
     public ResultReportingPredicateArguments(ResilienceContext context, Outcome<TResult> outcome)
     {

--- a/samples/Extensibility/Reactive/ResultReportingResilienceStrategyBuilderExtensions.cs
+++ b/samples/Extensibility/Reactive/ResultReportingResilienceStrategyBuilderExtensions.cs
@@ -10,16 +10,18 @@ public static class ResultReportingResilienceStrategyBuilderExtensions
 {
     // Add extensions for the generic builder.
     // Extensions should return the builder to support a fluent API.
-    public static ResiliencePipelineBuilder<TResult> AddResultReporting<TResult>(this ResiliencePipelineBuilder<TResult> builder, ResultReportingStrategyOptions<TResult> options)
+    public static ResiliencePipelineBuilder<TResult> AddResultReporting<TResult>(
+        this ResiliencePipelineBuilder<TResult> builder,
+        ResultReportingStrategyOptions<TResult> options)
     {
-        // Incorporate the strategy using the AddStrategy() method. This method receives a factory delegate
-        // and automatically checks the options.
+        // Add the strategy through the AddStrategy method. This method accepts a factory delegate
+        // and automatically validates the options.
         return builder.AddStrategy(
             context =>
             {
-                // The "context" offers various properties for the strategy to use.
-                // Here, we simply use the "Telemetry" property and hand it over to the strategy.
-                // The ShouldHandle and OnReportResult values come from the options.
+                // The "context" provides various properties for the strategy's use.
+                // In this case, we simply use the "Telemetry" property and pass it to the strategy.
+                // The ShouldHandle and OnReportResult values are sourced from the options.
                 var strategy = new ResultReportingResilienceStrategy<TResult>(
                     options.ShouldHandle,
                     options.OnReportResult!,
@@ -32,7 +34,9 @@ public static class ResultReportingResilienceStrategyBuilderExtensions
 
     // Optionally, if suitable for the strategy, add support for non-generic builders.
     // Observe the use of the non-generic ResultReportingStrategyOptions.
-    public static ResiliencePipelineBuilder AddResultReporting(this ResiliencePipelineBuilder builder, ResultReportingStrategyOptions options)
+    public static ResiliencePipelineBuilder AddResultReporting(
+        this ResiliencePipelineBuilder builder,
+        ResultReportingStrategyOptions options)
     {
         return builder.AddStrategy(
             context =>

--- a/samples/Extensibility/Reactive/ResultReportingStrategyOptions.cs
+++ b/samples/Extensibility/Reactive/ResultReportingStrategyOptions.cs
@@ -9,7 +9,7 @@ public class ResultReportingStrategyOptions<TResult> : ResilienceStrategyOptions
 {
     public ResultReportingStrategyOptions()
     {
-        // Set a default name for the options to enhance telemetry insights.
+        // Assign a default name to the options for more detailed telemetry insights.
         Name = "ResultReporting";
     }
 


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed

- `Arguments` and `PredicateArguments` were defined as `struct` not as `readonly struct`
- Inside the `samples/Extensibility/Program.cs` there were some dead code
- The comments on the reactive sample were a bit different than on the proactive sample


## Details on the issue fix or feature implementation

- Defined `Arguments` and `PredicateArguments` as `readonly struct`
- Deleted dead code Inside the `samples/Extensibility/Program.cs`
- Simplified one of the switch case's pattern matching
- Synchronized the comments between the reactive and the proactive samples
- Change the target of `samples/Extensibility/Extensibility.csproj` from .NET 7 to .NET 8

## Open question
- In order to enhance clarity shouldn't we use `TResult` instead of `T` for the `ResultReportingResilienceStrategy` class?

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
