### PR TITLE
Put dotnet_diagnostic.CA1852.severity = warning into effect. Fix the resulting warnings

### DIFF
--- a/eng/analyzers/Library.globalconfig
+++ b/eng/analyzers/Library.globalconfig
@@ -941,6 +941,7 @@ dotnet_diagnostic.CA1851.severity = suggestion
 # Help Link: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852
 # Tags     : Telemetry, EnabledRuleInAggressiveMode, CompilationEnd
 dotnet_diagnostic.CA1852.severity = warning
+dotnet_code_quality.CA1852.ignore_internalsvisibleto = true
 
 # Title    : Unnecessary call to 'Dictionary.ContainsKey(key)'
 # Category : Performance

--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerManualControl.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerManualControl.cs
@@ -148,7 +148,7 @@ public sealed class CircuitBreakerManualControl
         }
     }
 
-    private class RegistrationDisposable : IDisposable
+    private sealed class RegistrationDisposable : IDisposable
     {
         private readonly Action _disposeAction;
 

--- a/src/Polly.Core/CircuitBreaker/Controller/ScheduledTaskExecutor.cs
+++ b/src/Polly.Core/CircuitBreaker/Controller/ScheduledTaskExecutor.cs
@@ -84,5 +84,5 @@ internal sealed class ScheduledTaskExecutor : IDisposable
         }
     }
 
-    private record Entry(Func<Task> TaskFactory, bool ContinueOnCapturedContext, TaskCompletionSource<object> TaskCompletion);
+    private sealed record Entry(Func<Task> TaskFactory, bool ContinueOnCapturedContext, TaskCompletionSource<object> TaskCompletion);
 }

--- a/src/Polly.Core/Registry/RegistryPipelineComponentBuilder.cs
+++ b/src/Polly.Core/Registry/RegistryPipelineComponentBuilder.cs
@@ -6,7 +6,7 @@ namespace Polly.Registry;
 /// <summary>
 /// Builds a <see cref="PipelineComponent"/> used by the registry.
 /// </summary>
-internal class RegistryPipelineComponentBuilder<TBuilder, TKey>
+internal sealed class RegistryPipelineComponentBuilder<TBuilder, TKey>
     where TBuilder : ResiliencePipelineBuilderBase
     where TKey : notnull
 {
@@ -75,7 +75,7 @@ internal class RegistryPipelineComponentBuilder<TBuilder, TKey>
             builder);
     }
 
