### PR TITLE
Add TelemetrySource to ExecutionRejectedException

### DIFF
--- a/src/Polly.Core/CircuitBreaker/Controller/CircuitStateController.cs
+++ b/src/Polly.Core/CircuitBreaker/Controller/CircuitStateController.cs
@@ -96,7 +96,7 @@ internal sealed class CircuitStateController<T> : IDisposable
         lock (_lock)
         {
             var exception = new IsolatedCircuitException();
-            _telemetry.UpdateTelemetrySource(exception);
+            _telemetry.SetTelemetrySource(exception);
             SetLastHandledOutcome_NeedsLock(Outcome.FromException<T>(exception));
             OpenCircuitFor_NeedsLock(Outcome.FromResult<T>(default), TimeSpan.MaxValue, manual: true, context, out task);
             _circuitState = CircuitState.Isolated;
@@ -159,7 +159,7 @@ internal sealed class CircuitStateController<T> : IDisposable
 
         if (exception is not null)
         {
-            _telemetry.UpdateTelemetrySource(exception);
+            _telemetry.SetTelemetrySource(exception);
             return Outcome.FromException<T>(exception);
         }
 
@@ -311,12 +311,12 @@ internal sealed class CircuitStateController<T> : IDisposable
     private BrokenCircuitException CreateBrokenCircuitException()
     {
         TimeSpan retryAfter = _blockedUntil - _timeProvider.GetUtcNow();
-        BrokenCircuitException exception = _breakingException switch
+        var exception = _breakingException switch
         {
             Exception ex => new BrokenCircuitException(BrokenCircuitException.DefaultMessage, retryAfter, ex),
             _ => new BrokenCircuitException(BrokenCircuitException.DefaultMessage, retryAfter)
         };
-        _telemetry.UpdateTelemetrySource(exception);
+        _telemetry.SetTelemetrySource(exception);
         return exception;
     }
 

--- a/src/Polly.Core/CircuitBreaker/Controller/CircuitStateController.cs
+++ b/src/Polly.Core/CircuitBreaker/Controller/CircuitStateController.cs
@@ -95,7 +95,9 @@ internal sealed class CircuitStateController<T> : IDisposable
 
         lock (_lock)
         {
-            SetLastHandledOutcome_NeedsLock(Outcome.FromException<T>(new IsolatedCircuitException()));
+            var exception = new IsolatedCircuitException();
+            _telemetry.UpdateTelemetrySource(exception);
+            SetLastHandledOutcome_NeedsLock(Outcome.FromException<T>(exception));
             OpenCircuitFor_NeedsLock(Outcome.FromResult<T>(default), TimeSpan.MaxValue, manual: true, context, out task);
             _circuitState = CircuitState.Isolated;
         }
@@ -123,7 +125,7 @@ internal sealed class CircuitStateController<T> : IDisposable
     {
         EnsureNotDisposed();
 
-        Exception? exception = null;
+        BrokenCircuitException? exception = null;
         bool isHalfOpen = false;
 
         Task? task = null;
@@ -157,6 +159,7 @@ internal sealed class CircuitStateController<T> : IDisposable
 
         if (exception is not null)
         {
+            _telemetry.UpdateTelemetrySource(exception);
             return Outcome.FromException<T>(exception);
         }
 
@@ -308,11 +311,13 @@ internal sealed class CircuitStateController<T> : IDisposable
     private BrokenCircuitException CreateBrokenCircuitException()
     {
         TimeSpan retryAfter = _blockedUntil - _timeProvider.GetUtcNow();
-        return _breakingException switch
+        BrokenCircuitException exception = _breakingException switch
         {
-            Exception exception => new BrokenCircuitException(BrokenCircuitException.DefaultMessage, retryAfter, exception),
+            Exception ex => new BrokenCircuitException(BrokenCircuitException.DefaultMessage, retryAfter, ex),
             _ => new BrokenCircuitException(BrokenCircuitException.DefaultMessage, retryAfter)
         };
+        _telemetry.UpdateTelemetrySource(exception);
+        return exception;
     }
 
     private void OpenCircuit_NeedsLock(Outcome<T> outcome, bool manual, ResilienceContext context, out Task? scheduledTask)

--- a/src/Polly.Core/ExecutionRejectedException.cs
+++ b/src/Polly.Core/ExecutionRejectedException.cs
@@ -2,6 +2,8 @@
 using System.Runtime.Serialization;
 #endif
 
+using Polly.Telemetry;
+
 namespace Polly;
 
 /// <summary>
@@ -49,4 +51,10 @@ public abstract class ExecutionRejectedException : Exception
     }
 #endif
 #pragma warning restore RS0016 // Add public types and members to the declared API
+
+    /// <summary>
+    /// Gets the source of the strategy which has thrown the exception, if known.
+    /// </summary>
+    public virtual ResilienceTelemetrySource? TelemetrySource { get; internal set; }
+
 }

