### PR TITLE
Clearing out the only 1805 violation using the method listed here: ht…

### DIFF
--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -12,7 +12,6 @@
     <NoWarn>$(NoWarn);CA2211;S2223;CA1032;CA1815;CA1816;S4457;SA1615;SA1618;CA1033</NoWarn>
     <NoWarn>$(NoWarn);S4023;CA1010;S3442;CA1064;SA1649;SA1625;SA1623;SA1118</NoWarn>
     <NoWarn>$(NoWarn);S3253;S3971;S6605;CA1724;CA1716;SA1108;CA1710;S4049;S3246</NoWarn>
-    <NoWarn>$(NoWarn);CA1805</NoWarn>
 
     <!--Pulic API Analyzers: We do not need to fix these as it would break compatibility with released Polly versions-->
     <NoWarn>$(NoWarn);RS0037;</NoWarn>

--- a/src/Polly/RateLimit/LockFreeTokenBucketRateLimiter.cs
+++ b/src/Polly/RateLimit/LockFreeTokenBucketRateLimiter.cs
@@ -15,7 +15,7 @@ internal sealed class LockFreeTokenBucketRateLimiter : IRateLimiter
     private long addNextTokenAtTicks;
 
 #if !NETSTANDARD2_0
-    private SpinWait spinner = default;
+    private static SpinWait spinner => default;
 #endif
 
     /// <summary>


### PR DESCRIPTION
…tps://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1805#how-to-fix-violations

<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
Addressing the CA1805 as a part of [issue 1290](https://github.com/App-vNext/Polly/issues/1290)

<!-- Please include the existing GitHub issue number where relevant -->

## Details on the issue fix or feature implementation
Removed the NoWarn for CA1805, and changes the spinner to be static and have a lambda for the default value, as suggested here: https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1805#how-to-fix-violations
## Confirm the following

- [X]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [X]  I have successfully run a local build
