### PR TITLE
Fix warning CA1062#IAsyncPolicyPolicyWrapExtensions

### DIFF
--- a/src/Polly/Wrap/IAsyncPolicyPolicyWrapExtensions.cs
+++ b/src/Polly/Wrap/IAsyncPolicyPolicyWrapExtensions.cs
@@ -3,7 +3,6 @@
 /// <summary>
 /// Defines extensions for configuring <see cref="PolicyWrap"/> instances on an <see cref="IAsyncPolicy"/> or <see cref="IAsyncPolicy{TResult}"/>.
 /// </summary>
-#pragma warning disable CA1062 // Validate arguments of public methods
 public static class IAsyncPolicyPolicyWrapExtensions
 {
     /// <summary>
@@ -159,13 +158,21 @@ public partial class Policy
     /// <param name="policies">The policies to place in the wrap, outermost (at left) to innermost (at right).</param>
     /// <returns>The PolicyWrap.</returns>
     /// <exception cref="ArgumentException">The enumerable of policies to form the wrap must contain at least two policies.</exception>
-    public static AsyncPolicyWrap WrapAsync(params IAsyncPolicy[] policies) =>
-        policies.Length switch
+    public static AsyncPolicyWrap WrapAsync(params IAsyncPolicy[] policies)
+    {
+        if (policies is null)
         {
-            < MinimumPoliciesRequiredForWrap => throw new ArgumentException("The enumerable of policies to form the wrap must contain at least two policies.", nameof(policies)),
+            throw new ArgumentNullException(nameof(policies));
+        }
+
+        return policies.Length switch
+        {
+            < MinimumPoliciesRequiredForWrap => throw new ArgumentException(
+                "The enumerable of policies to form the wrap must contain at least two policies.", nameof(policies)),
             MinimumPoliciesRequiredForWrap => new AsyncPolicyWrap((AsyncPolicy)policies[0], policies[1]),
             _ => WrapAsync(policies[0], WrapAsync(policies.Skip(1).ToArray())),
         };
+    }
 
     /// <summary>
     /// Creates a <see cref="PolicyWrap" /> of the given policies governing delegates returning values of type <typeparamref name="TResult" />.
@@ -174,11 +181,20 @@ public partial class Policy
     /// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
     /// <returns>The PolicyWrap.</returns>
     /// <exception cref="ArgumentException">The enumerable of policies to form the wrap must contain at least two policies.</exception>
-    public static AsyncPolicyWrap<TResult> WrapAsync<TResult>(params IAsyncPolicy<TResult>[] policies) =>
-        policies.Length switch
+    public static AsyncPolicyWrap<TResult> WrapAsync<TResult>(params IAsyncPolicy<TResult>[] policies)
+    {
+        if (policies is null)
         {
-            < MinimumPoliciesRequiredForWrap => throw new ArgumentException("The enumerable of policies to form the wrap must contain at least two policies.", nameof(policies)),
-            MinimumPoliciesRequiredForWrap => new AsyncPolicyWrap<TResult>((AsyncPolicy<TResult>)policies[0], policies[1]),
+            throw new ArgumentNullException(nameof(policies));
+        }
+
+        return policies.Length switch
+        {
+            < MinimumPoliciesRequiredForWrap => throw new ArgumentException(
+                "The enumerable of policies to form the wrap must contain at least two policies.", nameof(policies)),
+            MinimumPoliciesRequiredForWrap => new AsyncPolicyWrap<TResult>((AsyncPolicy<TResult>)policies[0],
+                policies[1]),
             _ => WrapAsync(policies[0], WrapAsync(policies.Skip(1).ToArray())),
         };
+    }
 }

--- a/src/Polly/Wrap/IAsyncPolicyPolicyWrapExtensions.cs
+++ b/src/Polly/Wrap/IAsyncPolicyPolicyWrapExtensions.cs
@@ -167,8 +167,7 @@ public partial class Policy
 
         return policies.Length switch
         {
-            < MinimumPoliciesRequiredForWrap => throw new ArgumentException(
-                "The enumerable of policies to form the wrap must contain at least two policies.", nameof(policies)),
+            < MinimumPoliciesRequiredForWrap => throw new ArgumentException("The enumerable of policies to form the wrap must contain at least two policies.", nameof(policies)),
             MinimumPoliciesRequiredForWrap => new AsyncPolicyWrap((AsyncPolicy)policies[0], policies[1]),
             _ => WrapAsync(policies[0], WrapAsync(policies.Skip(1).ToArray())),
         };
@@ -190,10 +189,8 @@ public partial class Policy
 
         return policies.Length switch
         {
-            < MinimumPoliciesRequiredForWrap => throw new ArgumentException(
-                "The enumerable of policies to form the wrap must contain at least two policies.", nameof(policies)),
-            MinimumPoliciesRequiredForWrap => new AsyncPolicyWrap<TResult>((AsyncPolicy<TResult>)policies[0],
-                policies[1]),
+            < MinimumPoliciesRequiredForWrap => throw new ArgumentException("The enumerable of policies to form the wrap must contain at least two policies.", nameof(policies)),
+            MinimumPoliciesRequiredForWrap => new AsyncPolicyWrap<TResult>((AsyncPolicy<TResult>)policies[0], policies[1]),
             _ => WrapAsync(policies[0], WrapAsync(policies.Skip(1).ToArray())),
         };
     }

--- a/test/Polly.Specs/Caching/CacheAsyncSpecs.cs
+++ b/test/Polly.Specs/Caching/CacheAsyncSpecs.cs
@@ -31,6 +31,18 @@ public class CacheAsyncSpecs : IDisposable
         action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("cacheKeyStrategy");
     }
 
+    [Fact]
+    public void Should_throw_when_policies_is_null()
+    {
+        IAsyncPolicy[] policies = null!;
+        IAsyncPolicy<int>[] policiesGeneric = null!;
+
+        Action action = () => Policy.WrapAsync(policies);
+        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("policies");
+
+        action = () => Policy.WrapAsync<int>(policiesGeneric);
+        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("policies");
+    }
     #endregion
 
     #region Caching behaviours


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

[#2215](https://github.com/App-vNext/Polly/issues/2215)

## Details on the issue fix or feature implementation

*  [x]  Suppress [CA1062](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062) in src/Polly/Wrap/IAsyncPolicyPolicyWrapExtensions.cs or fix the warning

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature