### PR TITLE
Xml documentation cleanup

### DIFF
--- a/src/Polly/AsyncPolicy.TResult.cs
+++ b/src/Polly/AsyncPolicy.TResult.cs
@@ -8,7 +8,7 @@ namespace Polly;
 public abstract partial class AsyncPolicy<TResult> : PolicyBase<TResult>
 {
     /// <summary>
-    /// Constructs a new instance of a derived <see cref="AsyncPolicy{TResult}"/> type with the passed <paramref name="exceptionPredicates"/> and <paramref name="resultPredicates"/>.
+    /// Initializes a new instance of the <see cref="AsyncPolicy{TResult}"/> class.
     /// </summary>
     /// <param name="exceptionPredicates">Predicates indicating which exceptions the policy should handle. </param>
     /// <param name="resultPredicates">Predicates indicating which results the policy should handle. </param>
@@ -20,7 +20,7 @@ public abstract partial class AsyncPolicy<TResult> : PolicyBase<TResult>
     }
 
     /// <summary>
-    /// Constructs a new instance of a derived <see cref="AsyncPolicy{TResult}"/> type with the passed <paramref name="policyBuilder"/>.
+    /// Initializes a new instance of the <see cref="AsyncPolicy{TResult}"/> class.
     /// </summary>
     /// <param name="policyBuilder">A <see cref="PolicyBuilder{TResult}"/> indicating which exceptions and results the policy should handle.</param>
     protected AsyncPolicy(PolicyBuilder<TResult>? policyBuilder = null)

--- a/src/Polly/AsyncPolicy.cs
+++ b/src/Polly/AsyncPolicy.cs
@@ -7,7 +7,7 @@ namespace Polly;
 public abstract partial class AsyncPolicy
 {
     /// <summary>
-    /// Constructs a new instance of a derived <see cref="AsyncPolicy"/> type with the passed <paramref name="exceptionPredicates"/>.
+    /// Initializes a new instance of the <see cref="AsyncPolicy"/> class.
     /// </summary>
     /// <param name="exceptionPredicates">Predicates indicating which exceptions the policy should handle. </param>
     internal AsyncPolicy(ExceptionPredicates exceptionPredicates)
@@ -16,7 +16,7 @@ public abstract partial class AsyncPolicy
     }
 
     /// <summary>
-    /// Constructs a new instance of a derived <see cref="AsyncPolicy"/> type with the passed <paramref name="policyBuilder"/>.
+    /// Initializes a new instance of the <see cref="AsyncPolicy"/> class.
     /// </summary>
     /// <param name="policyBuilder">A <see cref="PolicyBuilder"/> specifying which exceptions the policy should handle. </param>
     protected AsyncPolicy(PolicyBuilder? policyBuilder = null)

