### PR TITLE
Add CI timeouts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
   build:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
 
     env:
       # HACK Running on Windows instead of Linux due to https://github.com/stryker-mutator/stryker-net/issues/2741

--- a/build.cake
+++ b/build.cake
@@ -157,6 +157,7 @@ Task("__RunTests")
             Configuration = configuration,
             Loggers = loggers,
             NoBuild = true,
+            ToolTimeout = System.TimeSpan.FromMinutes(10),
         });
     }
 });


### PR DESCRIPTION
- No CI job should take longer than an hour.
- No individual test run should take longer than 10 minutes.

Relates to #2087.
