### PR TITLE
Split docs build and publish

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,19 +11,13 @@ permissions:
   contents: read
 
 jobs:
-  publish-docs:
+
+  build-docs:
     runs-on: ubuntu-latest
 
-    concurrency:
-      group: ${{ github.event_name == 'pull_request' && github.event.ref || github.workflow }}
-      cancel-in-progress: false
-
-    permissions:
-      contents: write
-      pages: write
-
     steps:
-    - name: Checkout
+
+    - name: Checkout code
       uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
 
     - name: Lint Markdown files
@@ -48,12 +42,39 @@ jobs:
         dotnet build --configuration Release /p:SKIP_POLLY_ANALYZERS=true
         dotnet docfx docs/docfx.json
 
+    - name: Publish documentation
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+      with:
+        name: docs
+        path: docs/_site
+        if-no-files-found: error
+
+  publish-docs:
+    needs: [ build-docs ]
+    runs-on: ubuntu-latest
+    if: |
+      github.event.repository.fork == false &&
+      github.ref_name == github.event.repository.default_branch
+
+    concurrency:
+      group: ${{ github.workflow }}
+      cancel-in-progress: false
+
+    permissions:
+      contents: write
+      pages: write
+
+    steps:
+
+    - name: Download documentation
+      uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+      with:
+        name: docs
+        path: docs
+
     - name: Deploy to GitHub Pages
-      if: |
-        github.event.repository.fork == false &&
-        github.ref_name == github.event.repository.default_branch
       uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: docs/_site
+        publish_dir: docs
         cname: www.pollydocs.org


### PR DESCRIPTION
Separate the build and publish process for the documentation into two jobs so the concurrency only applies to publishing.

This should stop PRs being opened around the same time as each other (e.g. dependabot) having the docs jobs cancelled by GitHub.
