### PR TITLE
Fix SA1615/SA1623 warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -31,9 +31,6 @@ dotnet_diagnostic.S2094.severity = suggestion
 # SA1402 // File may only contain a single type
 dotnet_diagnostic.SA1402.severity = none
 
-# SA1623 // The property's documentation summary text should begin with: 'Gets'
-dotnet_diagnostic.SA1623.severity = none
-
 # S4023 // Interfaces should not be empty
 dotnet_diagnostic.S4023.severity = suggestion
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -31,6 +31,9 @@ dotnet_diagnostic.S2094.severity = suggestion
 # SA1402 // File may only contain a single type
 dotnet_diagnostic.SA1402.severity = none
 
+# SA1623 // The property's documentation summary text should begin with: 'Gets'
+dotnet_diagnostic.SA1623.severity = none
+
 # S4023 // Interfaces should not be empty
 dotnet_diagnostic.S4023.severity = suggestion
 

--- a/src/Polly/AsyncPolicy.ContextAndKeys.cs
+++ b/src/Polly/AsyncPolicy.ContextAndKeys.cs
@@ -7,6 +7,7 @@ public abstract partial class AsyncPolicy
     /// <remarks>Must be called before the policy is first used.  Can only be set once.</remarks>
     /// </summary>
     /// <param name="policyKey">The unique, used-definable key to assign to this <see cref="AsyncPolicy"/> instance.</param>
