### PR TITLE
Fix PipelineNameComparer example in documentation

### DIFF
--- a/docs/advanced/dependency-injection.md
+++ b/docs/advanced/dependency-injection.md
@@ -291,7 +291,7 @@ public sealed class PipelineNameComparer : IEqualityComparer<MyPipelineKey>
 {
     public bool Equals(MyPipelineKey x, MyPipelineKey y) => x.PipelineName == y.PipelineName;
 
-    public int GetHashCode(MyPipelineKey obj) => (obj.PipelineName, obj.InstanceName).GetHashCode();
+    public int GetHashCode(MyPipelineKey obj) => obj.PipelineName.GetHashCode();
 }
 ```
 <!-- endSnippet -->

--- a/src/Snippets/Docs/DependencyInjection.cs
+++ b/src/Snippets/Docs/DependencyInjection.cs
@@ -225,7 +225,7 @@ internal static class DependencyInjection
     {
         public bool Equals(MyPipelineKey x, MyPipelineKey y) => x.PipelineName == y.PipelineName;
 
-        public int GetHashCode(MyPipelineKey obj) => (obj.PipelineName, obj.InstanceName).GetHashCode();
+        public int GetHashCode(MyPipelineKey obj) => obj.PipelineName.GetHashCode();
     }
 
     #endregion

--- a/src/Snippets/Docs/DependencyInjection.cs
+++ b/src/Snippets/Docs/DependencyInjection.cs
@@ -225,7 +225,7 @@ internal static class DependencyInjection
     {
         public bool Equals(MyPipelineKey x, MyPipelineKey y) => x.PipelineName == y.PipelineName;
 
-        public int GetHashCode(MyPipelineKey obj) => obj.PipelineName.GetHashCode();
+        public int GetHashCode(MyPipelineKey obj) => obj.PipelineName.GetHashCode(StringComparison.Ordinal);
     }
 
     #endregion


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed

https://github.com/App-vNext/Polly/issues/1926

## Details on the issue fix or feature implementation

In the Complex Pipeline Keys documentation example:

https://www.pollydocs.org/advanced/dependency-injection.html#complex-pipeline-keys

PipelineNameComparer.GetHashCode takes the InstanceName into account, but shouldn't. This fixes that line in the documentation and snippet.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [-]  I have included unit tests for the issue/feature
- [-]  I have successfully run a local build
