### PR TITLE
Fix warning CA1062#AsyncRetryPolicy

### DIFF
--- a/src/Polly/Retry/AsyncRetryPolicy.cs
+++ b/src/Polly/Retry/AsyncRetryPolicy.cs
@@ -3,7 +3,6 @@
 /// <summary>
 /// A retry policy that can be applied to asynchronous delegates.
 /// </summary>
-#pragma warning disable CA1062 // Validate arguments of public methods
 public class AsyncRetryPolicy : AsyncPolicy, IRetryPolicy
 {
     private readonly Func<Exception, TimeSpan, int, Context, Task> _onRetryAsync;
@@ -34,6 +33,11 @@ public class AsyncRetryPolicy : AsyncPolicy, IRetryPolicy
         CancellationToken cancellationToken,
         bool continueOnCapturedContext)
     {
+        if (action is null)
+        {
+            throw new ArgumentNullException(nameof(action));
+        }
+
         var sleepDurationProvider = _sleepDurationProvider != null
             ? (retryCount, outcome, ctx) => _sleepDurationProvider(retryCount, outcome.Exception, ctx)
             : (Func<int, DelegateResult<TResult>, Context, TimeSpan>)null;
@@ -79,9 +83,18 @@ public class AsyncRetryPolicy<TResult> : AsyncPolicy<TResult>, IRetryPolicy<TRes
 
     /// <inheritdoc/>
     [DebuggerStepThrough]
-    protected override Task<TResult> ImplementationAsync(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken,
-        bool continueOnCapturedContext) =>
-        AsyncRetryEngine.ImplementationAsync(
+    protected override Task<TResult> ImplementationAsync(
+        Func<Context, CancellationToken, Task<TResult>> action,
+        Context context,
+        CancellationToken cancellationToken,
+        bool continueOnCapturedContext)
+    {
+        if (action is null)
+        {
+            throw new ArgumentNullException(nameof(action));
+        }
+
+        return AsyncRetryEngine.ImplementationAsync(
             action,
             context,
             ExceptionPredicates,
@@ -92,5 +105,6 @@ public class AsyncRetryPolicy<TResult> : AsyncPolicy<TResult>, IRetryPolicy<TRes
             _sleepDurationsEnumerable,
             _sleepDurationProvider,
             continueOnCapturedContext);
+    }
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

[#2215](https://github.com/App-vNext/Polly/issues/2215)

## Details on the issue fix or feature implementation

*  [x]  Suppress [CA1062](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062) in src/Polly/Retry/AsyncRetryPolicy.cs or fix the warning

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature