### PR TITLE
Fix Registry vs. Provider Migration doc typo

### DIFF
--- a/docs/migration-v8.md
+++ b/docs/migration-v8.md
@@ -1006,8 +1006,8 @@ In v7, the following registry APIs are exposed:
 
 In v8, these have been replaced by:
 
-- `ResiliencePipelineProvider<TKey>`: Allows adding and accessing resilience pipelines.
-- `ResiliencePipelineRegistry<TKey>`: Read-only access to resilience pipelines.
+- `ResiliencePipelineRegistry<TKey>`: Allows adding and accessing resilience pipelines.
+- `ResiliencePipelineProvider<TKey>`: Read-only access to resilience pipelines.
 
 The main updates:
 


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

The descriptions of `ResiliencePipelineProvider` & `ResiliencePipelineRegistry` are swapped.

## Details on the issue fix or feature implementation

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build