--- a/src/Polly/Bulkhead/AsyncBulkheadTResultSyntax.cs
+++ b/src/Polly/Bulkhead/AsyncBulkheadTResultSyntax.cs
@@ -36,7 +36,6 @@ public partial class Policy
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentOutOfRangeException">maxQueuingActions;Value must be greater than or equal to zero.</exception>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBulkheadRejectedAsync"/> is <see langword="null"/>.</exception>
     public static AsyncBulkheadPolicy<TResult> BulkheadAsync<TResult>(int maxParallelization, int maxQueuingActions)
     {
         Func<Context, Task> doNothingAsync = _ => TaskHelper.EmptyTask;

--- a/src/Polly/Bulkhead/BulkheadPolicy.cs
+++ b/src/Polly/Bulkhead/BulkheadPolicy.cs
@@ -58,7 +58,6 @@ public class BulkheadPolicy<TResult> : Policy<TResult>, IBulkheadPolicy<TResult>
     private readonly int _maxQueueingActions;
     private readonly Action<Context> _onBulkheadRejected;
 
-    /// <inheritdoc/>
     internal BulkheadPolicy(
         int maxParallelization,
         int maxQueueingActions,

--- a/src/Polly/Caching/AsyncCacheSyntax.cs
+++ b/src/Polly/Caching/AsyncCacheSyntax.cs
@@ -5,7 +5,7 @@ public partial class Policy
 {
     /// <summary>
     /// <para>Builds an <see cref="AsyncPolicy"/> that will function like a result cache for delegate executions returning a result.</para>
-    /// <para>Before executing a delegate returning a result, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="M:Context.OperationKey"/>.
+    /// <para>Before executing a delegate returning a result, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="Context.OperationKey"/>.
     /// If the <paramref name="cacheProvider"/> provides a value, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider"/> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider"/>, then returns the value.
     /// </para>
     /// </summary>
@@ -19,7 +19,7 @@ public partial class Policy
 
     /// <summary>
     /// <para>Builds an <see cref="AsyncPolicy"/> that will function like a result cache for delegate executions returning a result.</para>
-    /// <para>Before executing a delegate returning a result, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="M:Context.OperationKey"/>
+    /// <para>Before executing a delegate returning a result, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="Context.OperationKey"/>
     /// If the <paramref name="cacheProvider"/> provides a value, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider"/> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider"/>, then returns the value.
     /// </para>
     /// </summary>

--- a/src/Polly/Caching/AsyncCacheTResultSyntax.cs
+++ b/src/Polly/Caching/AsyncCacheTResultSyntax.cs
@@ -5,7 +5,7 @@ public partial class Policy
 {
     /// <summary>
     /// <para>Builds an <see cref="AsyncPolicy{TResult}"/> that will function like a result cache for delegate executions returning a <typeparamref name="TResult"/>.</para>
-    /// <para>Before executing a delegate, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="M:Context.OperationKey"/>.
+    /// <para>Before executing a delegate, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="Context.OperationKey"/>.
     /// If the <paramref name="cacheProvider"/> provides a value from cache, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider"/> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider"/>, then returns the value.
     /// </para>
     /// </summary>
@@ -24,7 +24,7 @@ public partial class Policy
 
     /// <summary>
     /// <para>Builds an <see cref="AsyncPolicy{TResult}"/> that will function like a result cache for delegate executions returning a <typeparamref name="TResult"/>.</para>
-    /// <para>Before executing a delegate, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="M:Context.OperationKey"/>.
+    /// <para>Before executing a delegate, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="Context.OperationKey"/>.
     /// If the <paramref name="cacheProvider"/> provides a value from cache, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider"/> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider"/>, then returns the value.
     /// </para>
     /// </summary>
@@ -343,7 +343,7 @@ public partial class Policy
 
     /// <summary>
     /// <para>Builds an <see cref="AsyncPolicy{TResult}"/> that will function like a result cache for delegate executions returning a <typeparamref name="TResult"/>.</para>
-    /// <para>Before executing a delegate, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="M:Context.OperationKey"/>.
+    /// <para>Before executing a delegate, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="Context.OperationKey"/>.
     /// If the <paramref name="cacheProvider"/> provides a value from cache, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider"/> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider"/>, then returns the value.
     /// </para>
     /// </summary>
@@ -357,7 +357,7 @@ public partial class Policy
 
     /// <summary>
     /// <para>Builds an <see cref="AsyncPolicy{TResult}"/> that will function like a result cache for delegate executions returning a <typeparamref name="TResult"/>.</para>
-    /// <para>Before executing a delegate, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="M:Context.OperationKey"/>.
+    /// <para>Before executing a delegate, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="Context.OperationKey"/>.
     /// If the <paramref name="cacheProvider"/> provides a value from cache, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider"/> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider"/>, then returns the value.
     /// </para>
     /// </summary>
@@ -372,7 +372,7 @@ public partial class Policy
 
     /// <summary>
     /// <para>Builds an <see cref="AsyncPolicy{TResult}"/> that will function like a result cache for delegate executions returning a <typeparamref name="TResult"/>.</para>
-    /// <para>Before executing a delegate, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="M:Context.OperationKey"/>.
+    /// <para>Before executing a delegate, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="Context.OperationKey"/>.
     /// If the <paramref name="cacheProvider"/> provides a value from cache, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider"/> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider"/>, then returns the value.
     /// </para>
     /// </summary>

--- a/src/Polly/Caching/AsyncSerializingCacheProvider.cs
+++ b/src/Polly/Caching/AsyncSerializingCacheProvider.cs
@@ -11,7 +11,7 @@ public class AsyncSerializingCacheProvider<TSerialized> : IAsyncCacheProvider
     private readonly ICacheItemSerializer<object, TSerialized> _serializer;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="AsyncSerializingCacheProvider{TResult, TSerialized}"/> class.
+    /// Initializes a new instance of the <see cref="AsyncSerializingCacheProvider{TSerialized}"/> class.
     /// </summary>
     /// <param name="wrappedCacheProvider">The wrapped cache provider.</param>
     /// <param name="serializer">The serializer.</param>

--- a/src/Polly/Caching/CacheProviderExtensions.cs
+++ b/src/Polly/Caching/CacheProviderExtensions.cs
@@ -7,7 +7,7 @@ namespace Polly.Caching;
 public static class CacheProviderExtensions
 {
     /// <summary>
-    /// Provides a strongly <typeparamref name="TCacheFormat"/>-typed version of the supplied <see cref="ISyncCacheProvider"/>
+    /// Provides a strongly <typeparamref name="TCacheFormat"/>-typed version of the supplied <see cref="ISyncCacheProvider"/>.
     /// </summary>
     /// <typeparam name="TCacheFormat">The type the returned <see cref="ISyncCacheProvider{TResult}"/> will handle.</typeparam>
     /// <param name="nonGenericCacheProvider">The non-generic cache provider to wrap.</param>
@@ -16,7 +16,7 @@ public static class CacheProviderExtensions
         new GenericCacheProvider<TCacheFormat>(nonGenericCacheProvider);
 
     /// <summary>
-    /// Provides a strongly <typeparamref name="TCacheFormat"/>-typed version of the supplied <see cref="IAsyncCacheProvider"/>
+    /// Provides a strongly <typeparamref name="TCacheFormat"/>-typed version of the supplied <see cref="IAsyncCacheProvider"/>.
     /// </summary>
     /// <typeparam name="TCacheFormat">The type the returned <see cref="IAsyncCacheProvider{TResult}"/> will handle.</typeparam>
     /// <param name="nonGenericCacheProvider">The non-generic cache provider to wrap.</param>

--- a/src/Polly/Caching/CacheSyntax.cs
+++ b/src/Polly/Caching/CacheSyntax.cs
@@ -5,7 +5,7 @@ public partial class Policy
 {
     /// <summary>
     /// <para>Builds a <see cref="Policy"/> that will function like a result cache for delegate executions returning a result.</para>
-    /// <para>Before executing a delegate returning a result, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="M:Context.OperationKey"/>.
+    /// <para>Before executing a delegate returning a result, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="Context.OperationKey"/>.
     /// If the <paramref name="cacheProvider"/> provides a value from cache, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider"/> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider"/>, then returns the value.
     /// </para>
     /// </summary>
@@ -19,7 +19,7 @@ public partial class Policy
 
     /// <summary>
     /// <para>Builds a <see cref="Policy" /> that will function like a result cache for delegate executions returning a result.</para>
-    /// <para>Before executing a delegate returning a result, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="M:Context.OperationKey"/>.
+    /// <para>Before executing a delegate returning a result, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="Context.OperationKey"/>.
     /// If the <paramref name="cacheProvider"/> provides a value from cache, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider"/> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider"/>, then returns the value.
     /// </para>
     /// </summary>

--- a/src/Polly/Caching/CacheTResultSyntax.cs
+++ b/src/Polly/Caching/CacheTResultSyntax.cs
@@ -5,7 +5,7 @@ public partial class Policy
 {
     /// <summary>
     /// <para>Builds a <see cref="Policy{TResult}"/> that will function like a result cache for delegate executions returning a <typeparamref name="TResult"/>.</para>
-    /// <para>Before executing a delegate, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="M:Context.OperationKey"/>.
+    /// <para>Before executing a delegate, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="Context.OperationKey"/>.
     /// If the <paramref name="cacheProvider"/> provides a value from cache, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider"/> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider"/>, then returns the value.
     /// </para>
     /// </summary>
@@ -24,7 +24,7 @@ public partial class Policy
 
     /// <summary>
     /// <para>Builds a <see cref="Policy{TResult}"/> that will function like a result cache for delegate executions returning a <typeparamref name="TResult"/>.</para>
-    /// <para>Before executing a delegate, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="M:Context.OperationKey"/>.
+    /// <para>Before executing a delegate, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="Context.OperationKey"/>.
     /// If the <paramref name="cacheProvider"/> provides a value from cache, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider"/> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider"/>, then returns the value.
     /// </para>
     /// </summary>
@@ -343,7 +343,7 @@ public partial class Policy
 
     /// <summary>
     /// <para>Builds a <see cref="Policy{TResult}"/> that will function like a result cache for delegate executions returning a <typeparamref name="TResult"/>.</para>
-    /// <para>Before executing a delegate, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="M:Context.OperationKey"/>.
+    /// <para>Before executing a delegate, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="Context.OperationKey"/>.
     /// If the <paramref name="cacheProvider"/> provides a value from cache, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider"/> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider"/>, then returns the value.
     /// </para>
     /// </summary>
@@ -357,7 +357,7 @@ public partial class Policy
 
     /// <summary>
     /// <para>Builds a <see cref="Policy{TResult}"/> that will function like a result cache for delegate executions returning a <typeparamref name="TResult"/>.</para>
-    /// <para>Before executing a delegate, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="M:Context.OperationKey"/>.
+    /// <para>Before executing a delegate, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="Context.OperationKey"/>.
     /// If the <paramref name="cacheProvider"/> provides a value from cache, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider"/> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider"/>, then returns the value.
     /// </para>
     /// </summary>
@@ -372,7 +372,7 @@ public partial class Policy
 
     /// <summary>
     /// <para>Builds a <see cref="Policy{TResult}"/> that will function like a result cache for delegate executions returning a <typeparamref name="TResult"/>.</para>
-    /// <para>Before executing a delegate, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="M:Context.OperationKey"/>.
+    /// <para>Before executing a delegate, checks whether the <paramref name="cacheProvider"/> holds a value for the cache key specified by <see cref="Context.OperationKey"/>.
     /// If the <paramref name="cacheProvider"/> provides a value from cache, returns that value and does not execute the governed delegate.  If the <paramref name="cacheProvider"/> does not provide a value, executes the governed delegate, stores the value with the <paramref name="cacheProvider"/>, then returns the value.
     /// </para>
     /// </summary>

--- a/src/Polly/Caching/DefaultCacheKeyStrategy.cs
+++ b/src/Polly/Caching/DefaultCacheKeyStrategy.cs
@@ -10,7 +10,7 @@ public class DefaultCacheKeyStrategy : ICacheKeyStrategy
     /// Gets the cache key from the given execution context.
     /// </summary>
     /// <param name="context">The execution context.</param>
-    /// <returns>The cache key</returns>
+    /// <returns>The cache key.</returns>
     public string GetCacheKey(Context context) =>
         context.OperationKey;
 

--- a/src/Polly/Caching/DefaultCacheKeyStrategy.cs
+++ b/src/Polly/Caching/DefaultCacheKeyStrategy.cs
@@ -2,7 +2,7 @@
 namespace Polly.Caching;
 
 /// <summary>
-/// The default cache key strategy for <see cref="CachePolicy"/>.  Returns the property <see cref="M:Context.OperationKey"/>.
+/// The default cache key strategy for <see cref="CachePolicy"/>.  Returns the property <see cref="Context.OperationKey"/>.
 /// </summary>
 public class DefaultCacheKeyStrategy : ICacheKeyStrategy
 {

--- a/src/Polly/Caching/ICacheItemSerializer.cs
+++ b/src/Polly/Caching/ICacheItemSerializer.cs
@@ -12,13 +12,13 @@ public interface ICacheItemSerializer<TResult, TSerialized>
     /// Serializes the specified object.
     /// </summary>
     /// <param name="objectToSerialize">The object to serialize.</param>
-    /// <returns>The serialized object</returns>
+    /// <returns>The serialized object.</returns>
     TSerialized? Serialize(TResult? objectToSerialize);
 
     /// <summary>
     /// Deserializes the specified object.
     /// </summary>
     /// <param name="objectToDeserialize">The object to deserialize.</param>
-    /// <returns>The deserialized object</returns>
+    /// <returns>The deserialized object.</returns>
     TResult? Deserialize(TSerialized? objectToDeserialize);
 }

--- a/src/Polly/Caching/ICacheKeyStrategy.cs
+++ b/src/Polly/Caching/ICacheKeyStrategy.cs
@@ -2,7 +2,7 @@
 namespace Polly.Caching;
 
 /// <summary>
-/// Defines how a <see cref="CachePolicy"/> should get a string cache key from an execution <see cref="Context"/>
+/// Defines how a <see cref="CachePolicy"/> should get a string cache key from an execution <see cref="Context"/>.
 /// </summary>
 public interface ICacheKeyStrategy
 {
@@ -10,6 +10,6 @@ public interface ICacheKeyStrategy
     /// Gets the cache key from the given execution context.
     /// </summary>
     /// <param name="context">The execution context.</param>
-    /// <returns>The cache key</returns>
+    /// <returns>The cache key.</returns>
     string GetCacheKey(Context context);
 }

--- a/src/Polly/Caching/NonSlidingTtl.cs
+++ b/src/Polly/Caching/NonSlidingTtl.cs
@@ -12,7 +12,7 @@ public abstract class NonSlidingTtl : ITtlStrategy
     protected readonly DateTimeOffset absoluteExpirationTime;
 
     /// <summary>
-    /// Constructs a new instance of the <see cref="NonSlidingTtl"/> strategy.
+    /// Initializes a new instance of the <see cref="NonSlidingTtl"/> class.
     /// </summary>
     /// <param name="absoluteExpirationTime">The absolute expiration time for cache items, represented by this strategy.</param>
     protected NonSlidingTtl(DateTimeOffset absoluteExpirationTime) =>

--- a/src/Polly/Caching/ResultTtl.cs
+++ b/src/Polly/Caching/ResultTtl.cs
@@ -10,7 +10,7 @@ public class ResultTtl<TResult> : ITtlStrategy<TResult>
     private readonly Func<Context, TResult?, Ttl> _ttlFunc;
 
     /// <summary>
-    /// Constructs a new instance of the <see cref="ResultTtl{TResult}"/> ttl strategy, with a func calculating <see cref="Ttl"/> based on the <typeparamref name="TResult"/> value to cache.
+    /// Initializes a new instance of the <see cref="ResultTtl{TResult}"/> class, with a func calculating <see cref="Ttl"/> based on the <typeparamref name="TResult"/> value to cache.
     /// </summary>
     /// <param name="ttlFunc">The function to calculate the TTL for which cache items should be considered valid.</param>
     public ResultTtl(Func<TResult?, Ttl> ttlFunc)
@@ -21,7 +21,7 @@ public class ResultTtl<TResult> : ITtlStrategy<TResult>
     }
 
     /// <summary>
-    /// Constructs a new instance of the <see cref="ResultTtl{TResult}"/> ttl strategy, with a func calculating <see cref="Ttl"/> based on the execution <see cref="Context"/> and <typeparamref name="TResult"/> value to cache.
+    /// Initializes a new instance of the <see cref="ResultTtl{TResult}"/> class, with a func calculating <see cref="Ttl"/> based on the execution <see cref="Context"/> and <typeparamref name="TResult"/> value to cache.
     /// </summary>
     /// <param name="ttlFunc">The function to calculate the TTL for which cache items should be considered valid.</param>
     public ResultTtl(Func<Context, TResult?, Ttl> ttlFunc) =>

--- a/src/Polly/Caching/SerializingCacheProvider.cs
+++ b/src/Polly/Caching/SerializingCacheProvider.cs
@@ -11,7 +11,7 @@ public class SerializingCacheProvider<TSerialized> : ISyncCacheProvider
     private readonly ICacheItemSerializer<object, TSerialized> _serializer;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="SerializingCacheProvider{TResult, TSerialized}" /> class.
+    /// Initializes a new instance of the <see cref="SerializingCacheProvider{TSerialized}"/> class.
     /// </summary>
     /// <param name="wrappedCacheProvider">The wrapped cache provider.</param>
     /// <param name="serializer">The serializer.</param>

--- a/src/Polly/Caching/SlidingTtl.cs
+++ b/src/Polly/Caching/SlidingTtl.cs
@@ -9,7 +9,7 @@ public class SlidingTtl : ITtlStrategy
     private readonly Ttl ttl;
 
     /// <summary>
-    /// Constructs a new instance of the <see cref="SlidingTtl"/> ttl strategy.
+    /// Initializes a new instance of the <see cref="SlidingTtl"/> class.
     /// </summary>
     /// <param name="slidingTtl">The sliding timespan for which cache items should be considered valid.</param>
     public SlidingTtl(TimeSpan slidingTtl)

--- a/src/Polly/Caching/Ttl.cs
+++ b/src/Polly/Caching/Ttl.cs
@@ -29,7 +29,7 @@ public struct Ttl
     /// <summary>
     /// Initializes a new instance of the <see cref="Ttl"/> struct.
     /// </summary>
-    /// <param name="timeSpan">The timespan for which this cache-item remains valid</param>
+    /// <param name="timeSpan">The timespan for which this cache-item remains valid.</param>
     /// <param name="slidingExpiration">Whether this <see cref="Ttl"/> should be considered as sliding expiration.</param>
     public Ttl(TimeSpan timeSpan, bool slidingExpiration)
     {

--- a/src/Polly/Caching/Ttl.cs
+++ b/src/Polly/Caching/Ttl.cs
@@ -17,7 +17,7 @@ public struct Ttl
     public bool SlidingExpiration;
 
     /// <summary>
-    /// Creates a new <see cref="Ttl"/> struct.
+    /// Initializes a new instance of the <see cref="Ttl"/> struct.
     /// </summary>
     /// <param name="timeSpan">The timespan for which this cache-item remains valid.
     /// <remarks>Will be considered as not denoting sliding expiration.</remarks></param>
@@ -27,7 +27,7 @@ public struct Ttl
     }
 
     /// <summary>
-    /// Creates a new <see cref="Ttl"/> struct.
+    /// Initializes a new instance of the <see cref="Ttl"/> struct.
     /// </summary>
     /// <param name="timeSpan">The timespan for which this cache-item remains valid</param>
     /// <param name="slidingExpiration">Whether this <see cref="Ttl"/> should be considered as sliding expiration.</param>

--- a/src/Polly/Caching/TtlStrategyExtensions.cs
+++ b/src/Polly/Caching/TtlStrategyExtensions.cs
@@ -7,7 +7,7 @@ namespace Polly.Caching;
 internal static class TtlStrategyExtensions
 {
     /// <summary>
-    /// Provides a strongly <typeparamref name="TResult"/>-typed version of the supplied <see cref="ITtlStrategy"/>
+    /// Provides a strongly <typeparamref name="TResult"/>-typed version of the supplied <see cref="ITtlStrategy"/>.
     /// </summary>
     /// <typeparam name="TResult">The type the returned <see cref="ITtlStrategy{TResult}"/> will handle.</typeparam>
     /// <param name="ttlStrategy">The non-generic ttl strategy to wrap.</param>

--- a/src/Polly/CircuitBreaker/CircuitBreakerSyntax.cs
+++ b/src/Polly/CircuitBreaker/CircuitBreakerSyntax.cs
@@ -23,8 +23,6 @@ public static class CircuitBreakerSyntax
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">exceptionsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static CircuitBreakerPolicy CircuitBreaker(this PolicyBuilder policyBuilder, int exceptionsAllowedBeforeBreaking, TimeSpan durationOfBreak)
     {
         Action<Exception, TimeSpan> doNothingOnBreak = (_, _) => { };

--- a/src/Polly/CircuitBreaker/CircuitBreakerTResultSyntax.cs
+++ b/src/Polly/CircuitBreaker/CircuitBreakerTResultSyntax.cs
@@ -23,8 +23,6 @@ public static class CircuitBreakerTResultSyntax
     /// <returns>The policy instance.</returns>
     /// <remarks>(see "Release It!" by Michael T. Nygard fi).</remarks>
     /// <exception cref="ArgumentOutOfRangeException">handledEventsAllowedBeforeBreaking;Value must be greater than zero.</exception>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onBreak"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onReset"/> is <see langword="null"/>.</exception>
     public static CircuitBreakerPolicy<TResult> CircuitBreaker<TResult>(this PolicyBuilder<TResult> policyBuilder, int handledEventsAllowedBeforeBreaking, TimeSpan durationOfBreak)
     {
         Action<DelegateResult<TResult>, TimeSpan> doNothingOnBreak = (_, _) => { };

--- a/src/Polly/CircuitBreaker/ICircuitController.cs
+++ b/src/Polly/CircuitBreaker/ICircuitController.cs
@@ -1,14 +1,57 @@
 ﻿namespace Polly.CircuitBreaker;
 
+/// <summary>
+/// Interface for controlling a circuit breaker.
+/// </summary>
+/// <typeparam name="TResult">The type of the result.</typeparam>
 internal interface ICircuitController<TResult>
 {
+    /// <summary>
+    /// Gets the state of the circuit.
+    /// </summary>
     CircuitState CircuitState { get; }
+
+    /// <summary>
+    /// Gets the last exception that was handled by the circuit breaker.
+    /// </summary>
     Exception LastException { get; }
+
+    /// <summary>
+    /// Gets the last result that was handled by the circuit breaker.
+    /// </summary>
     TResult LastHandledResult { get; }
+
+    /// <summary>
+    /// Isolates the circuit breaker.
+    /// </summary>
     void Isolate();
+
+    /// <summary>
+    /// Resets the circuit breaker.
+    /// </summary>
     void Reset();
+
+    /// <summary>
+    /// Handles the circuit reset event.
+    /// </summary>
+    /// <param name="context">The context.</param>
     void OnCircuitReset(Context context);
+
+    /// <summary>
+    /// Handles the action pre-execute event.
+    /// </summary>
     void OnActionPreExecute();
+
+    /// <summary>
+    /// Handles the action success event.
+    /// </summary>
+    /// <param name="context">The context.</param>
     void OnActionSuccess(Context context);
+
+    /// <summary>
+    /// Handles the action failure event.
+    /// </summary>
+    /// <param name="outcome">The outcome of the delegate.</param>
+    /// <param name="context">The context.</param>
     void OnActionFailure(DelegateResult<TResult> outcome, Context context);
 }

--- a/src/Polly/CircuitBreaker/IHealthMetrics.cs
+++ b/src/Polly/CircuitBreaker/IHealthMetrics.cs
@@ -1,11 +1,28 @@
 ﻿namespace Polly.CircuitBreaker;
 
+/// <summary>
+/// Interface for managing health metrics.
+/// </summary>
 internal interface IHealthMetrics
 {
+    /// <summary>
+    /// Increments the success count.
+    /// </summary>
     void IncrementSuccess_NeedsLock();
+
+    /// <summary>
+    /// Increments the failure count.
+    /// </summary>
     void IncrementFailure_NeedsLock();
 
+    /// <summary>
+    /// Resets the health metrics.
+    /// </summary>
     void Reset_NeedsLock();
 
+    /// <summary>
+    /// Gets the health count.
+    /// </summary>
+    /// <returns>The current health count.</returns>
     HealthCount GetHealthCount_NeedsLock();
 }

--- a/src/Polly/Context.Dictionary.cs
+++ b/src/Polly/Context.Dictionary.cs
@@ -118,8 +118,11 @@ public partial class Context : IDictionary<string, object>, IDictionary, IReadOn
     #endregion
 
     #region IReadOnlyDictionary<string, object> implementation
+
+    /// <inheritdoc/>
     IEnumerable<string> IReadOnlyDictionary<string, object>.Keys => ((IReadOnlyDictionary<string, object>)WrappedDictionary).Keys;
 
+    /// <inheritdoc/>
     IEnumerable<object> IReadOnlyDictionary<string, object>.Values => ((IReadOnlyDictionary<string, object>)WrappedDictionary).Values;
 
     #endregion
@@ -132,8 +135,10 @@ public partial class Context : IDictionary<string, object>, IDictionary, IReadOn
     /// <inheritdoc cref="IDictionary"/>
     bool IDictionary.IsReadOnly => ((IDictionary)WrappedDictionary).IsReadOnly;
 
+    /// <inheritdoc/>
     ICollection IDictionary.Keys => ((IDictionary)WrappedDictionary).Keys;
 
+    /// <inheritdoc/>
     ICollection IDictionary.Values => ((IDictionary)WrappedDictionary).Values;
 
     /// <inheritdoc cref="IDictionary"/>

--- a/src/Polly/DelegateResult.cs
+++ b/src/Polly/DelegateResult.cs
@@ -6,13 +6,13 @@
 public class DelegateResult<TResult>
 {
     /// <summary>
-    /// Create an instance of <see cref="DelegateResult{TResult}"/> representing an execution which returned <paramref name="result"/>.
+    /// Initializes a new instance of the <see cref="DelegateResult{TResult}"/> class representing an execution which returned <paramref name="result"/>.
     /// </summary>
     /// <param name="result">The result.</param>
     public DelegateResult(TResult result) => Result = result;
 
     /// <summary>
-    /// Create an instance of <see cref="DelegateResult{TResult}"/> representing an execution which threw <paramref name="exception"/>.
+    /// Initializes a new instance of the <see cref="DelegateResult{TResult}"/> class representing an execution which threw <paramref name="exception"/>.
     /// </summary>
     /// <param name="exception">The exception.</param>
     public DelegateResult(Exception exception) =>

--- a/src/Polly/IsPolicy.cs
+++ b/src/Polly/IsPolicy.cs
@@ -6,7 +6,7 @@
 public interface IsPolicy
 {
     /// <summary>
-    /// A key intended to be unique to each policy instance, which is passed with executions as the <see cref="M:Context.PolicyKey"/> property.
+    /// A key intended to be unique to each policy instance, which is passed with executions as the <see cref="Context.PolicyKey"/> property.
     /// </summary>
     string PolicyKey { get; }
 }

--- a/src/Polly/NoOp/NoOpPolicy.cs
+++ b/src/Polly/NoOp/NoOpPolicy.cs
@@ -18,7 +18,7 @@ public class NoOpPolicy : Policy, INoOpPolicy
 }
 
 /// <summary>
-/// A no op policy that can be applied to delegates returning a value of type <typeparamref name="TResult" />
+/// A no op policy that can be applied to delegates returning a value of type <typeparamref name="TResult" />.
 /// </summary>
 /// <typeparam name="TResult">The type of return values this policy will handle.</typeparam>
 public class NoOpPolicy<TResult> : Policy<TResult>, INoOpPolicy<TResult>

--- a/src/Polly/Policy.TResult.cs
+++ b/src/Polly/Policy.TResult.cs
@@ -4,6 +4,7 @@ namespace Polly;
 /// <summary>
 /// Transient fault handling policies that can be applied to delegates returning results of type <typeparamref name="TResult"/>.
 /// </summary>
+/// <typeparam name="TResult">The type of return value of the delegate that the policy will be applied to.</typeparam>
 public abstract partial class Policy<TResult> : PolicyBase<TResult>
 {
     /// <summary>

--- a/src/Polly/Policy.TResult.cs
+++ b/src/Polly/Policy.TResult.cs
@@ -7,7 +7,7 @@ namespace Polly;
 public abstract partial class Policy<TResult> : PolicyBase<TResult>
 {
     /// <summary>
-    /// Constructs a new instance of a derived <see cref="Policy{TResult}"/> type with the passed <paramref name="exceptionPredicates"/> and <paramref name="resultPredicates"/>.
+    /// Initializes a new instance of the <see cref="Policy{TResult}"/> class.
     /// </summary>
     /// <param name="exceptionPredicates">Predicates indicating which exceptions the policy should handle.</param>
     /// <param name="resultPredicates">Predicates indicating which results the policy should handle.</param>
@@ -17,7 +17,7 @@ public abstract partial class Policy<TResult> : PolicyBase<TResult>
     }
 
     /// <summary>
-    /// Constructs a new instance of a derived <see cref="Policy{TResult}"/> type with the passed <paramref name="policyBuilder"/>.
+    /// Initializes a new instance of the <see cref="Policy{TResult}"/> class.
     /// </summary>
     /// <param name="policyBuilder">A <see cref="PolicyBuilder{TResult}"/> indicating which exceptions and results the policy should handle.</param>
     protected Policy(PolicyBuilder<TResult>? policyBuilder = null)

--- a/src/Polly/Policy.cs
+++ b/src/Polly/Policy.cs
@@ -7,7 +7,7 @@ namespace Polly;
 public abstract partial class Policy : PolicyBase
 {
     /// <summary>
-    /// Constructs a new instance of a derived <see cref="Policy"/> type with the passed <paramref name="exceptionPredicates"/>.
+    /// Initializes a new instance of the <see cref="Policy"/> class.
     /// </summary>
     /// <param name="exceptionPredicates">Predicates indicating which exceptions the policy should handle. </param>
     internal Policy(ExceptionPredicates exceptionPredicates)
@@ -16,7 +16,7 @@ public abstract partial class Policy : PolicyBase
     }
 
     /// <summary>
-    /// Constructs a new instance of a derived <see cref="Policy"/> type with the passed <paramref name="policyBuilder"/>.
+    /// Initializes a new instance of the <see cref="Policy"/> class.
     /// </summary>
     /// <param name="policyBuilder">A <see cref="PolicyBuilder"/> specifying which exceptions the policy should handle. </param>
     protected Policy(PolicyBuilder? policyBuilder = null)

--- a/src/Polly/PolicyBase.ContextAndKeys.cs
+++ b/src/Polly/PolicyBase.ContextAndKeys.cs
@@ -8,7 +8,7 @@ public abstract partial class PolicyBase
     protected string policyKeyInternal;
 
     /// <summary>
-    /// A key intended to be unique to each <see cref="IsPolicy"/> instance, which is passed with executions as the <see cref="M:Context.PolicyKey"/> property.
+    /// A key intended to be unique to each <see cref="IsPolicy"/> instance, which is passed with executions as the <see cref="Context.PolicyKey"/> property.
     /// </summary>
     public string PolicyKey => policyKeyInternal ?? (policyKeyInternal = GetType().Name + "-" + KeyHelper.GuidPart());
 
@@ -18,8 +18,8 @@ public abstract partial class PolicyBase
     /// Restores the supplied keys to the execution <see cref="Context"/>.
     /// </summary>
     /// <param name="executionContext">The execution <see cref="Context"/>.</param>
-    /// <param name="priorPolicyWrapKey">The <see cref="M:Context.PolicyWrapKey"/> prior to execution through this policy.</param>
-    /// <param name="priorPolicyKey">The <see cref="M:Context.PolicyKey"/> prior to execution through this policy.</param>
+    /// <param name="priorPolicyWrapKey">The <see cref="Context.PolicyWrapKey"/> prior to execution through this policy.</param>
+    /// <param name="priorPolicyKey">The <see cref="Context.PolicyKey"/> prior to execution through this policy.</param>
     internal static void RestorePolicyContext(Context executionContext, string priorPolicyWrapKey, string priorPolicyKey)
     {
         executionContext.PolicyWrapKey = priorPolicyWrapKey;
@@ -30,8 +30,8 @@ public abstract partial class PolicyBase
     /// Updates the execution <see cref="Context"/> with context from the executing policy.
     /// </summary>
     /// <param name="executionContext">The execution <see cref="Context"/>.</param>
-    /// <param name="priorPolicyWrapKey">The <see cref="M:Context.PolicyWrapKey"/> prior to changes by this method.</param>
-    /// <param name="priorPolicyKey">The <see cref="M:Context.PolicyKey"/> prior to changes by this method.</param>
+    /// <param name="priorPolicyWrapKey">The <see cref="Context.PolicyWrapKey"/> prior to changes by this method.</param>
+    /// <param name="priorPolicyKey">The <see cref="Context.PolicyKey"/> prior to changes by this method.</param>
     internal virtual void SetPolicyContext(Context executionContext, out string priorPolicyWrapKey, out string priorPolicyKey) // priorPolicyWrapKey and priorPolicyKey could be handled as a (string, string) System.ValueTuple return type instead of out parameters, when our minimum supported target supports this.
     {
         priorPolicyWrapKey = executionContext.PolicyWrapKey;

--- a/src/Polly/PolicyBase.cs
+++ b/src/Polly/PolicyBase.cs
@@ -30,14 +30,14 @@ public abstract partial class PolicyBase
     }
 
     /// <summary>
-    /// Constructs a new instance of a derived type of <see cref="PolicyBase"/> with the passed <paramref name="exceptionPredicates"/>.
+    /// Initializes a new instance of the <see cref="PolicyBase"/> class.
     /// </summary>
     /// <param name="exceptionPredicates">Predicates indicating which exceptions the policy should handle. </param>
     internal PolicyBase(ExceptionPredicates exceptionPredicates) =>
         ExceptionPredicates = exceptionPredicates ?? ExceptionPredicates.None;
 
     /// <summary>
-    /// Constructs a new instance of a derived type of <see cref="PolicyBase"/> with the passed <paramref name="policyBuilder"/>.
+    /// Initializes a new instance of the <see cref="PolicyBase"/> class.
     /// </summary>
     /// <param name="policyBuilder">A <see cref="PolicyBuilder"/> indicating which exceptions the policy should handle.</param>
     protected PolicyBase(PolicyBuilder policyBuilder)
@@ -57,7 +57,7 @@ public abstract class PolicyBase<TResult> : PolicyBase
     protected internal ResultPredicates<TResult> ResultPredicates { get; }
 
     /// <summary>
-    /// Constructs a new instance of a derived type of <see cref="PolicyBase{TResult}"/>.
+    /// Initializes a new instance of the <see cref="PolicyBase{TResult}"/> class.
     /// </summary>
     /// <param name="exceptionPredicates">Predicates indicating which exceptions the policy should handle. </param>
     /// <param name="resultPredicates">Predicates indicating which results the policy should handle. </param>
@@ -68,7 +68,7 @@ public abstract class PolicyBase<TResult> : PolicyBase
         ResultPredicates = resultPredicates ?? ResultPredicates<TResult>.None;
 
     /// <summary>
-    /// Constructs a new instance of a derived type of <see cref="PolicyBase{TResult}"/> with the passed <paramref name="policyBuilder"/>.
+    /// Initializes a new instance of the <see cref="PolicyBase{TResult}"/> class.
     /// </summary>
     /// <param name="policyBuilder">A <see cref="PolicyBuilder"/> indicating which exceptions the policy should handle.</param>
     protected PolicyBase(PolicyBuilder<TResult> policyBuilder)

--- a/src/Polly/PolicyBuilder.cs
+++ b/src/Polly/PolicyBuilder.cs
@@ -52,10 +52,10 @@ public sealed partial class PolicyBuilder
         base.GetHashCode();
 
     /// <summary>
-    /// Gets the <see cref="T:System.Type" /> of the current instance.
+    /// Gets the <see cref="System.Type" /> of the current instance.
     /// </summary>
     /// <returns>
-    /// The <see cref="T:System.Type" /> instance that represents the exact runtime type of the current instance.
+    /// The <see cref="System.Type" /> instance that represents the exact runtime type of the current instance.
     /// </returns>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public new Type GetType() =>
@@ -130,10 +130,10 @@ public sealed partial class PolicyBuilder<TResult>
         base.GetHashCode();
 
     /// <summary>
-    /// Gets the <see cref="T:System.Type" /> of the current instance.
+    /// Gets the <see cref="System.Type" /> of the current instance.
     /// </summary>
     /// <returns>
-    /// The <see cref="T:System.Type" /> instance that represents the exact runtime type of the current instance.
+    /// The <see cref="System.Type" /> instance that represents the exact runtime type of the current instance.
     /// </returns>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public new Type GetType() =>

--- a/src/Polly/PolicyBuilder.cs
+++ b/src/Polly/PolicyBuilder.cs
@@ -67,6 +67,7 @@ public sealed partial class PolicyBuilder
 /// <summary>
 /// Builder class that holds the list of current execution predicates filtering TResult result values.
 /// </summary>
+/// <typeparam name="TResult">The type of the result value that the execution predicates are filtering.</typeparam>
 public sealed partial class PolicyBuilder<TResult>
 {
     private PolicyBuilder()

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0;net472;net462</TargetFrameworks>
     <AssemblyTitle>Polly</AssemblyTitle>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ProjectType>Library</ProjectType>
     <MutationScore>70</MutationScore>
     <IncludePollyUsings>true</IncludePollyUsings>

--- a/src/Polly/RateLimit/AsyncRateLimitTResultSyntax.cs
+++ b/src/Polly/RateLimit/AsyncRateLimitTResultSyntax.cs
@@ -48,7 +48,7 @@ public partial class Policy
 
     /// <summary>
     /// Builds a RateLimit <see cref="AsyncPolicy{TResult}"/> that will rate-limit executions to <paramref name="numberOfExecutions"/> per the timespan given,
-    /// with a maximum burst size of <paramref name="maxBurst"/>
+    /// with a maximum burst size of <paramref name="maxBurst"/>.
     /// </summary>
     /// <typeparam name="TResult">The type of return values this policy will handle.</typeparam>
     /// <param name="numberOfExecutions">The number of executions (call it N) permitted per timespan.</param>

--- a/src/Polly/RateLimit/IRateLimiter.cs
+++ b/src/Polly/RateLimit/IRateLimiter.cs
@@ -3,7 +3,7 @@
 namespace Polly.RateLimit;
 
 /// <summary>
-/// Defines methods to be provided by a rate-limiter used in a Polly <see cref="IRateLimitPolicy"/>
+/// Defines methods to be provided by a rate-limiter used in a Polly <see cref="IRateLimitPolicy"/>.
 /// </summary>
 internal interface IRateLimiter
 {

--- a/src/Polly/RateLimit/RateLimitTResultSyntax.cs
+++ b/src/Polly/RateLimit/RateLimitTResultSyntax.cs
@@ -48,7 +48,7 @@ public partial class Policy
 
     /// <summary>
     /// Builds a RateLimit <see cref="Policy{TResult}"/> that will rate-limit executions to <paramref name="numberOfExecutions"/> per the timespan given,
-    /// with a maximum burst size of <paramref name="maxBurst"/>
+    /// with a maximum burst size of <paramref name="maxBurst"/>.
     /// </summary>
     /// <typeparam name="TResult">The type of return values this policy will handle.</typeparam>
     /// <param name="numberOfExecutions">The number of executions (call it N) permitted per timespan.</param>

--- a/src/Polly/Registry/IConcurrentPolicyRegistry.cs
+++ b/src/Polly/Registry/IConcurrentPolicyRegistry.cs
@@ -37,7 +37,7 @@ public interface IConcurrentPolicyRegistry<TKey> : IPolicyRegistry<TKey>
     /// <param name="key">The key whose value is compared with comparisonPolicy, and possibly replaced.</param>
     /// <param name="newPolicy">The policy that replaces the value for the specified <paramref name="key"/>, if the comparison results in equality.</param>
     /// <param name="comparisonPolicy">The policy that is compared to the existing policy at the specified key.</param>
-    /// <returns></returns>
+    /// <returns>True if the policy is successfully updated. Otherwise false.</returns>
     bool TryUpdate<TPolicy>(TKey key, TPolicy newPolicy, TPolicy comparisonPolicy)
         where TPolicy : IsPolicy;
 

--- a/src/Polly/Registry/PolicyRegistry.cs
+++ b/src/Polly/Registry/PolicyRegistry.cs
@@ -21,7 +21,7 @@ public class PolicyRegistry : IConcurrentPolicyRegistry<string>
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="PolicyRegistry"/> class, with <see cref="IDictionary{string, IsPolicy}"/> dictionary.
+    /// Initializes a new instance of the <see cref="PolicyRegistry"/> class.
     /// <remarks>This internal constructor exists solely to facilitate testing of the GetEnumerator() methods, which allow us to support collection initialisation syntax.</remarks>
     /// </summary>
     /// <param name="registry">a dictionary containing keys and policies used for testing.</param>

--- a/src/Polly/Retry/AsyncRetrySyntax.cs
+++ b/src/Polly/Retry/AsyncRetrySyntax.cs
@@ -47,7 +47,7 @@ public static class AsyncRetrySyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy RetryAsync(this PolicyBuilder policyBuilder, Func<Exception, int, Task> onRetryAsync) =>
         policyBuilder.RetryAsync(1, onRetryAsync: (outcome, i, _) => onRetryAsync(outcome, i));
 
@@ -107,7 +107,7 @@ public static class AsyncRetrySyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy RetryAsync(this PolicyBuilder policyBuilder, Func<Exception, int, Context, Task> onRetryAsync) =>
         policyBuilder.RetryAsync(1, onRetryAsync);
 

--- a/src/Polly/Retry/AsyncRetryTResultSyntax.cs
+++ b/src/Polly/Retry/AsyncRetryTResultSyntax.cs
@@ -46,7 +46,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> RetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<DelegateResult<TResult>, int, Task> onRetryAsync) =>
         policyBuilder.RetryAsync(1, onRetryAsync: (outcome, i, _) => onRetryAsync(outcome, i));
 
@@ -107,7 +107,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <param name="onRetryAsync">The action to call asynchronously on each retry.</param>
     /// <returns>The policy instance.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetry"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> RetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<DelegateResult<TResult>, int, Context, Task> onRetryAsync) =>
         policyBuilder.RetryAsync(1, onRetryAsync);
 

--- a/src/Polly/Utilities/SystemClock.cs
+++ b/src/Polly/Utilities/SystemClock.cs
@@ -18,7 +18,7 @@ public static class SystemClock
 
     /// <summary>
     /// Allows the setting of a custom async Sleep implementation for testing.
-    /// By default this will be a call to <see cref="M:Task.Delay"/> taking a <see cref="CancellationToken"/>.
+    /// By default this will be a call to <see cref="Task.Delay(TimeSpan)"/> taking a <see cref="CancellationToken"/>.
     /// </summary>
     public static Func<TimeSpan, CancellationToken, Task> SleepAsync = Task.Delay;
 

--- a/src/Polly/Wrap/AsyncPolicyWrap.ContextAndKeys.cs
+++ b/src/Polly/Wrap/AsyncPolicyWrap.ContextAndKeys.cs
@@ -6,8 +6,8 @@ public partial class AsyncPolicyWrap
     /// Updates the execution <see cref="Context"/> with context from the executing <see cref="PolicyWrap"/>.
     /// </summary>
     /// <param name="executionContext">The execution <see cref="Context"/>.</param>
-    /// <param name="priorPolicyWrapKey">The <see cref="M:Context.PolicyWrapKey"/> prior to changes by this method.</param>
-    /// <param name="priorPolicyKey">The <see cref="M:Context.PolicyKey"/> prior to changes by this method.</param>
+    /// <param name="priorPolicyWrapKey">The <see cref="Context.PolicyWrapKey"/> prior to changes by this method.</param>
+    /// <param name="priorPolicyKey">The <see cref="Context.PolicyKey"/> prior to changes by this method.</param>
     internal override void SetPolicyContext(Context executionContext, out string priorPolicyWrapKey, out string priorPolicyKey)
     {
         priorPolicyWrapKey = executionContext.PolicyWrapKey;
@@ -26,8 +26,8 @@ public partial class AsyncPolicyWrap<TResult>
     /// Updates the execution <see cref="Context"/> with context from the executing <see cref="PolicyWrap{TResult}"/>.
     /// </summary>
     /// <param name="executionContext">The execution <see cref="Context"/>.</param>
-    /// <param name="priorPolicyWrapKey">The <see cref="M:Context.PolicyWrapKey"/> prior to changes by this method.</param>
-    /// <param name="priorPolicyKey">The <see cref="M:Context.PolicyKey"/> prior to changes by this method.</param>
+    /// <param name="priorPolicyWrapKey">The <see cref="Context.PolicyWrapKey"/> prior to changes by this method.</param>
+    /// <param name="priorPolicyKey">The <see cref="Context.PolicyKey"/> prior to changes by this method.</param>
     internal override void SetPolicyContext(Context executionContext, out string priorPolicyWrapKey, out string priorPolicyKey)
     {
         priorPolicyWrapKey = executionContext.PolicyWrapKey;

--- a/src/Polly/Wrap/AsyncPolicyWrap.cs
+++ b/src/Polly/Wrap/AsyncPolicyWrap.cs
@@ -9,12 +9,12 @@ public partial class AsyncPolicyWrap : AsyncPolicy, IPolicyWrap
     private readonly IAsyncPolicy _inner;
 
     /// <summary>
-    /// Returns the outer <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>
+    /// Returns the outer <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>.
     /// </summary>
     public IsPolicy Outer => _outer;
 
     /// <summary>
-    /// Returns the next inner <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>
+    /// Returns the next inner <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>.
     /// </summary>
     public IsPolicy Inner => _inner;
 
@@ -66,12 +66,12 @@ public partial class AsyncPolicyWrap<TResult> : AsyncPolicy<TResult>, IPolicyWra
     private readonly IAsyncPolicy<TResult> _innerGeneric;
 
     /// <summary>
-    /// Returns the outer <see cref="IsPolicy"/> in this <see cref="IPolicyWrap{TResult}"/>
+    /// Returns the outer <see cref="IsPolicy"/> in this <see cref="IPolicyWrap{TResult}"/>.
     /// </summary>
     public IsPolicy Outer => (IsPolicy)_outerGeneric ?? _outerNonGeneric;
 
     /// <summary>
-    /// Returns the next inner <see cref="IsPolicy"/> in this <see cref="IPolicyWrap{TResult}"/>
+    /// Returns the next inner <see cref="IsPolicy"/> in this <see cref="IPolicyWrap{TResult}"/>.
     /// </summary>
     public IsPolicy Inner => (IsPolicy)_innerGeneric ?? _innerNonGeneric;
 

--- a/src/Polly/Wrap/IPolicyWrap.cs
+++ b/src/Polly/Wrap/IPolicyWrap.cs
@@ -6,12 +6,12 @@
 public interface IPolicyWrap : IsPolicy
 {
     /// <summary>
-    /// Returns the outer <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>
+    /// Returns the outer <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>.
     /// </summary>
     IsPolicy Outer { get; }
 
     /// <summary>
-    /// Returns the next inner <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>
+    /// Returns the next inner <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>.
     /// </summary>
     IsPolicy Inner { get; }
 }

--- a/src/Polly/Wrap/PolicyWrap.ContextAndKeys.cs
+++ b/src/Polly/Wrap/PolicyWrap.ContextAndKeys.cs
@@ -6,8 +6,8 @@ public partial class PolicyWrap
     /// Updates the execution <see cref="Context"/> with context from the executing <see cref="PolicyWrap"/>.
     /// </summary>
     /// <param name="executionContext">The execution <see cref="Context"/>.</param>
-    /// <param name="priorPolicyWrapKey">The <see cref="M:Context.PolicyWrapKey"/> prior to changes by this method.</param>
-    /// <param name="priorPolicyKey">The <see cref="M:Context.PolicyKey"/> prior to changes by this method.</param>
+    /// <param name="priorPolicyWrapKey">The <see cref="Context.PolicyWrapKey"/> prior to changes by this method.</param>
+    /// <param name="priorPolicyKey">The <see cref="Context.PolicyKey"/> prior to changes by this method.</param>
     internal override void SetPolicyContext(Context executionContext, out string priorPolicyWrapKey, out string priorPolicyKey)
     {
         priorPolicyWrapKey = executionContext.PolicyWrapKey;
@@ -26,8 +26,8 @@ public partial class PolicyWrap<TResult>
     /// Updates the execution <see cref="Context"/> with context from the executing <see cref="PolicyWrap{TResult}"/>.
     /// </summary>
     /// <param name="executionContext">The execution <see cref="Context"/>.</param>
-    /// <param name="priorPolicyWrapKey">The <see cref="M:Context.PolicyWrapKey"/> prior to changes by this method.</param>
-    /// <param name="priorPolicyKey">The <see cref="M:Context.PolicyKey"/> prior to changes by this method.</param>
+    /// <param name="priorPolicyWrapKey">The <see cref="Context.PolicyWrapKey"/> prior to changes by this method.</param>
+    /// <param name="priorPolicyKey">The <see cref="Context.PolicyKey"/> prior to changes by this method.</param>
     internal override void SetPolicyContext(Context executionContext, out string priorPolicyWrapKey, out string priorPolicyKey)
     {
         priorPolicyWrapKey = executionContext.PolicyWrapKey;

--- a/src/Polly/Wrap/PolicyWrap.cs
+++ b/src/Polly/Wrap/PolicyWrap.cs
@@ -9,12 +9,12 @@ public partial class PolicyWrap : Policy, IPolicyWrap
     private readonly ISyncPolicy _inner;
 
     /// <summary>
-    /// Returns the outer <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>
+    /// Returns the outer <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>.
     /// </summary>
     public IsPolicy Outer => _outer;
 
     /// <summary>
-    /// Returns the next inner <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>
+    /// Returns the next inner <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>.
     /// </summary>
     public IsPolicy Inner => _inner;
 
@@ -59,12 +59,12 @@ public partial class PolicyWrap<TResult> : Policy<TResult>, IPolicyWrap<TResult>
     private readonly ISyncPolicy<TResult> _innerGeneric;
 
     /// <summary>
-    /// Returns the outer <see cref="IsPolicy"/> in this <see cref="IPolicyWrap{TResult}"/>
+    /// Returns the outer <see cref="IsPolicy"/> in this <see cref="IPolicyWrap{TResult}"/>.
     /// </summary>
     public IsPolicy Outer => (IsPolicy)_outerGeneric ?? _outerNonGeneric;
 
     /// <summary>
-    /// Returns the next inner <see cref="IsPolicy"/> in this <see cref="IPolicyWrap{TResult}"/>
+    /// Returns the next inner <see cref="IsPolicy"/> in this <see cref="IPolicyWrap{TResult}"/>.
     /// </summary>
     public IsPolicy Inner => (IsPolicy)_innerGeneric ?? _innerNonGeneric;
 


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed
Contributes to #1290 by further addressing some XML documentation quality issues as noted in #2007

## Details on the issue fix or feature implementation
- [x] Enables generation of the documentation file for `Polly` project, so we get documentation related compiler warnings.
- [x] Fixes identified XML comments quality issues:
- CS1734 "XML comment on '{1}' has a paramref tag for '{0}', but there is no parameter by that name"
- CS1658 "Type parameter declaration must be an identifier not a type."
- SA1616 "Element return value documentation should have text"
- SA1648 "inheritdoc should be used with inheriting class"
- SA1642 "Constructor summary documentation should begin with standard text"
- SA1629 "Documentation text should end with a period"
- SA1619 "The documentation for type parameter 'TResult' is missing"
- CA1200 "Avoid using cref tags with a prefix"
- SA1600 "Elements should be documented"

  
## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
