### PR TITLE
Add F# and VB.NET samples

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
     <PackageVersion Include="coverlet.msbuild" Version="6.0.1" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+    <PackageVersion Include="FSharp.Core" Version="8.0.200" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="$(MicrosoftExtensionsVersion)" />

--- a/samples/Intro.FSharp/Intro.FSharp.fsproj
+++ b/samples/Intro.FSharp/Intro.FSharp.fsproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FSharp.Core" />
+    <PackageReference Include="Polly.Core" />
+  </ItemGroup>
+
+</Project>

--- a/samples/Intro.FSharp/Program.fs
+++ b/samples/Intro.FSharp/Program.fs
@@ -1,0 +1,49 @@
+﻿open System
+open System.Threading
+open System.Threading.Tasks
+open Polly
+
+let getBestFilmAsync(token: CancellationToken) =
+    task {
+        do! Task.Delay(1000, token) |> Async.AwaitTask
+        return "https://www.imdb.com/title/tt0080684/"
+    }
+
+let demo() =
+    async {
+        // The ResiliencePipelineBuilder creates a ResiliencePipeline
+        // that can be executed synchronously or asynchronously
+        // and for both void and result-returning user-callbacks.
+        let pipeline = ResiliencePipelineBuilder().AddTimeout(TimeSpan.FromSeconds(5)).Build()
+
+        // Synchronously
+        pipeline.Execute(Action(fun () -> Console.WriteLine("Hello, world!")))
+
+        // Asynchronously
+        // Note that the function is wrapped in a ValueTask for Polly to use as F# cannot
+        // await ValueTask directly, and AsTask() is used to convert the ValueTask returned by
+        // ExecuteAsync() to a Task so it can be awaited.
+        do! pipeline.ExecuteAsync(Func<CancellationToken, ValueTask>(fun token -> new ValueTask(task {
+            Console.WriteLine("Hello, world! Waiting for 1 second...")
+            do! Task.Delay(1000, token) |> Async.AwaitTask
+        })),
+        CancellationToken.None).AsTask() |> Async.AwaitTask
+
+        // Synchronously with result
+        let someResult = pipeline.Execute(Func<CancellationToken, string>(fun token -> "some-result"))
+
+        // Asynchronously with result
+        // Note that the function is wrapped in a ValueTask<string> for Polly to use as F# cannot
+        // await ValueTask directly, and AsTask() is used to convert the ValueTask<string> returned by
+        // ExecuteAsync() to a Task<string> so it can be awaited.
+        let! bestFilm = pipeline.ExecuteAsync(
+            Func<CancellationToken, ValueTask<string>>(fun token -> new ValueTask<string>(getBestFilmAsync(token))),
+            CancellationToken.None).AsTask() |> Async.AwaitTask
+
+        Console.WriteLine("Link to the best film: {0}", bestFilm)
+    }
+
+[<EntryPoint>]
+let main _ =
+    demo() |> Async.RunSynchronously
+    0

--- a/samples/Intro.VisualBasic/Intro.VisualBasic.vbproj
+++ b/samples/Intro.VisualBasic/Intro.VisualBasic.vbproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Polly.Core" />
+  </ItemGroup>
+
+</Project>

--- a/samples/Intro.VisualBasic/Program.vb
+++ b/samples/Intro.VisualBasic/Program.vb
@@ -1,0 +1,56 @@
+Imports System.Threading
+Imports Polly
+
+Module Progam
+    Sub Main()
+        Demo().Wait()
+    End Sub
+
+    Async Function Demo() As Task
+        ' The ResiliencePipelineBuilder creates a ResiliencePipeline
+        ' that can be executed synchronously or asynchronously
+        ' and for both void and result-returning user-callbacks.
+        Dim pipeline = New ResiliencePipelineBuilder().AddTimeout(TimeSpan.FromSeconds(5)).Build()
+
+        ' Synchronously
+        pipeline.Execute(Sub()
+                             Console.WriteLine("Hello, world!")
+                         End Sub)
+
+        ' Asynchronously
+        ' Note that the function is wrapped in a ValueTask for Polly to use as VB.NET cannot
+        ' await ValueTask directly, and AsTask() is used to convert the ValueTask returned by
+        ' ExecuteAsync() to a Task so it can be awaited.
+        Await pipeline.ExecuteAsync(Function(token)
+                                        Return New ValueTask(GreetAndWaitAsync(token))
+                                    End Function,
+                                    CancellationToken.None).AsTask()
+
+        ' Synchronously with result
+        Dim someResult = pipeline.Execute(Function(token)
+                                              Return "some-result"
+                                          End Function)
+
+        ' Asynchronously with result
+        ' Note that the function is wrapped in a ValueTask(Of String) for Polly to use as VB.NET cannot
+        ' await ValueTask directly, and AsTask() is used to convert the ValueTask(Of String) returned by
+        ' ExecuteAsync() to a Task(Of String) so it can be awaited.
+        Dim bestFilm = Await pipeline.ExecuteAsync(Function(token)
+                                                       Return New ValueTask(Of String)(GetBestFilmAsync(token))
+                                                   End Function,
+                                    CancellationToken.None).AsTask()
+
+        Console.WriteLine("Link to the best film: {0}", bestFilm)
+
+    End Function
+
+    Async Function GreetAndWaitAsync(token As CancellationToken) As Task
+        Console.WriteLine("Hello, world! Waiting for 1 second...")
+        Await Task.Delay(1000, token)
+    End Function
+
+    Async Function GetBestFilmAsync(token As CancellationToken) As Task(Of String)
+        Await Task.Delay(1000, token)
+        Return "https://www.imdb.com/title/tt0080684/"
+    End Function
+End Module

--- a/samples/Samples.sln
+++ b/samples/Samples.sln
@@ -24,6 +24,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DependencyInjection", "Depe
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chaos", "Chaos\Chaos.csproj", "{A296E17C-B95F-4B15-8B0D-9D6CC0929A1D}"
 EndProject
+Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "Intro.VisualBasic", "Intro.VisualBasic\Intro.VisualBasic.vbproj", "{10F1C68E-DBF8-43DE-8A72-3EB4491ECD9C}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Intro.FSharp", "Intro.FSharp\Intro.FSharp.fsproj", "{2C0F3F7F-63ED-472B-80B7-905618B07714}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -54,6 +58,14 @@ Global
 		{A296E17C-B95F-4B15-8B0D-9D6CC0929A1D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A296E17C-B95F-4B15-8B0D-9D6CC0929A1D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A296E17C-B95F-4B15-8B0D-9D6CC0929A1D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{10F1C68E-DBF8-43DE-8A72-3EB4491ECD9C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{10F1C68E-DBF8-43DE-8A72-3EB4491ECD9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{10F1C68E-DBF8-43DE-8A72-3EB4491ECD9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{10F1C68E-DBF8-43DE-8A72-3EB4491ECD9C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2C0F3F7F-63ED-472B-80B7-905618B07714}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C0F3F7F-63ED-472B-80B7-905618B07714}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C0F3F7F-63ED-472B-80B7-905618B07714}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2C0F3F7F-63ED-472B-80B7-905618B07714}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Issue #2045 pointed out that the usage for Polly v8 isn't as terse as it is for C# due to the inability to directly await `ValueTask{<T>}`.

This PR adds some limited F# and VB.NET examples to the documentation that demonstrate how to bridge the gap between `ValueTask` and `Task` for Polly v8 pipelines.
