### PR TITLE
Fix potential github action smells

### DIFF
--- a/.github/workflows/after-release.yml
+++ b/.github/workflows/after-release.yml
@@ -16,7 +16,7 @@ jobs:
 
   update-changelog:
     runs-on: [ ubuntu-latest ]
-    if: github.event_name == 'release' && github.repository == 'App-vNext/Polly'
+    if: github.event_name == 'release' && github.event.repository.fork == false
 
     concurrency:
       group: '${{ github.workflow }}-changelog'
@@ -122,7 +122,7 @@ jobs:
     concurrency:
       group: '${{ github.workflow }}-milestone'
       cancel-in-progress: false
-    if: github.repository == 'App-vNext/Polly'
+    if: github.event.repository.fork == false
     permissions:
       issues: write
 

--- a/.github/workflows/after-release.yml
+++ b/.github/workflows/after-release.yml
@@ -16,7 +16,7 @@ jobs:
 
   update-changelog:
     runs-on: [ ubuntu-latest ]
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' && github.repository == 'App-vNext/Polly'
 
     concurrency:
       group: '${{ github.workflow }}-changelog'
@@ -122,7 +122,7 @@ jobs:
     concurrency:
       group: '${{ github.workflow }}-milestone'
       cancel-in-progress: false
-
+    if: github.repository == 'App-vNext/Polly'
     permissions:
       issues: write
 

--- a/.github/workflows/after-release.yml
+++ b/.github/workflows/after-release.yml
@@ -118,11 +118,10 @@ jobs:
 
   update-milestone:
     runs-on: [ ubuntu-latest ]
-
+    if: github.event.repository.fork == false
     concurrency:
       group: '${{ github.workflow }}-milestone'
       cancel-in-progress: false
-    if: github.event.repository.fork == false
     permissions:
       issues: write
 

--- a/.github/workflows/after-release.yml
+++ b/.github/workflows/after-release.yml
@@ -119,9 +119,11 @@ jobs:
   update-milestone:
     runs-on: [ ubuntu-latest ]
     if: github.event.repository.fork == false
+
     concurrency:
       group: '${{ github.workflow }}-milestone'
       cancel-in-progress: false
+
     permissions:
       issues: write
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
 
     - name: Upload signing file list
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
-      if: matrix.os_name == 'windows' 
+      if: matrix.os_name == 'windows'
       with:
         name: signing-config
         path: eng/signing

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
       run: ./build.ps1
 
     - name: Upload Coverage Reports
-      if: always() && github.event.repository.fork == false
+      if: always()
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: coverage-${{ matrix.os_name }}
@@ -85,22 +85,21 @@ jobs:
         if-no-files-found: ignore
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@5ecb98a3c6b747ed38dc09f787459979aebb39be # v4.3.1
       if: always() && github.event.repository.fork == false
+      uses: codecov/codecov-action@5ecb98a3c6b747ed38dc09f787459979aebb39be # v4.3.1
       with:
         files: ./artifacts/coverage-reports/Polly.Core.Tests/Cobertura.xml,./artifacts/coverage-reports/Polly.Specs/Cobertura.xml,./artifacts/coverage-reports/Polly.RateLimiting.Tests/Cobertura.xml,./artifacts/coverage-reports/Polly.Extensions.Tests/Cobertura.xml,./artifacts/coverage-reports/Polly.Testing.Tests/Cobertura.xml,
         flags: ${{ matrix.os_name }}
         token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Upload Mutation Report
-      if: always() && env.RUN_MUTATION_TESTS == 'true' && github.event.repository.fork == false
+      if: always() && env.RUN_MUTATION_TESTS == 'true'
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: mutation-report
         path: ./artifacts/mutation-report
 
     - name: Publish NuGet packages
-      if: github.event.repository.fork == false
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: packages-${{ matrix.os_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
       run: ./build.ps1
 
     - name: Upload Coverage Reports
-      if: always() && github.repository == 'App-vNext/Polly'
+      if: always() && github.event.repository.fork == false
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: coverage-${{ matrix.os_name }}
@@ -86,21 +86,21 @@ jobs:
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@5ecb98a3c6b747ed38dc09f787459979aebb39be # v4.3.1
-      if: always() && github.repository == 'App-vNext/Polly'
+      if: always() && github.event.repository.fork == false
       with:
         files: ./artifacts/coverage-reports/Polly.Core.Tests/Cobertura.xml,./artifacts/coverage-reports/Polly.Specs/Cobertura.xml,./artifacts/coverage-reports/Polly.RateLimiting.Tests/Cobertura.xml,./artifacts/coverage-reports/Polly.Extensions.Tests/Cobertura.xml,./artifacts/coverage-reports/Polly.Testing.Tests/Cobertura.xml,
         flags: ${{ matrix.os_name }}
         token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Upload Mutation Report
-      if: always() && env.RUN_MUTATION_TESTS == 'true' && github.repository == 'App-vNext/Polly'
+      if: always() && env.RUN_MUTATION_TESTS == 'true' && github.event.repository.fork == false
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: mutation-report
         path: ./artifacts/mutation-report
 
     - name: Publish NuGet packages
-      if: github.repository == 'App-vNext/Polly'
+      if: github.event.repository.fork == false
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: packages-${{ matrix.os_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
       run: ./build.ps1
 
     - name: Upload Coverage Reports
-      if: always()
+      if: always() && github.repository == 'App-vNext/Polly'
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: coverage-${{ matrix.os_name }}
@@ -86,19 +86,21 @@ jobs:
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@5ecb98a3c6b747ed38dc09f787459979aebb39be # v4.3.1
+      if: always() && github.repository == 'App-vNext/Polly'
       with:
         files: ./artifacts/coverage-reports/Polly.Core.Tests/Cobertura.xml,./artifacts/coverage-reports/Polly.Specs/Cobertura.xml,./artifacts/coverage-reports/Polly.RateLimiting.Tests/Cobertura.xml,./artifacts/coverage-reports/Polly.Extensions.Tests/Cobertura.xml,./artifacts/coverage-reports/Polly.Testing.Tests/Cobertura.xml,
         flags: ${{ matrix.os_name }}
         token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Upload Mutation Report
-      if: always() && env.RUN_MUTATION_TESTS == 'true'
+      if: always() && env.RUN_MUTATION_TESTS == 'true' && github.repository == 'App-vNext/Polly'
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: mutation-report
         path: ./artifacts/mutation-report
 
     - name: Publish NuGet packages
+      if: github.repository == 'App-vNext/Polly'
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: packages-${{ matrix.os_name }}
@@ -107,7 +109,7 @@ jobs:
 
     - name: Upload signing file list
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
-      if: matrix.os_name == 'windows'
+      if: matrix.os_name == 'windows' 
       with:
         name: signing-config
         path: eng/signing

--- a/.github/workflows/on-push-do-docs.yml
+++ b/.github/workflows/on-push-do-docs.yml
@@ -12,7 +12,6 @@ jobs:
   update-docs:
     name: update-docs
     runs-on: ubuntu-latest
-    if: github.repository == 'App-vNext/Polly'
     steps:
 
       - name: Generate GitHub application token

--- a/.github/workflows/on-push-do-docs.yml
+++ b/.github/workflows/on-push-do-docs.yml
@@ -12,7 +12,7 @@ jobs:
   update-docs:
     name: update-docs
     runs-on: ubuntu-latest
-
+    if: github.repository == 'App-vNext/Polly'
     steps:
 
       - name: Generate GitHub application token

--- a/.github/workflows/on-push-do-docs.yml
+++ b/.github/workflows/on-push-do-docs.yml
@@ -12,6 +12,8 @@ jobs:
   update-docs:
     name: update-docs
     runs-on: ubuntu-latest
+    if: github.event.repository.fork == false
+
     steps:
 
       - name: Generate GitHub application token

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -13,6 +13,7 @@ jobs:
   analysis:
     name: analysis
     runs-on: ubuntu-latest
+    if: github.event.repository.fork == false
 
     permissions:
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ permissions: {}
 jobs:
   release:
     runs-on: [ ubuntu-latest ]
-
+    if: github.repository == 'App-vNext/Polly'
     concurrency:
       group: ${{ github.workflow }}
       cancel-in-progress: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@ permissions: {}
 jobs:
   release:
     runs-on: [ ubuntu-latest ]
-    if: github.repository == 'App-vNext/Polly'
     concurrency:
       group: ${{ github.workflow }}
       cancel-in-progress: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ permissions: {}
 jobs:
   release:
     runs-on: [ ubuntu-latest ]
+
     concurrency:
       group: ${{ github.workflow }}
       cancel-in-progress: false

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,9 +12,12 @@ permissions:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    if: github.event.repository.fork == false
+
     permissions:
       issues: write
       pull-requests: write
+
     steps:
       - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:


### PR DESCRIPTION
# Pull Request

Hey! 🙂
I want to contribute the following changes to your workflow:

- Use 'if' for upload-artifact action
- Avoid uploading artifacts on forks
- Prevent running issue/PR actions on forks
- Avoid deploying jobs on forks

(These changes are part of a research Study at TU Delft looking at GitHub Action Smells. [Find out more](https://ceddy4395.github.io/research/gha-smells.html))

<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->


## The issue or feature being addressed

<!-- Please include the existing GitHub issue number where relevant -->

## Details on the issue fix or feature implementation

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build
