### PR TITLE
Fix warning CA1062#AsyncTimeoutPolicy

### DIFF
--- a/src/Polly/Timeout/AsyncTimeoutPolicy.cs
+++ b/src/Polly/Timeout/AsyncTimeoutPolicy.cs
@@ -3,7 +3,6 @@
 /// <summary>
 /// A timeout policy which can be applied to async delegates.
 /// </summary>
-#pragma warning disable CA1062 // Validate arguments of public methods
 public class AsyncTimeoutPolicy : AsyncPolicy, ITimeoutPolicy
 {
     private readonly Func<Context, TimeSpan> _timeoutProvider;
@@ -26,8 +25,14 @@ public class AsyncTimeoutPolicy : AsyncPolicy, ITimeoutPolicy
         Func<Context, CancellationToken, Task<TResult>> action,
         Context context,
         CancellationToken cancellationToken,
-        bool continueOnCapturedContext) =>
-        AsyncTimeoutEngine.ImplementationAsync(
+        bool continueOnCapturedContext)
+    {
+        if (action is null)
+        {
+            throw new ArgumentNullException(nameof(action));
+        }
+
+        return AsyncTimeoutEngine.ImplementationAsync(
             action,
             context,
             _timeoutProvider,
@@ -35,6 +40,7 @@ public class AsyncTimeoutPolicy : AsyncPolicy, ITimeoutPolicy
             _onTimeoutAsync,
             continueOnCapturedContext,
             cancellationToken);
+    }
 }
 
 /// <summary>
@@ -63,8 +69,14 @@ public class AsyncTimeoutPolicy<TResult> : AsyncPolicy<TResult>, ITimeoutPolicy<
         Func<Context, CancellationToken, Task<TResult>> action,
         Context context,
         CancellationToken cancellationToken,
-        bool continueOnCapturedContext) =>
-        AsyncTimeoutEngine.ImplementationAsync(
+        bool continueOnCapturedContext)
+    {
+        if (action is null)
+        {
+            throw new ArgumentNullException(nameof(action));
+        }
+
+        return AsyncTimeoutEngine.ImplementationAsync(
             action,
             context,
             _timeoutProvider,
@@ -72,4 +84,5 @@ public class AsyncTimeoutPolicy<TResult> : AsyncPolicy<TResult>, ITimeoutPolicy<
             _onTimeoutAsync,
             continueOnCapturedContext,
             cancellationToken);
+    }
 }

--- a/test/Polly.Specs/Timeout/TimeoutAsyncSpecs.cs
+++ b/test/Polly.Specs/Timeout/TimeoutAsyncSpecs.cs
@@ -8,6 +8,34 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
     #region Configuration
 
     [Fact]
+    public void Should_throw_when_action_is_null()
+    {
+        var flags = BindingFlags.NonPublic | BindingFlags.Instance;
+        Func<Context, CancellationToken, Task<EmptyStruct>> action = null!;
+        Func<Context, TimeSpan> timeoutProvider = (_) => TimeSpan.Zero;
+        TimeoutStrategy timeoutStrategy = TimeoutStrategy.Optimistic;
+        Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = (_, _, _, _) => Task.CompletedTask;
+
+        var instance = Activator.CreateInstance(
+            typeof(AsyncTimeoutPolicy),
+            flags,
+            null,
+            [timeoutProvider, timeoutStrategy, onTimeoutAsync],
+            null)!;
+        var instanceType = instance.GetType();
+        var methods = instanceType.GetMethods(flags);
+        var methodInfo = methods.First(method => method is { Name: "ImplementationAsync", ReturnType.Name: "Task`1" });
+        var generic = methodInfo.MakeGenericMethod(typeof(EmptyStruct));
+
+        var func = () => generic.Invoke(instance, [action, new Context(), CancellationToken.None, false]);
+
+        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
+        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
+            .Which.ParamName.Should().Be("action");
+    }
+
+    [Fact]
     public void Should_throw_when_timeout_is_zero_by_timespan()
     {
         Action policy = () => Policy.TimeoutAsync(TimeSpan.Zero);


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

[#2215](https://github.com/App-vNext/Polly/issues/2215)

## Details on the issue fix or feature implementation

*  [x]  Suppress [CA1062](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062) in src/Polly/Timeout/AsyncTimeoutPolicy.cs or fix the warning

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature