### PR TITLE
Fix CA1068 warning

### DIFF
--- a/src/Polly/AsyncPolicy.GenericImplementation.cs
+++ b/src/Polly/AsyncPolicy.GenericImplementation.cs
@@ -2,6 +2,7 @@
 
 public abstract partial class AsyncPolicy<TResult>
 {
+#pragma warning disable CA1068
     /// <summary>
     /// Defines the implementation of a policy for async executions returning <typeparamref name="TResult"/>.
     /// </summary>
@@ -11,6 +12,7 @@ public abstract partial class AsyncPolicy<TResult>
     /// <param name="continueOnCapturedContext">Whether async continuations should continue on a captured context.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the result of the execution.</returns>
     protected abstract Task<TResult> ImplementationAsync(
+#pragma warning restore CA1068
         Func<Context, CancellationToken, Task<TResult>> action,
         Context context,
         CancellationToken cancellationToken,

--- a/src/Polly/AsyncPolicy.GenericImplementation.cs
+++ b/src/Polly/AsyncPolicy.GenericImplementation.cs
@@ -13,8 +13,8 @@ public abstract partial class AsyncPolicy<TResult>
     /// <returns>A <see cref="Task{TResult}"/> representing the result of the execution.</returns>
     protected abstract Task<TResult> ImplementationAsync(
         Func<Context, CancellationToken, Task<TResult>> action,
-#pragma warning restore CA1068
         Context context,
         CancellationToken cancellationToken,
         bool continueOnCapturedContext);
+#pragma warning restore CA1068
 }

--- a/src/Polly/AsyncPolicy.GenericImplementation.cs
+++ b/src/Polly/AsyncPolicy.GenericImplementation.cs
@@ -12,8 +12,8 @@ public abstract partial class AsyncPolicy<TResult>
     /// <param name="continueOnCapturedContext">Whether async continuations should continue on a captured context.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the result of the execution.</returns>
     protected abstract Task<TResult> ImplementationAsync(
-#pragma warning restore CA1068
         Func<Context, CancellationToken, Task<TResult>> action,
+#pragma warning restore CA1068
         Context context,
         CancellationToken cancellationToken,
         bool continueOnCapturedContext);

--- a/src/Polly/AsyncPolicy.NonGenericImplementation.cs
+++ b/src/Polly/AsyncPolicy.NonGenericImplementation.cs
@@ -12,8 +12,8 @@ public abstract partial class AsyncPolicy
     /// <param name="continueOnCapturedContext">Whether async continuations should continue on a captured context.</param>
     /// <returns>A <see cref="Task"/> representing the result of the execution.</returns>
     protected virtual Task ImplementationAsync(
-#pragma warning restore CA1068
         Func<Context, CancellationToken, Task> action,
+#pragma warning restore CA1068
         Context context,
         CancellationToken cancellationToken,
         bool continueOnCapturedContext) =>
@@ -34,8 +34,8 @@ public abstract partial class AsyncPolicy
     /// <param name="continueOnCapturedContext">Whether async continuations should continue on a captured context.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the result of the execution.</returns>
     protected abstract Task<TResult> ImplementationAsync<TResult>(
-#pragma warning restore CA1068
         Func<Context, CancellationToken, Task<TResult>> action,
+#pragma warning restore CA1068
         Context context,
         CancellationToken cancellationToken,
         bool continueOnCapturedContext);

--- a/src/Polly/AsyncPolicy.NonGenericImplementation.cs
+++ b/src/Polly/AsyncPolicy.NonGenericImplementation.cs
@@ -13,11 +13,11 @@ public abstract partial class AsyncPolicy
     /// <returns>A <see cref="Task"/> representing the result of the execution.</returns>
     protected virtual Task ImplementationAsync(
         Func<Context, CancellationToken, Task> action,
-#pragma warning restore CA1068
         Context context,
         CancellationToken cancellationToken,
         bool continueOnCapturedContext) =>
         ImplementationAsync<EmptyStruct>(async (ctx, token) =>
+#pragma warning restore CA1068
         {
             await action(ctx, token).ConfigureAwait(continueOnCapturedContext);
             return EmptyStruct.Instance;
@@ -35,8 +35,8 @@ public abstract partial class AsyncPolicy
     /// <returns>A <see cref="Task{TResult}"/> representing the result of the execution.</returns>
     protected abstract Task<TResult> ImplementationAsync<TResult>(
         Func<Context, CancellationToken, Task<TResult>> action,
-#pragma warning restore CA1068
         Context context,
         CancellationToken cancellationToken,
         bool continueOnCapturedContext);
+#pragma warning restore CA1068
 }

--- a/src/Polly/AsyncPolicy.NonGenericImplementation.cs
+++ b/src/Polly/AsyncPolicy.NonGenericImplementation.cs
@@ -2,6 +2,7 @@
 
 public abstract partial class AsyncPolicy
 {
+#pragma warning disable CA1068
     /// <summary>
     /// Defines the implementation of a policy for async executions with no return value.
     /// </summary>
@@ -11,6 +12,7 @@ public abstract partial class AsyncPolicy
     /// <param name="continueOnCapturedContext">Whether async continuations should continue on a captured context.</param>
     /// <returns>A <see cref="Task"/> representing the result of the execution.</returns>
     protected virtual Task ImplementationAsync(
+#pragma warning restore CA1068
         Func<Context, CancellationToken, Task> action,
         Context context,
         CancellationToken cancellationToken,
@@ -21,6 +23,7 @@ public abstract partial class AsyncPolicy
             return EmptyStruct.Instance;
         }, context, cancellationToken, continueOnCapturedContext);
 
+#pragma warning disable CA1068
     /// <summary>
     /// Defines the implementation of a policy for async executions returning <typeparamref name="TResult"/>.
     /// </summary>
@@ -31,6 +34,7 @@ public abstract partial class AsyncPolicy
     /// <param name="continueOnCapturedContext">Whether async continuations should continue on a captured context.</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the result of the execution.</returns>
     protected abstract Task<TResult> ImplementationAsync<TResult>(
+#pragma warning restore CA1068
         Func<Context, CancellationToken, Task<TResult>> action,
         Context context,
         CancellationToken cancellationToken,

--- a/src/Polly/Bulkhead/AsyncBulkheadEngine.cs
+++ b/src/Polly/Bulkhead/AsyncBulkheadEngine.cs
@@ -9,8 +9,8 @@ internal static class AsyncBulkheadEngine
         Func<Context, Task> onBulkheadRejectedAsync,
         SemaphoreSlim maxParallelizationSemaphore,
         SemaphoreSlim maxQueuedActionsSemaphore,
-        CancellationToken cancellationToken,
-        bool continueOnCapturedContext)
+        bool continueOnCapturedContext,
+        CancellationToken cancellationToken)
     {
         if (!await maxQueuedActionsSemaphore.WaitAsync(TimeSpan.Zero, cancellationToken).ConfigureAwait(continueOnCapturedContext))
         {

--- a/src/Polly/Bulkhead/AsyncBulkheadPolicy.cs
+++ b/src/Polly/Bulkhead/AsyncBulkheadPolicy.cs
@@ -36,7 +36,7 @@ public class AsyncBulkheadPolicy : AsyncPolicy, IBulkheadPolicy
     [DebuggerStepThrough]
     protected override Task<TResult> ImplementationAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken,
         bool continueOnCapturedContext) =>
-        AsyncBulkheadEngine.ImplementationAsync(action, context, _onBulkheadRejectedAsync, _maxParallelizationSemaphore, _maxQueuedActionsSemaphore, cancellationToken, continueOnCapturedContext);
+        AsyncBulkheadEngine.ImplementationAsync(action, context, _onBulkheadRejectedAsync, _maxParallelizationSemaphore, _maxQueuedActionsSemaphore, continueOnCapturedContext, cancellationToken);
 
     /// <inheritdoc/>
     public void Dispose()
@@ -71,7 +71,7 @@ public class AsyncBulkheadPolicy<TResult> : AsyncPolicy<TResult>, IBulkheadPolic
     /// <inheritdoc/>
     [DebuggerStepThrough]
     protected override Task<TResult> ImplementationAsync(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext) =>
-        AsyncBulkheadEngine.ImplementationAsync(action, context, _onBulkheadRejectedAsync, _maxParallelizationSemaphore, _maxQueuedActionsSemaphore, cancellationToken, continueOnCapturedContext);
+        AsyncBulkheadEngine.ImplementationAsync(action, context, _onBulkheadRejectedAsync, _maxParallelizationSemaphore, _maxQueuedActionsSemaphore, continueOnCapturedContext, cancellationToken);
 
     /// <summary>
     /// Gets the number of slots currently available for executing actions through the bulkhead.

--- a/src/Polly/Caching/AsyncCacheEngine.cs
+++ b/src/Polly/Caching/AsyncCacheEngine.cs
@@ -3,19 +3,18 @@ namespace Polly.Caching;
 
 internal static class AsyncCacheEngine
 {
-    internal static async Task<TResult> ImplementationAsync<TResult>(
-        IAsyncCacheProvider<TResult> cacheProvider,
+    internal static async Task<TResult> ImplementationAsync<TResult>(IAsyncCacheProvider<TResult> cacheProvider,
         ITtlStrategy<TResult> ttlStrategy,
         Func<Context, string> cacheKeyStrategy,
         Func<Context, CancellationToken, Task<TResult>> action,
         Context context,
-        CancellationToken cancellationToken,
         bool continueOnCapturedContext,
         Action<Context, string> onCacheGet,
         Action<Context, string> onCacheMiss,
         Action<Context, string> onCachePut,
         Action<Context, string, Exception>? onCacheGetError,
-        Action<Context, string, Exception>? onCachePutError)
+        Action<Context, string, Exception>? onCachePutError,
+        CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Polly/Caching/AsyncCacheEngine.cs
+++ b/src/Polly/Caching/AsyncCacheEngine.cs
@@ -3,7 +3,8 @@ namespace Polly.Caching;
 
 internal static class AsyncCacheEngine
 {
-    internal static async Task<TResult> ImplementationAsync<TResult>(IAsyncCacheProvider<TResult> cacheProvider,
+    internal static async Task<TResult> ImplementationAsync<TResult>(
+        IAsyncCacheProvider<TResult> cacheProvider,
         ITtlStrategy<TResult> ttlStrategy,
         Func<Context, string> cacheKeyStrategy,
         Func<Context, CancellationToken, Task<TResult>> action,

--- a/src/Polly/Caching/AsyncCachePolicy.cs
+++ b/src/Polly/Caching/AsyncCachePolicy.cs
@@ -59,7 +59,8 @@ public class AsyncCachePolicy : AsyncPolicy
             _onCacheMiss,
             _onCachePut,
             _onCacheGetError,
-            _onCachePutError, cancellationToken);
+            _onCachePutError,
+            cancellationToken);
 }
 
 /// <summary>
@@ -115,6 +116,7 @@ public class AsyncCachePolicy<TResult> : AsyncPolicy<TResult>
             _onCacheMiss,
             _onCachePut,
             _onCacheGetError,
-            _onCachePutError, cancellationToken);
+            _onCachePutError,
+            cancellationToken);
 }
 

--- a/src/Polly/Caching/AsyncCachePolicy.cs
+++ b/src/Polly/Caching/AsyncCachePolicy.cs
@@ -54,13 +54,12 @@ public class AsyncCachePolicy : AsyncPolicy
             _cacheKeyStrategy,
             action,
             context,
-            cancellationToken,
             continueOnCapturedContext,
             _onCacheGet,
             _onCacheMiss,
             _onCachePut,
             _onCacheGetError,
-            _onCachePutError);
+            _onCachePutError, cancellationToken);
 }
 
 /// <summary>
