### PR TITLE
Do not encourage returning the same instance from chaos strategies

### DIFF
--- a/src/Polly.Core/PublicAPI.Unshipped.txt
+++ b/src/Polly.Core/PublicAPI.Unshipped.txt
@@ -100,11 +100,9 @@ Polly.Simmy.Outcomes.OutcomeStrategyOptions<TResult>.OutcomeGenerator.set -> voi
 Polly.Simmy.Outcomes.OutcomeStrategyOptions<TResult>.OutcomeStrategyOptions() -> void
 static Polly.Simmy.BehaviorPipelineBuilderExtensions.AddChaosBehavior<TBuilder>(this TBuilder! builder, double injectionRate, System.Func<System.Threading.Tasks.ValueTask>! behavior) -> TBuilder!
 static Polly.Simmy.BehaviorPipelineBuilderExtensions.AddChaosBehavior<TBuilder>(this TBuilder! builder, Polly.Simmy.Behavior.BehaviorStrategyOptions! options) -> TBuilder!
-static Polly.Simmy.FaultPipelineBuilderExtensions.AddChaosFault<TBuilder>(this TBuilder! builder, double injectionRate, System.Exception! fault) -> TBuilder!
 static Polly.Simmy.FaultPipelineBuilderExtensions.AddChaosFault<TBuilder>(this TBuilder! builder, double injectionRate, System.Func<System.Exception?>! faultGenerator) -> TBuilder!
 static Polly.Simmy.FaultPipelineBuilderExtensions.AddChaosFault<TBuilder>(this TBuilder! builder, Polly.Simmy.Fault.FaultStrategyOptions! options) -> TBuilder!
 static Polly.Simmy.LatencyPipelineBuilderExtensions.AddChaosLatency<TBuilder>(this TBuilder! builder, double injectionRate, System.TimeSpan latency) -> TBuilder!
 static Polly.Simmy.LatencyPipelineBuilderExtensions.AddChaosLatency<TBuilder>(this TBuilder! builder, Polly.Simmy.Latency.LatencyStrategyOptions! options) -> TBuilder!
 static Polly.Simmy.OutcomePipelineBuilderExtensions.AddChaosResult<TResult>(this Polly.ResiliencePipelineBuilder<TResult>! builder, double injectionRate, System.Func<TResult?>! resultGenerator) -> Polly.ResiliencePipelineBuilder<TResult>!
-static Polly.Simmy.OutcomePipelineBuilderExtensions.AddChaosResult<TResult>(this Polly.ResiliencePipelineBuilder<TResult>! builder, double injectionRate, TResult result) -> Polly.ResiliencePipelineBuilder<TResult>!
 static Polly.Simmy.OutcomePipelineBuilderExtensions.AddChaosResult<TResult>(this Polly.ResiliencePipelineBuilder<TResult>! builder, Polly.Simmy.Outcomes.OutcomeStrategyOptions<TResult>! options) -> Polly.ResiliencePipelineBuilder<TResult>!

--- a/src/Polly.Core/Simmy/Fault/FaultPipelineBuilderExtensions.cs
+++ b/src/Polly.Core/Simmy/Fault/FaultPipelineBuilderExtensions.cs
@@ -23,7 +23,7 @@ public static class FaultPipelineBuilderExtensions
         {
             Enabled = true,
             InjectionRate = injectionRate,
-            FaultGenerator = (_) => new ValueTask<Exception?>(Task.FromResult(faultGenerator()))
+            FaultGenerator = (_) => new ValueTask<Exception?>(faultGenerator())
         });
         return builder;
     }

--- a/src/Polly.Core/Simmy/Fault/FaultPipelineBuilderExtensions.cs
+++ b/src/Polly.Core/Simmy/Fault/FaultPipelineBuilderExtensions.cs
@@ -14,26 +14,6 @@ public static class FaultPipelineBuilderExtensions
     /// <typeparam name="TBuilder">The builder type.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="injectionRate">The injection rate for a given execution, which the value should be between [0, 1] (inclusive).</param>
-    /// <param name="fault">The exception to inject.</param>
-    /// <returns>The builder instance with the retry strategy added.</returns>
-    public static TBuilder AddChaosFault<TBuilder>(this TBuilder builder, double injectionRate, Exception fault)
-        where TBuilder : ResiliencePipelineBuilderBase
-    {
-        builder.AddChaosFault(new FaultStrategyOptions
-        {
-            Enabled = true,
-            InjectionRate = injectionRate,
-            Fault = fault
-        });
-        return builder;
-    }
-
-    /// <summary>
-    /// Adds a fault chaos strategy to the builder.
-    /// </summary>
-    /// <typeparam name="TBuilder">The builder type.</typeparam>
-    /// <param name="builder">The builder instance.</param>
-    /// <param name="injectionRate">The injection rate for a given execution, which the value should be between [0, 1] (inclusive).</param>
     /// <param name="faultGenerator">The exception generator delegate.</param>
     /// <returns>The builder instance with the retry strategy added.</returns>
     public static TBuilder AddChaosFault<TBuilder>(this TBuilder builder, double injectionRate, Func<Exception?> faultGenerator)

