### PR TITLE
Decrease the minimum allowed timeout

### DIFF
--- a/src/Polly.Core/Timeout/TimeoutStrategyOptions.cs
+++ b/src/Polly.Core/Timeout/TimeoutStrategyOptions.cs
@@ -19,7 +19,7 @@ public class TimeoutStrategyOptions : ResilienceStrategyOptions
     /// <value>
     /// This value must be greater than 1 second and less than 24 hours. The default value is 30 seconds.
     /// </value>
-    [Range(typeof(TimeSpan), "00:00:01", "1.00:00:00")]
+    [Range(typeof(TimeSpan), "00:00:00.010", "1.00:00:00")]
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Addressed with DynamicDependency on ValidationHelper.Validate method")]
     public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(30);
 

--- a/test/Polly.Core.Tests/Timeout/TimeoutTestUtils.cs
+++ b/test/Polly.Core.Tests/Timeout/TimeoutTestUtils.cs
@@ -15,12 +15,15 @@ public static class TimeoutTestUtils
         TimeSpan.Zero,
         TimeSpan.FromSeconds(-1),
         TimeSpan.FromHours(25),
+        TimeSpan.FromMilliseconds(9),
     };
 
     public static readonly TheoryData<TimeSpan> ValidTimeouts = new()
     {
         TimeSpan.FromSeconds(1),
         TimeSpan.FromHours(1),
+        TimeSpan.FromMilliseconds(10),
+
     };
 #pragma warning restore IDE0028
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

Closes #1884 

## Details on the issue fix or feature implementation

Relaxing the min allowed timeout to 10ms. (from 1 second)

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
