### PR TITLE
Update samples to .NET 8

### DIFF
--- a/docs/strategies/retry.md
+++ b/docs/strategies/retry.md
@@ -710,17 +710,15 @@ var ctsKey = new ResiliencePropertyKey<CancellationTokenSource>("cts");
 var retry = new ResiliencePipelineBuilder()
     .AddRetry(new()
     {
-        OnRetry = args =>
+        OnRetry = async args =>
         {
             if (args.Outcome.Exception is TimeoutException)
             {
                 if (args.Context.Properties.TryGetValue(ctsKey, out var cts))
                 {
-                    cts.Cancel();
+                    await cts.CancelAsync();
                 }
             }
-
-            return ValueTask.CompletedTask;
         }
     })
     .Build();

--- a/samples/DependencyInjection/DependencyInjection.csproj
+++ b/samples/DependencyInjection/DependencyInjection.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/GenericPipelines/GenericPipelines.csproj
+++ b/samples/GenericPipelines/GenericPipelines.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -10,5 +10,5 @@
   <ItemGroup>
     <PackageReference Include="Polly.Core" />
   </ItemGroup>
-  
+
 </Project>

--- a/samples/Intro/Intro.csproj
+++ b/samples/Intro/Intro.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Polly.Core"/>
+    <PackageReference Include="Polly.Core" />
   </ItemGroup>
 
 </Project>

--- a/samples/Retries/Retries.csproj
+++ b/samples/Retries/Retries.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Snippets/Docs/Retry.cs
+++ b/src/Snippets/Docs/Retry.cs
@@ -402,17 +402,15 @@ internal static class Retry
         var retry = new ResiliencePipelineBuilder()
             .AddRetry(new()
             {
-                OnRetry = args =>
+                OnRetry = async args =>
                 {
                     if (args.Outcome.Exception is TimeoutException)
                     {
                         if (args.Context.Properties.TryGetValue(ctsKey, out var cts))
                         {
-                            cts.Cancel();
+                            await cts.CancelAsync();
                         }
                     }
-
-                    return ValueTask.CompletedTask;
                 }
             })
             .Build();

--- a/src/Snippets/Snippets.csproj
+++ b/src/Snippets/Snippets.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <ProjectType>Library</ProjectType>

--- a/test/Polly.Specs/Retry/WaitAndRetryForeverAsyncSpecs.cs
+++ b/test/Polly.Specs/Retry/WaitAndRetryForeverAsyncSpecs.cs
@@ -86,7 +86,7 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
     {
         Action policy = () => Policy
                                .Handle<Exception>()
-                               .WaitAndRetryForeverAsync(default(Func<int, Context, TimeSpan>), default(Action<Exception, int, TimeSpan, Context>));
+                               .WaitAndRetryForeverAsync(default, default(Action<Exception, int, TimeSpan, Context>));
 
         policy.Should().Throw<ArgumentNullException>().And
               .ParamName.Should().Be("sleepDurationProvider");


### PR DESCRIPTION
- Update various sample projects from `net7.0` to `net8.0`.
- Fix CA1849 warning from updating snippets to .NET 8.
- Fix IDE0034 warning identified by the .NET 9 SDK in #2003.