@@ -111,12 +110,11 @@ public class AsyncCachePolicy<TResult> : AsyncPolicy<TResult>
             _cacheKeyStrategy,
             action,
             context,
-            cancellationToken,
             continueOnCapturedContext,
             _onCacheGet,
             _onCacheMiss,
             _onCachePut,
             _onCacheGetError,
-            _onCachePutError);
+            _onCachePutError, cancellationToken);
 }
 

--- a/src/Polly/Caching/CacheEngine.cs
+++ b/src/Polly/Caching/CacheEngine.cs
@@ -3,18 +3,17 @@ namespace Polly.Caching;
 
 internal static class CacheEngine
 {
-    internal static TResult Implementation<TResult>(
-        ISyncCacheProvider<TResult> cacheProvider,
+    internal static TResult Implementation<TResult>(ISyncCacheProvider<TResult> cacheProvider,
         ITtlStrategy<TResult> ttlStrategy,
         Func<Context, string> cacheKeyStrategy,
         Func<Context, CancellationToken, TResult> action,
         Context context,
-        CancellationToken cancellationToken,
         Action<Context, string> onCacheGet,
         Action<Context, string> onCacheMiss,
         Action<Context, string> onCachePut,
         Action<Context, string, Exception>? onCacheGetError,
-        Action<Context, string, Exception>? onCachePutError)
+        Action<Context, string, Exception>? onCachePutError,
+        CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Polly/Caching/CacheEngine.cs
+++ b/src/Polly/Caching/CacheEngine.cs
@@ -3,7 +3,8 @@ namespace Polly.Caching;
 
 internal static class CacheEngine
 {
-    internal static TResult Implementation<TResult>(ISyncCacheProvider<TResult> cacheProvider,
+    internal static TResult Implementation<TResult>(
+        ISyncCacheProvider<TResult> cacheProvider,
         ITtlStrategy<TResult> ttlStrategy,
         Func<Context, string> cacheKeyStrategy,
         Func<Context, CancellationToken, TResult> action,

--- a/src/Polly/Caching/CachePolicy.cs
+++ b/src/Polly/Caching/CachePolicy.cs
@@ -51,12 +51,11 @@ public class CachePolicy : Policy, ICachePolicy
             _cacheKeyStrategy,
             action,
             context,
-            cancellationToken,
             _onCacheGet,
             _onCacheMiss,
             _onCachePut,
             _onCacheGetError,
-            _onCachePutError);
+            _onCachePutError, cancellationToken);
 }
 
 /// <summary>
@@ -105,10 +104,9 @@ public class CachePolicy<TResult> : Policy<TResult>, ICachePolicy<TResult>
             _cacheKeyStrategy,
             action,
             context,
-            cancellationToken,
             _onCacheGet,
             _onCacheMiss,
             _onCachePut,
             _onCacheGetError,
-            _onCachePutError);
+            _onCachePutError, cancellationToken);
 }

--- a/src/Polly/Caching/CachePolicy.cs
+++ b/src/Polly/Caching/CachePolicy.cs
@@ -55,7 +55,8 @@ public class CachePolicy : Policy, ICachePolicy
             _onCacheMiss,
             _onCachePut,
             _onCacheGetError,
-            _onCachePutError, cancellationToken);
+            _onCachePutError,
+            cancellationToken);
 }
 
 /// <summary>
@@ -108,5 +109,6 @@ public class CachePolicy<TResult> : Policy<TResult>, ICachePolicy<TResult>
             _onCacheMiss,
             _onCachePut,
             _onCacheGetError,
-            _onCachePutError, cancellationToken);
+            _onCachePutError,
+            cancellationToken);
 }

--- a/src/Polly/Caching/IAsyncCacheProvider.cs
+++ b/src/Polly/Caching/IAsyncCacheProvider.cs
@@ -7,6 +7,7 @@ namespace Polly.Caching;
 public interface IAsyncCacheProvider
 {
 #pragma warning disable SA1414
+#pragma warning disable CA1068
     /// <summary>
     /// Gets a value from the cache asynchronously.
     /// </summary>
@@ -18,8 +19,10 @@ public interface IAsyncCacheProvider
     /// the key was found in the cache, and whose second element is the value from the cache (null if not found).
     /// </returns>
     Task<(bool, object?)> TryGetAsync(string key, CancellationToken cancellationToken, bool continueOnCapturedContext);
-#pragma warning restore  SA1414
+#pragma warning restore CA1068
+#pragma warning restore SA1414
 
+#pragma warning disable CA1068
     /// <summary>
     /// Puts the specified value in the cache asynchronously.
     /// </summary>
@@ -30,6 +33,7 @@ public interface IAsyncCacheProvider
     /// <param name="continueOnCapturedContext">Whether async calls should continue on a captured synchronization context.<para><remarks>Note: if the underlying cache's async API does not support controlling whether to continue on a captured context, async Policy executions with continueOnCapturedContext == true cannot be guaranteed to remain on the captured context.</remarks></para></param>
     /// <returns>A <see cref="Task" /> which completes when the value has been cached.</returns>
     Task PutAsync(string key, object? value, Ttl ttl, CancellationToken cancellationToken, bool continueOnCapturedContext);
+#pragma warning restore CA1068
 }
 
 /// <summary>
@@ -39,6 +43,7 @@ public interface IAsyncCacheProvider
 public interface IAsyncCacheProvider<TResult>
 {
 #pragma warning disable SA1414
+#pragma warning disable CA1068
     /// <summary>
     /// Gets a value from the cache asynchronously.
     /// </summary>
@@ -50,8 +55,10 @@ public interface IAsyncCacheProvider<TResult>
     /// the key was found in the cache, and whose second element is the value from the cache (default(TResult) if not found).
     /// </returns>
     Task<(bool, TResult?)> TryGetAsync(string key, CancellationToken cancellationToken, bool continueOnCapturedContext);
+#pragma warning restore CA1068
 #pragma warning restore SA1414
 
+#pragma warning disable CA1068
     /// <summary>
     /// Puts the specified value in the cache asynchronously.
     /// </summary>
@@ -62,4 +69,5 @@ public interface IAsyncCacheProvider<TResult>
     /// <param name="continueOnCapturedContext">Whether async calls should continue on a captured synchronization context.<para><remarks>Note: if the underlying cache's async API does not support controlling whether to continue on a captured context, async Policy executions with continueOnCapturedContext == true cannot be guaranteed to remain on the captured context.</remarks></para></param>
     /// <returns>A <see cref="Task" /> which completes when the value has been cached.</returns>
     Task PutAsync(string key, TResult? value, Ttl ttl, CancellationToken cancellationToken, bool continueOnCapturedContext);
+#pragma warning restore CA1068
 }

--- a/src/Polly/CircuitBreaker/AsyncCircuitBreakerEngine.cs
+++ b/src/Polly/CircuitBreaker/AsyncCircuitBreakerEngine.cs
@@ -5,11 +5,11 @@ internal class AsyncCircuitBreakerEngine
     internal static async Task<TResult> ImplementationAsync<TResult>(
         Func<Context, CancellationToken, Task<TResult>> action,
         Context context,
-        CancellationToken cancellationToken,
         bool continueOnCapturedContext,
         ExceptionPredicates shouldHandleExceptionPredicates,
         ResultPredicates<TResult> shouldHandleResultPredicates,
-        ICircuitController<TResult> breakerController)
+        ICircuitController<TResult> breakerController,
+        CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Polly/CircuitBreaker/AsyncCircuitBreakerPolicy.cs
+++ b/src/Polly/CircuitBreaker/AsyncCircuitBreakerPolicy.cs
@@ -44,11 +44,10 @@ public class AsyncCircuitBreakerPolicy : AsyncPolicy, ICircuitBreakerPolicy
         await AsyncCircuitBreakerEngine.ImplementationAsync<EmptyStruct>(
             async (ctx, ct) => { result = await action(ctx, ct).ConfigureAwait(continueOnCapturedContext); return EmptyStruct.Instance; },
             context,
-            cancellationToken,
             continueOnCapturedContext,
             ExceptionPredicates,
             ResultPredicates<EmptyStruct>.None,
-            BreakerController).ConfigureAwait(continueOnCapturedContext);
+            BreakerController, cancellationToken).ConfigureAwait(continueOnCapturedContext);
         return result;
     }
 }
@@ -103,9 +102,8 @@ public class AsyncCircuitBreakerPolicy<TResult> : AsyncPolicy<TResult>, ICircuit
         AsyncCircuitBreakerEngine.ImplementationAsync(
             action,
             context,
-            cancellationToken,
             continueOnCapturedContext,
             ExceptionPredicates,
             ResultPredicates,
-            BreakerController);
+            BreakerController, cancellationToken);
 }

--- a/src/Polly/CircuitBreaker/AsyncCircuitBreakerPolicy.cs
+++ b/src/Polly/CircuitBreaker/AsyncCircuitBreakerPolicy.cs
@@ -47,7 +47,8 @@ public class AsyncCircuitBreakerPolicy : AsyncPolicy, ICircuitBreakerPolicy
             continueOnCapturedContext,
             ExceptionPredicates,
             ResultPredicates<EmptyStruct>.None,
-            BreakerController, cancellationToken).ConfigureAwait(continueOnCapturedContext);
+            BreakerController,
+            cancellationToken).ConfigureAwait(continueOnCapturedContext);
         return result;
     }
 }
@@ -105,5 +106,6 @@ public class AsyncCircuitBreakerPolicy<TResult> : AsyncPolicy<TResult>, ICircuit
             continueOnCapturedContext,
             ExceptionPredicates,
             ResultPredicates,
-            BreakerController, cancellationToken);
+            BreakerController,
+            cancellationToken);
 }

--- a/src/Polly/CircuitBreaker/CircuitBreakerEngine.cs
+++ b/src/Polly/CircuitBreaker/CircuitBreakerEngine.cs
@@ -4,13 +4,12 @@ namespace Polly.CircuitBreaker;
 
 internal class CircuitBreakerEngine
 {
-    internal static TResult Implementation<TResult>(
-        Func<Context, CancellationToken, TResult> action,
+    internal static TResult Implementation<TResult>(Func<Context, CancellationToken, TResult> action,
         Context context,
-        CancellationToken cancellationToken,
         ExceptionPredicates shouldHandleExceptionPredicates,
         ResultPredicates<TResult> shouldHandleResultPredicates,
-        ICircuitController<TResult> breakerController)
+        ICircuitController<TResult> breakerController,
+        CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Polly/CircuitBreaker/CircuitBreakerEngine.cs
+++ b/src/Polly/CircuitBreaker/CircuitBreakerEngine.cs
@@ -4,7 +4,8 @@ namespace Polly.CircuitBreaker;
 
 internal class CircuitBreakerEngine
 {
-    internal static TResult Implementation<TResult>(Func<Context, CancellationToken, TResult> action,
+    internal static TResult Implementation<TResult>(
+        Func<Context, CancellationToken, TResult> action,
         Context context,
         ExceptionPredicates shouldHandleExceptionPredicates,
         ResultPredicates<TResult> shouldHandleResultPredicates,

--- a/src/Polly/CircuitBreaker/CircuitBreakerPolicy.cs
+++ b/src/Polly/CircuitBreaker/CircuitBreakerPolicy.cs
@@ -44,10 +44,9 @@ public class CircuitBreakerPolicy : Policy, ICircuitBreakerPolicy
         CircuitBreakerEngine.Implementation<EmptyStruct>(
             (ctx, ct) => { result = action(ctx, ct); return EmptyStruct.Instance; },
             context,
-            cancellationToken,
             ExceptionPredicates,
             ResultPredicates<EmptyStruct>.None,
-            BreakerController);
+            BreakerController, cancellationToken);
         return result;
     }
 }
@@ -101,8 +100,7 @@ public class CircuitBreakerPolicy<TResult> : Policy<TResult>, ICircuitBreakerPol
         CircuitBreakerEngine.Implementation(
             action,
             context,
-            cancellationToken,
             ExceptionPredicates,
             ResultPredicates,
-            BreakerController);
+            BreakerController, cancellationToken);
 }

--- a/src/Polly/CircuitBreaker/CircuitBreakerPolicy.cs
+++ b/src/Polly/CircuitBreaker/CircuitBreakerPolicy.cs
@@ -46,7 +46,8 @@ public class CircuitBreakerPolicy : Policy, ICircuitBreakerPolicy
             context,
             ExceptionPredicates,
             ResultPredicates<EmptyStruct>.None,
-            BreakerController, cancellationToken);
+            BreakerController,
+            cancellationToken);
         return result;
     }
 }
@@ -102,5 +103,6 @@ public class CircuitBreakerPolicy<TResult> : Policy<TResult>, ICircuitBreakerPol
             context,
             ExceptionPredicates,
             ResultPredicates,
-            BreakerController, cancellationToken);
+            BreakerController,
+            cancellationToken);
 }

--- a/src/Polly/Fallback/AsyncFallbackEngine.cs
+++ b/src/Polly/Fallback/AsyncFallbackEngine.cs
@@ -6,12 +6,12 @@ internal class AsyncFallbackEngine
     internal static async Task<TResult> ImplementationAsync<TResult>(
         Func<Context, CancellationToken, Task<TResult>> action,
         Context context,
-        CancellationToken cancellationToken,
         ExceptionPredicates shouldHandleExceptionPredicates,
         ResultPredicates<TResult> shouldHandleResultPredicates,
         Func<DelegateResult<TResult>, Context, Task> onFallbackAsync,
         Func<DelegateResult<TResult>, Context, CancellationToken, Task<TResult>> fallbackAction,
-        bool continueOnCapturedContext)
+        bool continueOnCapturedContext,
+        CancellationToken cancellationToken)
     {
         DelegateResult<TResult> delegateOutcome;
 

--- a/src/Polly/Fallback/AsyncFallbackPolicy.cs
+++ b/src/Polly/Fallback/AsyncFallbackPolicy.cs
@@ -39,7 +39,8 @@ public class AsyncFallbackPolicy : AsyncPolicy, IFallbackPolicy
                 await _fallbackAction(outcome.Exception, ctx, ct).ConfigureAwait(continueOnCapturedContext);
                 return EmptyStruct.Instance;
             },
-            continueOnCapturedContext, cancellationToken);
+            continueOnCapturedContext,
+            cancellationToken);
 
     /// <inheritdoc/>
     protected override Task<TResult> ImplementationAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken,
@@ -80,5 +81,6 @@ public class AsyncFallbackPolicy<TResult> : AsyncPolicy<TResult>, IFallbackPolic
             ResultPredicates,
             _onFallbackAsync,
             _fallbackAction,
-            continueOnCapturedContext, cancellationToken);
+            continueOnCapturedContext,
+            cancellationToken);
 }

--- a/src/Polly/Fallback/AsyncFallbackPolicy.cs
+++ b/src/Polly/Fallback/AsyncFallbackPolicy.cs
@@ -31,7 +31,6 @@ public class AsyncFallbackPolicy : AsyncPolicy, IFallbackPolicy
                 return EmptyStruct.Instance;
             },
             context,
-            cancellationToken,
             ExceptionPredicates,
             ResultPredicates<EmptyStruct>.None,
             (outcome, ctx) => _onFallbackAsync(outcome.Exception, ctx),
@@ -40,7 +39,7 @@ public class AsyncFallbackPolicy : AsyncPolicy, IFallbackPolicy
                 await _fallbackAction(outcome.Exception, ctx, ct).ConfigureAwait(continueOnCapturedContext);
                 return EmptyStruct.Instance;
             },
-            continueOnCapturedContext);
+            continueOnCapturedContext, cancellationToken);
 
     /// <inheritdoc/>
     protected override Task<TResult> ImplementationAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken,
@@ -77,10 +76,9 @@ public class AsyncFallbackPolicy<TResult> : AsyncPolicy<TResult>, IFallbackPolic
         AsyncFallbackEngine.ImplementationAsync(
             action,
             context,
-            cancellationToken,
             ExceptionPredicates,
             ResultPredicates,
             _onFallbackAsync,
             _fallbackAction,
-            continueOnCapturedContext);
+            continueOnCapturedContext, cancellationToken);
 }

--- a/src/Polly/Fallback/FallbackEngine.cs
+++ b/src/Polly/Fallback/FallbackEngine.cs
@@ -4,14 +4,13 @@ namespace Polly.Fallback;
 
 internal static class FallbackEngine
 {
-    internal static TResult Implementation<TResult>(
-        Func<Context, CancellationToken, TResult> action,
+    internal static TResult Implementation<TResult>(Func<Context, CancellationToken, TResult> action,
         Context context,
-        CancellationToken cancellationToken,
         ExceptionPredicates shouldHandleExceptionPredicates,
         ResultPredicates<TResult> shouldHandleResultPredicates,
         Action<DelegateResult<TResult>, Context> onFallback,
-        Func<DelegateResult<TResult>, Context, CancellationToken, TResult> fallbackAction)
+        Func<DelegateResult<TResult>, Context, CancellationToken, TResult> fallbackAction,
+        CancellationToken cancellationToken)
     {
         DelegateResult<TResult> delegateOutcome;
 

--- a/src/Polly/Fallback/FallbackEngine.cs
+++ b/src/Polly/Fallback/FallbackEngine.cs
@@ -4,7 +4,8 @@ namespace Polly.Fallback;
 
 internal static class FallbackEngine
 {
-    internal static TResult Implementation<TResult>(Func<Context, CancellationToken, TResult> action,
+    internal static TResult Implementation<TResult>(
+        Func<Context, CancellationToken, TResult> action,
         Context context,
         ExceptionPredicates shouldHandleExceptionPredicates,
         ResultPredicates<TResult> shouldHandleResultPredicates,

--- a/src/Polly/Fallback/FallbackPolicy.cs
+++ b/src/Polly/Fallback/FallbackPolicy.cs
@@ -37,7 +37,8 @@ public class FallbackPolicy : Policy, IFallbackPolicy
             {
                 _fallbackAction(outcome.Exception, ctx, ct);
                 return EmptyStruct.Instance;
-            }, cancellationToken);
+            },
+            cancellationToken);
 
     /// <inheritdoc/>
     protected override TResult Implementation<TResult>(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken) =>
@@ -75,5 +76,6 @@ public class FallbackPolicy<TResult> : Policy<TResult>, IFallbackPolicy<TResult>
             ExceptionPredicates,
             ResultPredicates,
             _onFallback,
-            _fallbackAction, cancellationToken);
+            _fallbackAction,
+            cancellationToken);
 }

--- a/src/Polly/Fallback/FallbackPolicy.cs
+++ b/src/Polly/Fallback/FallbackPolicy.cs
@@ -30,7 +30,6 @@ public class FallbackPolicy : Policy, IFallbackPolicy
                 return EmptyStruct.Instance;
             },
             context,
-            cancellationToken,
             ExceptionPredicates,
             ResultPredicates<EmptyStruct>.None,
             (outcome, ctx) => _onFallback(outcome.Exception, ctx),
@@ -38,7 +37,7 @@ public class FallbackPolicy : Policy, IFallbackPolicy
             {
                 _fallbackAction(outcome.Exception, ctx, ct);
                 return EmptyStruct.Instance;
-            });
+            }, cancellationToken);
 
     /// <inheritdoc/>
     protected override TResult Implementation<TResult>(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken) =>
@@ -73,9 +72,8 @@ public class FallbackPolicy<TResult> : Policy<TResult>, IFallbackPolicy<TResult>
         FallbackEngine.Implementation(
             action,
             context,
-            cancellationToken,
             ExceptionPredicates,
             ResultPredicates,
             _onFallback,
-            _fallbackAction);
+            _fallbackAction, cancellationToken);
 }

--- a/src/Polly/IAsyncPolicy.TResult.cs
+++ b/src/Polly/IAsyncPolicy.TResult.cs
@@ -63,6 +63,7 @@ public interface IAsyncPolicy<TResult> : IsPolicy
     /// <returns>The value returned by the action.</returns>
     Task<TResult> ExecuteAsync(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken);
 
+#pragma warning disable CA1068
     /// <summary>
     ///     Executes the specified asynchronous action within the policy and returns the result.
     /// </summary>
@@ -72,7 +73,9 @@ public interface IAsyncPolicy<TResult> : IsPolicy
     /// <returns>The value returned by the action.</returns>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
     Task<TResult> ExecuteAsync(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken, bool continueOnCapturedContext);
