### PR TITLE
Add package tools to manifest

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -8,16 +8,28 @@
         "dotnet-cake"
       ]
     },
+    "docfx": {
+      "version": "2.75.3",
+      "commands": [
+        "docfx"
+      ]
+    },
+    "dotnet-validate": {
+      "version": "0.0.1-preview.304",
+      "commands": [
+        "dotnet-validate"
+      ]
+    },
     "markdownsnippets.tool": {
       "version": "27.0.2",
       "commands": [
         "mdsnippets"
       ]
     },
-    "docfx": {
-      "version": "2.75.3",
+    "sign": {
+      "version": "0.9.1-beta.23530.1",
       "commands": [
-        "docfx"
+        "sign"
       ]
     }
   }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,8 @@ jobs:
 
     outputs:
       dotnet-sdk-version: ${{ steps.setup-dotnet.outputs.dotnet-version }}
+      dotnet-sign-version: ${{ steps.get-dotnet-tools-versions.outputs.dotnet-sign-version }}
+      dotnet-validate-version: ${{ steps.get-dotnet-tools-versions.outputs.dotnet-validate-version }}
 
     strategy:
       fail-fast: false
@@ -110,6 +112,16 @@ jobs:
         path: eng/signing
         if-no-files-found: error
 
+    - name: Get .NET tools versions
+      id: get-dotnet-tools-versions
+      shell: pwsh
+      run: |
+        $manifest = (Get-Content "./.config/dotnet-tools.json" | Out-String | ConvertFrom-Json)
+        $dotnetSignVersion = manifest.tools.'sign'.version
+        $dotnetValidateVersion = manifest.tools.'dotnet-validate'.version
+        "dotnet-sign-version=${dotnetSignVersion}" >> $env:GITHUB_OUTPUT
+        "dotnet-validate-version=${dotnetValidateVersion}" >> $env:GITHUB_OUTPUT
+
   validate-packages:
     needs: build
     runs-on: ubuntu-latest
@@ -127,8 +139,10 @@ jobs:
 
     - name: Validate NuGet packages
       shell: pwsh
+      env:
+        DOTNET_VALIDATE_VERSION: ${{ needs.build.outputs.dotnet-validate-version }}
       run: |
-        dotnet tool install --global dotnet-validate --version 0.0.1-preview.304
+        dotnet tool install --global dotnet-validate --version ${env:DOTNET_VALIDATE_VERSION}
         $packages = Get-ChildItem -Filter "*.nupkg" | ForEach-Object { $_.FullName }
         $invalidPackages = 0
         foreach ($package in $packages) {
@@ -168,7 +182,9 @@ jobs:
         dotnet-version: ${{ needs.build.outputs.dotnet-sdk-version }}
 
     - name: Install Sign CLI tool
-      run: dotnet tool install --tool-path . sign --version 0.9.1-beta.23530.1
+      env:
+        DOTNET_SIGN_VERSION: ${{ needs.build.outputs.dotnet-sign-version }}
+      run: dotnet tool install --tool-path . sign --version ${env:DOTNET_SIGN_VERSION}
 
     - name: Sign artifacts
       shell: pwsh
@@ -212,8 +228,10 @@ jobs:
 
     - name: Validate NuGet packages
       shell: pwsh
+      env:
+        DOTNET_VALIDATE_VERSION: ${{ needs.build.outputs.dotnet-validate-version }}
       run: |
-        dotnet tool install --global dotnet-validate --version 0.0.1-preview.304
+        dotnet tool install --global dotnet-validate --version ${env:DOTNET_VALIDATE_VERSION}
         $packages = Get-ChildItem -Filter "*.nupkg" | ForEach-Object { $_.FullName }
         $invalidPackages = 0
         foreach ($package in $packages) {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,8 +117,8 @@ jobs:
       shell: pwsh
       run: |
         $manifest = (Get-Content "./.config/dotnet-tools.json" | Out-String | ConvertFrom-Json)
-        $dotnetSignVersion = manifest.tools.'sign'.version
-        $dotnetValidateVersion = manifest.tools.'dotnet-validate'.version
+        $dotnetSignVersion = $manifest.tools.sign.version
+        $dotnetValidateVersion = $manifest.tools.'dotnet-validate'.version
         "dotnet-sign-version=${dotnetSignVersion}" >> $env:GITHUB_OUTPUT
         "dotnet-validate-version=${dotnetValidateVersion}" >> $env:GITHUB_OUTPUT
 

--- a/eng/Common.targets
+++ b/eng/Common.targets
@@ -19,12 +19,12 @@
   </ItemGroup>
 
   <PropertyGroup Label="MinVer">
-    <MinVerMinimumMajorMinor>8.3</MinVerMinimumMajorMinor>
+    <MinVerMinimumMajorMinor>8.4</MinVerMinimumMajorMinor>
   </PropertyGroup>
 
   <Target Name="CustomizeVersions" AfterTargets="MinVer" Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <PropertyGroup>
-      <FileVersion>$([MSBuild]::ValueOrDefault('$(MinVerMajor)', '8')).$([MSBuild]::ValueOrDefault('$(MinVerMinor)', '3')).$([MSBuild]::ValueOrDefault('$(MinVerPatch)', '0')).$(GITHUB_RUN_NUMBER)</FileVersion>
+      <FileVersion>$([MSBuild]::ValueOrDefault('$(MinVerMajor)', '8')).$([MSBuild]::ValueOrDefault('$(MinVerMinor)', '4')).$([MSBuild]::ValueOrDefault('$(MinVerPatch)', '0')).$(GITHUB_RUN_NUMBER)</FileVersion>
     </PropertyGroup>
     <PropertyGroup Condition="$(GITHUB_REF.StartsWith(`refs/pull/`))">
       <PackageVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch)-pr.$(GITHUB_REF_NAME.Replace(`/merge`, ``)).$(GITHUB_RUN_NUMBER)</PackageVersion>


### PR DESCRIPTION
Add dotnet-validate and sign to the tools manifest so that dependabot can update them if there's newer versions released, and then reference that version in the build workflow.
