### PR TITLE
Fix IDE1006 warning

### DIFF
--- a/src/Polly/Caching/ContextualTtl.cs
+++ b/src/Polly/Caching/ContextualTtl.cs
@@ -17,7 +17,7 @@ public class ContextualTtl : ITtlStrategy
     /// </summary>
     public static readonly string SlidingExpirationKey = "ContextualTtlSliding";
 
-    private static readonly Ttl _noTtl = new(TimeSpan.Zero, false);
+    private static readonly Ttl NoTtl = new(TimeSpan.Zero, false);
 
     /// <summary>
     /// Gets the TimeSpan for which to keep an item about to be cached, which may be influenced by data in the execution context.
@@ -29,7 +29,7 @@ public class ContextualTtl : ITtlStrategy
     {
         if (!context.ContainsKey(TimeSpanKey))
         {
-            return _noTtl;
+            return NoTtl;
         }
 
         bool sliding = false;

--- a/src/Polly/Caching/NonSlidingTtl.cs
+++ b/src/Polly/Caching/NonSlidingTtl.cs
@@ -6,10 +6,12 @@ namespace Polly.Caching;
 /// </summary>
 public abstract class NonSlidingTtl : ITtlStrategy
 {
+#pragma warning disable IDE1006
     /// <summary>
     /// The absolute expiration time for cache items, represented by this strategy.
     /// </summary>
     protected readonly DateTimeOffset absoluteExpirationTime;
+#pragma warning restore IDE1006
 
     /// <summary>
     /// Initializes a new instance of the <see cref="NonSlidingTtl"/> class.

--- a/src/Polly/Caching/RelativeTtl.cs
+++ b/src/Polly/Caching/RelativeTtl.cs
@@ -6,7 +6,7 @@ namespace Polly.Caching;
 /// </summary>
 public class RelativeTtl : ITtlStrategy
 {
-    private readonly TimeSpan ttl;
+    private readonly TimeSpan _ttl;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RelativeTtl"/> class.
@@ -19,7 +19,7 @@ public class RelativeTtl : ITtlStrategy
             throw new ArgumentOutOfRangeException(nameof(ttl), "The ttl for items to cache must be greater than zero.");
         }
 
-        this.ttl = ttl;
+        _ttl = ttl;
     }
 
     /// <summary>
@@ -28,5 +28,5 @@ public class RelativeTtl : ITtlStrategy
     /// <param name="context">The execution context.</param>
     /// <param name="result">The execution result.</param>
     /// <returns>A <see cref="Ttl"/> representing the remaining Ttl of the cached item.</returns>
-    public Ttl GetTtl(Context context, object? result) => new(ttl);
+    public Ttl GetTtl(Context context, object? result) => new(_ttl);
 }

--- a/src/Polly/Caching/SlidingTtl.cs
+++ b/src/Polly/Caching/SlidingTtl.cs
@@ -6,7 +6,7 @@ namespace Polly.Caching;
 /// </summary>
 public class SlidingTtl : ITtlStrategy
 {
-    private readonly Ttl ttl;
+    private readonly Ttl _ttl;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SlidingTtl"/> class.
@@ -19,7 +19,7 @@ public class SlidingTtl : ITtlStrategy
             throw new ArgumentOutOfRangeException(nameof(slidingTtl), "The ttl for items to cache must be greater than zero.");
         }
 
-        ttl = new Ttl(slidingTtl, true);
+        _ttl = new Ttl(slidingTtl, true);
     }
 
     /// <summary>
@@ -29,5 +29,5 @@ public class SlidingTtl : ITtlStrategy
     /// <param name="result">The execution result.</param>
     /// <returns>A <see cref="Ttl"/> representing the remaining Ttl of the cached item.</returns>
     public Ttl GetTtl(Context context, object? result) =>
-        ttl;
+        _ttl;
 }

--- a/src/Polly/CircuitBreaker/AdvancedCircuitController.cs
+++ b/src/Polly/CircuitBreaker/AdvancedCircuitController.cs
@@ -29,7 +29,7 @@ internal class AdvancedCircuitController<TResult> : CircuitStateController<TResu
 
     public override void OnCircuitReset(Context context)
     {
-        using var _ = TimedLock.Lock(_lock);
+        using var _ = TimedLock.Lock(Lock);
 
         // Is only null during initialization of the current class
         // as the variable is not set, before the base class calls
@@ -41,9 +41,9 @@ internal class AdvancedCircuitController<TResult> : CircuitStateController<TResu
 
     public override void OnActionSuccess(Context context)
     {
-        using var _ = TimedLock.Lock(_lock);
+        using var _ = TimedLock.Lock(Lock);
 
-        switch (_circuitState)
+        switch (InternalCircuitState)
         {
             case CircuitState.HalfOpen:
                 OnCircuitReset(context);
@@ -65,11 +65,11 @@ internal class AdvancedCircuitController<TResult> : CircuitStateController<TResu
 
     public override void OnActionFailure(DelegateResult<TResult> outcome, Context context)
     {
-        using var _ = TimedLock.Lock(_lock);
+        using var _ = TimedLock.Lock(Lock);
 
-        _lastOutcome = outcome;
+        LastOutcome = outcome;
 
-        switch (_circuitState)
+        switch (InternalCircuitState)
         {
             case CircuitState.HalfOpen:
                 Break_NeedsLock(context);

--- a/src/Polly/CircuitBreaker/AsyncCircuitBreakerPolicy.cs
+++ b/src/Polly/CircuitBreaker/AsyncCircuitBreakerPolicy.cs
@@ -5,36 +5,36 @@
 /// </summary>
 public class AsyncCircuitBreakerPolicy : AsyncPolicy, ICircuitBreakerPolicy
 {
-    internal readonly ICircuitController<EmptyStruct> _breakerController;
+    internal readonly ICircuitController<EmptyStruct> BreakerController;
 
     internal AsyncCircuitBreakerPolicy(
         PolicyBuilder policyBuilder,
         ICircuitController<EmptyStruct> breakerController)
         : base(policyBuilder) =>
-        _breakerController = breakerController;
+        BreakerController = breakerController;
 
     /// <summary>
     /// Gets the state of the underlying circuit.
     /// </summary>
-    public CircuitState CircuitState => _breakerController.CircuitState;
+    public CircuitState CircuitState => BreakerController.CircuitState;
 
     /// <summary>
     /// Gets the last exception handled by the circuit-breaker.
     /// <remarks>This will be null if no exceptions have been handled by the circuit-breaker since the circuit last closed.</remarks>
     /// </summary>
-    public Exception LastException => _breakerController.LastException;
+    public Exception LastException => BreakerController.LastException;
 
     /// <summary>
     /// Isolates (opens) the circuit manually, and holds it in this state until a call to <see cref="Reset()"/> is made.
     /// </summary>
     public void Isolate() =>
-        _breakerController.Isolate();
+        BreakerController.Isolate();
 
     /// <summary>
     /// Closes the circuit, and resets any statistics controlling automated circuit-breaking.
     /// </summary>
     public void Reset() =>
-        _breakerController.Reset();
+        BreakerController.Reset();
 
     /// <inheritdoc/>
     protected override async Task<TResult> ImplementationAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken,
@@ -48,7 +48,7 @@ public class AsyncCircuitBreakerPolicy : AsyncPolicy, ICircuitBreakerPolicy
             continueOnCapturedContext,
             ExceptionPredicates,
             ResultPredicates<EmptyStruct>.None,
-            _breakerController).ConfigureAwait(continueOnCapturedContext);
+            BreakerController).ConfigureAwait(continueOnCapturedContext);
         return result;
     }
 }
@@ -59,42 +59,42 @@ public class AsyncCircuitBreakerPolicy : AsyncPolicy, ICircuitBreakerPolicy
 /// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
 public class AsyncCircuitBreakerPolicy<TResult> : AsyncPolicy<TResult>, ICircuitBreakerPolicy<TResult>
 {
-    internal readonly ICircuitController<TResult> _breakerController;
+    internal readonly ICircuitController<TResult> BreakerController;
 
     internal AsyncCircuitBreakerPolicy(
         PolicyBuilder<TResult> policyBuilder,
         ICircuitController<TResult> breakerController)
         : base(policyBuilder) =>
-        _breakerController = breakerController;
+        BreakerController = breakerController;
 
     /// <summary>
     /// Gets the state of the underlying circuit.
     /// </summary>
-    public CircuitState CircuitState => _breakerController.CircuitState;
+    public CircuitState CircuitState => BreakerController.CircuitState;
 
     /// <summary>
     /// Gets the last exception handled by the circuit-breaker.
     /// <remarks>This will be null if no exceptions have been handled by the circuit-breaker since the circuit last closed.</remarks>
     /// </summary>
-    public Exception LastException => _breakerController.LastException;
+    public Exception LastException => BreakerController.LastException;
 
     /// <summary>
     /// Gets the last result returned from a user delegate which the circuit-breaker handled.
     /// <remarks>This will be default(<typeparamref name="TResult"/>) if no results have been handled by the circuit-breaker since the circuit last closed, or if the last event handled by the circuit was an exception.</remarks>
     /// </summary>
-    public TResult LastHandledResult => _breakerController.LastHandledResult;
+    public TResult LastHandledResult => BreakerController.LastHandledResult;
 
     /// <summary>
     /// Isolates (opens) the circuit manually, and holds it in this state until a call to <see cref="Reset()"/> is made.
     /// </summary>
     public void Isolate() =>
-        _breakerController.Isolate();
+        BreakerController.Isolate();
 
     /// <summary>
     /// Closes the circuit, and resets any statistics controlling automated circuit-breaking.
     /// </summary>
     public void Reset() =>
-        _breakerController.Reset();
+        BreakerController.Reset();
 
     /// <inheritdoc/>
     [DebuggerStepThrough]
@@ -107,5 +107,5 @@ public class AsyncCircuitBreakerPolicy<TResult> : AsyncPolicy<TResult>, ICircuit
             continueOnCapturedContext,
             ExceptionPredicates,
             ResultPredicates,
-            _breakerController);
+            BreakerController);
 }

--- a/src/Polly/CircuitBreaker/CircuitBreakerPolicy.cs
+++ b/src/Polly/CircuitBreaker/CircuitBreakerPolicy.cs
@@ -5,36 +5,36 @@
 /// </summary>
 public class CircuitBreakerPolicy : Policy, ICircuitBreakerPolicy
 {
-    internal readonly ICircuitController<EmptyStruct> _breakerController;
+    internal readonly ICircuitController<EmptyStruct> BreakerController;
 
     internal CircuitBreakerPolicy(
         PolicyBuilder policyBuilder,
         ICircuitController<EmptyStruct> breakerController)
         : base(policyBuilder) =>
-        _breakerController = breakerController;
+        BreakerController = breakerController;
 
     /// <summary>
     /// Gets the state of the underlying circuit.
     /// </summary>
-    public CircuitState CircuitState => _breakerController.CircuitState;
+    public CircuitState CircuitState => BreakerController.CircuitState;
 
     /// <summary>
     /// Gets the last exception handled by the circuit-breaker.
     /// <remarks>This will be null if no exceptions have been handled by the circuit-breaker since the circuit last closed.</remarks>
     /// </summary>
-    public Exception LastException => _breakerController.LastException;
+    public Exception LastException => BreakerController.LastException;
 
     /// <summary>
     /// Isolates (opens) the circuit manually, and holds it in this state until a call to <see cref="Reset()"/> is made.
     /// </summary>
     public void Isolate() =>
-        _breakerController.Isolate();
+        BreakerController.Isolate();
 
     /// <summary>
     /// Closes the circuit, and resets any statistics controlling automated circuit-breaking.
     /// </summary>
     public void Reset() =>
-        _breakerController.Reset();
+        BreakerController.Reset();
 
     /// <inheritdoc/>
     [DebuggerStepThrough]
@@ -47,7 +47,7 @@ public class CircuitBreakerPolicy : Policy, ICircuitBreakerPolicy
             cancellationToken,
             ExceptionPredicates,
             ResultPredicates<EmptyStruct>.None,
-            _breakerController);
+            BreakerController);
         return result;
     }
 }