+#pragma warning restore CA1068
 
+#pragma warning disable CA1068
     /// <summary>
     ///     Executes the specified asynchronous action within the policy and returns the result.
     /// </summary>
@@ -83,7 +86,9 @@ public interface IAsyncPolicy<TResult> : IsPolicy
     /// <returns>The value returned by the action.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     Task<TResult> ExecuteAsync(Func<Context, CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext);
+#pragma warning restore CA1068
 
+#pragma warning disable CA1068
     /// <summary>
     ///     Executes the specified asynchronous action within the policy and returns the result.
     /// </summary>
@@ -94,6 +99,7 @@ public interface IAsyncPolicy<TResult> : IsPolicy
     /// <returns>The value returned by the action.</returns>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
     Task<TResult> ExecuteAsync(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext);
+#pragma warning restore CA1068
 
     /// <summary>
     /// Executes the specified asynchronous action within the policy and returns the result.
@@ -146,6 +152,7 @@ public interface IAsyncPolicy<TResult> : IsPolicy
     /// <returns>The captured result.</returns>
     Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken);
 
+#pragma warning disable CA1068
     /// <summary>
     ///     Executes the specified asynchronous action within the policy and returns the result.
     /// </summary>
@@ -156,6 +163,7 @@ public interface IAsyncPolicy<TResult> : IsPolicy
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
     Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken, bool continueOnCapturedContext);
 
+#pragma warning disable CA1068
     /// <summary>
     ///     Executes the specified asynchronous action within the policy and returns the result.
     /// </summary>
@@ -166,7 +174,9 @@ public interface IAsyncPolicy<TResult> : IsPolicy
     /// <returns>The captured result.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext);
+#pragma warning restore CA1068
 
+#pragma warning disable CA1068
     /// <summary>
     ///     Executes the specified asynchronous action within the policy and returns the result.
     /// </summary>
@@ -177,4 +187,5 @@ public interface IAsyncPolicy<TResult> : IsPolicy
     /// <returns>The captured result.</returns>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
     Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext);
+#pragma warning restore CA1068
 }

--- a/src/Polly/IAsyncPolicy.TResult.cs
+++ b/src/Polly/IAsyncPolicy.TResult.cs
@@ -162,6 +162,7 @@ public interface IAsyncPolicy<TResult> : IsPolicy
     /// <returns>The captured result.</returns>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
     Task<PolicyResult<TResult>> ExecuteAndCaptureAsync(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken, bool continueOnCapturedContext);
+#pragma warning restore CA1068
 
 #pragma warning disable CA1068
     /// <summary>

--- a/src/Polly/IAsyncPolicy.cs
+++ b/src/Polly/IAsyncPolicy.cs
@@ -62,6 +62,7 @@ public interface IAsyncPolicy : IsPolicy
     /// <returns>A <see cref="Task" /> which completes when <see cref="IAsyncPolicy"/> is registered.</returns>
     Task ExecuteAsync(Func<Context, CancellationToken, Task> action, Context context, CancellationToken cancellationToken);
 
+#pragma warning disable CA1068
     /// <summary>
     ///     Executes the specified asynchronous action within the policy.
     /// </summary>
@@ -71,7 +72,9 @@ public interface IAsyncPolicy : IsPolicy
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
     /// <returns>A <see cref="Task" /> which completes when <see cref="IAsyncPolicy"/> is registered.</returns>
     Task ExecuteAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken, bool continueOnCapturedContext);
+#pragma warning restore CA1068
 
+#pragma warning disable CA1068
     /// <summary>
     ///     Executes the specified asynchronous action within the policy.
     /// </summary>
@@ -82,7 +85,9 @@ public interface IAsyncPolicy : IsPolicy
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>A <see cref="Task" /> which completes when <see cref="IAsyncPolicy"/> is registered.</returns>
     Task ExecuteAsync(Func<Context, CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext);
+#pragma warning restore CA1068
 
+#pragma warning disable CA1068
     /// <summary>
     ///     Executes the specified asynchronous action within the policy.
     /// </summary>
@@ -93,6 +98,7 @@ public interface IAsyncPolicy : IsPolicy
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
     /// <returns>A <see cref="Task" /> which completes when <see cref="IAsyncPolicy"/> is registered.</returns>
     Task ExecuteAsync(Func<Context, CancellationToken, Task> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext);
+#pragma warning restore CA1068
 
     /// <summary>
     ///     Executes the specified asynchronous action within the policy and returns the result.
@@ -149,6 +155,7 @@ public interface IAsyncPolicy : IsPolicy
     /// <returns>The value returned by the action.</returns>
     Task<TResult> ExecuteAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken);
 
+#pragma warning disable CA1068
     /// <summary>
     ///     Executes the specified asynchronous action within the policy and returns the result.
     /// </summary>
@@ -159,7 +166,9 @@ public interface IAsyncPolicy : IsPolicy
     /// <returns>The value returned by the action.</returns>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
     Task<TResult> ExecuteAsync<TResult>(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken, bool continueOnCapturedContext);
+#pragma warning restore CA1068
 
+#pragma warning disable CA1068
     /// <summary>
     ///     Executes the specified asynchronous action within the policy and returns the result.
     /// </summary>
@@ -171,7 +180,9 @@ public interface IAsyncPolicy : IsPolicy
     /// <returns>The value returned by the action.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     Task<TResult> ExecuteAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext);
+#pragma warning restore CA1068
 
+#pragma warning disable CA1068
     /// <summary>
     ///     Executes the specified asynchronous action within the policy and returns the result.
     /// </summary>
@@ -183,6 +194,7 @@ public interface IAsyncPolicy : IsPolicy
     /// <returns>The value returned by the action.</returns>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
     Task<TResult> ExecuteAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext);
+#pragma warning restore CA1068
 
     /// <summary>
     ///     Executes the specified asynchronous action within the policy and returns the captured result.
@@ -235,6 +247,7 @@ public interface IAsyncPolicy : IsPolicy
     /// <returns>The captured result.</returns>
     Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task> action, Context context, CancellationToken cancellationToken);
 
+#pragma warning disable CA1068
     /// <summary>
     ///     Executes the specified asynchronous action within the policy and returns the captured result.
     /// </summary>
@@ -244,7 +257,9 @@ public interface IAsyncPolicy : IsPolicy
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
     /// <returns>An instance of <see cref="PolicyResult"/>.</returns>
     Task<PolicyResult> ExecuteAndCaptureAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken, bool continueOnCapturedContext);
+#pragma warning restore CA1068
 
+#pragma warning disable CA1068
     /// <summary>
     ///     Executes the specified asynchronous action within the policy and returns the captured result.
     /// </summary>
@@ -255,7 +270,9 @@ public interface IAsyncPolicy : IsPolicy
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     /// <returns>The captured result.</returns>
     Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext);
+#pragma warning restore CA1068
 
+#pragma warning disable CA1068
     /// <summary>
     ///     Executes the specified asynchronous action within the policy and returns the captured result.
     /// </summary>
@@ -266,6 +283,7 @@ public interface IAsyncPolicy : IsPolicy
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
     /// <returns>The captured result.</returns>
     Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext);
+#pragma warning restore CA1068
 
     /// <summary>
     /// Executes the specified asynchronous action within the policy and returns the result.
@@ -324,6 +342,7 @@ public interface IAsyncPolicy : IsPolicy
     /// <returns>The captured result.</returns>
     Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken);
 
+#pragma warning disable CA1068
     /// <summary>
     ///     Executes the specified asynchronous action within the policy and returns the result.
     /// </summary>
@@ -334,7 +353,9 @@ public interface IAsyncPolicy : IsPolicy
     /// <returns>The captured result.</returns>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
     Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<CancellationToken, Task<TResult>> action, CancellationToken cancellationToken, bool continueOnCapturedContext);
+#pragma warning restore CA1068
 
+#pragma warning disable CA1068
     /// <summary>
     ///     Executes the specified asynchronous action within the policy and returns the result.
     /// </summary>
@@ -346,7 +367,9 @@ public interface IAsyncPolicy : IsPolicy
     /// <returns>The captured result.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="contextData"/> is <see langword="null"/>.</exception>
     Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext);
+#pragma warning restore CA1068
 
+#pragma warning disable CA1068
     /// <summary>
     ///     Executes the specified asynchronous action within the policy and returns the result.
     /// </summary>
@@ -358,4 +381,5 @@ public interface IAsyncPolicy : IsPolicy
     /// <returns>The captured result.</returns>
     /// <exception cref="InvalidOperationException">Please use asynchronous-defined policies when calling asynchronous ExecuteAsync (and similar) methods.</exception>
     Task<PolicyResult<TResult>> ExecuteAndCaptureAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext);
+#pragma warning restore CA1068
 }

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -7,7 +7,7 @@
     <ProjectType>Library</ProjectType>
     <MutationScore>70</MutationScore>
     <IncludePollyUsings>true</IncludePollyUsings>
-    <NoWarn>$(NoWarn);CA1010;CA1031;CA1032;CA1033;CA1051;CA1062;CA1063;CA1064;CA1068;CA1710;CA1716;CA1724;CA1805;CA1815;CA1816;CA2211</NoWarn>
+    <NoWarn>$(NoWarn);CA1010;CA1031;CA1032;CA1033;CA1051;CA1062;CA1063;CA1064;CA1710;CA1716;CA1724;CA1805;CA1815;CA1816;CA2211</NoWarn>
     <NoWarn>$(NoWarn);S2223;S3215;S3246;S3971;S4039;S4049;S4457</NoWarn>
     <!--Public API Analyzers: We do not need to fix these as it would break compatibility with released Polly versions-->
     <NoWarn>$(NoWarn);RS0037;</NoWarn>

