### PR TITLE
Update to .NET 9 SDK

### DIFF
--- a/.github/workflows/actions-lint.yml
+++ b/.github/workflows/actions-lint.yml
@@ -2,13 +2,18 @@ name: actions-lint
 
 on:
   push:
-    branches: [ main, release/* ]
+    branches:
+      - main
+      - release/*
     paths-ignore:
       - '**/*.gitattributes'
       - '**/*.gitignore'
       - '**/*.md'
   pull_request:
-    branches: [ main, release/* ]
+    branches:
+      - main
+      - release/*
+      - dotnet-vnext
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,15 @@ name: build
 
 on:
   push:
-    branches: [ main, release/* ]
+    branches:
+      - main
+      - release/*
     tags: [ '*' ]
   pull_request:
-    branches: [ main, release/* ]
+    branches:
+      - main
+      - release/*
+      - dotnet-vnext
   workflow_dispatch:
 
 env:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,7 +2,10 @@ name: dependency-review
 
 on:
   pull_request:
-    branches: [ main, release/* ]
+    branches: 
+      - main
+      - release/*
+      - dotnet-vnext
 
 permissions:
   contents: read

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -45,7 +45,6 @@ jobs:
     - name: Generate documentation
       env:
         DOTNET_ROLL_FORWARD: LatestMajor
-        DOTNET_ROLL_FORWARD_TO_PRERELEASE: 1
       run: |
         dotnet tool restore
         dotnet build --configuration Release /p:SKIP_POLLY_ANALYZERS=true

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,9 +2,14 @@ name: github-pages
 
 on:
   push:
-    branches: [ main, release/* ]
+    branches:
+      - main
+      - release/*
   pull_request:
-    branches: [ main, release/* ]
+    branches:
+      - main
+      - release/*
+      - dotnet-vnext
   workflow_dispatch:
 
 permissions:
@@ -14,6 +19,7 @@ jobs:
 
   build-docs:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
 
@@ -37,6 +43,9 @@ jobs:
       uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4.0.1
 
     - name: Generate documentation
+      env:
+        DOTNET_ROLL_FORWARD: LatestMajor
+        DOTNET_ROLL_FORWARD_TO_PRERELEASE: 1
       run: |
         dotnet tool restore
         dotnet build --configuration Release /p:SKIP_POLLY_ANALYZERS=true

--- a/.github/workflows/on-push-do-docs.yml
+++ b/.github/workflows/on-push-do-docs.yml
@@ -2,7 +2,7 @@ name: on-push-do-docs
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
     paths: [ "src/Snippets/**" ]
   workflow_dispatch:
 

--- a/.github/workflows/updater-approve.yml
+++ b/.github/workflows/updater-approve.yml
@@ -2,7 +2,10 @@ name: updater-approve
 
 on:
   pull_request:
-    branches: [ main, release/* ]
+    branches: 
+      - main
+      - release/*
+      - dotnet-vnext
 
 permissions:
   contents: read

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,8 +6,8 @@
     <MicrosoftExtensionsTimeProviderVersion>8.7.0</MicrosoftExtensionsTimeProviderVersion>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net9.0'))">
-    <MicrosoftExtensionsVersion>9.0.0-rc.1.24431.7</MicrosoftExtensionsVersion>
-    <MicrosoftExtensionsTimeProviderVersion>9.0.0-preview.8.24460.1</MicrosoftExtensionsTimeProviderVersion>
+    <MicrosoftExtensionsVersion>9.0.0-rc.2.24473.5</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsTimeProviderVersion>9.0.0-preview.9.24507.7</MicrosoftExtensionsTimeProviderVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
@@ -46,7 +46,7 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="System.Threading.RateLimiting" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.0-rc.1.24431.7" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.0-rc.2.24473.5" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,10 @@
     <MicrosoftExtensionsVersion>8.0.0</MicrosoftExtensionsVersion>
     <MicrosoftExtensionsTimeProviderVersion>8.7.0</MicrosoftExtensionsTimeProviderVersion>
   </PropertyGroup>
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net9.0'))">
+    <MicrosoftExtensionsVersion>9.0.0-preview.6.24327.7</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsTimeProviderVersion>9.0.0-preview.6.24353.1</MicrosoftExtensionsTimeProviderVersion>
+  </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
@@ -42,6 +46,7 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="System.Threading.RateLimiting" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.0-preview.6.24327.7" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net9.0'))">
     <MicrosoftExtensionsVersion>9.0.0-rc.1.24431.7</MicrosoftExtensionsVersion>
-    <MicrosoftExtensionsTimeProviderVersion>9.0.0-preview.7.24412.10</MicrosoftExtensionsTimeProviderVersion>
+    <MicrosoftExtensionsTimeProviderVersion>9.0.0-preview.8.24460.1</MicrosoftExtensionsTimeProviderVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <MicrosoftExtensionsTimeProviderVersion>8.7.0</MicrosoftExtensionsTimeProviderVersion>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net9.0'))">
-    <MicrosoftExtensionsVersion>9.0.0-preview.7.24405.7</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsVersion>9.0.0-rc.1.24431.7</MicrosoftExtensionsVersion>
     <MicrosoftExtensionsTimeProviderVersion>9.0.0-preview.7.24412.10</MicrosoftExtensionsTimeProviderVersion>
   </PropertyGroup>
   <ItemGroup>
@@ -46,7 +46,7 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="System.Threading.RateLimiting" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.0-preview.7.24405.7" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.0-rc.1.24431.7" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net9.0'))">
     <MicrosoftExtensionsVersion>9.0.0-preview.7.24405.7</MicrosoftExtensionsVersion>
-    <MicrosoftExtensionsTimeProviderVersion>9.0.0-preview.6.24353.1</MicrosoftExtensionsTimeProviderVersion>
+    <MicrosoftExtensionsTimeProviderVersion>9.0.0-preview.7.24412.10</MicrosoftExtensionsTimeProviderVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,8 +6,8 @@
     <MicrosoftExtensionsTimeProviderVersion>8.7.0</MicrosoftExtensionsTimeProviderVersion>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net9.0'))">
-    <MicrosoftExtensionsVersion>9.0.0-rc.2.24473.5</MicrosoftExtensionsVersion>
-    <MicrosoftExtensionsTimeProviderVersion>9.0.0-preview.9.24507.7</MicrosoftExtensionsTimeProviderVersion>
+    <MicrosoftExtensionsVersion>9.0.0</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsTimeProviderVersion>9.0.0</MicrosoftExtensionsTimeProviderVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
@@ -46,7 +46,7 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="System.Threading.RateLimiting" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.0-rc.2.24473.5" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <MicrosoftExtensionsTimeProviderVersion>8.7.0</MicrosoftExtensionsTimeProviderVersion>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net9.0'))">
-    <MicrosoftExtensionsVersion>9.0.0-preview.6.24327.7</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsVersion>9.0.0-preview.7.24405.7</MicrosoftExtensionsVersion>
     <MicrosoftExtensionsTimeProviderVersion>9.0.0-preview.6.24353.1</MicrosoftExtensionsTimeProviderVersion>
   </PropertyGroup>
   <ItemGroup>
@@ -46,7 +46,7 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="System.Threading.RateLimiting" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.0-preview.6.24327.7" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.0-preview.7.24405.7" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/bench/Polly.Benchmarks/Polly.Benchmarks.csproj
+++ b/bench/Polly.Benchmarks/Polly.Benchmarks.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ProjectType>Benchmark</ProjectType>
     <NoWarn>$(NoWarn);CA1822;IDE0060</NoWarn>

--- a/bench/Polly.Core.Benchmarks/Polly.Core.Benchmarks.csproj
+++ b/bench/Polly.Core.Benchmarks/Polly.Core.Benchmarks.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <RootNamespace>Polly</RootNamespace>
     <ImplicitUsings>true</ImplicitUsings>
     <ProjectType>Benchmark</ProjectType>

--- a/bench/benchmarks.ps1
+++ b/bench/benchmarks.ps1
@@ -20,6 +20,6 @@ if ($Interactive -ne $true) {
 
 $project = Join-Path "Polly.Core.Benchmarks" "Polly.Core.Benchmarks.csproj"
 
-dotnet run --configuration $Configuration --framework net8.0 --project $project $additionalArgs
+dotnet run --configuration $Configuration --framework net9.0 --project $project $additionalArgs
 
 exit $LASTEXITCODE

--- a/eng/Common.targets
+++ b/eng/Common.targets
@@ -4,6 +4,7 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\Polly.snk</AssemblyOriginatorKeyFile>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
+    <NuGetAuditMode>direct</NuGetAuditMode>
     <SignAssembly>true</SignAssembly>
     <PollyStrongNamePublicKey Condition=" '$(SignAssembly)' == 'true' ">0024000004800000940000000602000000240000525341310004000001000100150819e3494f97263a3abdd18e5e0c47b04e6c0ede44a6c51d50b545d403ceeb7cbb32d18dbbbcdd1d88a87d7b73206b126be134b0609c36aa3cb31dd2e47e393293102809b8d77f192f3188618a42e651c14ebf05f8f5b76aa91b431642b23497ed82b65d63791cdaa31d4282a2d6cbabc3fe0745b6b6690c417cabf6a1349c</PollyStrongNamePublicKey>
   </PropertyGroup>

--- a/eng/Common.targets
+++ b/eng/Common.targets
@@ -20,12 +20,12 @@
   </ItemGroup>
 
   <PropertyGroup Label="MinVer">
-    <MinVerMinimumMajorMinor>8.4</MinVerMinimumMajorMinor>
+    <MinVerMinimumMajorMinor>8.5</MinVerMinimumMajorMinor>
   </PropertyGroup>
 
   <Target Name="CustomizeVersions" AfterTargets="MinVer" Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <PropertyGroup>
-      <FileVersion>$([MSBuild]::ValueOrDefault('$(MinVerMajor)', '8')).$([MSBuild]::ValueOrDefault('$(MinVerMinor)', '4')).$([MSBuild]::ValueOrDefault('$(MinVerPatch)', '0')).$(GITHUB_RUN_NUMBER)</FileVersion>
+      <FileVersion>$([MSBuild]::ValueOrDefault('$(MinVerMajor)', '8')).$([MSBuild]::ValueOrDefault('$(MinVerMinor)', '5')).$([MSBuild]::ValueOrDefault('$(MinVerPatch)', '0')).$(GITHUB_RUN_NUMBER)</FileVersion>
     </PropertyGroup>
     <PropertyGroup Condition="$(GITHUB_REF.StartsWith(`refs/pull/`))">
       <PackageVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch)-pr.$(GITHUB_REF_NAME.Replace(`/merge`, ``)).$(GITHUB_RUN_NUMBER)</PackageVersion>

--- a/eng/Library.targets
+++ b/eng/Library.targets
@@ -14,7 +14,7 @@
 
   <PropertyGroup Label="NuGet package validation">
     <EnablePackageValidation Condition="'$(EnablePackageValidation)' == ''">true</EnablePackageValidation>
-    <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == ''">8.2.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == ''">8.4.2</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="SourceLink">

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100-preview.6.24328.19",
+    "version": "9.0.100-preview.7.24407.12",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100-rc.1.24452.12",
+    "version": "9.0.100-rc.2.24474.11",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100-rc.2.24474.11",
+    "version": "9.0.100",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.403",
+    "version": "9.0.100-preview.6.24328.19",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100-preview.7.24407.12",
+    "version": "9.0.100-rc.1.24452.12",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/samples/Chaos/Chaos.csproj
+++ b/samples/Chaos/Chaos.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Chaos</RootNamespace>
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Polly.Core" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
 </Project>

--- a/samples/DependencyInjection/DependencyInjection.csproj
+++ b/samples/DependencyInjection/DependencyInjection.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Polly.Extensions" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
 </Project>

--- a/samples/Extensibility/Extensibility.csproj
+++ b/samples/Extensibility/Extensibility.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/GenericPipelines/GenericPipelines.csproj
+++ b/samples/GenericPipelines/GenericPipelines.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/Intro/Intro.csproj
+++ b/samples/Intro/Intro.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/Retries/Retries.csproj
+++ b/samples/Retries/Retries.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Polly.Core/Hedging/Controller/TaskExecution.cs
+++ b/src/Polly.Core/Hedging/Controller/TaskExecution.cs
@@ -199,6 +199,7 @@ internal sealed class TaskExecution<T>
         _stopExecutionTimestamp = 0;
     }
 
+    [DebuggerDisableUserUnhandledExceptions]
     private async Task ExecuteSecondaryActionAsync(Func<ValueTask<Outcome<T>>> action)
     {
         Outcome<T> outcome;
@@ -218,6 +219,7 @@ internal sealed class TaskExecution<T>
 
     private async Task ExecuteCreateActionException(Exception e) => await UpdateOutcomeAsync(Polly.Outcome.FromException<T>(e)).ConfigureAwait(Context.ContinueOnCapturedContext);
 
+    [DebuggerDisableUserUnhandledExceptions]
     private async Task ExecutePrimaryActionAsync<TState>(Func<ResilienceContext, TState, ValueTask<Outcome<T>>> primaryCallback, TState state)
     {
         Outcome<T> outcome;

--- a/src/Polly.Core/Outcome.TResult.cs
+++ b/src/Polly.Core/Outcome.TResult.cs
@@ -90,5 +90,4 @@ public readonly struct Outcome<TResult>
         ExceptionDispatchInfo?.Throw();
         return Result!;
     }
-
 }

--- a/src/Polly.Core/Polly.Core.csproj
+++ b/src/Polly.Core/Polly.Core.csproj
@@ -36,4 +36,8 @@
     <PackageReference Include="System.ComponentModel.Annotations" Condition="!$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'netcoreapp3.1'))" />
   </ItemGroup>
 
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net9.0'))">
+    <Compile Include="$(MSBuildThisFileDirectory)..\Shared\DebuggerDisableUserUnhandledExceptionsAttribute.cs" Link="DebuggerDisableUserUnhandledExceptionsAttribute.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/Polly.Core/ResilienceContext.cs
+++ b/src/Polly.Core/ResilienceContext.cs
@@ -74,9 +74,11 @@ public sealed class ResilienceContext
         Properties.AddOrReplaceProperties(context.Properties);
     }
 
+#pragma warning disable S3236 // Remove this argument from the method call; it hides the caller information.
     [ExcludeFromCodeCoverage]
     [Conditional("DEBUG")]
     internal void AssertInitialized() => Debug.Assert(IsInitialized, "The resilience context is not initialized.");
+#pragma warning restore S3236 // Remove this argument from the method call; it hides the caller information.
 
     internal ResilienceContext Initialize<TResult>(bool isSynchronous)
     {

--- a/src/Polly.Core/ResiliencePipeline.Async.cs
+++ b/src/Polly.Core/ResiliencePipeline.Async.cs
@@ -25,7 +25,7 @@ public partial class ResiliencePipeline
         InitializeAsyncContext(context);
 
         var outcome = await Component.ExecuteCore(
-            static async (context, state) =>
+            [DebuggerDisableUserUnhandledExceptions] static async (context, state) =>
             {
                 try
                 {
@@ -60,7 +60,7 @@ public partial class ResiliencePipeline
         InitializeAsyncContext(context);
 
         var outcome = await Component.ExecuteCore(
-            static async (context, state) =>
+            [DebuggerDisableUserUnhandledExceptions] static async (context, state) =>
             {
                 try
                 {
@@ -99,7 +99,7 @@ public partial class ResiliencePipeline
         try
         {
             var outcome = await Component.ExecuteCore(
-                static async (context, state) =>
+                [DebuggerDisableUserUnhandledExceptions] static async (context, state) =>
                 {
                     try
                     {
@@ -140,7 +140,7 @@ public partial class ResiliencePipeline
         try
         {
             var outcome = await Component.ExecuteCore(
-                static async (context, state) =>
+                [DebuggerDisableUserUnhandledExceptions] static async (context, state) =>
                 {
                     try
                     {

--- a/src/Polly.Core/ResiliencePipeline.AsyncT.cs
+++ b/src/Polly.Core/ResiliencePipeline.AsyncT.cs
@@ -53,7 +53,7 @@ public partial class ResiliencePipeline
         InitializeAsyncContext<TResult>(context);
 
         var outcome = await Component.ExecuteCore(
-            static async (context, state) =>
+            [DebuggerDisableUserUnhandledExceptions] static async (context, state) =>
             {
                 try
                 {
@@ -88,7 +88,7 @@ public partial class ResiliencePipeline
         InitializeAsyncContext<TResult>(context);
 
         var outcome = await Component.ExecuteCore(
-            static async (context, state) =>
+            [DebuggerDisableUserUnhandledExceptions] static async (context, state) =>
             {
                 try
                 {
@@ -127,7 +127,7 @@ public partial class ResiliencePipeline
         try
         {
             var outcome = await Component.ExecuteCore(
-                static async (context, state) =>
+                [DebuggerDisableUserUnhandledExceptions] static async (context, state) =>
                 {
                     try
                     {
@@ -168,7 +168,7 @@ public partial class ResiliencePipeline
         try
         {
             var outcome = await Component.ExecuteCore(
-                static async (context, state) =>
+                [DebuggerDisableUserUnhandledExceptions] static async (context, state) =>
                 {
                     try
                     {

--- a/src/Polly.Core/ResiliencePipeline.Sync.cs
+++ b/src/Polly.Core/ResiliencePipeline.Sync.cs
@@ -24,7 +24,7 @@ public partial class ResiliencePipeline
         InitializeSyncContext(context);
 
         Component.ExecuteCoreSync(
-            static (context, state) =>
+            [DebuggerDisableUserUnhandledExceptions] static (context, state) =>
             {
                 try
                 {
@@ -56,7 +56,7 @@ public partial class ResiliencePipeline
         InitializeSyncContext(context);
 
         Component.ExecuteCoreSync(
-            static (context, state) =>
+            [DebuggerDisableUserUnhandledExceptions] static (context, state) =>
             {
                 try
                 {
@@ -92,7 +92,7 @@ public partial class ResiliencePipeline
         try
         {
             Component.ExecuteCoreSync(
-                static (context, state) =>
+                [DebuggerDisableUserUnhandledExceptions] static (context, state) =>
                 {
                     try
                     {
@@ -130,7 +130,7 @@ public partial class ResiliencePipeline
         try
         {
             Component.ExecuteCoreSync(
-                static (context, state) =>
+                [DebuggerDisableUserUnhandledExceptions] static (context, state) =>
                 {
                     try
                     {
@@ -169,7 +169,7 @@ public partial class ResiliencePipeline
         try
         {
             Component.ExecuteCoreSync(
-                static (_, state) =>
+                [DebuggerDisableUserUnhandledExceptions] static (_, state) =>
                 {
                     try
                     {
@@ -204,7 +204,7 @@ public partial class ResiliencePipeline
         try
         {
             Component.ExecuteCoreSync(
-                static (_, state) =>
+                [DebuggerDisableUserUnhandledExceptions] static (_, state) =>
                 {
                     try
                     {

--- a/src/Polly.Core/ResiliencePipeline.SyncT.cs
+++ b/src/Polly.Core/ResiliencePipeline.SyncT.cs
@@ -26,7 +26,7 @@ public partial class ResiliencePipeline
         InitializeSyncContext<TResult>(context);
 
         return Component.ExecuteCoreSync(
-           static (context, state) =>
+           [DebuggerDisableUserUnhandledExceptions] static (context, state) =>
            {
                try
                {
@@ -60,7 +60,7 @@ public partial class ResiliencePipeline
         InitializeSyncContext<TResult>(context);
 
         return Component.ExecuteCoreSync(
-            static (context, state) =>
+            [DebuggerDisableUserUnhandledExceptions] static (context, state) =>
             {
                 try
                 {
@@ -95,7 +95,7 @@ public partial class ResiliencePipeline
         try
         {
             return Component.ExecuteCoreSync(
-                static (context, state) =>
+                [DebuggerDisableUserUnhandledExceptions] static (context, state) =>
                 {
                     try
                     {
@@ -131,7 +131,7 @@ public partial class ResiliencePipeline
         try
         {
             return Component.ExecuteCoreSync(
-                static (_, state) =>
+                [DebuggerDisableUserUnhandledExceptions] static (_, state) =>
                 {
                     try
                     {
@@ -169,7 +169,7 @@ public partial class ResiliencePipeline
         try
         {
             return Component.ExecuteCoreSync(
-                static (_, state) =>
+                [DebuggerDisableUserUnhandledExceptions] static (_, state) =>
                 {
                     try
                     {
@@ -211,7 +211,7 @@ public partial class ResiliencePipeline
         try
         {
             return Component.ExecuteCoreSync(
-                static (context, state) =>
+                [DebuggerDisableUserUnhandledExceptions] static (context, state) =>
                 {
                     try
                     {

--- a/src/Polly.Core/Retry/RetryHelper.cs
+++ b/src/Polly.Core/Retry/RetryHelper.cs
@@ -124,7 +124,9 @@ internal static class RetryHelper
 
         long ticks = (long)Math.Min(formulaIntrinsicValue * RpScalingFactor * targetTicksFirstDelay, MaxTimeSpanTicks);
 
+#pragma warning disable S3236 // Remove this argument from the method call; it hides the caller information.
         Debug.Assert(ticks >= 0, "ticks cannot be negative");
+#pragma warning restore S3236 // Remove this argument from the method call; it hides the caller information.
 
         return TimeSpan.FromTicks(ticks);
     }

--- a/src/Polly.Core/Retry/RetryResilienceStrategy.cs
+++ b/src/Polly.Core/Retry/RetryResilienceStrategy.cs
@@ -83,7 +83,9 @@ internal sealed class RetryResilienceStrategy<T> : ResilienceStrategy<T>
                 }
             }
 
+#pragma warning disable S3236 // Remove this argument from the method call; it hides the caller information.
             Debug.Assert(delay >= TimeSpan.Zero, "The delay cannot be negative.");
+#pragma warning restore S3236 // Remove this argument from the method call; it hides the caller information.
 
             var onRetryArgs = new OnRetryArguments<T>(context, outcome, attempt, delay, executionTime);
             _telemetry.Report<OnRetryArguments<T>, T>(new(ResilienceEventSeverity.Warning, RetryConstants.OnRetryEvent), onRetryArgs);

--- a/src/Polly.Core/Utils/StrategyHelper.cs
+++ b/src/Polly.Core/Utils/StrategyHelper.cs
@@ -4,6 +4,7 @@
 
 internal static class StrategyHelper
 {
+    [DebuggerDisableUserUnhandledExceptions]
     public static ValueTask<Outcome<TResult>> ExecuteCallbackSafeAsync<TResult, TState>(
         Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,
         ResilienceContext context,
@@ -29,6 +30,7 @@ internal static class StrategyHelper
             return new ValueTask<Outcome<TResult>>(Outcome.FromException<TResult>(e));
         }
 
+        [DebuggerDisableUserUnhandledExceptions]
         static async ValueTask<Outcome<T>> AwaitTask<T>(ValueTask<Outcome<T>> task, bool continueOnCapturedContext)
         {
             try

--- a/src/Polly.Core/Utils/TaskHelper.cs
+++ b/src/Polly.Core/Utils/TaskHelper.cs
@@ -1,5 +1,6 @@
 ﻿namespace Polly.Utils;
 
+#pragma warning disable S3236 // Remove this argument from the method call; it hides the caller information.
 #pragma warning disable S5034 // "ValueTask" should be consumed correctly
 
 internal static class TaskHelper

--- a/src/Polly/Caching/AsyncCacheEngine.cs
+++ b/src/Polly/Caching/AsyncCacheEngine.cs
@@ -3,6 +3,7 @@ namespace Polly.Caching;
 
 internal static class AsyncCacheEngine
 {
+    [DebuggerDisableUserUnhandledExceptions]
     internal static async Task<TResult> ImplementationAsync<TResult>(
         IAsyncCacheProvider<TResult> cacheProvider,
         ITtlStrategy<TResult> ttlStrategy,

--- a/src/Polly/Caching/CacheEngine.cs
+++ b/src/Polly/Caching/CacheEngine.cs
@@ -3,6 +3,7 @@ namespace Polly.Caching;
 
 internal static class CacheEngine
 {
+    [DebuggerDisableUserUnhandledExceptions]
     internal static TResult Implementation<TResult>(
         ISyncCacheProvider<TResult> cacheProvider,
         ITtlStrategy<TResult> ttlStrategy,

--- a/src/Polly/CircuitBreaker/AsyncCircuitBreakerEngine.cs
+++ b/src/Polly/CircuitBreaker/AsyncCircuitBreakerEngine.cs
@@ -2,6 +2,7 @@
 
 internal static class AsyncCircuitBreakerEngine
 {
+    [DebuggerDisableUserUnhandledExceptions]
     internal static async Task<TResult> ImplementationAsync<TResult>(
         Func<Context, CancellationToken, Task<TResult>> action,
         Context context,

--- a/src/Polly/CircuitBreaker/CircuitBreakerEngine.cs
+++ b/src/Polly/CircuitBreaker/CircuitBreakerEngine.cs
@@ -4,6 +4,7 @@ namespace Polly.CircuitBreaker;
 
 internal static class CircuitBreakerEngine
 {
+    [DebuggerDisableUserUnhandledExceptions]
     internal static TResult Implementation<TResult>(
         Func<Context, CancellationToken, TResult> action,
         Context context,

--- a/src/Polly/Fallback/AsyncFallbackEngine.cs
+++ b/src/Polly/Fallback/AsyncFallbackEngine.cs
@@ -3,6 +3,7 @@ namespace Polly.Fallback;
 
 internal static class AsyncFallbackEngine
 {
+    [DebuggerDisableUserUnhandledExceptions]
     internal static async Task<TResult> ImplementationAsync<TResult>(
         Func<Context, CancellationToken, Task<TResult>> action,
         Context context,

--- a/src/Polly/Fallback/FallbackEngine.cs
+++ b/src/Polly/Fallback/FallbackEngine.cs
@@ -3,6 +3,7 @@ namespace Polly.Fallback;
 
 internal static class FallbackEngine
 {
+    [DebuggerDisableUserUnhandledExceptions]
     internal static TResult Implementation<TResult>(
         Func<Context, CancellationToken, TResult> action,
         Context context,

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -26,4 +26,8 @@
     <ProjectReference Include="..\Polly.Core\Polly.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net9.0'))">
+    <Compile Include="$(MSBuildThisFileDirectory)..\Shared\DebuggerDisableUserUnhandledExceptionsAttribute.cs" Link="DebuggerDisableUserUnhandledExceptionsAttribute.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/Polly/Retry/AsyncRetryEngine.cs
+++ b/src/Polly/Retry/AsyncRetryEngine.cs
@@ -3,6 +3,7 @@ namespace Polly.Retry;
 
 internal static class AsyncRetryEngine
 {
+    [DebuggerDisableUserUnhandledExceptions]
     internal static async Task<TResult> ImplementationAsync<TResult>(
         Func<Context, CancellationToken, Task<TResult>> action,
         Context context,

--- a/src/Polly/Retry/RetryEngine.cs
+++ b/src/Polly/Retry/RetryEngine.cs
@@ -3,6 +3,7 @@ namespace Polly.Retry;
 
 internal static class RetryEngine
 {
+    [DebuggerDisableUserUnhandledExceptions]
     internal static TResult Implementation<TResult>(
         Func<Context, CancellationToken, TResult> action,
         Context context,

--- a/src/Polly/Timeout/AsyncTimeoutEngine.cs
+++ b/src/Polly/Timeout/AsyncTimeoutEngine.cs
@@ -2,6 +2,7 @@
 
 internal static class AsyncTimeoutEngine
 {
+    [DebuggerDisableUserUnhandledExceptions]
     internal static async Task<TResult> ImplementationAsync<TResult>(
         Func<Context, CancellationToken, Task<TResult>> action,
         Context context,
@@ -57,7 +58,11 @@ internal static class AsyncTimeoutEngine
             // See https://github.com/App-vNext/Polly/issues/722.
             if (!combinedTokenSource.IsCancellationRequested && timeoutCancellationTokenSource.IsCancellationRequested)
             {
+#if NET8_0_OR_GREATER
+                await combinedTokenSource.CancelAsync().ConfigureAwait(false);
+#else
                 combinedTokenSource.Cancel();
+#endif
             }
         }
     }

--- a/src/Polly/Timeout/TimeoutEngine.cs
+++ b/src/Polly/Timeout/TimeoutEngine.cs
@@ -4,6 +4,7 @@ namespace Polly.Timeout;
 
 internal static class TimeoutEngine
 {
+    [DebuggerDisableUserUnhandledExceptions]
     internal static TResult Implementation<TResult>(
         Func<Context, CancellationToken, TResult> action,
         Context context,

--- a/src/Shared/DebuggerDisableUserUnhandledExceptionsAttribute.cs
+++ b/src/Shared/DebuggerDisableUserUnhandledExceptionsAttribute.cs
@@ -1,0 +1,21 @@
+﻿#pragma warning disable
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Adapted from https://github.com/dotnet/runtime/blob/bffe34e0c7ff8a05e79d884ed8447426aae17bfb/src/libraries/System.Private.CoreLib/src/System/Diagnostics/DebuggerDisableUserUnhandledExceptionsAttribute.cs
+// See the following links for more information and context:
+// https://github.com/dotnet/runtime/issues/103105,
+// https://github.com/dotnet/runtime/pull/104813
+// https://github.com/dotnet/aspnetcore/issues/57085
+
+namespace System.Diagnostics;
+
+/// <summary>
+/// If a .NET Debugger is attached which supports the Debugger.BreakForUserUnhandledException(Exception) API,
+/// this attribute will prevent the debugger from breaking on user-unhandled exceptions when the
+/// exception is caught by a method with this attribute, unless BreakForUserUnhandledException is called.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+internal sealed class DebuggerDisableUserUnhandledExceptionsAttribute : Attribute
+{
+}

--- a/src/Snippets/Snippets.csproj
+++ b/src/Snippets/Snippets.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <ProjectType>Library</ProjectType>

--- a/test/Polly.AotTest/Polly.AotTest.csproj
+++ b/test/Polly.AotTest/Polly.AotTest.csproj
@@ -5,7 +5,7 @@
     <PublishAot>true</PublishAot>
     <SKIP_POLLY_ANALYZERS>true</SKIP_POLLY_ANALYZERS>
     <SelfContained>true</SelfContained>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Polly.Core\Polly.Core.csproj" />

--- a/test/Polly.Core.Tests/CircuitBreaker/Controller/ScheduledTaskExecutorTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/Controller/ScheduledTaskExecutorTests.cs
@@ -106,7 +106,7 @@ public class ScheduledTaskExecutorTests
             .Throw<ObjectDisposedException>();
     }
 
-    [Fact(Skip = "TODO - Failing under .NET Framework for some reason.")]
+    [Fact]
     public void Dispose_WhenScheduledTaskExecuting()
     {
         using var disposed = new ManualResetEvent(false);

--- a/test/Polly.Core.Tests/CircuitBreaker/Controller/ScheduledTaskExecutorTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/Controller/ScheduledTaskExecutorTests.cs
@@ -106,7 +106,7 @@ public class ScheduledTaskExecutorTests
             .Throw<ObjectDisposedException>();
     }
 
-    [Fact]
+    [Fact(Skip = "TODO - Failing under .NET Framework for some reason.")]
     public void Dispose_WhenScheduledTaskExecuting()
     {
         using var disposed = new ManualResetEvent(false);

--- a/test/Polly.Core.Tests/Issues/IssuesTests.InfiniteRetry_2163.cs
+++ b/test/Polly.Core.Tests/Issues/IssuesTests.InfiniteRetry_2163.cs
@@ -5,7 +5,7 @@ namespace Polly.Core.Tests.Issues;
 
 public partial class IssuesTests
 {
-    [Fact(Timeout = 15_000)]
+    [Fact(Timeout = 15_000, Skip = "TODO - Failing under .NET 9 for some reason.")]
     public async Task InfiniteRetry_Delay_Does_Not_Overflow_2163()
     {
         // Arrange

--- a/test/Polly.Core.Tests/Issues/IssuesTests.InfiniteRetry_2163.cs
+++ b/test/Polly.Core.Tests/Issues/IssuesTests.InfiniteRetry_2163.cs
@@ -5,7 +5,7 @@ namespace Polly.Core.Tests.Issues;
 
 public partial class IssuesTests
 {
-    [Fact(Timeout = 15_000, Skip = "TODO - Failing under .NET 9 for some reason.")]
+    [Fact(Timeout = 15_000)]
     public async Task InfiniteRetry_Delay_Does_Not_Overflow_2163()
     {
         // Arrange

--- a/test/Polly.Core.Tests/Polly.Core.Tests.csproj
+++ b/test/Polly.Core.Tests/Polly.Core.Tests.csproj
@@ -6,8 +6,6 @@
     <ProjectType>Test</ProjectType>
     <Nullable>enable</Nullable>
     <Threshold>100</Threshold>
-    <!-- TODO Set back to 100 when failing tests re-enabled -->
-    <Threshold>99</Threshold>
     <NoWarn>$(NoWarn);S6966;SA1600;SA1204</NoWarn>
     <Include>[Polly.Core]*</Include>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>

--- a/test/Polly.Core.Tests/Polly.Core.Tests.csproj
+++ b/test/Polly.Core.Tests/Polly.Core.Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net481</TargetFrameworks>
+    <TestTfmsInParallel Condition="$([MSBuild]::IsOSPlatform('Windows'))">false</TestTfmsInParallel>
     <ProjectType>Test</ProjectType>
     <Nullable>enable</Nullable>
     <Threshold>100</Threshold>

--- a/test/Polly.Core.Tests/Polly.Core.Tests.csproj
+++ b/test/Polly.Core.Tests/Polly.Core.Tests.csproj
@@ -1,19 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net481</TargetFrameworks>
     <ProjectType>Test</ProjectType>
     <Nullable>enable</Nullable>
     <Threshold>100</Threshold>
+    <!-- TODO Set back to 100 when failing tests re-enabled -->
+    <Threshold>99</Threshold>
     <NoWarn>$(NoWarn);S6966;SA1600;SA1204</NoWarn>
     <Include>[Polly.Core]*</Include>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.TimeProvider" VersionOverride="8.0.1" />
+    <PackageReference Include="Microsoft.Bcl.TimeProvider" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" />
+  </ItemGroup>
+
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net9.0'))">
+    <PackageReference Update="Microsoft.Bcl.TimeProvider" VersionOverride="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Polly.Core.Tests/Retry/RetryHelperTests.cs
+++ b/test/Polly.Core.Tests/Retry/RetryHelperTests.cs
@@ -9,10 +9,8 @@ public class RetryHelperTests
     private Func<double> _randomizer = new RandomUtil(0).NextDouble;
 
     public static TheoryData<int> Attempts()
-    {
 #pragma warning disable IDE0028
-#pragma warning disable IDE0022 // Use expression body for method
-        return new()
+        => new()
         {
             1,
             2,
@@ -24,9 +22,7 @@ public class RetryHelperTests
             1_024,
             1_025,
         };
-#pragma warning restore IDE0022 // Use expression body for method
 #pragma warning restore IDE0028
-    }
 
     [Fact]
     public void IsValidDelay_Ok()

--- a/test/Polly.Extensions.Tests/Polly.Extensions.Tests.csproj
+++ b/test/Polly.Extensions.Tests/Polly.Extensions.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net481</TargetFrameworks>
     <ProjectType>Test</ProjectType>
     <Nullable>enable</Nullable>

--- a/test/Polly.RateLimiting.Tests/Polly.RateLimiting.Tests.csproj
+++ b/test/Polly.RateLimiting.Tests/Polly.RateLimiting.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net481</TargetFrameworks>
     <ProjectType>Test</ProjectType>
     <Nullable>enable</Nullable>

--- a/test/Polly.Specs/Polly.Specs.csproj
+++ b/test/Polly.Specs/Polly.Specs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net481</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ProjectType>Test</ProjectType>

--- a/test/Polly.TestUtils/Polly.TestUtils.csproj
+++ b/test/Polly.TestUtils/Polly.TestUtils.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net481</TargetFrameworks>
     <ProjectType>Library</ProjectType>
     <Nullable>enable</Nullable>

--- a/test/Polly.Testing.Tests/Polly.Testing.Tests.csproj
+++ b/test/Polly.Testing.Tests/Polly.Testing.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net481</TargetFrameworks>
     <ProjectType>Test</ProjectType>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
A long-lived PR for testing .NET 9 until the stable release in November 2024. `net9.0` is explicitly _not_ being added as a new TFM for the packages we ship to NuGet.org.

Changes include:

- Update to the .NET 9 SDK.
- Add usage of `[DebuggerDisableUserUnhandledExceptions]` to avoid newer versions of the Visual Studio debugger for breaking for exceptions on async code paths we are intentionally handling.
- Target `net8.0` and `net9.0` in tests, samples and benchmarks.
- Remove `net6.0` target from tests, samples and benchmarks as it will both be out-of-support by November 2024.
- Fix/suppress new IDE0022/S3236 warnings.
- Only enable NuGet Audit for direct dependencies, not transient ones.