--- a/src/Polly.Core/ExecutionRejectedException.cs
+++ b/src/Polly.Core/ExecutionRejectedException.cs
@@ -56,5 +56,4 @@ public abstract class ExecutionRejectedException : Exception
     /// Gets the source of the strategy which has thrown the exception, if known.
     /// </summary>
     public virtual ResilienceTelemetrySource? TelemetrySource { get; internal set; }
-
 }

--- a/src/Polly.Core/PublicAPI.Unshipped.txt
+++ b/src/Polly.Core/PublicAPI.Unshipped.txt
@@ -4,4 +4,4 @@ Polly.CircuitBreaker.BrokenCircuitException.BrokenCircuitException(string! messa
 Polly.CircuitBreaker.BrokenCircuitException.BrokenCircuitException(System.TimeSpan retryAfter) -> void
 Polly.CircuitBreaker.BrokenCircuitException.RetryAfter.get -> System.TimeSpan?
 virtual Polly.ExecutionRejectedException.TelemetrySource.get -> Polly.Telemetry.ResilienceTelemetrySource?
-Polly.Telemetry.ResilienceStrategyTelemetry.UpdateTelemetrySource(Polly.ExecutionRejectedException! exception) -> void
+Polly.Telemetry.ResilienceStrategyTelemetry.SetTelemetrySource(Polly.ExecutionRejectedException! exception) -> void

--- a/src/Polly.Core/PublicAPI.Unshipped.txt
+++ b/src/Polly.Core/PublicAPI.Unshipped.txt
@@ -3,3 +3,5 @@ Polly.CircuitBreaker.BrokenCircuitException.BrokenCircuitException(string! messa
 Polly.CircuitBreaker.BrokenCircuitException.BrokenCircuitException(string! message, System.TimeSpan retryAfter, System.Exception! inner) -> void
 Polly.CircuitBreaker.BrokenCircuitException.BrokenCircuitException(System.TimeSpan retryAfter) -> void
 Polly.CircuitBreaker.BrokenCircuitException.RetryAfter.get -> System.TimeSpan?
+virtual Polly.ExecutionRejectedException.TelemetrySource.get -> Polly.Telemetry.ResilienceTelemetrySource?
+Polly.Telemetry.ResilienceStrategyTelemetry.UpdateTelemetrySource(Polly.ExecutionRejectedException! exception) -> void

--- a/src/Polly.Core/Telemetry/ResilienceStrategyTelemetry.cs
+++ b/src/Polly.Core/Telemetry/ResilienceStrategyTelemetry.cs
@@ -26,7 +26,7 @@ public sealed class ResilienceStrategyTelemetry
     /// <summary>
     ///  Sets the source of the telemetry on the provided exception.
     /// </summary>
-    /// <param name="exception">The to-be-updated exception.</param>
+    /// <param name="exception">The to-be-set exception.</param>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public void SetTelemetrySource(ExecutionRejectedException exception)
     {

--- a/src/Polly.Core/Telemetry/ResilienceStrategyTelemetry.cs
+++ b/src/Polly.Core/Telemetry/ResilienceStrategyTelemetry.cs
@@ -24,11 +24,11 @@ public sealed class ResilienceStrategyTelemetry
     internal ResilienceTelemetrySource TelemetrySource { get; }
 
     /// <summary>
-    ///  Updates the source of the telemetry on the provided exception.
+    ///  Sets the source of the telemetry on the provided exception.
     /// </summary>
     /// <param name="exception">The to-be-updated exception.</param>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public void UpdateTelemetrySource(ExecutionRejectedException exception)
+    public void SetTelemetrySource(ExecutionRejectedException exception)
     {
         Guard.NotNull(exception);
 

--- a/src/Polly.Core/Telemetry/ResilienceStrategyTelemetry.cs
+++ b/src/Polly.Core/Telemetry/ResilienceStrategyTelemetry.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace Polly.Telemetry;
 
 /// <summary>
@@ -20,6 +22,18 @@ public sealed class ResilienceStrategyTelemetry
     internal TelemetryListener? Listener { get; }
 
     internal ResilienceTelemetrySource TelemetrySource { get; }
+
+    /// <summary>
+    ///  Updates the source of the telemetry on the provided exception.
+    /// </summary>
+    /// <param name="exception">The to-be-updated exception.</param>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public void UpdateTelemetrySource(ExecutionRejectedException exception)
+    {
+        Guard.NotNull(exception);
+
+        exception.TelemetrySource = TelemetrySource;
+    }
 
     /// <summary>
     /// Reports an event that occurred in a resilience strategy.

--- a/src/Polly.Core/Timeout/TimeoutResilienceStrategy.cs
+++ b/src/Polly.Core/Timeout/TimeoutResilienceStrategy.cs
@@ -74,6 +74,7 @@ internal sealed class TimeoutResilienceStrategy : ResilienceStrategy
                 timeout,
                 e);
 
+            _telemetry.UpdateTelemetrySource(timeoutException);
             return Outcome.FromException<TResult>(timeoutException.TrySetStackTrace());
         }
 

--- a/src/Polly.Core/Timeout/TimeoutResilienceStrategy.cs
+++ b/src/Polly.Core/Timeout/TimeoutResilienceStrategy.cs
@@ -74,7 +74,7 @@ internal sealed class TimeoutResilienceStrategy : ResilienceStrategy
                 timeout,
                 e);
 
-            _telemetry.UpdateTelemetrySource(timeoutException);
+            _telemetry.SetTelemetrySource(timeoutException);
             return Outcome.FromException<TResult>(timeoutException.TrySetStackTrace());
         }
 

