### PR TITLE
Fix S3246 warning

### DIFF
--- a/src/Polly/Caching/ITtlStrategy.cs
+++ b/src/Polly/Caching/ITtlStrategy.cs
@@ -12,7 +12,7 @@ public interface ITtlStrategy : ITtlStrategy<object>
 /// Defines a strategy for providing time-to-live durations for cacheable results.
 /// </summary>
 /// <typeparam name="TResult">The type of the result.</typeparam>
-public interface ITtlStrategy<TResult>
+public interface ITtlStrategy<in TResult>
 {
     /// <summary>
     /// Gets a TTL for a cacheable item, given the current execution context.

--- a/src/Polly/Caching/ITtlStrategy.cs
+++ b/src/Polly/Caching/ITtlStrategy.cs
@@ -12,7 +12,9 @@ public interface ITtlStrategy : ITtlStrategy<object>
 /// Defines a strategy for providing time-to-live durations for cacheable results.
 /// </summary>
 /// <typeparam name="TResult">The type of the result.</typeparam>
-public interface ITtlStrategy<in TResult>
+#pragma warning disable S3246
+public interface ITtlStrategy<TResult>
+#pragma warning restore S3246
 {
     /// <summary>
     /// Gets a TTL for a cacheable item, given the current execution context.

--- a/src/Polly/CircuitBreaker/ICircuitBreakerPolicy.cs
+++ b/src/Polly/CircuitBreaker/ICircuitBreakerPolicy.cs
@@ -31,7 +31,9 @@ public interface ICircuitBreakerPolicy : IsPolicy
 /// Defines properties and methods common to all circuit-breaker policies generic-typed for executions returning results of type <typeparamref name="TResult"/>.
 /// </summary>
 /// <typeparam name="TResult">The type of the result.</typeparam>
-public interface ICircuitBreakerPolicy<out TResult> : ICircuitBreakerPolicy
+#pragma warning disable S3246
+public interface ICircuitBreakerPolicy<TResult> : ICircuitBreakerPolicy
+#pragma warning restore S3246
 {
     /// <summary>
     /// Gets the last result returned from a user delegate which the circuit-breaker handled.

--- a/src/Polly/CircuitBreaker/ICircuitBreakerPolicy.cs
+++ b/src/Polly/CircuitBreaker/ICircuitBreakerPolicy.cs
@@ -31,7 +31,7 @@ public interface ICircuitBreakerPolicy : IsPolicy
 /// Defines properties and methods common to all circuit-breaker policies generic-typed for executions returning results of type <typeparamref name="TResult"/>.
 /// </summary>
 /// <typeparam name="TResult">The type of the result.</typeparam>
-public interface ICircuitBreakerPolicy<TResult> : ICircuitBreakerPolicy
+public interface ICircuitBreakerPolicy<out TResult> : ICircuitBreakerPolicy
 {
     /// <summary>
     /// Gets the last result returned from a user delegate which the circuit-breaker handled.

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -8,7 +8,7 @@
     <MutationScore>70</MutationScore>
     <IncludePollyUsings>true</IncludePollyUsings>
     <NoWarn>$(NoWarn);CA1010;CA1031;CA1051;CA1062;CA1063;CA1064;CA1710;CA1716;CA1724;CA1805;CA1815;CA1816;CA2211</NoWarn>
-    <NoWarn>$(NoWarn);S2223;S3215;S3246;S3971;S4039;S4457</NoWarn>
+    <NoWarn>$(NoWarn);S2223;S3215;S3971;S4039;S4457</NoWarn>
     <!--Public API Analyzers: We do not need to fix these as it would break compatibility with released Polly versions-->
     <NoWarn>$(NoWarn);RS0037;</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

[#1290](https://github.com/App-vNext/Polly/issues/1290)

## Details on the issue fix or feature implementation

 * [x]  Suppress [S3246](https://rules.sonarsource.com/csharp/RSPEC-3246) in the code or fix the warning

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build

<img width="889" alt="image" src="https://github.com/user-attachments/assets/165a0565-3de3-4357-8c6c-84cea840741e">
I did not make any changes to the PublicAPI.Shipped file. 

Not entirely sure, but in/out doesn’t seem to affect the API