### PR TITLE
Fix sliding window ratelimiter examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,7 @@ new ResiliencePipelineBuilder()
         new SlidingWindowRateLimiterOptions
         {
             PermitLimit = 100,
+            SegmentsPerWindow = 4,
             Window = TimeSpan.FromMinutes(1)
         }));
 ```

--- a/docs/migration-v8.md
+++ b/docs/migration-v8.md
@@ -468,6 +468,7 @@ ResiliencePipeline pipeline = new ResiliencePipelineBuilder()
     .AddRateLimiter(new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions
     {
         PermitLimit = 100,
+        SegmentsPerWindow = 4,
         Window = TimeSpan.FromMinutes(1),
     }))
     .Build();
@@ -479,6 +480,7 @@ ResiliencePipeline<HttpResponseMessage> pipelineT = new ResiliencePipelineBuilde
     .AddRateLimiter(new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions
     {
         PermitLimit = 100,
+        SegmentsPerWindow = 4,
         Window = TimeSpan.FromMinutes(1),
     }))
     .Build();

--- a/docs/strategies/rate-limiter.md
+++ b/docs/strategies/rate-limiter.md
@@ -41,6 +41,7 @@ new ResiliencePipelineBuilder()
         new SlidingWindowRateLimiterOptions
         {
             PermitLimit = 100,
+            SegmentsPerWindow = 4,
             Window = TimeSpan.FromMinutes(1)
         }));
 ```

--- a/src/Polly.RateLimiting/README.md
+++ b/src/Polly.RateLimiting/README.md
@@ -27,6 +27,7 @@ new ResiliencePipelineBuilder()
         new SlidingWindowRateLimiterOptions
         {
             PermitLimit = 100,
+            SegmentsPerWindow = 4,
             Window = TimeSpan.FromMinutes(1)
         }));
 ```

--- a/src/Snippets/Docs/Migration.RateLimiter.cs
+++ b/src/Snippets/Docs/Migration.RateLimiter.cs
@@ -44,6 +44,7 @@ internal static partial class Migration
             .AddRateLimiter(new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions
             {
                 PermitLimit = 100,
+                SegmentsPerWindow = 4,
                 Window = TimeSpan.FromMinutes(1),
             }))
             .Build();
@@ -55,6 +56,7 @@ internal static partial class Migration
             .AddRateLimiter(new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions
             {
                 PermitLimit = 100,
+                SegmentsPerWindow = 4,
                 Window = TimeSpan.FromMinutes(1),
             }))
             .Build();

--- a/src/Snippets/Docs/RateLimiter.cs
+++ b/src/Snippets/Docs/RateLimiter.cs
@@ -25,6 +25,7 @@ internal static class RateLimiter
                 new SlidingWindowRateLimiterOptions
                 {
                     PermitLimit = 100,
+                    SegmentsPerWindow = 4,
                     Window = TimeSpan.FromMinutes(1)
                 }));
 


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed

During this discussion #2425 I've realized that the current sample codes are failing with

>  System.ArgumentException: SegmentsPerWindow must be set to a value greater than 0. (Parameter 'options')

## Details on the issue fix or feature implementation

- Set the `SegmentsPerWindow ` to 4

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
