### PR TITLE
Increase test timeout

### DIFF
--- a/test/Polly.Core.Tests/Issues/IssuesTests.InfiniteRetry_2163.cs
+++ b/test/Polly.Core.Tests/Issues/IssuesTests.InfiniteRetry_2163.cs
@@ -5,7 +5,7 @@ namespace Polly.Core.Tests.Issues;
 
 public partial class IssuesTests
 {
-    [Fact(Timeout = 15_000)]
+    [Fact(Timeout = 30_000)]
     public async Task InfiniteRetry_Delay_Does_Not_Overflow_2163()
     {
         // Arrange


### PR DESCRIPTION
Increase the timeout on the `InfiniteRetry_Delay_Does_Not_Overflow_2163` test to (hopefully) reduce test flakiness in CI.
