### PR TITLE
Fix warning CA1062#DefaultCacheKeyStrategy

### DIFF
--- a/src/Polly/Caching/DefaultCacheKeyStrategy.cs
+++ b/src/Polly/Caching/DefaultCacheKeyStrategy.cs
@@ -4,7 +4,6 @@ namespace Polly.Caching;
 /// <summary>
 /// The default cache key strategy for <see cref="CachePolicy"/>.  Returns the property <see cref="Context.OperationKey"/>.
 /// </summary>
-#pragma warning disable CA1062 // Validate arguments of public methods
 public class DefaultCacheKeyStrategy : ICacheKeyStrategy
 {
     /// <summary>
@@ -12,8 +11,15 @@ public class DefaultCacheKeyStrategy : ICacheKeyStrategy
     /// </summary>
     /// <param name="context">The execution context.</param>
     /// <returns>The cache key.</returns>
-    public string GetCacheKey(Context context) =>
-        context.OperationKey;
+    public string GetCacheKey(Context context)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        return context.OperationKey;
+    }
 
     /// <summary>
     /// Gets an instance of the <see cref="DefaultCacheKeyStrategy"/>.

--- a/test/Polly.Specs/Caching/DefaultCacheKeyStrategySpecs.cs
+++ b/test/Polly.Specs/Caching/DefaultCacheKeyStrategySpecs.cs
@@ -3,6 +3,14 @@
 public class DefaultCacheKeyStrategySpecs
 {
     [Fact]
+    public void Should_throw_when_context_is_null()
+    {
+        Context context = null!;
+        Action action = () => DefaultCacheKeyStrategy.Instance.GetCacheKey(context);
+        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("context");
+    }
+
+    [Fact]
     public void Should_return_Context_OperationKey_as_cache_key()
     {
         string operationKey = "SomeKey";


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

[#2215](https://github.com/App-vNext/Polly/issues/2215)

## Details on the issue fix or feature implementation

*  [x]  Suppress [CA1062](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062) in src/Polly/Caching/DefaultCacheKeyStrategy.cs or fix the warning

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature