### PR TITLE
Clean the Polly.Utils.ObjectPool class

### DIFF
--- a/src/Polly.Core/Utils/ObjectPool.cs
+++ b/src/Polly.Core/Utils/ObjectPool.cs
@@ -6,7 +6,7 @@ internal sealed class ObjectPool<T>
 {
     internal static readonly int MaxCapacity = (Environment.ProcessorCount * 2) - 1; // the - 1 is to account for _fastItem
 
-    private readonly Func<ObjectPool<T>, T> _createFunc;
+    private readonly Func<T> _createFunc;
     private readonly Func<T, bool> _returnFunc;
 
     private readonly ConcurrentQueue<T> _items = new();
@@ -14,17 +14,7 @@ internal sealed class ObjectPool<T>
     private T? _fastItem;
     private int _numItems;
 
-    public ObjectPool(Func<T> createFunc, Action<T> reset)
-        : this(createFunc, o => { reset(o); return true; })
-    {
-    }
-
     public ObjectPool(Func<T> createFunc, Func<T, bool> returnFunc)
-        : this(_ => createFunc(), returnFunc)
-    {
-    }
-
-    public ObjectPool(Func<ObjectPool<T>, T> createFunc, Func<T, bool> returnFunc)
     {
         _createFunc = createFunc;
         _returnFunc = returnFunc;
@@ -42,7 +32,7 @@ internal sealed class ObjectPool<T>
             }
 
             // no object available, so go get a brand new one
-            return _createFunc(this);
+            return _createFunc();
         }
 
         return item;

--- a/test/Polly.Core.Tests/Utils/ObjectPoolTests.cs
+++ b/test/Polly.Core.Tests/Utils/ObjectPoolTests.cs
@@ -8,7 +8,7 @@ public class ObjectPoolTests
     public void GetAnd_ReturnObject_SameInstance()
     {
         // Arrange
-        var pool = new ObjectPool<object>(() => new object(), _ => { });
+        var pool = new ObjectPool<object>(() => new object(), _ => true);
 
         var obj1 = pool.Get();
         pool.Return(obj1);


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
<!-- Please include the existing GitHub issue number where relevant -->

Maintainability and code quality.

## Details on the issue fix or feature implementation

Remove code redundancy of constructors of class ObjectPool.
## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