--- a/src/Polly.RateLimiting/RateLimiterRejectedException.cs
+++ b/src/Polly.RateLimiting/RateLimiterRejectedException.cs
@@ -44,7 +44,8 @@ public sealed class RateLimiterRejectedException : ExecutionRejectedException
     /// <param name="message">The message that describes the error.</param>
     /// <param name="retryAfter">The retry after value.</param>
     public RateLimiterRejectedException(string message, TimeSpan retryAfter)
-        : base(message) => RetryAfter = retryAfter;
+        : base(message)
+        => RetryAfter = retryAfter;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RateLimiterRejectedException"/> class.
@@ -63,7 +64,8 @@ public sealed class RateLimiterRejectedException : ExecutionRejectedException
     /// <param name="retryAfter">The retry after value.</param>
     /// <param name="inner">The inner exception.</param>
     public RateLimiterRejectedException(string message, TimeSpan retryAfter, Exception inner)
-        : base(message, inner) => RetryAfter = retryAfter;
+        : base(message, inner)
+        => RetryAfter = retryAfter;
 
     /// <summary>
     /// Gets the amount of time to wait before retrying again.
@@ -84,10 +86,10 @@ public sealed class RateLimiterRejectedException : ExecutionRejectedException
     private RateLimiterRejectedException(SerializationInfo info, StreamingContext context)
         : base(info, context)
     {
-        var value = info.GetDouble("RetryAfter");
-        if (value >= 0.0)
+        var retryAfter = info.GetDouble(nameof(RetryAfter));
+        if (retryAfter >= 0.0)
         {
-            RetryAfter = TimeSpan.FromSeconds(value);
+            RetryAfter = TimeSpan.FromSeconds(retryAfter);
         }
     }
 
