### PR TITLE
Fix issue #1979: an unhandled exception in half open state must transition to closed and not prevent leaving half open state forever

### DIFF
--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerResilienceStrategy.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerResilienceStrategy.cs
@@ -39,11 +39,11 @@ internal sealed class CircuitBreakerResilienceStrategy<T> : ResilienceStrategy<T
         var args = new CircuitBreakerPredicateArguments<T>(context, outcome);
         if (await _handler(args).ConfigureAwait(context.ContinueOnCapturedContext))
         {
-            await _controller.OnActionFailureAsync(outcome, context).ConfigureAwait(context.ContinueOnCapturedContext);
+            await _controller.OnHandledOutcomeAsync(outcome, context).ConfigureAwait(context.ContinueOnCapturedContext);
         }
         else if (outcome.Exception is null)
         {
-            await _controller.OnActionSuccessAsync(outcome, context).ConfigureAwait(context.ContinueOnCapturedContext);
+            await _controller.OnUnhandledOutcomeAsync(outcome, context).ConfigureAwait(context.ContinueOnCapturedContext);
         }
 
         return outcome;

--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerResilienceStrategy.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerResilienceStrategy.cs
@@ -41,7 +41,7 @@ internal sealed class CircuitBreakerResilienceStrategy<T> : ResilienceStrategy<T
         {
             await _controller.OnHandledOutcomeAsync(outcome, context).ConfigureAwait(context.ContinueOnCapturedContext);
         }
-        else if (outcome.Exception is null)
+        else
         {
             await _controller.OnUnhandledOutcomeAsync(outcome, context).ConfigureAwait(context.ContinueOnCapturedContext);
         }

--- a/src/Polly.Core/CircuitBreaker/Controller/CircuitStateController.cs
+++ b/src/Polly.Core/CircuitBreaker/Controller/CircuitStateController.cs
@@ -163,7 +163,7 @@ internal sealed class CircuitStateController<T> : IDisposable
         return null;
     }
 
-    public ValueTask OnActionSuccessAsync(Outcome<T> outcome, ResilienceContext context)
+    public ValueTask OnUnhandledOutcomeAsync(Outcome<T> outcome, ResilienceContext context)
     {
         EnsureNotDisposed();
 
@@ -189,7 +189,7 @@ internal sealed class CircuitStateController<T> : IDisposable
         return ExecuteScheduledTaskAsync(task, context);
     }
 
-    public ValueTask OnActionFailureAsync(Outcome<T> outcome, ResilienceContext context)
+    public ValueTask OnHandledOutcomeAsync(Outcome<T> outcome, ResilienceContext context)
     {
         EnsureNotDisposed();
 

--- a/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerResilienceStrategyTests.cs
@@ -105,16 +105,14 @@ public class CircuitBreakerResilienceStrategyTests : IDisposable
     }
 
     [Fact]
-    public void Execute_UnhandledException_NoCalls()
+    public void Execute_UnhandledException_OnActionSuccess()
     {
         _options.ShouldHandle = args => new ValueTask<bool>(args.Outcome.Exception is InvalidOperationException);
         var strategy = Create();
 
         strategy.Invoking(s => s.Execute<int>(_ => throw new ArgumentException())).Should().Throw<ArgumentException>();
 
-        _behavior.DidNotReceiveWithAnyArgs().OnActionFailure(default, out Arg.Any<bool>());
-        _behavior.DidNotReceiveWithAnyArgs().OnActionSuccess(default);
-        _behavior.DidNotReceiveWithAnyArgs().OnCircuitClosed();
+        _behavior.Received(1).OnActionSuccess(CircuitState.Closed);
     }
 
     public void Dispose() => _controller.Dispose();

--- a/test/Polly.Core.Tests/Utils/StrategyHelperTests.cs
+++ b/test/Polly.Core.Tests/Utils/StrategyHelperTests.cs
@@ -39,4 +39,27 @@ public class StrategyHelperTests
 
             outcome.Exception.Should().BeOfType<InvalidOperationException>();
         });
+
+    [InlineData(true)]
+    [InlineData(false)]
+    [Theory]
+    public async Task ExecuteCallbackSafeAsync_AsyncCallback_CompletedOk(bool isAsync) =>
+        await TestUtilities.AssertWithTimeoutAsync(async () =>
+        {
+            var outcomeTask = StrategyHelper.ExecuteCallbackSafeAsync<string, string>(
+                async (_, _) =>
+                {
+                    if (isAsync)
+                    {
+                        await Task.Delay(15);
+                    }
+
+                    return Outcome.FromResult("success");
+                },
+                ResilienceContextPool.Shared.Get(),
+                "dummy");
+
+            outcomeTask.IsCompleted.Should().Be(!isAsync);
+            (await outcomeTask).Result.Should().Be("success");
+        });
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

The Pull Request fixes the issue https://github.com/App-vNext/Polly/issues/1979 following the instructions discussed there.

## Details on the issue fix or feature implementation
Before an unhandled exception lead to the circuit breaker being stuck forever in half open state. This fix allows the circuit breaker to transition from half open state to closed if a success result or an unhandled exception occurs.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
