### PR TITLE
Report last attempt as error if it would be handled

### DIFF
--- a/docs/advanced/telemetry.md
+++ b/docs/advanced/telemetry.md
@@ -26,7 +26,7 @@ telemetryOptions.MeteringEnrichers.Add(new MyMeteringEnricher());
 // Configure telemetry listeners
 telemetryOptions.TelemetryListeners.Add(new MyTelemetryListener());
 
-var builder = new ResiliencePipelineBuilder()
+var pipeline = new ResiliencePipelineBuilder()
     .AddTimeout(TimeSpan.FromSeconds(1))
     .ConfigureTelemetry(telemetryOptions) // This method enables telemetry in the builder
     .Build();
@@ -223,7 +223,7 @@ var telemetryOptions = new TelemetryOptions();
 // Register custom enricher
 telemetryOptions.MeteringEnrichers.Add(new CustomMeteringEnricher());
 
-var builder = new ResiliencePipelineBuilder()
+var pipeline = new ResiliencePipelineBuilder()
     .AddRetry(new RetryStrategyOptions())
     .ConfigureTelemetry(telemetryOptions) // This method enables telemetry in the builder
     .Build();

--- a/docs/strategies/retry.md
+++ b/docs/strategies/retry.md
@@ -168,7 +168,7 @@ Execution attempt. Source: 'MyPipeline/MyPipelineInstance/MyRetryStrategy', Oper
 >
 > Also remember that `Attempt: '0'` relates to the original execution attempt.
 >
-> Only the very last error event will have `Error` severity if it was unsuccessful.
+> Only the last error event will have `Error` severity if it was unsuccessful.
 
 For further information please check out the [telemetry page](../advanced/telemetry.md).
 