@@ -58,42 +58,42 @@ public class CircuitBreakerPolicy : Policy, ICircuitBreakerPolicy
 /// <typeparam name="TResult">The type of the result.</typeparam>
 public class CircuitBreakerPolicy<TResult> : Policy<TResult>, ICircuitBreakerPolicy<TResult>
 {
-    internal readonly ICircuitController<TResult> _breakerController;
+    internal readonly ICircuitController<TResult> BreakerController;
 
     internal CircuitBreakerPolicy(
         PolicyBuilder<TResult> policyBuilder,
         ICircuitController<TResult> breakerController)
         : base(policyBuilder) =>
-        _breakerController = breakerController;
+        BreakerController = breakerController;
 
     /// <summary>
     /// Gets the state of the underlying circuit.
     /// </summary>
-    public CircuitState CircuitState => _breakerController.CircuitState;
+    public CircuitState CircuitState => BreakerController.CircuitState;
 
     /// <summary>
     /// Gets the last exception handled by the circuit-breaker.
     /// <remarks>This will be null if no exceptions have been handled by the circuit-breaker since the circuit last closed, or if the last event handled by the circuit was a handled <typeparamref name="TResult"/> value.</remarks>
     /// </summary>
-    public Exception LastException => _breakerController.LastException;
+    public Exception LastException => BreakerController.LastException;
 
     /// <summary>
     /// Gets the last result returned from a user delegate which the circuit-breaker handled.
     /// <remarks>This will be default(<typeparamref name="TResult"/>) if no results have been handled by the circuit-breaker since the circuit last closed, or if the last event handled by the circuit was an exception.</remarks>
     /// </summary>
-    public TResult LastHandledResult => _breakerController.LastHandledResult;
+    public TResult LastHandledResult => BreakerController.LastHandledResult;
 
     /// <summary>
     /// Isolates (opens) the circuit manually, and holds it in this state until a call to <see cref="Reset()"/> is made.
     /// </summary>
     public void Isolate() =>
-        _breakerController.Isolate();
+        BreakerController.Isolate();
 
     /// <summary>
     /// Closes the circuit, and resets any statistics controlling automated circuit-breaking.
     /// </summary>
     public void Reset() =>
-        _breakerController.Reset();
+        BreakerController.Reset();
 
     /// <inheritdoc/>
     [DebuggerStepThrough]
@@ -104,5 +104,5 @@ public class CircuitBreakerPolicy<TResult> : Policy<TResult>, ICircuitBreakerPol
             cancellationToken,
             ExceptionPredicates,
             ResultPredicates,
-            _breakerController);
+            BreakerController);
 }

