### PR TITLE
Remove CA1816 NoWarn

### DIFF
--- a/src/Polly/Bulkhead/AsyncBulkheadPolicy.cs
+++ b/src/Polly/Bulkhead/AsyncBulkheadPolicy.cs
@@ -60,6 +60,7 @@ public class AsyncBulkheadPolicy : AsyncPolicy, IBulkheadPolicy
     {
         _maxParallelizationSemaphore.Dispose();
         _maxQueuedActionsSemaphore.Dispose();
+        GC.SuppressFinalize(this);
     }
 }
 
@@ -123,5 +124,6 @@ public class AsyncBulkheadPolicy<TResult> : AsyncPolicy<TResult>, IBulkheadPolic
     {
         _maxParallelizationSemaphore.Dispose();
         _maxQueuedActionsSemaphore.Dispose();
+        GC.SuppressFinalize(this);
     }
 }

--- a/src/Polly/Bulkhead/BulkheadPolicy.cs
+++ b/src/Polly/Bulkhead/BulkheadPolicy.cs
@@ -58,6 +58,7 @@ public class BulkheadPolicy : Policy, IBulkheadPolicy
     {
         _maxParallelizationSemaphore.Dispose();
         _maxQueuedActionsSemaphore.Dispose();
+        GC.SuppressFinalize(this);
     }
 }
 
@@ -118,5 +119,6 @@ public class BulkheadPolicy<TResult> : Policy<TResult>, IBulkheadPolicy<TResult>
     {
         _maxParallelizationSemaphore.Dispose();
         _maxQueuedActionsSemaphore.Dispose();
+        GC.SuppressFinalize(this);
     }
 }

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -7,7 +7,7 @@
     <ProjectType>Library</ProjectType>
     <MutationScore>70</MutationScore>
     <IncludePollyUsings>true</IncludePollyUsings>
-    <NoWarn>$(NoWarn);CA1010;CA1031;CA1051;CA1063;CA1064;CA1724;CA1816;</NoWarn>
+    <NoWarn>$(NoWarn);CA1010;CA1031;CA1051;CA1063;CA1064;CA1724;</NoWarn>
     <NoWarn>$(NoWarn);S2223;S3215;S4039</NoWarn>
     <!--Public API Analyzers: We do not need to fix these as it would break compatibility with released Polly versions-->
     <NoWarn>$(NoWarn);RS0037;</NoWarn>

--- a/src/Polly/Utilities/TimedLock.cs
+++ b/src/Polly/Utilities/TimedLock.cs
@@ -34,7 +34,9 @@ internal readonly struct TimedLock : IDisposable
 #if DEBUG
 #pragma warning disable S3234 // "GC.SuppressFinalize" should not be invoked for types without destructors
 #pragma warning disable S3971 // Do not call 'GC.SuppressFinalize'
+#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
             GC.SuppressFinalize(tl._leakDetector);
+#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
 #pragma warning restore S3971
 #pragma warning restore S3234
 #endif
@@ -64,7 +66,9 @@ internal readonly struct TimedLock : IDisposable
         // finalizer.
 #if DEBUG
 #pragma warning disable S3234 // "GC.SuppressFinalize" should not be invoked for types without destructors
+#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
         GC.SuppressFinalize(_leakDetector);
+#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
 #pragma warning restore S3234
 #endif
     }


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
https://github.com/App-vNext/Polly/issues/1290
<!-- Please include the existing GitHub issue number where relevant -->

## Details on the issue fix or feature implementation

| File  | Fix introduced |
| ------------- | ------------- |
| TimeLock  | The warning exists only in a Debug section so I preferred a local suppression   |
| AsyncBulkheadPolicy  | Add `GC.SuppressFinalize(this);` at the end f Dispose  |
| BulkheadPolicy  | Add `GC.SuppressFinalize(this);` at the end f Dispose  |
## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
