### PR TITLE
Fix warning CA1815

### DIFF
--- a/src/Polly/Caching/Ttl.cs
+++ b/src/Polly/Caching/Ttl.cs
@@ -4,7 +4,9 @@ namespace Polly.Caching;
 /// <summary>
 /// Represents a time-to-live for a given cache item.
 /// </summary>
+#pragma warning disable CA1815 //Override equals and operator equals on value types
 public struct Ttl
+#pragma warning restore CA1815
 {
     /// <summary>
     /// The timespan for which this cache-item remains valid.

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -7,7 +7,7 @@
     <ProjectType>Library</ProjectType>
     <MutationScore>70</MutationScore>
     <IncludePollyUsings>true</IncludePollyUsings>
-    <NoWarn>$(NoWarn);CA1010;CA1031;CA1051;CA1062;CA1063;CA1064;CA1710;CA1716;CA1724;CA1805;CA1815;CA1816;CA2211</NoWarn>
+    <NoWarn>$(NoWarn);CA1010;CA1031;CA1051;CA1062;CA1063;CA1064;CA1710;CA1716;CA1724;CA1805;CA1816;CA2211</NoWarn>
     <NoWarn>$(NoWarn);S2223;S3215;S4039</NoWarn>
     <!--Public API Analyzers: We do not need to fix these as it would break compatibility with released Polly versions-->
     <NoWarn>$(NoWarn);RS0037;</NoWarn>


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

[#1290](https://github.com/App-vNext/Polly/issues/1290)

## Details on the issue fix or feature implementation

 * [x]  Suppress [CA1815](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1815) in the code or fix the warning

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build

![image](https://github.com/user-attachments/assets/5f27569e-4df4-422c-863c-c3e71a3fb657)
As far as I can see, there are no comparisons in the code. Therefore, we simply suppress the warning