--- a/src/Polly/CircuitBreaker/ConsecutiveCountCircuitController.cs
+++ b/src/Polly/CircuitBreaker/ConsecutiveCountCircuitController.cs
@@ -16,16 +16,16 @@ internal class ConsecutiveCountCircuitController<TResult> : CircuitStateControll
 
     public override void OnCircuitReset(Context context)
     {
-        using var _ = TimedLock.Lock(_lock);
+        using var _ = TimedLock.Lock(Lock);
         _consecutiveFailureCount = 0;
         ResetInternal_NeedsLock(context);
     }
 
     public override void OnActionSuccess(Context context)
     {
-        using var _ = TimedLock.Lock(_lock);
+        using var _ = TimedLock.Lock(Lock);
 
-        switch (_circuitState)
+        switch (InternalCircuitState)
         {
             case CircuitState.HalfOpen:
                 OnCircuitReset(context);
@@ -46,11 +46,11 @@ internal class ConsecutiveCountCircuitController<TResult> : CircuitStateControll
 
     public override void OnActionFailure(DelegateResult<TResult> outcome, Context context)
     {
-        using var _ = TimedLock.Lock(_lock);
+        using var _ = TimedLock.Lock(Lock);
 
-        _lastOutcome = outcome;
+        LastOutcome = outcome;
 
-        switch (_circuitState)
+        switch (InternalCircuitState)
         {
             case CircuitState.HalfOpen:
                 Break_NeedsLock(context);

--- a/src/Polly/Context.Dictionary.cs
+++ b/src/Polly/Context.Dictionary.cs
@@ -9,9 +9,9 @@ public partial class Context : IDictionary<string, object>, IDictionary, IReadOn
     // For an individual execution through a policy or policywrap, it is expected that all execution steps (for example executing the user delegate, invoking policy-activity delegates such as onRetry, onBreak, onTimeout etc) execute sequentially.
     // Therefore, this class is intentionally not constructed to be safe for concurrent access from multiple threads.
 
-    private Dictionary<string, object> wrappedDictionary;
+    private Dictionary<string, object> _wrappedDictionary;
 
-    private Dictionary<string, object> WrappedDictionary => wrappedDictionary ?? (wrappedDictionary = []);
+    private Dictionary<string, object> WrappedDictionary => _wrappedDictionary ?? (_wrappedDictionary = []);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Context"/> class, with the specified <paramref name="operationKey" /> and the supplied <paramref name="contextData"/>.
@@ -30,7 +30,7 @@ public partial class Context : IDictionary<string, object>, IDictionary, IReadOn
             throw new ArgumentNullException(nameof(contextData));
         }
 
-        wrappedDictionary = new Dictionary<string, object>(contextData);
+        _wrappedDictionary = new Dictionary<string, object>(contextData);
     }
 
     #region IDictionary<string,object> implementation

--- a/src/Polly/IsPolicy.cs
+++ b/src/Polly/IsPolicy.cs
@@ -3,7 +3,9 @@
 /// <summary>
 /// A marker interface identifying Polly policies of all types, and containing properties common to all policies.
 /// </summary>
+#pragma warning disable IDE1006
 public interface IsPolicy
+#pragma warning restore IDE1006
 {
     /// <summary>
     /// Gets a key intended to be unique to each policy instance, which is passed with executions as the <see cref="Context.PolicyKey"/> property.

--- a/src/Polly/PolicyBase.ContextAndKeys.cs
+++ b/src/Polly/PolicyBase.ContextAndKeys.cs
@@ -2,10 +2,12 @@
 
 public abstract partial class PolicyBase
 {
+#pragma warning disable IDE1006
     /// <summary>
     /// A key intended to be unique to each <see cref="IsPolicy"/> instance.
     /// </summary>
     protected string policyKeyInternal;
+#pragma warning restore IDE1006
 
     /// <summary>
     /// Gets a key intended to be unique to each <see cref="IsPolicy"/> instance, which is passed with executions as the <see cref="Context.PolicyKey"/> property.

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -8,19 +8,24 @@
     <MutationScore>70</MutationScore>
     <IncludePollyUsings>true</IncludePollyUsings>
     <NoWarn>$(NoWarn);SA1414;S3215</NoWarn>
-    <NoWarn>$(NoWarn);IDE1006;CA1062;CA1068;S4039;CA1063;CA1031;CA1051</NoWarn>
+    <NoWarn>$(NoWarn);CA1062;CA1068;S4039;CA1063;CA1031;CA1051</NoWarn>
     <NoWarn>$(NoWarn);CA2211;S2223;CA1032;CA1815;CA1816;S4457;CA1033</NoWarn>
     <NoWarn>$(NoWarn);CA1010;CA1064;SA1118</NoWarn>
     <NoWarn>$(NoWarn);S3971;CA1724;CA1716;SA1108;CA1710;S4049;S3246</NoWarn>
     <NoWarn>$(NoWarn);CA1805</NoWarn>
 
-    <!--Public API Analyzers: We do not need to fix these as it would break compatibility with released Polly versions-->
+    <!--Public
+    API Analyzers: We do not need to fix these as it would break compatibility with released Polly
+    versions-->
     <NoWarn>$(NoWarn);RS0037;</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>
-    <Description>Polly is a .NET resilience and transient-fault-handling library that allows developers to express resilience and transient fault handling policies such as Retry, Circuit Breaker, Timeout, Bulkhead Isolation, and Fallback in a fluent and thread-safe manner.</Description>
-    <PackageTags>Polly Exception Handling Resilience Transient Fault Policy Circuit Breaker CircuitBreaker Retry Wait Cache Cache-aside Bulkhead Fallback Timeout Throttle</PackageTags>
+    <Description>Polly is a .NET resilience and transient-fault-handling library that allows
+      developers to express resilience and transient fault handling policies such as Retry, Circuit
+      Breaker, Timeout, Bulkhead Isolation, and Fallback in a fluent and thread-safe manner.</Description>
+    <PackageTags>Polly Exception Handling Resilience Transient Fault Policy Circuit Breaker
+      CircuitBreaker Retry Wait Cache Cache-aside Bulkhead Fallback Timeout Throttle</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -14,18 +14,13 @@
     <NoWarn>$(NoWarn);S3971;CA1724;CA1716;SA1108;CA1710;S4049;S3246</NoWarn>
     <NoWarn>$(NoWarn);CA1805</NoWarn>
 
-    <!--Public
-    API Analyzers: We do not need to fix these as it would break compatibility with released Polly
-    versions-->
+    <!--Public API Analyzers: We do not need to fix these as it would break compatibility with released Polly versions-->
     <NoWarn>$(NoWarn);RS0037;</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>
-    <Description>Polly is a .NET resilience and transient-fault-handling library that allows
-      developers to express resilience and transient fault handling policies such as Retry, Circuit
-      Breaker, Timeout, Bulkhead Isolation, and Fallback in a fluent and thread-safe manner.</Description>
-    <PackageTags>Polly Exception Handling Resilience Transient Fault Policy Circuit Breaker
-      CircuitBreaker Retry Wait Cache Cache-aside Bulkhead Fallback Timeout Throttle</PackageTags>
+    <Description>Polly is a .NET resilience and transient-fault-handling library that allows developers to express resilience and transient fault handling policies such as Retry, Circuit Breaker, Timeout, Bulkhead Isolation, and Fallback in a fluent and thread-safe manner.</Description>
+    <PackageTags>Polly Exception Handling Resilience Transient Fault Policy Circuit Breaker CircuitBreaker Retry Wait Cache Cache-aside Bulkhead Fallback Timeout Throttle</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerAsyncSpecs.cs
+++ b/test/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerAsyncSpecs.cs
@@ -1459,11 +1459,11 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution. (tho still in half-open condition).
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
     }
 
@@ -1495,11 +1495,11 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution. (tho still in half-open condition).
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // Allow another time window to pass (breaker should still be HalfOpen).
@@ -1507,7 +1507,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should now permit another trial execution.
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
     }
 

--- a/test/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerSpecs.cs
+++ b/test/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerSpecs.cs
@@ -1458,11 +1458,11 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution.
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
     }
 
@@ -1495,11 +1495,11 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution.
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // Allow another time window to pass (breaker should still be HalfOpen).
@@ -1507,7 +1507,7 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should now permit another trial execution.
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
     }
 