--- a/src/Polly/RateLimit/AsyncRateLimitEngine.cs
+++ b/src/Polly/RateLimit/AsyncRateLimitEngine.cs
@@ -4,13 +4,12 @@ namespace Polly.RateLimit;
 
 internal static class AsyncRateLimitEngine
 {
-    internal static async Task<TResult> ImplementationAsync<TResult>(
-        IRateLimiter rateLimiter,
+    internal static async Task<TResult> ImplementationAsync<TResult>(IRateLimiter rateLimiter,
         Func<TimeSpan, Context, TResult>? retryAfterFactory,
         Func<Context, CancellationToken, Task<TResult>> action,
         Context context,
-        CancellationToken cancellationToken,
-        bool continueOnCapturedContext)
+        bool continueOnCapturedContext,
+        CancellationToken cancellationToken)
     {
         (bool permit, TimeSpan retryAfter) = rateLimiter.PermitExecution();
 

--- a/src/Polly/RateLimit/AsyncRateLimitEngine.cs
+++ b/src/Polly/RateLimit/AsyncRateLimitEngine.cs
@@ -4,7 +4,8 @@ namespace Polly.RateLimit;
 
 internal static class AsyncRateLimitEngine
 {
-    internal static async Task<TResult> ImplementationAsync<TResult>(IRateLimiter rateLimiter,
+    internal static async Task<TResult> ImplementationAsync<TResult>(
+        IRateLimiter rateLimiter,
         Func<TimeSpan, Context, TResult>? retryAfterFactory,
         Func<Context, CancellationToken, Task<TResult>> action,
         Context context,

--- a/src/Polly/RateLimit/AsyncRateLimitPolicy.cs
+++ b/src/Polly/RateLimit/AsyncRateLimitPolicy.cs
@@ -16,7 +16,7 @@ public class AsyncRateLimitPolicy : AsyncPolicy, IRateLimitPolicy
     [DebuggerStepThrough]
     protected override Task<TResult> ImplementationAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken,
         bool continueOnCapturedContext) =>
-        AsyncRateLimitEngine.ImplementationAsync(_rateLimiter, null, action, context, cancellationToken, continueOnCapturedContext);
+        AsyncRateLimitEngine.ImplementationAsync(_rateLimiter, null, action, context, continueOnCapturedContext, cancellationToken);
 }
 
 /// <summary>
@@ -40,5 +40,5 @@ public class AsyncRateLimitPolicy<TResult> : AsyncPolicy<TResult>, IRateLimitPol
     [DebuggerStepThrough]
     protected override Task<TResult> ImplementationAsync(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken,
         bool continueOnCapturedContext) =>
-        AsyncRateLimitEngine.ImplementationAsync(_rateLimiter, _retryAfterFactory, action, context, cancellationToken, continueOnCapturedContext);
+        AsyncRateLimitEngine.ImplementationAsync(_rateLimiter, _retryAfterFactory, action, context, continueOnCapturedContext, cancellationToken);
 }

--- a/src/Polly/Retry/AsyncRetryEngine.cs
+++ b/src/Polly/Retry/AsyncRetryEngine.cs
@@ -6,10 +6,10 @@ internal static class AsyncRetryEngine
     internal static async Task<TResult> ImplementationAsync<TResult>(
         Func<Context, CancellationToken, Task<TResult>> action,
         Context context,
-        CancellationToken cancellationToken,
         ExceptionPredicates shouldRetryExceptionPredicates,
         ResultPredicates<TResult> shouldRetryResultPredicates,
         Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync,
+        CancellationToken cancellationToken,
         int permittedRetryCount = int.MaxValue,
         IEnumerable<TimeSpan>? sleepDurationsEnumerable = null,
         Func<int, DelegateResult<TResult>, Context, TimeSpan>? sleepDurationProvider = null,

--- a/src/Polly/Retry/AsyncRetryPolicy.cs
+++ b/src/Polly/Retry/AsyncRetryPolicy.cs
@@ -46,7 +46,8 @@ public class AsyncRetryPolicy : AsyncPolicy, IRetryPolicy
             cancellationToken,
             _permittedRetryCount,
             _sleepDurationsEnumerable,
-            sleepDurationProvider, continueOnCapturedContext);
+            sleepDurationProvider,
+            continueOnCapturedContext);
     }
 }
 
@@ -88,6 +89,7 @@ public class AsyncRetryPolicy<TResult> : AsyncPolicy<TResult>, IRetryPolicy<TRes
             cancellationToken,
             _permittedRetryCount,
             _sleepDurationsEnumerable,
-            _sleepDurationProvider, continueOnCapturedContext);
+            _sleepDurationProvider,
+            continueOnCapturedContext);
 }
 

--- a/src/Polly/Retry/AsyncRetryPolicy.cs
+++ b/src/Polly/Retry/AsyncRetryPolicy.cs
@@ -40,14 +40,13 @@ public class AsyncRetryPolicy : AsyncPolicy, IRetryPolicy
         return AsyncRetryEngine.ImplementationAsync(
             action,
             context,
-            cancellationToken,
             ExceptionPredicates,
             ResultPredicates<TResult>.None,
             (outcome, timespan, retryCount, ctx) => _onRetryAsync(outcome.Exception, timespan, retryCount, ctx),
+            cancellationToken,
             _permittedRetryCount,
             _sleepDurationsEnumerable,
-            sleepDurationProvider,
-            continueOnCapturedContext);
+            sleepDurationProvider, continueOnCapturedContext);
     }
 }
 
@@ -83,13 +82,12 @@ public class AsyncRetryPolicy<TResult> : AsyncPolicy<TResult>, IRetryPolicy<TRes
         AsyncRetryEngine.ImplementationAsync(
             action,
             context,
-            cancellationToken,
             ExceptionPredicates,
             ResultPredicates,
             _onRetryAsync,
+            cancellationToken,
             _permittedRetryCount,
             _sleepDurationsEnumerable,
-            _sleepDurationProvider,
-            continueOnCapturedContext);
+            _sleepDurationProvider, continueOnCapturedContext);
 }
 

--- a/src/Polly/Retry/RetryEngine.cs
+++ b/src/Polly/Retry/RetryEngine.cs
@@ -3,13 +3,12 @@ namespace Polly.Retry;
 
 internal static class RetryEngine
 {
-    internal static TResult Implementation<TResult>(
-        Func<Context, CancellationToken, TResult> action,
+    internal static TResult Implementation<TResult>(Func<Context, CancellationToken, TResult> action,
         Context context,
-        CancellationToken cancellationToken,
         ExceptionPredicates shouldRetryExceptionPredicates,
         ResultPredicates<TResult> shouldRetryResultPredicates,
         Action<DelegateResult<TResult>, TimeSpan, int, Context> onRetry,
+        CancellationToken cancellationToken,
         int permittedRetryCount = int.MaxValue,
         IEnumerable<TimeSpan>? sleepDurationsEnumerable = null,
         Func<int, DelegateResult<TResult>, Context, TimeSpan>? sleepDurationProvider = null)

--- a/src/Polly/Retry/RetryEngine.cs
+++ b/src/Polly/Retry/RetryEngine.cs
@@ -3,7 +3,8 @@ namespace Polly.Retry;
 
 internal static class RetryEngine
 {
-    internal static TResult Implementation<TResult>(Func<Context, CancellationToken, TResult> action,
+    internal static TResult Implementation<TResult>(
+        Func<Context, CancellationToken, TResult> action,
         Context context,
         ExceptionPredicates shouldRetryExceptionPredicates,
         ResultPredicates<TResult> shouldRetryResultPredicates,

--- a/src/Polly/Retry/RetryPolicy.cs
+++ b/src/Polly/Retry/RetryPolicy.cs
@@ -34,13 +34,12 @@ public class RetryPolicy : Policy, IRetryPolicy
 
         return RetryEngine.Implementation(action,
             context,
-            cancellationToken,
             ExceptionPredicates,
             ResultPredicates<TResult>.None,
             (outcome, timespan, retryCount, ctx) => _onRetry(outcome.Exception, timespan, retryCount, ctx),
+            cancellationToken,
             _permittedRetryCount,
-            _sleepDurationsEnumerable,
-            sleepDurationProvider);
+            _sleepDurationsEnumerable, sleepDurationProvider);
     }
 }
 
@@ -75,11 +74,10 @@ public class RetryPolicy<TResult> : Policy<TResult>, IRetryPolicy<TResult>
         RetryEngine.Implementation(
             action,
             context,
-            cancellationToken,
             ExceptionPredicates,
             ResultPredicates,
             _onRetry,
+            cancellationToken,
             _permittedRetryCount,
-            _sleepDurationsEnumerable,
-            _sleepDurationProvider);
+            _sleepDurationsEnumerable, _sleepDurationProvider);
 }

--- a/src/Polly/Retry/RetryPolicy.cs
+++ b/src/Polly/Retry/RetryPolicy.cs
@@ -39,7 +39,8 @@ public class RetryPolicy : Policy, IRetryPolicy
             (outcome, timespan, retryCount, ctx) => _onRetry(outcome.Exception, timespan, retryCount, ctx),
             cancellationToken,
             _permittedRetryCount,
-            _sleepDurationsEnumerable, sleepDurationProvider);
+            _sleepDurationsEnumerable,
+            sleepDurationProvider);
     }
 }
 
@@ -79,5 +80,6 @@ public class RetryPolicy<TResult> : Policy<TResult>, IRetryPolicy<TResult>
             _onRetry,
             cancellationToken,
             _permittedRetryCount,
-            _sleepDurationsEnumerable, _sleepDurationProvider);
+            _sleepDurationsEnumerable,
+            _sleepDurationProvider);
 }

--- a/src/Polly/Timeout/AsyncTimeoutEngine.cs
+++ b/src/Polly/Timeout/AsyncTimeoutEngine.cs
@@ -5,11 +5,11 @@ internal static class AsyncTimeoutEngine
     internal static async Task<TResult> ImplementationAsync<TResult>(
         Func<Context, CancellationToken, Task<TResult>> action,
         Context context,
-        CancellationToken cancellationToken,
         Func<Context, TimeSpan> timeoutProvider,
         TimeoutStrategy timeoutStrategy,
         Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync,
-        bool continueOnCapturedContext)
+        bool continueOnCapturedContext,
+        CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         TimeSpan timeout = timeoutProvider(context);

--- a/src/Polly/Timeout/AsyncTimeoutPolicy.cs
+++ b/src/Polly/Timeout/AsyncTimeoutPolicy.cs
@@ -32,7 +32,8 @@ public class AsyncTimeoutPolicy : AsyncPolicy, ITimeoutPolicy
             _timeoutProvider,
             _timeoutStrategy,
             _onTimeoutAsync,
-            continueOnCapturedContext, cancellationToken);
+            continueOnCapturedContext,
+            cancellationToken);
 }
 
 /// <summary>
@@ -68,5 +69,6 @@ public class AsyncTimeoutPolicy<TResult> : AsyncPolicy<TResult>, ITimeoutPolicy<
             _timeoutProvider,
             _timeoutStrategy,
             _onTimeoutAsync,
-            continueOnCapturedContext, cancellationToken);
+            continueOnCapturedContext,
+            cancellationToken);
 }

--- a/src/Polly/Timeout/AsyncTimeoutPolicy.cs
+++ b/src/Polly/Timeout/AsyncTimeoutPolicy.cs
@@ -29,11 +29,10 @@ public class AsyncTimeoutPolicy : AsyncPolicy, ITimeoutPolicy
         AsyncTimeoutEngine.ImplementationAsync(
             action,
             context,
-            cancellationToken,
             _timeoutProvider,
             _timeoutStrategy,
             _onTimeoutAsync,
-            continueOnCapturedContext);
+            continueOnCapturedContext, cancellationToken);
 }
 
 /// <summary>
@@ -66,9 +65,8 @@ public class AsyncTimeoutPolicy<TResult> : AsyncPolicy<TResult>, ITimeoutPolicy<
         AsyncTimeoutEngine.ImplementationAsync(
             action,
             context,
-            cancellationToken,
             _timeoutProvider,
             _timeoutStrategy,
             _onTimeoutAsync,
-            continueOnCapturedContext);
+            continueOnCapturedContext, cancellationToken);
 }

--- a/src/Polly/Timeout/TimeoutEngine.cs
+++ b/src/Polly/Timeout/TimeoutEngine.cs
@@ -4,13 +4,12 @@ namespace Polly.Timeout;
 
 internal static class TimeoutEngine
 {
-    internal static TResult Implementation<TResult>(
-        Func<Context, CancellationToken, TResult> action,
+    internal static TResult Implementation<TResult>(Func<Context, CancellationToken, TResult> action,
         Context context,
-        CancellationToken cancellationToken,
         Func<Context, TimeSpan> timeoutProvider,
         TimeoutStrategy timeoutStrategy,
-        Action<Context, TimeSpan, Task, Exception> onTimeout)
+        Action<Context, TimeSpan, Task, Exception> onTimeout,
+        CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         TimeSpan timeout = timeoutProvider(context);

--- a/src/Polly/Timeout/TimeoutEngine.cs
+++ b/src/Polly/Timeout/TimeoutEngine.cs
@@ -4,7 +4,8 @@ namespace Polly.Timeout;
 
 internal static class TimeoutEngine
 {
-    internal static TResult Implementation<TResult>(Func<Context, CancellationToken, TResult> action,
+    internal static TResult Implementation<TResult>(
+        Func<Context, CancellationToken, TResult> action,
         Context context,
         Func<Context, TimeSpan> timeoutProvider,
         TimeoutStrategy timeoutStrategy,

--- a/src/Polly/Timeout/TimeoutPolicy.cs
+++ b/src/Polly/Timeout/TimeoutPolicy.cs
@@ -25,10 +25,9 @@ public class TimeoutPolicy : Policy, ITimeoutPolicy
         TimeoutEngine.Implementation(
             action,
             context,
-            cancellationToken,
             _timeoutProvider,
             _timeoutStrategy,
-            _onTimeout);
+            _onTimeout, cancellationToken);
 }
 
 /// <summary>
@@ -56,8 +55,7 @@ public class TimeoutPolicy<TResult> : Policy<TResult>, ITimeoutPolicy<TResult>
         TimeoutEngine.Implementation(
             action,
             context,
-            cancellationToken,
             _timeoutProvider,
             _timeoutStrategy,
-            _onTimeout);
+            _onTimeout, cancellationToken);
 }

--- a/src/Polly/Timeout/TimeoutPolicy.cs
+++ b/src/Polly/Timeout/TimeoutPolicy.cs
@@ -27,7 +27,8 @@ public class TimeoutPolicy : Policy, ITimeoutPolicy
             context,
             _timeoutProvider,
             _timeoutStrategy,
-            _onTimeout, cancellationToken);
+            _onTimeout,
+            cancellationToken);
 }
 
 /// <summary>
@@ -57,5 +58,6 @@ public class TimeoutPolicy<TResult> : Policy<TResult>, ITimeoutPolicy<TResult>
             context,
             _timeoutProvider,
             _timeoutStrategy,
-            _onTimeout, cancellationToken);
+            _onTimeout,
+            cancellationToken);
 }

--- a/src/Polly/Utilities/Wrappers/ResilienceContextFactory.cs
+++ b/src/Polly/Utilities/Wrappers/ResilienceContextFactory.cs
@@ -2,7 +2,8 @@ namespace Polly.Utilities.Wrappers;
 
 internal static class ResilienceContextFactory
 {
-    public static ResilienceContext Create(Context context,
+    public static ResilienceContext Create(
+        Context context,
         bool continueOnCapturedContext,
         out IDictionary<string, object> oldProperties,
         CancellationToken cancellationToken)

--- a/src/Polly/Utilities/Wrappers/ResilienceContextFactory.cs
+++ b/src/Polly/Utilities/Wrappers/ResilienceContextFactory.cs
@@ -2,11 +2,10 @@ namespace Polly.Utilities.Wrappers;
 
 internal static class ResilienceContextFactory
 {
-    public static ResilienceContext Create(
-        Context context,
-        CancellationToken cancellationToken,
+    public static ResilienceContext Create(Context context,
         bool continueOnCapturedContext,
-        out IDictionary<string, object> oldProperties)
+        out IDictionary<string, object> oldProperties,
+        CancellationToken cancellationToken)
     {
         var resilienceContext = ResilienceContextPool.Shared.Get(context.OperationKey, continueOnCapturedContext, cancellationToken);
         resilienceContext.Properties.SetProperties(context, out oldProperties);

--- a/src/Polly/Utilities/Wrappers/ResiliencePipelineAsyncPolicy.TResult.cs
+++ b/src/Polly/Utilities/Wrappers/ResiliencePipelineAsyncPolicy.TResult.cs
@@ -11,7 +11,8 @@ internal sealed class ResiliencePipelineAsyncPolicy<TResult> : AsyncPolicy<TResu
         var resilienceContext = ResilienceContextFactory.Create(
             context,
             continueOnCapturedContext,
-            out var oldProperties, cancellationToken);
+            out var oldProperties,
+            cancellationToken);
 
         try
         {

--- a/src/Polly/Utilities/Wrappers/ResiliencePipelineAsyncPolicy.TResult.cs
+++ b/src/Polly/Utilities/Wrappers/ResiliencePipelineAsyncPolicy.TResult.cs
@@ -10,9 +10,8 @@ internal sealed class ResiliencePipelineAsyncPolicy<TResult> : AsyncPolicy<TResu
     {
         var resilienceContext = ResilienceContextFactory.Create(
             context,
-            cancellationToken,
             continueOnCapturedContext,
-            out var oldProperties);
+            out var oldProperties, cancellationToken);
 
         try
         {

--- a/src/Polly/Utilities/Wrappers/ResiliencePipelineAsyncPolicy.cs
+++ b/src/Polly/Utilities/Wrappers/ResiliencePipelineAsyncPolicy.cs
@@ -15,7 +15,8 @@ internal sealed class ResiliencePipelineAsyncPolicy : AsyncPolicy
         var resilienceContext = ResilienceContextFactory.Create(
             context,
             continueOnCapturedContext,
-            out var oldProperties, cancellationToken);
+            out var oldProperties,
+            cancellationToken);
 
         try
         {
@@ -42,7 +43,8 @@ internal sealed class ResiliencePipelineAsyncPolicy : AsyncPolicy
         var resilienceContext = ResilienceContextFactory.Create(
             context,
             continueOnCapturedContext,
-            out var oldProperties, cancellationToken);
+            out var oldProperties,
+            cancellationToken);
 
         try
         {

--- a/src/Polly/Utilities/Wrappers/ResiliencePipelineAsyncPolicy.cs
+++ b/src/Polly/Utilities/Wrappers/ResiliencePipelineAsyncPolicy.cs
@@ -14,9 +14,8 @@ internal sealed class ResiliencePipelineAsyncPolicy : AsyncPolicy
     {
         var resilienceContext = ResilienceContextFactory.Create(
             context,
-            cancellationToken,
             continueOnCapturedContext,
-            out var oldProperties);
+            out var oldProperties, cancellationToken);
 
         try
         {
@@ -42,9 +41,8 @@ internal sealed class ResiliencePipelineAsyncPolicy : AsyncPolicy
     {
         var resilienceContext = ResilienceContextFactory.Create(
             context,
-            cancellationToken,
             continueOnCapturedContext,
-            out var oldProperties);
+            out var oldProperties, cancellationToken);
 
         try
         {

--- a/src/Polly/Utilities/Wrappers/ResiliencePipelineSyncPolicy.TResult.cs
+++ b/src/Polly/Utilities/Wrappers/ResiliencePipelineSyncPolicy.TResult.cs
@@ -10,9 +10,8 @@ internal sealed class ResiliencePipelineSyncPolicy<TResult> : Policy<TResult>
     {
         var resilienceContext = ResilienceContextFactory.Create(
             context,
-            cancellationToken,
             true,
-            out var oldProperties);
+            out var oldProperties, cancellationToken);
 
         try
         {

--- a/src/Polly/Utilities/Wrappers/ResiliencePipelineSyncPolicy.TResult.cs
+++ b/src/Polly/Utilities/Wrappers/ResiliencePipelineSyncPolicy.TResult.cs
@@ -11,7 +11,8 @@ internal sealed class ResiliencePipelineSyncPolicy<TResult> : Policy<TResult>
         var resilienceContext = ResilienceContextFactory.Create(
             context,
             true,
-            out var oldProperties, cancellationToken);
+            out var oldProperties,
+            cancellationToken);
 
         try
         {

--- a/src/Polly/Utilities/Wrappers/ResiliencePipelineSyncPolicy.cs
+++ b/src/Polly/Utilities/Wrappers/ResiliencePipelineSyncPolicy.cs
@@ -10,9 +10,8 @@ internal sealed class ResiliencePipelineSyncPolicy : Policy
     {
         var resilienceContext = ResilienceContextFactory.Create(
             context,
-            cancellationToken,
             true,
-            out var oldProperties);
+            out var oldProperties, cancellationToken);
 
         try
         {
@@ -34,9 +33,8 @@ internal sealed class ResiliencePipelineSyncPolicy : Policy
     {
         var resilienceContext = ResilienceContextFactory.Create(
             context,
-            cancellationToken,
             true,
-            out var oldProperties);
+            out var oldProperties, cancellationToken);
 
         try
         {

--- a/src/Polly/Utilities/Wrappers/ResiliencePipelineSyncPolicy.cs
+++ b/src/Polly/Utilities/Wrappers/ResiliencePipelineSyncPolicy.cs
@@ -11,7 +11,8 @@ internal sealed class ResiliencePipelineSyncPolicy : Policy
         var resilienceContext = ResilienceContextFactory.Create(
             context,
             true,
-            out var oldProperties, cancellationToken);
+            out var oldProperties,
+            cancellationToken);
 
         try
         {
@@ -34,7 +35,8 @@ internal sealed class ResiliencePipelineSyncPolicy : Policy
         var resilienceContext = ResilienceContextFactory.Create(
             context,
             true,
-            out var oldProperties, cancellationToken);
+            out var oldProperties,
+            cancellationToken);
 
         try
         {

--- a/src/Polly/Wrap/AsyncPolicyWrap.cs
+++ b/src/Polly/Wrap/AsyncPolicyWrap.cs
@@ -35,10 +35,9 @@ public partial class AsyncPolicyWrap : AsyncPolicy, IPolicyWrap
         AsyncPolicyWrapEngine.ImplementationAsync(
             action,
             context,
-            cancellationToken,
             continueOnCapturedContext,
             _outer,
-            _inner);
+            _inner, cancellationToken);
 
     /// <inheritdoc/>
     [DebuggerStepThrough]
@@ -47,10 +46,9 @@ public partial class AsyncPolicyWrap : AsyncPolicy, IPolicyWrap
         AsyncPolicyWrapEngine.ImplementationAsync<TResult>(
             action,
             context,
-            cancellationToken,
             continueOnCapturedContext,
             _outer,
-            _inner);
+            _inner, cancellationToken);
 }
 
 /// <summary>
@@ -107,20 +105,18 @@ public partial class AsyncPolicyWrap<TResult> : AsyncPolicy<TResult>, IPolicyWra
                 return AsyncPolicyWrapEngine.ImplementationAsync<TResult>(
                     action,
                     context,
-                    cancellationToken,
                     continueOnCapturedContext,
                     _outerNonGeneric,
-                    _innerNonGeneric);
+                    _innerNonGeneric, cancellationToken);
             }
             else if (_innerGeneric != null)
             {
                 return AsyncPolicyWrapEngine.ImplementationAsync<TResult>(
                     action,
                     context,
-                    cancellationToken,
                     continueOnCapturedContext,
                     _outerNonGeneric,
-                    _innerGeneric);
+                    _innerGeneric, cancellationToken);
 
             }
             else
@@ -135,10 +131,9 @@ public partial class AsyncPolicyWrap<TResult> : AsyncPolicy<TResult>, IPolicyWra
                 return AsyncPolicyWrapEngine.ImplementationAsync<TResult>(
                     action,
                     context,
-                    cancellationToken,
                     continueOnCapturedContext,
                     _outerGeneric,
-                    _innerNonGeneric);
+                    _innerNonGeneric, cancellationToken);
 
             }
             else if (_innerGeneric != null)
@@ -146,10 +141,9 @@ public partial class AsyncPolicyWrap<TResult> : AsyncPolicy<TResult>, IPolicyWra
                 return AsyncPolicyWrapEngine.ImplementationAsync<TResult>(
                     action,
                     context,
-                    cancellationToken,
                     continueOnCapturedContext,
                     _outerGeneric,
-                    _innerGeneric);
+                    _innerGeneric, cancellationToken);
 
             }
             else

--- a/src/Polly/Wrap/AsyncPolicyWrap.cs
+++ b/src/Polly/Wrap/AsyncPolicyWrap.cs
@@ -37,7 +37,8 @@ public partial class AsyncPolicyWrap : AsyncPolicy, IPolicyWrap
             context,
             continueOnCapturedContext,
             _outer,
-            _inner, cancellationToken);
+            _inner,
+            cancellationToken);
 
     /// <inheritdoc/>
     [DebuggerStepThrough]
@@ -48,7 +49,8 @@ public partial class AsyncPolicyWrap : AsyncPolicy, IPolicyWrap
             context,
             continueOnCapturedContext,
             _outer,
-            _inner, cancellationToken);
+            _inner,
+            cancellationToken);
 }
 
 /// <summary>
@@ -107,7 +109,8 @@ public partial class AsyncPolicyWrap<TResult> : AsyncPolicy<TResult>, IPolicyWra
                     context,
                     continueOnCapturedContext,
                     _outerNonGeneric,
-                    _innerNonGeneric, cancellationToken);
+                    _innerNonGeneric,
+                    cancellationToken);
             }
             else if (_innerGeneric != null)
             {
@@ -116,7 +119,8 @@ public partial class AsyncPolicyWrap<TResult> : AsyncPolicy<TResult>, IPolicyWra
                     context,
                     continueOnCapturedContext,
                     _outerNonGeneric,
-                    _innerGeneric, cancellationToken);
+                    _innerGeneric,
+                    cancellationToken);
 
             }
             else
@@ -133,7 +137,8 @@ public partial class AsyncPolicyWrap<TResult> : AsyncPolicy<TResult>, IPolicyWra
                     context,
                     continueOnCapturedContext,
                     _outerGeneric,
-                    _innerNonGeneric, cancellationToken);
+                    _innerNonGeneric,
+                    cancellationToken);
 
             }
             else if (_innerGeneric != null)
@@ -143,7 +148,8 @@ public partial class AsyncPolicyWrap<TResult> : AsyncPolicy<TResult>, IPolicyWra
                     context,
                     continueOnCapturedContext,
                     _outerGeneric,
-                    _innerGeneric, cancellationToken);
+                    _innerGeneric,
+                    cancellationToken);
 
             }
             else

--- a/src/Polly/Wrap/AsyncPolicyWrapEngine.cs
+++ b/src/Polly/Wrap/AsyncPolicyWrapEngine.cs
@@ -2,7 +2,8 @@
 
 internal static class AsyncPolicyWrapEngine
 {
-    internal static Task<TResult> ImplementationAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> func,
+    internal static Task<TResult> ImplementationAsync<TResult>(
+        Func<Context, CancellationToken, Task<TResult>> func,
         Context context,
         bool continueOnCapturedContext,
         IAsyncPolicy<TResult> outerPolicy,
@@ -18,7 +19,8 @@ internal static class AsyncPolicyWrapEngine
             cancellationToken,
             continueOnCapturedContext);
 
-    internal static Task<TResult> ImplementationAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> func,
+    internal static Task<TResult> ImplementationAsync<TResult>(
+        Func<Context, CancellationToken, Task<TResult>> func,
         Context context,
         bool continueOnCapturedContext,
         IAsyncPolicy<TResult> outerPolicy,
@@ -34,7 +36,8 @@ internal static class AsyncPolicyWrapEngine
             cancellationToken,
             continueOnCapturedContext);
 
-    internal static Task<TResult> ImplementationAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> func,
+    internal static Task<TResult> ImplementationAsync<TResult>(
+        Func<Context, CancellationToken, Task<TResult>> func,
         Context context,
         bool continueOnCapturedContext,
         IAsyncPolicy outerPolicy,
@@ -50,7 +53,8 @@ internal static class AsyncPolicyWrapEngine
             cancellationToken,
             continueOnCapturedContext);
 
-    internal static Task<TResult> ImplementationAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> func,
+    internal static Task<TResult> ImplementationAsync<TResult>(
+        Func<Context, CancellationToken, Task<TResult>> func,
         Context context,
         bool continueOnCapturedContext,
         IAsyncPolicy outerPolicy,
@@ -66,7 +70,8 @@ internal static class AsyncPolicyWrapEngine
             cancellationToken,
             continueOnCapturedContext);
 
-    internal static Task ImplementationAsync(Func<Context, CancellationToken, Task> action,
+    internal static Task ImplementationAsync(
+        Func<Context, CancellationToken, Task> action,
         Context context,
         bool continueOnCapturedContext,
         IAsyncPolicy outerPolicy,

--- a/src/Polly/Wrap/AsyncPolicyWrapEngine.cs
+++ b/src/Polly/Wrap/AsyncPolicyWrapEngine.cs
@@ -2,13 +2,12 @@
 
 internal static class AsyncPolicyWrapEngine
 {
-    internal static Task<TResult> ImplementationAsync<TResult>(
-       Func<Context, CancellationToken, Task<TResult>> func,
+    internal static Task<TResult> ImplementationAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> func,
         Context context,
-        CancellationToken cancellationToken,
         bool continueOnCapturedContext,
         IAsyncPolicy<TResult> outerPolicy,
-        IAsyncPolicy<TResult> innerPolicy) =>
+        IAsyncPolicy<TResult> innerPolicy,
+        CancellationToken cancellationToken) =>
         outerPolicy.ExecuteAsync(
             (ctx, ct) => innerPolicy.ExecuteAsync(
                 func,
@@ -19,13 +18,12 @@ internal static class AsyncPolicyWrapEngine
             cancellationToken,
             continueOnCapturedContext);
 
-    internal static Task<TResult> ImplementationAsync<TResult>(
-       Func<Context, CancellationToken, Task<TResult>> func,
+    internal static Task<TResult> ImplementationAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> func,
         Context context,
-        CancellationToken cancellationToken,
         bool continueOnCapturedContext,
         IAsyncPolicy<TResult> outerPolicy,
-        IAsyncPolicy innerPolicy) =>
+        IAsyncPolicy innerPolicy,
+        CancellationToken cancellationToken) =>
         outerPolicy.ExecuteAsync(
             (ctx, ct) => innerPolicy.ExecuteAsync<TResult>(
                 func,
@@ -36,13 +34,12 @@ internal static class AsyncPolicyWrapEngine
             cancellationToken,
             continueOnCapturedContext);
 
-    internal static Task<TResult> ImplementationAsync<TResult>(
-        Func<Context, CancellationToken, Task<TResult>> func,
+    internal static Task<TResult> ImplementationAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> func,
         Context context,
-        CancellationToken cancellationToken,
         bool continueOnCapturedContext,
         IAsyncPolicy outerPolicy,
-        IAsyncPolicy<TResult> innerPolicy) =>
+        IAsyncPolicy<TResult> innerPolicy,
+        CancellationToken cancellationToken) =>
         outerPolicy.ExecuteAsync<TResult>(
             (ctx, ct) => innerPolicy.ExecuteAsync(
                 func,
@@ -53,13 +50,12 @@ internal static class AsyncPolicyWrapEngine
             cancellationToken,
             continueOnCapturedContext);
 
-    internal static Task<TResult> ImplementationAsync<TResult>(
-       Func<Context, CancellationToken, Task<TResult>> func,
-       Context context,
-       CancellationToken cancellationToken,
-       bool continueOnCapturedContext,
-       IAsyncPolicy outerPolicy,
-       IAsyncPolicy innerPolicy) =>
+    internal static Task<TResult> ImplementationAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> func,
+        Context context,
+        bool continueOnCapturedContext,
+        IAsyncPolicy outerPolicy,
+        IAsyncPolicy innerPolicy,
+        CancellationToken cancellationToken) =>
         outerPolicy.ExecuteAsync<TResult>(
             (ctx, ct) => innerPolicy.ExecuteAsync<TResult>(
                 func,
@@ -70,13 +66,12 @@ internal static class AsyncPolicyWrapEngine
             cancellationToken,
             continueOnCapturedContext);
 
-    internal static Task ImplementationAsync(
-        Func<Context, CancellationToken, Task> action,
+    internal static Task ImplementationAsync(Func<Context, CancellationToken, Task> action,
         Context context,
-        CancellationToken cancellationToken,
         bool continueOnCapturedContext,
         IAsyncPolicy outerPolicy,
-        IAsyncPolicy innerPolicy) =>
+        IAsyncPolicy innerPolicy,
+        CancellationToken cancellationToken) =>
         outerPolicy.ExecuteAsync(
             (ctx, ct) => innerPolicy.ExecuteAsync(
                 action,

--- a/src/Polly/Wrap/PolicyWrap.cs
+++ b/src/Polly/Wrap/PolicyWrap.cs
@@ -31,9 +31,8 @@ public partial class PolicyWrap : Policy, IPolicyWrap
         PolicyWrapEngine.Implementation(
             action,
             context,
-            cancellationToken,
             _outer,
-            _inner);
+            _inner, cancellationToken);
 
     /// <inheritdoc/>
     [DebuggerStepThrough]
@@ -41,9 +40,8 @@ public partial class PolicyWrap : Policy, IPolicyWrap
         PolicyWrapEngine.Implementation<TResult>(
             action,
             context,
-            cancellationToken,
             _outer,
-            _inner);
+            _inner, cancellationToken);
 }
 
 /// <summary>
@@ -99,18 +97,16 @@ public partial class PolicyWrap<TResult> : Policy<TResult>, IPolicyWrap<TResult>
                 return PolicyWrapEngine.Implementation<TResult>(
                     action,
                     context,
-                    cancellationToken,
                     _outerNonGeneric,
-                    _innerNonGeneric);
+                    _innerNonGeneric, cancellationToken);
             }
             else if (_innerGeneric != null)
             {
                 return PolicyWrapEngine.Implementation<TResult>(
                     action,
                     context,
-                    cancellationToken,
                     _outerNonGeneric,
-                    _innerGeneric);
+                    _innerGeneric, cancellationToken);
             }
             else
             {
@@ -124,9 +120,8 @@ public partial class PolicyWrap<TResult> : Policy<TResult>, IPolicyWrap<TResult>
                 return PolicyWrapEngine.Implementation<TResult>(
                     action,
                     context,
-                    cancellationToken,
                     _outerGeneric,
-                    _innerNonGeneric);
+                    _innerNonGeneric, cancellationToken);
 
             }
             else if (_innerGeneric != null)