+    /// <returns>An instance of <see cref="AsyncPolicy"/>.</returns>
     public AsyncPolicy WithPolicyKey(string policyKey)
     {
         if (policyKeyInternal != null)
@@ -23,6 +24,7 @@ public abstract partial class AsyncPolicy
     /// <remarks>Must be called before the policy is first used.  Can only be set once.</remarks>
     /// </summary>
     /// <param name="policyKey">The unique, used-definable key to assign to this <see cref="IAsyncPolicy"/> instance.</param>
+    /// <returns>An instance of <see cref="IAsyncPolicy"/>.</returns>
     IAsyncPolicy IAsyncPolicy.WithPolicyKey(string policyKey)
     {
         if (policyKeyInternal != null)
@@ -42,6 +44,7 @@ public abstract partial class AsyncPolicy<TResult>
     /// <remarks>Must be called before the policy is first used.  Can only be set once.</remarks>
     /// </summary>
     /// <param name="policyKey">The unique, used-definable key to assign to this <see cref="AsyncPolicy{TResult}"/> instance.</param>
+    /// <returns>An instance of <see cref="AsyncPolicy{TResult}"/>.</returns>
     public AsyncPolicy<TResult> WithPolicyKey(string policyKey)
     {
         if (policyKeyInternal != null)
@@ -58,6 +61,7 @@ public abstract partial class AsyncPolicy<TResult>
     /// <remarks>Must be called before the policy is first used.  Can only be set once.</remarks>
     /// </summary>
     /// <param name="policyKey">The unique, used-definable key to assign to this <see cref="IAsyncPolicy{TResult}"/> instance.</param>
+    /// <returns>An instance of <see cref="IAsyncPolicy{TResult}"/>.</returns>
     IAsyncPolicy<TResult> IAsyncPolicy<TResult>.WithPolicyKey(string policyKey)
     {
         if (policyKeyInternal != null)

--- a/src/Polly/AsyncPolicy.ExecuteOverloads.cs
+++ b/src/Polly/AsyncPolicy.ExecuteOverloads.cs
@@ -8,6 +8,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     ///     Executes the specified asynchronous action within the policy.
     /// </summary>
     /// <param name="action">The action to perform.</param>
+    /// <returns>A <see cref="Task" /> which completes when <see cref="AsyncPolicy"/> is registered.</returns>
     [DebuggerStepThrough]
     public Task ExecuteAsync(Func<Task> action) =>
         ExecuteAsync((_, _) => action(), [], DefaultCancellationToken, DefaultContinueOnCapturedContext);
@@ -17,6 +18,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
+    /// <returns>A <see cref="Task" /> which completes when <see cref="AsyncPolicy"/> is registered.</returns>
     [DebuggerStepThrough]
     public Task ExecuteAsync(Func<Context, Task> action, IDictionary<string, object> contextData) =>
         ExecuteAsync((ctx, _) => action(ctx), new Context(contextData), DefaultCancellationToken, DefaultContinueOnCapturedContext);
@@ -26,6 +28,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
+    /// <returns>A <see cref="Task" /> which completes when <see cref="AsyncPolicy"/> is registered.</returns>
     [DebuggerStepThrough]
     public Task ExecuteAsync(Func<Context, Task> action, Context context) =>
         ExecuteAsync((ctx, _) => action(ctx), context, DefaultCancellationToken, DefaultContinueOnCapturedContext);
@@ -35,6 +38,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+    /// <returns>A <see cref="Task" /> which completes when <see cref="AsyncPolicy"/> is registered.</returns>
     [DebuggerStepThrough]
     public Task ExecuteAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken) =>
         ExecuteAsync((_, ct) => action(ct), [], cancellationToken, DefaultContinueOnCapturedContext);
@@ -45,6 +49,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+    /// <returns>A <see cref="Task" /> which completes when <see cref="AsyncPolicy"/> is registered.</returns>
     [DebuggerStepThrough]
     public Task ExecuteAsync(Func<Context, CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken) =>
         ExecuteAsync(action, new Context(contextData), cancellationToken, DefaultContinueOnCapturedContext);
@@ -55,6 +60,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+    /// <returns>A <see cref="Task" /> which completes when <see cref="AsyncPolicy"/> is registered.</returns>
     [DebuggerStepThrough]
     public Task ExecuteAsync(Func<Context, CancellationToken, Task> action, Context context, CancellationToken cancellationToken) =>
         ExecuteAsync(action, context, cancellationToken, DefaultContinueOnCapturedContext);
@@ -66,6 +72,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
+    /// <returns>A <see cref="Task" /> which completes when <see cref="AsyncPolicy"/> is registered.</returns>
     [DebuggerStepThrough]
     public Task ExecuteAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken, bool continueOnCapturedContext) =>
         ExecuteAsync((_, ct) => action(ct), [], cancellationToken, continueOnCapturedContext);
@@ -78,6 +85,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <returns>A <see cref="Task" /> which completes when <see cref="AsyncPolicy"/> is registered.</returns>
     [DebuggerStepThrough]
     public Task ExecuteAsync(Func<Context, CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext) =>
         ExecuteAsync(action, new Context(contextData), cancellationToken, continueOnCapturedContext);
@@ -90,6 +98,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
+    /// <returns>A <see cref="Task" /> which completes when <see cref="AsyncPolicy"/> is registered.</returns>
     [DebuggerStepThrough]
     public async Task ExecuteAsync(Func<Context, CancellationToken, Task> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
     {
@@ -277,6 +286,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public Task<PolicyResult> ExecuteAndCaptureAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken) =>
         ExecuteAndCaptureAsync((_, ct) => action(ct), [], cancellationToken, DefaultContinueOnCapturedContext);
@@ -299,6 +309,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task> action, Context context, CancellationToken cancellationToken) =>
         ExecuteAndCaptureAsync(action, context, cancellationToken, DefaultContinueOnCapturedContext);
@@ -310,6 +321,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public Task<PolicyResult> ExecuteAndCaptureAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken, bool continueOnCapturedContext) =>
         ExecuteAndCaptureAsync((_, ct) => action(ct), [], cancellationToken, continueOnCapturedContext);
@@ -335,6 +347,7 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
+    /// <returns>The captured result.</returns>
     [DebuggerStepThrough]
     public async Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
     {

--- a/src/Polly/Context.cs
+++ b/src/Polly/Context.cs
@@ -25,24 +25,25 @@ public partial class Context
     }
 
     /// <summary>
+    /// Gets the wrapped <see cref="PolicyBase.PolicyKey"/>.
     /// When execution is through a <see cref="PolicyWrap"/>, identifies the PolicyWrap executing the current delegate by returning the <see cref="PolicyBase.PolicyKey"/> of the outermost layer in the PolicyWrap; otherwise, null.
     /// </summary>
     public string PolicyWrapKey { get; internal set; }
 
     /// <summary>
-    /// The <see cref="PolicyBase.PolicyKey"/> of the policy instance executing the current delegate.
+    /// Gets the <see cref="PolicyBase.PolicyKey"/> of the policy instance executing the current delegate.
     /// </summary>
     public string PolicyKey { get; internal set; }
 
     /// <summary>
-    /// A key unique to the call site of the current execution.
+    /// Gets a key unique to the call site of the current execution.
     /// <remarks>Policy instances are commonly reused across multiple call sites.  Set an OperationKey so that logging and metrics can distinguish usages of policy instances at different call sites.</remarks>
     /// <remarks>The value is set by using the <see cref="Context(string)"/> constructor taking an operationKey parameter.</remarks>
     /// </summary>
     public string OperationKey { get; }
 
     /// <summary>
-    /// A Guid guaranteed to be unique to each execution.
+    /// Gets a Guid guaranteed to be unique to each execution.
     /// <remarks>Acts as a correlation id so that events specific to a single execution can be identified in logging and telemetry.</remarks>
     /// </summary>
     public Guid CorrelationId

--- a/src/Polly/Context.cs
+++ b/src/Polly/Context.cs
@@ -43,7 +43,7 @@ public partial class Context
     public string OperationKey { get; }
 
     /// <summary>
-    /// Gets a Guid guaranteed to be unique to each execution.
+    /// Gets a GUID guaranteed to be unique to each execution.
     /// <remarks>Acts as a correlation id so that events specific to a single execution can be identified in logging and telemetry.</remarks>
     /// </summary>
     public Guid CorrelationId

--- a/src/Polly/DelegateResult.cs
+++ b/src/Polly/DelegateResult.cs
@@ -20,12 +20,12 @@ public class DelegateResult<TResult>
         Exception = exception;
 
     /// <summary>
-    /// The result of executing the delegate. Will be default(TResult) if an exception was thrown.
+    /// Gets the result of executing the delegate. Will be default(TResult) if an exception was thrown.
     /// </summary>
     public TResult Result { get; }
 
     /// <summary>
-    /// Any exception thrown while executing the delegate. Will be null if policy executed without exception.
+    /// Gets the exception thrown while executing the delegate. Will be null if policy executed without exception.
     /// </summary>
     public Exception Exception { get; }
 }

