### PR TITLE
BreakDurationGeneratorArguments now includes half-open attempts

### DIFF
--- a/src/Polly.Core/CircuitBreaker/BreakDurationGeneratorArguments.cs
+++ b/src/Polly.Core/CircuitBreaker/BreakDurationGeneratorArguments.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace Polly.CircuitBreaker;
 
 #pragma warning disable CA1815 // Override equals and operator equals on value types
@@ -16,6 +18,7 @@ public readonly struct BreakDurationGeneratorArguments
     /// This count is used to determine if the failure threshold has been reached.</param>
     /// <param name="context">The resilience context providing additional information
     /// about the execution state and failures.</param>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public BreakDurationGeneratorArguments(
         double failureRate,
         int failureCount,
@@ -24,6 +27,29 @@ public readonly struct BreakDurationGeneratorArguments
         FailureRate = failureRate;
         FailureCount = failureCount;
         Context = context;
+        HalfOpenAttempts = 0;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BreakDurationGeneratorArguments"/> struct.
+    /// </summary>
+    /// <param name="failureRate">The failure rate at which the circuit breaker should trip.
+    /// It represents the ratio of failed actions to the total executed actions.</param>
+    /// <param name="failureCount">The number of failures that have occurred.
+    /// This count is used to determine if the failure threshold has been reached.</param>
+    /// <param name="context">The resilience context providing additional information
+    /// about the execution state and failures.</param>
+    /// <param name="halfOpenAttempts">The number of half-open attempts.</param>
+    public BreakDurationGeneratorArguments(
+        double failureRate,
+        int failureCount,
+        ResilienceContext context,
+        int halfOpenAttempts)
+    {
+        FailureRate = failureRate;
+        FailureCount = failureCount;
+        Context = context;
+        HalfOpenAttempts = halfOpenAttempts;
     }
 
     /// <summary>
@@ -40,4 +66,9 @@ public readonly struct BreakDurationGeneratorArguments
     /// Gets the context that provides additional information about the resilience operation.
     /// </summary>
     public ResilienceContext Context { get; }
+
+    /// <summary>
+    /// Gets the number of half-open attempts.
+    /// </summary>
+    public int HalfOpenAttempts { get; }
 }

--- a/src/Polly.Core/PublicAPI.Unshipped.txt
+++ b/src/Polly.Core/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 ﻿#nullable enable
+Polly.CircuitBreaker.BreakDurationGeneratorArguments.BreakDurationGeneratorArguments(double failureRate, int failureCount, Polly.ResilienceContext! context, int halfOpenAttempts) -> void
+Polly.CircuitBreaker.BreakDurationGeneratorArguments.HalfOpenAttempts.get -> int
 Polly.Simmy.Behavior.BehaviorActionArguments
 Polly.Simmy.Behavior.BehaviorActionArguments.BehaviorActionArguments() -> void
 Polly.Simmy.Behavior.BehaviorActionArguments.BehaviorActionArguments(Polly.ResilienceContext! context) -> void

--- a/test/Polly.Core.Tests/CircuitBreaker/BreakDurationGeneratorArgumentsTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/BreakDurationGeneratorArgumentsTests.cs
@@ -6,7 +6,7 @@ namespace Polly.Core.Tests.CircuitBreaker;
 public class BreakDurationGeneratorArgumentsTests
 {
     [Fact]
-    public void Constructor_ShouldSetFailureRate()
+    public void Constructor_Old_Ok()
     {
         double expectedFailureRate = 0.5;
         int failureCount = 10;
@@ -15,29 +15,22 @@ public class BreakDurationGeneratorArgumentsTests
         var args = new BreakDurationGeneratorArguments(expectedFailureRate, failureCount, context);
 
         args.FailureRate.Should().Be(expectedFailureRate);
+        args.FailureCount.Should().Be(failureCount);
+        args.Context.Should().Be(context);
     }
 
     [Fact]
-    public void Constructor_ShouldSetFailureCount()
+    public void Constructor_Ok()
     {
-        double failureRate = 0.5;
-        int expectedFailureCount = 10;
+        double expectedFailureRate = 0.5;
+        int failureCount = 10;
         var context = new ResilienceContext();
 
-        var args = new BreakDurationGeneratorArguments(failureRate, expectedFailureCount, context);
+        var args = new BreakDurationGeneratorArguments(expectedFailureRate, failureCount, context, 99);
 
-        args.FailureCount.Should().Be(expectedFailureCount);
-    }
-
-    [Fact]
-    public void Constructor_ShouldSetContext()
-    {
-        double failureRate = 0.5;
-        int failureCount = 10;
-        var expectedContext = new ResilienceContext();
-
-        var args = new BreakDurationGeneratorArguments(failureRate, failureCount, expectedContext);
-
-        args.Context.Should().Be(expectedContext);
+        args.FailureRate.Should().Be(expectedFailureRate);
+        args.FailureCount.Should().Be(failureCount);
+        args.Context.Should().Be(context);
+        args.HalfOpenAttempts.Should().Be(99);
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

Closes #1895 

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
