### PR TITLE
Fix warning CA1062#CircuitBreakerPolicy

### DIFF
--- a/src/Polly/CircuitBreaker/CircuitBreakerPolicy.cs
+++ b/src/Polly/CircuitBreaker/CircuitBreakerPolicy.cs
@@ -3,7 +3,6 @@
 /// <summary>
 /// A circuit-breaker policy that can be applied to delegates.
 /// </summary>
-#pragma warning disable CA1062 // Validate arguments of public methods
 public class CircuitBreakerPolicy : Policy, ICircuitBreakerPolicy
 {
     internal readonly ICircuitController<EmptyStruct> BreakerController;
@@ -98,12 +97,19 @@ public class CircuitBreakerPolicy<TResult> : Policy<TResult>, ICircuitBreakerPol
 
     /// <inheritdoc/>
     [DebuggerStepThrough]
-    protected override TResult Implementation(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken) =>
-        CircuitBreakerEngine.Implementation(
+    protected override TResult Implementation(Func<Context, CancellationToken, TResult> action, Context context, CancellationToken cancellationToken)
+    {
+        if (action is null)
+        {
+            throw new ArgumentNullException(nameof(action));
+        }
+
+        return CircuitBreakerEngine.Implementation(
             action,
             context,
             ExceptionPredicates,
             ResultPredicates,
             BreakerController,
             cancellationToken);
+    }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

[#2215](https://github.com/App-vNext/Polly/issues/2215)

## Details on the issue fix or feature implementation

*  [x]  Suppress [CA1062](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062) in src/Polly/CircuitBreaker/CircuitBreakerPolicy.cs or fix the warning

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature