### PR TITLE
Remove CA2211 NoWarn

### DIFF
--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -7,7 +7,7 @@
     <ProjectType>Library</ProjectType>
     <MutationScore>70</MutationScore>
     <IncludePollyUsings>true</IncludePollyUsings>
-    <NoWarn>$(NoWarn);CA1010;CA1031;CA1051;CA1063;CA1064;CA1724;CA1816;CA2211</NoWarn>
+    <NoWarn>$(NoWarn);CA1010;CA1031;CA1051;CA1063;CA1064;CA1724;CA1816;</NoWarn>
     <NoWarn>$(NoWarn);S2223;S3215;S4039</NoWarn>
     <!--Public API Analyzers: We do not need to fix these as it would break compatibility with released Polly versions-->
     <NoWarn>$(NoWarn);RS0037;</NoWarn>

--- a/src/Polly/Utilities/SystemClock.cs
+++ b/src/Polly/Utilities/SystemClock.cs
@@ -1,6 +1,8 @@
 ﻿#nullable enable
 namespace Polly.Utilities;
 
+#pragma warning disable CA2211 // Non-constant fields should not be visible
+
 /// <summary>
 /// Time related delegates used to support different compilation targets and to improve testability of the code.
 /// </summary>

--- a/src/Polly/Utilities/TaskHelper.cs
+++ b/src/Polly/Utilities/TaskHelper.cs
@@ -6,8 +6,10 @@ namespace Polly.Utilities;
 /// </summary>
 public static class TaskHelper
 {
+#pragma warning disable CA2211 // Non-constant fields should not be visible
     /// <summary>
     /// Defines a completed Task for use as a completed, empty asynchronous delegate.
     /// </summary>
     public static Task EmptyTask = Task.CompletedTask;
+#pragma warning restore
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

https://github.com/App-vNext/Polly/issues/1290

<!-- Please include the existing GitHub issue number where relevant -->

## Details on the issue fix or feature implementation

I found that both classes SystemClock and TaskHelper are declared in the [Polly/PublicAPI.Shipped.txt](https://github.com/App-vNext/Polly/blob/main/src/Polly/PublicAPI.Shipped.txt), so I opt for disabling the warning locally to prevent adding new cases without editing the shipped API.

We can make the TaskHelper.EmptyTask get-only property and we can make SystemClock an internal class if they weren't in the shipped api.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
