### PR TITLE
Fix retry overflow with max delay

### DIFF
--- a/src/Polly.Core/Retry/RetryHelper.cs
+++ b/src/Polly.Core/Retry/RetryHelper.cs
@@ -31,9 +31,9 @@ internal static class RetryHelper
         }
         catch (OverflowException)
         {
-            if (maxDelay is not null)
+            if (maxDelay is { } value)
             {
-                return maxDelay.Value;
+                return value;
             }
 
             return TimeSpan.MaxValue;

--- a/src/Polly.Core/Retry/RetryHelper.cs
+++ b/src/Polly.Core/Retry/RetryHelper.cs
@@ -31,6 +31,11 @@ internal static class RetryHelper
         }
         catch (OverflowException)
         {
+            if (maxDelay is not null)
+            {
+                return maxDelay.Value;
+            }
+
             return TimeSpan.MaxValue;
         }
     }

--- a/test/Polly.Core.Tests/Retry/RetryHelperTests.cs
+++ b/test/Polly.Core.Tests/Retry/RetryHelperTests.cs
@@ -179,6 +179,14 @@ public class RetryHelperTests
         RetryHelper.GetRetryDelay(DelayBackoffType.Exponential, false, 1000, TimeSpan.FromDays(1), null, ref state, _randomizer).Should().Be(TimeSpan.MaxValue);
     }
 
+    [Fact]
+    public void GetRetryDelay_OverflowWithMaxDelay_ReturnsMaxDelay()
+    {
+        double state = 0;
+
+        RetryHelper.GetRetryDelay(DelayBackoffType.Exponential, false, 1000, TimeSpan.FromDays(1), TimeSpan.FromDays(2), ref state, _randomizer).Should().Be(TimeSpan.FromDays(2));
+    }
+
     [InlineData(1)]
     [InlineData(2)]
     [InlineData(3)]


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed

Fix issue #1866 Retry Startegy stops retrying unexpectedly

## Details on the issue fix or feature implementation

In case computing retry delay throws `OverflowException`, `RetryHelper.GetRetryDelay(...)` returns `maxDelay.value` if not null, `TimeSpan.MaxValue` otherwise.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