@@ -96,14 +98,7 @@ public sealed class RateLimiterRejectedException : ExecutionRejectedException
     {
         Guard.NotNull(info);
 
-        if (RetryAfter.HasValue)
-        {
-            info.AddValue("RetryAfter", RetryAfter.Value.TotalSeconds);
-        }
-        else
-        {
-            info.AddValue("RetryAfter", -1.0);
-        }
+        info.AddValue(nameof(RetryAfter), RetryAfter.HasValue ? RetryAfter.Value.TotalSeconds : -1.0);
 
         base.GetObjectData(info, context);
     }

--- a/src/Polly.RateLimiting/RateLimiterResilienceStrategy.cs
+++ b/src/Polly.RateLimiting/RateLimiterResilienceStrategy.cs
@@ -65,7 +65,11 @@ internal sealed class RateLimiterResilienceStrategy : ResilienceStrategy, IDispo
             await OnLeaseRejected(new OnRateLimiterRejectedArguments(context, lease)).ConfigureAwait(context.ContinueOnCapturedContext);
         }
 
-        var exception = retryAfter.HasValue ? new RateLimiterRejectedException(retryAfter.Value) : new RateLimiterRejectedException();
+        var exception = retryAfter.HasValue
+            ? new RateLimiterRejectedException(retryAfter.Value)
+            : new RateLimiterRejectedException();
+
+        _telemetry.UpdateTelemetrySource(exception);
 
         return Outcome.FromException<TResult>(exception.TrySetStackTrace());
     }

--- a/src/Polly.RateLimiting/RateLimiterResilienceStrategy.cs
+++ b/src/Polly.RateLimiting/RateLimiterResilienceStrategy.cs
@@ -65,11 +65,11 @@ internal sealed class RateLimiterResilienceStrategy : ResilienceStrategy, IDispo
             await OnLeaseRejected(new OnRateLimiterRejectedArguments(context, lease)).ConfigureAwait(context.ContinueOnCapturedContext);
         }
 
-        var exception = retryAfter.HasValue
-            ? new RateLimiterRejectedException(retryAfter.Value)
+        var exception = retryAfter is not null
+            ? new RateLimiterRejectedException(retryAfterValue)
             : new RateLimiterRejectedException();
 
-        _telemetry.UpdateTelemetrySource(exception);
+        _telemetry.SetTelemetrySource(exception);
 
         return Outcome.FromException<TResult>(exception.TrySetStackTrace());
     }

--- a/test/Polly.Core.Tests/Telemetry/ResilienceStrategyTelemetryTests.cs
+++ b/test/Polly.Core.Tests/Telemetry/ResilienceStrategyTelemetryTests.cs
@@ -114,7 +114,6 @@ public class ResilienceStrategyTelemetryTests
 
         _sut.Invoking(s => s.UpdateTelemetrySource(exception!))
             .Should()
-            .Throw<ArgumentNullException>()
-            .WithMessage("Value cannot be null. (Parameter 'exception')");
+            .Throw<ArgumentNullException>();
     }
 }

--- a/test/Polly.Core.Tests/Telemetry/ResilienceStrategyTelemetryTests.cs
+++ b/test/Polly.Core.Tests/Telemetry/ResilienceStrategyTelemetryTests.cs
@@ -97,22 +97,22 @@ public class ResilienceStrategyTelemetryTests
     }
 
     [Fact]
