### PR TITLE
Fix S3878 warning

### DIFF
--- a/test/Polly.Specs/Polly.Specs.csproj
+++ b/test/Polly.Specs/Polly.Specs.csproj
@@ -9,7 +9,7 @@
     <Include>[Polly]*</Include>
     <IncludePollyUsings>true</IncludePollyUsings>
     <NoWarn>$(NoWarn);CA1030;CA1031;CA2008;CA2201</NoWarn>
-    <NoWarn>$(NoWarn);S103;S104;S2184;S3878;S6966</NoWarn>
+    <NoWarn>$(NoWarn);S103;S104;S2184;S6966</NoWarn>
     <NoWarn>$(NoWarn);SA1204;SA1402;SA1600</NoWarn>
   </PropertyGroup>
 

--- a/test/Polly.Specs/Wrap/PolicyWrapSpecs.cs
+++ b/test/Polly.Specs/Wrap/PolicyWrapSpecs.cs
@@ -253,7 +253,10 @@ public class PolicyWrapSpecs
     public void Wrapping_only_one_policy_using_static_wrap_syntax_should_throw()
     {
         Policy singlePolicy = Policy.Handle<Exception>().Retry();
+
+#pragma warning disable S3878 // Remove this array creation and simply pass the elements
         Action config = () => Policy.Wrap(new[] { singlePolicy });
+#pragma warning restore S3878
 
         config.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policies");
     }
@@ -263,7 +266,7 @@ public class PolicyWrapSpecs
     {
         Policy retry = Policy.Handle<Exception>().Retry();
         Policy breaker = Policy.Handle<Exception>().CircuitBreaker(1, TimeSpan.FromSeconds(10));
-        Action config = () => Policy.Wrap(new[] { retry, breaker });
+        Action config = () => Policy.Wrap(retry, breaker);
 
         config.Should().NotThrow();
     }
@@ -275,7 +278,7 @@ public class PolicyWrapSpecs
         Policy divideByZeroRetry = Policy.Handle<DivideByZeroException>().Retry(2);
         Policy breaker = Policy.Handle<Exception>().CircuitBreaker(1, TimeSpan.FromSeconds(10));
 
-        Action config = () => Policy.Wrap(new[] { divideByZeroRetry, retry, breaker });
+        Action config = () => Policy.Wrap(divideByZeroRetry, retry, breaker);
 
         config.Should().NotThrow();
     }
@@ -308,7 +311,7 @@ public class PolicyWrapSpecs
     public void Wrapping_only_one_policy_using_static_wrap_strongly_typed_syntax_should_throw()
     {
         Policy<int> singlePolicy = Policy<int>.Handle<Exception>().Retry();
-        Action config = () => Policy.Wrap<int>(new[] { singlePolicy });
+        Action config = () => Policy.Wrap<int>(singlePolicy);
 
         config.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policies");
     }
@@ -318,7 +321,7 @@ public class PolicyWrapSpecs
     {
         Policy<int> retry = Policy<int>.Handle<Exception>().Retry();
         Policy<int> breaker = Policy<int>.Handle<Exception>().CircuitBreaker(1, TimeSpan.FromSeconds(10));
-        Action config = () => Policy.Wrap<int>(new[] { retry, breaker });
+        Action config = () => Policy.Wrap<int>(retry, breaker);
 
         config.Should().NotThrow();
     }
@@ -330,7 +333,7 @@ public class PolicyWrapSpecs
         Policy<int> divideByZeroRetry = Policy<int>.Handle<DivideByZeroException>().Retry(2);
         Policy<int> breaker = Policy<int>.Handle<Exception>().CircuitBreaker(1, TimeSpan.FromSeconds(10));
 
-        Action config = () => Policy.Wrap<int>(new[] { divideByZeroRetry, retry, breaker });
+        Action config = () => Policy.Wrap<int>(divideByZeroRetry, retry, breaker);
 
         config.Should().NotThrow();
     }

--- a/test/Polly.Specs/Wrap/PolicyWrapSpecsAsync.cs
+++ b/test/Polly.Specs/Wrap/PolicyWrapSpecsAsync.cs
@@ -253,7 +253,7 @@ public class PolicyWrapSpecsAsync
     public void Wrapping_only_one_policy_using_static_wrap_syntax_should_throw()
     {
         AsyncPolicy singlePolicy = Policy.Handle<Exception>().RetryAsync();
-        Action config = () => Policy.WrapAsync(new[] { singlePolicy });
+        Action config = () => Policy.WrapAsync(singlePolicy);
 
         config.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policies");
     }
@@ -263,7 +263,7 @@ public class PolicyWrapSpecsAsync
     {
         AsyncPolicy retry = Policy.Handle<Exception>().RetryAsync();
         AsyncPolicy breaker = Policy.Handle<Exception>().CircuitBreakerAsync(1, TimeSpan.FromSeconds(10));
-        Action config = () => Policy.WrapAsync(new[] { retry, breaker });
+        Action config = () => Policy.WrapAsync(retry, breaker);
 
         config.Should().NotThrow();
     }
@@ -275,7 +275,7 @@ public class PolicyWrapSpecsAsync
         AsyncPolicy divideByZeroRetry = Policy.Handle<DivideByZeroException>().RetryAsync(2);
         AsyncPolicy breaker = Policy.Handle<Exception>().CircuitBreakerAsync(1, TimeSpan.FromSeconds(10));
 
-        Action config = () => Policy.WrapAsync(new[] { divideByZeroRetry, retry, breaker });
+        Action config = () => Policy.WrapAsync(divideByZeroRetry, retry, breaker);
 
         config.Should().NotThrow();
     }
@@ -308,7 +308,7 @@ public class PolicyWrapSpecsAsync
     public void Wrapping_only_one_policy_using_static_wrap_strongly_typed_syntax_should_throw()
     {
         AsyncPolicy<int> singlePolicy = Policy<int>.Handle<Exception>().RetryAsync();
-        Action config = () => Policy.WrapAsync<int>(new[] { singlePolicy });
+        Action config = () => Policy.WrapAsync<int>(singlePolicy);
 
         config.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policies");
     }
@@ -318,7 +318,7 @@ public class PolicyWrapSpecsAsync
     {
         AsyncPolicy<int> retry = Policy<int>.Handle<Exception>().RetryAsync();
         AsyncPolicy<int> breaker = Policy<int>.Handle<Exception>().CircuitBreakerAsync(1, TimeSpan.FromSeconds(10));
-        Action config = () => Policy.WrapAsync<int>(new[] { retry, breaker });
+        Action config = () => Policy.WrapAsync<int>(retry, breaker);
 
         config.Should().NotThrow();
     }
@@ -330,7 +330,7 @@ public class PolicyWrapSpecsAsync
         AsyncPolicy<int> divideByZeroRetry = Policy<int>.Handle<DivideByZeroException>().RetryAsync(2);
         AsyncPolicy<int> breaker = Policy<int>.Handle<Exception>().CircuitBreakerAsync(1, TimeSpan.FromSeconds(10));
 
-        Action config = () => Policy.WrapAsync<int>(new[] { divideByZeroRetry, retry, breaker });
+        Action config = () => Policy.WrapAsync<int>(divideByZeroRetry, retry, breaker);
 
         config.Should().NotThrow();
     }


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

[#1290](https://github.com/App-vNext/Polly/issues/1290)

## Details on the issue fix or feature implementation

 * [x]  Suppress [S3878](https://rules.sonarsource.com/csharp/RSPEC-3878/) in the code or fix the warning

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build