### PR TITLE
Fix retry delay going negative for large retries with exponential delays

### DIFF
--- a/src/Polly.Core/Retry/RetryHelper.cs
+++ b/src/Polly.Core/Retry/RetryHelper.cs
@@ -26,7 +26,6 @@ internal static class RetryHelper
         {
             var delay = GetRetryDelayCore(type, jitter, attempt, baseDelay, ref state, randomizer);
 
-            // stryker disable once equality : no means to test this
             if (maxDelay is TimeSpan maxDelayValue && delay > maxDelayValue)
             {
                 return maxDelay.Value;

--- a/src/Polly.Core/Retry/RetryHelper.cs
+++ b/src/Polly.Core/Retry/RetryHelper.cs
@@ -26,6 +26,7 @@ internal static class RetryHelper
         {
             var delay = GetRetryDelayCore(type, jitter, attempt, baseDelay, ref state, randomizer);
 
+            // stryker disable once equality : no means to test this
             if (maxDelay is TimeSpan maxDelayValue && delay > maxDelayValue)
             {
                 return maxDelay.Value;

--- a/src/Polly.Core/Retry/RetryHelper.cs
+++ b/src/Polly.Core/Retry/RetryHelper.cs
@@ -6,6 +6,11 @@ internal static class RetryHelper
 
     private const double ExponentialFactor = 2.0;
 
+    // Upper-bound to prevent overflow beyond TimeSpan.MaxValue. Potential truncation during conversion from double to long
+    // (as described at https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/numeric-conversions)
+    // is avoided by the arbitrary subtraction of 1000. Validated by unit-test Backoff_should_not_overflow_to_give_negative_timespan.
+    private static readonly double MaxTimeSpanDouble = (double)TimeSpan.MaxValue.Ticks - 1000;
+
     public static bool IsValidDelay(TimeSpan delay) => delay >= TimeSpan.Zero;
 
     public static TimeSpan GetRetryDelay(
@@ -101,20 +106,27 @@ internal static class RetryHelper
         // This factor allows the median values to fall approximately at 1, 2, 4 etc seconds, instead of 1.4, 2.8, 5.6, 11.2.
         const double RpScalingFactor = 1 / 1.4d;
 
-        // Upper-bound to prevent overflow beyond TimeSpan.MaxValue. Potential truncation during conversion from double to long
-        // (as described at https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/numeric-conversions)
-        // is avoided by the arbitrary subtraction of 1000. Validated by unit-test Backoff_should_not_overflow_to_give_negative_timespan.
-        double maxTimeSpanDouble = (double)TimeSpan.MaxValue.Ticks - 1000;
-
         long targetTicksFirstDelay = baseDelay.Ticks;
 
         double t = attempt + randomizer();
         double next = Math.Pow(ExponentialFactor, t) * Math.Tanh(Math.Sqrt(PFactor * t));
 
+        // At t >=1024, the above will tend to infinity which would otherwise cause the
+        // ticks to go negative. See https://github.com/App-vNext/Polly/issues/2163.
+        if (double.IsInfinity(next))
+        {
+            prev = next;
+            return TimeSpan.FromTicks((long)MaxTimeSpanDouble);
+        }
+
         double formulaIntrinsicValue = next - prev;
         prev = next;
 
-        return TimeSpan.FromTicks((long)Math.Min(formulaIntrinsicValue * RpScalingFactor * targetTicksFirstDelay, maxTimeSpanDouble));
+        long ticks = (long)Math.Min(formulaIntrinsicValue * RpScalingFactor * targetTicksFirstDelay, MaxTimeSpanDouble);
+
+        Debug.Assert(ticks >= 0, "ticks cannot be negative");
+
+        return TimeSpan.FromTicks(ticks);
     }
 
 #pragma warning disable IDE0047 // Remove unnecessary parentheses which offer less mental gymnastics

--- a/src/Polly.Core/Retry/RetryHelper.cs
+++ b/src/Polly.Core/Retry/RetryHelper.cs
@@ -8,8 +8,8 @@ internal static class RetryHelper
 
     // Upper-bound to prevent overflow beyond TimeSpan.MaxValue. Potential truncation during conversion from double to long
     // (as described at https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/numeric-conversions)
-    // is avoided by the arbitrary subtraction of 1000. Validated by unit-test Backoff_should_not_overflow_to_give_negative_timespan.
-    private static readonly double MaxTimeSpanDouble = (double)TimeSpan.MaxValue.Ticks - 1000;
+    // is avoided by the arbitrary subtraction of 1,000.
+    private static readonly double MaxTimeSpanTicks = (double)TimeSpan.MaxValue.Ticks - 1_000;
 
     public static bool IsValidDelay(TimeSpan delay) => delay >= TimeSpan.Zero;
 
@@ -116,13 +116,13 @@ internal static class RetryHelper
         if (double.IsInfinity(next))
         {
             prev = next;
-            return TimeSpan.FromTicks((long)MaxTimeSpanDouble);
+            return TimeSpan.FromTicks((long)MaxTimeSpanTicks);
         }
 
         double formulaIntrinsicValue = next - prev;
         prev = next;
 
-        long ticks = (long)Math.Min(formulaIntrinsicValue * RpScalingFactor * targetTicksFirstDelay, MaxTimeSpanDouble);
+        long ticks = (long)Math.Min(formulaIntrinsicValue * RpScalingFactor * targetTicksFirstDelay, MaxTimeSpanTicks);
 
         Debug.Assert(ticks >= 0, "ticks cannot be negative");
 

--- a/src/Polly.Core/Retry/RetryResilienceStrategy.cs
+++ b/src/Polly.Core/Retry/RetryResilienceStrategy.cs
@@ -75,6 +75,8 @@ internal sealed class RetryResilienceStrategy<T> : ResilienceStrategy<T>
                 }
             }
 
+            Debug.Assert(delay >= TimeSpan.Zero, "The delay cannot be negative.");
+
             var onRetryArgs = new OnRetryArguments<T>(context, outcome, attempt, delay, executionTime);
             _telemetry.Report<OnRetryArguments<T>, T>(new(ResilienceEventSeverity.Warning, RetryConstants.OnRetryEvent), onRetryArgs);
 

--- a/test/Polly.Core.Tests/Issues/IssuesTests.InfiniteRetry_2163.cs
+++ b/test/Polly.Core.Tests/Issues/IssuesTests.InfiniteRetry_2163.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.Time.Testing;
+using Polly.Retry;
+
+namespace Polly.Core.Tests.Issues;
+
+public partial class IssuesTests
+{
+    [Fact(Timeout = 15_000)]
+    public async Task InfiniteRetry_Delay_Does_Not_Overflow_2163()
+    {
+        // Arrange
+        var options = new RetryStrategyOptions
+        {
+            BackoffType = DelayBackoffType.Exponential,
+            Delay = TimeSpan.FromSeconds(2),
+            MaxDelay = TimeSpan.FromSeconds(30),
+            MaxRetryAttempts = int.MaxValue,
+            UseJitter = true,
+            OnRetry = (args) =>
+            {
+                args.RetryDelay.Should().BeGreaterThan(TimeSpan.Zero, $"RetryDelay is less than zero after {args.AttemptNumber} attempts");
+                return default;
+            },
+        };
+
+        var listener = new FakeTelemetryListener();
+        var telemetry = TestUtilities.CreateResilienceTelemetry(listener);
+        var timeProvider = new FakeTimeProvider();
+
+        var strategy = new RetryResilienceStrategy<object>(options, timeProvider, telemetry);
+        var pipeline = strategy.AsPipeline();
+
+        int attempts = 0;
+        int succeedAfter = 2049;
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        // Act
+        var executing = pipeline.ExecuteAsync((_) =>
+        {
+            if (attempts++ < succeedAfter)
+            {
+                throw new InvalidOperationException("Simulated exception");
+            }
+
+            return new ValueTask<bool>(true);
+        }, cts.Token);
+
+        while (!executing.IsCompleted && !cts.IsCancellationRequested)
+        {
+            timeProvider.Advance(TimeSpan.FromSeconds(1));
+        }
+
+        // Assert
+        cts.Token.ThrowIfCancellationRequested();
+
+        var actual = await executing;
+
+        actual.Should().BeTrue();
+        attempts.Should().Be(succeedAfter);
+    }
+}

--- a/test/Polly.Core.Tests/Retry/RetryHelperTests.cs
+++ b/test/Polly.Core.Tests/Retry/RetryHelperTests.cs
@@ -8,6 +8,24 @@ public class RetryHelperTests
 {
     private Func<double> _randomizer = new RandomUtil(0).NextDouble;
 
+    public static TheoryData<int> Attempts()
+    {
+#pragma warning disable IDE0028
+        return new()
+        {
+            1,
+            2,
+            3,
+            4,
+            10,
+            100,
+            1_000,
+            1_024,
+            1_025,
+        };
+#pragma warning restore IDE0028
+    }
+
     [Fact]
     public void IsValidDelay_Ok()
     {
@@ -188,15 +206,7 @@ public class RetryHelperTests
     }
 
     [Theory]
-    [InlineData(1)]
-    [InlineData(2)]
-    [InlineData(3)]
-    [InlineData(4)]
-    [InlineData(10)]
-    [InlineData(100)]
-    [InlineData(1000)]
-    [InlineData(1024)]
-    [InlineData(1025)]
+    [MemberData(nameof(Attempts))]
     public void GetRetryDelay_Exponential_Is_Positive_When_No_Maximum_Delay(int attempt)
     {
         var jitter = true;
@@ -216,15 +226,7 @@ public class RetryHelperTests
     }
 
     [Theory]
-    [InlineData(1)]
-    [InlineData(2)]
-    [InlineData(3)]
-    [InlineData(4)]
-    [InlineData(10)]
-    [InlineData(100)]
-    [InlineData(1000)]
-    [InlineData(1024)]
-    [InlineData(1025)]
+    [MemberData(nameof(Attempts))]
     public void GetRetryDelay_Exponential_Does_Not_Exceed_MaxDelay(int attempt)
     {
         var jitter = true;
@@ -247,15 +249,7 @@ public class RetryHelperTests
     }
 
     [Theory]
-    [InlineData(1)]
-    [InlineData(2)]
-    [InlineData(3)]
-    [InlineData(4)]
-    [InlineData(10)]
-    [InlineData(100)]
-    [InlineData(1000)]
-    [InlineData(1024)]
-    [InlineData(1025)]
+    [MemberData(nameof(Attempts))]
     public void ExponentialWithJitter_Ok(int count)
     {
         var delay = TimeSpan.FromSeconds(7.8);

--- a/test/Polly.Core.Tests/Retry/RetryHelperTests.cs
+++ b/test/Polly.Core.Tests/Retry/RetryHelperTests.cs
@@ -187,6 +187,7 @@ public class RetryHelperTests
         RetryHelper.GetRetryDelay(DelayBackoffType.Exponential, false, 1000, TimeSpan.FromDays(1), TimeSpan.FromDays(2), ref state, _randomizer).Should().Be(TimeSpan.FromDays(2));
     }
 
+    [Theory]
     [InlineData(1)]
     [InlineData(2)]
     [InlineData(3)]
@@ -194,7 +195,8 @@ public class RetryHelperTests
     [InlineData(10)]
     [InlineData(100)]
     [InlineData(1000)]
-    [Theory]
+    [InlineData(1024)]
+    [InlineData(1025)]
     public void ExponentialWithJitter_Ok(int count)
     {
         var delay = TimeSpan.FromSeconds(7.8);
@@ -203,6 +205,7 @@ public class RetryHelperTests
 
         newDelays.Should().ContainInConsecutiveOrder(oldDelays);
         newDelays.Should().HaveCount(oldDelays.Count);
+        newDelays.Should().AllSatisfy(delay => delay.Should().BePositive());
     }
 
     [Fact]
@@ -213,6 +216,7 @@ public class RetryHelperTests
         var delays2 = GetExponentialWithJitterBackoff(false, delay, 100, RandomUtil.Instance.NextDouble);
 
         delays1.SequenceEqual(delays2).Should().BeFalse();
+        delays1.Should().AllSatisfy(delay => delay.Should().BePositive());
     }
 
     private static IReadOnlyList<TimeSpan> GetExponentialWithJitterBackoff(bool contrib, TimeSpan baseDelay, int retryCount, Func<double>? randomizer = null)

--- a/test/Polly.Core.Tests/Retry/RetryHelperTests.cs
+++ b/test/Polly.Core.Tests/Retry/RetryHelperTests.cs
@@ -197,6 +197,65 @@ public class RetryHelperTests
     [InlineData(1000)]
     [InlineData(1024)]
     [InlineData(1025)]
+    public void GetRetryDelay_Exponential_Is_Positive_When_No_Maximum_Delay(int attempt)
+    {
+        var jitter = true;
+        var type = DelayBackoffType.Exponential;
+
+        var baseDelay = TimeSpan.FromSeconds(2);
+        TimeSpan? maxDelay = null;
+
+        var random = new RandomUtil(0).NextDouble;
+        double state = 0;
+
+        var first = RetryHelper.GetRetryDelay(type, jitter, attempt, baseDelay, maxDelay, ref state, random);
+        var second = RetryHelper.GetRetryDelay(type, jitter, attempt, baseDelay, maxDelay, ref state, random);
+
+        first.Should().BePositive();
+        second.Should().BePositive();
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(10)]
+    [InlineData(100)]
+    [InlineData(1000)]
+    [InlineData(1024)]
+    [InlineData(1025)]
+    public void GetRetryDelay_Exponential_Does_Not_Exceed_MaxDelay(int attempt)
+    {
+        var jitter = true;
+        var type = DelayBackoffType.Exponential;
+
+        var baseDelay = TimeSpan.FromSeconds(2);
+        var maxDelay = TimeSpan.FromSeconds(30);
+
+        var random = new RandomUtil(0).NextDouble;
+        double state = 0;
+
+        var first = RetryHelper.GetRetryDelay(type, jitter, attempt, baseDelay, maxDelay, ref state, random);
+        var second = RetryHelper.GetRetryDelay(type, jitter, attempt, baseDelay, maxDelay, ref state, random);
+
+        first.Should().BePositive();
+        first.Should().BeLessThanOrEqualTo(maxDelay);
+
+        second.Should().BePositive();
+        second.Should().BeLessThanOrEqualTo(maxDelay);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(10)]
+    [InlineData(100)]
+    [InlineData(1000)]
+    [InlineData(1024)]
+    [InlineData(1025)]
     public void ExponentialWithJitter_Ok(int count)
     {
         var delay = TimeSpan.FromSeconds(7.8);

--- a/test/Polly.Core.Tests/Utils/CancellationTokenSourcePoolTests.cs
+++ b/test/Polly.Core.Tests/Utils/CancellationTokenSourcePoolTests.cs
@@ -24,7 +24,9 @@ public class CancellationTokenSourcePoolTests
         pool.Get(System.Threading.Timeout.InfiniteTimeSpan).Should().NotBeNull();
     }
 
+#pragma warning disable xUnit1042 // The member referenced by the MemberData attribute returns untyped data rows
     [MemberData(nameof(TimeProviders))]
+#pragma warning restore xUnit1042 // The member referenced by the MemberData attribute returns untyped data rows
     [Theory]
     public void RentReturn_Reusable_EnsureProperBehavior(object timeProvider)
     {
@@ -48,7 +50,9 @@ public class CancellationTokenSourcePoolTests
 #endif
     }
 
+#pragma warning disable xUnit1042 // The member referenced by the MemberData attribute returns untyped data rows
     [MemberData(nameof(TimeProviders))]
+#pragma warning restore xUnit1042 // The member referenced by the MemberData attribute returns untyped data rows
     [Theory]
     public void RentReturn_NotReusable_EnsureProperBehavior(object timeProvider)
     {
@@ -63,7 +67,9 @@ public class CancellationTokenSourcePoolTests
         cts2.Token.Should().NotBeNull();
     }
 
+#pragma warning disable xUnit1042 // The member referenced by the MemberData attribute returns untyped data rows
     [MemberData(nameof(TimeProviders))]
+#pragma warning restore xUnit1042 // The member referenced by the MemberData attribute returns untyped data rows
     [Theory]
     public async Task Rent_Cancellable_EnsureCancelled(object timeProvider)
     {
@@ -80,7 +86,9 @@ public class CancellationTokenSourcePoolTests
         await TestUtilities.AssertWithTimeoutAsync(() => cts.IsCancellationRequested.Should().BeTrue());
     }
 
+#pragma warning disable xUnit1042 // The member referenced by the MemberData attribute returns untyped data rows
     [MemberData(nameof(TimeProviders))]
+#pragma warning restore xUnit1042 // The member referenced by the MemberData attribute returns untyped data rows
     [Theory]
     public async Task Rent_NotCancellable_EnsureNotCancelled(object timeProvider)
     {


### PR DESCRIPTION
- Fix retry delays going negative with `DelayBackoffType.Exponential` after 1,024 retries.
- Only compute the effective maximum `TimeSpan` once.
- Assert delays are positive.
- Suppress some `xUnit1042` warnings.

Resolves #2163.