--- a/test/Polly.Specs/CircuitBreaker/CircuitBreakerAsyncSpecs.cs
+++ b/test/Polly.Specs/CircuitBreaker/CircuitBreakerAsyncSpecs.cs
@@ -323,11 +323,11 @@ public class CircuitBreakerAsyncSpecs : IDisposable
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution.
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
     }
 
@@ -353,11 +353,11 @@ public class CircuitBreakerAsyncSpecs : IDisposable
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution.
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // Allow another time window to pass (breaker should still be HalfOpen).
@@ -365,7 +365,7 @@ public class CircuitBreakerAsyncSpecs : IDisposable
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should now permit another trial execution.
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
     }
 

--- a/test/Polly.Specs/CircuitBreaker/CircuitBreakerSpecs.cs
+++ b/test/Polly.Specs/CircuitBreaker/CircuitBreakerSpecs.cs
@@ -321,11 +321,11 @@ public class CircuitBreakerSpecs : IDisposable
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution.
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
     }
 
@@ -351,11 +351,11 @@ public class CircuitBreakerSpecs : IDisposable
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution in the same time window.
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // Allow another time window to pass (breaker should still be HalfOpen).
@@ -363,7 +363,7 @@ public class CircuitBreakerSpecs : IDisposable
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should now permit another trial execution.
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
     }
 

--- a/test/Polly.Specs/CircuitBreaker/CircuitBreakerTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/CircuitBreaker/CircuitBreakerTResultAsyncSpecs.cs
@@ -385,11 +385,11 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution.
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
     }
 
@@ -415,11 +415,11 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution.
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // Allow another time window to pass (breaker should still be HalfOpen).
@@ -427,7 +427,7 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should now permit another trial execution.
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
     }
 

--- a/test/Polly.Specs/CircuitBreaker/CircuitBreakerTResultSpecs.cs
+++ b/test/Polly.Specs/CircuitBreaker/CircuitBreakerTResultSpecs.cs
@@ -385,11 +385,11 @@ public class CircuitBreakerTResultSpecs : IDisposable
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution.
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
     }
 
@@ -415,11 +415,11 @@ public class CircuitBreakerTResultSpecs : IDisposable
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution.
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // Allow another time window to pass (breaker should still be HalfOpen).
@@ -427,7 +427,7 @@ public class CircuitBreakerTResultSpecs : IDisposable
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should now permit another trial execution.
-        breaker._breakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
+        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
         breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
#1290

<!-- Please include the existing GitHub issue number where relevant -->

## Details on the issue fix or feature implementation
- [x] Suppress [IDE1006](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/naming-rules) in the code or fix the warning

Similar concept to #2111, if warning related to public API - suppress in the code, otherwise fix.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
