### PR TITLE
Port fixes from .NET 9 testing

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,8 +1,9 @@
 <Project>
   <PropertyGroup>
-    <MicrosoftExtensionsVersion>8.0.0</MicrosoftExtensionsVersion>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <PollyVersion>8.3.0</PollyVersion>
+    <PollyVersion>8.3.1</PollyVersion>
+    <MicrosoftExtensionsVersion>8.0.0</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsTimeProviderVersion>8.4.0</MicrosoftExtensionsTimeProviderVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.msbuild" Version="6.0.1" />
@@ -22,7 +23,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.3.0" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="$(MicrosoftExtensionsTimeProviderVersion)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageVersion Include="MinVer" Version="4.3.0" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />

--- a/src/Polly.Core/Polly.Core.csproj
+++ b/src/Polly.Core/Polly.Core.csproj
@@ -11,12 +11,8 @@
     <LegacySupport>true</LegacySupport>
     <InjectSharedSources>true</InjectSharedSources>
   </PropertyGroup>
-  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
-    <EnableAotAnalyzer>true</EnableAotAnalyzer>
-    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
-    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <IsAotCompatible>true</IsAotCompatible>
-    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Polly.Core/Utils/TypeNameFormatter.cs
+++ b/src/Polly.Core/Utils/TypeNameFormatter.cs
@@ -17,6 +17,12 @@ internal static class TypeNameFormatter
             return type.Name;
         }
 
-        return $"{type.Name.Substring(0, type.Name.Length - GenericSuffixLength)}<{Format(args[0])}>";
+#if NET6_0_OR_GREATER
+        var nameNoAirity = type.Name[..(type.Name.Length - GenericSuffixLength)];
+#else
+        var nameNoAirity = type.Name.Substring(0, type.Name.Length - GenericSuffixLength);
+#endif
+
+        return $"{nameNoAirity}<{Format(args[0])}>";
     }
 }

--- a/src/Polly.Extensions/Polly.Extensions.csproj
+++ b/src/Polly.Extensions/Polly.Extensions.csproj
@@ -9,12 +9,8 @@
     <MutationScore>100</MutationScore>
     <LegacySupport>true</LegacySupport>
   </PropertyGroup>
-  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
-    <EnableAotAnalyzer>true</EnableAotAnalyzer>
-    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
-    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <IsAotCompatible>true</IsAotCompatible>
-    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Polly.RateLimiting/Polly.RateLimiting.csproj
+++ b/src/Polly.RateLimiting/Polly.RateLimiting.csproj
@@ -9,12 +9,8 @@
     <MutationScore>100</MutationScore>
     <LegacySupport>true</LegacySupport>
   </PropertyGroup>
-  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
-    <EnableAotAnalyzer>true</EnableAotAnalyzer>
-    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
-    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <IsAotCompatible>true</IsAotCompatible>
-    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Polly/Utilities/KeyHelper.cs
+++ b/src/Polly/Utilities/KeyHelper.cs
@@ -6,5 +6,9 @@ internal static class KeyHelper
     private const int GuidPartLength = 8;
 
     public static string GuidPart() =>
+#if NET6_0_OR_GREATER
+        Guid.NewGuid().ToString()[..GuidPartLength];
+#else
         Guid.NewGuid().ToString().Substring(0, GuidPartLength);
+#endif
 }

--- a/test/Polly.Core.Tests/Hedging/Controller/HedgingExecutionContextTests.cs
+++ b/test/Polly.Core.Tests/Hedging/Controller/HedgingExecutionContextTests.cs
@@ -141,7 +141,9 @@ public class HedgingExecutionContextTests : IDisposable
         }
 
         var task = context.TryWaitForCompletedExecutionAsync(System.Threading.Timeout.InfiniteTimeSpan).AsTask();
+#pragma warning disable xUnit1031 // Do not use blocking task operations in test method
         task.Wait(20).Should().BeFalse();
+#pragma warning restore xUnit1031 // Do not use blocking task operations in test method
         _timeProvider.Advance(TimeSpan.FromDays(1));
         await task;
         context.Tasks[0].AcceptOutcome();
@@ -162,7 +164,9 @@ public class HedgingExecutionContextTests : IDisposable
         var hedgingDelay = TimeSpan.FromSeconds(5);
         var count = _timeProvider.TimerEntries.Count;
         var task = context.TryWaitForCompletedExecutionAsync(hedgingDelay).AsTask();
+#pragma warning disable xUnit1031 // Do not use blocking task operations in test method
         task.Wait(20).Should().BeFalse();
+#pragma warning restore xUnit1031 // Do not use blocking task operations in test method
         _timeProvider.TimerEntries.Should().HaveCount(count + 1);
         _timeProvider.TimerEntries.Last().Delay.Should().Be(hedgingDelay);
         _timeProvider.Advance(TimeSpan.FromDays(1));
@@ -382,7 +386,9 @@ public class HedgingExecutionContextTests : IDisposable
         await context.TryWaitForCompletedExecutionAsync(System.Threading.Timeout.InfiniteTimeSpan);
 
         var pending = context.Tasks[1].ExecutionTaskSafe!;
+#pragma warning disable xUnit1031 // Do not use blocking task operations in test method
         pending.Wait(10).Should().BeFalse();
+#pragma warning restore xUnit1031 // Do not use blocking task operations in test method
 
         context.Tasks[0].AcceptOutcome();
         await context.DisposeAsync();

--- a/test/Polly.Core.Tests/Simmy/ChaosStrategyConstantsTests.cs
+++ b/test/Polly.Core.Tests/Simmy/ChaosStrategyConstantsTests.cs
@@ -1,5 +1,7 @@
 using Polly.Simmy;
 
+namespace Polly.Core.Tests;
+
 public class ChaosStrategyConstantsTests
 {
     [Fact]


### PR DESCRIPTION
Port various changes/fixes from #2003 that don't depend on .NET 9.

- Fix IDE0057 warnings.
- Suppress xUnit1031 warnings in tests that explicitly test synchronous behaviours.
- Remove properties that are implied by `IsAotCompatible=true`.
- Only mark as AoT-compatible for `net8.0` where it's actually supported.
- Fix test not being declared in a namespace.
- Bump the samples' reference to ourself to the latest version.
- Bump `Microsoft.Extensions.TimeProvider.Testing` to 8.4.0.
- Use an MSBuild property to allow for easy conditions for multi-targeting.