--- a/docs/strategies/retry.md
+++ b/docs/strategies/retry.md
@@ -115,10 +115,10 @@ new ResiliencePipelineBuilder<HttpResponseMessage>().AddRetry(optionsExtractDela
 
 The retry strategy reports the following telemetry events:
 
-| Event Name         | Event Severity            | When?                                                 |
-|--------------------|---------------------------|-------------------------------------------------------|
-| `ExecutionAttempt` | `Information` / `Warning` | Just before the strategy calculates the next delay    |
-| `OnRetry`          | `Warning`                 | Just before the strategy calls the `OnRetry` delegate |
+| Event Name         | Event Severity                      | When?                                                 |
+|--------------------|-------------------------------------|-------------------------------------------------------|
+| `ExecutionAttempt` | `Information` / `Warning` / `Error` | Just before the strategy calculates the next delay    |
+| `OnRetry`          | `Warning`                           | Just before the strategy calls the `OnRetry` delegate |
 
 Here are some sample events:
 
@@ -138,7 +138,7 @@ Execution attempt. Source: 'MyPipeline/MyPipelineInstance/MyRetryStrategy', Oper
 
 ### Handled case
 
-If the retry strategy performs some retries then the reported telemetry events' severity will be `Warning`:
+If the retry strategy performs some retries then the reported telemetry events' severity will be `Warning`. If the retry strategy runs out of retry attempts then the last event's severity will be `Error`:
 
 ```none
 Execution attempt. Source: 'MyPipeline/MyPipelineInstance/MyRetryStrategy', Operation Key: 'MyRetryableOperation', Result: 'Failed', Handled: 'True', Attempt: '0', Execution Time: 5.0397ms
@@ -167,6 +167,8 @@ Execution attempt. Source: 'MyPipeline/MyPipelineInstance/MyRetryStrategy', Oper
 > On the other hand the `Execution attempt` event will be **always** reported regardless whether the strategy has to perform any retries.
 >
 > Also remember that `Attempt: '0'` relates to the original execution attempt.
+>
+> Only the very last error event will have `Error` severity if it was unsuccessful.
 
 For further information please check out the [telemetry page](../advanced/telemetry.md).
 

--- a/src/Polly.Core/Telemetry/TelemetryUtil.cs
+++ b/src/Polly.Core/Telemetry/TelemetryUtil.cs
@@ -18,15 +18,42 @@ internal static class TelemetryUtil
         TimeSpan executionTime,
         bool handled)
     {
+        ReportAttempt(
+            telemetry,
+            new(handled ? ResilienceEventSeverity.Warning : ResilienceEventSeverity.Information, ExecutionAttempt),
+            context,
+            outcome,
+            new ExecutionAttemptArguments(attempt, executionTime, handled));
+    }
+
+    public static void ReportFinalExecutionAttempt<TResult>(
+        ResilienceStrategyTelemetry telemetry,
+        ResilienceContext context,
+        Outcome<TResult> outcome,
+        int attempt,
+        TimeSpan executionTime,
+        bool handled)
+    {
+        ReportAttempt(
+            telemetry,
+            new(handled ? ResilienceEventSeverity.Error : ResilienceEventSeverity.Information, ExecutionAttempt),
+            context,
+            outcome,
+            new ExecutionAttemptArguments(attempt, executionTime, handled));
+    }
+
+    private static void ReportAttempt<TResult>(
+        ResilienceStrategyTelemetry telemetry,
+        ResilienceEvent resilienceEvent,
+        ResilienceContext context,
+        Outcome<TResult> outcome,
+        ExecutionAttemptArguments args)
+    {
         if (!telemetry.Enabled)
         {
             return;
         }
 
-        telemetry.Report(
-            new(handled ? ResilienceEventSeverity.Warning : ResilienceEventSeverity.Information, ExecutionAttempt),
-            context,
-            outcome,
-            new ExecutionAttemptArguments(attempt, executionTime, handled));
+        telemetry.Report<ExecutionAttemptArguments, TResult>(resilienceEvent, context, outcome, args);
     }
 }

--- a/src/Snippets/Docs/Telemetry.cs
+++ b/src/Snippets/Docs/Telemetry.cs
@@ -53,7 +53,7 @@ internal static class Telemetry
         // Configure telemetry listeners
         telemetryOptions.TelemetryListeners.Add(new MyTelemetryListener());
 
-        var builder = new ResiliencePipelineBuilder()
+        var pipeline = new ResiliencePipelineBuilder()
             .AddTimeout(TimeSpan.FromSeconds(1))
             .ConfigureTelemetry(telemetryOptions) // This method enables telemetry in the builder
             .Build();
@@ -109,7 +109,7 @@ internal static class Telemetry
         // Register custom enricher
         telemetryOptions.MeteringEnrichers.Add(new CustomMeteringEnricher());
 
-        var builder = new ResiliencePipelineBuilder()
+        var pipeline = new ResiliencePipelineBuilder()
             .AddRetry(new RetryStrategyOptions())
             .ConfigureTelemetry(telemetryOptions) // This method enables telemetry in the builder
             .Build();

--- a/test/Polly.Core.Tests/Retry/RetryResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Retry/RetryResilienceStrategyTests.cs
@@ -320,6 +320,7 @@ public class RetryResilienceStrategyTests
     public void Execute_NotHandledFinalAttempt_EnsureAttemptReported()
     {
         _options.MaxRetryAttempts = 1;
+        _options.Delay = TimeSpan.FromMilliseconds(50);
 
         // original attempt is handled, retried attempt is not handled
         _options.ShouldHandle = args => new ValueTask<bool>(args.AttemptNumber == 0);
@@ -360,6 +361,7 @@ public class RetryResilienceStrategyTests
     public void Execute_HandledFinalAttempt_EnsureAttemptReported()
     {
         _options.MaxRetryAttempts = 1;
+        _options.Delay = TimeSpan.FromMilliseconds(50);
         _options.ShouldHandle = _ => new ValueTask<bool>(true);
         var called = false;
         _telemetry = TestUtilities.CreateResilienceTelemetry(args =>

--- a/test/Polly.Core.Tests/Retry/RetryResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Retry/RetryResilienceStrategyTests.cs
@@ -292,16 +292,94 @@ public class RetryResilienceStrategyTests
     }
 
     [Fact]
-    public void Execute_EnsureAttemptReported()
+    public void Execute_NotHandledOriginalAttempt_EnsureAttemptReported()
     {
         var called = false;
         _telemetry = TestUtilities.CreateResilienceTelemetry(args =>
         {
             var attempt = args.Arguments.Should().BeOfType<ExecutionAttemptArguments>().Subject;
-
+            args.Event.Severity.Should().Be(ResilienceEventSeverity.Information);
             attempt.Handled.Should().BeFalse();
             attempt.AttemptNumber.Should().Be(0);
             attempt.Duration.Should().Be(TimeSpan.FromSeconds(1));
+            called = true;
+        });
+
+        var sut = CreateSut();
+
+        sut.Execute(() =>
+        {
+            _timeProvider.Advance(TimeSpan.FromSeconds(1));
+            return 0;
+        });
+
+        called.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Execute_NotHandledFinalAttempt_EnsureAttemptReported()
+    {
+        _options.MaxRetryAttempts = 1;
+
+        // original attempt is handled, retried attempt is not handled
+        _options.ShouldHandle = args => new ValueTask<bool>(args.AttemptNumber == 0);
+        var called = false;
+        _telemetry = TestUtilities.CreateResilienceTelemetry(args =>
+        {
+            // ignore OnRetry event
+            if (args.Arguments is OnRetryArguments<object>)
+            {
+                return;
+            }
+
+            var attempt = args.Arguments.Should().BeOfType<ExecutionAttemptArguments>().Subject;
+            if (attempt.AttemptNumber == 0)
+            {
+                args.Event.Severity.Should().Be(ResilienceEventSeverity.Warning);
+            }
+            else
+            {
+                args.Event.Severity.Should().Be(ResilienceEventSeverity.Information);
+            }
+
+            called = true;
+        });
+
+        var sut = CreateSut();
+
+        sut.Execute(() =>
+        {
+            _timeProvider.Advance(TimeSpan.FromSeconds(1));
+            return 0;
+        });
+
+        called.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Execute_HandledFinalAttempt_EnsureAttemptReported()
+    {
+        _options.MaxRetryAttempts = 1;
+        _options.ShouldHandle = _ => new ValueTask<bool>(true);
+        var called = false;
+        _telemetry = TestUtilities.CreateResilienceTelemetry(args =>
+        {
+            // ignore OnRetry event
+            if (args.Arguments is OnRetryArguments<object>)
+            {
+                return;
+            }
+
+            var attempt = args.Arguments.Should().BeOfType<ExecutionAttemptArguments>().Subject;
+            if (attempt.AttemptNumber == 0)
+            {
+                args.Event.Severity.Should().Be(ResilienceEventSeverity.Warning);
+            }
+            else
+            {
+                args.Event.Severity.Should().Be(ResilienceEventSeverity.Error);
+            }
+
             called = true;
         });
 

--- a/test/Polly.Core.Tests/Retry/RetryResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Retry/RetryResilienceStrategyTests.cs
@@ -320,7 +320,7 @@ public class RetryResilienceStrategyTests
     public void Execute_NotHandledFinalAttempt_EnsureAttemptReported()
     {
         _options.MaxRetryAttempts = 1;
-        _options.Delay = TimeSpan.FromMilliseconds(50);
+        _options.Delay = TimeSpan.Zero;
 
         // original attempt is handled, retried attempt is not handled
         _options.ShouldHandle = args => new ValueTask<bool>(args.AttemptNumber == 0);
@@ -361,7 +361,7 @@ public class RetryResilienceStrategyTests
     public void Execute_HandledFinalAttempt_EnsureAttemptReported()
     {
         _options.MaxRetryAttempts = 1;
-        _options.Delay = TimeSpan.FromMilliseconds(50);
+        _options.Delay = TimeSpan.Zero;
         _options.ShouldHandle = _ => new ValueTask<bool>(true);
         var called = false;
         _telemetry = TestUtilities.CreateResilienceTelemetry(args =>

--- a/test/Polly.Core.Tests/Telemetry/TelemetryUtilTests.cs
+++ b/test/Polly.Core.Tests/Telemetry/TelemetryUtilTests.cs
@@ -10,7 +10,6 @@ public class TelemetryUtilTests
     public void ReportExecutionAttempt_Ok(bool handled, ResilienceEventSeverity severity)
     {
         var asserted = false;
-        var props = new ResilienceProperties();
         var listener = TestUtilities.CreateResilienceTelemetry(args =>
         {
             args.Event.Severity.Should().Be(severity);
@@ -18,6 +17,22 @@ public class TelemetryUtilTests
         });
 
         TelemetryUtil.ReportExecutionAttempt(listener, ResilienceContextPool.Shared.Get(), Outcome.FromResult("dummy"), 0, TimeSpan.Zero, handled);
+        asserted.Should().BeTrue();
+    }
+
+    [InlineData(true, ResilienceEventSeverity.Error)]
+    [InlineData(false, ResilienceEventSeverity.Information)]
+    [Theory]
+    public void ReportFinalExecutionAttempt_Ok(bool handled, ResilienceEventSeverity severity)
+    {
+        var asserted = false;
+        var listener = TestUtilities.CreateResilienceTelemetry(args =>
+        {
+            args.Event.Severity.Should().Be(severity);
+            asserted = true;
+        });
+
+        TelemetryUtil.ReportFinalExecutionAttempt(listener, ResilienceContextPool.Shared.Get(), Outcome.FromResult("dummy"), 1, TimeSpan.Zero, handled);
         asserted.Should().BeTrue();
     }
 }


### PR DESCRIPTION
# Pull Request

- #2162

## Details on the issue fix or feature implementation
- If the retry exhausted all of its attempts then report the `ExecutionAttempt` as `Error` if it would handle it
- If the retry exhausted all of its attempts then report the `ExecutionAttempt` as `Warning` if it would not handle it

## Missing
- Update documentation 

## Out of scope
- This PR does not include changes for hedging strategy

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
