### PR TITLE
Fix warning CA1062#AsyncCircuitBreakerPolicy

### DIFF
--- a/src/Polly/CircuitBreaker/AsyncCircuitBreakerPolicy.cs
+++ b/src/Polly/CircuitBreaker/AsyncCircuitBreakerPolicy.cs
@@ -3,7 +3,6 @@
 /// <summary>
 /// A circuit-breaker policy that can be applied to async delegates.
 /// </summary>
-#pragma warning disable CA1062 // Validate arguments of public methods
 public class AsyncCircuitBreakerPolicy : AsyncPolicy, ICircuitBreakerPolicy
 {
     internal readonly ICircuitController<EmptyStruct> BreakerController;
@@ -99,9 +98,18 @@ public class AsyncCircuitBreakerPolicy<TResult> : AsyncPolicy<TResult>, ICircuit
 
     /// <inheritdoc/>
     [DebuggerStepThrough]
-    protected override Task<TResult> ImplementationAsync(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken,
-        bool continueOnCapturedContext) =>
-        AsyncCircuitBreakerEngine.ImplementationAsync(
+    protected override Task<TResult> ImplementationAsync(
+        Func<Context, CancellationToken, Task<TResult>> action,
+        Context context,
+        CancellationToken cancellationToken,
+        bool continueOnCapturedContext)
+    {
+        if (action is null)
+        {
+            throw new ArgumentNullException(nameof(action));
+        }
+
+        return AsyncCircuitBreakerEngine.ImplementationAsync(
             action,
             context,
             continueOnCapturedContext,
@@ -109,4 +117,5 @@ public class AsyncCircuitBreakerPolicy<TResult> : AsyncPolicy<TResult>, ICircuit
             ResultPredicates,
             BreakerController,
             cancellationToken);
+    }
 }

--- a/test/Polly.Specs/CircuitBreaker/CircuitBreakerTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/CircuitBreaker/CircuitBreakerTResultAsyncSpecs.cs
@@ -8,6 +8,43 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
     #region Configuration tests
 
     [Fact]
+    public void Should_throw_when_action_is_null()
+    {
+        var flags = BindingFlags.NonPublic | BindingFlags.Instance;
+        Func<Context, CancellationToken, Task<EmptyStruct>> action = null!;
+        PolicyBuilder<EmptyStruct> policyBuilder = new PolicyBuilder<EmptyStruct>(exception => exception);
+
+        var exceptionsAllowedBeforeBreaking = 1;
+        var durationOfBreak = TimeSpan.Zero;
+        Action<DelegateResult<EmptyStruct>, CircuitState, TimeSpan, Context> onBreak = null!;
+        Action<Context> onReset = null!;
+        Action onHalfOpen = null!;
+        ICircuitController<EmptyStruct> breakerController = new ConsecutiveCountCircuitController<EmptyStruct>(
+            exceptionsAllowedBeforeBreaking,
+            durationOfBreak,
+            onBreak,
+            onReset,
+            onHalfOpen);
+
+        var instance = Activator.CreateInstance(
+            typeof(AsyncCircuitBreakerPolicy<EmptyStruct>),
+            flags,
+            null,
+            [policyBuilder, breakerController],
+            null)!;
+        var instanceType = instance.GetType();
+        var methods = instanceType.GetMethods(flags);
+        var methodInfo = methods.First(method => method is { Name: "ImplementationAsync", ReturnType.Name: "Task`1" });
+
+        var func = () => methodInfo.Invoke(instance, [action, new Context(), CancellationToken.None, false]);
+
+        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
+        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
+            .Which.ParamName.Should().Be("action");
+    }
+
+    [Fact]
     public async Task Should_be_able_to_handle_a_duration_of_timespan_maxvalue()
     {
         var breaker = Policy


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

[#2215](https://github.com/App-vNext/Polly/issues/2215)

## Details on the issue fix or feature implementation

*  [x]  Suppress [CA1062](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1062) in src/Polly/CircuitBreaker/AsyncCircuitBreakerPolicy.cs or fix the warning

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature