### PR TITLE
Removing Warnings SA1108 and SA1118 from NoWarn list

### DIFF
--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -9,7 +9,7 @@
     <IncludePollyUsings>true</IncludePollyUsings>
     <NoWarn>$(NoWarn);CA1010;CA1031;CA1032;CA1033;CA1051;CA1062;CA1063;CA1064;CA1068;CA1710;CA1716;CA1724;CA1805;CA1815;CA1816;CA2211</NoWarn>
     <NoWarn>$(NoWarn);S2223;S3215;S3246;S3971;S4039;S4049;S4457</NoWarn>
-    <NoWarn>$(NoWarn);SA1108;SA1118;SA1414</NoWarn>
+    <NoWarn>$(NoWarn);SA1414</NoWarn>
     <!--Public API Analyzers: We do not need to fix these as it would break compatibility with released Polly versions-->
     <NoWarn>$(NoWarn);RS0037;</NoWarn>
   </PropertyGroup>

--- a/src/Polly/Timeout/TimeoutEngine.cs
+++ b/src/Polly/Timeout/TimeoutEngine.cs
@@ -46,8 +46,9 @@ internal static class TimeoutEngine
                  */
                 actionTask.Wait(timeoutCancellationTokenSource.Token);
             }
-            catch (AggregateException ex) when (ex.InnerExceptions.Count == 1) // Issue #270.  Unwrap extra AggregateException caused by the way pessimistic timeout policy for synchronous executions is necessarily constructed.
+            catch (AggregateException ex) when (ex.InnerExceptions.Count == 1)
             {
+                // Issue #270. Unwrap extra AggregateException caused by the way pessimistic timeout policy for synchronous executions is necessarily constructed.
                 ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
             }
 


### PR DESCRIPTION
The issue or feature being addressed
Contributes to https://github.com/App-vNext/Polly/issues/1290

Details on the issue fix or feature implementation
Got rid of SA1108;SA1118 warnings in the Polly project

Confirm the following

- [x] I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have successfully run a local build