### PR TITLE
Tweak sponsorship details

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ To learn more about Polly, visit [pollydocs.org][polly-docs].
 Thanks to the following companies for sponsoring the ongoing development of Polly.
 
 - [.NET on AWS Open Source Software Fund](https://github.com/aws/dotnet-foss)
-- [Microsoft](https://opensource.microsoft.com/)
+- [Microsoft's Free and Open Source Software Fund](https://github.com/microsoft/foss-fund)
 
 <!-- markdownlint-disable MD042 -->
 [![AWS logo](./logos/aws.png)](#)


### PR DESCRIPTION
Update Microsoft sponsorship link to refer to their FOSS fund after reading [_5 things we learned from sponsoring a sampling of our open source dependencies_](https://opensource.microsoft.com/blog/2024/06/27/5-things-we-learned-from-sponsoring-a-sampling-of-our-open-source-dependencies/).