--- a/src/Polly/IAsyncPolicy.TResult.cs
+++ b/src/Polly/IAsyncPolicy.TResult.cs
@@ -11,6 +11,7 @@ public interface IAsyncPolicy<TResult> : IsPolicy
     /// <remarks>Must be called before the policy is first used.  Can only be set once.</remarks>
     /// </summary>
     /// <param name="policyKey">The unique, used-definable key to assign to this <see cref="IAsyncPolicy{TResult}"/> instance.</param>
+    /// <returns>An instance of <see cref="IAsyncPolicy{TResult}"/>.</returns>
     IAsyncPolicy<TResult> WithPolicyKey(string policyKey);
 
     /// <summary>

--- a/src/Polly/IAsyncPolicy.cs
+++ b/src/Polly/IAsyncPolicy.cs
@@ -10,12 +10,14 @@ public interface IAsyncPolicy : IsPolicy
     /// <remarks>Must be called before the policy is first used.  Can only be set once.</remarks>
     /// </summary>
     /// <param name="policyKey">The unique, used-definable key to assign to this <see cref="IAsyncPolicy"/> instance.</param>
+    /// <returns>An instance of <see cref="IAsyncPolicy"/>.</returns>
     IAsyncPolicy WithPolicyKey(string policyKey);
 
     /// <summary>
     ///     Executes the specified asynchronous action within the policy.
     /// </summary>
     /// <param name="action">The action to perform.</param>
+    /// <returns>A <see cref="Task" /> which completes when <see cref="IAsyncPolicy"/> is registered.</returns>
     Task ExecuteAsync(Func<Task> action);
 
     /// <summary>
@@ -23,6 +25,7 @@ public interface IAsyncPolicy : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
+    /// <returns>A <see cref="Task" /> which completes when <see cref="IAsyncPolicy"/> is registered.</returns>
     Task ExecuteAsync(Func<Context, Task> action, IDictionary<string, object> contextData);
 
     /// <summary>
@@ -30,6 +33,7 @@ public interface IAsyncPolicy : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
+    /// <returns>A <see cref="Task" /> which completes when <see cref="IAsyncPolicy"/> is registered.</returns>
     Task ExecuteAsync(Func<Context, Task> action, Context context);
 
     /// <summary>
@@ -37,6 +41,7 @@ public interface IAsyncPolicy : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+    /// <returns>A <see cref="Task" /> which completes when <see cref="IAsyncPolicy"/> is registered.</returns>
     Task ExecuteAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken);
 
     /// <summary>
@@ -45,6 +50,7 @@ public interface IAsyncPolicy : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="contextData">Arbitrary data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+    /// <returns>A <see cref="Task" /> which completes when <see cref="IAsyncPolicy"/> is registered.</returns>
     Task ExecuteAsync(Func<Context, CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken);
 
     /// <summary>
