### PR TITLE
Fix CI for macOS 14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,13 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Setup .NET SDKs
+      uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
+      with:
+        dotnet-version: |
+          6.0.x
+          7.0.x
+
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
       id: setup-dotnet


### PR DESCRIPTION
The update of the `macos-latest` runner label from macOS 12 to 14 has broken the CI.

https://github.com/App-vNext/Polly/pull/2078#issuecomment-2078663143

This appears to be because the .NET 6 SDK is not installed by default on the macOS 14 runner, so Polly.Specs fails as it runs tests with the .NET 6 runtime.