--- a/src/Polly.Core/Simmy/Outcomes/OutcomePipelineBuilderExtensions.cs
+++ b/src/Polly.Core/Simmy/Outcomes/OutcomePipelineBuilderExtensions.cs
@@ -27,7 +27,10 @@ public static class OutcomePipelineBuilderExtensions
         {
             Enabled = true,
             InjectionRate = injectionRate,
-            OutcomeGenerator = (_) => new ValueTask<Outcome<TResult>?>(Task.FromResult<Outcome<TResult>?>(Outcome.FromResult(resultGenerator())))
+            OutcomeGenerator = (_) =>
+            {
+                return new ValueTask<Outcome<TResult>?>(Outcome.FromResult(resultGenerator()));
+            }
         });
         return builder;
     }

--- a/src/Polly.Core/Simmy/Outcomes/OutcomePipelineBuilderExtensions.cs
+++ b/src/Polly.Core/Simmy/Outcomes/OutcomePipelineBuilderExtensions.cs
@@ -14,30 +14,6 @@ public static class OutcomePipelineBuilderExtensions
     /// <typeparam name="TResult">The type of result the retry strategy handles.</typeparam>
     /// <param name="builder">The builder instance.</param>
     /// <param name="injectionRate">The injection rate for a given execution, which the value should be between [0, 1] (inclusive).</param>
-    /// <param name="result">The outcome to inject. For disposable outcomes use either the generator or the options overload.</param>
-    /// <returns>The builder instance with the retry strategy added.</returns>
-    public static ResiliencePipelineBuilder<TResult> AddChaosResult<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TResult>(
-        this ResiliencePipelineBuilder<TResult> builder,
-        double injectionRate,
-        TResult result)
-    {
-        Guard.NotNull(builder);
-
-        builder.AddChaosResult(new OutcomeStrategyOptions<TResult>
-        {
-            Enabled = true,
-            InjectionRate = injectionRate,
-            OutcomeGenerator = (_) => new ValueTask<Outcome<TResult>?>(Task.FromResult<Outcome<TResult>?>(Outcome.FromResult(result)))
-        });
-        return builder;
-    }
-
-    /// <summary>
-    /// Adds an outcome chaos strategy to the builder.
-    /// </summary>
-    /// <typeparam name="TResult">The type of result the retry strategy handles.</typeparam>
-    /// <param name="builder">The builder instance.</param>
-    /// <param name="injectionRate">The injection rate for a given execution, which the value should be between [0, 1] (inclusive).</param>
     /// <param name="resultGenerator">The outcome generator delegate.</param>
     /// <returns>The builder instance with the retry strategy added.</returns>
     public static ResiliencePipelineBuilder<TResult> AddChaosResult<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TResult>(

--- a/test/Polly.Core.Tests/Simmy/Fault/FaultChaosPipelineBuilderExtensionsTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Fault/FaultChaosPipelineBuilderExtensionsTests.cs
@@ -59,17 +59,6 @@ public class FaultChaosPipelineBuilderExtensionsTests
     }
 
     [Fact]
-    public void AddFault_Shortcut_Option_Ok()
-    {
-        var builder = new ResiliencePipelineBuilder();
-        builder
-            .AddChaosFault(0.5, new InvalidOperationException("Dummy exception"))
-            .Build();
-
-        AssertFaultStrategy<InvalidOperationException>(builder, true, 0.5);
-    }
-
-    [Fact]
     public void AddFault_Generic_Shortcut_Generator_Option_Throws()
     {
         new ResiliencePipelineBuilder<int>()
@@ -100,26 +89,6 @@ public class FaultChaosPipelineBuilderExtensionsTests
             .Build();
 
         AssertFaultStrategy<InvalidOperationException>(builder, true, 0.5);
-    }
-
-    [Fact]
-    public void AddFault_Generic_Shortcut_Option_Ok()
-    {
-        var builder = new ResiliencePipelineBuilder<string>();
-        builder
-            .AddChaosFault(0.5, new InvalidOperationException("Dummy exception"))
-            .Build();
-
-        AssertFaultStrategy<string, InvalidOperationException>(builder, true, 0.5);
-    }
-
-    [Fact]
-    public void AddFault_Generic_Shortcut_Option_Throws()
-    {
-        new ResiliencePipelineBuilder<int>()
-            .Invoking(b => b.AddChaosFault(-1, new InvalidOperationException()))
-            .Should()
-            .Throw<ValidationException>();
     }
 
     [Fact]

--- a/test/Polly.Core.Tests/Simmy/Outcomes/OutcomeChaosPipelineBuilderExtensionsTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Outcomes/OutcomeChaosPipelineBuilderExtensionsTests.cs
@@ -44,17 +44,6 @@ public class OutcomeChaosPipelineBuilderExtensionsTests
     }
 
     [Fact]
-    public void AddResult_Shortcut_Option_Ok()
-    {
-        var builder = new ResiliencePipelineBuilder<int>();
-        builder
-            .AddChaosResult(0.5, 120)
-            .Build();
-
-        AssertResultStrategy(builder, true, 0.5, new(120));
-    }
-
-    [Fact]
     public void AddResult_Shortcut_Generator_Option_Ok()
     {
         var builder = new ResiliencePipelineBuilder<int>();


### PR DESCRIPTION
## Details on the issue fix or feature implementation

These overloads could lead to the same problems as in #1877. For results, returning the same cached value (i.e. `HttpResponseMessage` can also cause issues. 

Better not to encourage this in our APIs.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
