### PR TITLE
Allow changing the severity of resilience events

### DIFF
--- a/docs/advanced/telemetry.md
+++ b/docs/advanced/telemetry.md
@@ -264,15 +264,15 @@ services.AddResiliencePipeline("my-strategy", (builder, context) =>
     // This ensures that common configuration is preserved.
     var telemetryOptions = new TelemetryOptions(context.GetOptions<TelemetryOptions>());
 
-    telemetryOptions.SeverityProvider = @event =>
+    telemetryOptions.SeverityProvider = args =>
     {
-        if (@event.Event.EventName == "OnRetry")
+        if (args.Event.EventName == "OnRetry")
         {
             // Decrease the severity of particular event.
             return ResilienceEventSeverity.Debug;
         }
 
-        return @event.Event.Severity;
+        return args.Event.Severity;
     };
 
     builder.AddTimeout(TimeSpan.FromSeconds(1));

--- a/docs/advanced/telemetry.md
+++ b/docs/advanced/telemetry.md
@@ -264,15 +264,15 @@ services.AddResiliencePipeline("my-strategy", (builder, context) =>
     // This ensures that common configuration is preserved.
     var telemetryOptions = new TelemetryOptions(context.GetOptions<TelemetryOptions>());
 
-    telemetryOptions.SeverityProvider = ev =>
+    telemetryOptions.SeverityProvider = @event =>
     {
-        if (ev.Event.EventName == "OnRetry")
+        if (@event.Event.EventName == "OnRetry")
         {
             // Decrease the severity of particular event.
             return ResilienceEventSeverity.Debug;
         }
 
-        return ev.Event.Severity;
+        return @event.Event.Severity;
     };
 
     builder.AddTimeout(TimeSpan.FromSeconds(1));

--- a/docs/advanced/telemetry.md
+++ b/docs/advanced/telemetry.md
@@ -251,3 +251,34 @@ Each resilience strategy can generate telemetry data through the [`ResilienceStr
 To leverage this telemetry data, users should assign a `TelemetryListener` instance to `ResiliencePipelineBuilder.TelemetryListener` and then consume the `TelemetryEventArguments`.
 
 For common scenarios, it is expected that users would make use of `Polly.Extensions`. This extension enables telemetry configuration through the `ResiliencePipelineBuilder.ConfigureTelemetry(...)` method, which processes `TelemetryEventArguments` to generate logs and metrics.
+
+## Customizing the severity of telemetry events
+
+To customize the severity of telemetry events, set the [`SeverityProvider`](xref:Polly.Telemetry.TelemetryOptions.SeverityProvider) delegate that allows changing the default severity of resilience events:
+
+<!-- snippet: telemetry-severity-override -->
+```cs
+services.AddResiliencePipeline("my-strategy", (builder, context) =>
+{
+    // Create a new instance of telemetry options by using copy-constructor of the global ones.
+    // This ensures that common configuration is preserved.
+    var telemetryOptions = new TelemetryOptions(context.GetOptions<TelemetryOptions>());
+
+    telemetryOptions.SeverityProvider = ev =>
+    {
+        if (ev.Event.EventName == "OnRetry")
+        {
+            // Decrease the severity of particular event.
+            return ResilienceEventSeverity.Debug;
+        }
+
+        return ev.Event.Severity;
+    };
+
+    builder.AddTimeout(TimeSpan.FromSeconds(1));
+
+    // Override the telemetry configuration for this pipeline.
+    builder.ConfigureTelemetry(telemetryOptions);
+});
+```
+<!-- endSnippet -->

--- a/docs/advanced/telemetry.md
+++ b/docs/advanced/telemetry.md
@@ -264,18 +264,15 @@ services.AddResiliencePipeline("my-strategy", (builder, context) =>
     // This ensures that common configuration is preserved.
     var telemetryOptions = new TelemetryOptions(context.GetOptions<TelemetryOptions>());
 
-    telemetryOptions.SeverityProvider = args =>
+    telemetryOptions.SeverityProvider = args => args.Event.EventName switch
     {
-        if (args.Event.EventName == "OnRetry")
-        {
-            // Decrease the severity of particular event.
-            return ResilienceEventSeverity.Debug;
-        }
-
-        return args.Event.Severity;
+        // Decrease severity of specific events
+        "OnRetry" => ResilienceEventSeverity.Debug,
+        "ExecutionAttempt" => ResilienceEventSeverity.Debug,
+        _ => args.Event.Severity
     };
 
-    builder.AddTimeout(TimeSpan.FromSeconds(1));
+    builder.AddRetry(new RetryStrategyOptions());
 
     // Override the telemetry configuration for this pipeline.
     builder.ConfigureTelemetry(telemetryOptions);

--- a/src/Polly.Extensions/PublicAPI.Unshipped.txt
+++ b/src/Polly.Extensions/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 ﻿#nullable enable
+Polly.Telemetry.TelemetryOptions.SeverityProvider.get -> System.Func<Polly.Telemetry.ResilienceEvent, Polly.Telemetry.ResilienceEventSeverity>?
+Polly.Telemetry.TelemetryOptions.SeverityProvider.set -> void
+Polly.Telemetry.TelemetryOptions.TelemetryOptions(Polly.Telemetry.TelemetryOptions! other) -> void
 static Polly.PollyServiceCollectionExtensions.AddResiliencePipelines<TKey>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<Polly.DependencyInjection.AddResiliencePipelinesContext<TKey>!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 Polly.DependencyInjection.AddResiliencePipelinesContext<TKey>
 Polly.DependencyInjection.AddResiliencePipelinesContext<TKey>.AddResiliencePipeline(TKey key, System.Action<Polly.ResiliencePipelineBuilder!, Polly.DependencyInjection.AddResiliencePipelineContext<TKey>!>! configure) -> void

--- a/src/Polly.Extensions/PublicAPI.Unshipped.txt
+++ b/src/Polly.Extensions/PublicAPI.Unshipped.txt
@@ -1,5 +1,11 @@
 ﻿#nullable enable
-Polly.Telemetry.TelemetryOptions.SeverityProvider.get -> System.Func<Polly.Telemetry.ResilienceEvent, Polly.Telemetry.ResilienceEventSeverity>?
+Polly.Telemetry.SeverityProviderArguments
+Polly.Telemetry.SeverityProviderArguments.Context.get -> Polly.ResilienceContext!
+Polly.Telemetry.SeverityProviderArguments.Event.get -> Polly.Telemetry.ResilienceEvent
+Polly.Telemetry.SeverityProviderArguments.SeverityProviderArguments() -> void
+Polly.Telemetry.SeverityProviderArguments.SeverityProviderArguments(Polly.Telemetry.ResilienceTelemetrySource! source, Polly.Telemetry.ResilienceEvent resilienceEvent, Polly.ResilienceContext! context) -> void
+Polly.Telemetry.SeverityProviderArguments.Source.get -> Polly.Telemetry.ResilienceTelemetrySource!
+Polly.Telemetry.TelemetryOptions.SeverityProvider.get -> System.Func<Polly.Telemetry.SeverityProviderArguments, Polly.Telemetry.ResilienceEventSeverity>?
 Polly.Telemetry.TelemetryOptions.SeverityProvider.set -> void
 Polly.Telemetry.TelemetryOptions.TelemetryOptions(Polly.Telemetry.TelemetryOptions! other) -> void
 static Polly.PollyServiceCollectionExtensions.AddResiliencePipelines<TKey>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<Polly.DependencyInjection.AddResiliencePipelinesContext<TKey>!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Polly.Extensions/Telemetry/SeverityProviderArguments.cs
+++ b/src/Polly.Extensions/Telemetry/SeverityProviderArguments.cs
@@ -1,0 +1,37 @@
+﻿namespace Polly.Telemetry;
+
+#pragma warning disable CA1815 // Override equals and operator equals on value types
+
+/// <summary>
+/// Arguments used by <see cref="TelemetryOptions.SeverityProvider"/>.
+/// </summary>
+public readonly struct SeverityProviderArguments
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SeverityProviderArguments"/> struct.
+    /// </summary>
+    /// <param name="source">The source that produced the resilience event.</param>
+    /// <param name="resilienceEvent">The resilience event.</param>
+    /// <param name="context">The resilience context.</param>
+    public SeverityProviderArguments(ResilienceTelemetrySource source, ResilienceEvent resilienceEvent, ResilienceContext context)
+    {
+        Source = source;
+        Event = resilienceEvent;
+        Context = context;
+    }
+
+    /// <summary>
+    /// Gets the source that produced the resilience event.
+    /// </summary>
+    public ResilienceTelemetrySource Source { get; }
+
+    /// <summary>
+    /// Gets the resilience event.
+    /// </summary>
+    public ResilienceEvent Event { get; }
+
+    /// <summary>
+    /// Gets the resilience context.
+    /// </summary>
+    public ResilienceContext Context { get; }
+}

--- a/src/Polly.Extensions/Telemetry/TelemetryListenerImpl.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryListenerImpl.cs
@@ -11,7 +11,7 @@ internal sealed class TelemetryListenerImpl : TelemetryListener
     private readonly ILogger _logger;
     private readonly Func<ResilienceContext, object?, object?> _resultFormatter;
     private readonly List<TelemetryListener> _listeners;
-    private readonly Func<ResilienceEvent, ResilienceEventSeverity>? _severityProvider;
+    private readonly Func<SeverityProviderArguments, ResilienceEventSeverity>? _severityProvider;
     private readonly List<MeteringEnricher> _enrichers;
 
     public TelemetryListenerImpl(TelemetryOptions options)
@@ -58,7 +58,7 @@ internal sealed class TelemetryListenerImpl : TelemetryListener
 
         if (_severityProvider is { } provider)
         {
-            severity = provider(args.Event);
+            severity = provider(new SeverityProviderArguments(args.Source, args.Event, args.Context));
         }
 
         LogEvent(in args, severity);

--- a/src/Polly.Extensions/Telemetry/TelemetryListenerImpl.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryListenerImpl.cs
@@ -11,6 +11,7 @@ internal sealed class TelemetryListenerImpl : TelemetryListener
     private readonly ILogger _logger;
     private readonly Func<ResilienceContext, object?, object?> _resultFormatter;
     private readonly List<TelemetryListener> _listeners;
+    private readonly Func<ResilienceEvent, ResilienceEventSeverity>? _severityProvider;
     private readonly List<MeteringEnricher> _enrichers;
 
     public TelemetryListenerImpl(TelemetryOptions options)
@@ -19,6 +20,7 @@ internal sealed class TelemetryListenerImpl : TelemetryListener
         _logger = options.LoggerFactory.CreateLogger(TelemetryUtil.PollyDiagnosticSource);
         _resultFormatter = options.ResultFormatter;
         _listeners = options.TelemetryListeners.ToList();
+        _severityProvider = options.SeverityProvider;
 
         Counter = Meter.CreateCounter<int>(
             "resilience.polly.strategy.events",
@@ -52,8 +54,15 @@ internal sealed class TelemetryListenerImpl : TelemetryListener
             }
         }
 
-        LogEvent(in args);
-        MeterEvent(in args);
+        var severity = args.Event.Severity;
+
+        if (_severityProvider is { } provider)
+        {
+            severity = provider(args.Event);
+        }
+
+        LogEvent(in args, severity);
+        MeterEvent(in args, severity);
     }
 
     private static bool GetArgs<T, TArgs>(T inArgs, out TArgs outArgs)
@@ -68,13 +77,13 @@ internal sealed class TelemetryListenerImpl : TelemetryListener
         return false;
     }
 
-    private static void AddCommonTags<TResult, TArgs>(in EnrichmentContext<TResult, TArgs> context)
+    private static void AddCommonTags<TResult, TArgs>(in EnrichmentContext<TResult, TArgs> context, ResilienceEventSeverity severity)
     {
         var source = context.TelemetryEvent.Source;
         var ev = context.TelemetryEvent.Event;
 
         context.Tags.Add(new(ResilienceTelemetryTags.EventName, context.TelemetryEvent.Event.EventName));
-        context.Tags.Add(new(ResilienceTelemetryTags.EventSeverity, context.TelemetryEvent.Event.Severity.AsString()));
+        context.Tags.Add(new(ResilienceTelemetryTags.EventSeverity, severity.AsString()));
 
         if (source.PipelineName is not null)
         {
@@ -102,7 +111,7 @@ internal sealed class TelemetryListenerImpl : TelemetryListener
         }
     }
 
-    private void MeterEvent<TResult, TArgs>(in TelemetryEventArguments<TResult, TArgs> args)
+    private void MeterEvent<TResult, TArgs>(in TelemetryEventArguments<TResult, TArgs> args, ResilienceEventSeverity severity)
     {
         var arguments = args.Arguments;
 
@@ -115,7 +124,7 @@ internal sealed class TelemetryListenerImpl : TelemetryListener
 
             var tags = TagsList.Get();
             var context = new EnrichmentContext<TResult, TArgs>(in args, tags.Tags);
-            UpdateEnrichmentContext(in context);
+            UpdateEnrichmentContext(in context, severity);
             ExecutionDuration.Record(executionFinished.Duration.TotalMilliseconds, tags.TagsSpan);
             TagsList.Return(tags);
         }
@@ -128,7 +137,7 @@ internal sealed class TelemetryListenerImpl : TelemetryListener
 
             var tags = TagsList.Get();
             var context = new EnrichmentContext<TResult, TArgs>(in args, tags.Tags);
-            UpdateEnrichmentContext(in context);
+            UpdateEnrichmentContext(in context, severity);
             context.Tags.Add(new(ResilienceTelemetryTags.AttemptNumber, executionAttempt.AttemptNumber.AsBoxedInt()));
             context.Tags.Add(new(ResilienceTelemetryTags.AttemptHandled, executionAttempt.Handled.AsBoxedBool()));
             AttemptDuration.Record(executionAttempt.Duration.TotalMilliseconds, tags.TagsSpan);
@@ -138,15 +147,15 @@ internal sealed class TelemetryListenerImpl : TelemetryListener
         {
             var tags = TagsList.Get();
             var context = new EnrichmentContext<TResult, TArgs>(in args, tags.Tags);
-            UpdateEnrichmentContext(in context);
+            UpdateEnrichmentContext(in context, severity);
             Counter.Add(1, tags.TagsSpan);
             TagsList.Return(tags);
         }
     }
 
-    private void UpdateEnrichmentContext<TResult, TArgs>(in EnrichmentContext<TResult, TArgs> context)
+    private void UpdateEnrichmentContext<TResult, TArgs>(in EnrichmentContext<TResult, TArgs> context, ResilienceEventSeverity severity)
     {
-        AddCommonTags(in context);
+        AddCommonTags(in context, severity);
 
         if (_enrichers.Count != 0)
         {
@@ -157,10 +166,10 @@ internal sealed class TelemetryListenerImpl : TelemetryListener
         }
     }
 
-    private void LogEvent<TResult, TArgs>(in TelemetryEventArguments<TResult, TArgs> args)
+    private void LogEvent<TResult, TArgs>(in TelemetryEventArguments<TResult, TArgs> args, ResilienceEventSeverity severity)
     {
         var result = GetResult(args.Context, args.Outcome);
-        var level = args.Event.Severity.AsLogLevel();
+        var level = severity.AsLogLevel();
 
         if (GetArgs<TArgs, PipelineExecutingArguments>(args.Arguments, out _))
         {

--- a/src/Polly.Extensions/Telemetry/TelemetryOptions.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryOptions.cs
@@ -78,5 +78,5 @@ public class TelemetryOptions
     /// <value>
     /// The default value is <see langword="null"/>.
     /// </value>
-    public Func<ResilienceEvent, ResilienceEventSeverity>? SeverityProvider { get; set; }
+    public Func<SeverityProviderArguments, ResilienceEventSeverity>? SeverityProvider { get; set; }
 }

--- a/src/Polly.Extensions/Telemetry/TelemetryOptions.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryOptions.cs
@@ -2,6 +2,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Net.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Polly.Utils;
 
 namespace Polly.Telemetry;
 
@@ -10,6 +11,28 @@ namespace Polly.Telemetry;
 /// </summary>
 public class TelemetryOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryOptions"/> class.
+    /// </summary>
+    public TelemetryOptions()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TelemetryOptions"/> class.
+    /// </summary>
+    /// <param name="other">The telemetry options instance to copy the data from.</param>
+    public TelemetryOptions(TelemetryOptions other)
+    {
+        Guard.NotNull(other);
+
+        TelemetryListeners = other.TelemetryListeners.ToList();
+        LoggerFactory = other.LoggerFactory;
+        MeteringEnrichers = other.MeteringEnrichers.ToList();
+        ResultFormatter = other.ResultFormatter;
+        SeverityProvider = other.SeverityProvider;
+    }
+
     /// <summary>
     /// Gets the collection of telemetry listeners.
     /// </summary>
@@ -48,4 +71,12 @@ public class TelemetryOptions
         HttpResponseMessage response => (int)response.StatusCode,
         _ => result,
     };
+
+    /// <summary>
+    /// Gets or sets the resilience event severity provider that allows customizing the severity of resilience events.
+    /// </summary>
+    /// <value>
+    /// The default value is <see langword="null"/>.
+    /// </value>
+    public Func<ResilienceEvent, ResilienceEventSeverity>? SeverityProvider { get; set; }
 }

--- a/src/Snippets/Docs/Telemetry.cs
+++ b/src/Snippets/Docs/Telemetry.cs
@@ -149,13 +149,13 @@ internal static class Telemetry
 
             telemetryOptions.SeverityProvider = ev =>
             {
-                if (ev.EventName == "OnRetry")
+                if (ev.Event.EventName == "OnRetry")
                 {
                     // Decrease the severity of particular event.
                     return ResilienceEventSeverity.Debug;
                 }
 
-                return ev.Severity;
+                return ev.Event.Severity;
             };
 
             builder.AddTimeout(TimeSpan.FromSeconds(1));

--- a/src/Snippets/Docs/Telemetry.cs
+++ b/src/Snippets/Docs/Telemetry.cs
@@ -134,4 +134,36 @@ internal static class Telemetry
     }
 
     #endregion
+
+    public static void SeverityOverrides()
+    {
+        var services = new ServiceCollection();
+
+        #region telemetry-severity-override
+
+        services.AddResiliencePipeline("my-strategy", (builder, context) =>
+        {
+            // Create a new instance of telemetry options by using copy-constructor of the global ones.
+            // This ensures that common configuration is preserved.
+            var telemetryOptions = new TelemetryOptions(context.GetOptions<TelemetryOptions>());
+
+            telemetryOptions.SeverityProvider = ev =>
+            {
+                if (ev.EventName == "OnRetry")
+                {
+                    // Decrease the severity of particular event.
+                    return ResilienceEventSeverity.Debug;
+                }
+
+                return ev.Severity;
+            };
+
+            builder.AddTimeout(TimeSpan.FromSeconds(1));
+
+            // Override the telemetry configuration for this pipeline.
+            builder.ConfigureTelemetry(telemetryOptions);
+        });
+
+        #endregion
+    }
 }

--- a/src/Snippets/Docs/Telemetry.cs
+++ b/src/Snippets/Docs/Telemetry.cs
@@ -147,15 +147,15 @@ internal static class Telemetry
             // This ensures that common configuration is preserved.
             var telemetryOptions = new TelemetryOptions(context.GetOptions<TelemetryOptions>());
 
-            telemetryOptions.SeverityProvider = ev =>
+            telemetryOptions.SeverityProvider = @event =>
             {
-                if (ev.Event.EventName == "OnRetry")
+                if (@event.Event.EventName == "OnRetry")
                 {
                     // Decrease the severity of particular event.
                     return ResilienceEventSeverity.Debug;
                 }
 
-                return ev.Event.Severity;
+                return @event.Event.Severity;
             };
 
             builder.AddTimeout(TimeSpan.FromSeconds(1));

--- a/src/Snippets/Docs/Telemetry.cs
+++ b/src/Snippets/Docs/Telemetry.cs
@@ -147,15 +147,15 @@ internal static class Telemetry
             // This ensures that common configuration is preserved.
             var telemetryOptions = new TelemetryOptions(context.GetOptions<TelemetryOptions>());
 
-            telemetryOptions.SeverityProvider = @event =>
+            telemetryOptions.SeverityProvider = args =>
             {
-                if (@event.Event.EventName == "OnRetry")
+                if (args.Event.EventName == "OnRetry")
                 {
                     // Decrease the severity of particular event.
                     return ResilienceEventSeverity.Debug;
                 }
 
-                return @event.Event.Severity;
+                return args.Event.Severity;
             };
 
             builder.AddTimeout(TimeSpan.FromSeconds(1));

--- a/src/Snippets/Docs/Telemetry.cs
+++ b/src/Snippets/Docs/Telemetry.cs
@@ -147,18 +147,15 @@ internal static class Telemetry
             // This ensures that common configuration is preserved.
             var telemetryOptions = new TelemetryOptions(context.GetOptions<TelemetryOptions>());
 
-            telemetryOptions.SeverityProvider = args =>
+            telemetryOptions.SeverityProvider = args => args.Event.EventName switch
             {
-                if (args.Event.EventName == "OnRetry")
-                {
-                    // Decrease the severity of particular event.
-                    return ResilienceEventSeverity.Debug;
-                }
-
-                return args.Event.Severity;
+                // Decrease severity of specific events
+                "OnRetry" => ResilienceEventSeverity.Debug,
+                "ExecutionAttempt" => ResilienceEventSeverity.Debug,
+                _ => args.Event.Severity
             };
 
-            builder.AddTimeout(TimeSpan.FromSeconds(1));
+            builder.AddRetry(new RetryStrategyOptions());
 
             // Override the telemetry configuration for this pipeline.
             builder.ConfigureTelemetry(telemetryOptions);

--- a/test/Polly.Extensions.Tests/Telemetry/TelemetryListenerImplTests.cs
+++ b/test/Polly.Extensions.Tests/Telemetry/TelemetryListenerImplTests.cs
@@ -454,6 +454,18 @@ public class TelemetryListenerImplTests : IDisposable
     }
 
     [Fact]
+    public void SeverityProvider_NotSet_SeverityRespected()
+    {
+        var telemetry = Create();
+
+        ReportEvent(telemetry, null, severity: ResilienceEventSeverity.Critical);
+
+        var records = _logger.GetRecords();
+
+        records.Single().LogLevel.Should().Be(LogLevel.Critical);
+    }
+
+    [Fact]
     public void SeverityProvider_EnsureRespected()
     {
         var called = false;

--- a/test/Polly.Extensions.Tests/Telemetry/TelemetryOptionsTests.cs
+++ b/test/Polly.Extensions.Tests/Telemetry/TelemetryOptionsTests.cs
@@ -28,7 +28,7 @@ public class TelemetryOptionsTests
     public void CopyCtor_Ok()
     {
         var options = new TelemetryOptions
-        {
+        { 
             LoggerFactory = Substitute.For<ILoggerFactory>(),
             SeverityProvider = _ => ResilienceEventSeverity.Error,
             ResultFormatter = (_, _) => "x",
@@ -44,8 +44,14 @@ public class TelemetryOptionsTests
         other.SeverityProvider.Should().Be(options.SeverityProvider);
         other.MeteringEnrichers.Should().BeEquivalentTo(options.MeteringEnrichers);
         other.TelemetryListeners.Should().BeEquivalentTo(options.TelemetryListeners);
-
         other.TelemetryListeners.Should().NotBeSameAs(options.TelemetryListeners);
         other.MeteringEnrichers.Should().NotBeSameAs(options.MeteringEnrichers);
+
+        typeof(TelemetryOptions).GetRuntimeProperties().Should().HaveCount(5);
     }
+
+    [Fact]
+    public void CopyCtor_Reminder()
+        => typeof(TelemetryOptions).GetRuntimeProperties().Should()
+        .HaveCount(5, "Make sure that when you increase this number, you also update the copy constructor to assign the new property.");
 }

--- a/test/Polly.Extensions.Tests/Telemetry/TelemetryOptionsTests.cs
+++ b/test/Polly.Extensions.Tests/Telemetry/TelemetryOptionsTests.cs
@@ -28,7 +28,7 @@ public class TelemetryOptionsTests
     public void CopyCtor_Ok()
     {
         var options = new TelemetryOptions
-        { 
+        {
             LoggerFactory = Substitute.For<ILoggerFactory>(),
             SeverityProvider = _ => ResilienceEventSeverity.Error,
             ResultFormatter = (_, _) => "x",

--- a/test/Polly.Extensions.Tests/Telemetry/TelemetryOptionsTests.cs
+++ b/test/Polly.Extensions.Tests/Telemetry/TelemetryOptionsTests.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using System.Net.Http;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 using Polly.Telemetry;
 
 namespace Polly.Extensions.Tests.Telemetry;
@@ -20,5 +22,30 @@ public class TelemetryOptionsTests
 
         using var response = new HttpResponseMessage(HttpStatusCode.OK);
         options.ResultFormatter(resilienceContext, response).Should().Be(200);
+    }
+
+    [Fact]
+    public void CopyCtor_Ok()
+    {
+        var options = new TelemetryOptions
+        {
+            LoggerFactory = Substitute.For<ILoggerFactory>(),
+            SeverityProvider = _ => ResilienceEventSeverity.Error,
+            ResultFormatter = (_, _) => "x",
+        };
+
+        options.MeteringEnrichers.Add(Substitute.For<MeteringEnricher>());
+        options.TelemetryListeners.Add(Substitute.For<TelemetryListener>());
+
+        var other = new TelemetryOptions(options);
+
+        other.ResultFormatter.Should().Be(options.ResultFormatter);
+        other.LoggerFactory.Should().Be(options.LoggerFactory);
+        other.SeverityProvider.Should().Be(options.SeverityProvider);
+        other.MeteringEnrichers.Should().BeEquivalentTo(options.MeteringEnrichers);
+        other.TelemetryListeners.Should().BeEquivalentTo(options.TelemetryListeners);
+
+        other.TelemetryListeners.Should().NotBeSameAs(options.TelemetryListeners);
+        other.MeteringEnrichers.Should().NotBeSameAs(options.MeteringEnrichers);
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

#1859 

## Details on the issue fix or feature implementation

This can be used to customize the severity of resilience events as:

``` csharp
services.AddResiliencePipeline("my-strategy", (builder, context) =>
{
    // Create a new instance of telemetry options by using copy-constructor of the global ones.
    // This ensures that common configuration is preserved.
    var telemetryOptions = new TelemetryOptions(context.GetOptions<TelemetryOptions>());

    telemetryOptions.SeverityProvider = ev =>
    {
        if (ev.EventName == "OnRetry")
        {
            // Decrease the severity of particular event.
            return ResilienceEventSeverity.Debug;
        }

        return ev.Severity;
    };

    builder.AddTimeout(TimeSpan.FromSeconds(1));

    // Override the telemetry configuration for this pipeline.
    builder.ConfigureTelemetry(telemetryOptions);
});
```

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
