### PR TITLE
Downgrade sign tool

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -33,7 +33,7 @@
       ]
     },
     "sign": {
-      "version": "0.9.1-beta.24406.1",
+      "version": "0.9.1-beta.24312.3",
       "commands": [
         "sign"
       ]


### PR DESCRIPTION
Downgrade the `sign` tool to the [same version used when we published v8.4.1](https://github.com/App-vNext/Polly/blob/2b44e7a655e4cf24f5135efcce50ac713c13abea/.config/dotnet-tools.json#L36) to see if it's the source of the failure.
