### PR TITLE
Introduce `ExecutionRejectedException.TelemetrySource` property

### DIFF
--- a/src/Polly.Core/CircuitBreaker/BrokenCircuitException.cs
+++ b/src/Polly.Core/CircuitBreaker/BrokenCircuitException.cs
@@ -2,6 +2,8 @@
 using System.Runtime.Serialization;
 #endif
 
+using Polly.Telemetry;
+
 namespace Polly.CircuitBreaker;
 
 /// <summary>
@@ -114,4 +116,6 @@ public class BrokenCircuitException : ExecutionRejectedException
     /// Can be <see langword="null"/> if not provided or if the circuit was manually isolated.
     /// </remarks>
     public TimeSpan? RetryAfter { get; }
+
+    public ResilienceTelemetrySource? TelemetrySource { get; internal set; }
 }

--- a/src/Polly.Core/ExecutionRejectedException.cs
+++ b/src/Polly.Core/ExecutionRejectedException.cs
@@ -2,6 +2,8 @@
 using System.Runtime.Serialization;
 #endif
 
+using Polly.Telemetry;
+
 namespace Polly;
 
 /// <summary>
@@ -35,6 +37,8 @@ public abstract class ExecutionRejectedException : Exception
         : base(message, inner)
     {
     }
+
+    public ResilienceTelemetrySource? TelemetrySource { get; internal set; }
 
 #pragma warning disable RS0016 // Add public types and members to the declared API
 #if !NETCOREAPP

--- a/src/Polly.Core/Telemetry/ResilienceStrategyTelemetry.cs
+++ b/src/Polly.Core/Telemetry/ResilienceStrategyTelemetry.cs
@@ -60,6 +60,17 @@ public sealed class ResilienceStrategyTelemetry
         Listener.Write<TResult, TArgs>(new(TelemetrySource, resilienceEvent, context, args, outcome));
     }
 
+    /// <summary>
+    /// Updates the <see cref="ExecutionRejectedException.TelemetrySource"/> property of the exception.
+    /// </summary>
+    /// <param name="exception">The exception to update.</param>
+    public void UpdateTelemetrySource(ExecutionRejectedException exception)
+    {
+        Guard.NotNull(exception);
+
+        exception.TelemetrySource = TelemetrySource;
+    }
+
     internal void Report<TArgs, TResult>(ResilienceEvent resilienceEvent, TArgs args)
         where TArgs : IOutcomeArguments<TResult>
     {

--- a/src/Polly.Core/Timeout/TimeoutResilienceStrategy.cs
+++ b/src/Polly.Core/Timeout/TimeoutResilienceStrategy.cs
@@ -74,6 +74,8 @@ internal sealed class TimeoutResilienceStrategy : ResilienceStrategy
                 timeout,
                 e);
 
+            _telemetry.UpdateTelemetrySource(timeoutException);
+
             return Outcome.FromException<TResult>(timeoutException.TrySetStackTrace());
         }
 


### PR DESCRIPTION
Just an experiment on how we can uniformly introduce telemetry source to all our exceptions.

The idea is that rather to introduce many new overloads to exception constructors, we can update this property centrally. It's niche enough< so my thinking is we don't need to expose this parameter in exception constructor. If someone complains, we can do it later anyway.


Contributes to #2346 and #2345

cc @peter-csala, @martincostello 

Your thoughts?

# Pull Request

## The issue or feature being addressed

<!-- Please include the existing GitHub issue number where relevant -->

## Details on the issue fix or feature implementation

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build
