### PR TITLE
Fix warning CA1062#ContextualTtl

### DIFF
--- a/src/Polly/Caching/ContextualTtl.cs
+++ b/src/Polly/Caching/ContextualTtl.cs
@@ -4,7 +4,6 @@ namespace Polly.Caching;
 /// <summary>
 /// Defines a ttl strategy which will cache items for a TimeSpan which may be influenced by data in the execution context.
 /// </summary>
-#pragma warning disable CA1062 // Validate arguments of public methods
 public class ContextualTtl : ITtlStrategy
 {
     /// <summary>
@@ -28,6 +27,11 @@ public class ContextualTtl : ITtlStrategy
     /// <returns>TimeSpan.</returns>
     public Ttl GetTtl(Context context, object? result)
     {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
         if (!context.ContainsKey(TimeSpanKey))
         {
             return NoTtl;

--- a/test/Polly.Specs/Caching/ContextualTtlSpecs.cs
+++ b/test/Polly.Specs/Caching/ContextualTtlSpecs.cs
@@ -3,6 +3,14 @@
 public class ContextualTtlSpecs
 {
     [Fact]
+    public void Should_throw_when_context_is_null()
+    {
+        Context context = null!;
+        Action action = () => new ContextualTtl().GetTtl(context, null);
+        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("context");
+    }
+
+    [Fact]
     public void Should_return_zero_if_no_value_set_on_context() =>
         new ContextualTtl().GetTtl(new Context("someOperationKey"), null).Timespan.Should().Be(TimeSpan.Zero);
 


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

[#2215](https://github.com/App-vNext/Polly/issues/2215)

## Details on the issue fix or feature implementation

*  [x]  Suppress [CA1062](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062) in src/Polly/Caching/ContextualTtl.cs or fix the warning

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature