### PR TITLE
Handle CancellationToken for Retry

### DIFF
--- a/src/Polly.Core/Retry/RetryResilienceStrategy.cs
+++ b/src/Polly.Core/Retry/RetryResilienceStrategy.cs
@@ -76,7 +76,7 @@ internal sealed class RetryResilienceStrategy<T> : ResilienceStrategy<T>
                 TelemetryUtil.ReportExecutionAttempt(_telemetry, context, outcome, attempt, executionTime, handle);
             }
 
-            if (isLastAttempt || !handle)
+            if (context.CancellationToken.IsCancellationRequested || isLastAttempt || !handle)
             {
                 return outcome;
             }


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

#2375 

## Details on the issue fix or feature implementation

- Retry: handle cancelled `CancellationToken` as `OperationCanceledException`
- Assessment
  - Hedging: handles cancelled `CancellationToken` as `OperationCanceledException`
  - Timeout: does not handle cancelled `CancellationToken` as `OperationCanceledException`
    - We might want to tackle that as a separate PR 

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
