### PR TITLE
Allow roll-forward for dotnet-validate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -234,7 +234,7 @@ jobs:
       env:
         DOTNET_VALIDATE_VERSION: ${{ needs.build.outputs.dotnet-validate-version }}
       run: |
-        dotnet tool install --global dotnet-validate --version ${env:DOTNET_VALIDATE_VERSION}
+        dotnet tool install --global dotnet-validate --version ${env:DOTNET_VALIDATE_VERSION} --allow-roll-forward
         $packages = Get-ChildItem -Filter "*.nupkg" | ForEach-Object { $_.FullName }
         $invalidPackages = 0
         foreach ($package in $packages) {


### PR DESCRIPTION
Fix package validation by allowing `dotnet-validate` to roll-forward to a newer .NET runtime than .NET 6.

Otherwise when the GitHub Actions `ubuntu-latest` label rolls over to Ubuntu 24.04, .NET 6 will no longer be installed and the job will fail. See https://github.com/actions/runner-images/issues/10636.
