### PR TITLE
Update ResilienceProperties to correctly handle null values

### DIFF
--- a/src/Polly.Core/ResilienceProperties.cs
+++ b/src/Polly.Core/ResilienceProperties.cs
@@ -29,6 +29,12 @@ public sealed class ResilienceProperties
             }
             else if (val is null)
             {
+                // We have to use null-forgiving operator "!" here to suppress a null-state analysis warning.
+                // The reason is the following. The output type "TValue" doesn't have any type constraints as
+                // "notnull", "class" or "struct", therefore the analyzer considers "TValue" as non-nullable
+                // and warns us that we're assigning "null" to it. But that's not correct, because "TValue"
+                // could be a nullable type, e.g. "string?", and assigning "null" to it is correct. Therefore
+                // it is reasonable to use "!" here to suppress the warning.
                 value = default!;
                 return true;
             }

--- a/src/Polly.Core/ResilienceProperties.cs
+++ b/src/Polly.Core/ResilienceProperties.cs
@@ -20,10 +20,18 @@ public sealed class ResilienceProperties
     /// <returns>True, if a property was retrieved.</returns>
     public bool TryGetValue<TValue>(ResiliencePropertyKey<TValue> key, [MaybeNullWhen(false)] out TValue value)
     {
-        if (Options.TryGetValue(key.Key, out object? val) && val is TValue typedValue)
+        if (Options.TryGetValue(key.Key, out object? val))
         {
-            value = typedValue;
-            return true;
+            if (val is TValue typedValue)
+            {
+                value = typedValue;
+                return true;
+            }
+            else if (val == null)
+            {
+                value = default!;
+                return true;
+            }
         }
 
         value = default;

--- a/src/Polly.Core/ResilienceProperties.cs
+++ b/src/Polly.Core/ResilienceProperties.cs
@@ -27,7 +27,7 @@ public sealed class ResilienceProperties
                 value = typedValue;
                 return true;
             }
-            else if (val == null)
+            else if (val is null)
             {
                 value = default!;
                 return true;

--- a/test/Polly.Core.Tests/ResiliencePropertiesTests.cs
+++ b/test/Polly.Core.Tests/ResiliencePropertiesTests.cs
@@ -15,6 +15,18 @@ public class ResiliencePropertiesTests
     }
 
     [Fact]
+    public void TryGetValue_ValueIsNull_Ok()
+    {
+        var key = new ResiliencePropertyKey<string?>("dummy");
+        var props = new ResilienceProperties();
+
+        props.Set(key, null);
+
+        props.TryGetValue(key, out var val).Should().Be(true);
+        val.Should().Be(null);
+    }
+
+    [Fact]
     public void TryGetValue_NotFound_Ok()
     {
         var key = new ResiliencePropertyKey<long>("dummy");
@@ -32,6 +44,17 @@ public class ResiliencePropertiesTests
         props.Set(key, 12345);
 
         props.GetValue(key, default).Should().Be(12345);
+    }
+
+    [Fact]
+    public void GetValue_ValueIsNull_Ok()
+    {
+        var key = new ResiliencePropertyKey<string?>("dummy");
+        var props = new ResilienceProperties();
+
+        props.Set(key, null);
+
+        props.GetValue(key, "default").Should().Be(null);
     }
 
     [Fact]


### PR DESCRIPTION
The PR adds logic to handling cases when the value being requested from `ResilienceProperties` is null.

Fixes #2299 
