### PR TITLE
 Specs is at the end of the test class

### DIFF
--- a/test/Polly.Specs/Retry/RetryTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/Retry/RetryTResultAsyncSpecs.cs
@@ -2,7 +2,7 @@
 
 namespace Polly.Specs.Retry;
 
-public class RetryTResultSpecsAsync
+public class RetryTResultAsyncSpecs
 {
     [Fact]
     public void Should_throw_when_retry_count_is_less_than_zero_without_context()

--- a/test/Polly.Specs/Wrap/PolicyWrapAsyncSpecs.cs
+++ b/test/Polly.Specs/Wrap/PolicyWrapAsyncSpecs.cs
@@ -1,7 +1,7 @@
 ﻿namespace Polly.Specs.Wrap;
 
 [Collection(Constants.SystemClockDependentTestCollection)]
-public class PolicyWrapSpecsAsync
+public class PolicyWrapAsyncSpecs
 {
     #region Instance configuration syntax tests, non-generic outer
 

--- a/test/Polly.Specs/Wrap/PolicyWrapContextAndKeyAsyncSpecs.cs
+++ b/test/Polly.Specs/Wrap/PolicyWrapContextAndKeyAsyncSpecs.cs
@@ -1,7 +1,7 @@
 ﻿namespace Polly.Specs.Wrap;
 
 [Collection(Constants.SystemClockDependentTestCollection)]
-public class PolicyWrapContextAndKeySpecsAsync
+public class PolicyWrapContextAndKeyAsyncSpecs
 {
     #region PolicyKey and execution Context tests
 
@@ -188,7 +188,7 @@ public class PolicyWrapContextAndKeySpecsAsync
 }
 
 [Collection(Constants.SystemClockDependentTestCollection)]
-public class PolicyWrapTResultContextAndKeySpecsAsync
+public class PolicyWrapTResultContextAndKeyAsyncSpecs
 {
     #region PolicyKey and execution Context tests
 


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

Editing the name to fit a single style. 
Everywhere in the code, Specs is at the end of the test class nameзвания класса тестов

## Details on the issue fix or feature implementation

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
