### PR TITLE
Run workflows on release branches

### DIFF
--- a/.github/workflows/actions-lint.yml
+++ b/.github/workflows/actions-lint.yml
@@ -2,13 +2,13 @@ name: actions-lint
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, release/* ]
     paths-ignore:
-    - '**/*.gitattributes'
-    - '**/*.gitignore'
-    - '**/*.md'
+      - '**/*.gitattributes'
+      - '**/*.gitignore'
+      - '**/*.md'
   pull_request:
-    branches: [ main ]
+    branches: [ main, release/* ]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,10 @@ name: build
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, release/* ]
     tags: [ '*' ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, release/* ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,9 +2,9 @@ name: code-scan
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, release/* ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, release/* ]
   schedule:
     - cron: '0 8 * * MON'
   workflow_dispatch:

--- a/.github/workflows/dependabot-approve.yml
+++ b/.github/workflows/dependabot-approve.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   review:
     runs-on: ubuntu-latest
-    if: ${{ github.event.repository.fork == false && github.event.pull_request.user.login == 'dependabot[bot]' }}
+    if: github.event.repository.fork == false && github.event.pull_request.user.login == 'dependabot[bot]'
 
     steps:
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,7 +2,7 @@ name: dependency-review
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, release/* ]
 
 permissions:
   contents: read
@@ -10,7 +10,7 @@ permissions:
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
-    if: ${{ github.event.repository.fork == false }}
+    if: github.event.repository.fork == false
 
     steps:
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,9 +2,9 @@ name: github-pages
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, release/* ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, release/* ]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/updater-approve.yml
+++ b/.github/workflows/updater-approve.yml
@@ -2,7 +2,7 @@ name: updater-approve
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, release/* ]
 
 permissions:
   contents: read
@@ -10,7 +10,7 @@ permissions:
 jobs:
   review:
     runs-on: ubuntu-latest
-    if: ${{ github.event.repository.fork == false && github.event.pull_request.user.login == 'polly-updater-bot[bot]' }}
+    if: github.event.repository.fork == false && github.event.pull_request.user.login == 'polly-updater-bot[bot]'
 
     env:
       REVIEWER_LOGIN: "polly-reviewer-bot[bot]"
@@ -98,7 +98,7 @@ jobs:
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Approve pull request and enable auto-merge
-      if: ${{ steps.check-dependencies.outputs.is-trusted-update == 'true' }}
+      if: steps.check-dependencies.outputs.is-trusted-update == 'true'
       env:
         GH_TOKEN: ${{ steps.generate-application-token.outputs.token }}
         PR_URL: ${{ github.event.pull_request.html_url }}
@@ -118,7 +118,7 @@ jobs:
         }
 
     - name: Disable auto-merge and dismiss approvals
-      if: ${{ steps.check-dependencies.outputs.is-trusted-update != 'true' }}
+      if: steps.check-dependencies.outputs.is-trusted-update != 'true'
       env:
         GH_TOKEN: ${{ steps.generate-application-token.outputs.token }}
         PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
- Allow workflows to run on `release/*` branches where appropriate to make it easier to validate branches for patch releases if we need them (https://github.com/App-vNext/Polly/issues/1877#issuecomment-1875042229).
- Remove redundant `if` condition escaping.