@@ -134,9 +129,8 @@ public partial class PolicyWrap<TResult> : Policy<TResult>, IPolicyWrap<TResult>
                 return PolicyWrapEngine.Implementation<TResult>(
                     action,
                     context,
-                    cancellationToken,
                     _outerGeneric,
-                    _innerGeneric);
+                    _innerGeneric, cancellationToken);
             }
             else
             {

--- a/src/Polly/Wrap/PolicyWrap.cs
+++ b/src/Polly/Wrap/PolicyWrap.cs
@@ -32,7 +32,8 @@ public partial class PolicyWrap : Policy, IPolicyWrap
             action,
             context,
             _outer,
-            _inner, cancellationToken);
+            _inner,
+            cancellationToken);
 
     /// <inheritdoc/>
     [DebuggerStepThrough]
@@ -41,7 +42,8 @@ public partial class PolicyWrap : Policy, IPolicyWrap
             action,
             context,
             _outer,
-            _inner, cancellationToken);
+            _inner,
+            cancellationToken);
 }
 
 /// <summary>
@@ -98,7 +100,8 @@ public partial class PolicyWrap<TResult> : Policy<TResult>, IPolicyWrap<TResult>
                     action,
                     context,
                     _outerNonGeneric,
-                    _innerNonGeneric, cancellationToken);
+                    _innerNonGeneric,
+                    cancellationToken);
             }
             else if (_innerGeneric != null)
             {
@@ -106,7 +109,8 @@ public partial class PolicyWrap<TResult> : Policy<TResult>, IPolicyWrap<TResult>
                     action,
                     context,
                     _outerNonGeneric,
-                    _innerGeneric, cancellationToken);
+                    _innerGeneric,
+                    cancellationToken);
             }
             else
             {
@@ -121,7 +125,8 @@ public partial class PolicyWrap<TResult> : Policy<TResult>, IPolicyWrap<TResult>
                     action,
                     context,
                     _outerGeneric,
-                    _innerNonGeneric, cancellationToken);
+                    _innerNonGeneric,
+                    cancellationToken);
 
             }
             else if (_innerGeneric != null)
@@ -130,7 +135,8 @@ public partial class PolicyWrap<TResult> : Policy<TResult>, IPolicyWrap<TResult>
                     action,
                     context,
                     _outerGeneric,
-                    _innerGeneric, cancellationToken);
+                    _innerGeneric,
+                    cancellationToken);
             }
             else
             {

--- a/src/Polly/Wrap/PolicyWrapEngine.cs
+++ b/src/Polly/Wrap/PolicyWrapEngine.cs
@@ -2,35 +2,40 @@
 
 internal static class PolicyWrapEngine
 {
-    internal static TResult Implementation<TResult>(Func<Context, CancellationToken, TResult> func,
+    internal static TResult Implementation<TResult>(
+        Func<Context, CancellationToken, TResult> func,
         Context context,
         ISyncPolicy<TResult> outerPolicy,
         ISyncPolicy<TResult> innerPolicy,
         CancellationToken cancellationToken) =>
         outerPolicy.Execute((ctx, ct) => innerPolicy.Execute(func, ctx, ct), context, cancellationToken);
 
-    internal static TResult Implementation<TResult>(Func<Context, CancellationToken, TResult> func,
+    internal static TResult Implementation<TResult>(
+        Func<Context, CancellationToken, TResult> func,
         Context context,
         ISyncPolicy<TResult> outerPolicy,
         ISyncPolicy innerPolicy,
         CancellationToken cancellationToken) =>
         outerPolicy.Execute((ctx, ct) => innerPolicy.Execute<TResult>(func, ctx, ct), context, cancellationToken);
 
-    internal static TResult Implementation<TResult>(Func<Context, CancellationToken, TResult> func,
+    internal static TResult Implementation<TResult>(
+        Func<Context, CancellationToken, TResult> func,
         Context context,
         ISyncPolicy outerPolicy,
         ISyncPolicy<TResult> innerPolicy,
         CancellationToken cancellationToken) =>
         outerPolicy.Execute<TResult>((ctx, ct) => innerPolicy.Execute(func, ctx, ct), context, cancellationToken);
 
-    internal static TResult Implementation<TResult>(Func<Context, CancellationToken, TResult> func,
+    internal static TResult Implementation<TResult>(
+        Func<Context, CancellationToken, TResult> func,
         Context context,
         ISyncPolicy outerPolicy,
         ISyncPolicy innerPolicy,
         CancellationToken cancellationToken) =>
         outerPolicy.Execute<TResult>((ctx, ct) => innerPolicy.Execute<TResult>(func, ctx, ct), context, cancellationToken);
 
-    internal static void Implementation(Action<Context, CancellationToken> action,
+    internal static void Implementation(
+        Action<Context, CancellationToken> action,
         Context context,
         ISyncPolicy outerPolicy,
         ISyncPolicy innerPolicy,

--- a/src/Polly/Wrap/PolicyWrapEngine.cs
+++ b/src/Polly/Wrap/PolicyWrapEngine.cs
@@ -2,43 +2,38 @@
 
 internal static class PolicyWrapEngine
 {
-    internal static TResult Implementation<TResult>(
-        Func<Context, CancellationToken, TResult> func,
+    internal static TResult Implementation<TResult>(Func<Context, CancellationToken, TResult> func,
         Context context,
-        CancellationToken cancellationToken,
         ISyncPolicy<TResult> outerPolicy,
-        ISyncPolicy<TResult> innerPolicy) =>
+        ISyncPolicy<TResult> innerPolicy,
+        CancellationToken cancellationToken) =>
         outerPolicy.Execute((ctx, ct) => innerPolicy.Execute(func, ctx, ct), context, cancellationToken);
 
-    internal static TResult Implementation<TResult>(
-       Func<Context, CancellationToken, TResult> func,
-       Context context,
-       CancellationToken cancellationToken,
-       ISyncPolicy<TResult> outerPolicy,
-       ISyncPolicy innerPolicy) =>
+    internal static TResult Implementation<TResult>(Func<Context, CancellationToken, TResult> func,
+        Context context,
+        ISyncPolicy<TResult> outerPolicy,
+        ISyncPolicy innerPolicy,
+        CancellationToken cancellationToken) =>
         outerPolicy.Execute((ctx, ct) => innerPolicy.Execute<TResult>(func, ctx, ct), context, cancellationToken);
 
-    internal static TResult Implementation<TResult>(
-       Func<Context, CancellationToken, TResult> func,
-       Context context,
-       CancellationToken cancellationToken,
-       ISyncPolicy outerPolicy,
-       ISyncPolicy<TResult> innerPolicy) =>
+    internal static TResult Implementation<TResult>(Func<Context, CancellationToken, TResult> func,
+        Context context,
+        ISyncPolicy outerPolicy,
+        ISyncPolicy<TResult> innerPolicy,
+        CancellationToken cancellationToken) =>
         outerPolicy.Execute<TResult>((ctx, ct) => innerPolicy.Execute(func, ctx, ct), context, cancellationToken);
 
-    internal static TResult Implementation<TResult>(
-       Func<Context, CancellationToken, TResult> func,
-       Context context,
-       CancellationToken cancellationToken,
-       ISyncPolicy outerPolicy,
-       ISyncPolicy innerPolicy) =>
+    internal static TResult Implementation<TResult>(Func<Context, CancellationToken, TResult> func,
+        Context context,
+        ISyncPolicy outerPolicy,
+        ISyncPolicy innerPolicy,
+        CancellationToken cancellationToken) =>
         outerPolicy.Execute<TResult>((ctx, ct) => innerPolicy.Execute<TResult>(func, ctx, ct), context, cancellationToken);
 
-    internal static void Implementation(
-       Action<Context, CancellationToken> action,
-       Context context,
-       CancellationToken cancellationToken,
-       ISyncPolicy outerPolicy,
-       ISyncPolicy innerPolicy) =>
+    internal static void Implementation(Action<Context, CancellationToken> action,
+        Context context,
+        ISyncPolicy outerPolicy,
+        ISyncPolicy innerPolicy,
+        CancellationToken cancellationToken) =>
         outerPolicy.Execute((ctx, ct) => innerPolicy.Execute(action, ctx, ct), context, cancellationToken);
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
#1290

<!-- Please include the existing GitHub issue number where relevant -->

## Details on the issue fix or feature implementation
- [x] Fix [CA1068](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1068)

For public interfaces, `pragma` suppression was used. For non-public code, refactored code to make `CancellationToken` last param.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
