### PR TITLE
Supress S4039, CA1010 in Context.Dictionary

### DIFF
--- a/src/Polly/Context.Dictionary.cs
+++ b/src/Polly/Context.Dictionary.cs
@@ -1,6 +1,6 @@
 ﻿namespace Polly;
 
-#pragma warning disable CA1033 // Interface methods should be callable by child types
+#pragma warning disable CA1033,S4039 // Interface methods should be callable by child types
 
 /// <summary>
 /// Context that carries with a single execution through a Policy.   Commonly-used properties are directly on the class.  Backed by a dictionary of string key / object value pairs, to which user-defined values may be added.

--- a/src/Polly/Context.cs
+++ b/src/Polly/Context.cs
@@ -4,6 +4,7 @@ namespace Polly;
 /// Context that carries with a single execution through a Policy.   Commonly-used properties are directly on the class.  Backed by a dictionary of string key / object value pairs, to which user-defined values may be added.
 /// <remarks>Do not re-use an instance of <see cref="Context"/> across more than one call through .Execute(...) or .ExecuteAsync(...).</remarks>
 /// </summary>
+#pragma warning disable CA1010 // Collections should implement generic interface
 #pragma warning disable CA1710 // Identifiers should have correct suffix
 public partial class Context
 #pragma warning restore CA1710

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -7,8 +7,8 @@
     <ProjectType>Library</ProjectType>
     <MutationScore>70</MutationScore>
     <IncludePollyUsings>true</IncludePollyUsings>
-    <NoWarn>$(NoWarn);CA1010;CA1031;CA1051;CA1063;CA1064;CA1724;</NoWarn>
-    <NoWarn>$(NoWarn);S2223;S3215;S4039</NoWarn>
+    <NoWarn>$(NoWarn);CA1031;CA1051;CA1063;CA1064;CA1724;</NoWarn>
+    <NoWarn>$(NoWarn);S2223;S3215;</NoWarn>
     <!--Public API Analyzers: We do not need to fix these as it would break compatibility with released Polly versions-->
     <NoWarn>$(NoWarn);RS0037;</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

Related issue #1290

## Details on the issue fix or feature implementation
Reason for supressing S4039: Same as existing supression CA1033, reason refers to PR #2193.
Reason for supressing CA1010: Fixing this warning requires removing implementation for IDictionary, implement only the generic type `IDictionary<string, object>`, which would be a breaking change, so supress it.
## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
