### PR TITLE
Fix S3872 warning

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,6 +18,10 @@ indent_style = space
 indent_size = 2
 tab_width = 2
 
+# S3872 // Interfaces should not be empty
+[**/Timeout/{TimeoutSyntax,TimeoutTResultSyntax}.cs]
+dotnet_diagnostic.S3872.severity = suggestion
+
 # C# files
 [*.cs]
 

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -7,7 +7,7 @@
     <ProjectType>Library</ProjectType>
     <MutationScore>70</MutationScore>
     <IncludePollyUsings>true</IncludePollyUsings>
-    <NoWarn>$(NoWarn);S3872;SA1414;S3215</NoWarn>
+    <NoWarn>$(NoWarn);SA1414;S3215</NoWarn>
     <NoWarn>$(NoWarn);IDE1006;CA1062;CA1068;S4039;CA1063;CA1031;CA1051</NoWarn>
     <NoWarn>$(NoWarn);CA2211;S2223;CA1032;CA1815;CA1816;S4457;CA1033</NoWarn>
     <NoWarn>$(NoWarn);CA1010;CA1064;SA1118</NoWarn>


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
#1290

<!-- Please include the existing GitHub issue number where relevant -->

## Details on the issue fix or feature implementation
- [x] Fix [S3872](https://sonarsource.github.io/rspec/#/rspec/S3872/csharp) by renaming `timeout` parameter to `duration` in `Policy.Timeout` APIs
- [x] Rename `timeout` -> `duration` in `Policy.TimeoutAsync` async APIs to unify naming

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