@@ -53,6 +59,7 @@ public interface IAsyncPolicy : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+    /// <returns>A <see cref="Task" /> which completes when <see cref="IAsyncPolicy"/> is registered.</returns>
     Task ExecuteAsync(Func<Context, CancellationToken, Task> action, Context context, CancellationToken cancellationToken);
 
     /// <summary>
@@ -62,6 +69,7 @@ public interface IAsyncPolicy : IsPolicy
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
+    /// <returns>A <see cref="Task" /> which completes when <see cref="IAsyncPolicy"/> is registered.</returns>
     Task ExecuteAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken, bool continueOnCapturedContext);
 
     /// <summary>
@@ -72,6 +80,7 @@ public interface IAsyncPolicy : IsPolicy
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
+    /// <returns>A <see cref="Task" /> which completes when <see cref="IAsyncPolicy"/> is registered.</returns>
     Task ExecuteAsync(Func<Context, CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext);
 
     /// <summary>
@@ -82,6 +91,7 @@ public interface IAsyncPolicy : IsPolicy
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
+    /// <returns>A <see cref="Task" /> which completes when <see cref="IAsyncPolicy"/> is registered.</returns>
     Task ExecuteAsync(Func<Context, CancellationToken, Task> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext);
 
     /// <summary>
@@ -203,6 +213,7 @@ public interface IAsyncPolicy : IsPolicy
     /// </summary>
     /// <param name="action">The action to perform.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+    /// <returns>The captured result.</returns>
     Task<PolicyResult> ExecuteAndCaptureAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken);
 
     /// <summary>
@@ -221,6 +232,7 @@ public interface IAsyncPolicy : IsPolicy
     /// <param name="action">The action to perform.</param>
     /// <param name="context">Context data that is passed to the exception policy.</param>
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
+    /// <returns>The captured result.</returns>
     Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task> action, Context context, CancellationToken cancellationToken);
 
     /// <summary>
@@ -230,6 +242,7 @@ public interface IAsyncPolicy : IsPolicy
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
+    /// <returns>An instance of <see cref="PolicyResult"/>.</returns>
     Task<PolicyResult> ExecuteAndCaptureAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken, bool continueOnCapturedContext);
 
     /// <summary>
@@ -251,6 +264,7 @@ public interface IAsyncPolicy : IsPolicy
     /// <param name="cancellationToken">A cancellation token which can be used to cancel the action.  When a retry policy in use, also cancels any further retries.</param>
     /// <param name="continueOnCapturedContext">Whether to continue on a captured synchronization context.</param>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
+    /// <returns>The captured result.</returns>
     Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext);
 
     /// <summary>

--- a/src/Polly/ISyncPolicy.TResult.cs
+++ b/src/Polly/ISyncPolicy.TResult.cs
@@ -11,6 +11,7 @@ public interface ISyncPolicy<TResult> : IsPolicy
     /// <remarks>Must be called before the policy is first used.  Can only be set once.</remarks>
     /// </summary>
     /// <param name="policyKey">The unique, used-definable key to assign to this <see cref="Policy"/> instance.</param>
+    /// <returns>An instance of <see cref="ISyncPolicy{TResult}"/>.</returns>
     ISyncPolicy<TResult> WithPolicyKey(string policyKey);
 
     /// <summary>

--- a/src/Polly/ISyncPolicy.cs
+++ b/src/Polly/ISyncPolicy.cs
@@ -10,6 +10,7 @@ public interface ISyncPolicy : IsPolicy
     /// <remarks>Must be called before the policy is first used.  Can only be set once.</remarks>
     /// </summary>
     /// <param name="policyKey">The unique, used-definable key to assign to this <see cref="Policy"/> instance.</param>
+    /// <returns>An instance of <see cref="ISyncPolicy"/>.</returns>
     ISyncPolicy WithPolicyKey(string policyKey);
 
     /// <summary>

--- a/src/Polly/IsPolicy.cs
+++ b/src/Polly/IsPolicy.cs
@@ -6,7 +6,7 @@
 public interface IsPolicy
 {
     /// <summary>
-    /// A key intended to be unique to each policy instance, which is passed with executions as the <see cref="Context.PolicyKey"/> property.
+    /// Gets a key intended to be unique to each policy instance, which is passed with executions as the <see cref="Context.PolicyKey"/> property.
     /// </summary>
     string PolicyKey { get; }
 }

