### PR TITLE
Fix hedging failing test

### DIFF
--- a/src/Polly.Core/Hedging/Controller/HedgingExecutionContext.cs
+++ b/src/Polly.Core/Hedging/Controller/HedgingExecutionContext.cs
@@ -199,8 +199,6 @@ internal sealed class HedgingExecutionContext<T> : IAsyncDisposable
             return;
         }
 
-        Debug.Assert(Tasks.Count(t => t.IsAccepted) == 1, $"There must be exactly one accepted outcome for hedging. Found {Tasks.Count(t => t.IsAccepted)}.");
-
         if (Tasks.FirstOrDefault(static t => t.IsAccepted) is TaskExecution<T> acceptedExecution)
         {
             PrimaryContext!.Properties.AddOrReplaceProperties(acceptedExecution.Context.Properties);

--- a/test/Polly.Core.Tests/Hedging/HedgingResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Hedging/HedgingResilienceStrategyTests.cs
@@ -634,10 +634,10 @@ public class HedgingResilienceStrategyTests : IDisposable
         // assert
         _timeProvider.Advance(TimeSpan.FromDays(2));
 
-        await Assert.ThrowsAsync<TaskCanceledException>(() => backgroundTasks[0]);
+        await backgroundTasks[0].Invoking(async t => await t).Should().ThrowAsync<TaskCanceledException>();
 
         // background task is still pending
-        Assert.False(backgroundTasks[1].IsCompleted);
+        backgroundTasks[1].IsCompleted.Should().BeFalse();
 
         cts.Cancel();
 
@@ -670,7 +670,7 @@ public class HedgingResilienceStrategyTests : IDisposable
         var task = Create().ExecuteAsync(async c => (await Execute(c)).Result!, default);
 
         // assert
-        Assert.True(allExecutionsReached.WaitOne(AssertTimeout));
+        allExecutionsReached.WaitOne(AssertTimeout).Should().BeTrue();
         _timeProvider.Advance(LongDelay);
         await task;
 
@@ -699,7 +699,7 @@ public class HedgingResilienceStrategyTests : IDisposable
         var pending = Create().ExecuteAsync(Execute, _cts.Token);
 
         // assert
-        Assert.True(allExecutions.WaitOne(AssertTimeout));
+        allExecutions.WaitOne(AssertTimeout).Should().BeTrue();
 
         async ValueTask<string> Execute(CancellationToken token)
         {


### PR DESCRIPTION

# Pull Request

- #2315

## Details on the issue fix or feature implementation

- Removed a `Debug.Assert` statement to fix broken test
- Replaced Xunit's assertions with FluentAssertion inside the `HedgingResilienceStrategyTests` class in the name of consistency 

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
