### PR TITLE
Xml comments cleanup and improvement

### DIFF
--- a/src/Polly.Core/ResiliencePipelineBuilderExtensions.cs
+++ b/src/Polly.Core/ResiliencePipelineBuilderExtensions.cs
@@ -16,7 +16,7 @@ public static class ResiliencePipelineBuilderExtensions
     /// <param name="builder">The builder instance.</param>
     /// <param name="pipeline">The pipeline instance.</param>
     /// <returns>The same builder instance.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="pipeline"/> is null.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="pipeline"/> is <see langword="null"/>.</exception>
     /// <exception cref="InvalidOperationException">Thrown when this builder was already used to create a pipeline. The builder cannot be modified after it has been used.</exception>
     [UnconditionalSuppressMessage(
         "Trimming",
@@ -39,7 +39,7 @@ public static class ResiliencePipelineBuilderExtensions
     /// <param name="builder">The builder instance.</param>
     /// <param name="pipeline">The pipeline instance.</param>
     /// <returns>The same builder instance.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="pipeline"/> is null.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="pipeline"/> is <see langword="null"/>.</exception>
     /// <exception cref="InvalidOperationException">Thrown when this builder was already used to create a strategy. The builder cannot be modified after it has been used.</exception>
     [UnconditionalSuppressMessage(
         "Trimming",

--- a/src/Polly/AsyncPolicy.ExecuteOverloads.cs
+++ b/src/Polly/AsyncPolicy.ExecuteOverloads.cs
@@ -409,7 +409,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// </summary>
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="action">The action to perform.</param>
-    /// <param name="context">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+    /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <returns>The captured result.</returns>
     [DebuggerStepThrough]

--- a/src/Polly/AsyncPolicy.ExecuteOverloads.cs
+++ b/src/Polly/AsyncPolicy.ExecuteOverloads.cs
@@ -77,7 +77,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public Task ExecuteAsync(Func<Context, CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext) =>
         ExecuteAsync(action, new Context(contextData), cancellationToken, continueOnCapturedContext);
@@ -115,7 +115,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// </summary>
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="action">The action to perform.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     [DebuggerStepThrough]
     public Task<TResult> ExecuteAsync<TResult>(Func<Task<TResult>> action) =>
         ExecuteAsync((_, _) => action(), [], DefaultCancellationToken, DefaultContinueOnCapturedContext);
@@ -125,7 +125,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     [DebuggerStepThrough]
     public Task<TResult> ExecuteAsync<TResult>(Func<Context, Task<TResult>> action, IDictionary<string, object> contextData) =>
         ExecuteAsync((ctx, _) => action(ctx), new Context(contextData), DefaultCancellationToken, DefaultContinueOnCapturedContext);
@@ -136,7 +136,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     [DebuggerStepThrough]
     public Task<TResult> ExecuteAsync<TResult>(Func<Context, Task<TResult>> action, Context context) =>
         ExecuteAsync((ctx, _) => action(ctx), context, DefaultCancellationToken, DefaultContinueOnCapturedContext);
@@ -147,7 +147,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="action">The action to perform.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     [DebuggerStepThrough]
     public Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken) =>
         ExecuteAsync((_, ct) => action(ct), [], cancellationToken, DefaultContinueOnCapturedContext);
@@ -158,7 +158,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     [DebuggerStepThrough]
     public Task<TResult> ExecuteAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken) =>
         ExecuteAsync(action, new Context(contextData), cancellationToken, DefaultContinueOnCapturedContext);
@@ -170,7 +170,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     [DebuggerStepThrough]
     public Task<TResult> ExecuteAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken) =>
         ExecuteAsync(action, context, cancellationToken, DefaultContinueOnCapturedContext);
@@ -182,7 +182,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
     [DebuggerStepThrough]
     public Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken, bool continueOnCapturedContext) =>
@@ -195,8 +195,8 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-    /// <returns>The value returned by the action</returns>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <returns>The value returned by the action.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public Task<TResult> ExecuteAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext) =>
         ExecuteAsync(action, new Context(contextData), cancellationToken, continueOnCapturedContext);
@@ -209,7 +209,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
     [DebuggerStepThrough]
     public async Task<TResult> ExecuteAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
@@ -239,7 +239,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     ///     Executes the specified asynchronous action within the policy and returns the captured result.
     /// </summary>
     /// <param name="action">The action to perform.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Task> action) =>
         ExecuteAndCaptureAsync((_, _) => action(), [], DefaultCancellationToken, DefaultContinueOnCapturedContext);
@@ -249,8 +249,8 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
-    /// <returns>The captured result</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, Task> action, IDictionary<string, object> contextData) =>
         ExecuteAndCaptureAsync((ctx, _) => action(ctx), new Context(contextData), DefaultCancellationToken, DefaultContinueOnCapturedContext);
@@ -260,7 +260,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, Task> action, Context context) =>
         ExecuteAndCaptureAsync((ctx, _) => action(ctx), context, DefaultCancellationToken, DefaultContinueOnCapturedContext);
@@ -280,8 +280,8 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
-    /// <returns>The captured result</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken) =>
         ExecuteAndCaptureAsync(action, new Context(contextData), cancellationToken, DefaultContinueOnCapturedContext);
@@ -314,8 +314,8 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
-    /// <returns>The captured result</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext) =>
         ExecuteAndCaptureAsync(action, new Context(contextData), cancellationToken, continueOnCapturedContext);
@@ -352,7 +352,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// </summary>
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="action">The action to perform.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Task<TResult>> action) =>
         ExecuteAndCaptureAsync((_, _) => action(), [], DefaultCancellationToken, DefaultContinueOnCapturedContext);
@@ -363,8 +363,8 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
-    /// <returns>The captured result</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Context, Task<TResult>> action, IDictionary<string, object> contextData) =>
         ExecuteAndCaptureAsync((ctx, _) => action(ctx), new Context(contextData), DefaultCancellationToken, DefaultContinueOnCapturedContext);
@@ -375,7 +375,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Context, Task<TResult>> action, Context context) =>
         ExecuteAndCaptureAsync((ctx, _) => action(ctx), context, DefaultCancellationToken, DefaultContinueOnCapturedContext);
@@ -386,7 +386,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="action">The action to perform.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken) =>
         ExecuteAndCaptureAsync((_, ct) => action(ct), [], cancellationToken, DefaultContinueOnCapturedContext);
@@ -398,8 +398,8 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
-    /// <returns>The captured result</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken) =>
         ExecuteAndCaptureAsync(action, new Context(contextData), cancellationToken, DefaultContinueOnCapturedContext);
@@ -411,7 +411,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="context">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken) =>
         ExecuteAndCaptureAsync(action, context, cancellationToken, DefaultContinueOnCapturedContext);
@@ -423,7 +423,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
     [DebuggerStepThrough]
     public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken, bool continueOnCapturedContext) =>
@@ -437,8 +437,8 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-    /// <returns>The captured result</returns>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <returns>The captured result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext) =>
         ExecuteAndCaptureAsync(action, new Context(contextData), cancellationToken, continueOnCapturedContext);
@@ -451,7 +451,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
     [DebuggerStepThrough]
     public async Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)

--- a/src/Polly/AsyncPolicy.ExecuteOverloads.cs
+++ b/src/Polly/AsyncPolicy.ExecuteOverloads.cs
@@ -249,8 +249,8 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>The captured result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, Task> action, IDictionary<string, object> contextData) =>
         ExecuteAndCaptureAsync((ctx, _) => action(ctx), new Context(contextData), DefaultCancellationToken, DefaultContinueOnCapturedContext);
@@ -280,8 +280,8 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>The captured result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken) =>
         ExecuteAndCaptureAsync(action, new Context(contextData), cancellationToken, DefaultContinueOnCapturedContext);
@@ -314,8 +314,8 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>The captured result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext) =>
         ExecuteAndCaptureAsync(action, new Context(contextData), cancellationToken, continueOnCapturedContext);
@@ -363,8 +363,8 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>The captured result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Context, Task<TResult>> action, IDictionary<string, object> contextData) =>
         ExecuteAndCaptureAsync((ctx, _) => action(ctx), new Context(contextData), DefaultCancellationToken, DefaultContinueOnCapturedContext);
@@ -398,8 +398,8 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>The captured result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken) =>
         ExecuteAndCaptureAsync(action, new Context(contextData), cancellationToken, DefaultContinueOnCapturedContext);

--- a/src/Polly/AsyncPolicy.TResult.ExecuteOverloads.cs
+++ b/src/Polly/AsyncPolicy.TResult.ExecuteOverloads.cs
@@ -8,7 +8,7 @@ public abstract partial class AsyncPolicy<TResult> : IAsyncPolicy<TResult>
     ///     Executes the specified asynchronous action within the policy and returns the result.
     /// </summary>
     /// <param name="action">The action to perform.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     [DebuggerStepThrough]
     public Task<TResult> ExecuteAsync(Func<Task<TResult>> action) =>
         ExecuteAsync((_, _) => action(), [], CancellationToken.None, DefaultContinueOnCapturedContext);
@@ -18,7 +18,7 @@ public abstract partial class AsyncPolicy<TResult> : IAsyncPolicy<TResult>
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     [DebuggerStepThrough]
     public Task<TResult> ExecuteAsync(Func<Context, Task<TResult>> action, IDictionary<string, object> contextData) =>
         ExecuteAsync((ctx, _) => action(ctx), new Context(contextData), CancellationToken.None, DefaultContinueOnCapturedContext);
@@ -28,7 +28,7 @@ public abstract partial class AsyncPolicy<TResult> : IAsyncPolicy<TResult>
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     [DebuggerStepThrough]
     public Task<TResult> ExecuteAsync(Func<Context, Task<TResult>> action, Context context) =>
         ExecuteAsync((ctx, _) => action(ctx), context, CancellationToken.None, DefaultContinueOnCapturedContext);
@@ -38,7 +38,7 @@ public abstract partial class AsyncPolicy<TResult> : IAsyncPolicy<TResult>
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     [DebuggerStepThrough]
     public Task<TResult> ExecuteAsync(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken) =>
         ExecuteAsync((_, ct) => action(ct), [], cancellationToken, DefaultContinueOnCapturedContext);
@@ -49,7 +49,7 @@ public abstract partial class AsyncPolicy<TResult> : IAsyncPolicy<TResult>
     /// <param name="action">The action to perform.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
     [DebuggerStepThrough]
     public Task<TResult> ExecuteAsync(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken, bool continueOnCapturedContext) =>
@@ -61,7 +61,7 @@ public abstract partial class AsyncPolicy<TResult> : IAsyncPolicy<TResult>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     [DebuggerStepThrough]
     public Task<TResult> ExecuteAsync(Func<Context, CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken) =>
         ExecuteAsync(action, new Context(contextData), cancellationToken, DefaultContinueOnCapturedContext);
@@ -72,7 +72,7 @@ public abstract partial class AsyncPolicy<TResult> : IAsyncPolicy<TResult>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     [DebuggerStepThrough]
     public Task<TResult> ExecuteAsync(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken) =>
         ExecuteAsync(action, context, cancellationToken, DefaultContinueOnCapturedContext);
@@ -84,8 +84,8 @@ public abstract partial class AsyncPolicy<TResult> : IAsyncPolicy<TResult>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-    /// <returns>The value returned by the action</returns>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <returns>The value returned by the action.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public Task<TResult> ExecuteAsync(Func<Context, CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext) =>
         ExecuteAsync(action, new Context(contextData), cancellationToken, continueOnCapturedContext);
@@ -97,7 +97,7 @@ public abstract partial class AsyncPolicy<TResult> : IAsyncPolicy<TResult>
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
     [DebuggerStepThrough]
     public async Task<TResult> ExecuteAsync(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
@@ -125,7 +125,7 @@ public abstract partial class AsyncPolicy<TResult> : IAsyncPolicy<TResult>
     /// Executes the specified asynchronous action within the policy and returns the result.
     /// </summary>
     /// <param name="action">The action to perform.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Task<TResult>> action) =>
         ExecuteAndCaptureAsync((_, _) => action(), [], CancellationToken.None, DefaultContinueOnCapturedContext);
@@ -135,8 +135,8 @@ public abstract partial class AsyncPolicy<TResult> : IAsyncPolicy<TResult>
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
-    /// <returns>The captured result</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Context, Task<TResult>> action, IDictionary<string, object> contextData) =>
         ExecuteAndCaptureAsync((ctx, _) => action(ctx), new Context(contextData), CancellationToken.None, DefaultContinueOnCapturedContext);
@@ -146,7 +146,7 @@ public abstract partial class AsyncPolicy<TResult> : IAsyncPolicy<TResult>
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Context, Task<TResult>> action, Context context) =>
         ExecuteAndCaptureAsync((ctx, _) => action(ctx), context, CancellationToken.None, DefaultContinueOnCapturedContext);
@@ -156,7 +156,7 @@ public abstract partial class AsyncPolicy<TResult> : IAsyncPolicy<TResult>
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken) =>
         ExecuteAndCaptureAsync((_, ct) => action(ct), [], cancellationToken, DefaultContinueOnCapturedContext);
@@ -167,7 +167,7 @@ public abstract partial class AsyncPolicy<TResult> : IAsyncPolicy<TResult>
     /// <param name="action">The action to perform.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
     [DebuggerStepThrough]
     public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken, bool continueOnCapturedContext) =>
@@ -179,8 +179,8 @@ public abstract partial class AsyncPolicy<TResult> : IAsyncPolicy<TResult>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
-    /// <returns>The captured result</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken) =>
         ExecuteAndCaptureAsync(action, new Context(contextData), cancellationToken, DefaultContinueOnCapturedContext);
@@ -191,7 +191,7 @@ public abstract partial class AsyncPolicy<TResult> : IAsyncPolicy<TResult>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken) =>
         ExecuteAndCaptureAsync(action, context, cancellationToken, DefaultContinueOnCapturedContext);
@@ -203,8 +203,8 @@ public abstract partial class AsyncPolicy<TResult> : IAsyncPolicy<TResult>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-    /// <returns>The captured result</returns>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <returns>The captured result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext) =>
         ExecuteAndCaptureAsync(action, new Context(contextData), cancellationToken, continueOnCapturedContext);
@@ -216,7 +216,7 @@ public abstract partial class AsyncPolicy<TResult> : IAsyncPolicy<TResult>
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
     [DebuggerStepThrough]
     public async Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)

--- a/src/Polly/AsyncPolicy.TResult.ExecuteOverloads.cs
+++ b/src/Polly/AsyncPolicy.TResult.ExecuteOverloads.cs
@@ -135,8 +135,8 @@ public abstract partial class AsyncPolicy<TResult> : IAsyncPolicy<TResult>
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>The captured result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Context, Task<TResult>> action, IDictionary<string, object> contextData) =>
         ExecuteAndCaptureAsync((ctx, _) => action(ctx), new Context(contextData), CancellationToken.None, DefaultContinueOnCapturedContext);
@@ -179,8 +179,8 @@ public abstract partial class AsyncPolicy<TResult> : IAsyncPolicy<TResult>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>The captured result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken) =>
         ExecuteAndCaptureAsync(action, new Context(contextData), cancellationToken, DefaultContinueOnCapturedContext);

--- a/src/Polly/AsyncPolicy.TResult.cs
+++ b/src/Polly/AsyncPolicy.TResult.cs
@@ -2,7 +2,7 @@
 namespace Polly;
 
 /// <summary>
-/// Transient exception handling policies that can be applied to asynchronous delegates
+/// Transient exception handling policies that can be applied to asynchronous delegates.
 /// </summary>
 /// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
 public abstract partial class AsyncPolicy<TResult> : PolicyBase<TResult>

--- a/src/Polly/AsyncPolicy.cs
+++ b/src/Polly/AsyncPolicy.cs
@@ -2,7 +2,7 @@
 namespace Polly;
 
 /// <summary>