--- a/src/Polly/Policy.ContextAndKeys.cs
+++ b/src/Polly/Policy.ContextAndKeys.cs
@@ -7,6 +7,7 @@ public abstract partial class Policy
     /// <remarks>Must be called before the policy is first used.  Can only be set once.</remarks>
     /// </summary>
     /// <param name="policyKey">The unique, used-definable key to assign to this <see cref="Policy"/> instance.</param>
+    /// <returns>An instance of <see cref="Policy"/>.</returns>
     public Policy WithPolicyKey(string policyKey)
     {
         if (policyKeyInternal != null)
@@ -23,6 +24,7 @@ public abstract partial class Policy
     /// <remarks>Must be called before the policy is first used.  Can only be set once.</remarks>
     /// </summary>
     /// <param name="policyKey">The unique, used-definable key to assign to this <see cref="Policy"/> instance.</param>
+    /// <returns>An instance of <see cref="ISyncPolicy"/>.</returns>
     ISyncPolicy ISyncPolicy.WithPolicyKey(string policyKey)
     {
         if (policyKeyInternal != null)
@@ -42,6 +44,7 @@ public abstract partial class Policy<TResult>
     /// <remarks>Must be called before the policy is first used.  Can only be set once.</remarks>
     /// </summary>
     /// <param name="policyKey">The unique, used-definable key to assign to this <see cref="Policy{TResult}"/> instance.</param>
+    /// <returns>An instance of <see cref="Policy{TResult}"/>.</returns>
     public Policy<TResult> WithPolicyKey(string policyKey)
     {
         if (policyKeyInternal != null)
@@ -58,6 +61,7 @@ public abstract partial class Policy<TResult>
     /// <remarks>Must be called before the policy is first used.  Can only be set once.</remarks>
     /// </summary>
     /// <param name="policyKey">The unique, used-definable key to assign to this <see cref="Policy{TResult}"/> instance.</param>
+    /// <returns>An instance of <see cref="ISyncPolicy{TResult}"/>.</returns>
     ISyncPolicy<TResult> ISyncPolicy<TResult>.WithPolicyKey(string policyKey)
     {
         if (policyKeyInternal != null)

--- a/src/Polly/PolicyBase.ContextAndKeys.cs
+++ b/src/Polly/PolicyBase.ContextAndKeys.cs
@@ -8,7 +8,7 @@ public abstract partial class PolicyBase
     protected string policyKeyInternal;
 
     /// <summary>
-    /// A key intended to be unique to each <see cref="IsPolicy"/> instance, which is passed with executions as the <see cref="Context.PolicyKey"/> property.
+    /// Gets a key intended to be unique to each <see cref="IsPolicy"/> instance, which is passed with executions as the <see cref="Context.PolicyKey"/> property.
     /// </summary>
     public string PolicyKey => policyKeyInternal ?? (policyKeyInternal = GetType().Name + "-" + KeyHelper.GuidPart());
 

--- a/src/Polly/PolicyBase.cs
+++ b/src/Polly/PolicyBase.cs
@@ -11,7 +11,7 @@ public abstract partial class PolicyBase
     internal const bool DefaultContinueOnCapturedContext = false;
 
     /// <summary>
-    /// Predicates indicating which exceptions the policy handles.
+    /// Gets the predicates indicating which exceptions the policy handles.
     /// </summary>
     protected internal ExceptionPredicates ExceptionPredicates { get; }
 
@@ -53,7 +53,7 @@ public abstract partial class PolicyBase
 public abstract class PolicyBase<TResult> : PolicyBase
 {
     /// <summary>
-    /// Predicates indicating which results the policy handles.
+    /// Gets the predicates indicating which results the policy handles.
     /// </summary>
     protected internal ResultPredicates<TResult> ResultPredicates { get; }
 

--- a/src/Polly/PolicyBuilder.cs
+++ b/src/Polly/PolicyBuilder.cs
@@ -92,7 +92,7 @@ public sealed partial class PolicyBuilder<TResult>
     internal ExceptionPredicates ExceptionPredicates { get; }
 
     /// <summary>
-    /// Gets the Predicates specifying results that the policy is being configured to handle.
+    /// Gets the predicates specifying results that the policy is being configured to handle.
     /// </summary>
     internal ResultPredicates<TResult> ResultPredicates { get; }
 

--- a/src/Polly/PolicyBuilder.cs
+++ b/src/Polly/PolicyBuilder.cs
@@ -14,7 +14,7 @@ public sealed partial class PolicyBuilder
     }
 
     /// <summary>
-    /// Predicates specifying exceptions that the policy is being configured to handle.
+    /// Gets the predicates specifying exceptions that the policy is being configured to handle.
     /// </summary>
     internal ExceptionPredicates ExceptionPredicates { get; }
 
@@ -87,12 +87,12 @@ public sealed partial class PolicyBuilder<TResult>
         ExceptionPredicates = exceptionPredicates;
 
     /// <summary>
-    /// Predicates specifying exceptions that the policy is being configured to handle.
+    /// Gets the predicates specifying exceptions that the policy is being configured to handle.
     /// </summary>
     internal ExceptionPredicates ExceptionPredicates { get; }
 
     /// <summary>
-    /// Predicates specifying results that the policy is being configured to handle.
+    /// Gets the Predicates specifying results that the policy is being configured to handle.
     /// </summary>
     internal ResultPredicates<TResult> ResultPredicates { get; }
 

--- a/src/Polly/PolicyResult.cs
+++ b/src/Polly/PolicyResult.cs
@@ -14,22 +14,22 @@ public class PolicyResult
     }
 
     /// <summary>
-    ///   The outcome of executing the policy.
+    ///  Gets the outcome of executing the policy.
     /// </summary>
     public OutcomeType Outcome { get; }
 
     /// <summary>
-    ///  The final exception captured. Will be null if policy executed successfully.
+    /// Gets the final exception captured. Will be null if policy executed successfully.
     /// </summary>
     public Exception FinalException { get; }
 
     /// <summary>
-    ///  The exception type of the final exception captured. Will be null if policy executed successfully.
+    /// Gets the exception type of the final exception captured. Will be null if policy executed successfully.
     /// </summary>
     public ExceptionType? ExceptionType { get; }
 
     /// <summary>
-    ///  The context for this execution.
+    /// Gets the context for this execution.
     /// </summary>
     public Context Context { get; }
 
@@ -79,37 +79,37 @@ public class PolicyResult<TResult>
     }
 
     /// <summary>
-    ///   The outcome of executing the policy.
+    /// Gets the outcome of executing the policy.
     /// </summary>
     public OutcomeType Outcome { get; }
 
     /// <summary>
-    ///  The final exception captured. Will be null if policy executed without exception.
+    /// Gets the final exception captured. Will be null if policy executed without exception.
     /// </summary>
     public Exception FinalException { get; }
 
     /// <summary>
-    ///  The exception type of the final exception captured. Will be null if policy executed successfully.
+    /// Gets the exception type of the final exception captured. Will be null if policy executed successfully.
     /// </summary>
     public ExceptionType? ExceptionType { get; }
 
     /// <summary>
-    /// The result of executing the policy. Will be default(TResult) if the policy failed.
+    /// Gets the result of executing the policy. Will be default(TResult) if the policy failed.
     /// </summary>
     public TResult Result { get; }
 
     /// <summary>
-    /// The final handled result captured. Will be default(TResult) if the policy executed successfully, or terminated with an exception.
+    /// Gets the final handled result captured. Will be default(TResult) if the policy executed successfully, or terminated with an exception.
     /// </summary>
     public TResult FinalHandledResult { get; }
 
     /// <summary>
-    ///  The fault type of the final fault captured. Will be null if policy executed successfully.
+    /// Gets the fault type of the final fault captured. Will be null if policy executed successfully.
     /// </summary>
     public FaultType? FaultType { get; }
 
     /// <summary>
-    ///  The context for this execution.
+    /// Gets the context for this execution.
     /// </summary>
     public Context Context { get; }
 

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -9,8 +9,8 @@
     <IncludePollyUsings>true</IncludePollyUsings>
     <NoWarn>$(NoWarn);S3872;SA1414;S3215</NoWarn>
     <NoWarn>$(NoWarn);IDE1006;CA1062;CA1068;S4039;CA1063;CA1031;CA1051</NoWarn>
-    <NoWarn>$(NoWarn);CA2211;S2223;CA1032;CA1815;CA1816;S4457;SA1615;CA1033</NoWarn>
-    <NoWarn>$(NoWarn);CA1010;CA1064;SA1623;SA1118</NoWarn>
+    <NoWarn>$(NoWarn);CA2211;S2223;CA1032;CA1815;CA1816;S4457;CA1033</NoWarn>
+    <NoWarn>$(NoWarn);CA1010;CA1064;SA1118</NoWarn>
     <NoWarn>$(NoWarn);S3971;CA1724;CA1716;SA1108;CA1710;S4049;S3246</NoWarn>
     <NoWarn>$(NoWarn);CA1805</NoWarn>
 

--- a/src/Polly/RateLimit/IRateLimiter.cs
+++ b/src/Polly/RateLimit/IRateLimiter.cs
@@ -13,7 +13,7 @@ internal interface IRateLimiter
     /// </summary>
     /// <returns>
     /// A tuple whose first element is a value indicating whether the execution is permitted,
-    /// and whose second element is the <see cref="TimeSpan"/> should be waited before retrying.
+    /// and whose second element is the what <see cref="TimeSpan"/> should be waited before retrying.
     /// </returns>
     (bool PermitExecution, TimeSpan RetryAfter) PermitExecution();
 }

--- a/src/Polly/RateLimit/IRateLimiter.cs
+++ b/src/Polly/RateLimit/IRateLimiter.cs
@@ -11,5 +11,9 @@ internal interface IRateLimiter
     /// Returns whether the execution is permitted; if not, returns what <see cref="TimeSpan"/> should be waited before retrying.
     /// <remarks>Calling this method consumes an execution permit if one is available: a caller receiving a return value true should make an execution.</remarks>
     /// </summary>
+    /// <returns>
+    /// A tuple whose first element is a value indicating whether the execution is permitted,
+    /// and whose second element is the <see cref="TimeSpan"/> should be waited before retrying.
+    /// </returns>
     (bool PermitExecution, TimeSpan RetryAfter) PermitExecution();
 }

