### PR TITLE
Re-enable failing tests

### DIFF
--- a/test/Polly.Core.Tests/CircuitBreaker/Controller/ScheduledTaskExecutorTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/Controller/ScheduledTaskExecutorTests.cs
@@ -106,7 +106,7 @@ public class ScheduledTaskExecutorTests
             .Throw<ObjectDisposedException>();
     }
 
-    [Fact(Skip = "TODO - Failing under .NET Framework for some reason.")]
+    [Fact]
     public void Dispose_WhenScheduledTaskExecuting()
     {
         using var disposed = new ManualResetEvent(false);

--- a/test/Polly.Core.Tests/Issues/IssuesTests.InfiniteRetry_2163.cs
+++ b/test/Polly.Core.Tests/Issues/IssuesTests.InfiniteRetry_2163.cs
@@ -5,7 +5,7 @@ namespace Polly.Core.Tests.Issues;
 
 public partial class IssuesTests
 {
-    [Fact(Timeout = 15_000, Skip = "TODO - Failing under .NET 9 for some reason.")]
+    [Fact(Timeout = 15_000)]
     public async Task InfiniteRetry_Delay_Does_Not_Overflow_2163()
     {
         // Arrange

--- a/test/Polly.Core.Tests/Polly.Core.Tests.csproj
+++ b/test/Polly.Core.Tests/Polly.Core.Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net481</TargetFrameworks>
+    <TestTfmsInParallel Condition="$([MSBuild]::IsOSPlatform('Windows'))">false</TestTfmsInParallel>
     <ProjectType>Test</ProjectType>
     <Nullable>enable</Nullable>
     <Threshold>100</Threshold>
@@ -10,7 +11,6 @@
     <NoWarn>$(NoWarn);S6966;SA1600;SA1204</NoWarn>
     <Include>[Polly.Core]*</Include>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
-    <TestTfmsInParallel>false</TestTfmsInParallel>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Polly.Core.Tests/Polly.Core.Tests.csproj
+++ b/test/Polly.Core.Tests/Polly.Core.Tests.csproj
@@ -10,6 +10,7 @@
     <NoWarn>$(NoWarn);S6966;SA1600;SA1204</NoWarn>
     <Include>[Polly.Core]*</Include>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+    <TestTfmsInParallel>false</TestTfmsInParallel>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Disable TFM parallelism for `dotnet test` in the Polly.Core project to see if it is the cause of the two failing tests.

See [_What's new in the SDK for .NET 9 - Run tests in parallel_](https://learn.microsoft.com/dotnet/core/whats-new/dotnet-9/sdk#run-tests-in-parallel).