-    public void UpdateTelemetrySource_Ok()
+    public void SetTelemetrySource_Ok()
     {
         var sut = new ResilienceStrategyTelemetry(_source, null);
         var exception = new TimeoutRejectedException();
 
-        sut.UpdateTelemetrySource(exception);
+        sut.SetTelemetrySource(exception);
 
         exception.TelemetrySource.Should().Be(_source);
     }
 
     [Fact]
-    public void UpdateTelemetrySource_ShouldThrow()
+    public void SetTelemetrySource_ShouldThrow()
     {
         ExecutionRejectedException? exception = null;
 
-        _sut.Invoking(s => s.UpdateTelemetrySource(exception!))
+        _sut.Invoking(s => s.SetTelemetrySource(exception!))
             .Should()
             .Throw<ArgumentNullException>();
     }

--- a/test/Polly.Core.Tests/Telemetry/ResilienceStrategyTelemetryTests.cs
+++ b/test/Polly.Core.Tests/Telemetry/ResilienceStrategyTelemetryTests.cs
@@ -1,4 +1,5 @@
 using Polly.Telemetry;
+using Polly.Timeout;
 
 namespace Polly.Core.Tests.Telemetry;
 
@@ -93,5 +94,27 @@ public class ResilienceStrategyTelemetryTests
         sut.Invoking(s => s.Report(new(ResilienceEventSeverity.None, "dummy-event"), ResilienceContextPool.Shared.Get(), new TestArguments()))
            .Should()
            .NotThrow();
+    }
+
+    [Fact]
+    public void UpdateTelemetrySource_Ok()
+    {
+        var sut = new ResilienceStrategyTelemetry(_source, null);
+        var exception = new TimeoutRejectedException();
+
+        sut.UpdateTelemetrySource(exception);
+
+        exception.TelemetrySource.Should().Be(_source);
+    }
+
+    [Fact]
+    public void UpdateTelemetrySource_ShouldThrow()
+    {
+        ExecutionRejectedException? exception = null;
+
+        _sut.Invoking(s => s.UpdateTelemetrySource(exception!))
+            .Should()
+            .Throw<ArgumentNullException>()
+            .WithMessage("Value cannot be null. (Parameter 'exception')");
     }
 }

--- a/test/Polly.RateLimiting.Tests/RateLimiterRejectedExceptionTests.cs
+++ b/test/Polly.RateLimiting.Tests/RateLimiterRejectedExceptionTests.cs
@@ -4,19 +4,67 @@ namespace Polly.Core.Tests.Timeout;
 
 public class RateLimiterRejectedExceptionTests
 {
+    private readonly string _message = "dummy";
+    private readonly TimeSpan _retryAfter = TimeSpan.FromSeconds(4);
+
     [Fact]
     public void Ctor_Ok()
     {
-        var retryAfter = TimeSpan.FromSeconds(4);
+        var exception = new RateLimiterRejectedException();
+        exception.InnerException.Should().BeNull();
+        exception.Message.Should().Be("The operation could not be executed because it was rejected by the rate limiter.");
+        exception.RetryAfter.Should().BeNull();
+        exception.TelemetrySource.Should().BeNull();
+    }
 
-        new RateLimiterRejectedException().Message.Should().Be("The operation could not be executed because it was rejected by the rate limiter.");
-        new RateLimiterRejectedException().RetryAfter.Should().BeNull();
-        new RateLimiterRejectedException("dummy").Message.Should().Be("dummy");
-        new RateLimiterRejectedException("dummy", new InvalidOperationException()).Message.Should().Be("dummy");
-        new RateLimiterRejectedException(retryAfter).RetryAfter.Should().Be(retryAfter);
-        new RateLimiterRejectedException(retryAfter).Message.Should().Be($"The operation could not be executed because it was rejected by the rate limiter. It can be retried after '{retryAfter}'.");
-        new RateLimiterRejectedException("dummy", retryAfter).RetryAfter.Should().Be(retryAfter);
-        new RateLimiterRejectedException("dummy", retryAfter, new InvalidOperationException()).RetryAfter.Should().Be(retryAfter);
+    [Fact]
+    public void Ctor_RetryAfter_Ok()
+    {
+        var exception = new RateLimiterRejectedException(_retryAfter);
+        exception.InnerException.Should().BeNull();
+        exception.Message.Should().Be($"The operation could not be executed because it was rejected by the rate limiter. It can be retried after '00:00:04'.");
+        exception.RetryAfter.Should().Be(_retryAfter);
+        exception.TelemetrySource.Should().BeNull();
+    }
+
+    [Fact]
+    public void Ctor_Message_Ok()
+    {
+        var exception = new RateLimiterRejectedException(_message);
+        exception.InnerException.Should().BeNull();
+        exception.Message.Should().Be(_message);
+        exception.RetryAfter.Should().BeNull();
+        exception.TelemetrySource.Should().BeNull();
+    }
+
+    [Fact]
+    public void Ctor_Message_RetryAfter_Ok()
+    {
+        var exception = new RateLimiterRejectedException(_message, _retryAfter);
+        exception.InnerException.Should().BeNull();
+        exception.Message.Should().Be(_message);
+        exception.RetryAfter.Should().Be(_retryAfter);
+        exception.TelemetrySource.Should().BeNull();
+    }
+
+    [Fact]
+    public void Ctor_Message_InnerException_Ok()
+    {
+        var exception = new RateLimiterRejectedException(_message, new InvalidOperationException());
+        exception.InnerException.Should().BeOfType<InvalidOperationException>();
+        exception.Message.Should().Be(_message);
+        exception.RetryAfter.Should().BeNull();
+        exception.TelemetrySource.Should().BeNull();
+    }
+
+    [Fact]
+    public void Ctor_Message_RetryAfter_InnerException_Ok()
+    {
+        var exception = new RateLimiterRejectedException(_message, _retryAfter, new InvalidOperationException());
+        exception.InnerException.Should().BeOfType<InvalidOperationException>();
+        exception.Message.Should().Be(_message);
+        exception.RetryAfter.Should().Be(_retryAfter);
+        exception.TelemetrySource.Should().BeNull();
     }
 
 #if !NETCOREAPP

--- a/test/Polly.RateLimiting.Tests/RateLimiterResilienceStrategyTests.cs
+++ b/test/Polly.RateLimiting.Tests/RateLimiterResilienceStrategyTests.cs
@@ -70,13 +70,13 @@ public class RateLimiterResilienceStrategyTests
         var context = ResilienceContextPool.Shared.Get(cts.Token);
         var outcome = await strategy.ExecuteOutcomeAsync((_, _) => Outcome.FromResultAsValueTask("dummy"), context, "state");
 
-        outcome.Exception
+        RateLimiterRejectedException exception = outcome.Exception
             .Should()
-            .BeOfType<RateLimiterRejectedException>().Subject
-            .RetryAfter
-            .Should().Be((TimeSpan?)metadata);
+            .BeOfType<RateLimiterRejectedException>().Subject;
 
-        outcome.Exception!.StackTrace.Should().Contain("Execute_LeaseRejected");
+        exception.RetryAfter.Should().Be((TimeSpan?)metadata);
+        exception.StackTrace.Should().Contain("Execute_LeaseRejected");
+        exception.TelemetrySource.Should().NotBeNull();
 
         eventCalled.Should().Be(hasEvents);
 


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

#2345 

## Details on the issue fix or feature implementation

### Done
- Added `TelemetrySource` property to the `ExecutionRejectedException`
- Extended `ResilienceStrategyTelemetry` with a `UpdateTelemetrySource` method
- Updated several strategies to populate `TelemetrySource` on the thrown exception

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