--- a/src/Polly/RateLimit/RateLimitRejectedException.cs
+++ b/src/Polly/RateLimit/RateLimitRejectedException.cs
@@ -17,7 +17,7 @@ namespace Polly.RateLimit;
 public class RateLimitRejectedException : ExecutionRejectedException
 {
     /// <summary>
-    /// The timespan after which the operation may be retried.
+    /// Gets the timespan after which the operation may be retried.
     /// </summary>
     public TimeSpan RetryAfter { get; private set; }
 

--- a/src/Polly/Registry/IReadOnlyPolicyRegistry.cs
+++ b/src/Polly/Registry/IReadOnlyPolicyRegistry.cs
@@ -41,7 +41,7 @@ public interface IReadOnlyPolicyRegistry<TKey> : IEnumerable<KeyValuePair<TKey, 
         where TPolicy : IsPolicy;
 
     /// <summary>
-    /// Total number of policies in the registry.
+    /// Gets the total number of policies in the registry.
     /// </summary>
     int Count { get; }
 

--- a/src/Polly/Registry/PolicyRegistry.cs
+++ b/src/Polly/Registry/PolicyRegistry.cs
@@ -39,7 +39,7 @@ public class PolicyRegistry : IConcurrentPolicyRegistry<string>
     }
 
     /// <summary>