-/// Transient exception handling policies that can be applied to asynchronous delegates
+/// Transient exception handling policies that can be applied to asynchronous delegates.
 /// </summary>
 public abstract partial class AsyncPolicy
 {

--- a/src/Polly/Bulkhead/AsyncBulkheadSyntax.cs
+++ b/src/Polly/Bulkhead/AsyncBulkheadSyntax.cs
@@ -23,7 +23,7 @@ public partial class Policy
     /// <param name="onBulkheadRejectedAsync">An action to call asynchronously, if the bulkhead rejects execution due to oversubscription.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onBulkheadRejectedAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBulkheadRejectedAsync"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static AsyncBulkheadPolicy BulkheadAsync(int maxParallelization, Func<Context, Task> onBulkheadRejectedAsync) =>
         BulkheadAsync(maxParallelization, 0, onBulkheadRejectedAsync);
@@ -53,7 +53,7 @@ public partial class Policy
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentOutOfRangeException">maxQueuingActions;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">onBulkheadRejectedAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBulkheadRejectedAsync"/> is <see langword="null"/>.</exception>
     public static AsyncBulkheadPolicy BulkheadAsync(
         int maxParallelization,
         int maxQueuingActions,

--- a/src/Polly/Bulkhead/AsyncBulkheadTResultSyntax.cs
+++ b/src/Polly/Bulkhead/AsyncBulkheadTResultSyntax.cs
@@ -22,7 +22,7 @@ public partial class Policy
     /// <param name="maxParallelization">The maximum number of concurrent actions that may be executing through the policy.</param>
     /// <param name="onBulkheadRejectedAsync">An action to call asynchronously, if the bulkhead rejects execution due to oversubscription.</param>
     /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onBulkheadRejectedAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBulkheadRejectedAsync"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static AsyncBulkheadPolicy<TResult> BulkheadAsync<TResult>(int maxParallelization, Func<Context, Task> onBulkheadRejectedAsync) =>
         BulkheadAsync<TResult>(maxParallelization, 0, onBulkheadRejectedAsync);
@@ -36,7 +36,7 @@ public partial class Policy
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentOutOfRangeException">maxQueuingActions;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">onBulkheadRejectedAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBulkheadRejectedAsync"/> is <see langword="null"/>.</exception>
     public static AsyncBulkheadPolicy<TResult> BulkheadAsync<TResult>(int maxParallelization, int maxQueuingActions)
     {
         Func<Context, Task> doNothingAsync = _ => TaskHelper.EmptyTask;
@@ -53,7 +53,7 @@ public partial class Policy
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentOutOfRangeException">maxQueuingActions;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">onBulkheadRejectedAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBulkheadRejectedAsync"/> is <see langword="null"/>.</exception>
     public static AsyncBulkheadPolicy<TResult> BulkheadAsync<TResult>(int maxParallelization, int maxQueuingActions, Func<Context, Task> onBulkheadRejectedAsync)
     {
         if (maxParallelization <= 0)

--- a/src/Polly/Bulkhead/BulkheadSyntax.cs
+++ b/src/Polly/Bulkhead/BulkheadSyntax.cs
@@ -23,7 +23,7 @@ public partial class Policy
     /// <param name="maxParallelization">The maximum number of concurrent actions that may be executing through the policy.</param>
     /// <param name="onBulkheadRejected">An action to call, if the bulkhead rejects execution due to oversubscription.</param>
     /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onBulkheadRejected</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBulkheadRejected"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static BulkheadPolicy Bulkhead(int maxParallelization, Action<Context> onBulkheadRejected) =>
         Bulkhead(maxParallelization, 0, onBulkheadRejected);
@@ -53,7 +53,7 @@ public partial class Policy
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onBulkheadRejected</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBulkheadRejected"/> is <see langword="null"/>.</exception>
     public static BulkheadPolicy Bulkhead(int maxParallelization, int maxQueuingActions, Action<Context> onBulkheadRejected)
     {
         if (maxParallelization <= 0)

--- a/src/Polly/Bulkhead/BulkheadTResultSyntax.cs
+++ b/src/Polly/Bulkhead/BulkheadTResultSyntax.cs
@@ -23,7 +23,7 @@ public partial class Policy
     /// <param name="maxParallelization">The maximum number of concurrent actions that may be executing through the policy.</param>
     /// <param name="onBulkheadRejected">An action to call, if the bulkhead rejects execution due to oversubscription.</param>
     /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onBulkheadRejected</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBulkheadRejected"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static BulkheadPolicy<TResult> Bulkhead<TResult>(int maxParallelization, Action<Context> onBulkheadRejected) =>
         Bulkhead<TResult>(maxParallelization, 0, onBulkheadRejected);
@@ -53,7 +53,7 @@ public partial class Policy
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentOutOfRangeException">maxQueuingActions;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">onBulkheadRejected</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBulkheadRejected"/> is <see langword="null"/>.</exception>
     public static BulkheadPolicy<TResult> Bulkhead<TResult>(int maxParallelization, int maxQueuingActions, Action<Context> onBulkheadRejected)
     {
         if (maxParallelization <= 0)

--- a/src/Polly/Caching/AsyncCacheSyntax.cs
+++ b/src/Polly/Caching/AsyncCacheSyntax.cs
@@ -13,7 +13,7 @@ public partial class Policy
     /// <param name="ttl">Duration (ttl) for which to cache values.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy CacheAsync(IAsyncCacheProvider cacheProvider, TimeSpan ttl, Action<Context, string, Exception>? onCacheError = null) =>
         CacheAsync(cacheProvider, new RelativeTtl(ttl), DefaultCacheKeyStrategy.Instance.GetCacheKey, onCacheError);
 
@@ -27,8 +27,8 @@ public partial class Policy
     /// <param name="ttlStrategy">A strategy for specifying ttl for values to be cached.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy CacheAsync(IAsyncCacheProvider cacheProvider, ITtlStrategy ttlStrategy, Action<Context, string, Exception>? onCacheError = null) =>
         CacheAsync(cacheProvider, ttlStrategy, DefaultCacheKeyStrategy.Instance.GetCacheKey, onCacheError);
 
@@ -43,8 +43,8 @@ public partial class Policy
     /// <param name="cacheKeyStrategy">The cache key strategy.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy CacheAsync(IAsyncCacheProvider cacheProvider, TimeSpan ttl, ICacheKeyStrategy cacheKeyStrategy, Action<Context, string, Exception>? onCacheError = null) =>
         CacheAsync(cacheProvider, new RelativeTtl(ttl), cacheKeyStrategy.GetCacheKey, onCacheError);
 
@@ -59,9 +59,9 @@ public partial class Policy
     /// <param name="cacheKeyStrategy">The cache key strategy.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy CacheAsync(IAsyncCacheProvider cacheProvider, ITtlStrategy ttlStrategy, ICacheKeyStrategy cacheKeyStrategy, Action<Context, string, Exception>? onCacheError = null)
     {
         if (cacheProvider == null)
@@ -87,8 +87,8 @@ public partial class Policy
     /// <param name="cacheKeyStrategy">The cache key strategy.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy CacheAsync(IAsyncCacheProvider cacheProvider, TimeSpan ttl, Func<Context, string> cacheKeyStrategy, Action<Context, string, Exception>? onCacheError = null) =>
         CacheAsync(cacheProvider, new RelativeTtl(ttl), cacheKeyStrategy, onCacheError);
 
@@ -103,9 +103,9 @@ public partial class Policy
     /// <param name="cacheKeyStrategy">The cache key strategy.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy CacheAsync(IAsyncCacheProvider cacheProvider, ITtlStrategy ttlStrategy, Func<Context, string> cacheKeyStrategy, Action<Context, string, Exception>? onCacheError = null)
     {
         if (cacheProvider == null)
@@ -134,10 +134,10 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy CacheAsync(
         IAsyncCacheProvider cacheProvider,
         TimeSpan ttl,
@@ -162,11 +162,11 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy CacheAsync(
         IAsyncCacheProvider cacheProvider,
         ITtlStrategy ttlStrategy,
@@ -192,11 +192,11 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy CacheAsync(
         IAsyncCacheProvider cacheProvider,
         TimeSpan ttl,
@@ -223,12 +223,12 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy CacheAsync(
         IAsyncCacheProvider cacheProvider,
         ITtlStrategy ttlStrategy,
@@ -255,11 +255,11 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy CacheAsync(
         IAsyncCacheProvider cacheProvider,
         TimeSpan ttl,
@@ -286,12 +286,12 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy CacheAsync(
         IAsyncCacheProvider cacheProvider,
         ITtlStrategy ttlStrategy,

--- a/src/Polly/Caching/AsyncCacheTResultSyntax.cs
+++ b/src/Polly/Caching/AsyncCacheTResultSyntax.cs
@@ -13,7 +13,7 @@ public partial class Policy
     /// <param name="ttl">Duration (ttl) for which to cache values.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(IAsyncCacheProvider cacheProvider, TimeSpan ttl, Action<Context, string, Exception>? onCacheError = null)
     {
         if (cacheProvider == null)
@@ -32,8 +32,8 @@ public partial class Policy
     /// <param name="ttlStrategy">A strategy for specifying ttl for values to be cached.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(IAsyncCacheProvider cacheProvider, ITtlStrategy ttlStrategy, Action<Context, string, Exception>? onCacheError = null)
     {
         if (cacheProvider == null)
@@ -53,8 +53,8 @@ public partial class Policy
     /// <param name="cacheKeyStrategy">The cache key strategy.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(IAsyncCacheProvider cacheProvider, TimeSpan ttl, ICacheKeyStrategy cacheKeyStrategy, Action<Context, string, Exception>? onCacheError = null)
     {
         if (cacheProvider == null)
@@ -74,9 +74,9 @@ public partial class Policy
     /// <param name="cacheKeyStrategy">The cache key strategy.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(IAsyncCacheProvider cacheProvider, ITtlStrategy ttlStrategy, ICacheKeyStrategy cacheKeyStrategy, Action<Context, string, Exception>? onCacheError = null)
     {
         if (cacheProvider == null)
@@ -96,8 +96,8 @@ public partial class Policy
     /// <param name="cacheKeyStrategy">The cache key strategy.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(IAsyncCacheProvider cacheProvider, TimeSpan ttl, Func<Context, string> cacheKeyStrategy, Action<Context, string, Exception>? onCacheError = null)
     {
         if (cacheProvider == null)
@@ -117,9 +117,9 @@ public partial class Policy
     /// <param name="cacheKeyStrategy">The cache key strategy.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(IAsyncCacheProvider cacheProvider, ITtlStrategy ttlStrategy, Func<Context, string> cacheKeyStrategy, Action<Context, string, Exception>? onCacheError = null)
     {
         if (cacheProvider == null)
@@ -142,10 +142,10 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(
         IAsyncCacheProvider cacheProvider,
         TimeSpan ttl,
@@ -175,11 +175,11 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(
         IAsyncCacheProvider cacheProvider,
         ITtlStrategy ttlStrategy,
@@ -210,11 +210,11 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(
         IAsyncCacheProvider cacheProvider,
         TimeSpan ttl,
@@ -246,12 +246,12 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(
         IAsyncCacheProvider cacheProvider,
         ITtlStrategy ttlStrategy,
@@ -283,11 +283,11 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(
         IAsyncCacheProvider cacheProvider,
         TimeSpan ttl,
@@ -319,12 +319,12 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(
         IAsyncCacheProvider cacheProvider,
         ITtlStrategy ttlStrategy,
@@ -351,7 +351,7 @@ public partial class Policy
     /// <param name="ttl">Duration (ttl) for which to cache values.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(IAsyncCacheProvider<TResult> cacheProvider, TimeSpan ttl, Action<Context, string, Exception>? onCacheError = null) =>
         CacheAsync<TResult>(cacheProvider, new RelativeTtl(ttl), DefaultCacheKeyStrategy.Instance.GetCacheKey, onCacheError);
 
@@ -365,8 +365,8 @@ public partial class Policy
     /// <param name="ttlStrategy">A strategy for specifying ttl for values to be cached.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(IAsyncCacheProvider<TResult> cacheProvider, ITtlStrategy ttlStrategy, Action<Context, string, Exception>? onCacheError = null) =>
         CacheAsync<TResult>(cacheProvider, ttlStrategy, DefaultCacheKeyStrategy.Instance.GetCacheKey, onCacheError);
 
@@ -380,8 +380,8 @@ public partial class Policy
     /// <param name="ttlStrategy">A strategy for specifying ttl for values to be cached.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(IAsyncCacheProvider<TResult> cacheProvider, ITtlStrategy<TResult> ttlStrategy, Action<Context, string, Exception>? onCacheError = null) =>
         CacheAsync<TResult>(cacheProvider, ttlStrategy, DefaultCacheKeyStrategy.Instance.GetCacheKey, onCacheError);
 
@@ -396,8 +396,8 @@ public partial class Policy
     /// <param name="cacheKeyStrategy">The cache key strategy.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(IAsyncCacheProvider<TResult> cacheProvider, TimeSpan ttl, ICacheKeyStrategy cacheKeyStrategy, Action<Context, string, Exception>? onCacheError = null) =>
         CacheAsync<TResult>(cacheProvider, new RelativeTtl(ttl), cacheKeyStrategy.GetCacheKey, onCacheError);
 
@@ -412,9 +412,9 @@ public partial class Policy
     /// <param name="cacheKeyStrategy">The cache key strategy.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(IAsyncCacheProvider<TResult> cacheProvider, ITtlStrategy ttlStrategy, ICacheKeyStrategy cacheKeyStrategy, Action<Context, string, Exception>? onCacheError = null)
     {
         Action<Context, string> emptyDelegate = (_, _) => { };
@@ -433,9 +433,9 @@ public partial class Policy
     /// <param name="cacheKeyStrategy">The cache key strategy.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(IAsyncCacheProvider<TResult> cacheProvider, ITtlStrategy<TResult> ttlStrategy, ICacheKeyStrategy cacheKeyStrategy, Action<Context, string, Exception>? onCacheError = null)
     {
         Action<Context, string> emptyDelegate = (_, _) => { };
@@ -454,8 +454,8 @@ public partial class Policy
     /// <param name="cacheKeyStrategy">The cache key strategy.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(IAsyncCacheProvider<TResult> cacheProvider, TimeSpan ttl, Func<Context, string> cacheKeyStrategy, Action<Context, string, Exception>? onCacheError = null) =>
         CacheAsync<TResult>(cacheProvider, new RelativeTtl(ttl), cacheKeyStrategy, onCacheError);
 
@@ -470,9 +470,9 @@ public partial class Policy
     /// <param name="cacheKeyStrategy">The cache key strategy.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(IAsyncCacheProvider<TResult> cacheProvider, ITtlStrategy ttlStrategy, Func<Context, string> cacheKeyStrategy, Action<Context, string, Exception>? onCacheError = null)
     {
         Action<Context, string> emptyDelegate = (_, _) => { };
@@ -491,9 +491,9 @@ public partial class Policy
     /// <param name="cacheKeyStrategy">The cache key strategy.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(IAsyncCacheProvider<TResult> cacheProvider, ITtlStrategy<TResult> ttlStrategy, Func<Context, string> cacheKeyStrategy, Action<Context, string, Exception>? onCacheError = null)
     {
         Action<Context, string> emptyDelegate = (_, _) => { };
@@ -515,10 +515,10 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(
         IAsyncCacheProvider<TResult> cacheProvider,
         TimeSpan ttl,
@@ -544,11 +544,11 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(
         IAsyncCacheProvider<TResult> cacheProvider,
         ITtlStrategy ttlStrategy,
@@ -573,11 +573,11 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(
         IAsyncCacheProvider<TResult> cacheProvider,
         ITtlStrategy<TResult> ttlStrategy,
@@ -603,11 +603,11 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(
         IAsyncCacheProvider<TResult> cacheProvider,
         TimeSpan ttl,
@@ -635,12 +635,12 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(
         IAsyncCacheProvider<TResult> cacheProvider,
         ITtlStrategy ttlStrategy,
@@ -667,12 +667,12 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(
         IAsyncCacheProvider<TResult> cacheProvider,
         ITtlStrategy<TResult> ttlStrategy,
@@ -699,11 +699,11 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(
         IAsyncCacheProvider<TResult> cacheProvider,
         TimeSpan ttl,
@@ -731,12 +731,12 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(
         IAsyncCacheProvider<TResult> cacheProvider,
         ITtlStrategy ttlStrategy,
@@ -763,12 +763,12 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static AsyncCachePolicy<TResult> CacheAsync<TResult>(
         IAsyncCacheProvider<TResult> cacheProvider,
         ITtlStrategy<TResult> ttlStrategy,

--- a/src/Polly/Caching/AsyncSerializingCacheProvider.cs
+++ b/src/Polly/Caching/AsyncSerializingCacheProvider.cs
@@ -15,8 +15,8 @@ public class AsyncSerializingCacheProvider<TSerialized> : IAsyncCacheProvider
     /// </summary>
     /// <param name="wrappedCacheProvider">The wrapped cache provider.</param>
     /// <param name="serializer">The serializer.</param>
-    /// <exception cref="ArgumentNullException">wrappedCacheProvider </exception>
-    /// <exception cref="ArgumentNullException">serializer </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="wrappedCacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="serializer"/> is <see langword="null"/>.</exception>
     public AsyncSerializingCacheProvider(IAsyncCacheProvider<TSerialized> wrappedCacheProvider, ICacheItemSerializer<object, TSerialized> serializer)
     {
         _wrappedCacheProvider = wrappedCacheProvider ?? throw new ArgumentNullException(nameof(wrappedCacheProvider));
@@ -73,8 +73,8 @@ public class AsyncSerializingCacheProvider<TResult, TSerialized> : IAsyncCachePr
     /// </summary>
     /// <param name="wrappedCacheProvider">The wrapped cache provider.</param>
     /// <param name="serializer">The serializer.</param>
-    /// <exception cref="ArgumentNullException">wrappedCacheProvider </exception>
-    /// <exception cref="ArgumentNullException">serializer </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="wrappedCacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="serializer"/> is <see langword="null"/>.</exception>
     public AsyncSerializingCacheProvider(IAsyncCacheProvider<TSerialized> wrappedCacheProvider, ICacheItemSerializer<TResult, TSerialized> serializer)
     {
         _wrappedCacheProvider = wrappedCacheProvider ?? throw new ArgumentNullException(nameof(wrappedCacheProvider));

--- a/src/Polly/Caching/CacheSyntax.cs
+++ b/src/Polly/Caching/CacheSyntax.cs
@@ -134,8 +134,6 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">
-    /// </exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
@@ -164,8 +162,6 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">
-    /// </exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
@@ -196,8 +192,6 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">
-    /// </exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
@@ -229,8 +223,6 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">
-    /// </exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
@@ -263,8 +255,6 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">
-    /// </exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
@@ -296,8 +286,6 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">
-    /// </exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>

--- a/src/Polly/Caching/CacheSyntax.cs
+++ b/src/Polly/Caching/CacheSyntax.cs
@@ -13,7 +13,7 @@ public partial class Policy
     /// <param name="ttl">Duration (ttl) for which to cache values.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
     public static CachePolicy Cache(ISyncCacheProvider cacheProvider, TimeSpan ttl, Action<Context, string, Exception>? onCacheError = null) =>
         Cache(cacheProvider, new RelativeTtl(ttl), DefaultCacheKeyStrategy.Instance.GetCacheKey, onCacheError);
 
@@ -27,8 +27,8 @@ public partial class Policy
     /// <param name="ttlStrategy">A strategy for specifying ttl for values to be cached.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
     public static CachePolicy Cache(ISyncCacheProvider cacheProvider, ITtlStrategy ttlStrategy, Action<Context, string, Exception>? onCacheError = null) =>
         Cache(cacheProvider, ttlStrategy, DefaultCacheKeyStrategy.Instance.GetCacheKey, onCacheError);
 
@@ -43,8 +43,8 @@ public partial class Policy
     /// <param name="cacheKeyStrategy">The cache key strategy.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     public static CachePolicy Cache(ISyncCacheProvider cacheProvider, TimeSpan ttl, ICacheKeyStrategy cacheKeyStrategy, Action<Context, string, Exception>? onCacheError = null) =>
         Cache(cacheProvider, new RelativeTtl(ttl), cacheKeyStrategy.GetCacheKey, onCacheError);
 
@@ -59,9 +59,9 @@ public partial class Policy
     /// <param name="cacheKeyStrategy">The cache key strategy.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     public static CachePolicy Cache(ISyncCacheProvider cacheProvider, ITtlStrategy ttlStrategy, ICacheKeyStrategy cacheKeyStrategy, Action<Context, string, Exception>? onCacheError = null)
     {
         if (cacheProvider == null)
@@ -87,8 +87,8 @@ public partial class Policy
     /// <param name="cacheKeyStrategy">The cache key strategy.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     public static CachePolicy Cache(ISyncCacheProvider cacheProvider, TimeSpan ttl, Func<Context, string> cacheKeyStrategy, Action<Context, string, Exception>? onCacheError = null) =>
         Cache(cacheProvider, new RelativeTtl(ttl), cacheKeyStrategy, onCacheError);
 
@@ -103,9 +103,9 @@ public partial class Policy
     /// <param name="cacheKeyStrategy">The cache key strategy.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     public static CachePolicy Cache(ISyncCacheProvider cacheProvider, ITtlStrategy ttlStrategy, Func<Context, string> cacheKeyStrategy, Action<Context, string, Exception>? onCacheError = null)
     {
         if (cacheProvider == null)
@@ -136,10 +136,10 @@ public partial class Policy
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentNullException">
     /// </exception>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static CachePolicy Cache(
         ISyncCacheProvider cacheProvider,
         TimeSpan ttl,
@@ -166,11 +166,11 @@ public partial class Policy
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentNullException">
     /// </exception>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static CachePolicy Cache(
         ISyncCacheProvider cacheProvider,
         ITtlStrategy ttlStrategy,
@@ -198,11 +198,11 @@ public partial class Policy
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentNullException">
     /// </exception>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static CachePolicy Cache(
         ISyncCacheProvider cacheProvider,
         TimeSpan ttl,
@@ -231,12 +231,12 @@ public partial class Policy
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentNullException">
     /// </exception>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static CachePolicy Cache(
         ISyncCacheProvider cacheProvider,
         ITtlStrategy ttlStrategy,
@@ -265,11 +265,11 @@ public partial class Policy
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentNullException">
     /// </exception>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static CachePolicy Cache(
         ISyncCacheProvider cacheProvider,
         TimeSpan ttl,
@@ -298,12 +298,12 @@ public partial class Policy
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentNullException">
     /// </exception>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static CachePolicy Cache(
         ISyncCacheProvider cacheProvider,
         ITtlStrategy ttlStrategy,

--- a/src/Polly/Caching/CacheTResultSyntax.cs
+++ b/src/Polly/Caching/CacheTResultSyntax.cs
@@ -13,7 +13,7 @@ public partial class Policy
     /// <param name="ttl">Duration (ttl) for which to cache values.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(ISyncCacheProvider cacheProvider, TimeSpan ttl, Action<Context, string, Exception>? onCacheError = null)
     {
         if (cacheProvider == null)
@@ -32,8 +32,8 @@ public partial class Policy
     /// <param name="ttlStrategy">A strategy for specifying ttl for values to be cached.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(ISyncCacheProvider cacheProvider, ITtlStrategy ttlStrategy, Action<Context, string, Exception>? onCacheError = null)
     {
         if (cacheProvider == null)
@@ -53,8 +53,8 @@ public partial class Policy
     /// <param name="cacheKeyStrategy">The cache key strategy.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(ISyncCacheProvider cacheProvider, TimeSpan ttl, ICacheKeyStrategy cacheKeyStrategy, Action<Context, string, Exception>? onCacheError = null)
     {
         if (cacheProvider == null)
@@ -74,9 +74,9 @@ public partial class Policy
     /// <param name="cacheKeyStrategy">The cache key strategy.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(ISyncCacheProvider cacheProvider, ITtlStrategy ttlStrategy, ICacheKeyStrategy cacheKeyStrategy, Action<Context, string, Exception>? onCacheError = null)
     {
         if (cacheProvider == null)
@@ -96,8 +96,8 @@ public partial class Policy
     /// <param name="cacheKeyStrategy">The cache key strategy.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(ISyncCacheProvider cacheProvider, TimeSpan ttl, Func<Context, string> cacheKeyStrategy, Action<Context, string, Exception>? onCacheError = null)
     {
         if (cacheProvider == null)
@@ -117,9 +117,9 @@ public partial class Policy
     /// <param name="cacheKeyStrategy">The cache key strategy.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(ISyncCacheProvider cacheProvider, ITtlStrategy ttlStrategy, Func<Context, string> cacheKeyStrategy, Action<Context, string, Exception>? onCacheError = null)
     {
         if (cacheProvider == null)
@@ -142,10 +142,10 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(
         ISyncCacheProvider cacheProvider,
         TimeSpan ttl,
@@ -175,11 +175,11 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(
         ISyncCacheProvider cacheProvider,
         ITtlStrategy ttlStrategy,
@@ -210,11 +210,11 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(
         ISyncCacheProvider cacheProvider,
         TimeSpan ttl,
@@ -246,12 +246,12 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(
         ISyncCacheProvider cacheProvider,
         ITtlStrategy ttlStrategy,
@@ -283,11 +283,11 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(
         ISyncCacheProvider cacheProvider,
         TimeSpan ttl,
@@ -319,12 +319,12 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(
         ISyncCacheProvider cacheProvider,
         ITtlStrategy ttlStrategy,
@@ -351,7 +351,7 @@ public partial class Policy
     /// <param name="ttl">Duration (ttl) for which to cache values.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(ISyncCacheProvider<TResult> cacheProvider, TimeSpan ttl, Action<Context, string, Exception>? onCacheError = null) =>
         Cache<TResult>(cacheProvider, new RelativeTtl(ttl), DefaultCacheKeyStrategy.Instance.GetCacheKey, onCacheError);
 
@@ -365,8 +365,8 @@ public partial class Policy
     /// <param name="ttlStrategy">A strategy for specifying ttl for values to be cached.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(ISyncCacheProvider<TResult> cacheProvider, ITtlStrategy ttlStrategy, Action<Context, string, Exception>? onCacheError = null) =>
         Cache<TResult>(cacheProvider, ttlStrategy, DefaultCacheKeyStrategy.Instance.GetCacheKey, onCacheError);
 
@@ -380,8 +380,8 @@ public partial class Policy
     /// <param name="ttlStrategy">A strategy for specifying ttl for values to be cached.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(ISyncCacheProvider<TResult> cacheProvider, ITtlStrategy<TResult> ttlStrategy, Action<Context, string, Exception>? onCacheError = null) =>
         Cache<TResult>(cacheProvider, ttlStrategy, DefaultCacheKeyStrategy.Instance.GetCacheKey, onCacheError);
 
@@ -396,8 +396,8 @@ public partial class Policy
     /// <param name="cacheKeyStrategy">The cache key strategy.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(ISyncCacheProvider<TResult> cacheProvider, TimeSpan ttl, ICacheKeyStrategy cacheKeyStrategy, Action<Context, string, Exception>? onCacheError = null) =>
         Cache<TResult>(cacheProvider, new RelativeTtl(ttl), cacheKeyStrategy.GetCacheKey, onCacheError);
 
@@ -412,9 +412,9 @@ public partial class Policy
     /// <param name="cacheKeyStrategy">The cache key strategy.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(ISyncCacheProvider<TResult> cacheProvider, ITtlStrategy ttlStrategy, ICacheKeyStrategy cacheKeyStrategy, Action<Context, string, Exception>? onCacheError = null)
     {
         Action<Context, string> emptyDelegate = (_, _) => { };
@@ -434,9 +434,9 @@ public partial class Policy
     /// <param name="cacheKeyStrategy">The cache key strategy.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(ISyncCacheProvider<TResult> cacheProvider, ITtlStrategy<TResult> ttlStrategy, ICacheKeyStrategy cacheKeyStrategy, Action<Context, string, Exception>? onCacheError = null)
     {
         Action<Context, string> emptyDelegate = (_, _) => { };
@@ -456,8 +456,8 @@ public partial class Policy
     /// <param name="cacheKeyStrategy">The cache key strategy.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(ISyncCacheProvider<TResult> cacheProvider, TimeSpan ttl, Func<Context, string> cacheKeyStrategy, Action<Context, string, Exception>? onCacheError = null) =>
         Cache<TResult>(cacheProvider, new RelativeTtl(ttl), cacheKeyStrategy, onCacheError);
 
@@ -472,9 +472,9 @@ public partial class Policy
     /// <param name="cacheKeyStrategy">The cache key strategy.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(ISyncCacheProvider<TResult> cacheProvider, ITtlStrategy ttlStrategy, Func<Context, string> cacheKeyStrategy, Action<Context, string, Exception>? onCacheError = null)
     {
         Action<Context, string> emptyDelegate = (_, _) => { };
@@ -494,9 +494,9 @@ public partial class Policy
     /// <param name="cacheKeyStrategy">The cache key strategy.</param>
     /// <param name="onCacheError">Delegate to call if an exception is thrown when attempting to get a value from or put a value into the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(ISyncCacheProvider<TResult> cacheProvider, ITtlStrategy<TResult> ttlStrategy, Func<Context, string> cacheKeyStrategy, Action<Context, string, Exception>? onCacheError = null)
     {
         Action<Context, string> emptyDelegate = (_, _) => { };
@@ -519,10 +519,10 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(
         ISyncCacheProvider<TResult> cacheProvider,
         TimeSpan ttl,
@@ -548,11 +548,11 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(
         ISyncCacheProvider<TResult> cacheProvider,
         ITtlStrategy ttlStrategy,
@@ -577,11 +577,11 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(
         ISyncCacheProvider<TResult> cacheProvider,
         ITtlStrategy<TResult> ttlStrategy,
@@ -607,11 +607,11 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(
         ISyncCacheProvider<TResult> cacheProvider,
         TimeSpan ttl,
@@ -639,12 +639,12 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(
         ISyncCacheProvider<TResult> cacheProvider,
         ITtlStrategy ttlStrategy,
@@ -671,12 +671,12 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(
         ISyncCacheProvider<TResult> cacheProvider,
         ITtlStrategy<TResult> ttlStrategy,
@@ -703,11 +703,11 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(
         ISyncCacheProvider<TResult> cacheProvider,
         TimeSpan ttl,
@@ -735,12 +735,12 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(
         ISyncCacheProvider<TResult> cacheProvider,
         ITtlStrategy ttlStrategy,
@@ -768,12 +768,12 @@ public partial class Policy
     /// <param name="onCacheGetError">Delegate to call if an exception is thrown when attempting to get a value from the cache, passing the execution context, the cache key, and the exception.</param>
     /// <param name="onCachePutError">Delegate to call if an exception is thrown when attempting to put a value in the cache, passing the execution context, the cache key, and the exception.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">cacheProvider</exception>
-    /// <exception cref="ArgumentNullException">ttlStrategy</exception>
-    /// <exception cref="ArgumentNullException">cacheKeyStrategy</exception>
-    /// <exception cref="ArgumentNullException">onCacheGet</exception>
-    /// <exception cref="ArgumentNullException">onCacheMiss</exception>
-    /// <exception cref="ArgumentNullException">onCachePut</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ttlStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="cacheKeyStrategy"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheGet"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCacheMiss"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onCachePut"/> is <see langword="null"/>.</exception>
     public static CachePolicy<TResult> Cache<TResult>(
         ISyncCacheProvider<TResult> cacheProvider,
         ITtlStrategy<TResult> ttlStrategy,

--- a/src/Polly/Caching/SerializingCacheProvider.cs
+++ b/src/Polly/Caching/SerializingCacheProvider.cs
@@ -15,8 +15,8 @@ public class SerializingCacheProvider<TSerialized> : ISyncCacheProvider
     /// </summary>
     /// <param name="wrappedCacheProvider">The wrapped cache provider.</param>
     /// <param name="serializer">The serializer.</param>
-    /// <exception cref="ArgumentNullException">wrappedCacheProvider </exception>
-    /// <exception cref="ArgumentNullException">serializer </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="wrappedCacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="serializer"/> is <see langword="null"/>.</exception>
     public SerializingCacheProvider(ISyncCacheProvider<TSerialized> wrappedCacheProvider, ICacheItemSerializer<object, TSerialized> serializer)
     {
         _wrappedCacheProvider = wrappedCacheProvider ?? throw new ArgumentNullException(nameof(wrappedCacheProvider));
@@ -62,8 +62,8 @@ public class SerializingCacheProvider<TResult, TSerialized> : ISyncCacheProvider
     /// </summary>
     /// <param name="wrappedCacheProvider">The wrapped cache provider.</param>
     /// <param name="serializer">The serializer.</param>
-    /// <exception cref="ArgumentNullException">wrappedCacheProvider </exception>
-    /// <exception cref="ArgumentNullException">serializer </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="wrappedCacheProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="serializer"/> is <see langword="null"/>.</exception>
     public SerializingCacheProvider(ISyncCacheProvider<TSerialized> wrappedCacheProvider, ICacheItemSerializer<TResult, TSerialized> serializer)
     {
         _wrappedCacheProvider = wrappedCacheProvider ?? throw new ArgumentNullException(nameof(wrappedCacheProvider));

--- a/src/Polly/CircuitBreaker/AdvancedCircuitBreakerSyntax.cs
+++ b/src/Polly/CircuitBreaker/AdvancedCircuitBreakerSyntax.cs
@@ -23,11 +23,11 @@ public static class AdvancedCircuitBreakerSyntax
     /// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero.</exception>
     public static CircuitBreakerPolicy AdvancedCircuitBreaker(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak)
     {
         Action<Exception, TimeSpan> doNothingOnBreak = (_, _) => { };
@@ -59,11 +59,11 @@ public static class AdvancedCircuitBreakerSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static CircuitBreakerPolicy AdvancedCircuitBreaker(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan> onBreak, Action onReset) =>
@@ -92,11 +92,11 @@ public static class AdvancedCircuitBreakerSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static CircuitBreakerPolicy AdvancedCircuitBreaker(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset)
@@ -129,11 +129,11 @@ public static class AdvancedCircuitBreakerSyntax
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>
@@ -165,11 +165,11 @@ public static class AdvancedCircuitBreakerSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed" /> state.</param>
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen" /> state, ready to try action executions again.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>
@@ -202,11 +202,11 @@ public static class AdvancedCircuitBreakerSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed" /> state.</param>
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen" /> state, ready to try action executions again.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>

--- a/src/Polly/CircuitBreaker/AdvancedCircuitBreakerSyntax.cs
+++ b/src/Polly/CircuitBreaker/AdvancedCircuitBreakerSyntax.cs
@@ -22,7 +22,7 @@ public static class AdvancedCircuitBreakerSyntax
     /// <param name="minimumThroughput">The minimum throughput: this many actions or more must pass through the circuit in the timeslice, for statistics to be considered significant and the circuit-breaker to come into action.</param>
     /// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
@@ -58,7 +58,7 @@ public static class AdvancedCircuitBreakerSyntax
     /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
@@ -91,7 +91,7 @@ public static class AdvancedCircuitBreakerSyntax
     /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
@@ -128,7 +128,7 @@ public static class AdvancedCircuitBreakerSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
@@ -173,7 +173,7 @@ public static class AdvancedCircuitBreakerSyntax
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     public static CircuitBreakerPolicy AdvancedCircuitBreaker(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen) =>
         policyBuilder.AdvancedCircuitBreaker(
             failureThreshold, samplingDuration, minimumThroughput,
@@ -210,7 +210,7 @@ public static class AdvancedCircuitBreakerSyntax
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     public static CircuitBreakerPolicy AdvancedCircuitBreaker(
         this PolicyBuilder policyBuilder,
         double failureThreshold,

--- a/src/Polly/CircuitBreaker/AdvancedCircuitBreakerSyntax.cs
+++ b/src/Polly/CircuitBreaker/AdvancedCircuitBreakerSyntax.cs
@@ -64,8 +64,8 @@ public static class AdvancedCircuitBreakerSyntax
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
     /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
     /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static CircuitBreakerPolicy AdvancedCircuitBreaker(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan> onBreak, Action onReset) =>
         policyBuilder.AdvancedCircuitBreaker(
             failureThreshold, samplingDuration, minimumThroughput,
@@ -97,8 +97,8 @@ public static class AdvancedCircuitBreakerSyntax
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
     /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
     /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static CircuitBreakerPolicy AdvancedCircuitBreaker(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset)
     {
         Action doNothingOnHalfOpen = () => { };
@@ -134,9 +134,9 @@ public static class AdvancedCircuitBreakerSyntax
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
     /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
     /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
-    /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>
     public static CircuitBreakerPolicy AdvancedCircuitBreaker(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan> onBreak, Action onReset, Action onHalfOpen) =>
         policyBuilder.AdvancedCircuitBreaker(
             failureThreshold, samplingDuration, minimumThroughput,
@@ -170,9 +170,9 @@ public static class AdvancedCircuitBreakerSyntax
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
     /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
     /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
-    /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
     public static CircuitBreakerPolicy AdvancedCircuitBreaker(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen) =>
         policyBuilder.AdvancedCircuitBreaker(
@@ -207,9 +207,9 @@ public static class AdvancedCircuitBreakerSyntax
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
     /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
     /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
-    /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
     public static CircuitBreakerPolicy AdvancedCircuitBreaker(
         this PolicyBuilder policyBuilder,

--- a/src/Polly/CircuitBreaker/AdvancedCircuitBreakerTResultSyntax.cs
+++ b/src/Polly/CircuitBreaker/AdvancedCircuitBreakerTResultSyntax.cs
@@ -22,11 +22,11 @@ public static class AdvancedCircuitBreakerTResultSyntax
     /// <param name="minimumThroughput">The minimum throughput: this many actions or more must pass through the circuit in the timeslice, for statistics to be considered significant and the circuit-breaker to come into action.</param>
     /// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero.</exception>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     public static CircuitBreakerPolicy<TResult> AdvancedCircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak)
     {
@@ -59,11 +59,11 @@ public static class AdvancedCircuitBreakerTResultSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static CircuitBreakerPolicy<TResult> AdvancedCircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan> onBreak, Action onReset) =>
@@ -92,11 +92,11 @@ public static class AdvancedCircuitBreakerTResultSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static CircuitBreakerPolicy<TResult> AdvancedCircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset)
@@ -129,11 +129,11 @@ public static class AdvancedCircuitBreakerTResultSyntax
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>
@@ -166,11 +166,11 @@ public static class AdvancedCircuitBreakerTResultSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed" /> state.</param>
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen" /> state, ready to try action executions again.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>
@@ -204,11 +204,11 @@ public static class AdvancedCircuitBreakerTResultSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed" /> state.</param>
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen" /> state, ready to try action executions again.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>

--- a/src/Polly/CircuitBreaker/AdvancedCircuitBreakerTResultSyntax.cs
+++ b/src/Polly/CircuitBreaker/AdvancedCircuitBreakerTResultSyntax.cs
@@ -64,8 +64,8 @@ public static class AdvancedCircuitBreakerTResultSyntax
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
     /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
     /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static CircuitBreakerPolicy<TResult> AdvancedCircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan> onBreak, Action onReset) =>
         policyBuilder.AdvancedCircuitBreaker(
             failureThreshold, samplingDuration, minimumThroughput,
@@ -97,8 +97,8 @@ public static class AdvancedCircuitBreakerTResultSyntax
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
     /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
     /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static CircuitBreakerPolicy<TResult> AdvancedCircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset)
     {
         Action doNothingOnHalfOpen = () => { };
@@ -134,9 +134,9 @@ public static class AdvancedCircuitBreakerTResultSyntax
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
     /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
     /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
-    /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>
     public static CircuitBreakerPolicy<TResult> AdvancedCircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan> onBreak, Action onReset, Action onHalfOpen) =>
         policyBuilder.AdvancedCircuitBreaker(
             failureThreshold, samplingDuration, minimumThroughput,
@@ -171,9 +171,9 @@ public static class AdvancedCircuitBreakerTResultSyntax
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
     /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
     /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
-    /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
     public static CircuitBreakerPolicy<TResult> AdvancedCircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen) =>
         policyBuilder.AdvancedCircuitBreaker(
@@ -209,9 +209,9 @@ public static class AdvancedCircuitBreakerTResultSyntax
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
     /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
     /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
-    /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
     public static CircuitBreakerPolicy<TResult> AdvancedCircuitBreaker<TResult>(
         this PolicyBuilder<TResult> policyBuilder,

--- a/src/Polly/CircuitBreaker/AdvancedCircuitBreakerTResultSyntax.cs
+++ b/src/Polly/CircuitBreaker/AdvancedCircuitBreakerTResultSyntax.cs
@@ -27,7 +27,7 @@ public static class AdvancedCircuitBreakerTResultSyntax
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
     /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
     /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     public static CircuitBreakerPolicy<TResult> AdvancedCircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak)
     {
         Action<DelegateResult<TResult>, TimeSpan> doNothingOnBreak = (_, _) => { };
@@ -58,7 +58,7 @@ public static class AdvancedCircuitBreakerTResultSyntax
     /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
@@ -91,7 +91,7 @@ public static class AdvancedCircuitBreakerTResultSyntax
     /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
@@ -128,7 +128,7 @@ public static class AdvancedCircuitBreakerTResultSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
@@ -174,7 +174,7 @@ public static class AdvancedCircuitBreakerTResultSyntax
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     public static CircuitBreakerPolicy<TResult> AdvancedCircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen) =>
         policyBuilder.AdvancedCircuitBreaker(
             failureThreshold, samplingDuration, minimumThroughput,
@@ -212,7 +212,7 @@ public static class AdvancedCircuitBreakerTResultSyntax
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     public static CircuitBreakerPolicy<TResult> AdvancedCircuitBreaker<TResult>(
         this PolicyBuilder<TResult> policyBuilder,
         double failureThreshold,

--- a/src/Polly/CircuitBreaker/AsyncAdvancedCircuitBreakerSyntax.cs
+++ b/src/Polly/CircuitBreaker/AsyncAdvancedCircuitBreakerSyntax.cs
@@ -66,8 +66,8 @@ public static class AsyncAdvancedCircuitBreakerSyntax
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
     /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
     /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static AsyncCircuitBreakerPolicy AdvancedCircuitBreakerAsync(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan> onBreak, Action onReset) =>
         policyBuilder.AdvancedCircuitBreakerAsync(
             failureThreshold, samplingDuration, minimumThroughput,
@@ -100,8 +100,8 @@ public static class AsyncAdvancedCircuitBreakerSyntax
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
     /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
     /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static AsyncCircuitBreakerPolicy AdvancedCircuitBreakerAsync(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset)
     {
         Action doNothingOnHalfOpen = () => { };
@@ -139,8 +139,8 @@ public static class AsyncAdvancedCircuitBreakerSyntax
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
     /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
     /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static AsyncCircuitBreakerPolicy AdvancedCircuitBreakerAsync(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan> onBreak, Action onReset, Action onHalfOpen) =>
         policyBuilder.AdvancedCircuitBreakerAsync(
             failureThreshold, samplingDuration, minimumThroughput,
@@ -175,9 +175,9 @@ public static class AsyncAdvancedCircuitBreakerSyntax
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
     /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
     /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
-    /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>
     public static AsyncCircuitBreakerPolicy AdvancedCircuitBreakerAsync(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen) =>
         policyBuilder.AdvancedCircuitBreakerAsync(
             failureThreshold, samplingDuration, minimumThroughput,
@@ -212,9 +212,9 @@ public static class AsyncAdvancedCircuitBreakerSyntax
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
     /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
     /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
-    /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>
     public static AsyncCircuitBreakerPolicy AdvancedCircuitBreakerAsync(
         this PolicyBuilder policyBuilder,
         double failureThreshold,

--- a/src/Polly/CircuitBreaker/AsyncAdvancedCircuitBreakerSyntax.cs
+++ b/src/Polly/CircuitBreaker/AsyncAdvancedCircuitBreakerSyntax.cs
@@ -27,7 +27,7 @@ public static class AsyncAdvancedCircuitBreakerSyntax
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
     /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
     /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
     public static AsyncCircuitBreakerPolicy AdvancedCircuitBreakerAsync(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak)
     {
@@ -60,7 +60,7 @@ public static class AsyncAdvancedCircuitBreakerSyntax
     /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
@@ -94,7 +94,7 @@ public static class AsyncAdvancedCircuitBreakerSyntax
     /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
@@ -133,7 +133,7 @@ public static class AsyncAdvancedCircuitBreakerSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
@@ -169,7 +169,7 @@ public static class AsyncAdvancedCircuitBreakerSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
@@ -206,7 +206,7 @@ public static class AsyncAdvancedCircuitBreakerSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>

--- a/src/Polly/CircuitBreaker/AsyncAdvancedCircuitBreakerSyntax.cs
+++ b/src/Polly/CircuitBreaker/AsyncAdvancedCircuitBreakerSyntax.cs
@@ -22,11 +22,11 @@ public static class AsyncAdvancedCircuitBreakerSyntax
     /// <param name="minimumThroughput">The minimum throughput: this many actions or more must pass through the circuit in the timeslice, for statistics to be considered significant and the circuit-breaker to come into action.</param>
     /// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero.</exception>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
     public static AsyncCircuitBreakerPolicy AdvancedCircuitBreakerAsync(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak)
@@ -61,11 +61,11 @@ public static class AsyncAdvancedCircuitBreakerSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static AsyncCircuitBreakerPolicy AdvancedCircuitBreakerAsync(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan> onBreak, Action onReset) =>
@@ -95,11 +95,11 @@ public static class AsyncAdvancedCircuitBreakerSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static AsyncCircuitBreakerPolicy AdvancedCircuitBreakerAsync(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset)
@@ -134,11 +134,11 @@ public static class AsyncAdvancedCircuitBreakerSyntax
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static AsyncCircuitBreakerPolicy AdvancedCircuitBreakerAsync(this PolicyBuilder policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<Exception, TimeSpan> onBreak, Action onReset, Action onHalfOpen) =>
@@ -170,11 +170,11 @@ public static class AsyncAdvancedCircuitBreakerSyntax
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>
@@ -207,11 +207,11 @@ public static class AsyncAdvancedCircuitBreakerSyntax
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>

--- a/src/Polly/CircuitBreaker/AsyncAdvancedCircuitBreakerTResultSyntax.cs
+++ b/src/Polly/CircuitBreaker/AsyncAdvancedCircuitBreakerTResultSyntax.cs
@@ -65,8 +65,8 @@ public static class AsyncAdvancedCircuitBreakerTResultSyntax
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
     /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
     /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static AsyncCircuitBreakerPolicy<TResult> AdvancedCircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan> onBreak, Action onReset) =>
         policyBuilder.AdvancedCircuitBreakerAsync(
             failureThreshold, samplingDuration, minimumThroughput,
@@ -99,8 +99,8 @@ public static class AsyncAdvancedCircuitBreakerTResultSyntax
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
     /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
     /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static AsyncCircuitBreakerPolicy<TResult> AdvancedCircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset)
     {
         Action doNothingOnHalfOpen = () => { };
@@ -139,8 +139,8 @@ public static class AsyncAdvancedCircuitBreakerTResultSyntax
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
     /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
     /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static AsyncCircuitBreakerPolicy<TResult> AdvancedCircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan> onBreak, Action onReset, Action onHalfOpen) =>
         policyBuilder.AdvancedCircuitBreakerAsync(
             failureThreshold, samplingDuration, minimumThroughput,
@@ -175,9 +175,9 @@ public static class AsyncAdvancedCircuitBreakerTResultSyntax
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
     /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
     /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
-    /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>
     public static AsyncCircuitBreakerPolicy<TResult> AdvancedCircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen) =>
         policyBuilder.AdvancedCircuitBreakerAsync(
             failureThreshold, samplingDuration, minimumThroughput,
@@ -212,9 +212,9 @@ public static class AsyncAdvancedCircuitBreakerTResultSyntax
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
     /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
     /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
-    /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>
     public static AsyncCircuitBreakerPolicy<TResult> AdvancedCircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
     {
         var resolutionOfCircuit = TimeSpan.FromTicks(AdvancedCircuitController<EmptyStruct>.ResolutionOfCircuitTimer);

--- a/src/Polly/CircuitBreaker/AsyncAdvancedCircuitBreakerTResultSyntax.cs
+++ b/src/Polly/CircuitBreaker/AsyncAdvancedCircuitBreakerTResultSyntax.cs
@@ -23,11 +23,11 @@ public static class AsyncAdvancedCircuitBreakerTResultSyntax
     /// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero.</exception>
     public static AsyncCircuitBreakerPolicy<TResult> AdvancedCircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak)
     {
         Action<DelegateResult<TResult>, TimeSpan> doNothingOnBreak = (_, _) => { };
@@ -60,11 +60,11 @@ public static class AsyncAdvancedCircuitBreakerTResultSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static AsyncCircuitBreakerPolicy<TResult> AdvancedCircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan> onBreak, Action onReset) =>
@@ -94,11 +94,11 @@ public static class AsyncAdvancedCircuitBreakerTResultSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static AsyncCircuitBreakerPolicy<TResult> AdvancedCircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset)
@@ -134,11 +134,11 @@ public static class AsyncAdvancedCircuitBreakerTResultSyntax
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static AsyncCircuitBreakerPolicy<TResult> AdvancedCircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, double failureThreshold, TimeSpan samplingDuration, int minimumThroughput, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan> onBreak, Action onReset, Action onHalfOpen) =>
@@ -170,11 +170,11 @@ public static class AsyncAdvancedCircuitBreakerTResultSyntax
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>
@@ -207,11 +207,11 @@ public static class AsyncAdvancedCircuitBreakerTResultSyntax
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
-    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
-    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one</exception>
-    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">minimumThroughput;Value must be greater than one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">durationOfBreak;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>

--- a/src/Polly/CircuitBreaker/AsyncAdvancedCircuitBreakerTResultSyntax.cs
+++ b/src/Polly/CircuitBreaker/AsyncAdvancedCircuitBreakerTResultSyntax.cs
@@ -22,7 +22,7 @@ public static class AsyncAdvancedCircuitBreakerTResultSyntax
     /// <param name="minimumThroughput">The minimum throughput: this many actions or more must pass through the circuit in the timeslice, for statistics to be considered significant and the circuit-breaker to come into action.</param>
     /// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
@@ -59,7 +59,7 @@ public static class AsyncAdvancedCircuitBreakerTResultSyntax
     /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
@@ -93,7 +93,7 @@ public static class AsyncAdvancedCircuitBreakerTResultSyntax
     /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
@@ -133,7 +133,7 @@ public static class AsyncAdvancedCircuitBreakerTResultSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
@@ -169,7 +169,7 @@ public static class AsyncAdvancedCircuitBreakerTResultSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>
@@ -206,7 +206,7 @@ public static class AsyncAdvancedCircuitBreakerTResultSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be greater than zero</exception>
     /// <exception cref="ArgumentOutOfRangeException">failureThreshold;Value must be less than or equal to one</exception>
     /// <exception cref="ArgumentOutOfRangeException">samplingDuration;Value must be equal to or greater than the minimum resolution of the CircuitBreaker timer</exception>

--- a/src/Polly/CircuitBreaker/AsyncCircuitBreakerSyntax.cs
+++ b/src/Polly/CircuitBreaker/AsyncCircuitBreakerSyntax.cs
@@ -21,7 +21,7 @@ public static class AsyncCircuitBreakerSyntax
     /// <param name="exceptionsAllowedBeforeBreaking">The number of exceptions that are allowed before opening the circuit.</param>
     /// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
     public static AsyncCircuitBreakerPolicy CircuitBreakerAsync(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak)
     {
@@ -53,7 +53,7 @@ public static class AsyncCircuitBreakerSyntax
     /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
@@ -82,7 +82,7 @@ public static class AsyncCircuitBreakerSyntax
     /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
@@ -117,7 +117,7 @@ public static class AsyncCircuitBreakerSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
@@ -148,7 +148,7 @@ public static class AsyncCircuitBreakerSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
@@ -180,7 +180,7 @@ public static class AsyncCircuitBreakerSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>

--- a/src/Polly/CircuitBreaker/AsyncCircuitBreakerSyntax.cs
+++ b/src/Polly/CircuitBreaker/AsyncCircuitBreakerSyntax.cs
@@ -55,8 +55,8 @@ public static class AsyncCircuitBreakerSyntax
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
     /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static AsyncCircuitBreakerPolicy CircuitBreakerAsync(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, TimeSpan> onBreak, Action onReset) =>
         policyBuilder.CircuitBreakerAsync(
             exceptionsAllowedBeforeBreaking,
@@ -84,8 +84,8 @@ public static class AsyncCircuitBreakerSyntax
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
     /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static AsyncCircuitBreakerPolicy CircuitBreakerAsync(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset)
     {
         Action doNothingOnHalfOpen = () => { };
@@ -119,8 +119,8 @@ public static class AsyncCircuitBreakerSyntax
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
     /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static AsyncCircuitBreakerPolicy CircuitBreakerAsync(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, TimeSpan> onBreak, Action onReset, Action onHalfOpen) =>
         policyBuilder.CircuitBreakerAsync(
             exceptionsAllowedBeforeBreaking,
@@ -150,9 +150,9 @@ public static class AsyncCircuitBreakerSyntax
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
     /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
-    /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>
     public static AsyncCircuitBreakerPolicy CircuitBreakerAsync(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen) =>
         policyBuilder.CircuitBreakerAsync(
             exceptionsAllowedBeforeBreaking,
@@ -182,9 +182,9 @@ public static class AsyncCircuitBreakerSyntax
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
     /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
-    /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>
     public static AsyncCircuitBreakerPolicy CircuitBreakerAsync(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
     {
         if (exceptionsAllowedBeforeBreaking <= 0)

--- a/src/Polly/CircuitBreaker/AsyncCircuitBreakerTResultSyntax.cs
+++ b/src/Polly/CircuitBreaker/AsyncCircuitBreakerTResultSyntax.cs
@@ -55,8 +55,8 @@ public static class AsyncCircuitBreakerTResultSyntax
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
     /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static AsyncCircuitBreakerPolicy<TResult> CircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan> onBreak, Action onReset) =>
         policyBuilder.CircuitBreakerAsync(
             handledEventsAllowedBeforeBreaking,
@@ -84,8 +84,8 @@ public static class AsyncCircuitBreakerTResultSyntax
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
     /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static AsyncCircuitBreakerPolicy<TResult> CircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset)
     {
         Action doNothingOnHalfOpen = () => { };
@@ -119,8 +119,8 @@ public static class AsyncCircuitBreakerTResultSyntax
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
     /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static AsyncCircuitBreakerPolicy<TResult> CircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan> onBreak, Action onReset, Action onHalfOpen) =>
         policyBuilder.CircuitBreakerAsync(
             handledEventsAllowedBeforeBreaking,
@@ -150,9 +150,9 @@ public static class AsyncCircuitBreakerTResultSyntax
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
     /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
-    /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>
     public static AsyncCircuitBreakerPolicy<TResult> CircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen) =>
         policyBuilder.CircuitBreakerAsync(
             handledEventsAllowedBeforeBreaking,
@@ -182,9 +182,9 @@ public static class AsyncCircuitBreakerTResultSyntax
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
     /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
-    /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>
     public static AsyncCircuitBreakerPolicy<TResult> CircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
     {
         if (handledEventsAllowedBeforeBreaking <= 0)

--- a/src/Polly/CircuitBreaker/AsyncCircuitBreakerTResultSyntax.cs
+++ b/src/Polly/CircuitBreaker/AsyncCircuitBreakerTResultSyntax.cs
@@ -21,7 +21,7 @@ public static class AsyncCircuitBreakerTResultSyntax
     /// <param name="handledEventsAllowedBeforeBreaking">The number of exceptions or handled results that are allowed before opening the circuit.</param>
     /// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
     public static AsyncCircuitBreakerPolicy<TResult> CircuitBreakerAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak)
     {
@@ -53,7 +53,7 @@ public static class AsyncCircuitBreakerTResultSyntax
     /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
@@ -82,7 +82,7 @@ public static class AsyncCircuitBreakerTResultSyntax
     /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
@@ -117,7 +117,7 @@ public static class AsyncCircuitBreakerTResultSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
@@ -148,7 +148,7 @@ public static class AsyncCircuitBreakerTResultSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
@@ -180,7 +180,7 @@ public static class AsyncCircuitBreakerTResultSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>

--- a/src/Polly/CircuitBreaker/CircuitBreakerSyntax.cs
+++ b/src/Polly/CircuitBreaker/CircuitBreakerSyntax.cs
@@ -23,8 +23,8 @@ public static class CircuitBreakerSyntax
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
     /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static CircuitBreakerPolicy CircuitBreaker(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak)
     {
         Action<Exception, TimeSpan> doNothingOnBreak = (_, _) => { };
@@ -57,8 +57,8 @@ public static class CircuitBreakerSyntax
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
     /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static CircuitBreakerPolicy CircuitBreaker(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, TimeSpan> onBreak, Action onReset) =>
         policyBuilder.CircuitBreaker(
             exceptionsAllowedBeforeBreaking,
@@ -86,8 +86,8 @@ public static class CircuitBreakerSyntax
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
     /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static CircuitBreakerPolicy CircuitBreaker(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset)
     {
         Action doNothingOnHalfOpen = () => { };
@@ -120,8 +120,8 @@ public static class CircuitBreakerSyntax
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
     /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static CircuitBreakerPolicy CircuitBreaker(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, TimeSpan> onBreak, Action onReset, Action onHalfOpen) =>
         policyBuilder.CircuitBreaker(
             exceptionsAllowedBeforeBreaking,
@@ -151,9 +151,9 @@ public static class CircuitBreakerSyntax
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
     /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
-    /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>
     public static CircuitBreakerPolicy CircuitBreaker(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen) =>
         policyBuilder.CircuitBreaker(
             exceptionsAllowedBeforeBreaking,
@@ -183,9 +183,9 @@ public static class CircuitBreakerSyntax
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
     /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
-    /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>
     public static CircuitBreakerPolicy CircuitBreaker(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<Exception, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
     {
         if (exceptionsAllowedBeforeBreaking <= 0)

--- a/src/Polly/CircuitBreaker/CircuitBreakerSyntax.cs
+++ b/src/Polly/CircuitBreaker/CircuitBreakerSyntax.cs
@@ -21,7 +21,7 @@ public static class CircuitBreakerSyntax
     /// <param name="exceptionsAllowedBeforeBreaking">The number of exceptions that are allowed before opening the circuit.</param>
     /// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
@@ -55,7 +55,7 @@ public static class CircuitBreakerSyntax
     /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
@@ -84,7 +84,7 @@ public static class CircuitBreakerSyntax
     /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
@@ -118,7 +118,7 @@ public static class CircuitBreakerSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
@@ -149,7 +149,7 @@ public static class CircuitBreakerSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
@@ -181,7 +181,7 @@ public static class CircuitBreakerSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>

--- a/src/Polly/CircuitBreaker/CircuitBreakerTResultSyntax.cs
+++ b/src/Polly/CircuitBreaker/CircuitBreakerTResultSyntax.cs
@@ -21,7 +21,7 @@ public static class CircuitBreakerTResultSyntax
     /// <param name="handledEventsAllowedBeforeBreaking">The number of exceptions or handled results that are allowed before opening the circuit.</param>
     /// <param name="durationOfBreak">The duration the circuit will stay open before resetting.</param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
@@ -55,7 +55,7 @@ public static class CircuitBreakerTResultSyntax
     /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
@@ -84,7 +84,7 @@ public static class CircuitBreakerTResultSyntax
     /// <param name="onBreak">The action to call when the circuit transitions to an <see cref="CircuitState.Open"/> state.</param>
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
@@ -118,7 +118,7 @@ public static class CircuitBreakerTResultSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
@@ -149,7 +149,7 @@ public static class CircuitBreakerTResultSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
@@ -181,7 +181,7 @@ public static class CircuitBreakerTResultSyntax
     /// <param name="onReset">The action to call when the circuit resets to a <see cref="CircuitState.Closed"/> state.</param>
     /// <param name="onHalfOpen">The action to call when the circuit transitions to <see cref="CircuitState.HalfOpen"/> state, ready to try action executions again. </param>
     /// <returns>The policy instance.</returns>
-    /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
+    /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>

--- a/src/Polly/CircuitBreaker/CircuitBreakerTResultSyntax.cs
+++ b/src/Polly/CircuitBreaker/CircuitBreakerTResultSyntax.cs
@@ -23,8 +23,8 @@ public static class CircuitBreakerTResultSyntax
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
     /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static CircuitBreakerPolicy<TResult> CircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak)
     {
         Action<DelegateResult<TResult>, TimeSpan> doNothingOnBreak = (_, _) => { };
@@ -57,8 +57,8 @@ public static class CircuitBreakerTResultSyntax
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
     /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static CircuitBreakerPolicy<TResult> CircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan> onBreak, Action onReset) =>
         policyBuilder.CircuitBreaker(
             handledEventsAllowedBeforeBreaking,
@@ -86,8 +86,8 @@ public static class CircuitBreakerTResultSyntax
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
     /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static CircuitBreakerPolicy<TResult> CircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset)
     {
         Action doNothingOnHalfOpen = () => { };
@@ -120,8 +120,8 @@ public static class CircuitBreakerTResultSyntax
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
     /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static CircuitBreakerPolicy<TResult> CircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan> onBreak, Action onReset, Action onHalfOpen) =>
         policyBuilder.CircuitBreaker(
             handledEventsAllowedBeforeBreaking,
@@ -151,9 +151,9 @@ public static class CircuitBreakerTResultSyntax
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
     /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
-    /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>
     public static CircuitBreakerPolicy<TResult> CircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen) =>
         policyBuilder.CircuitBreaker(
             handledEventsAllowedBeforeBreaking,
@@ -183,9 +183,9 @@ public static class CircuitBreakerTResultSyntax
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi)</remarks>
     /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onBreak</exception>
-    /// <exception cref="ArgumentNullException">onReset</exception>
-    /// <exception cref="ArgumentNullException">onHalfOpen</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onHalfOpen"/> is <see langword="null"/>.</exception>
     public static CircuitBreakerPolicy<TResult> CircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak, Action<DelegateResult<TResult>, CircuitState, TimeSpan, Context> onBreak, Action<Context> onReset, Action onHalfOpen)
     {
         if (handledEventsAllowedBeforeBreaking <= 0)

--- a/src/Polly/DelegateResult.cs
+++ b/src/Polly/DelegateResult.cs
@@ -1,18 +1,18 @@
 ﻿namespace Polly;
 
 /// <summary>
-/// The captured outcome of executing an individual Func&lt;TResult&gt;
+/// The captured outcome of executing an individual Func&lt;TResult&gt;.
 /// </summary>
 public class DelegateResult<TResult>
 {
     /// <summary>
-    /// Create an instance of <see cref="DelegateResult{TResult}"/> representing an execution which returned <paramref name="result"/>
+    /// Create an instance of <see cref="DelegateResult{TResult}"/> representing an execution which returned <paramref name="result"/>.
     /// </summary>
     /// <param name="result">The result.</param>
     public DelegateResult(TResult result) => Result = result;
 
     /// <summary>
-    /// Create an instance of <see cref="DelegateResult{TResult}"/> representing an execution which threw <paramref name="exception"/>
+    /// Create an instance of <see cref="DelegateResult{TResult}"/> representing an execution which threw <paramref name="exception"/>.
     /// </summary>
     /// <param name="exception">The exception.</param>
     public DelegateResult(Exception exception) =>

--- a/src/Polly/Fallback/AsyncFallbackSyntax.cs
+++ b/src/Polly/Fallback/AsyncFallbackSyntax.cs
@@ -12,7 +12,7 @@ public static class AsyncFallbackSyntax
     /// </summary>
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="fallbackAction">The fallback delegate.</param>
-    /// <exception cref="ArgumentNullException">fallbackAction</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static AsyncFallbackPolicy FallbackAsync(this PolicyBuilder policyBuilder, Func<CancellationToken, Task> fallbackAction)
     {
@@ -31,8 +31,8 @@ public static class AsyncFallbackSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="fallbackAction">The fallback delegate.</param>
     /// <param name="onFallbackAsync">The action to call asynchronously before invoking the fallback delegate.</param>
-    /// <exception cref="ArgumentNullException">fallbackAction</exception>
-    /// <exception cref="ArgumentNullException">onFallbackAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onFallbackAsync"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static AsyncFallbackPolicy FallbackAsync(this PolicyBuilder policyBuilder, Func<CancellationToken, Task> fallbackAction, Func<Exception, Task> onFallbackAsync)
     {
@@ -52,8 +52,8 @@ public static class AsyncFallbackSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="fallbackAction">The fallback delegate.</param>
     /// <param name="onFallbackAsync">The action to call asynchronously before invoking the fallback delegate.</param>
-    /// <exception cref="ArgumentNullException">fallbackAction</exception>
-    /// <exception cref="ArgumentNullException">onFallbackAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onFallbackAsync"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static AsyncFallbackPolicy FallbackAsync(this PolicyBuilder policyBuilder, Func<Context, CancellationToken, Task> fallbackAction, Func<Exception, Context, Task> onFallbackAsync)
     {
@@ -71,8 +71,8 @@ public static class AsyncFallbackSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="fallbackAction">The fallback delegate.</param>
     /// <param name="onFallbackAsync">The action to call asynchronously before invoking the fallback delegate.</param>
-    /// <exception cref="ArgumentNullException">fallbackAction</exception>
-    /// <exception cref="ArgumentNullException">onFallbackAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onFallbackAsync"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static AsyncFallbackPolicy FallbackAsync(this PolicyBuilder policyBuilder, Func<Exception, Context, CancellationToken, Task> fallbackAction, Func<Exception, Context, Task> onFallbackAsync)
     {
@@ -109,7 +109,7 @@ public static class AsyncFallbackTResultSyntax
     /// </summary>
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="fallbackAction">The fallback delegate.</param>
-    /// <exception cref="ArgumentNullException">fallbackAction</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static AsyncFallbackPolicy<TResult> FallbackAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<CancellationToken, Task<TResult>> fallbackAction)
     {
@@ -128,7 +128,7 @@ public static class AsyncFallbackTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="fallbackValue">The fallback <typeparamref name="TResult"/> value to provide.</param>
     /// <param name="onFallbackAsync">The action to call asynchronously before invoking the fallback delegate.</param>
-    /// <exception cref="ArgumentNullException">onFallbackAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onFallbackAsync"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static AsyncFallbackPolicy<TResult> FallbackAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, TResult fallbackValue, Func<DelegateResult<TResult>, Task> onFallbackAsync)
     {
@@ -146,8 +146,8 @@ public static class AsyncFallbackTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="fallbackAction">The fallback delegate.</param>
     /// <param name="onFallbackAsync">The action to call asynchronously before invoking the fallback delegate.</param>
-    /// <exception cref="ArgumentNullException">fallbackAction</exception>
-    /// <exception cref="ArgumentNullException">onFallbackAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onFallbackAsync"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static AsyncFallbackPolicy<TResult> FallbackAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<CancellationToken, Task<TResult>> fallbackAction, Func<DelegateResult<TResult>, Task> onFallbackAsync)
     {
@@ -167,7 +167,7 @@ public static class AsyncFallbackTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="fallbackValue">The fallback <typeparamref name="TResult"/> value to provide.</param>
     /// <param name="onFallbackAsync">The action to call asynchronously before invoking the fallback delegate.</param>
-    /// <exception cref="ArgumentNullException">onFallbackAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onFallbackAsync"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static AsyncFallbackPolicy<TResult> FallbackAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, TResult fallbackValue, Func<DelegateResult<TResult>, Context, Task> onFallbackAsync)
     {
@@ -185,8 +185,8 @@ public static class AsyncFallbackTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="fallbackAction">The fallback delegate.</param>
     /// <param name="onFallbackAsync">The action to call asynchronously before invoking the fallback delegate.</param>
-    /// <exception cref="ArgumentNullException">fallbackAction</exception>
-    /// <exception cref="ArgumentNullException">onFallbackAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onFallbackAsync"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static AsyncFallbackPolicy<TResult> FallbackAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<Context, CancellationToken, Task<TResult>> fallbackAction, Func<DelegateResult<TResult>, Context, Task> onFallbackAsync)
     {
@@ -204,8 +204,8 @@ public static class AsyncFallbackTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="fallbackAction">The fallback delegate.</param>
     /// <param name="onFallbackAsync">The action to call asynchronously before invoking the fallback delegate.</param>
-    /// <exception cref="ArgumentNullException">fallbackAction</exception>
-    /// <exception cref="ArgumentNullException">onFallbackAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onFallbackAsync"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static AsyncFallbackPolicy<TResult> FallbackAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<DelegateResult<TResult>, Context, CancellationToken, Task<TResult>> fallbackAction, Func<DelegateResult<TResult>, Context, Task> onFallbackAsync)
     {

--- a/src/Polly/Fallback/FallbackSyntax.cs
+++ b/src/Polly/Fallback/FallbackSyntax.cs
@@ -12,7 +12,7 @@ public static class FallbackSyntax
     /// </summary>
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="fallbackAction">The fallback action.</param>
-    /// <exception cref="ArgumentNullException">fallbackAction</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static FallbackPolicy Fallback(this PolicyBuilder policyBuilder, Action fallbackAction)
     {
@@ -28,7 +28,7 @@ public static class FallbackSyntax
     /// </summary>
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="fallbackAction">The fallback action.</param>
-    /// <exception cref="ArgumentNullException">fallbackAction</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static FallbackPolicy Fallback(this PolicyBuilder policyBuilder, Action<CancellationToken> fallbackAction)
     {
@@ -45,8 +45,8 @@ public static class FallbackSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="fallbackAction">The fallback action.</param>
     /// <param name="onFallback">The action to call before invoking the fallback delegate.</param>
-    /// <exception cref="ArgumentNullException">fallbackAction</exception>
-    /// <exception cref="ArgumentNullException">onFallback</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onFallback"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static FallbackPolicy Fallback(this PolicyBuilder policyBuilder, Action fallbackAction, Action<Exception> onFallback)
     {
@@ -64,8 +64,8 @@ public static class FallbackSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="fallbackAction">The fallback action.</param>
     /// <param name="onFallback">The action to call before invoking the fallback delegate.</param>
-    /// <exception cref="ArgumentNullException">fallbackAction</exception>
-    /// <exception cref="ArgumentNullException">onFallback</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onFallback"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static FallbackPolicy Fallback(this PolicyBuilder policyBuilder, Action<CancellationToken> fallbackAction, Action<Exception> onFallback)
     {
@@ -83,8 +83,8 @@ public static class FallbackSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="fallbackAction">The fallback action.</param>
     /// <param name="onFallback">The action to call before invoking the fallback delegate.</param>
-    /// <exception cref="ArgumentNullException">fallbackAction</exception>
-    /// <exception cref="ArgumentNullException">onFallback</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onFallback"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static FallbackPolicy Fallback(this PolicyBuilder policyBuilder, Action<Context> fallbackAction, Action<Exception, Context> onFallback)
     {
@@ -102,8 +102,8 @@ public static class FallbackSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="fallbackAction">The fallback action.</param>
     /// <param name="onFallback">The action to call before invoking the fallback delegate.</param>
-    /// <exception cref="ArgumentNullException">fallbackAction</exception>
-    /// <exception cref="ArgumentNullException">onFallback</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onFallback"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static FallbackPolicy Fallback(this PolicyBuilder policyBuilder, Action<Context, CancellationToken> fallbackAction, Action<Exception, Context> onFallback)
     {
@@ -121,8 +121,8 @@ public static class FallbackSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="fallbackAction">The fallback action.</param>
     /// <param name="onFallback">The action to call before invoking the fallback delegate.</param>
-    /// <exception cref="ArgumentNullException">fallbackAction</exception>
-    /// <exception cref="ArgumentNullException">onFallback</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onFallback"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static FallbackPolicy Fallback(this PolicyBuilder policyBuilder, Action<Exception, Context, CancellationToken> fallbackAction, Action<Exception, Context> onFallback)
     {
@@ -160,7 +160,7 @@ public static class FallbackTResultSyntax
     /// </summary>
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="fallbackAction">The fallback action.</param>
-    /// <exception cref="ArgumentNullException">fallbackAction</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static FallbackPolicy<TResult> Fallback<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<TResult> fallbackAction)
     {
@@ -176,7 +176,7 @@ public static class FallbackTResultSyntax
     /// </summary>
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="fallbackAction">The fallback action.</param>
-    /// <exception cref="ArgumentNullException">fallbackAction</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static FallbackPolicy<TResult> Fallback<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<CancellationToken, TResult> fallbackAction)
     {
@@ -193,7 +193,7 @@ public static class FallbackTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="fallbackValue">The fallback <typeparamref name="TResult"/> value to provide.</param>
     /// <param name="onFallback">The action to call before invoking the fallback delegate.</param>
-    /// <exception cref="ArgumentNullException">onFallback</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onFallback"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static FallbackPolicy<TResult> Fallback<TResult>(this PolicyBuilder<TResult> policyBuilder, TResult fallbackValue, Action<DelegateResult<TResult>> onFallback)
     {
@@ -209,8 +209,8 @@ public static class FallbackTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="fallbackAction">The fallback action.</param>
     /// <param name="onFallback">The action to call before invoking the fallback delegate.</param>
-    /// <exception cref="ArgumentNullException">fallbackAction</exception>
-    /// <exception cref="ArgumentNullException">onFallback</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onFallback"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static FallbackPolicy<TResult> Fallback<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<TResult> fallbackAction, Action<DelegateResult<TResult>> onFallback)
     {
@@ -228,8 +228,8 @@ public static class FallbackTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="fallbackAction">The fallback action.</param>
     /// <param name="onFallback">The action to call before invoking the fallback delegate.</param>
-    /// <exception cref="ArgumentNullException">fallbackAction</exception>
-    /// <exception cref="ArgumentNullException">onFallback</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onFallback"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static FallbackPolicy<TResult> Fallback<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<CancellationToken, TResult> fallbackAction, Action<DelegateResult<TResult>> onFallback)
     {
@@ -247,7 +247,7 @@ public static class FallbackTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="fallbackValue">The fallback <typeparamref name="TResult"/> value to provide.</param>
     /// <param name="onFallback">The action to call before invoking the fallback delegate.</param>
-    /// <exception cref="ArgumentNullException">onFallback</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onFallback"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static FallbackPolicy<TResult> Fallback<TResult>(this PolicyBuilder<TResult> policyBuilder, TResult fallbackValue, Action<DelegateResult<TResult>, Context> onFallback)
     {
@@ -263,8 +263,8 @@ public static class FallbackTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="fallbackAction">The fallback action.</param>
     /// <param name="onFallback">The action to call before invoking the fallback delegate.</param>
-    /// <exception cref="ArgumentNullException">fallbackAction</exception>
-    /// <exception cref="ArgumentNullException">onFallback</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onFallback"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static FallbackPolicy<TResult> Fallback<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<Context, TResult> fallbackAction, Action<DelegateResult<TResult>, Context> onFallback)
     {
@@ -282,8 +282,8 @@ public static class FallbackTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="fallbackAction">The fallback action.</param>
     /// <param name="onFallback">The action to call before invoking the fallback delegate.</param>
-    /// <exception cref="ArgumentNullException">fallbackAction</exception>
-    /// <exception cref="ArgumentNullException">onFallback</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onFallback"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static FallbackPolicy<TResult> Fallback<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<Context, CancellationToken, TResult> fallbackAction, Action<DelegateResult<TResult>, Context> onFallback)
     {
@@ -301,8 +301,8 @@ public static class FallbackTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="fallbackAction">The fallback action.</param>
     /// <param name="onFallback">The action to call before invoking the fallback delegate.</param>
-    /// <exception cref="ArgumentNullException">fallbackAction</exception>
-    /// <exception cref="ArgumentNullException">onFallback</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onFallback"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static FallbackPolicy<TResult> Fallback<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<DelegateResult<TResult>, Context, CancellationToken, TResult> fallbackAction, Action<DelegateResult<TResult>, Context> onFallback)
     {

--- a/src/Polly/IAsyncPolicy.Extensions.cs
+++ b/src/Polly/IAsyncPolicy.Extensions.cs
@@ -1,7 +1,7 @@
 ﻿namespace Polly;
 
 /// <summary>
-/// Contains extensions methods on <see cref="IAsyncPolicy"/>
+/// Contains extensions methods on <see cref="IAsyncPolicy"/>.
 /// </summary>
 public static class IAsyncPolicyExtensions
 {

--- a/src/Polly/IAsyncPolicy.TResult.cs
+++ b/src/Polly/IAsyncPolicy.TResult.cs
@@ -140,7 +140,7 @@ public interface IAsyncPolicy<TResult> : IsPolicy
     ///     Executes the specified asynchronous action within the policy and returns the result.
     /// </summary>
     /// <param name="action">The action to perform.</param>
-    /// <param name="context">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+    /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <returns>The captured result.</returns>
     Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken);

--- a/src/Polly/IAsyncPolicy.TResult.cs
+++ b/src/Polly/IAsyncPolicy.TResult.cs
@@ -17,7 +17,7 @@ public interface IAsyncPolicy<TResult> : IsPolicy
     ///     Executes the specified asynchronous action within the policy and returns the result.
     /// </summary>
     /// <param name="action">The action to perform.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     Task<TResult> ExecuteAsync(Func<Task<TResult>> action);
 
     /// <summary>
@@ -25,7 +25,7 @@ public interface IAsyncPolicy<TResult> : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     Task<TResult> ExecuteAsync(Func<Context, Task<TResult>> action, Context context);
 
     /// <summary>
@@ -33,7 +33,7 @@ public interface IAsyncPolicy<TResult> : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     Task<TResult> ExecuteAsync(Func<Context, Task<TResult>> action, IDictionary<string, object> contextData);
 
     /// <summary>
@@ -41,7 +41,7 @@ public interface IAsyncPolicy<TResult> : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     Task<TResult> ExecuteAsync(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken);
 
     /// <summary>
@@ -50,7 +50,7 @@ public interface IAsyncPolicy<TResult> : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     Task<TResult> ExecuteAsync(Func<Context, CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken);
 
     /// <summary>
@@ -59,7 +59,7 @@ public interface IAsyncPolicy<TResult> : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     Task<TResult> ExecuteAsync(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken);
 
     /// <summary>
@@ -68,7 +68,7 @@ public interface IAsyncPolicy<TResult> : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
     Task<TResult> ExecuteAsync(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken, bool continueOnCapturedContext);
 
@@ -79,8 +79,8 @@ public interface IAsyncPolicy<TResult> : IsPolicy
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-    /// <returns>The value returned by the action</returns>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <returns>The value returned by the action.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     Task<TResult> ExecuteAsync(Func<Context, CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext);
 
     /// <summary>
@@ -90,7 +90,7 @@ public interface IAsyncPolicy<TResult> : IsPolicy
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
     Task<TResult> ExecuteAsync(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext);
 
@@ -98,7 +98,7 @@ public interface IAsyncPolicy<TResult> : IsPolicy
     /// Executes the specified asynchronous action within the policy and returns the result.
     /// </summary>
     /// <param name="action">The action to perform.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Task<TResult>> action);
 
     /// <summary>
@@ -106,8 +106,8 @@ public interface IAsyncPolicy<TResult> : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
-    /// <returns>The captured result</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <returns>The captured result.</returns>
     Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Context, Task<TResult>> action, IDictionary<string, object> contextData);
 
     /// <summary>
@@ -115,7 +115,7 @@ public interface IAsyncPolicy<TResult> : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Context, Task<TResult>> action, Context context);
 
     /// <summary>
@@ -123,7 +123,7 @@ public interface IAsyncPolicy<TResult> : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken);
 
     /// <summary>
@@ -132,8 +132,8 @@ public interface IAsyncPolicy<TResult> : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
-    /// <returns>The captured result</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <returns>The captured result.</returns>
     Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken);
 
     /// <summary>
@@ -142,7 +142,7 @@ public interface IAsyncPolicy<TResult> : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="context">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken);
 
     /// <summary>
@@ -151,7 +151,7 @@ public interface IAsyncPolicy<TResult> : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
     Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken, bool continueOnCapturedContext);
 
@@ -162,8 +162,8 @@ public interface IAsyncPolicy<TResult> : IsPolicy
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-    /// <returns>The captured result</returns>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <returns>The captured result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext);
 
     /// <summary>
@@ -173,7 +173,7 @@ public interface IAsyncPolicy<TResult> : IsPolicy
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
     Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext);
 }

--- a/src/Polly/IAsyncPolicy.cs
+++ b/src/Polly/IAsyncPolicy.cs
@@ -70,7 +70,7 @@ public interface IAsyncPolicy : IsPolicy
     /// <param name="action">The action to perform.</param>        /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     Task ExecuteAsync(Func<Context, CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext);
 
     /// <summary>
@@ -88,7 +88,7 @@ public interface IAsyncPolicy : IsPolicy
     /// </summary>
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="action">The action to perform.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     Task<TResult> ExecuteAsync<TResult>(Func<Task<TResult>> action);
 
     /// <summary>
@@ -97,7 +97,7 @@ public interface IAsyncPolicy : IsPolicy
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     Task<TResult> ExecuteAsync<TResult>(Func<Context, Task<TResult>> action, Context context);
 
     /// <summary>
@@ -105,7 +105,7 @@ public interface IAsyncPolicy : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     Task<TResult> ExecuteAsync<TResult>(Func<Context, Task<TResult>> action, IDictionary<string, object> contextData);
 
     /// <summary>
@@ -114,7 +114,7 @@ public interface IAsyncPolicy : IsPolicy
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="action">The action to perform.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken);
 
     /// <summary>
@@ -123,7 +123,7 @@ public interface IAsyncPolicy : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     Task<TResult> ExecuteAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken);
 
     /// <summary>
@@ -133,7 +133,7 @@ public interface IAsyncPolicy : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     Task<TResult> ExecuteAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken);
 
     /// <summary>
@@ -143,7 +143,7 @@ public interface IAsyncPolicy : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
     Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken, bool continueOnCapturedContext);
 
@@ -154,8 +154,8 @@ public interface IAsyncPolicy : IsPolicy
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-    /// <returns>The value returned by the action</returns>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <returns>The value returned by the action.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     Task<TResult> ExecuteAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext);
 
     /// <summary>
@@ -166,7 +166,7 @@ public interface IAsyncPolicy : IsPolicy
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy is in use, also cancels any further retries.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
     Task<TResult> ExecuteAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext);
 
@@ -174,7 +174,7 @@ public interface IAsyncPolicy : IsPolicy
     ///     Executes the specified asynchronous action within the policy and returns the captured result.
     /// </summary>
     /// <param name="action">The action to perform.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     Task<PolicyResult> ExecuteAndCaptureAsync(Func<Task> action);
 
     /// <summary>
@@ -182,8 +182,8 @@ public interface IAsyncPolicy : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
-    /// <returns>The captured result</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <returns>The captured result.</returns>
     Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, Task> action, IDictionary<string, object> contextData);
 
     /// <summary>
@@ -191,7 +191,7 @@ public interface IAsyncPolicy : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, Task> action, Context context);
 
     /// <summary>
@@ -207,8 +207,8 @@ public interface IAsyncPolicy : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
-    /// <returns>The captured result</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <returns>The captured result.</returns>
     Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken);
 
     /// <summary>
@@ -235,8 +235,8 @@ public interface IAsyncPolicy : IsPolicy
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
-    /// <returns>The captured result</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <returns>The captured result.</returns>
     Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext);
 
     /// <summary>
@@ -254,7 +254,7 @@ public interface IAsyncPolicy : IsPolicy
     /// </summary>
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="action">The action to perform.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Task<TResult>> action);
 
     /// <summary>
@@ -263,8 +263,8 @@ public interface IAsyncPolicy : IsPolicy
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
-    /// <returns>The captured result</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <returns>The captured result.</returns>
     Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Context, Task<TResult>> action, IDictionary<string, object> contextData);
 
     /// <summary>
@@ -273,7 +273,7 @@ public interface IAsyncPolicy : IsPolicy
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Context, Task<TResult>> action, Context context);
 
     /// <summary>
@@ -282,7 +282,7 @@ public interface IAsyncPolicy : IsPolicy
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="action">The action to perform.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken);
 
     /// <summary>
@@ -292,8 +292,8 @@ public interface IAsyncPolicy : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
-    /// <returns>The captured result</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <returns>The captured result.</returns>
     Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken);
 
     /// <summary>
@@ -303,7 +303,7 @@ public interface IAsyncPolicy : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="context">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken);
 
     /// <summary>
@@ -313,7 +313,7 @@ public interface IAsyncPolicy : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
     Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken, bool continueOnCapturedContext);
 
@@ -325,8 +325,8 @@ public interface IAsyncPolicy : IsPolicy
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
-    /// <returns>The captured result</returns>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <returns>The captured result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext);
 
     /// <summary>
@@ -337,7 +337,7 @@ public interface IAsyncPolicy : IsPolicy
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
     Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext);
 }

--- a/src/Polly/IAsyncPolicy.cs
+++ b/src/Polly/IAsyncPolicy.cs
@@ -1,7 +1,7 @@
 ﻿namespace Polly;
 
 /// <summary>
-/// An interface defining all executions available on a non-generic, asynchronous policy
+/// An interface defining all executions available on a non-generic, asynchronous policy.
 /// </summary>
 public interface IAsyncPolicy : IsPolicy
 {

--- a/src/Polly/IAsyncPolicy.cs
+++ b/src/Polly/IAsyncPolicy.cs
@@ -67,7 +67,8 @@ public interface IAsyncPolicy : IsPolicy
     /// <summary>
     ///     Executes the specified asynchronous action within the policy.
     /// </summary>
-    /// <param name="action">The action to perform.</param>        /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
+    /// <param name="action">The action to perform.</param>
+    /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
@@ -301,7 +302,7 @@ public interface IAsyncPolicy : IsPolicy
     /// </summary>
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="action">The action to perform.</param>
-    /// <param name="context">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+    /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <returns>The captured result.</returns>
     Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken);

--- a/src/Polly/ISyncPolicy.Extensions.cs
+++ b/src/Polly/ISyncPolicy.Extensions.cs
@@ -1,7 +1,7 @@
 ﻿namespace Polly;
 
 /// <summary>
-/// Contains extensions methods on <see cref="ISyncPolicy"/>
+/// Contains extensions methods on <see cref="ISyncPolicy"/>.
 /// </summary>
 public static class ISyncPolicyExtensions
 {

--- a/src/Polly/ISyncPolicy.TResult.cs
+++ b/src/Polly/ISyncPolicy.TResult.cs
@@ -25,7 +25,6 @@ public interface ISyncPolicy<TResult> : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>The value returned by the action.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     TResult Execute(Func<Context, TResult> action, IDictionary<string, object> contextData);
@@ -35,9 +34,8 @@ public interface ISyncPolicy<TResult> : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context"/> is <see langword="null"/>.</exception>
     /// <returns>The value returned by the action.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context"/> is <see langword="null"/>.</exception>
     TResult Execute(Func<Context, TResult> action, Context context);
 
     /// <summary>
@@ -79,8 +77,8 @@ public interface ISyncPolicy<TResult> : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>The captured result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     PolicyResult<TResult> ExecuteAndCapture(Func<Context, TResult> action, IDictionary<string, object> contextData);
 
     /// <summary>
@@ -88,8 +86,8 @@ public interface ISyncPolicy<TResult> : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>The captured result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context"/> is <see langword="null"/>.</exception>
     PolicyResult<TResult> ExecuteAndCapture(Func<Context, TResult> action, Context context);
 
     /// <summary>

--- a/src/Polly/ISyncPolicy.TResult.cs
+++ b/src/Polly/ISyncPolicy.TResult.cs
@@ -26,9 +26,7 @@ public interface ISyncPolicy<TResult> : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
-    /// <returns>
-    /// The value returned by the action
-    /// </returns>
+    /// <returns>The value returned by the action.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     TResult Execute(Func<Context, TResult> action, IDictionary<string, object> contextData);
 
@@ -38,9 +36,7 @@ public interface ISyncPolicy<TResult> : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="context"/> is <see langword="null"/>.</exception>
-    /// <returns>
-    /// The value returned by the action
-    /// </returns>
+    /// <returns>The value returned by the action.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     TResult Execute(Func<Context, TResult> action, Context context);
 
@@ -72,7 +68,7 @@ public interface ISyncPolicy<TResult> : IsPolicy
     TResult Execute(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Executes the specified action within the policy and returns the captured result
+    /// Executes the specified action within the policy and returns the captured result.
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <returns>The captured result.</returns>
@@ -97,7 +93,7 @@ public interface ISyncPolicy<TResult> : IsPolicy
     PolicyResult<TResult> ExecuteAndCapture(Func<Context, TResult> action, Context context);
 
     /// <summary>
-    /// Executes the specified action within the policy and returns the captured result
+    /// Executes the specified action within the policy and returns the captured result.
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="cancellationToken">The cancellation token.</param>

--- a/src/Polly/ISyncPolicy.TResult.cs
+++ b/src/Polly/ISyncPolicy.TResult.cs
@@ -17,7 +17,7 @@ public interface ISyncPolicy<TResult> : IsPolicy
     /// Executes the specified action within the policy and returns the Result.
     /// </summary>
     /// <param name="action">The action to perform.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     TResult Execute(Func<TResult> action);
 
     /// <summary>
@@ -25,11 +25,11 @@ public interface ISyncPolicy<TResult> : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>
     /// The value returned by the action
     /// </returns>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     TResult Execute(Func<Context, TResult> action, IDictionary<string, object> contextData);
 
     /// <summary>
@@ -37,11 +37,11 @@ public interface ISyncPolicy<TResult> : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">context</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context"/> is <see langword="null"/>.</exception>
     /// <returns>
     /// The value returned by the action
     /// </returns>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     TResult Execute(Func<Context, TResult> action, Context context);
 
     /// <summary>
@@ -49,7 +49,7 @@ public interface ISyncPolicy<TResult> : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     TResult Execute(Func<CancellationToken, TResult> action, CancellationToken cancellationToken);
 
     /// <summary>
@@ -58,8 +58,8 @@ public interface ISyncPolicy<TResult> : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The value returned by the action</returns>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <returns>The value returned by the action.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     TResult Execute(Func<Context, CancellationToken, TResult> action, IDictionary<string, object> contextData, CancellationToken cancellationToken);
 
     /// <summary>
@@ -68,14 +68,14 @@ public interface ISyncPolicy<TResult> : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     TResult Execute(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken);
 
     /// <summary>
     /// Executes the specified action within the policy and returns the captured result
     /// </summary>
     /// <param name="action">The action to perform.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     PolicyResult<TResult> ExecuteAndCapture(Func<TResult> action);
 
     /// <summary>
@@ -83,8 +83,8 @@ public interface ISyncPolicy<TResult> : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
-    /// <returns>The captured result</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <returns>The captured result.</returns>
     PolicyResult<TResult> ExecuteAndCapture(Func<Context, TResult> action, IDictionary<string, object> contextData);
 
     /// <summary>
@@ -92,8 +92,8 @@ public interface ISyncPolicy<TResult> : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
-    /// <returns>The captured result</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <returns>The captured result.</returns>
     PolicyResult<TResult> ExecuteAndCapture(Func<Context, TResult> action, Context context);
 
     /// <summary>
@@ -101,7 +101,7 @@ public interface ISyncPolicy<TResult> : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     PolicyResult<TResult> ExecuteAndCapture(Func<CancellationToken, TResult> action, CancellationToken cancellationToken);
 
     /// <summary>
@@ -110,8 +110,8 @@ public interface ISyncPolicy<TResult> : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The captured result</returns>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <returns>The captured result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     PolicyResult<TResult> ExecuteAndCapture(Func<Context, CancellationToken, TResult> action, IDictionary<string, object> contextData, CancellationToken cancellationToken);
 
     /// <summary>
@@ -120,6 +120,6 @@ public interface ISyncPolicy<TResult> : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     PolicyResult<TResult> ExecuteAndCapture(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken);
 }

--- a/src/Polly/ISyncPolicy.cs
+++ b/src/Polly/ISyncPolicy.cs
@@ -70,7 +70,6 @@ public interface ISyncPolicy : IsPolicy
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>The value returned by the action.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     TResult Execute<TResult>(Func<Context, TResult> action, IDictionary<string, object> contextData);
@@ -81,9 +80,8 @@ public interface ISyncPolicy : IsPolicy
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>The value returned by the action.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context"/> is <see langword="null"/>.</exception>
     TResult Execute<TResult>(Func<Context, TResult> action, Context context);
 
     /// <summary>
@@ -128,8 +126,8 @@ public interface ISyncPolicy : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>The captured result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     PolicyResult ExecuteAndCapture(Action<Context> action, IDictionary<string, object> contextData);
 
     /// <summary>
@@ -179,8 +177,8 @@ public interface ISyncPolicy : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>The captured result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     PolicyResult<TResult> ExecuteAndCapture<TResult>(Func<Context, TResult> action, IDictionary<string, object> contextData);
 
     /// <summary>
@@ -188,8 +186,8 @@ public interface ISyncPolicy : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>The captured result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context"/> is <see langword="null"/>.</exception>
     PolicyResult<TResult> ExecuteAndCapture<TResult>(Func<Context, TResult> action, Context context);
 
     /// <summary>

--- a/src/Polly/ISyncPolicy.cs
+++ b/src/Polly/ISyncPolicy.cs
@@ -45,7 +45,7 @@ public interface ISyncPolicy : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     void Execute(Action<Context, CancellationToken> action, IDictionary<string, object> contextData, CancellationToken cancellationToken);
 
     /// <summary>
@@ -61,7 +61,7 @@ public interface ISyncPolicy : IsPolicy
     /// </summary>
     /// <typeparam name="TResult">The type of the Result.</typeparam>
     /// <param name="action">The action to perform.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     TResult Execute<TResult>(Func<TResult> action);
 
     /// <summary>
@@ -70,11 +70,11 @@ public interface ISyncPolicy : IsPolicy
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>
     /// The value returned by the action
     /// </returns>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     TResult Execute<TResult>(Func<Context, TResult> action, IDictionary<string, object> contextData);
 
     /// <summary>
@@ -83,11 +83,11 @@ public interface ISyncPolicy : IsPolicy
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>
     /// The value returned by the action
     /// </returns>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     TResult Execute<TResult>(Func<Context, TResult> action, Context context);
 
     /// <summary>
@@ -96,7 +96,7 @@ public interface ISyncPolicy : IsPolicy
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="action">The action to perform.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     TResult Execute<TResult>(Func<CancellationToken, TResult> action, CancellationToken cancellationToken);
 
     /// <summary>
@@ -106,8 +106,8 @@ public interface ISyncPolicy : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The value returned by the action</returns>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <returns>The value returned by the action.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     TResult Execute<TResult>(Func<Context, CancellationToken, TResult> action, IDictionary<string, object> contextData, CancellationToken cancellationToken);
 
     /// <summary>
@@ -117,14 +117,14 @@ public interface ISyncPolicy : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     TResult Execute<TResult>(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken);
 
     /// <summary>
     /// Executes the specified action within the policy and returns the captured result
     /// </summary>
     /// <param name="action">The action to perform.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     PolicyResult ExecuteAndCapture(Action action);
 
     /// <summary>
@@ -132,8 +132,8 @@ public interface ISyncPolicy : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
-    /// <returns>The captured result</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <returns>The captured result.</returns>
     PolicyResult ExecuteAndCapture(Action<Context> action, IDictionary<string, object> contextData);
 
     /// <summary>
@@ -141,7 +141,7 @@ public interface ISyncPolicy : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     PolicyResult ExecuteAndCapture(Action<Context> action, Context context);
 
     /// <summary>
@@ -149,7 +149,7 @@ public interface ISyncPolicy : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     PolicyResult ExecuteAndCapture(Action<CancellationToken> action, CancellationToken cancellationToken);
 
     /// <summary>
@@ -158,8 +158,8 @@ public interface ISyncPolicy : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The captured result</returns>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <returns>The captured result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     PolicyResult ExecuteAndCapture(Action<Context, CancellationToken> action, IDictionary<string, object> contextData, CancellationToken cancellationToken);
 
     /// <summary>
@@ -168,14 +168,14 @@ public interface ISyncPolicy : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     PolicyResult ExecuteAndCapture(Action<Context, CancellationToken> action, Context context, CancellationToken cancellationToken);
 
     /// <summary>
     /// Executes the specified action within the policy and returns the captured result
     /// </summary>
     /// <param name="action">The action to perform.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     PolicyResult<TResult> ExecuteAndCapture<TResult>(Func<TResult> action);
 
     /// <summary>
@@ -183,8 +183,8 @@ public interface ISyncPolicy : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
-    /// <returns>The captured result</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <returns>The captured result.</returns>
     PolicyResult<TResult> ExecuteAndCapture<TResult>(Func<Context, TResult> action, IDictionary<string, object> contextData);
 
     /// <summary>
@@ -192,8 +192,8 @@ public interface ISyncPolicy : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
-    /// <returns>The captured result</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <returns>The captured result.</returns>
     PolicyResult<TResult> ExecuteAndCapture<TResult>(Func<Context, TResult> action, Context context);
 
     /// <summary>
@@ -202,7 +202,7 @@ public interface ISyncPolicy : IsPolicy
     /// <typeparam name="TResult">The type of the t result.</typeparam>
     /// <param name="action">The action to perform.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     PolicyResult<TResult> ExecuteAndCapture<TResult>(Func<CancellationToken, TResult> action, CancellationToken cancellationToken);
 
     /// <summary>
@@ -212,8 +212,8 @@ public interface ISyncPolicy : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The captured result</returns>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <returns>The captured result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     PolicyResult<TResult> ExecuteAndCapture<TResult>(Func<Context, CancellationToken, TResult> action, IDictionary<string, object> contextData, CancellationToken cancellationToken);
 
     /// <summary>
@@ -222,6 +222,6 @@ public interface ISyncPolicy : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     PolicyResult<TResult> ExecuteAndCapture<TResult>(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken);
 }

--- a/src/Polly/ISyncPolicy.cs
+++ b/src/Polly/ISyncPolicy.cs
@@ -1,7 +1,7 @@
 ﻿namespace Polly;
 
 /// <summary>
-/// An interface defining all executions available on a non-generic, synchronous policy
+/// An interface defining all executions available on a non-generic, synchronous policy.
 /// </summary>
 public interface ISyncPolicy : IsPolicy
 {
@@ -71,9 +71,7 @@ public interface ISyncPolicy : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
-    /// <returns>
-    /// The value returned by the action
-    /// </returns>
+    /// <returns>The value returned by the action.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     TResult Execute<TResult>(Func<Context, TResult> action, IDictionary<string, object> contextData);
 
@@ -84,9 +82,7 @@ public interface ISyncPolicy : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
-    /// <returns>
-    /// The value returned by the action
-    /// </returns>
+    /// <returns>The value returned by the action.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     TResult Execute<TResult>(Func<Context, TResult> action, Context context);
 
@@ -121,7 +117,7 @@ public interface ISyncPolicy : IsPolicy
     TResult Execute<TResult>(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Executes the specified action within the policy and returns the captured result
+    /// Executes the specified action within the policy and returns the captured result.
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <returns>The captured result.</returns>
@@ -145,7 +141,7 @@ public interface ISyncPolicy : IsPolicy
     PolicyResult ExecuteAndCapture(Action<Context> action, Context context);
 
     /// <summary>
-    /// Executes the specified action within the policy and returns the captured result
+    /// Executes the specified action within the policy and returns the captured result.
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
@@ -163,7 +159,7 @@ public interface ISyncPolicy : IsPolicy
     PolicyResult ExecuteAndCapture(Action<Context, CancellationToken> action, IDictionary<string, object> contextData, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Executes the specified action within the policy and returns the captured result
+    /// Executes the specified action within the policy and returns the captured result.
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
@@ -172,7 +168,7 @@ public interface ISyncPolicy : IsPolicy
     PolicyResult ExecuteAndCapture(Action<Context, CancellationToken> action, Context context, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Executes the specified action within the policy and returns the captured result
+    /// Executes the specified action within the policy and returns the captured result.
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <returns>The captured result.</returns>
@@ -197,7 +193,7 @@ public interface ISyncPolicy : IsPolicy
     PolicyResult<TResult> ExecuteAndCapture<TResult>(Func<Context, TResult> action, Context context);
 
     /// <summary>
-    /// Executes the specified action within the policy and returns the captured result
+    /// Executes the specified action within the policy and returns the captured result.
     /// </summary>
     /// <typeparam name="TResult">The type of the t result.</typeparam>
     /// <param name="action">The action to perform.</param>

--- a/src/Polly/IsPolicy.cs
+++ b/src/Polly/IsPolicy.cs
@@ -1,7 +1,7 @@
 ﻿namespace Polly;
 
 /// <summary>
-/// A marker interface identifying Polly policies of all types, and containing properties common to all policies
+/// A marker interface identifying Polly policies of all types, and containing properties common to all policies.
 /// </summary>
 public interface IsPolicy
 {

--- a/src/Polly/Policy.ExecuteOverloads.cs
+++ b/src/Polly/Policy.ExecuteOverloads.cs
@@ -92,7 +92,6 @@ public abstract partial class Policy : ISyncPolicy
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>The value returned by the action.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
@@ -105,9 +104,8 @@ public abstract partial class Policy : ISyncPolicy
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>The value returned by the action.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public TResult Execute<TResult>(Func<Context, TResult> action, Context context) =>
         Execute((ctx, _) => action(ctx), context, DefaultCancellationToken);
@@ -182,8 +180,8 @@ public abstract partial class Policy : ISyncPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>The captured result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public PolicyResult ExecuteAndCapture(Action<Context> action, IDictionary<string, object> contextData) =>
         ExecuteAndCapture((ctx, _) => action(ctx), new Context(contextData), DefaultCancellationToken);
@@ -260,8 +258,8 @@ public abstract partial class Policy : ISyncPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>The captured result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public PolicyResult<TResult> ExecuteAndCapture<TResult>(Func<Context, TResult> action, IDictionary<string, object> contextData) =>
         ExecuteAndCapture((ctx, _) => action(ctx), new Context(contextData), DefaultCancellationToken);
@@ -271,8 +269,8 @@ public abstract partial class Policy : ISyncPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>The captured result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public PolicyResult<TResult> ExecuteAndCapture<TResult>(Func<Context, TResult> action, Context context) =>
         ExecuteAndCapture((ctx, _) => action(ctx), context, DefaultCancellationToken);

--- a/src/Polly/Policy.ExecuteOverloads.cs
+++ b/src/Polly/Policy.ExecuteOverloads.cs
@@ -45,7 +45,7 @@ public abstract partial class Policy : ISyncPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public void Execute(Action<Context, CancellationToken> action, IDictionary<string, object> contextData, CancellationToken cancellationToken) =>
         Execute(action, new Context(contextData), cancellationToken);
@@ -81,7 +81,7 @@ public abstract partial class Policy : ISyncPolicy
     /// </summary>
     /// <typeparam name="TResult">The type of the Result.</typeparam>
     /// <param name="action">The action to perform.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     [DebuggerStepThrough]
     public TResult Execute<TResult>(Func<TResult> action) =>
         Execute((_, _) => action(), [], DefaultCancellationToken);
@@ -92,11 +92,11 @@ public abstract partial class Policy : ISyncPolicy
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>
     /// The value returned by the action
     /// </returns>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public TResult Execute<TResult>(Func<Context, TResult> action, IDictionary<string, object> contextData) =>
         Execute((ctx, _) => action(ctx), new Context(contextData), DefaultCancellationToken);
@@ -107,11 +107,11 @@ public abstract partial class Policy : ISyncPolicy
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>
     /// The value returned by the action
     /// </returns>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public TResult Execute<TResult>(Func<Context, TResult> action, Context context) =>
         Execute((ctx, _) => action(ctx), context, DefaultCancellationToken);
@@ -122,7 +122,7 @@ public abstract partial class Policy : ISyncPolicy
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <param name="action">The action to perform.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     [DebuggerStepThrough]
     public TResult Execute<TResult>(Func<CancellationToken, TResult> action, CancellationToken cancellationToken) =>
         Execute((_, ct) => action(ct), [], cancellationToken);
@@ -134,8 +134,8 @@ public abstract partial class Policy : ISyncPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The value returned by the action</returns>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <returns>The value returned by the action.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public TResult Execute<TResult>(Func<Context, CancellationToken, TResult> action, IDictionary<string, object> contextData, CancellationToken cancellationToken) =>
         Execute(action, new Context(contextData), cancellationToken);
@@ -147,7 +147,7 @@ public abstract partial class Policy : ISyncPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     [DebuggerStepThrough]
     public TResult Execute<TResult>(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken)
     {
@@ -176,7 +176,7 @@ public abstract partial class Policy : ISyncPolicy
     /// Executes the specified action within the policy and returns the captured result
     /// </summary>
     /// <param name="action">The action to perform.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public PolicyResult ExecuteAndCapture(Action action) =>
         ExecuteAndCapture((_, _) => action(), [], DefaultCancellationToken);
@@ -186,8 +186,8 @@ public abstract partial class Policy : ISyncPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
-    /// <returns>The captured result</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public PolicyResult ExecuteAndCapture(Action<Context> action, IDictionary<string, object> contextData) =>
         ExecuteAndCapture((ctx, _) => action(ctx), new Context(contextData), DefaultCancellationToken);
@@ -197,7 +197,7 @@ public abstract partial class Policy : ISyncPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public PolicyResult ExecuteAndCapture(Action<Context> action, Context context) =>
         ExecuteAndCapture((ctx, _) => action(ctx), context, DefaultCancellationToken);
@@ -207,7 +207,7 @@ public abstract partial class Policy : ISyncPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public PolicyResult ExecuteAndCapture(Action<CancellationToken> action, CancellationToken cancellationToken) =>
         ExecuteAndCapture((_, ct) => action(ct), [], cancellationToken);
@@ -218,8 +218,8 @@ public abstract partial class Policy : ISyncPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The captured result</returns>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <returns>The captured result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public PolicyResult ExecuteAndCapture(Action<Context, CancellationToken> action, IDictionary<string, object> contextData, CancellationToken cancellationToken) =>
         ExecuteAndCapture(action, new Context(contextData), cancellationToken);
@@ -230,7 +230,7 @@ public abstract partial class Policy : ISyncPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public PolicyResult ExecuteAndCapture(Action<Context, CancellationToken> action, Context context, CancellationToken cancellationToken)
     {
@@ -254,7 +254,7 @@ public abstract partial class Policy : ISyncPolicy
     /// Executes the specified action within the policy and returns the captured result
     /// </summary>
     /// <param name="action">The action to perform.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public PolicyResult<TResult> ExecuteAndCapture<TResult>(Func<TResult> action) =>
         ExecuteAndCapture((_, _) => action(), [], DefaultCancellationToken);
@@ -264,8 +264,8 @@ public abstract partial class Policy : ISyncPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
-    /// <returns>The captured result</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public PolicyResult<TResult> ExecuteAndCapture<TResult>(Func<Context, TResult> action, IDictionary<string, object> contextData) =>
         ExecuteAndCapture((ctx, _) => action(ctx), new Context(contextData), DefaultCancellationToken);
@@ -275,8 +275,8 @@ public abstract partial class Policy : ISyncPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
-    /// <returns>The captured result</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public PolicyResult<TResult> ExecuteAndCapture<TResult>(Func<Context, TResult> action, Context context) =>
         ExecuteAndCapture((ctx, _) => action(ctx), context, DefaultCancellationToken);
@@ -287,7 +287,7 @@ public abstract partial class Policy : ISyncPolicy
     /// <typeparam name="TResult">The type of the t result.</typeparam>
     /// <param name="action">The action to perform.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     public PolicyResult<TResult> ExecuteAndCapture<TResult>(Func<CancellationToken, TResult> action, CancellationToken cancellationToken) =>
         ExecuteAndCapture((_, ct) => action(ct), [], cancellationToken);
 
@@ -298,8 +298,8 @@ public abstract partial class Policy : ISyncPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The captured result</returns>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <returns>The captured result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public PolicyResult<TResult> ExecuteAndCapture<TResult>(Func<Context, CancellationToken, TResult> action, IDictionary<string, object> contextData, CancellationToken cancellationToken) =>
         ExecuteAndCapture(action, new Context(contextData), cancellationToken);
@@ -310,7 +310,7 @@ public abstract partial class Policy : ISyncPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public PolicyResult<TResult> ExecuteAndCapture<TResult>(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken)
     {

--- a/src/Polly/Policy.ExecuteOverloads.cs
+++ b/src/Polly/Policy.ExecuteOverloads.cs
@@ -31,7 +31,7 @@ public abstract partial class Policy : ISyncPolicy
         Execute((ctx, _) => action(ctx), context, DefaultCancellationToken);
 
     /// <summary>
-    /// Executes the specified action within the policy
+    /// Executes the specified action within the policy.
     /// </summary>
     /// <param name="action"></param>
     /// <param name="cancellationToken"></param>
@@ -93,9 +93,7 @@ public abstract partial class Policy : ISyncPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
-    /// <returns>
-    /// The value returned by the action
-    /// </returns>
+    /// <returns>The value returned by the action.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public TResult Execute<TResult>(Func<Context, TResult> action, IDictionary<string, object> contextData) =>
@@ -108,9 +106,7 @@ public abstract partial class Policy : ISyncPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
-    /// <returns>
-    /// The value returned by the action
-    /// </returns>
+    /// <returns>The value returned by the action.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public TResult Execute<TResult>(Func<Context, TResult> action, Context context) =>
@@ -173,7 +169,7 @@ public abstract partial class Policy : ISyncPolicy
     #region ExecuteAndCapture overloads
 
     /// <summary>
-    /// Executes the specified action within the policy and returns the captured result
+    /// Executes the specified action within the policy and returns the captured result.
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <returns>The captured result.</returns>
@@ -203,7 +199,7 @@ public abstract partial class Policy : ISyncPolicy
         ExecuteAndCapture((ctx, _) => action(ctx), context, DefaultCancellationToken);
 
     /// <summary>
-    /// Executes the specified action within the policy and returns the captured result
+    /// Executes the specified action within the policy and returns the captured result.
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
@@ -225,7 +221,7 @@ public abstract partial class Policy : ISyncPolicy
         ExecuteAndCapture(action, new Context(contextData), cancellationToken);
 
     /// <summary>
-    /// Executes the specified action within the policy and returns the captured result
+    /// Executes the specified action within the policy and returns the captured result.
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
@@ -251,7 +247,7 @@ public abstract partial class Policy : ISyncPolicy
     #region Overloads method-generic in TResult
 
     /// <summary>
-    /// Executes the specified action within the policy and returns the captured result
+    /// Executes the specified action within the policy and returns the captured result.
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <returns>The captured result.</returns>
@@ -282,7 +278,7 @@ public abstract partial class Policy : ISyncPolicy
         ExecuteAndCapture((ctx, _) => action(ctx), context, DefaultCancellationToken);
 
     /// <summary>
-    /// Executes the specified action within the policy and returns the captured result
+    /// Executes the specified action within the policy and returns the captured result.
     /// </summary>
     /// <typeparam name="TResult">The type of the t result.</typeparam>
     /// <param name="action">The action to perform.</param>

--- a/src/Polly/Policy.ExecuteOverloads.cs
+++ b/src/Polly/Policy.ExecuteOverloads.cs
@@ -33,8 +33,8 @@ public abstract partial class Policy : ISyncPolicy
     /// <summary>
     /// Executes the specified action within the policy.
     /// </summary>
-    /// <param name="action"></param>
-    /// <param name="cancellationToken"></param>
+    /// <param name="action">The action to perform.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     [DebuggerStepThrough]
     public void Execute(Action<CancellationToken> action, CancellationToken cancellationToken) =>
         Execute((_, ct) => action(ct), [], cancellationToken);

--- a/src/Polly/Policy.HandleSyntax.cs
+++ b/src/Polly/Policy.HandleSyntax.cs
@@ -37,6 +37,7 @@ public partial class Policy
     /// Specifies the type of exception that this policy can handle, with additional filters on this exception type, if found as an InnerException of a regular <see cref="Exception"/>, or at any level of nesting within an <see cref="AggregateException"/>.
     /// </summary>
     /// <typeparam name="TException">The type of the exception to handle.</typeparam>
+    /// <param name="exceptionPredicate">The exception predicate to filter the type of exception this policy can handle.</param>
     /// <returns>The PolicyBuilder instance, for fluent chaining.</returns>
     public static PolicyBuilder HandleInner<TException>(Func<TException, bool> exceptionPredicate)
         where TException : Exception
@@ -100,6 +101,7 @@ public partial class Policy<TResult>
     /// Specifies the type of exception that this policy can handle, with additional filters on this exception type, if found as an InnerException of a regular <see cref="Exception"/>, or at any level of nesting within an <see cref="AggregateException"/>.
     /// </summary>
     /// <typeparam name="TException">The type of the exception to handle.</typeparam>
+    /// <param name="exceptionPredicate">The exception predicate to filter the type of exception this policy can handle.</param>
     /// <returns>The PolicyBuilder instance, for fluent chaining.</returns>
     public static PolicyBuilder<TResult> HandleInner<TException>(Func<TException, bool> exceptionPredicate)
         where TException : Exception

--- a/src/Polly/Policy.TResult.ExecuteOverloads.cs
+++ b/src/Polly/Policy.TResult.ExecuteOverloads.cs
@@ -8,7 +8,7 @@ public abstract partial class Policy<TResult> : ISyncPolicy<TResult>
     /// Executes the specified action within the policy and returns the Result.
     /// </summary>
     /// <param name="action">The action to perform.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     [DebuggerStepThrough]
     public TResult Execute(Func<TResult> action) =>
         Execute((_, _) => action(), [], DefaultCancellationToken);
@@ -18,11 +18,11 @@ public abstract partial class Policy<TResult> : ISyncPolicy<TResult>
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>
     /// The value returned by the action
     /// </returns>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public TResult Execute(Func<Context, TResult> action, IDictionary<string, object> contextData) =>
         Execute((ctx, _) => action(ctx), new Context(contextData), DefaultCancellationToken);
@@ -32,11 +32,11 @@ public abstract partial class Policy<TResult> : ISyncPolicy<TResult>
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">context</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context"/> is <see langword="null"/>.</exception>
     /// <returns>
     /// The value returned by the action
     /// </returns>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public TResult Execute(Func<Context, TResult> action, Context context) =>
         Execute((ctx, _) => action(ctx), context, DefaultCancellationToken);
@@ -46,7 +46,7 @@ public abstract partial class Policy<TResult> : ISyncPolicy<TResult>
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     [DebuggerStepThrough]
     public TResult Execute(Func<CancellationToken, TResult> action, CancellationToken cancellationToken) =>
         Execute((_, ct) => action(ct), [], cancellationToken);
@@ -57,8 +57,8 @@ public abstract partial class Policy<TResult> : ISyncPolicy<TResult>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The value returned by the action</returns>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <returns>The value returned by the action.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public TResult Execute(Func<Context, CancellationToken, TResult> action, IDictionary<string, object> contextData, CancellationToken cancellationToken) =>
         Execute(action, new Context(contextData), cancellationToken);
@@ -69,7 +69,7 @@ public abstract partial class Policy<TResult> : ISyncPolicy<TResult>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The value returned by the action</returns>
+    /// <returns>The value returned by the action.</returns>
     [DebuggerStepThrough]
     public TResult Execute(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken)
     {
@@ -96,7 +96,7 @@ public abstract partial class Policy<TResult> : ISyncPolicy<TResult>
     /// Executes the specified action within the policy and returns the captured result
     /// </summary>
     /// <param name="action">The action to perform.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public PolicyResult<TResult> ExecuteAndCapture(Func<TResult> action) =>
         ExecuteAndCapture((_, _) => action(), [], DefaultCancellationToken);
@@ -106,8 +106,8 @@ public abstract partial class Policy<TResult> : ISyncPolicy<TResult>
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
-    /// <returns>The captured result</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public PolicyResult<TResult> ExecuteAndCapture(Func<Context, TResult> action, IDictionary<string, object> contextData) =>
         ExecuteAndCapture((ctx, _) => action(ctx), new Context(contextData), DefaultCancellationToken);
@@ -117,8 +117,8 @@ public abstract partial class Policy<TResult> : ISyncPolicy<TResult>
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">contextData</exception>
-    /// <returns>The captured result</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public PolicyResult<TResult> ExecuteAndCapture(Func<Context, TResult> action, Context context) =>
         ExecuteAndCapture((ctx, _) => action(ctx), context, DefaultCancellationToken);
@@ -128,7 +128,7 @@ public abstract partial class Policy<TResult> : ISyncPolicy<TResult>
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public PolicyResult<TResult> ExecuteAndCapture(Func<CancellationToken, TResult> action, CancellationToken cancellationToken) =>
         ExecuteAndCapture((_, ct) => action(ct), [], cancellationToken);
@@ -139,8 +139,8 @@ public abstract partial class Policy<TResult> : ISyncPolicy<TResult>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The captured result</returns>
-    /// <exception cref="ArgumentNullException">contextData</exception>
+    /// <returns>The captured result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public PolicyResult<TResult> ExecuteAndCapture(Func<Context, CancellationToken, TResult> action, IDictionary<string, object> contextData, CancellationToken cancellationToken) =>
         ExecuteAndCapture(action, new Context(contextData), cancellationToken);
@@ -151,7 +151,7 @@ public abstract partial class Policy<TResult> : ISyncPolicy<TResult>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The captured result</returns>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public PolicyResult<TResult> ExecuteAndCapture(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken)
     {

--- a/src/Polly/Policy.TResult.ExecuteOverloads.cs
+++ b/src/Polly/Policy.TResult.ExecuteOverloads.cs
@@ -18,7 +18,6 @@ public abstract partial class Policy<TResult> : ISyncPolicy<TResult>
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>The value returned by the action.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
@@ -30,9 +29,8 @@ public abstract partial class Policy<TResult> : ISyncPolicy<TResult>
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context"/> is <see langword="null"/>.</exception>
     /// <returns>The value returned by the action.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public TResult Execute(Func<Context, TResult> action, Context context) =>
         Execute((ctx, _) => action(ctx), context, DefaultCancellationToken);
@@ -102,8 +100,8 @@ public abstract partial class Policy<TResult> : ISyncPolicy<TResult>
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>The captured result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public PolicyResult<TResult> ExecuteAndCapture(Func<Context, TResult> action, IDictionary<string, object> contextData) =>
         ExecuteAndCapture((ctx, _) => action(ctx), new Context(contextData), DefaultCancellationToken);
@@ -113,8 +111,8 @@ public abstract partial class Policy<TResult> : ISyncPolicy<TResult>
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>The captured result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public PolicyResult<TResult> ExecuteAndCapture(Func<Context, TResult> action, Context context) =>
         ExecuteAndCapture((ctx, _) => action(ctx), context, DefaultCancellationToken);

--- a/src/Polly/Policy.TResult.ExecuteOverloads.cs
+++ b/src/Polly/Policy.TResult.ExecuteOverloads.cs
@@ -19,9 +19,7 @@ public abstract partial class Policy<TResult> : ISyncPolicy<TResult>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
-    /// <returns>
-    /// The value returned by the action
-    /// </returns>
+    /// <returns>The value returned by the action.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public TResult Execute(Func<Context, TResult> action, IDictionary<string, object> contextData) =>
@@ -33,9 +31,7 @@ public abstract partial class Policy<TResult> : ISyncPolicy<TResult>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="context"/> is <see langword="null"/>.</exception>
-    /// <returns>
-    /// The value returned by the action
-    /// </returns>
+    /// <returns>The value returned by the action.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     [DebuggerStepThrough]
     public TResult Execute(Func<Context, TResult> action, Context context) =>
@@ -93,7 +89,7 @@ public abstract partial class Policy<TResult> : ISyncPolicy<TResult>
     #region ExecuteAndCapture overloads
 
     /// <summary>
-    /// Executes the specified action within the policy and returns the captured result
+    /// Executes the specified action within the policy and returns the captured result.
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <returns>The captured result.</returns>
@@ -124,7 +120,7 @@ public abstract partial class Policy<TResult> : ISyncPolicy<TResult>
         ExecuteAndCapture((ctx, _) => action(ctx), context, DefaultCancellationToken);
 
     /// <summary>
-    /// Executes the specified action within the policy and returns the captured result
+    /// Executes the specified action within the policy and returns the captured result.
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="cancellationToken">The cancellation token.</param>

--- a/src/Polly/Policy.TResult.cs
+++ b/src/Polly/Policy.TResult.cs
@@ -2,7 +2,7 @@
 namespace Polly;
 
 /// <summary>
-/// Transient fault handling policies that can be applied to delegates returning results of type <typeparamref name="TResult"/>
+/// Transient fault handling policies that can be applied to delegates returning results of type <typeparamref name="TResult"/>.
 /// </summary>
 public abstract partial class Policy<TResult> : PolicyBase<TResult>
 {

--- a/src/Polly/Policy.cs
+++ b/src/Polly/Policy.cs
@@ -2,7 +2,7 @@
 namespace Polly;
 
 /// <summary>
-/// Transient exception handling policies that can be applied to synchronous delegates
+/// Transient exception handling policies that can be applied to synchronous delegates.
 /// </summary>
 public abstract partial class Policy : PolicyBase
 {

--- a/src/Polly/PolicyResult.cs
+++ b/src/Polly/PolicyResult.cs
@@ -1,7 +1,7 @@
 ﻿namespace Polly;
 
 /// <summary>
-/// The captured result of executing a policy
+/// The captured result of executing a policy.
 /// </summary>
 public class PolicyResult
 {
@@ -14,17 +14,17 @@ public class PolicyResult
     }
 
     /// <summary>
-    ///   The outcome of executing the policy
+    ///   The outcome of executing the policy.
     /// </summary>
     public OutcomeType Outcome { get; }
 
     /// <summary>
-    ///  The final exception captured. Will be null if policy executed successfully
+    ///  The final exception captured. Will be null if policy executed successfully.
     /// </summary>
     public Exception FinalException { get; }
 
     /// <summary>
-    ///  The exception type of the final exception captured. Will be null if policy executed successfully
+    ///  The exception type of the final exception captured. Will be null if policy executed successfully.
     /// </summary>
     public ExceptionType? ExceptionType { get; }
 
@@ -36,7 +36,7 @@ public class PolicyResult
     /// <summary>
     /// Builds a <see cref="PolicyResult" /> representing a successful execution through the policy.
     /// </summary>
-    /// <param name="context">The policy execution context</param>
+    /// <param name="context">The policy execution context.</param>
     /// <returns>
     /// A <see cref="PolicyResult" /> representing a successful execution through the policy.
     /// </returns>
@@ -44,11 +44,11 @@ public class PolicyResult
         new(OutcomeType.Successful, null, null, context);
 
     /// <summary>
-    /// Builds a <see cref="PolicyResult" /> representing a failed execution through the policy. />
+    /// Builds a <see cref="PolicyResult" /> representing a failed execution through the policy.
     /// </summary>
-    /// <param name="exception">The exception</param>
-    /// <param name="exceptionType">The exception type</param>
-    /// <param name="context">The policy execution context</param>
+    /// <param name="exception">The exception.</param>
+    /// <param name="exceptionType">The exception type.</param>
+    /// <param name="context">The policy execution context.</param>
     /// <returns>
     /// A <see cref="PolicyResult" /> representing a failed execution through the policy.
     /// </returns>
@@ -57,7 +57,7 @@ public class PolicyResult
 }
 
 /// <summary>
-/// The captured result of executing a policy
+/// The captured result of executing a policy.
 /// </summary>
 public class PolicyResult<TResult>
 {
@@ -78,7 +78,7 @@ public class PolicyResult<TResult>
     }
 
     /// <summary>
-    ///   The outcome of executing the policy
+    ///   The outcome of executing the policy.
     /// </summary>
     public OutcomeType Outcome { get; }
 
@@ -88,12 +88,12 @@ public class PolicyResult<TResult>
     public Exception FinalException { get; }
 
     /// <summary>
-    ///  The exception type of the final exception captured. Will be null if policy executed successfully
+    ///  The exception type of the final exception captured. Will be null if policy executed successfully.
     /// </summary>
     public ExceptionType? ExceptionType { get; }
 
     /// <summary>
-    /// The result of executing the policy. Will be default(TResult) if the policy failed
+    /// The result of executing the policy. Will be default(TResult) if the policy failed.
     /// </summary>
     public TResult Result { get; }
 
@@ -103,7 +103,7 @@ public class PolicyResult<TResult>
     public TResult FinalHandledResult { get; }
 
     /// <summary>
-    ///  The fault type of the final fault captured. Will be null if policy executed successfully
+    ///  The fault type of the final fault captured. Will be null if policy executed successfully.
     /// </summary>
     public FaultType? FaultType { get; }
 
@@ -115,8 +115,8 @@ public class PolicyResult<TResult>
     /// <summary>
     /// Builds a <see cref="PolicyResult" /> representing a successful execution through the policy.
     /// </summary>
-    /// <param name="result">The result returned by execution through the policy</param>
-    /// <param name="context">The policy execution context</param>
+    /// <param name="result">The result returned by execution through the policy.</param>
+    /// <param name="context">The policy execution context.</param>
     /// <returns>
     /// A <see cref="PolicyResult" /> representing a successful execution through the policy.
     /// </returns>
@@ -126,9 +126,9 @@ public class PolicyResult<TResult>
     /// <summary>
     /// Builds a <see cref="PolicyResult" /> representing a failed execution through the policy.
     /// </summary>
-    /// <param name="exception">The exception</param>
-    /// <param name="exceptionType">The exception type</param>
-    /// <param name="context">The policy execution context</param>
+    /// <param name="exception">The exception.</param>
+    /// <param name="exceptionType">The exception type.</param>
+    /// <param name="context">The policy execution context.</param>
     /// <returns>
     /// A <see cref="PolicyResult" /> representing a failed execution through the policy.
     /// </returns>
@@ -151,8 +151,8 @@ public class PolicyResult<TResult>
     /// <summary>
     /// Builds a <see cref="PolicyResult" /> representing a failed execution through the policy.
     /// </summary>
-    /// <param name="handledResult">The result returned by execution through the policy, which was treated as a handled failure</param>
-    /// <param name="context">The policy execution context</param>
+    /// <param name="handledResult">The result returned by execution through the policy, which was treated as a handled failure.</param>
+    /// <param name="context">The policy execution context.</param>
     /// <returns>
     /// A <see cref="PolicyResult" /> representing a failed execution through the policy.
     /// </returns>
@@ -161,54 +161,54 @@ public class PolicyResult<TResult>
 }
 
 /// <summary>
-/// Represents the outcome of executing a policy
+/// Represents the outcome of executing a policy.
 /// </summary>
 public enum OutcomeType
 {
     /// <summary>
-    /// Indicates that the policy ultimately executed successfully
+    /// Indicates that the policy ultimately executed successfully.
     /// </summary>
     Successful,
 
     /// <summary>
-    /// Indicates that the policy ultimately failed
+    /// Indicates that the policy ultimately failed.
     /// </summary>
     Failure
 }
 
 /// <summary>
-/// Represents the type of exception resulting from a failed policy
+/// Represents the type of exception resulting from a failed policy.
 /// </summary>
 public enum ExceptionType
 {
     /// <summary>
-    /// An exception type that has been defined to be handled by this policy
+    /// An exception type that has been defined to be handled by this policy.
     /// </summary>
     HandledByThisPolicy,
 
     /// <summary>
-    /// An exception type that has been not been defined to be handled by this policy
+    /// An exception type that has been not been defined to be handled by this policy.
     /// </summary>
     Unhandled
 }
 
 /// <summary>
-/// Represents the type of outcome from a failed policy
+/// Represents the type of outcome from a failed policy.
 /// </summary>
 public enum FaultType
 {
     /// <summary>
-    /// An exception type that has been defined to be handled by this policy
+    /// An exception type that has been defined to be handled by this policy.
     /// </summary>
     ExceptionHandledByThisPolicy,
 
     /// <summary>
-    /// An exception type that has been not been defined to be handled by this policy
+    /// An exception type that has been not been defined to be handled by this policy.
     /// </summary>
     UnhandledException,
 
     /// <summary>
-    /// A result value that has been defined to be handled by this policy
+    /// A result value that has been defined to be handled by this policy.
     /// </summary>
     ResultHandledByThisPolicy
 }

--- a/src/Polly/Registry/IConcurrentPolicyRegistry.cs
+++ b/src/Polly/Registry/IConcurrentPolicyRegistry.cs
@@ -33,7 +33,7 @@ public interface IConcurrentPolicyRegistry<TKey> : IPolicyRegistry<TKey>
     /// <summary>
     /// Compares the existing policy for the specified key with a specified policy, and if they are equal, updates the policy with a third value.
     /// </summary>
-    /// <typeparam name="TPolicy"></typeparam>
+    /// <typeparam name="TPolicy">The type of Policy.</typeparam>
     /// <param name="key">The key whose value is compared with comparisonPolicy, and possibly replaced.</param>
     /// <param name="newPolicy">The policy that replaces the value for the specified <paramref name="key"/>, if the comparison results in equality.</param>
     /// <param name="comparisonPolicy">The policy that is compared to the existing policy at the specified key.</param>
@@ -46,8 +46,8 @@ public interface IConcurrentPolicyRegistry<TKey> : IPolicyRegistry<TKey>
     /// if the key does not already exist.
     /// </summary>
     /// <param name="key">The key of the policy to add.</param>
-    /// <param name="policyFactory">The function used to generate a policy for the key</param>
-    /// <returns>The policy for the key.  This will be either the existing policy for the key if the
+    /// <param name="policyFactory">The function used to generate a policy for the key.</param>
+    /// <returns>The policy for the key. This will be either the existing policy for the key if the
     /// key is already in the registry, or the new policy for the key as returned by policyFactory
     /// if the key was not in the registry.</returns>
     TPolicy GetOrAdd<TPolicy>(TKey key, Func<TKey, TPolicy> policyFactory)
@@ -58,8 +58,8 @@ public interface IConcurrentPolicyRegistry<TKey> : IPolicyRegistry<TKey>
     /// if the key does not already exist.
     /// </summary>
     /// <param name="key">The key of the policy to add.</param>
-    /// <param name="policy">the value to be added, if the key does not already exist</param>
-    /// <returns>The policy for the key.  This will be either the existing policy for the key if the
+    /// <param name="policy">The value to be added, if the key does not already exist.</param>
+    /// <returns>The policy for the key. This will be either the existing policy for the key if the
     /// key is already in the registry, or the new policy if the key was not in the registry.</returns>
     TPolicy GetOrAdd<TPolicy>(TKey key, TPolicy policy)
         where TPolicy : IsPolicy;
@@ -69,11 +69,11 @@ public interface IConcurrentPolicyRegistry<TKey> : IPolicyRegistry<TKey>
     /// exist, or updates a key/policy pair in the registry if the key
     /// already exists.
     /// </summary>
-    /// <param name="key">The key to be added or whose policy should be updated</param>
-    /// <param name="addPolicyFactory">The function used to generate a policy for an absent key</param>
+    /// <param name="key">The key to be added or whose policy should be updated.</param>
+    /// <param name="addPolicyFactory">The function used to generate a policy for an absent key.</param>
     /// <param name="updatePolicyFactory">The function used to generate a new policy for an existing key
-    /// based on the key's existing value</param>
-    /// <returns>The new policy for the key.  This will be either be the result of addPolicyFactory (if the key was
+    /// based on the key's existing value.</param>
+    /// <returns>The new policy for the key. This will be either be the result of addPolicyFactory (if the key was
     /// absent) or the result of updatePolicyFactory (if the key was present).</returns>
     TPolicy AddOrUpdate<TPolicy>(TKey key, Func<TKey, TPolicy> addPolicyFactory, Func<TKey, TPolicy, TPolicy> updatePolicyFactory)
         where TPolicy : IsPolicy;
@@ -83,11 +83,11 @@ public interface IConcurrentPolicyRegistry<TKey> : IPolicyRegistry<TKey>
     /// exist, or updates a key/policy pair in the registry if the key
     /// already exists.
     /// </summary>
-    /// <param name="key">The key to be added or whose policy should be updated</param>
-    /// <param name="addPolicy">The policy to be added for an absent key</param>
+    /// <param name="key">The key to be added or whose policy should be updated.</param>
+    /// <param name="addPolicy">The policy to be added for an absent key.</param>
     /// <param name="updatePolicyFactory">The function used to generate a new policy for an existing key based on
-    /// the key's existing value</param>
-    /// <returns>The new policy for the key.  This will be either be addPolicy (if the key was
+    /// the key's existing value.</param>
+    /// <returns>The new policy for the key. This will be either be addPolicy (if the key was
     /// absent) or the result of updatePolicyFactory (if the key was present).</returns>
     TPolicy AddOrUpdate<TPolicy>(TKey key, TPolicy addPolicy, Func<TKey, TPolicy, TPolicy> updatePolicyFactory)
         where TPolicy : IsPolicy;

--- a/src/Polly/Registry/IPolicyRegistry.cs
+++ b/src/Polly/Registry/IPolicyRegistry.cs
@@ -22,7 +22,7 @@ public interface IPolicyRegistry<TKey> : IReadOnlyPolicyRegistry<TKey>
     /// <remarks>To retrieve a policy directly as a particular Policy type or Policy interface (avoiding a cast), use the <see cref="IReadOnlyPolicyRegistry{TKey}.Get{TPolicy}"/> method.</remarks>
     /// </summary>
     /// <param name="key">The key of the value to get or set.</param>
-    /// <exception cref="T:System.ArgumentNullException"><paramref name="key" /> is null.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="key"/> is <see langword="null"/>.</exception>
     /// <exception cref="KeyNotFoundException">The given key was not present in the dictionary.</exception>
     /// <returns>The value associated with the specified key.</returns>
     new IsPolicy this[TKey key] { get; set; }

--- a/src/Polly/Registry/IPolicyRegistry.cs
+++ b/src/Polly/Registry/IPolicyRegistry.cs
@@ -12,7 +12,7 @@ public interface IPolicyRegistry<TKey> : IReadOnlyPolicyRegistry<TKey>
     /// <param name="key">The key for the policy.</param>
     /// <param name="policy">The policy to store in the registry.</param>
     /// <typeparam name="TPolicy">The type of Policy.</typeparam>
-    /// <exception cref="ArgumentNullException"><paramref name="key"/> is null.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">A Policy with same <paramref name="key"/> already exists.</exception>
     void Add<TPolicy>(TKey key, TPolicy policy)
         where TPolicy : IsPolicy;
@@ -32,7 +32,7 @@ public interface IPolicyRegistry<TKey> : IReadOnlyPolicyRegistry<TKey>
     /// </summary>
     /// <param name="key">The key of the policy to remove.</param>
     /// <returns>True if the policy is successfully removed. Otherwise false.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="key"/> is null.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
     bool Remove(TKey key);
 
     /// <summary>

--- a/src/Polly/Registry/IPolicyRegistry.cs
+++ b/src/Polly/Registry/IPolicyRegistry.cs
@@ -12,7 +12,7 @@ public interface IPolicyRegistry<TKey> : IReadOnlyPolicyRegistry<TKey>
     /// <param name="key">The key for the policy.</param>
     /// <param name="policy">The policy to store in the registry.</param>
     /// <typeparam name="TPolicy">The type of Policy.</typeparam>
-    /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="key"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">A Policy with same <paramref name="key"/> already exists.</exception>
     void Add<TPolicy>(TKey key, TPolicy policy)
         where TPolicy : IsPolicy;
@@ -32,7 +32,7 @@ public interface IPolicyRegistry<TKey> : IReadOnlyPolicyRegistry<TKey>
     /// </summary>
     /// <param name="key">The key of the policy to remove.</param>
     /// <returns>True if the policy is successfully removed. Otherwise false.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="key"/> is <see langword="null"/>.</exception>
     bool Remove(TKey key);
 
     /// <summary>

--- a/src/Polly/Registry/IReadOnlyPolicyRegistry.cs
+++ b/src/Polly/Registry/IReadOnlyPolicyRegistry.cs
@@ -11,7 +11,7 @@ public interface IReadOnlyPolicyRegistry<TKey> : IEnumerable<KeyValuePair<TKey, 
     /// <remarks>To retrieve a policy directly as a particular Policy type or Policy interface (avoiding a cast), use the <see cref="Get{TPolicy}"/> method.</remarks>
     /// </summary>
     /// <param name="key">The key of the value to get or set.</param>
-    /// <exception cref="T:System.ArgumentNullException"><paramref name="key" /> is null.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="key"/> is <see langword="null"/>.</exception>
     /// <exception cref="KeyNotFoundException">The given key was not present in the dictionary.</exception>
     /// <returns>The value associated with the specified key.</returns>
     IsPolicy this[TKey key] { get; }

--- a/src/Polly/Registry/IReadOnlyPolicyRegistry.cs
+++ b/src/Polly/Registry/IReadOnlyPolicyRegistry.cs
@@ -49,6 +49,6 @@ public interface IReadOnlyPolicyRegistry<TKey> : IEnumerable<KeyValuePair<TKey, 
     /// </summary>
     /// <param name="key">The Key to locate in the registry</param>
     /// <returns>True if <paramref name="key"/> exists otherwise false</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="key"/> is null</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="key"/> is <see langword="null"/>.</exception>
     bool ContainsKey(TKey key);
 }

--- a/src/Polly/Registry/IReadOnlyPolicyRegistry.cs
+++ b/src/Polly/Registry/IReadOnlyPolicyRegistry.cs
@@ -19,6 +19,7 @@ public interface IReadOnlyPolicyRegistry<TKey> : IEnumerable<KeyValuePair<TKey, 
     /// <summary>
     /// Gets the policy stored under the provided key, casting to <typeparamref name="TPolicy"/>.
     /// </summary>
+    /// <param name="key">The key of the policy to get.</param>
     /// <typeparam name="TPolicy">The type of Policy.</typeparam>
     /// <returns>The policy stored in the registry under the given key.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="key"/> is <see langword="null"/>.</exception>
@@ -47,8 +48,8 @@ public interface IReadOnlyPolicyRegistry<TKey> : IEnumerable<KeyValuePair<TKey, 
     /// <summary>
     /// Determines whether the specified <paramref name="key"/> exists.
     /// </summary>
-    /// <param name="key">The Key to locate in the registry</param>
-    /// <returns>True if <paramref name="key"/> exists otherwise false</returns>
+    /// <param name="key">The Key to locate in the registry.</param>
+    /// <returns>True if <paramref name="key"/> exists otherwise false.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="key"/> is <see langword="null"/>.</exception>
     bool ContainsKey(TKey key);
 }

--- a/src/Polly/Registry/IReadOnlyPolicyRegistry.cs
+++ b/src/Polly/Registry/IReadOnlyPolicyRegistry.cs
@@ -21,7 +21,7 @@ public interface IReadOnlyPolicyRegistry<TKey> : IEnumerable<KeyValuePair<TKey, 
     /// </summary>
     /// <typeparam name="TPolicy">The type of Policy.</typeparam>
     /// <returns>The policy stored in the registry under the given key.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="key"/> is null.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
     TPolicy Get<TPolicy>(TKey key)
         where TPolicy : IsPolicy;
 

--- a/src/Polly/Registry/IReadOnlyPolicyRegistry.cs
+++ b/src/Polly/Registry/IReadOnlyPolicyRegistry.cs
@@ -21,7 +21,7 @@ public interface IReadOnlyPolicyRegistry<TKey> : IEnumerable<KeyValuePair<TKey, 
     /// </summary>
     /// <typeparam name="TPolicy">The type of Policy.</typeparam>
     /// <returns>The policy stored in the registry under the given key.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="key"/> is <see langword="null"/>.</exception>
     TPolicy Get<TPolicy>(TKey key)
         where TPolicy : IsPolicy;
 

--- a/src/Polly/Registry/PolicyRegistry.cs
+++ b/src/Polly/Registry/PolicyRegistry.cs
@@ -49,7 +49,7 @@ public class PolicyRegistry : IConcurrentPolicyRegistry<string>
     /// <param name="key">The key for the policy.</param>
     /// <param name="policy">The policy to store in the registry.</param>
     /// <typeparam name="TPolicy">The type of Policy.</typeparam>
-    /// <exception cref="ArgumentNullException"><paramref name="key"/> is null.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">A Policy with same <paramref name="key"/> already exists.</exception>
     public void Add<TPolicy>(string key, TPolicy policy)
         where TPolicy : IsPolicy => _registry.Add(key, policy);
@@ -89,7 +89,7 @@ public class PolicyRegistry : IConcurrentPolicyRegistry<string>
     /// <typeparam name="TPolicy">The type of Policy.</typeparam>
     /// <param name="key">The key of the policy to get.</param>
     /// <returns>The policy stored in the registry under the given key.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="key"/> is null.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
     /// <exception cref="KeyNotFoundException">The given key was not present in the registry.</exception>
     public TPolicy Get<TPolicy>(string key)
         where TPolicy : IsPolicy => (TPolicy)_registry[key];
@@ -124,7 +124,7 @@ public class PolicyRegistry : IConcurrentPolicyRegistry<string>
     /// </summary>
     /// <param name="key">The key to locate in the registry.</param>
     /// <returns>True if <paramref name="key"/> exists otherwise false.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="key"/> is null.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
     public bool ContainsKey(string key) =>
         _registry.ContainsKey(key);
 
@@ -133,7 +133,7 @@ public class PolicyRegistry : IConcurrentPolicyRegistry<string>
     /// </summary>
     /// <param name="key">The <paramref name="key"/> of the policy to remove.</param>
     /// <returns>True if the policy is successfully removed. Otherwise false.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="key"/> is null.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
     public bool Remove(string key) =>
         _registry.Remove(key);
 

--- a/src/Polly/Registry/PolicyRegistry.cs
+++ b/src/Polly/Registry/PolicyRegistry.cs
@@ -74,7 +74,7 @@ public class PolicyRegistry : IConcurrentPolicyRegistry<string>
     /// <remarks>To retrieve a policy directly as a particular Policy type or Policy interface (avoiding a cast), use the <see cref="Get{TPolicy}"/> method.</remarks>
     /// </summary>
     /// <param name="key">The key of the policy to get or set.</param>
-    /// <exception cref="T:System.ArgumentNullException"><paramref name="key" /> is null.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="key"/> is <see langword="null"/>.</exception>
     /// <exception cref="KeyNotFoundException">The given key was not present in the registry.</exception>
     /// <returns>The policy associated with the specified key.</returns>
     public IsPolicy this[string key]

--- a/src/Polly/Registry/PolicyRegistry.cs
+++ b/src/Polly/Registry/PolicyRegistry.cs
@@ -49,7 +49,7 @@ public class PolicyRegistry : IConcurrentPolicyRegistry<string>
     /// <param name="key">The key for the policy.</param>
     /// <param name="policy">The policy to store in the registry.</param>
     /// <typeparam name="TPolicy">The type of Policy.</typeparam>
-    /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="key"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">A Policy with same <paramref name="key"/> already exists.</exception>
     public void Add<TPolicy>(string key, TPolicy policy)
         where TPolicy : IsPolicy => _registry.Add(key, policy);

--- a/src/Polly/Registry/PolicyRegistry.cs
+++ b/src/Polly/Registry/PolicyRegistry.cs
@@ -182,7 +182,7 @@ public class PolicyRegistry : IConcurrentPolicyRegistry<string>
     /// if the key does not already exist.
     /// </summary>
     /// <param name="key">The key of the policy to add.</param>
-    /// <param name="policyFactory">The function used to generate a policy for the key</param>
+    /// <param name="policyFactory">The function used to generate a policy for the key.</param>
     /// <returns>The policy for the key.  This will be either the existing policy for the key if the
     /// key is already in the registry, or the new policy for the key as returned by policyFactory
     /// if the key was not in the registry.</returns>
@@ -199,7 +199,7 @@ public class PolicyRegistry : IConcurrentPolicyRegistry<string>
     /// if the key does not already exist.
     /// </summary>
     /// <param name="key">The key of the policy to add.</param>
-    /// <param name="policy">the policy to be added, if the key does not already exist</param>
+    /// <param name="policy">the policy to be added, if the key does not already exist.</param>
     /// <returns>The policy for the key.  This will be either the existing policy for the key if the
     /// key is already in the registry, or the new policy if the key was not in the registry.</returns>
     public TPolicy GetOrAdd<TPolicy>(string key, TPolicy policy)
@@ -215,10 +215,10 @@ public class PolicyRegistry : IConcurrentPolicyRegistry<string>
     /// exist, or updates a key/policy pair in the registry if the key
     /// already exists.
     /// </summary>
-    /// <param name="key">The key to be added or whose policy should be updated</param>
-    /// <param name="addPolicyFactory">The function used to generate a policy for an absent key</param>
+    /// <param name="key">The key to be added or whose policy should be updated.</param>
+    /// <param name="addPolicyFactory">The function used to generate a policy for an absent key.</param>
     /// <param name="updatePolicyFactory">The function used to generate a new policy for an existing key
-    /// based on the key's existing value</param>
+    /// based on the key's existing value.</param>
     /// <returns>The new policy for the key.  This will be either be the result of addPolicyFactory (if the key was
     /// absent) or the result of updatePolicyFactory (if the key was present).</returns>
     public TPolicy AddOrUpdate<TPolicy>(string key, Func<string, TPolicy> addPolicyFactory, Func<string, TPolicy, TPolicy> updatePolicyFactory)
@@ -234,10 +234,10 @@ public class PolicyRegistry : IConcurrentPolicyRegistry<string>
     /// exist, or updates a key/policy pair in the registry if the key
     /// already exists.
     /// </summary>
-    /// <param name="key">The key to be added or whose policy should be updated</param>
-    /// <param name="addPolicy">The policy to be added for an absent key</param>
+    /// <param name="key">The key to be added or whose policy should be updated.</param>
+    /// <param name="addPolicy">The policy to be added for an absent key.</param>
     /// <param name="updatePolicyFactory">The function used to generate a new policy for an existing key based on
-    /// the key's existing value</param>
+    /// the key's existing value.</param>
     /// <returns>The new policy for the key.  This will be either be addPolicy (if the key was
     /// absent) or the result of updatePolicyFactory (if the key was present).</returns>
     public TPolicy AddOrUpdate<TPolicy>(string key, TPolicy addPolicy, Func<string, TPolicy, TPolicy> updatePolicyFactory)

--- a/src/Polly/Retry/AsyncRetrySyntax.cs
+++ b/src/Polly/Retry/AsyncRetrySyntax.cs
@@ -339,11 +339,7 @@ public static class AsyncRetrySyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurationProvider
-    ///     or
-    ///     onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan> onRetry)
     {
         if (onRetry == null)
@@ -369,11 +365,7 @@ public static class AsyncRetrySyntax
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurationProvider
-    ///     or
-    ///     onRetryAsync
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, Task> onRetryAsync)
     {
         if (onRetryAsync == null)
@@ -399,11 +391,7 @@ public static class AsyncRetrySyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurationProvider
-    ///     or
-    ///     onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
         Func<int, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, Context> onRetry)
     {
@@ -430,11 +418,7 @@ public static class AsyncRetrySyntax
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurationProvider
-    ///     or
-    ///     onRetryAsync
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
         Func<int, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, Context, Task> onRetryAsync)
     {
@@ -459,11 +443,7 @@ public static class AsyncRetrySyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurationProvider
-    ///     or
-    ///     onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, int, Context> onRetry)
     {
         if (onRetry == null)
@@ -489,11 +469,7 @@ public static class AsyncRetrySyntax
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurationProvider
-    ///     or
-    ///     onRetryAsync
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
         Func<int, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, int, Context, Task> onRetryAsync)
     {
@@ -526,11 +502,7 @@ public static class AsyncRetrySyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurationProvider
-    ///     or
-    ///     onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
         Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, Context> onRetry)
     {
@@ -557,11 +529,7 @@ public static class AsyncRetrySyntax
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurationProvider
-    ///     or
-    ///     onRetryAsync
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
         Func<int, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, Context, Task> onRetryAsync)
     {
@@ -586,11 +554,7 @@ public static class AsyncRetrySyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurationProvider
-    ///     or
-    ///     onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, int, Context> onRetry)
     {
         if (onRetry == null)
@@ -616,11 +580,7 @@ public static class AsyncRetrySyntax
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurationProvider
-    ///     or
-    ///     onRetryAsync
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
         Func<int, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, int, Context, Task> onRetryAsync)
     {
@@ -644,11 +604,7 @@ public static class AsyncRetrySyntax
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurationProvider
-    ///     or
-    ///     onRetryAsync
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, int retryCount,
         Func<int, Exception, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, int, Context, Task> onRetryAsync)
     {
@@ -691,11 +647,7 @@ public static class AsyncRetrySyntax
     /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurations
-    ///     or
-    ///     onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurations"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, IEnumerable<TimeSpan> sleepDurations, Action<Exception, TimeSpan> onRetry)
     {
         if (onRetry == null)
@@ -718,11 +670,7 @@ public static class AsyncRetrySyntax
     /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurations
-    ///     or
-    ///     onRetryAsync
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurations"/> or <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, IEnumerable<TimeSpan> sleepDurations, Func<Exception, TimeSpan, Task> onRetryAsync)
     {
         if (onRetryAsync == null)
@@ -743,11 +691,7 @@ public static class AsyncRetrySyntax
     /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurations
-    ///     or
-    ///     onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurations"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, IEnumerable<TimeSpan> sleepDurations, Action<Exception, TimeSpan, Context> onRetry)
     {
         if (onRetry == null)
@@ -770,11 +714,7 @@ public static class AsyncRetrySyntax
     /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurations
-    ///     or
-    ///     onRetryAsync
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurations"/> or <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, IEnumerable<TimeSpan> sleepDurations, Func<Exception, TimeSpan, Context, Task> onRetryAsync)
     {
         if (onRetryAsync == null)
@@ -795,11 +735,7 @@ public static class AsyncRetrySyntax
     /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurations
-    ///     or
-    ///     onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurations"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, IEnumerable<TimeSpan> sleepDurations, Action<Exception, TimeSpan, int, Context> onRetry)
     {
         if (onRetry == null)
@@ -822,11 +758,7 @@ public static class AsyncRetrySyntax
     /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurations
-    ///     or
-    ///     onRetryAsync
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurations"/> or <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy WaitAndRetryAsync(this PolicyBuilder policyBuilder, IEnumerable<TimeSpan> sleepDurations, Func<Exception, TimeSpan, int, Context, Task> onRetryAsync)
     {
         if (sleepDurations == null)

--- a/src/Polly/Retry/AsyncRetrySyntax.cs
+++ b/src/Polly/Retry/AsyncRetrySyntax.cs
@@ -33,7 +33,7 @@ public static class AsyncRetrySyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy RetryAsync(this PolicyBuilder policyBuilder, Action<Exception, int> onRetry) =>
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
         policyBuilder.RetryAsync(1,
@@ -47,7 +47,7 @@ public static class AsyncRetrySyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy RetryAsync(this PolicyBuilder policyBuilder, Func<Exception, int, Task> onRetryAsync) =>
         policyBuilder.RetryAsync(1, onRetryAsync: (outcome, i, _) => onRetryAsync(outcome, i));
 
@@ -60,7 +60,7 @@ public static class AsyncRetrySyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy RetryAsync(this PolicyBuilder policyBuilder, int retryCount, Action<Exception, int> onRetry)
     {
         if (onRetry == null)
@@ -80,7 +80,7 @@ public static class AsyncRetrySyntax
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">onRetryAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy RetryAsync(this PolicyBuilder policyBuilder, int retryCount, Func<Exception, int, Task> onRetryAsync)
     {
         if (onRetryAsync == null)
@@ -96,7 +96,7 @@ public static class AsyncRetrySyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy RetryAsync(this PolicyBuilder policyBuilder, Action<Exception, int, Context> onRetry) =>
         policyBuilder.RetryAsync(1, onRetry);
 
@@ -107,7 +107,7 @@ public static class AsyncRetrySyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy RetryAsync(this PolicyBuilder policyBuilder, Func<Exception, int, Context, Task> onRetryAsync) =>
         policyBuilder.RetryAsync(1, onRetryAsync);
 
@@ -120,7 +120,7 @@ public static class AsyncRetrySyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy RetryAsync(this PolicyBuilder policyBuilder, int retryCount, Action<Exception, int, Context> onRetry)
     {
         if (onRetry == null)
@@ -141,7 +141,7 @@ public static class AsyncRetrySyntax
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onRetryAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy RetryAsync(this PolicyBuilder policyBuilder, int retryCount, Func<Exception, int, Context, Task> onRetryAsync)
     {
         if (retryCount < 0)
@@ -174,7 +174,7 @@ public static class AsyncRetrySyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy RetryForeverAsync(this PolicyBuilder policyBuilder, Action<Exception> onRetry)
     {
         if (onRetry == null)
@@ -193,7 +193,7 @@ public static class AsyncRetrySyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy RetryForeverAsync(this PolicyBuilder policyBuilder, Action<Exception, int> onRetry)
     {
         if (onRetry == null)
@@ -212,7 +212,7 @@ public static class AsyncRetrySyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetryAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy RetryForeverAsync(this PolicyBuilder policyBuilder, Func<Exception, Task> onRetryAsync)
     {
         if (onRetryAsync == null)
@@ -228,7 +228,7 @@ public static class AsyncRetrySyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetryAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy RetryForeverAsync(this PolicyBuilder policyBuilder, Func<Exception, int, Task> onRetryAsync)
     {
         if (onRetryAsync == null)
@@ -244,7 +244,7 @@ public static class AsyncRetrySyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy RetryForeverAsync(this PolicyBuilder policyBuilder, Action<Exception, Context> onRetry)
     {
         if (onRetry == null)
@@ -263,7 +263,7 @@ public static class AsyncRetrySyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy RetryForeverAsync(this PolicyBuilder policyBuilder, Action<Exception, int, Context> onRetry)
     {
         if (onRetry == null)
@@ -282,7 +282,7 @@ public static class AsyncRetrySyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetryAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy RetryForeverAsync(this PolicyBuilder policyBuilder, Func<Exception, Context, Task> onRetryAsync)
     {
         if (onRetryAsync == null)
@@ -300,7 +300,7 @@ public static class AsyncRetrySyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetryAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy RetryForeverAsync(this PolicyBuilder policyBuilder, Func<Exception, int, Context, Task> onRetryAsync)
     {
         if (onRetryAsync == null)
@@ -848,7 +848,7 @@ public static class AsyncRetrySyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, TimeSpan> sleepDurationProvider)
     {
         if (sleepDurationProvider == null)
@@ -867,7 +867,7 @@ public static class AsyncRetrySyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider)
     {
         if (sleepDurationProvider == null)
@@ -888,8 +888,8 @@ public static class AsyncRetrySyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan> onRetry)
     {
         if (sleepDurationProvider == null)
@@ -912,8 +912,8 @@ public static class AsyncRetrySyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, int, TimeSpan> onRetry)
     {
         if (sleepDurationProvider == null)
@@ -936,8 +936,8 @@ public static class AsyncRetrySyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetryAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, Task> onRetryAsync)
     {
         if (sleepDurationProvider == null)
@@ -960,8 +960,8 @@ public static class AsyncRetrySyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetryAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Func<Exception, int, TimeSpan, Task> onRetryAsync)
     {
         if (sleepDurationProvider == null)
@@ -984,8 +984,8 @@ public static class AsyncRetrySyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, Context> onRetry)
     {
         if (sleepDurationProvider == null)
@@ -1010,8 +1010,8 @@ public static class AsyncRetrySyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, int, TimeSpan, Context> onRetry)
     {
         if (sleepDurationProvider == null)
@@ -1036,8 +1036,8 @@ public static class AsyncRetrySyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetryAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, Context, Task> onRetryAsync)
     {
         if (sleepDurationProvider == null)
@@ -1058,8 +1058,8 @@ public static class AsyncRetrySyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetryAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Func<Exception, int, TimeSpan, Context, Task> onRetryAsync)
     {
         if (sleepDurationProvider == null)
@@ -1080,8 +1080,8 @@ public static class AsyncRetrySyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetryAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, Exception, Context, TimeSpan> sleepDurationProvider, Func<Exception, TimeSpan, Context, Task> onRetryAsync)
     {
         if (sleepDurationProvider == null)
@@ -1105,8 +1105,8 @@ public static class AsyncRetrySyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetryAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy WaitAndRetryForeverAsync(this PolicyBuilder policyBuilder, Func<int, Exception, Context, TimeSpan> sleepDurationProvider, Func<Exception, int, TimeSpan, Context, Task> onRetryAsync)
     {
         if (sleepDurationProvider == null)

--- a/src/Polly/Retry/AsyncRetrySyntax.cs
+++ b/src/Polly/Retry/AsyncRetrySyntax.cs
@@ -775,7 +775,7 @@ public static class AsyncRetrySyntax
     /// <summary>
     /// Builds an <see cref="AsyncRetryPolicy"/> that will wait and retry indefinitely until the action succeeds.
     ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-    ///     the current retry number (1 for first retry, 2 for second etc)
+    ///     the current retry number (1 for first retry, 2 for second etc).
     /// </summary>
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
@@ -814,7 +814,7 @@ public static class AsyncRetrySyntax
     /// Builds an <see cref="AsyncRetryPolicy"/> that will wait and retry indefinitely
     /// calling <paramref name="onRetry"/> on each retry with the raised exception.
     ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-    ///     the current retry number (1 for first retry, 2 for second etc)
+    ///     the current retry number (1 for first retry, 2 for second etc).
     /// </summary>
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
@@ -838,7 +838,7 @@ public static class AsyncRetrySyntax
     /// Builds an <see cref="AsyncRetryPolicy"/> that will wait and retry indefinitely
     /// calling <paramref name="onRetry"/> on each retry with the raised exception and retry count.
     ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-    ///     the current retry number (1 for first retry, 2 for second etc)
+    ///     the current retry number (1 for first retry, 2 for second etc).
     /// </summary>
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
@@ -862,7 +862,7 @@ public static class AsyncRetrySyntax
     /// Builds an <see cref="AsyncRetryPolicy"/> that will wait and retry indefinitely
     /// calling <paramref name="onRetryAsync"/> on each retry with the raised exception.
     ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-    ///     the current retry number (1 for first retry, 2 for second etc)
+    ///     the current retry number (1 for first retry, 2 for second etc).
     /// </summary>
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
@@ -886,7 +886,7 @@ public static class AsyncRetrySyntax
     /// Builds an <see cref="AsyncRetryPolicy"/> that will wait and retry indefinitely
     /// calling <paramref name="onRetryAsync"/> on each retry with the raised exception and retry count.
     ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-    ///     the current retry number (1 for first retry, 2 for second etc)
+    ///     the current retry number (1 for first retry, 2 for second etc).
     /// </summary>
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>

--- a/src/Polly/Retry/AsyncRetryTResultSyntax.cs
+++ b/src/Polly/Retry/AsyncRetryTResultSyntax.cs
@@ -339,11 +339,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurationProvider
-    ///     or
-    ///     onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
         Func<int, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan> onRetry)
     {
@@ -370,11 +366,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurationProvider
-    ///     or
-    ///     onRetryAsync
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, Task> onRetryAsync)
     {
         if (onRetryAsync == null)
@@ -400,11 +392,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurationProvider
-    ///     or
-    ///     onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
         Func<int, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
     {
@@ -431,11 +419,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurationProvider
-    ///     or
-    ///     onRetryAsync
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, Context, Task> onRetryAsync)
     {
         if (onRetryAsync == null)
@@ -459,11 +443,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurationProvider
-    ///     or
-    ///     onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
     {
         if (onRetry == null)
@@ -489,11 +469,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurationProvider
-    ///     or
-    ///     onRetryAsync
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
         Func<int, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync)
     {
@@ -526,11 +502,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurationProvider
-    ///     or
-    ///     onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
         Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
     {
@@ -557,11 +529,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurationProvider
-    ///     or
-    ///     onRetryAsync
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, Context, Task> onRetryAsync)
     {
         if (onRetryAsync == null)
@@ -585,11 +553,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurationProvider
-    ///     or
-    ///     onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
     {
         if (onRetry == null)
@@ -615,11 +579,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurationProvider
-    ///     or
-    ///     onRetryAsync
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
         Func<int, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync)
     {
@@ -644,11 +604,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurationProvider
-    ///     or
-    ///     onRetryAsync
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
         Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync)
     {
@@ -691,11 +647,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurations
-    ///     or
-    ///     onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurations"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, IEnumerable<TimeSpan> sleepDurations, Action<DelegateResult<TResult>, TimeSpan> onRetry)
     {
         if (onRetry == null)
@@ -718,11 +670,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurations
-    ///     or
-    ///     onRetryAsync
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurations"/> or <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, IEnumerable<TimeSpan> sleepDurations, Func<DelegateResult<TResult>, TimeSpan, Task> onRetryAsync)
     {
         if (onRetryAsync == null)
@@ -743,11 +691,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurations
-    ///     or
-    ///     onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurations"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, IEnumerable<TimeSpan> sleepDurations, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
     {
         if (onRetry == null)
@@ -770,11 +714,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurations
-    ///     or
-    ///     onRetryAsync
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurations"/> or <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, IEnumerable<TimeSpan> sleepDurations, Func<DelegateResult<TResult>, TimeSpan, Context, Task> onRetryAsync)
     {
         if (onRetryAsync == null)
@@ -795,11 +735,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurations
-    ///     or
-    ///     onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurations"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, IEnumerable<TimeSpan> sleepDurations, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
     {
         if (onRetry == null)
@@ -822,11 +758,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">
-    ///     sleepDurations
-    ///     or
-    ///     onRetryAsync
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurations"/> or <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, IEnumerable<TimeSpan> sleepDurations, Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync)
     {
         if (sleepDurations == null)

--- a/src/Polly/Retry/AsyncRetryTResultSyntax.cs
+++ b/src/Polly/Retry/AsyncRetryTResultSyntax.cs
@@ -33,7 +33,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> RetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>, int> onRetry) =>
 #pragma warning disable 1998 // async method has no awaits, will run synchronously
         policyBuilder.RetryAsync(1, onRetryAsync: async (outcome, i, _) => onRetry(outcome, i));
@@ -46,7 +46,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> RetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<DelegateResult<TResult>, int, Task> onRetryAsync) =>
         policyBuilder.RetryAsync(1, onRetryAsync: (outcome, i, _) => onRetryAsync(outcome, i));
 
@@ -59,7 +59,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> RetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Action<DelegateResult<TResult>, int> onRetry)
     {
         if (onRetry == null)
@@ -80,7 +80,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">onRetryAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> RetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<DelegateResult<TResult>, int, Task> onRetryAsync)
     {
         if (onRetryAsync == null)
@@ -96,7 +96,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> RetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>, int, Context> onRetry) =>
         policyBuilder.RetryAsync(1, onRetry);
 
@@ -107,7 +107,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> RetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<DelegateResult<TResult>, int, Context, Task> onRetryAsync) =>
         policyBuilder.RetryAsync(1, onRetryAsync);
 
@@ -120,7 +120,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> RetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Action<DelegateResult<TResult>, int, Context> onRetry)
     {
         if (onRetry == null)
@@ -141,7 +141,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onRetryAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> RetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<DelegateResult<TResult>, int, Context, Task> onRetryAsync)
     {
         if (retryCount < 0)
@@ -174,7 +174,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> RetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>> onRetry)
     {
         if (onRetry == null)
@@ -193,7 +193,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> RetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>, int> onRetry)
     {
         if (onRetry == null)
@@ -212,7 +212,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetryAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> RetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<DelegateResult<TResult>, Task> onRetryAsync)
     {
         if (onRetryAsync == null)
@@ -228,7 +228,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetryAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> RetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<DelegateResult<TResult>, int, Task> onRetryAsync)
     {
         if (onRetryAsync == null)
@@ -244,7 +244,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> RetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>, Context> onRetry)
     {
         if (onRetry == null)
@@ -263,7 +263,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> RetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>, int, Context> onRetry)
     {
         if (onRetry == null)
@@ -282,7 +282,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetryAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> RetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<DelegateResult<TResult>, Context, Task> onRetryAsync)
     {
         if (onRetryAsync == null)
@@ -300,7 +300,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetryAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> RetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<DelegateResult<TResult>, int, Context, Task> onRetryAsync)
     {
         if (onRetryAsync == null)
@@ -848,7 +848,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, TimeSpan> sleepDurationProvider)
     {
         if (sleepDurationProvider == null)
@@ -867,7 +867,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider)
     {
         if (sleepDurationProvider == null)
@@ -888,8 +888,8 @@ public static class AsyncRetryTResultSyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan> onRetry)
     {
         if (sleepDurationProvider == null)
@@ -912,8 +912,8 @@ public static class AsyncRetryTResultSyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, int, TimeSpan> onRetry)
     {
         if (sleepDurationProvider == null)
@@ -936,8 +936,8 @@ public static class AsyncRetryTResultSyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetryAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, Task> onRetryAsync)
     {
         if (sleepDurationProvider == null)
@@ -960,8 +960,8 @@ public static class AsyncRetryTResultSyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetryAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, int, TimeSpan, Task> onRetryAsync)
     {
         if (sleepDurationProvider == null)
@@ -984,8 +984,8 @@ public static class AsyncRetryTResultSyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
     {
         if (onRetry == null)
@@ -1008,8 +1008,8 @@ public static class AsyncRetryTResultSyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, int, TimeSpan, Context> onRetry)
     {
         if (onRetry == null)
@@ -1032,8 +1032,8 @@ public static class AsyncRetryTResultSyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetryAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, Context, Task> onRetryAsync)
     {
         if (sleepDurationProvider == null)
@@ -1054,8 +1054,8 @@ public static class AsyncRetryTResultSyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetryAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, int, TimeSpan, Context, Task> onRetryAsync)
     {
         if (sleepDurationProvider == null)
@@ -1076,8 +1076,8 @@ public static class AsyncRetryTResultSyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetryAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, Context, Task> onRetryAsync)
     {
         if (sleepDurationProvider == null)
@@ -1101,8 +1101,8 @@ public static class AsyncRetryTResultSyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetryAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, int, TimeSpan, Context, Task> onRetryAsync)
     {
         if (sleepDurationProvider == null)

--- a/src/Polly/Retry/AsyncRetryTResultSyntax.cs
+++ b/src/Polly/Retry/AsyncRetryTResultSyntax.cs
@@ -331,7 +331,7 @@ public static class AsyncRetryTResultSyntax
     ///     Builds an <see cref="AsyncRetryPolicy{TResult}" /> that will wait and retry <paramref name="retryCount" /> times
     ///     calling <paramref name="onRetry" /> on each retry with the handled exception or result and the current sleep duration.
     ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-    ///     the current retry number (1 for first retry, 2 for second etc)
+    ///     the current retry number (1 for first retry, 2 for second etc).
     /// </summary>
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="retryCount">The retry count.</param>

--- a/src/Polly/Retry/RetrySyntax.cs
+++ b/src/Polly/Retry/RetrySyntax.cs
@@ -33,7 +33,7 @@ public static class RetrySyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy Retry(this PolicyBuilder policyBuilder, Action<Exception, int> onRetry) =>
         policyBuilder.Retry(1, onRetry);
 
@@ -46,7 +46,7 @@ public static class RetrySyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy Retry(this PolicyBuilder policyBuilder, int retryCount, Action<Exception, int> onRetry)
     {
         if (retryCount < 0)
@@ -64,7 +64,7 @@ public static class RetrySyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy Retry(this PolicyBuilder policyBuilder, Action<Exception, int, Context> onRetry) =>
         policyBuilder.Retry(1, onRetry);
 
@@ -77,7 +77,7 @@ public static class RetrySyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy Retry(this PolicyBuilder policyBuilder, int retryCount, Action<Exception, int, Context> onRetry)
     {
         if (retryCount < 0)
@@ -110,7 +110,7 @@ public static class RetrySyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy RetryForever(this PolicyBuilder policyBuilder, Action<Exception> onRetry)
     {
         if (onRetry == null)
@@ -126,7 +126,7 @@ public static class RetrySyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy RetryForever(this PolicyBuilder policyBuilder, Action<Exception, int> onRetry)
     {
         if (onRetry == null)
@@ -142,7 +142,7 @@ public static class RetrySyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy RetryForever(this PolicyBuilder policyBuilder, Action<Exception, Context> onRetry)
     {
         if (onRetry == null)
@@ -160,7 +160,7 @@ public static class RetrySyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy RetryForever(this PolicyBuilder policyBuilder, Action<Exception, int, Context> onRetry)
     {
         if (onRetry == null)
@@ -476,7 +476,7 @@ public static class RetrySyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
     public static RetryPolicy WaitAndRetryForever(this PolicyBuilder policyBuilder, Func<int, TimeSpan> sleepDurationProvider)
     {
         if (sleepDurationProvider == null)
@@ -495,7 +495,7 @@ public static class RetrySyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
     public static RetryPolicy WaitAndRetryForever(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider)
     {
         if (sleepDurationProvider == null)
@@ -516,8 +516,8 @@ public static class RetrySyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy WaitAndRetryForever(this PolicyBuilder policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan> onRetry)
     {
         if (sleepDurationProvider == null)
@@ -540,8 +540,8 @@ public static class RetrySyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy WaitAndRetryForever(this PolicyBuilder policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, int, TimeSpan> onRetry)
     {
         if (sleepDurationProvider == null)
@@ -564,8 +564,8 @@ public static class RetrySyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy WaitAndRetryForever(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, Context> onRetry)
     {
         if (sleepDurationProvider == null)
@@ -586,8 +586,8 @@ public static class RetrySyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy WaitAndRetryForever(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, int, TimeSpan, Context> onRetry)
     {
         if (sleepDurationProvider == null)
@@ -608,8 +608,8 @@ public static class RetrySyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy WaitAndRetryForever(this PolicyBuilder policyBuilder, Func<int, Exception, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, Context> onRetry)
     {
         if (sleepDurationProvider == null)
@@ -633,8 +633,8 @@ public static class RetrySyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy WaitAndRetryForever(this PolicyBuilder policyBuilder, Func<int, Exception, Context, TimeSpan> sleepDurationProvider, Action<Exception, int, TimeSpan, Context> onRetry)
     {
         if (sleepDurationProvider == null)

--- a/src/Polly/Retry/RetrySyntax.cs
+++ b/src/Polly/Retry/RetrySyntax.cs
@@ -199,11 +199,7 @@ public static class RetrySyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    /// sleepDurationProvider
-    /// or
-    /// onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan> onRetry)
     {
         if (onRetry == null)
@@ -227,11 +223,7 @@ public static class RetrySyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    /// sleepDurationProvider
-    /// or
-    /// onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, Context> onRetry)
     {
         if (onRetry == null)
@@ -255,11 +247,7 @@ public static class RetrySyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    /// timeSpanProvider
-    /// or
-    /// onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, int, Context> onRetry)
     {
         if (retryCount < 0)
@@ -307,11 +295,7 @@ public static class RetrySyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    /// sleepDurationProvider
-    /// or
-    /// onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, Context> onRetry)
     {
         if (onRetry == null)
@@ -335,11 +319,7 @@ public static class RetrySyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    /// timeSpanProvider
-    /// or
-    /// onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, int, Context> onRetry)
     {
         if (sleepDurationProvider == null)
@@ -362,11 +342,7 @@ public static class RetrySyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    /// timeSpanProvider
-    /// or
-    /// onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, Exception, Context, TimeSpan> sleepDurationProvider, Action<Exception, TimeSpan, int, Context> onRetry)
     {
         if (retryCount < 0)
@@ -406,11 +382,7 @@ public static class RetrySyntax
     /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">
-    /// sleepDurations
-    /// or
-    /// onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurations"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, IEnumerable<TimeSpan> sleepDurations, Action<Exception, TimeSpan> onRetry)
     {
         if (onRetry == null)
@@ -428,11 +400,7 @@ public static class RetrySyntax
     /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">
-    /// sleepDurations
-    /// or
-    /// onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurations"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, IEnumerable<TimeSpan> sleepDurations, Action<Exception, TimeSpan, Context> onRetry)
     {
         if (onRetry == null)
@@ -450,11 +418,7 @@ public static class RetrySyntax
     /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">
-    /// sleepDurations
-    /// or
-    /// onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurations"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, IEnumerable<TimeSpan> sleepDurations, Action<Exception, TimeSpan, int, Context> onRetry)
     {
         if (sleepDurations == null)

--- a/src/Polly/Retry/RetrySyntax.cs
+++ b/src/Polly/Retry/RetrySyntax.cs
@@ -435,7 +435,7 @@ public static class RetrySyntax
     /// <summary>
     /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds.
     ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-    ///     the current retry number (1 for first retry, 2 for second etc)
+    ///     the current retry number (1 for first retry, 2 for second etc).
     /// </summary>
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
@@ -474,7 +474,7 @@ public static class RetrySyntax
     /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds,
     /// calling <paramref name="onRetry"/> on each retry with the raised exception.
     ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-    ///     the current retry number (1 for first retry, 2 for second etc)
+    ///     the current retry number (1 for first retry, 2 for second etc).
     /// </summary>
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
@@ -498,7 +498,7 @@ public static class RetrySyntax
     /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds,
     /// calling <paramref name="onRetry"/> on each retry with the raised exception and retry count.
     ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-    ///     the current retry number (1 for first retry, 2 for second etc)
+    ///     the current retry number (1 for first retry, 2 for second etc).
     /// </summary>
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>

--- a/src/Polly/Retry/RetryTResultSyntax.cs
+++ b/src/Polly/Retry/RetryTResultSyntax.cs
@@ -199,11 +199,7 @@ public static class RetryTResultSyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    /// sleepDurationProvider
-    /// or
-    /// onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan> onRetry)
     {
         if (onRetry == null)
@@ -227,11 +223,7 @@ public static class RetryTResultSyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    /// sleepDurationProvider
-    /// or
-    /// onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
     {
         if (onRetry == null)
@@ -255,11 +247,7 @@ public static class RetryTResultSyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    /// timeSpanProvider
-    /// or
-    /// onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
     {
         if (retryCount < 0)
@@ -307,11 +295,7 @@ public static class RetryTResultSyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    /// sleepDurationProvider
-    /// or
-    /// onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
     {
         if (onRetry == null)
@@ -335,11 +319,7 @@ public static class RetryTResultSyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    /// timeSpanProvider
-    /// or
-    /// onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry) =>
         policyBuilder.WaitAndRetry(
             retryCount,
@@ -374,11 +354,7 @@ public static class RetryTResultSyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    /// sleepDurationProvider
-    /// or
-    /// onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
     {
         if (onRetry == null)
@@ -402,11 +378,7 @@ public static class RetryTResultSyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">
-    /// timeSpanProvider
-    /// or
-    /// onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
     {
         if (retryCount < 0)
@@ -446,11 +418,7 @@ public static class RetryTResultSyntax
     /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">
-    /// sleepDurations
-    /// or
-    /// onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurations"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, IEnumerable<TimeSpan> sleepDurations, Action<DelegateResult<TResult>, TimeSpan> onRetry)
     {
         if (onRetry == null)
@@ -468,11 +436,7 @@ public static class RetryTResultSyntax
     /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">
-    /// sleepDurations
-    /// or
-    /// onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurations"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, IEnumerable<TimeSpan> sleepDurations, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
     {
         if (onRetry == null)
@@ -490,11 +454,7 @@ public static class RetryTResultSyntax
     /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">
-    /// sleepDurations
-    /// or
-    /// onRetry
-    /// </exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurations"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy<TResult> WaitAndRetry<TResult>(this PolicyBuilder<TResult> policyBuilder, IEnumerable<TimeSpan> sleepDurations, Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry)
     {
         if (sleepDurations == null)

--- a/src/Polly/Retry/RetryTResultSyntax.cs
+++ b/src/Polly/Retry/RetryTResultSyntax.cs
@@ -471,7 +471,7 @@ public static class RetryTResultSyntax
     /// <summary>
     /// Builds a <see cref="Policy{TResult}"/> that will wait and retry indefinitely until the action succeeds.
     ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-    ///     the current retry number (1 for first retry, 2 for second etc)
+    ///     the current retry number (1 for first retry, 2 for second etc).
     /// </summary>
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
@@ -490,7 +490,7 @@ public static class RetryTResultSyntax
     /// <summary>
     /// Builds a <see cref="Policy{TResult}"/> that will wait and retry indefinitely until the action succeeds.
     ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-    ///     the current retry number (1 for first retry, 2 for second etc) and execution context
+    ///     the current retry number (1 for first retry, 2 for second etc) and execution context.
     /// </summary>
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
@@ -510,7 +510,7 @@ public static class RetryTResultSyntax
     /// Builds a <see cref="Policy{TResult}"/> that will wait and retry indefinitely until the action succeeds,
     /// calling <paramref name="onRetry"/> on each retry with the handled exception or result.
     ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-    ///     the current retry number (1 for first retry, 2 for second etc)
+    ///     the current retry number (1 for first retry, 2 for second etc).
     /// </summary>
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
@@ -534,7 +534,7 @@ public static class RetryTResultSyntax
     /// Builds a <see cref="Policy{TResult}"/> that will wait and retry indefinitely until the action succeeds,
     /// calling <paramref name="onRetry"/> on each retry with the handled exception or result and retry count.
     ///     On each retry, the duration to wait is calculated by calling <paramref name="sleepDurationProvider" /> with
-    ///     the current retry number (1 for first retry, 2 for second etc)
+    ///     the current retry number (1 for first retry, 2 for second etc).
     /// </summary>
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>

--- a/src/Polly/Retry/RetryTResultSyntax.cs
+++ b/src/Polly/Retry/RetryTResultSyntax.cs
@@ -33,7 +33,7 @@ public static class RetryTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy<TResult> Retry<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>, int> onRetry) =>
         policyBuilder.Retry(1, onRetry);
 
@@ -46,7 +46,7 @@ public static class RetryTResultSyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy<TResult> Retry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Action<DelegateResult<TResult>, int> onRetry)
     {
         if (retryCount < 0)
@@ -64,7 +64,7 @@ public static class RetryTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy<TResult> Retry<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>, int, Context> onRetry) =>
         policyBuilder.Retry(1, onRetry);
 
@@ -77,7 +77,7 @@ public static class RetryTResultSyntax
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy<TResult> Retry<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Action<DelegateResult<TResult>, int, Context> onRetry)
     {
         if (retryCount < 0)
@@ -110,7 +110,7 @@ public static class RetryTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy<TResult> RetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>> onRetry)
     {
         if (onRetry == null)
@@ -126,7 +126,7 @@ public static class RetryTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy<TResult> RetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>, int> onRetry)
     {
         if (onRetry == null)
@@ -142,7 +142,7 @@ public static class RetryTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy<TResult> RetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>, Context> onRetry)
     {
         if (onRetry == null)
@@ -160,7 +160,7 @@ public static class RetryTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy<TResult> RetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>, int, Context> onRetry)
     {
         if (onRetry == null)
@@ -516,7 +516,7 @@ public static class RetryTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
     public static RetryPolicy<TResult> WaitAndRetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, TimeSpan> sleepDurationProvider)
     {
         if (sleepDurationProvider == null)
@@ -535,7 +535,7 @@ public static class RetryTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="sleepDurationProvider">The function that provides the duration to wait for for a particular retry attempt.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
     public static RetryPolicy<TResult> WaitAndRetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider)
     {
         if (sleepDurationProvider == null)
@@ -556,8 +556,8 @@ public static class RetryTResultSyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy<TResult> WaitAndRetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan> onRetry)
     {
         if (sleepDurationProvider == null)
@@ -580,8 +580,8 @@ public static class RetryTResultSyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy<TResult> WaitAndRetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, int, TimeSpan> onRetry)
     {
         if (sleepDurationProvider == null)
@@ -604,8 +604,8 @@ public static class RetryTResultSyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy<TResult> WaitAndRetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
     {
         if (sleepDurationProvider == null)
@@ -626,8 +626,8 @@ public static class RetryTResultSyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy<TResult> WaitAndRetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, int, TimeSpan, Context> onRetry)
     {
         if (sleepDurationProvider == null)
@@ -648,8 +648,8 @@ public static class RetryTResultSyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy<TResult> WaitAndRetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan, Context> onRetry)
     {
         if (sleepDurationProvider == null)
@@ -673,8 +673,8 @@ public static class RetryTResultSyntax
     /// <param name="sleepDurationProvider">A function providing the duration to wait before retrying.</param>
     /// <param name="onRetry">The action to call on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">sleepDurationProvider</exception>
-    /// <exception cref="ArgumentNullException">onRetry</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
     public static RetryPolicy<TResult> WaitAndRetryForever<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, int, TimeSpan, Context> onRetry)
     {
         if (sleepDurationProvider == null)

--- a/src/Polly/Timeout/AsyncTimeoutSyntax.cs
+++ b/src/Polly/Timeout/AsyncTimeoutSyntax.cs
@@ -109,7 +109,7 @@ public partial class Policy
     /// </summary>
     /// <param name="timeout">The timeout.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
+    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout).</exception>
     public static AsyncTimeoutPolicy TimeoutAsync(TimeSpan timeout)
     {
         TimeoutValidator.ValidateTimeSpanTimeout(timeout);
@@ -124,7 +124,7 @@ public partial class Policy
     /// <param name="timeout">The timeout.</param>
     /// <param name="timeoutStrategy">The timeout strategy.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
+    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout).</exception>
     public static AsyncTimeoutPolicy TimeoutAsync(TimeSpan timeout, TimeoutStrategy timeoutStrategy)
     {
         TimeoutValidator.ValidateTimeSpanTimeout(timeout);
@@ -140,7 +140,7 @@ public partial class Policy
     /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task"/> capturing the abandoned, timed-out action.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
+    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout).</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy TimeoutAsync(TimeSpan timeout, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
     {
@@ -173,7 +173,7 @@ public partial class Policy
     /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task" /> capturing the abandoned, timed-out action.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
+    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout).</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy TimeoutAsync(TimeSpan timeout, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
     {

--- a/src/Polly/Timeout/AsyncTimeoutSyntax.cs
+++ b/src/Polly/Timeout/AsyncTimeoutSyntax.cs
@@ -39,7 +39,7 @@ public partial class Policy
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy TimeoutAsync(int seconds, Func<Context
         , TimeSpan, Task, Task> onTimeoutAsync)
     {
@@ -58,7 +58,7 @@ public partial class Policy
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy TimeoutAsync(int seconds, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
     {
         if (seconds <= 0)
@@ -141,7 +141,7 @@ public partial class Policy
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy TimeoutAsync(TimeSpan timeout, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
     {
         TimeoutValidator.ValidateTimeSpanTimeout(timeout);
@@ -157,7 +157,7 @@ public partial class Policy
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy TimeoutAsync(TimeSpan timeout, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
     {
         TimeoutValidator.ValidateTimeSpanTimeout(timeout);
@@ -174,7 +174,7 @@ public partial class Policy
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy TimeoutAsync(TimeSpan timeout, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
     {
         TimeoutValidator.ValidateTimeSpanTimeout(timeout);
@@ -191,7 +191,7 @@ public partial class Policy
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy TimeoutAsync(TimeSpan timeout, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
     {
         TimeoutValidator.ValidateTimeSpanTimeout(timeout);
@@ -203,7 +203,7 @@ public partial class Policy
     /// Builds an <see cref="AsyncPolicy"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
     /// </summary>
     /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static AsyncTimeoutPolicy TimeoutAsync(Func<TimeSpan> timeoutProvider)
     {
@@ -220,7 +220,7 @@ public partial class Policy
     /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
     /// <param name="timeoutStrategy">The timeout strategy.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy TimeoutAsync(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy)
     {
         if (timeoutProvider == null)
@@ -237,8 +237,8 @@ public partial class Policy
     /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task"/> capturing the abandoned, timed-out action.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy TimeoutAsync(Func<TimeSpan> timeoutProvider, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
     {
         if (timeoutProvider == null)
@@ -254,8 +254,8 @@ public partial class Policy
     /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task"/> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy TimeoutAsync(Func<TimeSpan> timeoutProvider, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
     {
         if (timeoutProvider == null)
@@ -272,8 +272,8 @@ public partial class Policy
     /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task" /> capturing the abandoned, timed-out action.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy TimeoutAsync(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
     {
         if (timeoutProvider == null)
@@ -290,8 +290,8 @@ public partial class Policy
     /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task" /> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy TimeoutAsync(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
     {
         if (timeoutProvider == null)
@@ -304,7 +304,7 @@ public partial class Policy
     /// Builds an <see cref="AsyncPolicy"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
     /// </summary>
     /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static AsyncTimeoutPolicy TimeoutAsync(Func<Context, TimeSpan> timeoutProvider)
     {
@@ -319,7 +319,7 @@ public partial class Policy
     /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
     /// <param name="timeoutStrategy">The timeout strategy.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy TimeoutAsync(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy)
     {
         Func<Context, TimeSpan, Task, Exception, Task> doNothingAsync = (_, _, _, _) => TaskHelper.EmptyTask;
@@ -334,8 +334,8 @@ public partial class Policy
     /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task"/> capturing the abandoned, timed-out action.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy TimeoutAsync(Func<Context, TimeSpan> timeoutProvider, Func<Context, TimeSpan, Task, Task> onTimeoutAsync) =>
         TimeoutAsync(timeoutProvider, TimeoutStrategy.Optimistic, onTimeoutAsync);
 
@@ -346,8 +346,8 @@ public partial class Policy
     /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task"/> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy TimeoutAsync(Func<Context, TimeSpan> timeoutProvider, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync) =>
         TimeoutAsync(timeoutProvider, TimeoutStrategy.Optimistic, onTimeoutAsync);
 
@@ -359,8 +359,8 @@ public partial class Policy
     /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task" /> capturing the abandoned, timed-out action.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy TimeoutAsync(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
     {
         if (onTimeoutAsync == null)
@@ -377,8 +377,8 @@ public partial class Policy
     /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task" /> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy TimeoutAsync(
         Func<Context, TimeSpan> timeoutProvider,
         TimeoutStrategy timeoutStrategy,

--- a/src/Polly/Timeout/AsyncTimeoutTResultSyntax.cs
+++ b/src/Polly/Timeout/AsyncTimeoutTResultSyntax.cs
@@ -104,7 +104,7 @@ public partial class Policy
     /// </summary>
     /// <param name="timeout">The timeout.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
+    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout).</exception>
     public static AsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(TimeSpan timeout)
     {
         TimeoutValidator.ValidateTimeSpanTimeout(timeout);
@@ -119,7 +119,7 @@ public partial class Policy
     /// <param name="timeout">The timeout.</param>
     /// <param name="timeoutStrategy">The timeout strategy.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
+    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout).</exception>
     public static AsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(TimeSpan timeout, TimeoutStrategy timeoutStrategy)
     {
         TimeoutValidator.ValidateTimeSpanTimeout(timeout);
@@ -135,7 +135,7 @@ public partial class Policy
     /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task"/> capturing the abandoned, timed-out action.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
+    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout).</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(TimeSpan timeout, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
     {
@@ -173,7 +173,7 @@ public partial class Policy
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <param name="timeoutStrategy">The timeout strategy.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
+    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout).</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(TimeSpan timeout, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
     {

--- a/src/Polly/Timeout/AsyncTimeoutTResultSyntax.cs
+++ b/src/Polly/Timeout/AsyncTimeoutTResultSyntax.cs
@@ -39,7 +39,7 @@ public partial class Policy
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(int seconds, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
     {
         TimeoutValidator.ValidateSecondsTimeout(seconds);
@@ -55,7 +55,7 @@ public partial class Policy
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(int seconds, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
     {
         if (seconds <= 0)
@@ -73,7 +73,7 @@ public partial class Policy
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(int seconds, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
     {
         TimeoutValidator.ValidateSecondsTimeout(seconds);
@@ -90,7 +90,7 @@ public partial class Policy
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(int seconds, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
     {
         if (seconds <= 0)
@@ -136,7 +136,7 @@ public partial class Policy
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(TimeSpan timeout, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
     {
         TimeoutValidator.ValidateTimeSpanTimeout(timeout);
@@ -154,7 +154,7 @@ public partial class Policy
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(TimeSpan timeout, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
     {
         if (timeout <= TimeSpan.Zero)
@@ -174,7 +174,7 @@ public partial class Policy
     /// <param name="timeoutStrategy">The timeout strategy.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(TimeSpan timeout, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
     {
         TimeoutValidator.ValidateTimeSpanTimeout(timeout);
@@ -191,7 +191,7 @@ public partial class Policy
     /// <param name="timeoutStrategy">The timeout strategy.</param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(TimeSpan timeout, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
     {
         if (timeout <= TimeSpan.Zero)
@@ -204,7 +204,7 @@ public partial class Policy
     /// Builds an <see cref="AsyncPolicy{TResult}"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
     /// </summary>
     /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static AsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<TimeSpan> timeoutProvider)
     {
@@ -220,7 +220,7 @@ public partial class Policy
     /// </summary>
     /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
     /// <param name="timeoutStrategy">The timeout strategy.</param>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static AsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy)
     {
@@ -238,8 +238,8 @@ public partial class Policy
     /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task"/> capturing the abandoned, timed-out action.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<TimeSpan> timeoutProvider, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
     {
         if (timeoutProvider == null)
@@ -255,8 +255,8 @@ public partial class Policy
     /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task"/> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<TimeSpan> timeoutProvider, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
     {
         if (timeoutProvider == null)
@@ -273,8 +273,8 @@ public partial class Policy
     /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task"/> capturing the abandoned, timed-out action.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
     {
         if (timeoutProvider == null)
@@ -291,8 +291,8 @@ public partial class Policy
     /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task"/> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
     {
         if (timeoutProvider == null)
@@ -305,7 +305,7 @@ public partial class Policy
     /// Builds an <see cref="AsyncPolicy{TResult}"/> that will wait asynchronously for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
     /// </summary>
     /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static AsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<Context, TimeSpan> timeoutProvider)
     {
@@ -318,7 +318,7 @@ public partial class Policy
     /// </summary>
     /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
     /// <param name="timeoutStrategy">The timeout strategy.</param>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static AsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy)
     {
@@ -333,8 +333,8 @@ public partial class Policy
     /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task"/> capturing the abandoned, timed-out action.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<Context, TimeSpan> timeoutProvider, Func<Context, TimeSpan, Task, Task> onTimeoutAsync) =>
         TimeoutAsync<TResult>(timeoutProvider, TimeoutStrategy.Optimistic, onTimeoutAsync);
 
@@ -345,8 +345,8 @@ public partial class Policy
     /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task"/> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<Context, TimeSpan> timeoutProvider, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync) =>
         TimeoutAsync<TResult>(timeoutProvider, TimeoutStrategy.Optimistic, onTimeoutAsync);
 
@@ -358,8 +358,8 @@ public partial class Policy
     /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task"/> capturing the abandoned, timed-out action.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Task> onTimeoutAsync)
     {
         if (onTimeoutAsync == null)
@@ -376,8 +376,8 @@ public partial class Policy
     /// <param name="onTimeoutAsync">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task"/> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeoutAsync</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeoutAsync"/> is <see langword="null"/>.</exception>
     public static AsyncTimeoutPolicy<TResult> TimeoutAsync<TResult>(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync)
     {
         if (timeoutProvider == null)

--- a/src/Polly/Timeout/TimeoutSyntax.cs
+++ b/src/Polly/Timeout/TimeoutSyntax.cs
@@ -39,7 +39,7 @@ public partial class Policy
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy Timeout(int seconds, Action<Context, TimeSpan, Task> onTimeout)
     {
         TimeoutValidator.ValidateSecondsTimeout(seconds);
@@ -55,7 +55,7 @@ public partial class Policy
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy Timeout(int seconds, Action<Context, TimeSpan, Task, Exception> onTimeout)
     {
         if (seconds <= 0)
@@ -73,7 +73,7 @@ public partial class Policy
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy Timeout(int seconds, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task> onTimeout)
     {
         TimeoutValidator.ValidateSecondsTimeout(seconds);
@@ -90,7 +90,7 @@ public partial class Policy
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy Timeout(int seconds, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task, Exception> onTimeout)
     {
         if (seconds <= 0)
@@ -136,7 +136,7 @@ public partial class Policy
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy Timeout(TimeSpan timeout, Action<Context, TimeSpan, Task> onTimeout)
     {
         TimeoutValidator.ValidateTimeSpanTimeout(timeout);
@@ -152,7 +152,7 @@ public partial class Policy
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy Timeout(TimeSpan timeout, Action<Context, TimeSpan, Task, Exception> onTimeout)
     {
         TimeoutValidator.ValidateTimeSpanTimeout(timeout);
@@ -169,7 +169,7 @@ public partial class Policy
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy Timeout(TimeSpan timeout, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task> onTimeout)
     {
         TimeoutValidator.ValidateTimeSpanTimeout(timeout);
@@ -186,7 +186,7 @@ public partial class Policy
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy Timeout(TimeSpan timeout, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task, Exception> onTimeout)
     {
         TimeoutValidator.ValidateTimeSpanTimeout(timeout);
@@ -198,7 +198,7 @@ public partial class Policy
     /// Builds a <see cref="Policy"/> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
     /// </summary>
     /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static TimeoutPolicy Timeout(Func<TimeSpan> timeoutProvider)
     {
@@ -215,7 +215,7 @@ public partial class Policy
     /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
     /// <param name="timeoutStrategy">The timeout strategy.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy Timeout(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy)
     {
         if (timeoutProvider == null)
@@ -232,8 +232,8 @@ public partial class Policy
     /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task" /> capturing the abandoned, timed-out action.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy Timeout(Func<TimeSpan> timeoutProvider, Action<Context, TimeSpan, Task> onTimeout)
     {
         if (timeoutProvider == null)
@@ -249,8 +249,8 @@ public partial class Policy
     /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task" /> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy Timeout(Func<TimeSpan> timeoutProvider, Action<Context, TimeSpan, Task, Exception> onTimeout)
     {
         if (timeoutProvider == null)
@@ -267,8 +267,8 @@ public partial class Policy
     /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task" /> capturing the abandoned, timed-out action.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy Timeout(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task> onTimeout)
     {
         if (timeoutProvider == null)
@@ -285,8 +285,8 @@ public partial class Policy
     /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task" /> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy Timeout(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task, Exception> onTimeout)
     {
         if (timeoutProvider == null)
@@ -299,7 +299,7 @@ public partial class Policy
     /// Builds a <see cref="Policy"/> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
     /// </summary>
     /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static TimeoutPolicy Timeout(Func<Context, TimeSpan> timeoutProvider)
     {
@@ -313,7 +313,7 @@ public partial class Policy
     /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
     /// <param name="timeoutStrategy">The timeout strategy.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy Timeout(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy)
     {
         Action<Context, TimeSpan, Task, Exception> doNothing = (_, _, _, _) => { };
@@ -327,8 +327,8 @@ public partial class Policy
     /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task" /> capturing the abandoned, timed-out action.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy Timeout(Func<Context, TimeSpan> timeoutProvider, Action<Context, TimeSpan, Task> onTimeout) =>
         Timeout(timeoutProvider, TimeoutStrategy.Optimistic, onTimeout);
 
@@ -339,8 +339,8 @@ public partial class Policy
     /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task" /> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy Timeout(Func<Context, TimeSpan> timeoutProvider, Action<Context, TimeSpan, Task, Exception> onTimeout) =>
         Timeout(timeoutProvider, TimeoutStrategy.Optimistic, onTimeout);
 
@@ -352,8 +352,8 @@ public partial class Policy
     /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task" /> capturing the abandoned, timed-out action.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy Timeout(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task> onTimeout)
     {
         if (onTimeout == null)
@@ -370,8 +370,8 @@ public partial class Policy
     /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task" /> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy Timeout(
         Func<Context, TimeSpan> timeoutProvider,
         TimeoutStrategy timeoutStrategy,

--- a/src/Polly/Timeout/TimeoutSyntax.cs
+++ b/src/Polly/Timeout/TimeoutSyntax.cs
@@ -104,7 +104,7 @@ public partial class Policy
     /// </summary>
     /// <param name="timeout">The timeout.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
+    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout).</exception>
     public static TimeoutPolicy Timeout(TimeSpan timeout)
     {
         TimeoutValidator.ValidateTimeSpanTimeout(timeout);
@@ -119,7 +119,7 @@ public partial class Policy
     /// <param name="timeout">The timeout.</param>
     /// <param name="timeoutStrategy">The timeout strategy.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
+    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout).</exception>
     public static TimeoutPolicy Timeout(TimeSpan timeout, TimeoutStrategy timeoutStrategy)
     {
         TimeoutValidator.ValidateTimeSpanTimeout(timeout);
@@ -135,7 +135,7 @@ public partial class Policy
     /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task"/> capturing the abandoned, timed-out action.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
+    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout).</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy Timeout(TimeSpan timeout, Action<Context, TimeSpan, Task> onTimeout)
     {
@@ -168,7 +168,7 @@ public partial class Policy
     /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task" /> capturing the abandoned, timed-out action.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
+    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout).</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy Timeout(TimeSpan timeout, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task> onTimeout)
     {

--- a/src/Polly/Timeout/TimeoutTResultSyntax.cs
+++ b/src/Polly/Timeout/TimeoutTResultSyntax.cs
@@ -41,7 +41,7 @@ public partial class Policy
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy<TResult> Timeout<TResult>(int seconds, Action<Context, TimeSpan, Task> onTimeout)
     {
         TimeoutValidator.ValidateSecondsTimeout(seconds);
@@ -56,7 +56,7 @@ public partial class Policy
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy<TResult> Timeout<TResult>(int seconds, Action<Context, TimeSpan, Task, Exception> onTimeout)
     {
         if (seconds <= 0)
@@ -75,7 +75,7 @@ public partial class Policy
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy<TResult> Timeout<TResult>(int seconds, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task> onTimeout)
     {
         TimeoutValidator.ValidateSecondsTimeout(seconds);
@@ -93,7 +93,7 @@ public partial class Policy
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">seconds;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy<TResult> Timeout<TResult>(int seconds, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task, Exception> onTimeout)
     {
         if (seconds <= 0)
@@ -140,7 +140,7 @@ public partial class Policy
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy<TResult> Timeout<TResult>(TimeSpan timeout, Action<Context, TimeSpan, Task> onTimeout)
     {
         TimeoutValidator.ValidateTimeSpanTimeout(timeout);
@@ -155,7 +155,7 @@ public partial class Policy
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy<TResult> Timeout<TResult>(TimeSpan timeout, Action<Context, TimeSpan, Task, Exception> onTimeout)
     {
         TimeoutValidator.ValidateTimeSpanTimeout(timeout);
@@ -172,7 +172,7 @@ public partial class Policy
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy<TResult> Timeout<TResult>(TimeSpan timeout, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task> onTimeout)
     {
         TimeoutValidator.ValidateTimeSpanTimeout(timeout);
@@ -189,7 +189,7 @@ public partial class Policy
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy<TResult> Timeout<TResult>(TimeSpan timeout, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task, Exception> onTimeout)
     {
         TimeoutValidator.ValidateTimeSpanTimeout(timeout);
@@ -200,7 +200,7 @@ public partial class Policy
     /// Builds a <see cref="Policy{TResult}"/> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
     /// </summary>
     /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static TimeoutPolicy<TResult> Timeout<TResult>(Func<TimeSpan> timeoutProvider)
     {
@@ -218,7 +218,7 @@ public partial class Policy
     /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
     /// <param name="timeoutStrategy">The timeout strategy.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy<TResult> Timeout<TResult>(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy)
     {
         if (timeoutProvider == null)
@@ -235,8 +235,8 @@ public partial class Policy
     /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task{TResult}"/> capturing the abandoned, timed-out action.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy<TResult> Timeout<TResult>(Func<TimeSpan> timeoutProvider, Action<Context, TimeSpan, Task> onTimeout)
     {
         if (timeoutProvider == null)
@@ -252,8 +252,8 @@ public partial class Policy
     /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task{TResult}"/> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy<TResult> Timeout<TResult>(Func<TimeSpan> timeoutProvider, Action<Context, TimeSpan, Task, Exception> onTimeout)
     {
         if (timeoutProvider == null)
@@ -271,8 +271,8 @@ public partial class Policy
     /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task{TResult}" /> capturing the abandoned, timed-out action.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy<TResult> Timeout<TResult>(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task> onTimeout)
     {
         if (timeoutProvider == null)
@@ -290,8 +290,8 @@ public partial class Policy
     /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task{TResult}" /> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy<TResult> Timeout<TResult>(Func<TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task, Exception> onTimeout)
     {
         if (timeoutProvider == null)
@@ -304,7 +304,7 @@ public partial class Policy
     /// Builds a <see cref="Policy{TResult}"/> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.
     /// </summary>
     /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static TimeoutPolicy<TResult> Timeout<TResult>(Func<Context, TimeSpan> timeoutProvider)
     {
@@ -319,7 +319,7 @@ public partial class Policy
     /// <param name="timeoutProvider">A function to provide the timeout for this execution.</param>
     /// <param name="timeoutStrategy">The timeout strategy.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy<TResult> Timeout<TResult>(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy)
     {
         Action<Context, TimeSpan, Task, Exception> doNothing = (_, _, _, _) => { };
@@ -333,8 +333,8 @@ public partial class Policy
     /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task{TResult}"/> capturing the abandoned, timed-out action.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy<TResult> Timeout<TResult>(Func<Context, TimeSpan> timeoutProvider, Action<Context, TimeSpan, Task> onTimeout) =>
         Timeout<TResult>(timeoutProvider, TimeoutStrategy.Optimistic, onTimeout);
 
@@ -345,8 +345,8 @@ public partial class Policy
     /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task{TResult}"/> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy<TResult> Timeout<TResult>(Func<Context, TimeSpan> timeoutProvider, Action<Context, TimeSpan, Task, Exception> onTimeout) =>
         Timeout<TResult>(timeoutProvider, TimeoutStrategy.Optimistic, onTimeout);
 
@@ -359,8 +359,8 @@ public partial class Policy
     /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task{TResult}" /> capturing the abandoned, timed-out action.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy<TResult> Timeout<TResult>(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task> onTimeout)
     {
         if (onTimeout == null)
@@ -378,8 +378,8 @@ public partial class Policy
     /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, the <see cref="Task{TResult}" /> capturing the abandoned, timed-out action, and the captured <see cref="Exception"/>.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">timeoutProvider</exception>
-    /// <exception cref="ArgumentNullException">onTimeout</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy<TResult> Timeout<TResult>(
         Func<Context, TimeSpan> timeoutProvider,
         TimeoutStrategy timeoutStrategy,

--- a/src/Polly/Timeout/TimeoutTResultSyntax.cs
+++ b/src/Polly/Timeout/TimeoutTResultSyntax.cs
@@ -107,7 +107,7 @@ public partial class Policy
     /// </summary>
     /// <param name="timeout">The timeout.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
+    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout).</exception>
     public static TimeoutPolicy<TResult> Timeout<TResult>(TimeSpan timeout)
     {
         TimeoutValidator.ValidateTimeSpanTimeout(timeout);
@@ -123,7 +123,7 @@ public partial class Policy
     /// <param name="timeout">The timeout.</param>
     /// <param name="timeoutStrategy">The timeout strategy.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
+    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout).</exception>
     public static TimeoutPolicy<TResult> Timeout<TResult>(TimeSpan timeout, TimeoutStrategy timeoutStrategy)
     {
         TimeoutValidator.ValidateTimeSpanTimeout(timeout);
@@ -139,7 +139,7 @@ public partial class Policy
     /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task{TResult}"/> capturing the abandoned, timed-out action.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
+    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout).</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy<TResult> Timeout<TResult>(TimeSpan timeout, Action<Context, TimeSpan, Task> onTimeout)
     {
@@ -171,7 +171,7 @@ public partial class Policy
     /// <param name="onTimeout">An action to call on timeout, passing the execution context, the timeout applied, and a <see cref="Task{TResult}" /> capturing the abandoned, timed-out action.
     /// <remarks>The Task parameter will be null if the executed action responded cooperatively to cancellation before the policy timed it out.</remarks></param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout)</exception>
+    /// <exception cref="ArgumentOutOfRangeException">timeout;Value must be a positive TimeSpan (or Timeout.InfiniteTimeSpan to indicate no timeout).</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="onTimeout"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy<TResult> Timeout<TResult>(TimeSpan timeout, TimeoutStrategy timeoutStrategy, Action<Context, TimeSpan, Task> onTimeout)
     {

--- a/src/Polly/Utilities/ExceptionExtensions.cs
+++ b/src/Polly/Utilities/ExceptionExtensions.cs
@@ -11,7 +11,7 @@ public static class ExceptionExtensions
     /// <summary>
     /// Rethrows the extended <see cref="Exception"/>, <paramref name="exceptionPossiblyToThrow"/>, using the <see cref="ExceptionDispatchInfo"/> class to rethrow it with its original stack trace, if <paramref name="exceptionPossiblyToThrow"/> differs from <paramref name="exceptionToCompare"/>.
     /// </summary>
-    /// <param name="exceptionPossiblyToThrow">The exception to throw, if it differs from <paramref name="exceptionToCompare"/></param>
+    /// <param name="exceptionPossiblyToThrow">The exception to throw, if it differs from <paramref name="exceptionToCompare"/>.</param>
     /// <param name="exceptionToCompare">The exception to compare against.</param>
     public static void RethrowWithOriginalStackTraceIfDiffersFrom(this Exception exceptionPossiblyToThrow, Exception exceptionToCompare)
     {

--- a/src/Polly/Utilities/SystemClock.cs
+++ b/src/Polly/Utilities/SystemClock.cs
@@ -18,25 +18,25 @@ public static class SystemClock
 
     /// <summary>
     /// Allows the setting of a custom async Sleep implementation for testing.
-    /// By default this will be a call to <see cref="M:Task.Delay"/> taking a <see cref="CancellationToken"/>
+    /// By default this will be a call to <see cref="M:Task.Delay"/> taking a <see cref="CancellationToken"/>.
     /// </summary>
     public static Func<TimeSpan, CancellationToken, Task> SleepAsync = Task.Delay;
 
     /// <summary>
     /// Allows the setting of a custom DateTime.UtcNow implementation for testing.
-    /// By default this will be a call to <see cref="DateTime.UtcNow"/>
+    /// By default this will be a call to <see cref="DateTime.UtcNow"/>.
     /// </summary>
     public static Func<DateTime> UtcNow = () => DateTime.UtcNow;
 
     /// <summary>
     /// Allows the setting of a custom DateTimeOffset.UtcNow implementation for testing.
-    /// By default this will be a call to <see cref="DateTime.UtcNow"/>
+    /// By default this will be a call to <see cref="DateTime.UtcNow"/>.
     /// </summary>
     public static Func<DateTimeOffset> DateTimeOffsetUtcNow = () => DateTimeOffset.UtcNow;
 
     /// <summary>
     /// Allows the setting of a custom method for cancelling tokens after a timespan, for use in testing.
-    /// By default this will be a call to CancellationTokenSource.CancelAfter(timespan)
+    /// By default this will be a call to CancellationTokenSource.CancelAfter(timespan).
     /// </summary>
     public static Action<CancellationTokenSource, TimeSpan> CancelTokenAfter = (tokenSource, timespan) => tokenSource.CancelAfter(timespan);
 


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed
Contributes to #1290 by addressing some XML documentation quality issues

## Details on the issue fix or feature implementation
Fixes various XML comments quality issues
- Fixes SA1629 "Documentation text should end with a period"
- Fixes CA1200 "Avoid using cref tags with a prefix"
- Fixes SA1627 "The documentation text within the 'exception' tag should not be empty"
- Fixes SA1629 "Documentation text should end with a period" in `ArgumentOutOfRangeException` (but these could be further improved)
- Fixes SA1614 "Element parameter documentation should have text"
- Unifies XML comments for `ArgumentNullException` as following 
  ```c#
  /// <exception cref="ArgumentNullException">Thrown when <paramref name="parameter"/> is <see langword="null"/>.</exception>"
  ```
  as already used in other places. i.e.
  https://github.com/App-vNext/Polly/blob/1dba402d0d6c96a92794ac02be3d9d5ba320e685/src/Polly.Core/CircuitBreaker/CircuitBreakerResiliencePipelineBuilderExtensions.cs#L26
  
## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
