### PR TITLE
[Docs] Fix calculation of exponential delay in flow chart

### DIFF
--- a/docs/strategies/retry.md
+++ b/docs/strategies/retry.md
@@ -234,7 +234,7 @@ stateDiagram-v2
     state if_state_step2 <<choice>>
     state if_state_step3 <<choice>>
 
-    exponential: Delay * AttemptNumber^2
+    exponential: Delay * 2^AttemptNumber
     exponentialWJitter: Decorrelated Jitter Backoff V2
     compare: MaxDelay < BaseDelay
     setBase: Set BaseDelay


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
Documentation fix:

The exponential flow chart showed the delay calculation to be Delay * AttemptNumber^2, but it should be Delay * 2^AttemptNumber. e.g. when AttemptNumber is 3, the delay is multiplied by 8, not 9.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build