-    /// Total number of policies in the registry.
+    /// Gets the total number of policies in the registry.
     /// </summary>
     public int Count => _registry.Count;
 

--- a/src/Polly/ResultPredicates.cs
+++ b/src/Polly/ResultPredicates.cs
@@ -19,7 +19,7 @@ public class ResultPredicates<TResult>
     /// Returns a bool indicating whether the passed <typeparamref name="TResult"/> value matched any predicates.
     /// </summary>
     /// <param name="result">The <typeparamref name="TResult"/> value to assess against the predicates.</param>
-    /// <returns><see langword="true"/> if <typeparamref name="TResult"/> value matches any predicates. <see langword="true"/> otherwise.</returns>
+    /// <returns><see langword="true"/> if <typeparamref name="TResult"/> value matches any predicates. <see langword="false"/> otherwise.</returns>
     public bool AnyMatch(TResult result)
     {
         if (_predicates == null)

--- a/src/Polly/ResultPredicates.cs
+++ b/src/Polly/ResultPredicates.cs
@@ -19,6 +19,7 @@ public class ResultPredicates<TResult>
     /// Returns a bool indicating whether the passed <typeparamref name="TResult"/> value matched any predicates.
     /// </summary>
     /// <param name="result">The <typeparamref name="TResult"/> value to assess against the predicates.</param>
+    /// <returns><see langword="true"/> if <typeparamref name="TResult"/> value matches any predicates. <see langword="true"/> otherwise.</returns>
     public bool AnyMatch(TResult result)
     {
         if (_predicates == null)

--- a/src/Polly/Wrap/AsyncPolicyWrap.cs
+++ b/src/Polly/Wrap/AsyncPolicyWrap.cs
@@ -9,12 +9,12 @@ public partial class AsyncPolicyWrap : AsyncPolicy, IPolicyWrap
     private readonly IAsyncPolicy _inner;
 
     /// <summary>
-    /// Returns the outer <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>.
+    /// Gets the outer <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>.
     /// </summary>
     public IsPolicy Outer => _outer;
 
     /// <summary>
-    /// Returns the next inner <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>.
+    /// Gets the next inner <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>.
     /// </summary>
     public IsPolicy Inner => _inner;
 
@@ -66,12 +66,12 @@ public partial class AsyncPolicyWrap<TResult> : AsyncPolicy<TResult>, IPolicyWra
     private readonly IAsyncPolicy<TResult> _innerGeneric;
 
     /// <summary>
-    /// Returns the outer <see cref="IsPolicy"/> in this <see cref="IPolicyWrap{TResult}"/>.
+    /// Gets the outer <see cref="IsPolicy"/> in this <see cref="IPolicyWrap{TResult}"/>.
     /// </summary>
     public IsPolicy Outer => (IsPolicy)_outerGeneric ?? _outerNonGeneric;
 
     /// <summary>
-    /// Returns the next inner <see cref="IsPolicy"/> in this <see cref="IPolicyWrap{TResult}"/>.
+    /// Gets the next inner <see cref="IsPolicy"/> in this <see cref="IPolicyWrap{TResult}"/>.
     /// </summary>
     public IsPolicy Inner => (IsPolicy)_innerGeneric ?? _innerNonGeneric;
 

--- a/src/Polly/Wrap/IPolicyWrap.cs
+++ b/src/Polly/Wrap/IPolicyWrap.cs
@@ -6,12 +6,12 @@
 public interface IPolicyWrap : IsPolicy
 {
     /// <summary>
-    /// Returns the outer <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>.
+    /// Gets the outer <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>.
     /// </summary>
     IsPolicy Outer { get; }
 
     /// <summary>
-    /// Returns the next inner <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>.
+    /// Gets the next inner <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>.
     /// </summary>
     IsPolicy Inner { get; }
 }

--- a/src/Polly/Wrap/PolicyWrap.cs
+++ b/src/Polly/Wrap/PolicyWrap.cs
@@ -9,12 +9,12 @@ public partial class PolicyWrap : Policy, IPolicyWrap
     private readonly ISyncPolicy _inner;
 
     /// <summary>
-    /// Returns the outer <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>.
+    /// Gets the outer <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>.
     /// </summary>
     public IsPolicy Outer => _outer;
 
     /// <summary>
-    /// Returns the next inner <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>.
+    /// Gets the next inner <see cref="IsPolicy"/> in this <see cref="IPolicyWrap"/>.
     /// </summary>
     public IsPolicy Inner => _inner;
 
@@ -59,12 +59,12 @@ public partial class PolicyWrap<TResult> : Policy<TResult>, IPolicyWrap<TResult>
     private readonly ISyncPolicy<TResult> _innerGeneric;
 
     /// <summary>
-    /// Returns the outer <see cref="IsPolicy"/> in this <see cref="IPolicyWrap{TResult}"/>.
+    /// Gets the outer <see cref="IsPolicy"/> in this <see cref="IPolicyWrap{TResult}"/>.
     /// </summary>
     public IsPolicy Outer => (IsPolicy)_outerGeneric ?? _outerNonGeneric;
 
     /// <summary>
-    /// Returns the next inner <see cref="IsPolicy"/> in this <see cref="IPolicyWrap{TResult}"/>.
+    /// Gets the next inner <see cref="IsPolicy"/> in this <see cref="IPolicyWrap{TResult}"/>.
     /// </summary>
     public IsPolicy Inner => (IsPolicy)_innerGeneric ?? _innerNonGeneric;
 


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
#1290
<!-- Please include the existing GitHub issue number where relevant -->

## Details on the issue fix or feature implementation

- [x] Fix [SA1615](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1615.md) by adding documentation to return values 
- [x] Fix [SA1623](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1623.md) by prefixing property docs to `Gets`/`Sets`

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
