### PR TITLE
[Docs] Add clarification about property precedence

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -13,6 +13,7 @@ deserialization
 dotnet
 dotnetrocks
 durations
+enum
 eshoponcontainers
 extensibility
 flurl

--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -13,7 +13,6 @@ deserialization
 dotnet
 dotnetrocks
 durations
-enum
 eshoponcontainers
 extensibility
 flurl

--- a/docs/chaos/index.md
+++ b/docs/chaos/index.md
@@ -66,7 +66,7 @@ Chaos strategies (formerly known as Monkey strategies) are in essence a [Resilie
 | [Fault](fault.md)       | No       | Injects exceptions in your system.                                   |
 | [Outcome](outcome.md)   | Yes      | Injects fake outcomes (results or exceptions) in your system.        |
 | [Latency](latency.md)   | No       | Injects latency into executions before the calls are made.           |
-| [Behavior](behavior.md) | No       | Allows you to inject *any* extra behaviour, before a call is placed. |
+| [Behavior](behavior.md) | No       | Allows you to inject *any* extra behavior, before a call is placed.  |
 
 ## Common options across strategies
 
@@ -85,6 +85,8 @@ All the strategies' options implement the [`ChaosStrategyOptions`](xref:Polly.Si
 | `EnabledGenerator`       | `null`        | The generator that indicates whether the chaos strategy is enabled for a given execution.                                                                                                                                        |
 
 > [!NOTE]
+> If both `InjectionRate` and `InjectionRateGenerator` are specified then `InjectionRate` will be ignored.
+>
 > If both `Enabled` and `EnabledGenerator` are specified then `Enabled` will be ignored.
 
 [simmy]: https://github.com/Polly-Contrib/Simmy

--- a/docs/strategies/circuit-breaker.md
+++ b/docs/strategies/circuit-breaker.md
@@ -105,6 +105,9 @@ new ResiliencePipelineBuilder<HttpResponseMessage>().AddCircuitBreaker(optionsSt
 | `ManualControl`          | `null`                                                                     | Allows for manual control to isolate or close the circuit.                                 |
 | `StateProvider`          | `null`                                                                     | Enables the retrieval of the current state of the circuit.                                 |
 
+> [!NOTE]
+> If both `BreakDuration` and `BreakDurationGenerator` are specified then `BreakDuration` will be ignored.
+
 ## Diagrams
 
 ### State diagram

--- a/docs/strategies/hedging.md
+++ b/docs/strategies/hedging.md
@@ -60,18 +60,21 @@ new ResiliencePipelineBuilder<HttpResponseMessage>().AddHedging(optionsDefaults)
 ## Defaults
 
 | Property            | Default Value                                                              | Description                                                                              |
-| ------------------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+|---------------------|----------------------------------------------------------------------------|------------------------------------------------------------------------------------------|
 | `ShouldHandle`      | Predicate that handles all exceptions except `OperationCanceledException`. | Predicate that determines what results and exceptions are handled by the retry strategy. |
 | `MaxHedgedAttempts` | 1                                                                          | The maximum number of hedged actions to use, in addition to the original action.         |
 | `Delay`             | 2 seconds                                                                  | The maximum waiting time before spawning a new hedged action.                            |
 | `ActionGenerator`   | Returns the original callback that was passed to the hedging strategy.     | Generator that creates hedged actions.                                                   |
-| `DelayGenerator`    | `null`                                                                     | Used for generating custom delays for hedging. If `null` then `Delay` is used.           |
+| `DelayGenerator`    | `null`                                                                     | Used for generating custom delays for hedging.                                           |
 | `OnHedging`         | `null`                                                                     | Event that is raised when a hedging is performed.                                        |
 
 You can use the following special values for `Delay` or in `DelayGenerator`:
 
 - `0 seconds` - the hedging strategy immediately creates a total of `MaxHedgedAttempts` and completes when the fastest acceptable result is available.
 - `-1 millisecond` - this value indicates that the strategy does not create a new hedged task before the previous one completes. This enables scenarios where having multiple concurrent hedged tasks can cause side effects.
+
+> [!NOTE]
+> If both `Delay` and `DelayGenerator` are specified then `Delay` will be ignored.
 
 ## Concurrency modes
 

--- a/docs/strategies/retry.md
+++ b/docs/strategies/retry.md
@@ -150,6 +150,19 @@ Step 3: Using the generator if supplied
 
 ### Linear
 
+This algorithm increases the delays for every attempt in a linear fashion if no jitter is used.
+
+Step 1: Calculating the base delay:
+
+- If `UseJitter` is set to `false` and `Delay` is specified then `Delay` multiplied by the actual attempt number will be used.
+- If `UseJitter` is set to `true` and `Delay` is specified then a random value is added to the `Delay` multiplied by the actual attempt number.
+  - The random value is between -25% of the newly calculated `Delay` and +25% of the newly calculated `Delay`.
+
+> [!NOTE]
+> Because the jitter's offset is based on the newly calculated delay that's why the new delay could be smaller than the previous one.
+
+Step 2 and 3 are the same as for the Constant algorithm.
+
 ### Exponential
 
 > [!TIP]

--- a/docs/strategies/retry.md
+++ b/docs/strategies/retry.md
@@ -123,7 +123,7 @@ There are many properties that may contribute to this calculation:
 > [!IMPORTANT]
 > The summarized description below is an implementation detail. It may change in the future without notice.
 
-The `BackoffType` property's data type is the [`DelayBackOffType`](xref:Polly.DelayBackOffType) enumeration. This primarily controls how the calculation is done.
+The `BackoffType` property's data type is the [`DelayBackoffType`](xref:Polly.DelayBackoffType) enumeration. This primarily controls how the calculation is done.
 
 ### Constant
 

--- a/docs/strategies/retry.md
+++ b/docs/strategies/retry.md
@@ -127,13 +127,13 @@ The `BackoffType` property's data type is the [`DelayBackOffType`](xref:Polly.De
 
 ### Constant
 
-One might think that here we only put into the account the `Delay` property. In reality all above listed properties are used.
+Even though the `Constant` name could imply that only the `Delay` property is used, in reality all the above listed properties are used.
 
 Step 1: Calculating the base delay:
 
 - If `UseJitter` is set to `false` and `Delay` is specified then `Delay` will be used.
 - If `UseJitter` is set to `true` and `Delay` is specified then a random value is added to the `Delay`.
-  - The random value is between [-25% of `Delay`, +25% of `Delay`].
+  - The random value is between -25% of `Delay` and +25% of `Delay`.
 
 Step 2: Capping the delay if needed:
 

--- a/docs/strategies/retry.md
+++ b/docs/strategies/retry.md
@@ -115,7 +115,7 @@ If the `ShouldHandle` predicate returns `true` and the next attempt number is no
 There are many properties that may contribute to this calculation:
 
 - `BackoffType`: Specifies which calculation algorithm should run.
-- `Delay`: If only this property is specified then it will be used as-is. If others are also specified then this will be used as a _base delay_.
+- `Delay`: If only this property is specified then it will be used as-is. If others are also specified then this will be used as a *base delay*.
 - `DelayGenerator`: If specified, will override other property-based calculations, **except** if it returns a negative `TimeSpan`, in which case the other property-based calculations are used.
 - `MaxDelay`: If specified, caps the delay if the calculated delay is greater than this value, **except** if `DelayGenerator` is used, where no capping is applied.
 - `UseJitter`: If enabled, then adds a random value between between -25% of `Delay` and +25% of `Delay`, **except** if `BackoffType` is `Exponential`, where a bit more complex jitter calculation is used.

--- a/docs/strategies/retry.md
+++ b/docs/strategies/retry.md
@@ -188,7 +188,7 @@ The delays column contains an example series of five values to depict the patter
 This algorithm increases the delays for every attempt in an exponential fashion if no jitter is used.
 
 - If `UseJitter` is set to `false` and `Delay` is specified then squaring actual attempt number multiplied by the `Delay` will be used (*`attempt^2 * delay`*).
-- If `UseJitter` is set to `true` and the `Delay` is specified then a `DecorrelatedJitterBackoffV2` formula (based on the [Polly.Contrib.WaitAndRetry](https://github.com/Polly-Contrib/Polly.Contrib.WaitAndRetry)) will be used.
+- If `UseJitter` is set to `true` and the `Delay` is specified then a `DecorrelatedJitterBackoffV2` formula (based on [Polly.Contrib.WaitAndRetry](https://github.com/Polly-Contrib/Polly.Contrib.WaitAndRetry)) will be used.
 
 > [!NOTE]
 > Because the jitter calculation is based on the newly calculated delay, the new delay could be less than the previous value.

--- a/docs/strategies/retry.md
+++ b/docs/strategies/retry.md
@@ -112,7 +112,7 @@ new ResiliencePipelineBuilder<HttpResponseMessage>().AddRetry(optionsExtractDela
 
 If the `ShouldHandle` predicate returns `true` and the next attempt number is not greater than `MaxRetryAttempts` then the retry strategy calculates the next delay.
 
-There are many properties that are somehow contribute to this calculation:
+There are many properties that may contribute to this calculation:
 
 - `Delay`
 - `DelayGenerator`
@@ -121,11 +121,9 @@ There are many properties that are somehow contribute to this calculation:
 - `BackoffType`
 
 > [!IMPORTANT]
-> The below described algorithm is an implementation detail. It might change in the future without further notice.
->
-> Also please bear in mind that some details are not mentioned here to keep the algorithm description short and terse.
+> The summarized description below is an implementation detail. It may change in the future without notice.
 
-The `BackoffType` property's data type is a [`DelayBackOffType`](xref:Polly.DelayBackOffType) enum. This controls primarily how the calculation is done.
+The `BackoffType` property's data type is the [`DelayBackOffType`](xref:Polly.DelayBackOffType) enumeration. This primarily controls how the calculation is done.
 
 ### Constant
 

--- a/docs/strategies/retry.md
+++ b/docs/strategies/retry.md
@@ -133,7 +133,7 @@ Step 1: Calculating the base delay:
 
 - If `UseJitter` is set to `false` and `Delay` is specified then `Delay` will be used.
 - If `UseJitter` is set to `true` and `Delay` is specified then a random value is added to the `Delay`.
-  - The random value is between -25% of `Delay` and +25% of `Delay`.
+  - The random value is between -25% and +25% of `Delay`.
 
 Step 2: Capping the delay if needed:
 
@@ -156,14 +156,24 @@ Step 1: Calculating the base delay:
 
 - If `UseJitter` is set to `false` and `Delay` is specified then `Delay` multiplied by the actual attempt number will be used.
 - If `UseJitter` is set to `true` and `Delay` is specified then a random value is added to the `Delay` multiplied by the actual attempt number.
-  - The random value is between -25% of the newly calculated `Delay` and +25% of the newly calculated `Delay`.
+  - The random value is between -25% and +25% of the newly calculated `Delay`.
 
 > [!NOTE]
-> Because the jitter calculation is based on the newly calculated delay that's why the new delay could be smaller than the previous one.
+> Because the jitter calculation is based on the newly calculated delay, the new delay could be less than the previous value.
 
 Step 2 and 3 are the same as for the Constant algorithm.
 
 ### Exponential
+
+This algorithm increases the delays for every attempt in an exponential fashion if no jitter is used.
+
+- If `UseJitter` is set to `false` and `Delay` is specified then squaring actual attempt number multiplied by the `Delay` will be used.
+- If `UseJitter` is set to `true` and the `Delay` is specified then a `DecorrelatedJitterBackoffV2` formula (based on the [Polly.Contrib.WaitAndRetry](https://github.com/Polly-Contrib/Polly.Contrib.WaitAndRetry)) will be used.
+
+> [!NOTE]
+> Because the jitter calculation is based on the newly calculated delay, the new delay could be less than the previous value.
+
+Step 2 and 3 are the same as for the Constant algorithm.
 
 > [!TIP]
 > For more details please check out the [`RetryHelper`](https://github.com/App-vNext/Polly/blob/main/src/Polly.Core/Retry/RetryHelper.cs)

--- a/docs/strategies/retry.md
+++ b/docs/strategies/retry.md
@@ -115,7 +115,7 @@ If the `ShouldHandle` predicate returns `true` and the next attempt number is no
 There are many properties that may contribute to this calculation:
 
 - `BackoffType`: It specifies which calculation algorithm should run.
-- `Delay`: If only this one is specified then it will be used as is. If others are defined as well then this will be used as a _base delay_.
+- `Delay`: If only this one is specified then it will be used as is. If others are defined as well then this will be used as a *base delay*.
 - `DelayGenerator`: If specified then it will overwrite other properties based calculation. **Except** if it returns a negative `TimeSpan` where the other properties based calculation is used.
 - `MaxDelay`: If specified then it caps the delay if the calculated one is greater than this value. **Except** if `DelayGenerator` is used where no capping is applied.
 - `UseJitter`: If enabled then it adds a random value between between -25% of `Delay` and +25% of `Delay`. **Except** if `BackoffType` is set to `Exponential` where jitter is always used.

--- a/docs/strategies/retry.md
+++ b/docs/strategies/retry.md
@@ -114,11 +114,11 @@ If the `ShouldHandle` predicate returns `true` and the next attempt number is no
 
 There are many properties that may contribute to this calculation:
 
-- `Delay`
-- `DelayGenerator`
-- `MaxDelay`
-- `UseJitter`
-- `BackoffType`
+- `BackoffType`: It specifies which calculation algorithm should run.
+- `Delay`: If only this one is specified then it will be used as is. If others are defined as well then this will be used as a _base delay_.
+- `DelayGenerator`: If specified then it will overwrite other properties based calculation. **Except** if it returns a negative `TimeSpan` where the other properties based calculation is used.
+- `MaxDelay`: If specified then it caps the delay if the calculated one is greater than this value. **Except** if `DelayGenerator` is used where no capping is applied.
+- `UseJitter`: If enabled then it adds a random value between between -25% of `Delay` and +25% of `Delay`. **Except** if `BackoffType` is set to `Exponential` where jitter is always used.
 
 > [!IMPORTANT]
 > The summarized description below is an implementation detail. It may change in the future without notice.
@@ -137,7 +137,8 @@ Step 1: Calculating the base delay:
 
 Step 2: Capping the delay if needed:
 
-- If the previously calculated delay is greater than `MaxDelay` then `MaxDelay` will be used.
+- If `MaxDelay` is not set then the previously calculated delay will be used.
+- If `MaxDelay` is set and the previously calculated delay is greater than `MaxDelay` then `MaxDelay` will be used.
 
 Step 3: Using the generator if supplied
 

--- a/docs/strategies/retry.md
+++ b/docs/strategies/retry.md
@@ -116,7 +116,7 @@ There are many properties that may contribute to this calculation:
 
 - `BackoffType`: Specifies which calculation algorithm should run.
 - `Delay`: If only this property is specified then it will be used as-is. If others are also specified then this will be used as a *base delay*.
-- `DelayGenerator`: If specified, will override other property-based calculations, **except** if it returns a negative `TimeSpan`, in which case the other property-based calculations are used.
+- `DelayGenerator`: If specified, will override other property-based calculations, **except** if it returns `null` or a negative `TimeSpan`, in which case the other property-based calculations are used.
 - `MaxDelay`: If specified, caps the delay if the calculated delay is greater than this value, **except** if `DelayGenerator` is used, where no capping is applied.
 - `UseJitter`: If enabled, then adds a random value between between -25% of `Delay` and +25% of `Delay`, **except** if `BackoffType` is `Exponential`, where a bit more complex jitter calculation is used.
 
@@ -144,6 +144,7 @@ Step 3: Using the generator if supplied
 
 - If the returned `TimeSpan` of the `DelayGenerator` method call is positive then it will be used.
 - If the returned `TimeSpan` of the `DelayGenerator` method call is negative then it will use the step 2's result.
+- If the `DelayGenerator` method call is `null` then it will use the step 2's result.
 
 > [!NOTE]
 > The `DelayGenerator`'s returned value is not capped with the `MaxDelay`.

--- a/docs/strategies/retry.md
+++ b/docs/strategies/retry.md
@@ -159,7 +159,7 @@ Step 1: Calculating the base delay:
   - The random value is between -25% of the newly calculated `Delay` and +25% of the newly calculated `Delay`.
 
 > [!NOTE]
-> Because the jitter's offset is based on the newly calculated delay that's why the new delay could be smaller than the previous one.
+> Because the jitter calculation is based on the newly calculated delay that's why the new delay could be smaller than the previous one.
 
 Step 2 and 3 are the same as for the Constant algorithm.
 

--- a/docs/strategies/retry.md
+++ b/docs/strategies/retry.md
@@ -148,6 +148,16 @@ Step 3: Using the generator if supplied
 > [!NOTE]
 > The `DelayGenerator`'s returned value is not capped with the `MaxDelay`.
 
+#### Constant examples
+
+The delays column contains an example series of five values to depict the patterns.
+
+| Settings | Delays in milliseconds |
+|--|--|
+| `Delay`: `1sec` | [1000,1000,1000,1000,1000] |
+| `Delay`: `1sec`, `UseJitter`: `true` | [986,912,842,972,1007] |
+| `Delay`: `1sec`, `UseJitter`: `true`, `MaxDelay`: `1100ms` | [1100,978,1100,1041,916] |
+
 ### Linear
 
 This algorithm increases the delays for every attempt in a linear fashion if no jitter is used.
@@ -163,6 +173,16 @@ Step 1: Calculating the base delay:
 
 Step 2 and 3 are the same as for the Constant algorithm.
 
+#### Linear examples
+
+The delays column contains an example series of five values to depict the patterns.
+
+| Settings | Delays in milliseconds |
+|--|--|
+| `Delay`: `1sec` | [1000,2000,3000,4000,5000] |
+| `Delay`: `1sec`, `UseJitter`: `true` | [1129,2147,2334,4894,4102] |
+| `Delay`: `1sec`, `UseJitter`: `true`, `MaxDelay`: `4500ms` | [907,2199,2869,4500,4500] |
+
 ### Exponential
 
 This algorithm increases the delays for every attempt in an exponential fashion if no jitter is used.
@@ -174,6 +194,18 @@ This algorithm increases the delays for every attempt in an exponential fashion 
 > Because the jitter calculation is based on the newly calculated delay, the new delay could be less than the previous value.
 
 Step 2 and 3 are the same as for the Constant algorithm.
+
+#### Exponential examples
+
+The delays column contains an example series of five values to depict the patterns.
+
+| Settings | Delays in milliseconds |
+|--|--|
+| `Delay`: `1sec` | [1000,2000,4000,8000,16000] |
+| `Delay`: `1sec`, `UseJitter`: `true` | [393,1453,4235,5369,16849] |
+| `Delay`: `1sec`, `UseJitter`: `true`, `MaxDelay`: `15000ms` | [477,793,2227,5651,15000] |
+
+---
 
 > [!TIP]
 > For more details please check out the [`RetryHelper`](https://github.com/App-vNext/Polly/blob/main/src/Polly.Core/Retry/RetryHelper.cs)

--- a/docs/strategies/retry.md
+++ b/docs/strategies/retry.md
@@ -114,11 +114,11 @@ If the `ShouldHandle` predicate returns `true` and the next attempt number is no
 
 There are many properties that may contribute to this calculation:
 
-- `BackoffType`: It specifies which calculation algorithm should run.
-- `Delay`: If only this one is specified then it will be used as is. If others are defined as well then this will be used as a *base delay*.
-- `DelayGenerator`: If specified then it will overwrite other properties based calculation. **Except** if it returns a negative `TimeSpan` where the other properties based calculation is used.
-- `MaxDelay`: If specified then it caps the delay if the calculated one is greater than this value. **Except** if `DelayGenerator` is used where no capping is applied.
-- `UseJitter`: If enabled then it adds a random value between between -25% of `Delay` and +25% of `Delay`. **Except** if `BackoffType` is set to `Exponential` where jitter is always used.
+- `BackoffType`: Specifies which calculation algorithm should run.
+- `Delay`: If only this property is specified then it will be used as-is. If others are also specified then this will be used as a _base delay_.
+- `DelayGenerator`: If specified, will override other property-based calculations, **except** if it returns a negative `TimeSpan`, in which case the other property-based calculations are used.
+- `MaxDelay`: If specified, caps the delay if the calculated delay is greater than this value, **except** if `DelayGenerator` is used, where no capping is applied.
+- `UseJitter`: If enabled, then adds a random value between between -25% of `Delay` and +25% of `Delay`, **except** if `BackoffType` is `Exponential`, where a bit more complex jitter calculation is used.
 
 > [!IMPORTANT]
 > The summarized description below is an implementation detail. It may change in the future without notice.

--- a/docs/strategies/retry.md
+++ b/docs/strategies/retry.md
@@ -187,7 +187,7 @@ The delays column contains an example series of five values to depict the patter
 
 This algorithm increases the delays for every attempt in an exponential fashion if no jitter is used.
 
-- If `UseJitter` is set to `false` and `Delay` is specified then squaring actual attempt number multiplied by the `Delay` will be used.
+- If `UseJitter` is set to `false` and `Delay` is specified then squaring actual attempt number multiplied by the `Delay` will be used (*`attempt^2 * delay`*).
 - If `UseJitter` is set to `true` and the `Delay` is specified then a `DecorrelatedJitterBackoffV2` formula (based on the [Polly.Contrib.WaitAndRetry](https://github.com/Polly-Contrib/Polly.Contrib.WaitAndRetry)) will be used.
 
 > [!NOTE]

--- a/docs/strategies/timeout.md
+++ b/docs/strategies/timeout.md
@@ -125,6 +125,9 @@ The `OnTimeout` delegate can be useful when you define a resilience pipeline whi
 | `TimeoutGenerator` | `null`        | Generates the timeout for a given execution. |
 | `OnTimeout`        | `null`        | Event that is raised when timeout occurs.    |
 
+> [!NOTE]
+> If both `InjectionRate` and `InjectionRateGenerator` are specified then `InjectionRate` will be ignored.
+
 ## Diagrams
 
 ### Happy path sequence diagram

--- a/docs/strategies/timeout.md
+++ b/docs/strategies/timeout.md
@@ -126,7 +126,7 @@ The `OnTimeout` delegate can be useful when you define a resilience pipeline whi
 | `OnTimeout`        | `null`        | Event that is raised when timeout occurs.    |
 
 > [!NOTE]
-> If both `InjectionRate` and `InjectionRateGenerator` are specified then `InjectionRate` will be ignored.
+> If both `Timeout` and `TimeoutGenerator` are specified then `Timeout` will be ignored.
 
 ## Diagrams
 


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

#1916 

- I've added some notes about property precedence but not everywhere 

<!-- Please include the existing GitHub issue number where relevant -->

## Details on the issue fix or feature implementation

- Added clarification for Timeout about `Timeout` and `TimeoutGenerator` 
- Added clarification for CircuitBreaker about `BreakDuration` and `BreakDurationGenerator` 
- Added clarification for Hedging about `Delay` and `DelayGenerator` 
- Added clarification for Chaos about `InjectionRate` and `InjectionRateGenerator` 

## Extra
- Added clarification and examples about next delay calculation for retry logic

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build
