### PR TITLE
Fix warning CA1710

### DIFF
--- a/src/Polly/Context.cs
+++ b/src/Polly/Context.cs
@@ -4,7 +4,9 @@ namespace Polly;
 /// Context that carries with a single execution through a Policy.   Commonly-used properties are directly on the class.  Backed by a dictionary of string key / object value pairs, to which user-defined values may be added.
 /// <remarks>Do not re-use an instance of <see cref="Context"/> across more than one call through .Execute(...) or .ExecuteAsync(...).</remarks>
 /// </summary>
+#pragma warning disable CA1710 // Identifiers should have correct suffix
 public partial class Context
+#pragma warning restore CA1710
 {
     internal static Context None() => [];
 

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -7,7 +7,7 @@
     <ProjectType>Library</ProjectType>
     <MutationScore>70</MutationScore>
     <IncludePollyUsings>true</IncludePollyUsings>
-    <NoWarn>$(NoWarn);CA1010;CA1031;CA1051;CA1062;CA1063;CA1064;CA1710;CA1716;CA1724;CA1805;CA1816;CA2211</NoWarn>
+    <NoWarn>$(NoWarn);CA1010;CA1031;CA1051;CA1062;CA1063;CA1064;CA1716;CA1724;CA1805;CA1816;CA2211</NoWarn>
     <NoWarn>$(NoWarn);S2223;S3215;S4039</NoWarn>
     <!--Public API Analyzers: We do not need to fix these as it would break compatibility with released Polly versions-->
     <NoWarn>$(NoWarn);RS0037;</NoWarn>


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

[#1290](https://github.com/App-vNext/Polly/issues/1290)

## Details on the issue fix or feature implementation

 * [x]  Suppress [CA1710](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1710) in the code or fix the warning

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build

Context in public API