-    private record Builder(
+    private sealed record Builder(
         Func<PipelineComponent> ComponentFactory,
         List<CancellationToken> ReloadTokens,
         ResilienceStrategyTelemetry Telemetry,

--- a/src/Polly.Core/Simmy/Fault/ChaosFaultStrategy.cs
+++ b/src/Polly.Core/Simmy/Fault/ChaosFaultStrategy.cs
@@ -2,7 +2,7 @@
 
 namespace Polly.Simmy.Fault;
 
-internal class ChaosFaultStrategy : ChaosStrategy
+internal sealed class ChaosFaultStrategy : ChaosStrategy
 {
     private readonly ResilienceStrategyTelemetry _telemetry;
 

--- a/src/Polly.Core/Simmy/Outcomes/ChaosOutcomeStrategy.cs
+++ b/src/Polly.Core/Simmy/Outcomes/ChaosOutcomeStrategy.cs
@@ -2,7 +2,7 @@
 
 namespace Polly.Simmy.Outcomes;
 
-internal class ChaosOutcomeStrategy<T> : ChaosStrategy<T>
+internal sealed class ChaosOutcomeStrategy<T> : ChaosStrategy<T>
 {
     private readonly ResilienceStrategyTelemetry _telemetry;
     private readonly Func<OnOutcomeInjectedArguments<T>, ValueTask>? _onOutcomeInjected;

--- a/src/Polly.Core/Utils/Pipeline/ComponentWithDisposeCallbacks.cs
+++ b/src/Polly.Core/Utils/Pipeline/ComponentWithDisposeCallbacks.cs
@@ -1,6 +1,6 @@
 ﻿namespace Polly.Utils.Pipeline;
 
-internal class ComponentWithDisposeCallbacks : PipelineComponent
+internal sealed class ComponentWithDisposeCallbacks : PipelineComponent
 {
     private readonly List<Action> _callbacks;
 

--- a/src/Polly.Core/Utils/Pipeline/ExternalComponent.cs
+++ b/src/Polly.Core/Utils/Pipeline/ExternalComponent.cs
@@ -1,7 +1,7 @@
 ﻿namespace Polly.Utils.Pipeline;
 
 [DebuggerDisplay("{Component}")]
-internal class ExternalComponent : PipelineComponent
+internal sealed class ExternalComponent : PipelineComponent
 {
     public ExternalComponent(PipelineComponent component) => Component = component;
 

--- a/src/Polly.Core/Utils/Pipeline/ReloadableComponent.cs
+++ b/src/Polly.Core/Utils/Pipeline/ReloadableComponent.cs
@@ -98,15 +98,15 @@ internal sealed class ReloadableComponent : PipelineComponent
         _tokenSource.Dispose();
     }
 
-    internal record ReloadFailedArguments(Exception Exception);
+    internal sealed record ReloadFailedArguments(Exception Exception);
 
-    internal record DisposedFailedArguments(Exception Exception);
+    internal sealed record DisposedFailedArguments(Exception Exception);
 
 #pragma warning disable S2094 // Classes should not be empty
 #pragma warning disable S3253 // Constructor and destructor declarations should not be redundant
-    internal record OnReloadArguments();
+    internal sealed record OnReloadArguments();
 #pragma warning restore S3253 // Constructor and destructor declarations should not be redundant
 #pragma warning restore S2094 // Classes should not be empty
 
-    internal record Entry(PipelineComponent Component, List<CancellationToken> ReloadTokens, ResilienceStrategyTelemetry Telemetry);
+    internal sealed record Entry(PipelineComponent Component, List<CancellationToken> ReloadTokens, ResilienceStrategyTelemetry Telemetry);
 }

--- a/src/Polly.Extensions/DependencyInjection/PollyServiceCollectionExtensions.cs
+++ b/src/Polly.Extensions/DependencyInjection/PollyServiceCollectionExtensions.cs
@@ -288,7 +288,7 @@ public static class PollyServiceCollectionExtensions
         });
     }
 
-    private class RegistryMarker<TKey>
+    private sealed class RegistryMarker<TKey>
     {
         public static readonly ServiceDescriptor ServiceDescriptor = ServiceDescriptor.Singleton(new RegistryMarker<TKey>());
     }

--- a/src/Polly.Extensions/Telemetry/ResilienceTelemetryTags.cs
+++ b/src/Polly.Extensions/Telemetry/ResilienceTelemetryTags.cs
@@ -1,6 +1,6 @@
 namespace Polly.Telemetry;
 
-internal class ResilienceTelemetryTags
+internal static class ResilienceTelemetryTags
 {
     public const string EventName = "event.name";
 

--- a/src/Polly/Caching/AsyncGenericCacheProvider.cs
+++ b/src/Polly/Caching/AsyncGenericCacheProvider.cs
@@ -5,7 +5,7 @@ namespace Polly.Caching;
 /// Provides a strongly-typed wrapper over a non-generic CacheProviderAsync.
 /// </summary>
 /// <typeparam name="TCacheFormat">The type of the objects in the cache.</typeparam>
-internal class AsyncGenericCacheProvider<TCacheFormat> : IAsyncCacheProvider<TCacheFormat>
+internal sealed class AsyncGenericCacheProvider<TCacheFormat> : IAsyncCacheProvider<TCacheFormat>
 {
     private readonly IAsyncCacheProvider _wrappedCacheProvider;
 

--- a/src/Polly/Caching/GenericCacheProvider.cs
+++ b/src/Polly/Caching/GenericCacheProvider.cs
@@ -5,7 +5,7 @@ namespace Polly.Caching;
 /// Provides a strongly-typed wrapper over a non-generic CacheProvider.
 /// </summary>
 /// <typeparam name="TCacheFormat">The type of the objects in the cache.</typeparam>
-internal class GenericCacheProvider<TCacheFormat> : ISyncCacheProvider<TCacheFormat>
+internal sealed class GenericCacheProvider<TCacheFormat> : ISyncCacheProvider<TCacheFormat>
 {
     private readonly ISyncCacheProvider _wrappedCacheProvider;
 

--- a/src/Polly/Caching/GenericTtlStrategy.cs
+++ b/src/Polly/Caching/GenericTtlStrategy.cs
@@ -4,7 +4,7 @@ namespace Polly.Caching;
 /// <summary>
 /// Represents a strongly-typed <see cref="ITtlStrategy"/> wrapper of a non-generic strategy.
 /// </summary>
-internal class GenericTtlStrategy<TResult> : ITtlStrategy<TResult>
+internal sealed class GenericTtlStrategy<TResult> : ITtlStrategy<TResult>
 {
     private readonly ITtlStrategy _wrappedTtlStrategy;
 

--- a/src/Polly/CircuitBreaker/AdvancedCircuitController.cs
+++ b/src/Polly/CircuitBreaker/AdvancedCircuitController.cs
@@ -1,6 +1,6 @@
 ﻿namespace Polly.CircuitBreaker;
 
-internal class AdvancedCircuitController<TResult> : CircuitStateController<TResult>
+internal sealed class AdvancedCircuitController<TResult> : CircuitStateController<TResult>
 {
     private const short NumberOfWindows = 10;
     internal static readonly long ResolutionOfCircuitTimer = TimeSpan.FromMilliseconds(20).Ticks;

--- a/src/Polly/CircuitBreaker/AsyncCircuitBreakerEngine.cs
+++ b/src/Polly/CircuitBreaker/AsyncCircuitBreakerEngine.cs
@@ -1,6 +1,6 @@
 ﻿namespace Polly.CircuitBreaker;
 
-internal class AsyncCircuitBreakerEngine
+internal static class AsyncCircuitBreakerEngine
 {
     internal static async Task<TResult> ImplementationAsync<TResult>(
         Func<Context, CancellationToken, Task<TResult>> action,

--- a/src/Polly/CircuitBreaker/CircuitBreakerEngine.cs
+++ b/src/Polly/CircuitBreaker/CircuitBreakerEngine.cs
@@ -2,7 +2,7 @@
 
 namespace Polly.CircuitBreaker;
 
-internal class CircuitBreakerEngine
+internal static class CircuitBreakerEngine
 {
     internal static TResult Implementation<TResult>(
         Func<Context, CancellationToken, TResult> action,

--- a/src/Polly/CircuitBreaker/ConsecutiveCountCircuitController.cs
+++ b/src/Polly/CircuitBreaker/ConsecutiveCountCircuitController.cs
@@ -1,6 +1,6 @@
 ﻿namespace Polly.CircuitBreaker;
 
-internal class ConsecutiveCountCircuitController<TResult> : CircuitStateController<TResult>
+internal sealed class ConsecutiveCountCircuitController<TResult> : CircuitStateController<TResult>
 {
     private readonly int _exceptionsAllowedBeforeBreaking;
     private int _consecutiveFailureCount;

--- a/src/Polly/CircuitBreaker/HealthCount.cs
+++ b/src/Polly/CircuitBreaker/HealthCount.cs
@@ -1,6 +1,6 @@
 ﻿namespace Polly.CircuitBreaker;
 
-internal class HealthCount
+internal sealed class HealthCount
 {
     public int Successes { get; set; }
 

--- a/src/Polly/CircuitBreaker/RollingHealthMetrics.cs
+++ b/src/Polly/CircuitBreaker/RollingHealthMetrics.cs
@@ -1,7 +1,7 @@
 ﻿#nullable enable
 namespace Polly.CircuitBreaker;
 
-internal class RollingHealthMetrics : IHealthMetrics
+internal sealed class RollingHealthMetrics : IHealthMetrics
 {
     private readonly long _samplingDuration;
     private readonly long _windowDuration;

--- a/src/Polly/CircuitBreaker/SingleHealthMetrics.cs
+++ b/src/Polly/CircuitBreaker/SingleHealthMetrics.cs
@@ -1,7 +1,7 @@
 ﻿#nullable enable
 namespace Polly.CircuitBreaker;
 
-internal class SingleHealthMetrics : IHealthMetrics
+internal sealed class SingleHealthMetrics : IHealthMetrics
 {
     private readonly long _samplingDuration;
 

--- a/src/Polly/Fallback/AsyncFallbackEngine.cs
+++ b/src/Polly/Fallback/AsyncFallbackEngine.cs
@@ -1,7 +1,7 @@
 ﻿#nullable enable
 namespace Polly.Fallback;
 
-internal class AsyncFallbackEngine
+internal static class AsyncFallbackEngine
 {
     internal static async Task<TResult> ImplementationAsync<TResult>(
         Func<Context, CancellationToken, Task<TResult>> action,

--- a/src/Polly/Utilities/TimedLock.cs
+++ b/src/Polly/Utilities/TimedLock.cs
@@ -68,7 +68,7 @@ internal readonly struct TimedLock : IDisposable
 #if DEBUG
     // (In Debug mode, we make it a class so that we can add a finalizer
     // in order to detect when the object is not freed.)
-    private class Sentinel
+    private sealed class Sentinel
     {
 #if NETSTANDARD2_0
         ~Sentinel()
@@ -85,7 +85,7 @@ internal readonly struct TimedLock : IDisposable
 #endif
 }
 
-internal class LockTimeoutException : Exception
+internal sealed class LockTimeoutException : Exception
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="LockTimeoutException"/> class.

--- a/src/Snippets/Docs/Chaos.Behavior.cs
+++ b/src/Snippets/Docs/Chaos.Behavior.cs
@@ -86,7 +86,7 @@ internal static partial class Chaos
     }
 }
 
-internal class RedisConnectionException : Exception
+internal sealed class RedisConnectionException : Exception
 {
     public RedisConnectionException()
     {

--- a/src/Snippets/Docs/Chaos.Index.cs
+++ b/src/Snippets/Docs/Chaos.Index.cs
@@ -174,7 +174,7 @@ internal static partial class Chaos
     #region chaos-extension
 
     // Options that represent the chaos pipeline
-    public class MyChaosOptions
+    public sealed class MyChaosOptions
     {
         public ChaosFaultStrategyOptions Fault { get; set; } = new()
         {

--- a/src/Snippets/Docs/DependencyInjection.cs
+++ b/src/Snippets/Docs/DependencyInjection.cs
@@ -108,7 +108,7 @@ internal static class DependencyInjection
 
     #region di-keyed-services-use
 
-    public class MyApi
+    public sealed class MyApi
     {
         private readonly ResiliencePipeline _pipeline;
         private readonly ResiliencePipeline<HttpResponseMessage> _genericPipeline;

--- a/src/Snippets/Docs/Fallback.cs
+++ b/src/Snippets/Docs/Fallback.cs
@@ -57,14 +57,14 @@ internal static class Fallback
         #endregion
     }
 
-    public class UserAvatar
+    public sealed class UserAvatar
     {
         public static readonly UserAvatar Blank = new();
 
         public static UserAvatar GetRandomAvatar() => new();
     }
 
-    private class CustomNetworkException : Exception
+    private sealed class CustomNetworkException : Exception
     {
         public CustomNetworkException()
         {

--- a/src/Snippets/Docs/Hedging.cs
+++ b/src/Snippets/Docs/Hedging.cs
@@ -132,7 +132,7 @@ internal static class Hedging
 
     #region hedging-handler
 
-    internal class HedgingHandler : DelegatingHandler
+    internal sealed class HedgingHandler : DelegatingHandler
     {
         private readonly ResiliencePipeline<HttpResponseMessage> _pipeline;
 

--- a/src/Snippets/Docs/Performance.cs
+++ b/src/Snippets/Docs/Performance.cs
@@ -120,13 +120,13 @@ internal static class Performance
 
     private static ValueTask<Member> GetMemberAsync(string id, CancellationToken token) => default;
 
-    public class Member
+    public sealed class Member
     {
     }
 
     #region perf-reuse-pipelines
 
-    public class MyApi
+    public sealed class MyApi
     {
         private readonly ResiliencePipelineRegistry<string> _registry;
 

--- a/src/Snippets/Docs/Telemetry.cs
+++ b/src/Snippets/Docs/Telemetry.cs
@@ -82,7 +82,7 @@ internal static class Telemetry
 
     #region telemetry-listeners
 
-    internal class MyTelemetryListener : TelemetryListener
+    internal sealed class MyTelemetryListener : TelemetryListener
     {
         public override void Write<TResult, TArgs>(in TelemetryEventArguments<TResult, TArgs> args)
         {
@@ -90,7 +90,7 @@ internal static class Telemetry
         }
     }
 
-    internal class MyMeteringEnricher : MeteringEnricher
+    internal sealed class MyMeteringEnricher : MeteringEnricher
     {
         public override void Enrich<TResult, TArgs>(in EnrichmentContext<TResult, TArgs> context)
         {

--- a/src/Snippets/Docs/Utils/SomeExceptionType.cs
+++ b/src/Snippets/Docs/Utils/SomeExceptionType.cs
@@ -1,6 +1,6 @@
 ﻿namespace Snippets.Docs.Utils;
 
-internal class SomeExceptionType : Exception
+internal sealed class SomeExceptionType : Exception
 {
     public SomeExceptionType(string message)
         : base(message)


### PR DESCRIPTION

<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

Performance

## Details on the issue fix or feature implementation
`InternalsVisibleTo` disables CA1852, so it is not in effect.
https://github.com/dotnet/roslyn-analyzers/issues/6438

I have set this to ignore `InternalsVisibleTo`:
`dotnet_code_quality.CA1852.ignore_internalsvisibleto = true`

I have fixed the resulting warnings

~~I have locally set this to ignore `InternalsVisibleTo`:~~ 
~~`dotnet_code_quality.CA1852.ignore_internalsvisibleto = true`~~

~~Let me know if I should commit that change as well.~~ 
~~Then the snippet project also need some changes to obey CA1852.~~

## Confirm the following

- [X]  I started this PR by branching from the head of the default branch
- [X]  I have targeted the PR to merge into the default branch
- [X]  I have included unit tests for the issue/feature
- [X]  I have successfully run a local build
