### PR TITLE
Drop net7.0 from test projects

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,6 @@ jobs:
       with:
         dotnet-version: |
           6.0.x
-          7.0.x
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0

--- a/bench/Polly.Benchmarks/Polly.Benchmarks.csproj
+++ b/bench/Polly.Benchmarks/Polly.Benchmarks.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ProjectType>Benchmark</ProjectType>
     <NoWarn>$(NoWarn);CA1822;SA1414;IDE0060</NoWarn>

--- a/bench/Polly.Core.Benchmarks/Polly.Core.Benchmarks.csproj
+++ b/bench/Polly.Core.Benchmarks/Polly.Core.Benchmarks.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Polly</RootNamespace>
     <ImplicitUsings>true</ImplicitUsings>
     <ProjectType>Benchmark</ProjectType>

--- a/test/Polly.Core.Tests/Polly.Core.Tests.csproj
+++ b/test/Polly.Core.Tests/Polly.Core.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net481</TargetFrameworks>
     <ProjectType>Test</ProjectType>
     <Nullable>enable</Nullable>

--- a/test/Polly.Extensions.Tests/Polly.Extensions.Tests.csproj
+++ b/test/Polly.Extensions.Tests/Polly.Extensions.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net481</TargetFrameworks>
     <ProjectType>Test</ProjectType>
     <Nullable>enable</Nullable>

--- a/test/Polly.RateLimiting.Tests/Polly.RateLimiting.Tests.csproj
+++ b/test/Polly.RateLimiting.Tests/Polly.RateLimiting.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net481</TargetFrameworks>
     <ProjectType>Test</ProjectType>
     <Nullable>enable</Nullable>

--- a/test/Polly.Specs/Polly.Specs.csproj
+++ b/test/Polly.Specs/Polly.Specs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net481</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ProjectType>Test</ProjectType>

--- a/test/Polly.TestUtils/Polly.TestUtils.csproj
+++ b/test/Polly.TestUtils/Polly.TestUtils.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net481</TargetFrameworks>
     <ProjectType>Library</ProjectType>
     <Nullable>enable</Nullable>

--- a/test/Polly.Testing.Tests/Polly.Testing.Tests.csproj
+++ b/test/Polly.Testing.Tests/Polly.Testing.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net481</TargetFrameworks>
     <ProjectType>Test</ProjectType>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Stop testing with `net7.0` as it is at the end of its support life as of Tuesday 14th May 2024.
