### PR TITLE
Use Shouldly in all test projects except Polly.Specs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,6 +39,7 @@
     <PackageVersion Include="Polly.Testing" Version="$(PollyVersion)" />
     <PackageVersion Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageVersion Include="ReportGenerator" Version="5.4.3" />
+    <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.5.0.109200" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="4.5.0" />

--- a/eng/Test.targets
+++ b/eng/Test.targets
@@ -6,13 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Using Include="FluentAssertions"/>
-    <Using Include="Xunit"/>
+    <Using Include="Xunit" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" PrivateAssets="all" />
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="GitHubActionsTestLogger" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />

--- a/test/Polly.Core.Tests/CircuitBreaker/BreakDurationGeneratorArgumentsTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/BreakDurationGeneratorArgumentsTests.cs
@@ -14,9 +14,9 @@ public class BreakDurationGeneratorArgumentsTests
 
         var args = new BreakDurationGeneratorArguments(expectedFailureRate, failureCount, context);
 
-        args.FailureRate.Should().Be(expectedFailureRate);
-        args.FailureCount.Should().Be(failureCount);
-        args.Context.Should().Be(context);
+        args.FailureRate.ShouldBe(expectedFailureRate);
+        args.FailureCount.ShouldBe(failureCount);
+        args.Context.ShouldBe(context);
     }
 
     [Fact]
@@ -28,9 +28,9 @@ public class BreakDurationGeneratorArgumentsTests
 
         var args = new BreakDurationGeneratorArguments(expectedFailureRate, failureCount, context, 99);
 
-        args.FailureRate.Should().Be(expectedFailureRate);
-        args.FailureCount.Should().Be(failureCount);
-        args.Context.Should().Be(context);
-        args.HalfOpenAttempts.Should().Be(99);
+        args.FailureRate.ShouldBe(expectedFailureRate);
+        args.FailureCount.ShouldBe(failureCount);
+        args.Context.ShouldBe(context);
+        args.HalfOpenAttempts.ShouldBe(99);
     }
 }

--- a/test/Polly.Core.Tests/CircuitBreaker/BrokenCircuitExceptionTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/BrokenCircuitExceptionTests.cs
@@ -8,50 +8,50 @@ public class BrokenCircuitExceptionTests
     public void Ctor_Default_Ok()
     {
         var exception = new BrokenCircuitException();
-        exception.Message.Should().Be("The circuit is now open and is not allowing calls.");
-        exception.RetryAfter.Should().BeNull();
+        exception.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        exception.RetryAfter.ShouldBeNull();
     }
 
     [Fact]
     public void Ctor_Message_Ok()
     {
         var exception = new BrokenCircuitException(TestMessage);
-        exception.Message.Should().Be(TestMessage);
-        exception.RetryAfter.Should().BeNull();
+        exception.Message.ShouldBe(TestMessage);
+        exception.RetryAfter.ShouldBeNull();
     }
 
     [Fact]
     public void Ctor_RetryAfter_Ok()
     {
         var exception = new BrokenCircuitException(TestRetryAfter);
-        exception.Message.Should().Be($"The circuit is now open and is not allowing calls. It can be retried after '{TestRetryAfter}'.");
-        exception.RetryAfter.Should().Be(TestRetryAfter);
+        exception.Message.ShouldBe($"The circuit is now open and is not allowing calls. It can be retried after '{TestRetryAfter}'.");
+        exception.RetryAfter.ShouldBe(TestRetryAfter);
     }
 
     [Fact]
     public void Ctor_Message_RetryAfter_Ok()
     {
         var exception = new BrokenCircuitException(TestMessage, TestRetryAfter);
-        exception.Message.Should().Be(TestMessage);
-        exception.RetryAfter.Should().Be(TestRetryAfter);
+        exception.Message.ShouldBe(TestMessage);
+        exception.RetryAfter.ShouldBe(TestRetryAfter);
     }
 
     [Fact]
     public void Ctor_Message_InnerException_Ok()
     {
         var exception = new BrokenCircuitException(TestMessage, new InvalidOperationException());
-        exception.Message.Should().Be(TestMessage);
-        exception.InnerException.Should().BeOfType<InvalidOperationException>();
-        exception.RetryAfter.Should().BeNull();
+        exception.Message.ShouldBe(TestMessage);
+        exception.InnerException.ShouldBeOfType<InvalidOperationException>();
+        exception.RetryAfter.ShouldBeNull();
     }
 
     [Fact]
     public void Ctor_Message_RetryAfter_InnerException_Ok()
     {
         var exception = new BrokenCircuitException(TestMessage, TestRetryAfter, new InvalidOperationException());
-        exception.Message.Should().Be(TestMessage);
-        exception.InnerException.Should().BeOfType<InvalidOperationException>();
-        exception.RetryAfter.Should().Be(TestRetryAfter);
+        exception.Message.ShouldBe(TestMessage);
+        exception.InnerException.ShouldBeOfType<InvalidOperationException>();
+        exception.RetryAfter.ShouldBe(TestRetryAfter);
     }
 
 #if NETFRAMEWORK
@@ -60,10 +60,10 @@ public class BrokenCircuitExceptionTests
     {
         var exception = new BrokenCircuitException(TestMessage, TestRetryAfter, new InvalidOperationException());
         BrokenCircuitException roundtripResult = BinarySerializationUtil.SerializeAndDeserializeException(exception);
-        roundtripResult.Should().NotBeNull();
-        roundtripResult.Message.Should().Be(TestMessage);
-        roundtripResult.InnerException.Should().BeOfType<InvalidOperationException>();
-        roundtripResult.RetryAfter.Should().Be(TestRetryAfter);
+        roundtripResult.ShouldNotBeNull();
+        roundtripResult.Message.ShouldBe(TestMessage);
+        roundtripResult.InnerException.ShouldBeOfType<InvalidOperationException>();
+        roundtripResult.RetryAfter.ShouldBe(TestRetryAfter);
     }
 
     [Fact]
@@ -71,10 +71,10 @@ public class BrokenCircuitExceptionTests
     {
         var exception = new BrokenCircuitException(TestMessage, new InvalidOperationException());
         BrokenCircuitException roundtripResult = BinarySerializationUtil.SerializeAndDeserializeException(exception);
-        roundtripResult.Should().NotBeNull();
-        roundtripResult.Message.Should().Be(TestMessage);
-        roundtripResult.InnerException.Should().BeOfType<InvalidOperationException>();
-        roundtripResult.RetryAfter.Should().BeNull();
+        roundtripResult.ShouldNotBeNull();
+        roundtripResult.Message.ShouldBe(TestMessage);
+        roundtripResult.InnerException.ShouldBeOfType<InvalidOperationException>();
+        roundtripResult.RetryAfter.ShouldBeNull();
     }
 #endif
 

--- a/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerManualControlTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerManualControlTests.cs
@@ -15,13 +15,13 @@ public class CircuitBreakerManualControlTests
         using var reg = control.Initialize(
             c =>
             {
-                c.IsSynchronous.Should().BeTrue();
+                c.IsSynchronous.ShouldBeTrue();
                 isolateCalled = true;
                 return Task.CompletedTask;
             },
             _ => Task.CompletedTask);
 
-        isolateCalled.Should().Be(isolated);
+        isolateCalled.ShouldBe(isolated);
     }
 
     [InlineData(true)]
@@ -42,13 +42,13 @@ public class CircuitBreakerManualControlTests
         using var reg = control.Initialize(
             c =>
             {
-                c.IsSynchronous.Should().BeTrue();
+                c.IsSynchronous.ShouldBeTrue();
                 isolated = true;
                 return Task.CompletedTask;
             },
             _ => Task.CompletedTask);
 
-        isolated.Should().Be(!closedAfter);
+        isolated.ShouldBe(!closedAfter);
     }
 
     [Fact]
@@ -56,10 +56,7 @@ public class CircuitBreakerManualControlTests
     {
         var control = new CircuitBreakerManualControl();
 
-        await control
-            .Invoking(c => c.CloseAsync())
-            .Should()
-            .NotThrowAsync();
+        await Should.NotThrowAsync(() => control.CloseAsync());
     }
 
     [Fact]
@@ -74,7 +71,7 @@ public class CircuitBreakerManualControlTests
         await control.IsolateAsync(cancellationToken);
         await control.CloseAsync(cancellationToken);
 
-        called.Should().Be(2);
+        called.ShouldBe(2);
     }
 
     [Fact]
@@ -93,7 +90,7 @@ public class CircuitBreakerManualControlTests
         await control.IsolateAsync(cancellationToken);
         await control.CloseAsync(cancellationToken);
 
-        called.Should().Be(2);
+        called.ShouldBe(2);
     }
 
     [Fact]
@@ -107,15 +104,15 @@ public class CircuitBreakerManualControlTests
         control.Initialize(
             context =>
             {
-                context.IsVoid.Should().BeTrue();
-                context.IsSynchronous.Should().BeFalse();
+                context.IsVoid.ShouldBeTrue();
+                context.IsSynchronous.ShouldBeFalse();
                 isolateCalled = true;
                 return Task.CompletedTask;
             },
             context =>
             {
-                context.IsVoid.Should().BeTrue();
-                context.IsSynchronous.Should().BeFalse();
+                context.IsVoid.ShouldBeTrue();
+                context.IsSynchronous.ShouldBeFalse();
                 resetCalled = true;
                 return Task.CompletedTask;
             });
@@ -123,7 +120,7 @@ public class CircuitBreakerManualControlTests
         await control.IsolateAsync(cancellationToken);
         await control.CloseAsync(cancellationToken);
 
-        isolateCalled.Should().BeTrue();
-        resetCalled.Should().BeTrue();
+        isolateCalled.ShouldBeTrue();
+        resetCalled.ShouldBeTrue();
     }
 }

--- a/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerOptionsTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerOptionsTests.cs
@@ -12,9 +12,9 @@ public class CircuitBreakerOptionsTests
         var options = new CircuitBreakerStrategyOptions();
         var context = ResilienceContextPool.Shared.Get();
 
-        (await options.ShouldHandle(new CircuitBreakerPredicateArguments<object>(context, Outcome.FromResult<object>("dummy")))).Should().Be(false);
-        (await options.ShouldHandle(new CircuitBreakerPredicateArguments<object>(context, Outcome.FromException<object>(new OperationCanceledException())))).Should().Be(false);
-        (await options.ShouldHandle(new CircuitBreakerPredicateArguments<object>(context, Outcome.FromException<object>(new InvalidOperationException())))).Should().Be(true);
+        (await options.ShouldHandle(new CircuitBreakerPredicateArguments<object>(context, Outcome.FromResult<object>("dummy")))).ShouldBe(false);
+        (await options.ShouldHandle(new CircuitBreakerPredicateArguments<object>(context, Outcome.FromException<object>(new OperationCanceledException())))).ShouldBe(false);
+        (await options.ShouldHandle(new CircuitBreakerPredicateArguments<object>(context, Outcome.FromException<object>(new InvalidOperationException())))).ShouldBe(true);
     }
 
     [Fact]
@@ -22,15 +22,15 @@ public class CircuitBreakerOptionsTests
     {
         var options = new CircuitBreakerStrategyOptions<int>();
 
-        options.BreakDuration.Should().Be(TimeSpan.FromSeconds(5));
-        options.FailureRatio.Should().Be(0.1);
-        options.MinimumThroughput.Should().Be(100);
-        options.SamplingDuration.Should().Be(TimeSpan.FromSeconds(30));
-        options.OnOpened.Should().BeNull();
-        options.OnClosed.Should().BeNull();
-        options.OnHalfOpened.Should().BeNull();
-        options.ShouldHandle.Should().NotBeNull();
-        options.Name.Should().Be("CircuitBreaker");
+        options.BreakDuration.ShouldBe(TimeSpan.FromSeconds(5));
+        options.FailureRatio.ShouldBe(0.1);
+        options.MinimumThroughput.ShouldBe(100);
+        options.SamplingDuration.ShouldBe(TimeSpan.FromSeconds(30));
+        options.OnOpened.ShouldBeNull();
+        options.OnClosed.ShouldBeNull();
+        options.OnHalfOpened.ShouldBeNull();
+        options.ShouldHandle.ShouldNotBeNull();
+        options.Name.ShouldBe("CircuitBreaker");
 
         // now set to min values
         options.FailureRatio = 0.001;
@@ -56,18 +56,15 @@ public class CircuitBreakerOptionsTests
             ShouldHandle = null!,
         };
 
-        options
-            .Invoking(o => ValidationHelper.ValidateObject(new(o, "Dummy.")))
-            .Should()
-            .Throw<ValidationException>()
-            .WithMessage("""
+        var exception = Should.Throw<ValidationException>(() => ValidationHelper.ValidateObject(new(options, "Dummy.")));
+        exception.Message.Trim().ShouldBe("""
             Dummy.
-
             Validation Errors:
             The field MinimumThroughput must be between 2 and 2147483647.
             The field SamplingDuration must be between 00:00:00.5000000 and 1.00:00:00.
             The field BreakDuration must be between 00:00:00.5000000 and 1.00:00:00.
             The ShouldHandle field is required.
-            """);
+            """,
+            StringCompareShould.IgnoreLineEndings);
     }
 }

--- a/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerPredicateArgumentsTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerPredicateArgumentsTests.cs
@@ -11,7 +11,7 @@ public static class CircuitBreakerPredicateArgumentsTests
             ResilienceContextPool.Shared.Get(CancellationToken.None),
             Outcome.FromResult(1));
 
-        args.Context.Should().NotBeNull();
-        args.Outcome.Result.Should().Be(1);
+        args.Context.ShouldNotBeNull();
+        args.Outcome.Result.ShouldBe(1);
     }
 }

--- a/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerResiliencePipelineBuilderTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerResiliencePipelineBuilderTests.cs
@@ -33,7 +33,7 @@ public class CircuitBreakerResiliencePipelineBuilderTests
 
         builderAction(builder);
 
-        builder.Build().GetPipelineDescriptor().FirstStrategy.StrategyInstance.Should().BeOfType<CircuitBreakerResilienceStrategy<object>>();
+        builder.Build().GetPipelineDescriptor().FirstStrategy.StrategyInstance.ShouldBeOfType<CircuitBreakerResilienceStrategy<object>>();
     }
 
     [MemberData(nameof(ConfigureDataGeneric))]
@@ -44,21 +44,14 @@ public class CircuitBreakerResiliencePipelineBuilderTests
 
         builderAction(builder);
 
-        builder.Build().GetPipelineDescriptor().FirstStrategy.StrategyInstance.Should().BeOfType<CircuitBreakerResilienceStrategy<int>>();
+        builder.Build().GetPipelineDescriptor().FirstStrategy.StrategyInstance.ShouldBeOfType<CircuitBreakerResilienceStrategy<int>>();
     }
 
     [Fact]
     public void AddCircuitBreaker_Validation()
     {
-        new ResiliencePipelineBuilder<int>()
-            .Invoking(b => b.AddCircuitBreaker(new CircuitBreakerStrategyOptions<int> { BreakDuration = TimeSpan.MinValue }))
-            .Should()
-            .Throw<ValidationException>();
-
-        new ResiliencePipelineBuilder()
-            .Invoking(b => b.AddCircuitBreaker(new CircuitBreakerStrategyOptions { BreakDuration = TimeSpan.MinValue }))
-            .Should()
-            .Throw<ValidationException>();
+        Should.Throw<ValidationException>(() => new ResiliencePipelineBuilder<int>().AddCircuitBreaker(new CircuitBreakerStrategyOptions<int> { BreakDuration = TimeSpan.MinValue }));
+        Should.Throw<ValidationException>(() => new ResiliencePipelineBuilder().AddCircuitBreaker(new CircuitBreakerStrategyOptions { BreakDuration = TimeSpan.MinValue }));
     }
 
     [Fact]
@@ -93,35 +86,35 @@ public class CircuitBreakerResiliencePipelineBuilderTests
         }
 
         // Circuit opened
-        opened.Should().Be(1);
-        halfOpened.Should().Be(0);
-        closed.Should().Be(0);
+        opened.ShouldBe(1);
+        halfOpened.ShouldBe(0);
+        closed.ShouldBe(0);
         BrokenCircuitException exception = Assert.Throws<BrokenCircuitException>(() => strategy.Execute(_ => 0, cancellationToken));
-        exception.RetryAfter.Should().Be(breakDuration);
+        exception.RetryAfter.ShouldBe(breakDuration);
 
         // Circuit still open after some time
         timeProvider.Advance(halfBreakDuration);
-        opened.Should().Be(1);
-        halfOpened.Should().Be(0);
-        closed.Should().Be(0);
+        opened.ShouldBe(1);
+        halfOpened.ShouldBe(0);
+        closed.ShouldBe(0);
         exception = Assert.Throws<BrokenCircuitException>(() => strategy.Execute(_ => 0, cancellationToken));
-        exception.RetryAfter.Should().Be(halfBreakDuration);
+        exception.RetryAfter.ShouldBe(halfBreakDuration);
 
         // Circuit Half Opened
         timeProvider.Advance(halfBreakDuration);
         strategy.Execute(_ => -1, cancellationToken);
         exception = Assert.Throws<BrokenCircuitException>(() => strategy.Execute(_ => 0, cancellationToken));
-        opened.Should().Be(2);
-        halfOpened.Should().Be(1);
-        closed.Should().Be(0);
-        exception.RetryAfter.Should().Be(breakDuration);
+        opened.ShouldBe(2);
+        halfOpened.ShouldBe(1);
+        closed.ShouldBe(0);
+        exception.RetryAfter.ShouldBe(breakDuration);
 
         // Now close it
         timeProvider.Advance(breakDuration);
         strategy.Execute(_ => 0, cancellationToken);
-        opened.Should().Be(2);
-        halfOpened.Should().Be(2);
-        closed.Should().Be(1);
+        opened.ShouldBe(2);
+        halfOpened.ShouldBe(2);
+        closed.ShouldBe(1);
     }
 
     [Fact]
@@ -157,35 +150,35 @@ public class CircuitBreakerResiliencePipelineBuilderTests
         }
 
         // Circuit opened
-        opened.Should().Be(1);
-        halfOpened.Should().Be(0);
-        closed.Should().Be(0);
+        opened.ShouldBe(1);
+        halfOpened.ShouldBe(0);
+        closed.ShouldBe(0);
         BrokenCircuitException exception = Assert.Throws<BrokenCircuitException>(() => strategy.Execute(_ => 0, cancellationToken));
-        exception.RetryAfter.Should().Be(breakDuration);
+        exception.RetryAfter.ShouldBe(breakDuration);
 
         // Circuit still open after some time
         timeProvider.Advance(halfBreakDuration);
-        opened.Should().Be(1);
-        halfOpened.Should().Be(0);
-        closed.Should().Be(0);
+        opened.ShouldBe(1);
+        halfOpened.ShouldBe(0);
+        closed.ShouldBe(0);
         exception = Assert.Throws<BrokenCircuitException>(() => strategy.Execute(_ => 0, cancellationToken));
-        exception.RetryAfter.Should().Be(halfBreakDuration);
+        exception.RetryAfter.ShouldBe(halfBreakDuration);
 
         // Circuit Half Opened
         timeProvider.Advance(halfBreakDuration);
         strategy.Execute(_ => -1, cancellationToken);
         exception = Assert.Throws<BrokenCircuitException>(() => strategy.Execute(_ => 0, cancellationToken));
-        opened.Should().Be(2);
-        halfOpened.Should().Be(1);
-        closed.Should().Be(0);
-        exception.RetryAfter.Should().Be(breakDuration);
+        opened.ShouldBe(2);
+        halfOpened.ShouldBe(1);
+        closed.ShouldBe(0);
+        exception.RetryAfter.ShouldBe(breakDuration);
 
         // Now close it
         timeProvider.Advance(breakDuration);
         strategy.Execute(_ => 0, cancellationToken);
-        opened.Should().Be(2);
-        halfOpened.Should().Be(2);
-        closed.Should().Be(1);
+        opened.ShouldBe(2);
+        halfOpened.ShouldBe(2);
+        closed.ShouldBe(1);
     }
 
     [Fact]
@@ -203,8 +196,8 @@ public class CircuitBreakerResiliencePipelineBuilderTests
             .AddCircuitBreaker(new() { ManualControl = manualControl })
             .Build();
 
-        strategy1.Invoking(s => s.Execute(() => { })).Should().Throw<IsolatedCircuitException>().Where(e => e.RetryAfter == null);
-        strategy2.Invoking(s => s.Execute(() => { })).Should().Throw<IsolatedCircuitException>().Where(e => e.RetryAfter == null);
+        Should.Throw<IsolatedCircuitException>(() => strategy1.Execute(() => { })).RetryAfter.ShouldBeNull();
+        Should.Throw<IsolatedCircuitException>(() => strategy2.Execute(() => { })).RetryAfter.ShouldBeNull();
 
         await manualControl.CloseAsync(cancellationToken);
 
@@ -227,18 +220,18 @@ public class CircuitBreakerResiliencePipelineBuilderTests
 
         if (attachManualControl)
         {
-            manualControl!.IsEmpty.Should().BeFalse();
+            manualControl!.IsEmpty.ShouldBeFalse();
         }
 
         var strategy = (ResilienceStrategy<object>)pipeline.GetPipelineDescriptor().FirstStrategy.StrategyInstance;
 
         await pipeline.DisposeHelper.DisposeAsync();
 
-        strategy.AsPipeline().Invoking(s => s.Execute(() => 1)).Should().Throw<ObjectDisposedException>();
+        Should.Throw<ObjectDisposedException>(() => strategy.AsPipeline().Execute(() => 1));
 
         if (attachManualControl)
         {
-            manualControl!.IsEmpty.Should().BeTrue();
+            manualControl!.IsEmpty.ShouldBeTrue();
         }
     }
 }

--- a/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerStateProviderTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/CircuitBreakerStateProviderTests.cs
@@ -9,7 +9,7 @@ public class CircuitBreakerStateProviderTests
     {
         var provider = new CircuitBreakerStateProvider();
 
-        provider.IsInitialized.Should().BeFalse();
+        provider.IsInitialized.ShouldBeFalse();
     }
 
     [Fact]
@@ -17,7 +17,7 @@ public class CircuitBreakerStateProviderTests
     {
         var provider = new CircuitBreakerStateProvider();
 
-        provider.CircuitState.Should().Be(CircuitState.Closed);
+        provider.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
@@ -25,10 +25,7 @@ public class CircuitBreakerStateProviderTests
     {
         var control = new CircuitBreakerManualControl();
 
-        await control
-            .Invoking(c => c.CloseAsync(CancellationToken.None))
-            .Should()
-            .NotThrowAsync<InvalidOperationException>();
+        await Should.NotThrowAsync(() => control.CloseAsync(CancellationToken.None));
     }
 
     [Fact]
@@ -37,10 +34,7 @@ public class CircuitBreakerStateProviderTests
         var provider = new CircuitBreakerStateProvider();
         provider.Initialize(() => CircuitState.Closed);
 
-        provider
-            .Invoking(c => c.Initialize(() => CircuitState.Closed))
-            .Should()
-            .Throw<InvalidOperationException>();
+        Should.Throw<InvalidOperationException>(() => provider.Initialize(() => CircuitState.Closed));
     }
 
     [Fact]
@@ -56,8 +50,8 @@ public class CircuitBreakerStateProviderTests
                 return CircuitState.HalfOpen;
             });
 
-        provider.CircuitState.Should().Be(CircuitState.HalfOpen);
+        provider.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
-        stateCalled.Should().BeTrue();
+        stateCalled.ShouldBeTrue();
     }
 }

--- a/test/Polly.Core.Tests/CircuitBreaker/Controller/AdvancedCircuitBehaviorTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/Controller/AdvancedCircuitBehaviorTests.cs
@@ -28,7 +28,7 @@ public class AdvancedCircuitBehaviorTests
 
         behavior.OnActionFailure(CircuitState.Closed, out var shouldBreak);
 
-        shouldBreak.Should().Be(expectedShouldBreak);
+        shouldBreak.ShouldBe(expectedShouldBreak);
         _metrics.Received(1).IncrementFailure();
     }
 
@@ -44,7 +44,7 @@ public class AdvancedCircuitBehaviorTests
         var sut = Create();
         sut.OnActionFailure(state, out var shouldBreak);
 
-        shouldBreak.Should().BeFalse();
+        shouldBreak.ShouldBeFalse();
         if (shouldIncrementFailure)
         {
             _metrics.Received(1).IncrementFailure();
@@ -83,8 +83,8 @@ public class AdvancedCircuitBehaviorTests
         _metrics.GetHealthInfo().Returns(new HealthInfo(throughput, failureRate, failureCount));
         var behavior = new AdvancedCircuitBehavior(anyFailureThreshold, anyMinimumThruput, _metrics);
 
-        behavior.FailureCount.Should().Be(failureCount, "because the FailureCount should match the HealthInfo");
-        behavior.FailureRate.Should().Be(failureRate, "because the FailureRate should match the HealthInfo");
+        behavior.FailureCount.ShouldBe(failureCount, "because the FailureCount should match the HealthInfo");
+        behavior.FailureRate.ShouldBe(failureRate, "because the FailureRate should match the HealthInfo");
     }
 
     private AdvancedCircuitBehavior Create() =>

--- a/test/Polly.Core.Tests/CircuitBreaker/Controller/ScheduledTaskExecutorTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/Controller/ScheduledTaskExecutorTests.cs
@@ -22,7 +22,7 @@ public class ScheduledTaskExecutorTests
 
         await task;
 
-        executed.Should().BeTrue();
+        executed.ShouldBeTrue();
     }
 
     [Fact]
@@ -34,7 +34,7 @@ public class ScheduledTaskExecutorTests
             ResilienceContextPool.Shared.Get(CancellationToken),
             out var task);
 
-        await task.Invoking(async t => await task).Should().ThrowAsync<OperationCanceledException>();
+        await Should.ThrowAsync<OperationCanceledException>(() => task);
     }
 
     [Fact]
@@ -46,7 +46,7 @@ public class ScheduledTaskExecutorTests
             ResilienceContextPool.Shared.Get(CancellationToken),
             out var task);
 
-        await task.Invoking(async t => await task).Should().ThrowAsync<InvalidOperationException>();
+        await Should.ThrowAsync<InvalidOperationException>(() => task);
     }
 
     [Fact]
@@ -71,7 +71,7 @@ public class ScheduledTaskExecutorTests
         scheduler.ScheduleTask(() => Task.CompletedTask, ResilienceContextPool.Shared.Get(CancellationToken), out var otherTask);
 
 #pragma warning disable xUnit1031 // Do not use blocking task operations in test method
-        otherTask.Wait(50, CancellationToken).Should().BeFalse();
+        otherTask.Wait(50, CancellationToken).ShouldBeFalse();
 #pragma warning restore xUnit1031 // Do not use blocking task operations in test method
 
         verified.Set();
@@ -103,12 +103,10 @@ public class ScheduledTaskExecutorTests
         verified.Set();
         await task;
 
-        await otherTask.Invoking(t => otherTask).Should().ThrowAsync<OperationCanceledException>();
+        await Should.ThrowAsync<OperationCanceledException>(() => otherTask);
 
-        scheduler
-            .Invoking(s => s.ScheduleTask(() => Task.CompletedTask, ResilienceContextPool.Shared.Get(CancellationToken), out _))
-            .Should()
-            .Throw<ObjectDisposedException>();
+        Should.Throw<ObjectDisposedException>(
+            () => scheduler.ScheduleTask(() => Task.CompletedTask, ResilienceContextPool.Shared.Get(CancellationToken), out _));
     }
 
     [Fact]
@@ -130,15 +128,15 @@ public class ScheduledTaskExecutorTests
             ResilienceContextPool.Shared.Get(CancellationToken),
             out var task);
 
-        ready.WaitOne(timeout).Should().BeTrue();
+        ready.WaitOne(timeout).ShouldBeTrue();
         scheduler.Dispose();
         disposed.Set();
 
 #pragma warning disable xUnit1031
 #if NET
-        scheduler.ProcessingTask.Wait(timeout, CancellationToken).Should().BeTrue();
+        scheduler.ProcessingTask.Wait(timeout, CancellationToken).ShouldBeTrue();
 #else
-        scheduler.ProcessingTask.Wait(timeout).Should().BeTrue();
+        scheduler.ProcessingTask.Wait(timeout).ShouldBeTrue();
 #endif
 #pragma warning restore xUnit1031
     }
@@ -156,6 +154,6 @@ public class ScheduledTaskExecutorTests
 
         await scheduler.ProcessingTask;
 
-        scheduler.ProcessingTask.IsCompleted.Should().BeTrue();
+        scheduler.ProcessingTask.IsCompleted.ShouldBeTrue();
     }
 }

--- a/test/Polly.Core.Tests/CircuitBreaker/Health/HealthMetricsTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/Health/HealthMetricsTests.cs
@@ -13,8 +13,7 @@ public class HealthMetricsTests
         HealthMetrics.Create(
             TimeSpan.FromMilliseconds(samplingDurationMs),
             TimeProvider.System)
-            .Should()
-            .BeOfType(expectedType);
+            .ShouldBeOfType(expectedType);
 
     [Fact]
     public void HealthInfo_WithZeroTotal_ShouldSetValuesCorrectly()
@@ -23,9 +22,9 @@ public class HealthMetricsTests
         var result = HealthInfo.Create(0, 0);
 
         // Assert
-        result.Throughput.Should().Be(0);
-        result.FailureRate.Should().Be(0);
-        result.FailureCount.Should().Be(0);
+        result.Throughput.ShouldBe(0);
+        result.FailureRate.ShouldBe(0);
+        result.FailureCount.ShouldBe(0);
     }
 
     [Fact]
@@ -40,9 +39,9 @@ public class HealthMetricsTests
         var result = new HealthInfo(expectedThroughput, expectedFailureRate, expectedFailureCount);
 
         // Assert
-        result.Throughput.Should().Be(expectedThroughput);
-        result.FailureRate.Should().Be(expectedFailureRate);
-        result.FailureCount.Should().Be(expectedFailureCount);
+        result.Throughput.ShouldBe(expectedThroughput);
+        result.FailureRate.ShouldBe(expectedFailureRate);
+        result.FailureCount.ShouldBe(expectedFailureCount);
     }
 
     [Fact]
@@ -57,8 +56,8 @@ public class HealthMetricsTests
         var result = new HealthInfo(throughput, failureRate, failureCount);
 
         // Assert
-        result.Throughput.Should().Be(throughput);
-        result.FailureRate.Should().Be(failureRate);
-        result.FailureCount.Should().Be(failureCount);
+        result.Throughput.ShouldBe(throughput);
+        result.FailureRate.ShouldBe(failureRate);
+        result.FailureCount.ShouldBe(failureCount);
     }
 }

--- a/test/Polly.Core.Tests/CircuitBreaker/Health/RollingHealthMetricsTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/Health/RollingHealthMetricsTests.cs
@@ -16,8 +16,8 @@ public class RollingHealthMetricsTests
     {
         var metrics = Create();
         var health = metrics.GetHealthInfo();
-        health.FailureRate.Should().Be(0);
-        health.Throughput.Should().Be(0);
+        health.FailureRate.ShouldBe(0);
+        health.Throughput.ShouldBe(0);
     }
 
     [Fact]
@@ -33,8 +33,8 @@ public class RollingHealthMetricsTests
 
         var health = metrics.GetHealthInfo();
 
-        health.FailureRate.Should().Be(0.2);
-        health.Throughput.Should().Be(5);
+        health.FailureRate.ShouldBe(0.2);
+        health.Throughput.ShouldBe(5);
     }
 
     [Fact]
@@ -62,11 +62,11 @@ public class RollingHealthMetricsTests
         _timeProvider.Advance(TimeSpan.FromSeconds(2));
         health.Add(metrics.GetHealthInfo());
 
-        health[0].Should().Be(new HealthInfo(2, 0.5, 1));
-        health[1].Should().Be(new HealthInfo(4, 0.5, 2));
-        health[3].Should().Be(new HealthInfo(8, 0.25, 2));
-        health[4].Should().Be(new HealthInfo(8, 0.125, 1));
-        health[5].Should().Be(new HealthInfo(6, 0.0, 0));
+        health[0].ShouldBe(new HealthInfo(2, 0.5, 1));
+        health[1].ShouldBe(new HealthInfo(4, 0.5, 2));
+        health[3].ShouldBe(new HealthInfo(8, 0.25, 2));
+        health[4].ShouldBe(new HealthInfo(8, 0.125, 1));
+        health[5].ShouldBe(new HealthInfo(6, 0.0, 0));
     }
 
     [Fact]
@@ -81,9 +81,9 @@ public class RollingHealthMetricsTests
             _timeProvider.Advance(delay);
         }
 
-        metrics.GetHealthInfo().Throughput.Should().Be(9);
+        metrics.GetHealthInfo().Throughput.ShouldBe(9);
         _timeProvider.Advance(delay);
-        metrics.GetHealthInfo().Throughput.Should().Be(8);
+        metrics.GetHealthInfo().Throughput.ShouldBe(8);
     }
 
     [Fact]
@@ -94,7 +94,7 @@ public class RollingHealthMetricsTests
         metrics.IncrementSuccess();
         metrics.Reset();
 
-        metrics.GetHealthInfo().Throughput.Should().Be(0);
+        metrics.GetHealthInfo().Throughput.ShouldBe(0);
     }
 
     [InlineData(true)]
@@ -109,7 +109,7 @@ public class RollingHealthMetricsTests
 
         _timeProvider.Advance(_samplingDuration + (variance ? TimeSpan.FromMilliseconds(1) : TimeSpan.Zero));
 
-        metrics.GetHealthInfo().Should().Be(new HealthInfo(0, 0, 0));
+        metrics.GetHealthInfo().ShouldBe(new HealthInfo(0, 0, 0));
     }
 
     private RollingHealthMetrics Create() => new(_samplingDuration, _windows, _timeProvider);

--- a/test/Polly.Core.Tests/CircuitBreaker/Health/SingleHealthMetricsTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/Health/SingleHealthMetricsTests.cs
@@ -15,8 +15,8 @@ public class SingleHealthMetricsTests
         var metrics = new SingleHealthMetrics(TimeSpan.FromMilliseconds(100), _timeProvider);
         var health = metrics.GetHealthInfo();
 
-        health.FailureRate.Should().Be(0);
-        health.Throughput.Should().Be(0);
+        health.FailureRate.ShouldBe(0);
+        health.Throughput.ShouldBe(0);
     }
 
     [Fact]
@@ -32,8 +32,8 @@ public class SingleHealthMetricsTests
 
         var health = metrics.GetHealthInfo();
 
-        health.FailureRate.Should().Be(0.2);
-        health.Throughput.Should().Be(5);
+        health.FailureRate.ShouldBe(0.2);
+        health.Throughput.ShouldBe(5);
     }
 
     [Fact]
@@ -44,7 +44,7 @@ public class SingleHealthMetricsTests
         metrics.IncrementSuccess();
         metrics.Reset();
 
-        metrics.GetHealthInfo().Throughput.Should().Be(0);
+        metrics.GetHealthInfo().Throughput.ShouldBe(0);
     }
 
     [Fact]
@@ -57,6 +57,6 @@ public class SingleHealthMetricsTests
 
         _timeProvider.Advance(TimeSpan.FromMilliseconds(100));
 
-        metrics.GetHealthInfo().Throughput.Should().Be(0);
+        metrics.GetHealthInfo().Throughput.ShouldBe(0);
     }
 }

--- a/test/Polly.Core.Tests/CircuitBreaker/IsolatedCircuitExceptionTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/IsolatedCircuitExceptionTests.cs
@@ -8,25 +8,25 @@ public class IsolatedCircuitExceptionTests
     public void Ctor_Default_Ok()
     {
         var exception = new IsolatedCircuitException();
-        exception.Message.Should().Be("The circuit is manually held open and is not allowing calls.");
-        exception.RetryAfter.Should().BeNull();
+        exception.Message.ShouldBe("The circuit is manually held open and is not allowing calls.");
+        exception.RetryAfter.ShouldBeNull();
     }
 
     [Fact]
     public void Ctor_Message_Ok()
     {
         var exception = new IsolatedCircuitException(TestMessage);
-        exception.Message.Should().Be(TestMessage);
-        exception.RetryAfter.Should().BeNull();
+        exception.Message.ShouldBe(TestMessage);
+        exception.RetryAfter.ShouldBeNull();
     }
 
     [Fact]
     public void Ctor_Message_InnerException_Ok()
     {
         var exception = new IsolatedCircuitException(TestMessage, new InvalidOperationException());
-        exception.Message.Should().Be(TestMessage);
-        exception.InnerException.Should().BeOfType<InvalidOperationException>();
-        exception.RetryAfter.Should().BeNull();
+        exception.Message.ShouldBe(TestMessage);
+        exception.InnerException.ShouldBeOfType<InvalidOperationException>();
+        exception.RetryAfter.ShouldBeNull();
     }
 
 #if NETFRAMEWORK
@@ -35,10 +35,10 @@ public class IsolatedCircuitExceptionTests
     {
         var exception = new IsolatedCircuitException(TestMessage, new InvalidOperationException());
         IsolatedCircuitException roundtripResult = BinarySerializationUtil.SerializeAndDeserializeException(exception);
-        roundtripResult.Should().NotBeNull();
-        roundtripResult.Message.Should().Be(TestMessage);
-        roundtripResult.InnerException.Should().BeOfType<InvalidOperationException>();
-        roundtripResult.RetryAfter.Should().BeNull();
+        roundtripResult.ShouldNotBeNull();
+        roundtripResult.Message.ShouldBe(TestMessage);
+        roundtripResult.InnerException.ShouldBeOfType<InvalidOperationException>();
+        roundtripResult.RetryAfter.ShouldBeNull();
     }
 #endif
 

--- a/test/Polly.Core.Tests/CircuitBreaker/OnCircuitClosedArgumentsTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/OnCircuitClosedArgumentsTests.cs
@@ -14,8 +14,8 @@ public static class OnCircuitClosedArgumentsTests
         var args = new OnCircuitClosedArguments<int>(context, Outcome.FromResult(1), true);
 
         // Assert
-        args.Context.Should().Be(context);
-        args.Outcome.Result.Should().Be(1);
-        args.IsManual.Should().BeTrue();
+        args.Context.ShouldBe(context);
+        args.Outcome.Result.ShouldBe(1);
+        args.IsManual.ShouldBeTrue();
     }
 }

--- a/test/Polly.Core.Tests/CircuitBreaker/OnCircuitHalfOpenedArgumentsTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/OnCircuitHalfOpenedArgumentsTests.cs
@@ -14,6 +14,6 @@ public static class OnCircuitHalfOpenedArgumentsTests
         var target = new OnCircuitHalfOpenedArguments(context);
 
         // Assert
-        target.Context.Should().Be(context);
+        target.Context.ShouldBe(context);
     }
 }

--- a/test/Polly.Core.Tests/CircuitBreaker/OnCircuitOpenedArgumentsTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/OnCircuitOpenedArgumentsTests.cs
@@ -14,9 +14,9 @@ public static class OnCircuitOpenedArgumentsTests
         var args = new OnCircuitOpenedArguments<int>(context, Outcome.FromResult(1), TimeSpan.FromSeconds(2), true);
 
         // Assert
-        args.Context.Should().Be(context);
-        args.Outcome.Result.Should().Be(1);
-        args.BreakDuration.Should().Be(TimeSpan.FromSeconds(2));
-        args.IsManual.Should().BeTrue();
+        args.Context.ShouldBe(context);
+        args.Outcome.Result.ShouldBe(1);
+        args.BreakDuration.ShouldBe(TimeSpan.FromSeconds(2));
+        args.IsManual.ShouldBeTrue();
     }
 }

--- a/test/Polly.Core.Tests/ExecutionRejectedExceptionTests.cs
+++ b/test/Polly.Core.Tests/ExecutionRejectedExceptionTests.cs
@@ -5,8 +5,8 @@ public class ExecutionRejectedExceptionTests
     [Fact]
     public void Ctor_Ok()
     {
-        new CustomException().Message.Should().Be("Exception of type 'Polly.Core.Tests.ExecutionRejectedExceptionTests+CustomException' was thrown.");
-        new CustomException("Dummy").Message.Should().Be("Dummy");
+        new CustomException().Message.ShouldBe("Exception of type 'Polly.Core.Tests.ExecutionRejectedExceptionTests+CustomException' was thrown.");
+        new CustomException("Dummy").Message.ShouldBe("Dummy");
     }
 
     private class CustomException : ExecutionRejectedException

--- a/test/Polly.Core.Tests/Fallback/FallbackHandlerTests.cs
+++ b/test/Polly.Core.Tests/Fallback/FallbackHandlerTests.cs
@@ -10,6 +10,6 @@ public class FallbackHandlerTests
         var context = ResilienceContextPool.Shared.Get();
         var outcome = await handler.GetFallbackOutcomeAsync(new FallbackActionArguments<string>(context, Outcome.FromResult("primary")))!;
 
-        outcome.Result.Should().Be("secondary");
+        outcome.Result.ShouldBe("secondary");
     }
 }

--- a/test/Polly.Core.Tests/Fallback/FallbackResiliencePipelineBuilderExtensionsTests.cs
+++ b/test/Polly.Core.Tests/Fallback/FallbackResiliencePipelineBuilderExtensionsTests.cs
@@ -27,13 +27,10 @@ public class FallbackResiliencePipelineBuilderExtensionsTests
         var builder = new ResiliencePipelineBuilder<int>();
         configure(builder);
 
-        builder.Build().GetPipelineDescriptor().FirstStrategy.StrategyInstance.Should().BeOfType<FallbackResilienceStrategy<int>>();
+        builder.Build().GetPipelineDescriptor().FirstStrategy.StrategyInstance.ShouldBeOfType<FallbackResilienceStrategy<int>>();
     }
 
     [Fact]
-    public void AddFallbackT_InvalidOptions_Throws() =>
-        new ResiliencePipelineBuilder<double>()
-            .Invoking(b => b.AddFallback(new FallbackStrategyOptions<double>()))
-            .Should()
-            .Throw<ValidationException>();
+    public void AddFallbackT_InvalidOptions_Throws()
+        => Should.Throw<ValidationException>(() => new ResiliencePipelineBuilder<double>().AddFallback(new FallbackStrategyOptions<double>()));
 }

--- a/test/Polly.Core.Tests/Fallback/FallbackResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Fallback/FallbackResilienceStrategyTests.cs
@@ -14,7 +14,7 @@ public class FallbackResilienceStrategyTests
 
     [Fact]
     public void Ctor_Ok() =>
-        Create().Should().NotBeNull();
+        Create().ShouldNotBeNull();
 
     [Fact]
     public void Handle_Result_Ok()
@@ -23,10 +23,10 @@ public class FallbackResilienceStrategyTests
         _options.OnFallback = _ => { called = true; return default; };
         SetHandler(outcome => outcome.Result == "error", () => Outcome.FromResult("success"));
 
-        Create().Execute(_ => "error").Should().Be("success");
+        Create().Execute(_ => "error").ShouldBe("success");
 
-        _args.Should().ContainSingle(v => v.Arguments is OnFallbackArguments<string>);
-        called.Should().BeTrue();
+        _args.Count(v => v.Arguments is OnFallbackArguments<string>).ShouldBe(1);
+        called.ShouldBeTrue();
     }
 
     [InlineData(true)]
@@ -39,16 +39,16 @@ public class FallbackResilienceStrategyTests
         _handler = new FallbackHandler<string>(
             args =>
             {
-                args.Outcome.Result.Should().Be("ok");
-                args.Context.Should().NotBeNull();
+                args.Outcome.Result.ShouldBe("ok");
+                args.Context.ShouldNotBeNull();
                 called++;
 
                 return new ValueTask<bool>(handle);
             },
             args =>
             {
-                args.Outcome.Result.Should().Be("ok");
-                args.Context.Should().NotBeNull();
+                args.Outcome.Result.ShouldBe("ok");
+                args.Context.ShouldNotBeNull();
                 called++;
                 return Outcome.FromResultAsValueTask("fallback");
             });
@@ -57,13 +57,13 @@ public class FallbackResilienceStrategyTests
 
         if (handle)
         {
-            result.Should().Be("fallback");
-            called.Should().Be(2);
+            result.ShouldBe("fallback");
+            called.ShouldBe(2);
         }
         else
         {
-            result.Should().Be("ok");
-            called.Should().Be(1);
+            result.ShouldBe("ok");
+            called.ShouldBe(1);
         }
     }
 
@@ -71,7 +71,7 @@ public class FallbackResilienceStrategyTests
     public void Handle_Result_FallbackActionThrows()
     {
         SetHandler(_ => true, () => throw new InvalidOperationException());
-        Create().Invoking(s => s.Execute(_ => "dummy")).Should().Throw<InvalidOperationException>();
+        Should.Throw<InvalidOperationException>(() => Create().Execute(_ => "dummy"));
     }
 
     [Fact]
@@ -81,10 +81,10 @@ public class FallbackResilienceStrategyTests
         _options.OnFallback = _ => { called = true; return default; };
 
         SetHandler(outcome => outcome.Exception is InvalidOperationException, () => Outcome.FromResult("secondary"));
-        Create().Execute<string>(_ => throw new InvalidOperationException()).Should().Be("secondary");
+        Create().Execute<string>(_ => throw new InvalidOperationException()).ShouldBe("secondary");
 
-        _args.Should().ContainSingle(v => v.Arguments is OnFallbackArguments<string>);
-        called.Should().BeTrue();
+        _args.Count(v => v.Arguments is OnFallbackArguments<string>).ShouldBe(1);
+        called.ShouldBeTrue();
     }
 
     [Fact]
@@ -96,11 +96,11 @@ public class FallbackResilienceStrategyTests
         _options.OnFallback = _ => { called = true; return default; };
         SetHandler(outcome => outcome.Exception is InvalidOperationException, () => { fallbackActionCalled = true; return Outcome.FromResult("secondary"); });
 
-        Create().Invoking(s => s.Execute<string>(_ => throw new ArgumentException())).Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => Create().Execute<string>(_ => throw new ArgumentException()));
 
-        _args.Should().BeEmpty();
-        called.Should().BeFalse();
-        fallbackActionCalled.Should().BeFalse();
+        _args.ShouldBeEmpty();
+        called.ShouldBeFalse();
+        fallbackActionCalled.ShouldBeFalse();
     }
 
     [Fact]
@@ -112,10 +112,10 @@ public class FallbackResilienceStrategyTests
         _options.OnFallback = _ => { called = true; return default; };
         SetHandler(outcome => false, () => Outcome.FromResult("secondary"));
 
-        Create().Execute(_ => "primary").Should().Be("primary");
-        _args.Should().BeEmpty();
-        called.Should().BeFalse();
-        fallbackActionCalled.Should().BeFalse();
+        Create().Execute(_ => "primary").ShouldBe("primary");
+        _args.ShouldBeEmpty();
+        called.ShouldBeFalse();
+        fallbackActionCalled.ShouldBeFalse();
     }
 
     private void SetHandler(

--- a/test/Polly.Core.Tests/Fallback/FallbackStrategyOptionsTests.cs
+++ b/test/Polly.Core.Tests/Fallback/FallbackStrategyOptionsTests.cs
@@ -11,10 +11,10 @@ public class FallbackStrategyOptionsTests
     {
         var options = new FallbackStrategyOptions<int>();
 
-        options.ShouldHandle.Should().NotBeNull();
-        options.OnFallback.Should().BeNull();
-        options.FallbackAction.Should().BeNull();
-        options.Name.Should().Be("Fallback");
+        options.ShouldHandle.ShouldNotBeNull();
+        options.OnFallback.ShouldBeNull();
+        options.FallbackAction.ShouldBeNull();
+        options.Name.ShouldBe("Fallback");
     }
 
     [Fact]
@@ -23,9 +23,9 @@ public class FallbackStrategyOptionsTests
         var options = new FallbackStrategyOptions<int>();
         var context = ResilienceContextPool.Shared.Get();
 
-        (await options.ShouldHandle(new FallbackPredicateArguments<int>(context, Outcome.FromResult(0)))).Should().Be(false);
-        (await options.ShouldHandle(new FallbackPredicateArguments<int>(context, Outcome.FromException<int>(new OperationCanceledException())))).Should().Be(false);
-        (await options.ShouldHandle(new FallbackPredicateArguments<int>(context, Outcome.FromException<int>(new InvalidOperationException())))).Should().Be(true);
+        (await options.ShouldHandle(new FallbackPredicateArguments<int>(context, Outcome.FromResult(0)))).ShouldBe(false);
+        (await options.ShouldHandle(new FallbackPredicateArguments<int>(context, Outcome.FromException<int>(new OperationCanceledException())))).ShouldBe(false);
+        (await options.ShouldHandle(new FallbackPredicateArguments<int>(context, Outcome.FromException<int>(new InvalidOperationException())))).ShouldBe(true);
     }
 
     [Fact]
@@ -36,16 +36,13 @@ public class FallbackStrategyOptionsTests
             ShouldHandle = null!
         };
 
-        options
-            .Invoking(o => ValidationHelper.ValidateObject(new(o, "Invalid.")))
-            .Should()
-            .Throw<ValidationException>()
-            .WithMessage("""
+        var exception = Should.Throw<ValidationException>(() => ValidationHelper.ValidateObject(new(options, "Invalid.")));
+        exception.Message.Trim().ShouldBe("""
             Invalid.
-
             Validation Errors:
             The ShouldHandle field is required.
             The FallbackAction field is required.
-            """);
+            """,
+            StringCompareShould.IgnoreLineEndings);
     }
 }

--- a/test/Polly.Core.Tests/GenericResiliencePipelineBuilderTests.cs
+++ b/test/Polly.Core.Tests/GenericResiliencePipelineBuilderTests.cs
@@ -12,23 +12,23 @@ public class GenericResiliencePipelineBuilderTests
     [Fact]
     public void Ctor_EnsureDefaults()
     {
-        _builder.Name.Should().BeNull();
-        _builder.TimeProvider.Should().BeNull();
+        _builder.Name.ShouldBeNull();
+        _builder.TimeProvider.ShouldBeNull();
     }
 
     [Fact]
     public void CopyCtor_Ok() =>
-        new ResiliencePipelineBuilder<string>(new ResiliencePipelineBuilder()).Should().NotBeNull();
+        new ResiliencePipelineBuilder<string>(new ResiliencePipelineBuilder()).ShouldNotBeNull();
 
     [Fact]
     public void Properties_GetSet_Ok()
     {
         _builder.Name = "dummy";
-        _builder.Name.Should().Be("dummy");
+        _builder.Name.ShouldBe("dummy");
 
         var timeProvider = new FakeTimeProvider();
         _builder.TimeProvider = timeProvider;
-        _builder.TimeProvider.Should().Be(timeProvider);
+        _builder.TimeProvider.ShouldBe(timeProvider);
     }
 
     [Fact]
@@ -42,8 +42,8 @@ public class GenericResiliencePipelineBuilderTests
         var strategy = _builder.Build();
 
         // assert
-        strategy.Should().NotBeNull();
-        strategy.Component.Should().BeOfType<CompositeComponent>().Subject.Components.Should().HaveCount(2);
+        strategy.ShouldNotBeNull();
+        strategy.Component.ShouldBeOfType<CompositeComponent>().Components.Count.ShouldBe(2);
     }
 
     [Fact]
@@ -57,12 +57,10 @@ public class GenericResiliencePipelineBuilderTests
         var pipeline = _builder.Build();
 
         // assert
-        strategy.Should().NotBeNull();
+        strategy.ShouldNotBeNull();
         ((CompositeComponent)pipeline.Component).Components[0]
-            .Should()
-            .BeOfType<BridgeComponent<string>>().Subject.Strategy
-            .Should()
-            .Be(strategy);
+            .ShouldBeOfType<BridgeComponent<string>>().Strategy
+            .ShouldBe(strategy);
     }
 
     [Fact]
@@ -76,7 +74,7 @@ public class GenericResiliencePipelineBuilderTests
         builder
             .Build()
             .GetPipelineDescriptor()
-            .FirstStrategy.StrategyInstance.Should()
-            .BeSameAs(strategy);
+            .FirstStrategy.StrategyInstance
+            .ShouldBeSameAs(strategy);
     }
 }

--- a/test/Polly.Core.Tests/Hedging/Controller/HedgingControllerTests.cs
+++ b/test/Polly.Core.Tests/Hedging/Controller/HedgingControllerTests.cs
@@ -17,14 +17,14 @@ public class HedgingControllerTests
         var context2 = controller.GetContext(context);
         await PrepareAsync(context2);
 
-        controller.RentedContexts.Should().Be(2);
-        controller.RentedExecutions.Should().Be(2);
+        controller.RentedContexts.ShouldBe(2);
+        controller.RentedExecutions.ShouldBe(2);
 
         await context1.DisposeAsync();
         await context2.DisposeAsync();
 
-        controller.RentedContexts.Should().Be(0);
-        controller.RentedExecutions.Should().Be(0);
+        controller.RentedContexts.ShouldBe(0);
+        controller.RentedExecutions.ShouldBe(0);
     }
 
     private static async Task PrepareAsync(HedgingExecutionContext<int> context)

--- a/test/Polly.Core.Tests/Hedging/Controller/HedgingExecutionContextTests.cs
+++ b/test/Polly.Core.Tests/Hedging/Controller/HedgingExecutionContextTests.cs
@@ -52,10 +52,10 @@ public class HedgingExecutionContextTests : IDisposable
     {
         var context = Create();
 
-        context.LoadedTasks.Should().Be(0);
-        context.PrimaryContext.Should().BeNull();
+        context.LoadedTasks.ShouldBe(0);
+        context.PrimaryContext.ShouldBeNull();
 
-        context.Should().NotBeNull();
+        context.ShouldNotBeNull();
     }
 
     [Fact]
@@ -66,8 +66,8 @@ public class HedgingExecutionContextTests : IDisposable
 
         context.Initialize(_resilienceContext);
 
-        context.PrimaryContext.Should().Be(_resilienceContext);
-        context.IsInitialized.Should().BeTrue();
+        context.PrimaryContext.ShouldBe(_resilienceContext);
+        context.IsInitialized.ShouldBeTrue();
     }
 
     [InlineData(0)]
@@ -84,7 +84,7 @@ public class HedgingExecutionContextTests : IDisposable
 
         _timeProvider.Advance(TimeSpan.FromHours(1));
 
-        (await task).Should().BeNull();
+        (await task).ShouldBeNull();
     }
 
     [Fact]
@@ -96,12 +96,12 @@ public class HedgingExecutionContextTests : IDisposable
 
         var task = await context.TryWaitForCompletedExecutionAsync(TimeSpan.Zero);
 
-        task.Should().NotBeNull();
-        task!.ExecutionTaskSafe!.IsCompleted.Should().BeTrue();
+        task.ShouldNotBeNull();
+        task!.ExecutionTaskSafe!.IsCompleted.ShouldBeTrue();
 
-        task.Outcome.Result!.Name.Should().Be("dummy");
+        task.Outcome.Result!.Name.ShouldBe("dummy");
         task.AcceptOutcome();
-        context.LoadedTasks.Should().Be(1);
+        context.LoadedTasks.ShouldBe(1);
     }
 
     [Fact]
@@ -118,7 +118,7 @@ public class HedgingExecutionContextTests : IDisposable
 
         for (int i = 0; i < _maxAttempts; i++)
         {
-            (await context.TryWaitForCompletedExecutionAsync(TimeSpan.Zero)).Should().BeNull();
+            (await context.TryWaitForCompletedExecutionAsync(TimeSpan.Zero)).ShouldBeNull();
         }
 
         _timeProvider.Advance(TimeSpan.FromDays(1));
@@ -141,7 +141,7 @@ public class HedgingExecutionContextTests : IDisposable
 
         var task = context.TryWaitForCompletedExecutionAsync(System.Threading.Timeout.InfiniteTimeSpan).AsTask();
 #pragma warning disable xUnit1031 // Do not use blocking task operations in test method
-        task.Wait(20).Should().BeFalse();
+        task.Wait(20).ShouldBeFalse();
 #pragma warning restore xUnit1031 // Do not use blocking task operations in test method
         _timeProvider.Advance(TimeSpan.FromDays(1));
         await task;
@@ -164,10 +164,10 @@ public class HedgingExecutionContextTests : IDisposable
         var count = _timeProvider.TimerEntries.Count;
         var task = context.TryWaitForCompletedExecutionAsync(hedgingDelay).AsTask();
 #pragma warning disable xUnit1031 // Do not use blocking task operations in test method
-        task.Wait(20).Should().BeFalse();
+        task.Wait(20).ShouldBeFalse();
 #pragma warning restore xUnit1031 // Do not use blocking task operations in test method
-        _timeProvider.TimerEntries.Should().HaveCount(count + 1);
-        _timeProvider.TimerEntries.Last().Delay.Should().Be(hedgingDelay);
+        _timeProvider.TimerEntries.Count.ShouldBe(count + 1);
+        _timeProvider.TimerEntries.Last().Delay.ShouldBe(hedgingDelay);
         _timeProvider.Advance(TimeSpan.FromDays(1));
         await task;
         await context.Tasks[0].ExecutionTaskSafe!;
@@ -187,7 +187,7 @@ public class HedgingExecutionContextTests : IDisposable
         var task = await context.TryWaitForCompletedExecutionAsync(TimeSpan.Zero);
 
         task!.AcceptOutcome();
-        context.LoadedTasks.Should().Be(1);
+        context.LoadedTasks.ShouldBe(1);
     }
 
     [Fact]
@@ -201,11 +201,11 @@ public class HedgingExecutionContextTests : IDisposable
         Generator = args => () => Outcome.FromResultAsValueTask(new DisposableResult { Name = "secondary" });
 
         var task = await context.TryWaitForCompletedExecutionAsync(TimeSpan.Zero);
-        task!.Type.Should().Be(HedgedTaskType.Primary);
+        task!.Type.ShouldBe(HedgedTaskType.Primary);
         task!.AcceptOutcome();
-        context.LoadedTasks.Should().Be(2);
-        context.Tasks[0].Type.Should().Be(HedgedTaskType.Primary);
-        context.Tasks[1].Type.Should().Be(HedgedTaskType.Secondary);
+        context.LoadedTasks.ShouldBe(2);
+        context.Tasks[0].Type.ShouldBe(HedgedTaskType.Primary);
+        context.Tasks[1].Type.ShouldBe(HedgedTaskType.Secondary);
     }
 
     [Fact]
@@ -218,14 +218,14 @@ public class HedgingExecutionContextTests : IDisposable
 
         for (int i = 0; i < _maxAttempts; i++)
         {
-            (await LoadExecutionAsync(context)).Loaded.Should().BeTrue();
+            (await LoadExecutionAsync(context)).Loaded.ShouldBeTrue();
         }
 
-        (await LoadExecutionAsync(context)).Loaded.Should().BeFalse();
+        (await LoadExecutionAsync(context)).Loaded.ShouldBeFalse();
 
-        context.LoadedTasks.Should().Be(_maxAttempts);
+        context.LoadedTasks.ShouldBe(_maxAttempts);
         context.Tasks[0].AcceptOutcome();
-        _returnedExecutions.Should().HaveCount(0);
+        _returnedExecutions.Count.ShouldBe(0);
     }
 
     [Fact]
@@ -244,7 +244,7 @@ public class HedgingExecutionContextTests : IDisposable
         await LoadExecutionAsync(context);
 
         // primary is 0, this one is 1
-        attempt.Should().Be(1);
+        attempt.ShouldBe(1);
     }
 
     [InlineData(true)]
@@ -271,18 +271,18 @@ public class HedgingExecutionContextTests : IDisposable
         }
 
         var pair = await LoadExecutionAsync(context);
-        pair.Loaded.Should().BeFalse();
+        pair.Loaded.ShouldBeFalse();
 
-        _returnedExecutions.Count.Should().Be(1);
+        _returnedExecutions.Count.ShouldBe(1);
         if (allExecuted)
         {
-            pair.Outcome.Should().NotBeNull();
-            context.Tasks[0].IsAccepted.Should().BeTrue();
+            pair.Outcome.ShouldNotBeNull();
+            context.Tasks[0].IsAccepted.ShouldBeTrue();
         }
         else
         {
-            pair.Outcome.Should().BeNull();
-            context.Tasks[0].IsAccepted.Should().BeFalse();
+            pair.Outcome.ShouldBeNull();
+            context.Tasks[0].IsAccepted.ShouldBeFalse();
         }
 
         context.Tasks[0].AcceptOutcome();
@@ -295,7 +295,7 @@ public class HedgingExecutionContextTests : IDisposable
         var context = Create();
         context.Initialize(_resilienceContext);
 
-        await context.Invoking(c => LoadExecutionAsync(c)).Should().ThrowAsync<InvalidOperationException>();
+        await Should.ThrowAsync<InvalidOperationException>(() => LoadExecutionAsync(context));
     }
 
     [InlineData(true)]
@@ -316,14 +316,14 @@ public class HedgingExecutionContextTests : IDisposable
         await context.DisposeAsync();
 
         // assert
-        _resilienceContext.Properties.Should().BeSameAs(originalProps);
+        _resilienceContext.Properties.ShouldBeSameAs(originalProps);
         if (primary)
         {
-            _resilienceContext.Properties.Options.Should().HaveCount(1);
+            _resilienceContext.Properties.Options.Count.ShouldBe(1);
         }
         else
         {
-            _resilienceContext.Properties.Options.Should().HaveCount(2);
+            _resilienceContext.Properties.Options.Count.ShouldBe(2);
         }
     }
 
@@ -334,7 +334,7 @@ public class HedgingExecutionContextTests : IDisposable
         var context = Create();
         context.Initialize(_resilienceContext);
         await context.DisposeAsync();
-        _resilienceContext.Properties.Should().BeSameAs(props);
+        _resilienceContext.Properties.ShouldBeSameAs(props);
     }
 
     [Fact]
@@ -345,7 +345,7 @@ public class HedgingExecutionContextTests : IDisposable
         ConfigureSecondaryTasks(TimeSpan.Zero);
         await ExecuteAllTasksAsync(context, 2);
 
-        context.Invoking(c => c.DisposeAsync().AsTask().Wait()).Should().NotThrow();
+        Should.NotThrow(() => context.DisposeAsync().AsTask().Wait());
     }
 
     [Fact]
@@ -358,7 +358,7 @@ public class HedgingExecutionContextTests : IDisposable
         context.Tasks[0].AcceptOutcome();
         context.Tasks[1].AcceptOutcome();
 
-        context.Invoking(c => c.DisposeAsync().AsTask().Wait()).Should().NotThrow();
+        Should.NotThrow(() => context.DisposeAsync().AsTask().Wait());
     }
 
     [Fact]
@@ -372,13 +372,13 @@ public class HedgingExecutionContextTests : IDisposable
         ConfigureSecondaryTasks(TimeSpan.FromHours(1));
         (await LoadExecutionAsync(context)).Execution!.OnReset = (execution) =>
         {
-            execution.Outcome.Result.Should().BeOfType<DisposableResult>();
-            execution.Outcome.Exception.Should().BeNull();
+            execution.Outcome.Result.ShouldBeOfType<DisposableResult>();
+            execution.Outcome.Exception.ShouldBeNull();
             assertPrimary.Set();
         };
         (await LoadExecutionAsync(context)).Execution!.OnReset = (execution) =>
         {
-            execution.Outcome.Exception.Should().BeAssignableTo<OperationCanceledException>();
+            execution.Outcome.Exception.ShouldBeAssignableTo<OperationCanceledException>();
             assertSecondary.Set();
         };
 
@@ -386,7 +386,7 @@ public class HedgingExecutionContextTests : IDisposable
 
         var pending = context.Tasks[1].ExecutionTaskSafe!;
 #pragma warning disable xUnit1031 // Do not use blocking task operations in test method
-        pending.Wait(10).Should().BeFalse();
+        pending.Wait(10).ShouldBeFalse();
 #pragma warning restore xUnit1031 // Do not use blocking task operations in test method
 
         context.Tasks[0].AcceptOutcome();
@@ -394,8 +394,8 @@ public class HedgingExecutionContextTests : IDisposable
 
         await pending;
 
-        assertPrimary.WaitOne(AssertTimeout).Should().BeTrue();
-        assertSecondary.WaitOne(AssertTimeout).Should().BeTrue();
+        assertPrimary.WaitOne(AssertTimeout).ShouldBeTrue();
+        assertSecondary.WaitOne(AssertTimeout).ShouldBeTrue();
     }
 
     [Fact]
@@ -409,19 +409,19 @@ public class HedgingExecutionContextTests : IDisposable
 
         await context.DisposeAsync();
 
-        context.LoadedTasks.Should().Be(0);
-        context.PrimaryContext!.Should().BeNull();
+        context.LoadedTasks.ShouldBe(0);
+        context.PrimaryContext!.ShouldBeNull();
 
         _onReset.WaitOne(AssertTimeout);
-        _resets.Count.Should().Be(1);
-        _returnedExecutions.Count.Should().Be(2);
+        _resets.Count.ShouldBe(1);
+        _returnedExecutions.Count.ShouldBe(2);
     }
 
     private async Task ExecuteAllTasksAsync(HedgingExecutionContext<DisposableResult> context, int count)
     {
         for (int i = 0; i < count; i++)
         {
-            (await LoadExecutionAsync(context)).Loaded.Should().BeTrue();
+            (await LoadExecutionAsync(context)).Loaded.ShouldBeTrue();
             await context.TryWaitForCompletedExecutionAsync(System.Threading.Timeout.InfiniteTimeSpan);
         }
     }

--- a/test/Polly.Core.Tests/Hedging/Controller/HedgingExecutionContextTests.cs
+++ b/test/Polly.Core.Tests/Hedging/Controller/HedgingExecutionContextTests.cs
@@ -225,7 +225,7 @@ public class HedgingExecutionContextTests : IDisposable
 
         context.LoadedTasks.ShouldBe(_maxAttempts);
         context.Tasks[0].AcceptOutcome();
-        _returnedExecutions.Count.ShouldBe(0);
+        _returnedExecutions.ShouldBeEmpty();
     }
 
     [Fact]

--- a/test/Polly.Core.Tests/Hedging/Controller/TaskExecutionTests.cs
+++ b/test/Polly.Core.Tests/Hedging/Controller/TaskExecutionTests.cs
@@ -52,20 +52,20 @@ public class TaskExecutionTests : IDisposable
             (context, state) =>
             {
                 AssertContext(context);
-                state.Should().Be("dummy-state");
+                state.ShouldBe("dummy-state");
                 return Outcome.FromResultAsValueTask(new DisposableResult { Name = value });
             },
             "dummy-state",
             99);
 
         await execution.ExecutionTaskSafe!;
-        execution.Outcome.Result!.Name.Should().Be(value);
-        execution.IsHandled.Should().Be(handled);
+        execution.Outcome.Result!.Name.ShouldBe(value);
+        execution.IsHandled.ShouldBe(handled);
         AssertContext(execution.Context);
 
-        _args.Should().HaveCount(1);
-        _args[0].Handled.Should().Be(handled);
-        _args[0].AttemptNumber.Should().Be(99);
+        _args.Count.ShouldBe(1);
+        _args[0].Handled.ShouldBe(handled);
+        _args[0].AttemptNumber.ShouldBe(99);
     }
 
     [Fact]
@@ -79,7 +79,7 @@ public class TaskExecutionTests : IDisposable
 
         await execution.ExecutionTaskSafe!;
 
-        execution.Outcome.Exception.Should().BeOfType<InvalidOperationException>();
+        execution.Outcome.Exception.ShouldBeOfType<InvalidOperationException>();
     }
 
     [InlineData(Handled, true)]
@@ -91,16 +91,16 @@ public class TaskExecutionTests : IDisposable
         Generator = args =>
         {
             AssertContext(args.ActionContext);
-            args.AttemptNumber.Should().Be(4);
+            args.AttemptNumber.ShouldBe(4);
             return () => Outcome.FromResultAsValueTask(new DisposableResult { Name = value });
         };
 
-        (await execution.InitializeAsync<string>(HedgedTaskType.Secondary, _primaryContext, null!, "dummy-state", 4)).Should().BeTrue();
+        (await execution.InitializeAsync<string>(HedgedTaskType.Secondary, _primaryContext, null!, "dummy-state", 4)).ShouldBeTrue();
 
         await execution.ExecutionTaskSafe!;
 
-        execution.Outcome.Result!.Name.Should().Be(value);
-        execution.IsHandled.Should().Be(handled);
+        execution.Outcome.Result!.Name.ShouldBe(value);
+        execution.IsHandled.ShouldBe(handled);
         AssertContext(execution.Context);
     }
 
@@ -110,9 +110,9 @@ public class TaskExecutionTests : IDisposable
         var execution = Create();
         Generator = args => null;
 
-        (await execution.InitializeAsync<string>(HedgedTaskType.Secondary, _primaryContext, null!, "dummy-state", 4)).Should().BeFalse();
+        (await execution.InitializeAsync(HedgedTaskType.Secondary, _primaryContext, null!, "dummy-state", 4)).ShouldBeFalse();
 
-        execution.Invoking(e => e.Context).Should().Throw<InvalidOperationException>();
+        Should.Throw<InvalidOperationException>(() => execution.Context);
     }
 
     [Fact]
@@ -126,7 +126,7 @@ public class TaskExecutionTests : IDisposable
         execution.AcceptOutcome();
         execution.Cancel();
 
-        cancelled.Should().BeFalse();
+        cancelled.ShouldBeFalse();
     }
 
     [Fact]
@@ -138,7 +138,7 @@ public class TaskExecutionTests : IDisposable
         await InitializePrimaryAsync(execution, onContext: context => context.CancellationToken.Register(() => cancelled = true));
 
         execution.Cancel();
-        cancelled.Should().BeTrue();
+        cancelled.ShouldBeTrue();
     }
 
     [Fact]
@@ -147,10 +147,10 @@ public class TaskExecutionTests : IDisposable
         var execution = Create();
         Generator = args => throw new FormatException();
 
-        (await execution.InitializeAsync<string>(HedgedTaskType.Secondary, _primaryContext, null!, "dummy-state", 4)).Should().BeTrue();
+        (await execution.InitializeAsync<string>(HedgedTaskType.Secondary, _primaryContext, null!, "dummy-state", 4)).ShouldBeTrue();
 
         await execution.ExecutionTaskSafe!;
-        execution.Outcome.Exception.Should().BeOfType<FormatException>();
+        execution.Outcome.Exception.ShouldBeOfType<FormatException>();
     }
 
     [Fact]
@@ -159,9 +159,9 @@ public class TaskExecutionTests : IDisposable
         var execution = Create();
         Generator = args => throw new FormatException();
 
-        (await execution.InitializeAsync<string>(HedgedTaskType.Secondary, _primaryContext, null!, "dummy-state", 4)).Should().BeTrue();
+        (await execution.InitializeAsync<string>(HedgedTaskType.Secondary, _primaryContext, null!, "dummy-state", 4)).ShouldBeTrue();
 
-        await execution.ExecutionTaskSafe!.Invoking(async t => await t).Should().NotThrowAsync();
+        await Should.NotThrowAsync(async () => await execution.ExecutionTaskSafe!);
     }
 
     [InlineData(true)]
@@ -202,7 +202,7 @@ public class TaskExecutionTests : IDisposable
         await execution.ExecutionTaskSafe!;
 
         // assert
-        execution.Outcome.Exception.Should().BeAssignableTo<OperationCanceledException>();
+        execution.Outcome.Exception.ShouldBeAssignableTo<OperationCanceledException>();
     }
 
     [Fact]
@@ -210,7 +210,7 @@ public class TaskExecutionTests : IDisposable
     {
         var execution = Create();
 
-        execution.Invoking(e => e.AcceptOutcome()).Should().Throw<InvalidOperationException>();
+        Should.Throw<InvalidOperationException>(() => execution.AcceptOutcome());
     }
 
     [InlineData(true)]
@@ -235,20 +235,20 @@ public class TaskExecutionTests : IDisposable
         await execution.ResetAsync();
 
         // assert
-        execution.IsAccepted.Should().BeFalse();
-        execution.IsHandled.Should().BeFalse();
-        context.Properties.Options.Should().HaveCount(0);
-        execution.Invoking(e => e.Context).Should().Throw<InvalidOperationException>();
+        execution.IsAccepted.ShouldBeFalse();
+        execution.IsHandled.ShouldBeFalse();
+        context.Properties.Options.ShouldBeEmpty();
+        Should.Throw<InvalidOperationException>(() => execution.Context);
 #if NETFRAMEWORK
-        token.Invoking(t => t.WaitHandle).Should().Throw<InvalidOperationException>();
+        Should.Throw<InvalidOperationException>(() => token.WaitHandle);
 #endif
         if (accept)
         {
-            result.IsDisposed.Should().BeFalse();
+            result.IsDisposed.ShouldBeFalse();
         }
         else
         {
-            result.IsDisposed.Should().BeTrue();
+            result.IsDisposed.ShouldBeTrue();
         }
     }
 
@@ -261,14 +261,14 @@ public class TaskExecutionTests : IDisposable
 
     private void AssertContext(ResilienceContext context)
     {
-        context.Should().NotBeSameAs(_primaryContext);
-        context.Properties.Should().NotBeSameAs(_primaryContext.Properties);
-        context.CancellationToken.Should().NotBeSameAs(_primaryContext.CancellationToken);
-        context.CancellationToken.CanBeCanceled.Should().BeTrue();
+        context.ShouldNotBeSameAs(_primaryContext);
+        context.Properties.ShouldNotBeSameAs(_primaryContext.Properties);
+        context.CancellationToken.ShouldNotBeSameAs(_primaryContext.CancellationToken);
+        context.CancellationToken.CanBeCanceled.ShouldBeTrue();
 
-        context.Properties.Options.Should().HaveCount(1);
-        context.Properties.TryGetValue(_myKey, out var value).Should().BeTrue();
-        value.Should().Be("dummy-value");
+        context.Properties.Options.Count.ShouldBe(1);
+        context.Properties.TryGetValue(_myKey, out var value).ShouldBeTrue();
+        value.ShouldBe("dummy-value");
     }
 
     private void CreateSnapshot(CancellationToken? token = null)

--- a/test/Polly.Core.Tests/Hedging/HedgingActionGeneratorArgumentsTests.cs
+++ b/test/Polly.Core.Tests/Hedging/HedgingActionGeneratorArgumentsTests.cs
@@ -16,9 +16,9 @@ public static class HedgingActionGeneratorArgumentsTests
         var args = new HedgingActionGeneratorArguments<string>(primaryContext, actionContext, 5, _ => Outcome.FromResultAsValueTask("dummy"));
 
         // Assert
-        args.PrimaryContext.Should().Be(primaryContext);
-        args.ActionContext.Should().Be(actionContext);
-        args.AttemptNumber.Should().Be(5);
-        args.Callback.Should().NotBeNull();
+        args.PrimaryContext.ShouldBe(primaryContext);
+        args.ActionContext.ShouldBe(actionContext);
+        args.AttemptNumber.ShouldBe(5);
+        args.Callback.ShouldNotBeNull();
     }
 }

--- a/test/Polly.Core.Tests/Hedging/HedgingDelayGeneratorArgumentsTests.cs
+++ b/test/Polly.Core.Tests/Hedging/HedgingDelayGeneratorArgumentsTests.cs
@@ -14,7 +14,7 @@ public static class HedgingDelayGeneratorArgumentsTests
         var args = new HedgingDelayGeneratorArguments(context, 5);
 
         // Assert
-        args.Context.Should().Be(context);
-        args.AttemptNumber.Should().Be(5);
+        args.Context.ShouldBe(context);
+        args.AttemptNumber.ShouldBe(5);
     }
 }

--- a/test/Polly.Core.Tests/Hedging/HedgingHandlerTests.cs
+++ b/test/Polly.Core.Tests/Hedging/HedgingHandlerTests.cs
@@ -16,7 +16,7 @@ public static class HedgingHandlerTests
             args => () => Outcome.FromResultAsValueTask("ok"),
             args => default);
 
-        handler.OnHedging.Should().NotBeNull();
+        handler.OnHedging.ShouldNotBeNull();
 
         var action = handler.GenerateAction(new HedgingActionGeneratorArguments<string>(
             context,
@@ -28,6 +28,6 @@ public static class HedgingHandlerTests
         var res = await action();
 
         // Assert
-        res.Result.Should().Be("ok");
+        res.Result.ShouldBe("ok");
     }
 }

--- a/test/Polly.Core.Tests/Hedging/HedgingPredicateArgumentsTests.cs
+++ b/test/Polly.Core.Tests/Hedging/HedgingPredicateArgumentsTests.cs
@@ -14,7 +14,7 @@ public static class HedgingPredicateArgumentsTests
         var args = new HedgingPredicateArguments<int>(context, Outcome.FromResult(1));
 
         // Assert
-        args.Context.Should().Be(context);
-        args.Outcome.Result.Should().Be(1);
+        args.Context.ShouldBe(context);
+        args.Outcome.Result.ShouldBe(1);
     }
 }

--- a/test/Polly.Core.Tests/Hedging/HedgingResiliencePipelineBuilderExtensionsTests.cs
+++ b/test/Polly.Core.Tests/Hedging/HedgingResiliencePipelineBuilderExtensionsTests.cs
@@ -18,16 +18,13 @@ public class HedgingResiliencePipelineBuilderExtensionsTests
         });
 
         _builder.Build().GetPipelineDescriptor().FirstStrategy.StrategyInstance
-            .Should().BeOfType<HedgingResilienceStrategy<string>>().Subject
-            .HedgingHandler.ActionGenerator.Should().NotBeNull();
+            .ShouldBeOfType<HedgingResilienceStrategy<string>>()
+            .HedgingHandler.ActionGenerator.ShouldNotBeNull();
     }
 
     [Fact]
     public void AddHedgingT_InvalidOptions_Throws() =>
-        _builder
-            .Invoking(b => b.AddHedging(new HedgingStrategyOptions<string> { ShouldHandle = null! }))
-            .Should()
-            .Throw<ValidationException>();
+        Should.Throw<ValidationException>(() => _builder.AddHedging(new HedgingStrategyOptions<string> { ShouldHandle = null! }));
 
     [Fact]
     public async Task AddHedging_IntegrationTest()
@@ -60,8 +57,8 @@ public class HedgingResiliencePipelineBuilderExtensionsTests
         .Build();
 
         var result = await strategy.ExecuteAsync(token => new ValueTask<string>("error"));
-        result.Should().Be("success");
-        hedgingCount.Should().Be(3);
+        result.ShouldBe("success");
+        hedgingCount.ShouldBe(3);
     }
 
     [Fact]
@@ -92,6 +89,6 @@ public class HedgingResiliencePipelineBuilderExtensionsTests
         .Build();
 
         var result = await strategy.ExecuteAsync(token => new ValueTask<string>("error"));
-        result.Should().Be("success");
+        result.ShouldBe("success");
     }
 }

--- a/test/Polly.Core.Tests/Hedging/HedgingResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Hedging/HedgingResilienceStrategyTests.cs
@@ -914,7 +914,7 @@ public class HedgingResilienceStrategyTests : IDisposable
         await strategy.ExecuteAsync(_ => new ValueTask<string>(Failure), primaryContext);
 
         attempts.Count.ShouldBe(_options.MaxHedgedAttempts);
-        attempts.OrderBy(p => p).ShouldBe(attempts);
+        attempts.ShouldBeInOrder();
         attempts[0].ShouldBe(0);
     }
 

--- a/test/Polly.Core.Tests/Hedging/HedgingResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Hedging/HedgingResilienceStrategyTests.cs
@@ -50,10 +50,10 @@ public class HedgingResilienceStrategyTests : IDisposable
         ConfigureHedging();
         var strategy = (HedgingResilienceStrategy<string>)Create().GetPipelineDescriptor().FirstStrategy.StrategyInstance;
 
-        strategy.TotalAttempts.Should().Be(_options.MaxHedgedAttempts + 1);
-        strategy.HedgingDelay.Should().Be(_options.Delay);
-        strategy.DelayGenerator.Should().BeNull();
-        strategy.HedgingHandler.Should().NotBeNull();
+        strategy.TotalAttempts.ShouldBe(_options.MaxHedgedAttempts + 1);
+        strategy.HedgingDelay.ShouldBe(_options.Delay);
+        strategy.DelayGenerator.ShouldBeNull();
+        strategy.HedgingHandler.ShouldNotBeNull();
     }
 
     [Fact]
@@ -67,8 +67,9 @@ public class HedgingResilienceStrategyTests : IDisposable
         context.CancellationToken = _cts.Token;
 
         var outcome = await strategy.ExecuteCore((_, _) => Outcome.FromResultAsValueTask("dummy"), context, "state");
-        outcome.Exception.Should().BeOfType<OperationCanceledException>();
-        outcome.Exception!.StackTrace.Should().Contain("Execute_CancellationRequested_Throws");
+        outcome.Exception.ShouldBeOfType<OperationCanceledException>();
+        outcome.Exception.StackTrace.ShouldNotBeNull();
+        outcome.Exception.StackTrace.ShouldContain("Execute_CancellationRequested_Throws");
     }
 
     [Fact]
@@ -88,13 +89,13 @@ public class HedgingResilienceStrategyTests : IDisposable
 
         var attempts = _events.Select(v => v.Arguments).OfType<ExecutionAttemptArguments>().ToArray();
 
-        attempts[0].Handled.Should().BeTrue();
-        attempts[0].Duration.Should().BeGreaterThan(TimeSpan.Zero);
-        attempts[0].AttemptNumber.Should().Be(0);
+        attempts[0].Handled.ShouldBeTrue();
+        attempts[0].Duration.ShouldBeGreaterThan(TimeSpan.Zero);
+        attempts[0].AttemptNumber.ShouldBe(0);
 
-        attempts[1].Handled.Should().BeTrue();
-        attempts[1].Duration.Should().BeGreaterThan(TimeSpan.Zero);
-        attempts[1].AttemptNumber.Should().Be(1);
+        attempts[1].Handled.ShouldBeTrue();
+        attempts[1].Duration.ShouldBeGreaterThan(TimeSpan.Zero);
+        attempts[1].AttemptNumber.ShouldBe(1);
     }
 
     [Fact]
@@ -116,7 +117,7 @@ public class HedgingResilienceStrategyTests : IDisposable
             },
             ResilienceContextPool.Shared.Get(CancellationToken));
 
-        result.Should().Be("secondary");
+        result.ShouldBe("secondary");
     }
 
     [InlineData(-1)]
@@ -133,7 +134,7 @@ public class HedgingResilienceStrategyTests : IDisposable
 
         var result = await strategy.GetHedgingDelayAsync(ResilienceContextPool.Shared.Get(CancellationToken), 0);
 
-        result.Should().Be(TimeSpan.FromSeconds(seconds));
+        result.ShouldBe(TimeSpan.FromSeconds(seconds));
     }
 
     [Fact]
@@ -145,7 +146,7 @@ public class HedgingResilienceStrategyTests : IDisposable
 
         var result = await strategy.GetHedgingDelayAsync(ResilienceContextPool.Shared.Get(CancellationToken), 0);
 
-        result.Should().Be(TimeSpan.FromMilliseconds(123));
+        result.ShouldBe(TimeSpan.FromMilliseconds(123));
     }
 
     [Fact]
@@ -156,13 +157,13 @@ public class HedgingResilienceStrategyTests : IDisposable
         var strategy = Create();
         var result = await strategy.ExecuteAsync(_primaryTasks.SlowTask, CancellationToken);
 
-        result.Should().NotBeNull();
+        result.ShouldNotBeNull();
 #if NET8_0_OR_GREATER
-        _timeProvider.TimerEntries.Should().HaveCount(8);
+        _timeProvider.TimerEntries.Count.ShouldBe(8);
 #else
-        _timeProvider.TimerEntries.Should().HaveCount(5);
+        _timeProvider.TimerEntries.Count.ShouldBe(5);
 #endif
-        result.Should().Be("Oranges");
+        result.ShouldBe("Oranges");
     }
 
     [Fact]
@@ -175,9 +176,9 @@ public class HedgingResilienceStrategyTests : IDisposable
         _options.MaxHedgedAttempts = 3;
         _options.OnHedging = args =>
         {
-            args.ActionContext.Should().NotBe(args.PrimaryContext);
-            args.PrimaryContext.Should().Be(primaryContext);
-            args.PrimaryContext.Properties.GetValue(key, string.Empty).Should().Be("dummy");
+            args.ActionContext.ShouldNotBe(args.PrimaryContext);
+            args.PrimaryContext.ShouldBe(primaryContext);
+            args.PrimaryContext.Properties.GetValue(key, string.Empty).ShouldBe("dummy");
             attempts++;
             return default;
         };
@@ -189,15 +190,15 @@ public class HedgingResilienceStrategyTests : IDisposable
                 args.PrimaryContext.Properties.Set(key, "dummy");
             }
 
-            args.PrimaryContext.Should().Be(primaryContext);
+            args.PrimaryContext.ShouldBe(primaryContext);
             return () => Outcome.FromResultAsValueTask(Failure);
         });
 
         var strategy = Create();
         var result = await strategy.ExecuteAsync(_ => new ValueTask<string>(Failure), primaryContext);
 
-        attempts.Should().Be(3);
-        primaryContext.Properties.GetValue(key, string.Empty).Should().Be("dummy");
+        attempts.ShouldBe(3);
+        primaryContext.Properties.GetValue(key, string.Empty).ShouldBe("dummy");
     }
 
     [Fact]
@@ -247,8 +248,8 @@ public class HedgingResilienceStrategyTests : IDisposable
         await Task.Delay(20, CancellationToken);
 
         _timeProvider.Advance(TimeSpan.FromHours(1));
-        (await result).Should().Be(Success);
-        cancelled.WaitOne(AssertTimeout).Should().BeTrue();
+        (await result).ShouldBe(Success);
+        cancelled.WaitOne(AssertTimeout).ShouldBeTrue();
     }
 
     [Fact]
@@ -284,7 +285,7 @@ public class HedgingResilienceStrategyTests : IDisposable
 
         await TestUtilities.AssertWithTimeoutAsync(() =>
         {
-            cancelled.WaitOne(TimeSpan.FromMilliseconds(10)).Should().BeTrue();
+            cancelled.WaitOne(TimeSpan.FromMilliseconds(10)).ShouldBeTrue();
         });
 
         await task;
@@ -322,8 +323,8 @@ public class HedgingResilienceStrategyTests : IDisposable
         await primaryResult.WaitForDisposalAsync();
         await resultTask;
 
-        primaryResult.IsDisposed.Should().BeTrue();
-        secondaryResult.IsDisposed.Should().BeFalse();
+        primaryResult.IsDisposed.ShouldBeTrue();
+        secondaryResult.IsDisposed.ShouldBeFalse();
     }
 
     [Fact]
@@ -344,8 +345,8 @@ public class HedgingResilienceStrategyTests : IDisposable
             return async () =>
             {
                 tokenHashCodes.Add(args.ActionContext.CancellationToken.GetHashCode());
-                args.ActionContext.CancellationToken.CanBeCanceled.Should().BeTrue();
-                args.ActionContext.Properties.GetValue(beforeKey, "wrong").Should().Be("before");
+                args.ActionContext.CancellationToken.CanBeCanceled.ShouldBeTrue();
+                args.ActionContext.Properties.GetValue(beforeKey, "wrong").ShouldBe("before");
                 contexts.Add(args.ActionContext);
                 await Task.Yield();
                 args.ActionContext.Properties.Set(afterKey, "after");
@@ -359,10 +360,10 @@ public class HedgingResilienceStrategyTests : IDisposable
         var result = await strategy.ExecuteAsync(
             async (context, _) =>
             {
-                context.CancellationToken.CanBeCanceled.Should().BeTrue();
+                context.CancellationToken.CanBeCanceled.ShouldBeTrue();
                 tokenHashCodes.Add(context.CancellationToken.GetHashCode());
-                context.Properties.GetValue(beforeKey, "wrong").Should().Be("before");
-                context.Should().NotBe(primaryContext);
+                context.Properties.GetValue(beforeKey, "wrong").ShouldBe("before");
+                context.ShouldNotBe(primaryContext);
                 contexts.Add(context);
                 await _timeProvider.Delay(LongDelay, context.CancellationToken);
                 return "primary";
@@ -371,10 +372,10 @@ public class HedgingResilienceStrategyTests : IDisposable
             "dummy");
 
         // assert
-        contexts.Should().HaveCountGreaterThan(1);
-        contexts.Count.Should().Be(contexts.Distinct().Count());
+        contexts.Count.ShouldBeGreaterThan(1);
+        contexts.Count.ShouldBe(contexts.Distinct().Count());
         _timeProvider.Advance(LongDelay);
-        tokenHashCodes.Distinct().Should().HaveCountGreaterThan(1);
+        tokenHashCodes.Distinct().Count().ShouldBeGreaterThan(1);
     }
 
     [Fact]
@@ -391,7 +392,7 @@ public class HedgingResilienceStrategyTests : IDisposable
         var result = await strategy.ExecuteAsync((_, _) => new ValueTask<string>("primary"), primaryContext, "dummy");
 
         // assert
-        primaryContext.CancellationToken.Should().Be(cancellationSource.Token);
+        primaryContext.CancellationToken.ShouldBe(cancellationSource.Token);
     }
 
     [InlineData(true)]
@@ -415,7 +416,7 @@ public class HedgingResilienceStrategyTests : IDisposable
             return () =>
             {
                 contexts.Add(args.ActionContext);
-                args.ActionContext.Properties.GetValue(primaryKey, string.Empty).Should().Be("primary");
+                args.ActionContext.Properties.GetValue(primaryKey, string.Empty).ShouldBe("primary");
                 args.ActionContext.Properties.Set(secondaryKey, "secondary");
                 return Outcome.FromResultAsValueTask(primaryFails ? Success : Failure);
             };
@@ -426,9 +427,9 @@ public class HedgingResilienceStrategyTests : IDisposable
         await strategy.ExecuteAsync(
             (context, _) =>
             {
-                context.Should().NotBe(primaryContext);
+                context.ShouldNotBe(primaryContext);
                 contexts.Add(context);
-                context.Properties.GetValue(primaryKey, string.Empty).Should().Be("primary");
+                context.Properties.GetValue(primaryKey, string.Empty).ShouldBe("primary");
                 context.Properties.Set(primaryKey2, "primary-2");
                 return new ValueTask<string>(primaryFails ? Failure : Success);
             },
@@ -437,21 +438,21 @@ public class HedgingResilienceStrategyTests : IDisposable
 
         // assert
 
-        primaryContext.Properties.GetValue(primaryKey, string.Empty).Should().Be("primary");
-        primaryContext.Properties.Options.Should().HaveCount(2);
-        primaryContext.Properties.Should().BeSameAs(storedProps);
+        primaryContext.Properties.GetValue(primaryKey, string.Empty).ShouldBe("primary");
+        primaryContext.Properties.Options.Count.ShouldBe(2);
+        primaryContext.Properties.ShouldBeSameAs(storedProps);
 
         if (primaryFails)
         {
-            contexts.Should().HaveCount(2);
-            primaryContext.Properties.GetValue(secondaryKey, string.Empty).Should().Be("secondary");
-            primaryContext.Properties.GetValue(primaryKey2, string.Empty).Should().BeEmpty();
+            contexts.Count.ShouldBe(2);
+            primaryContext.Properties.GetValue(secondaryKey, string.Empty).ShouldBe("secondary");
+            primaryContext.Properties.GetValue(primaryKey2, string.Empty).ShouldBeEmpty();
         }
         else
         {
-            contexts.Should().HaveCount(1);
-            primaryContext.Properties.GetValue(primaryKey2, string.Empty).Should().Be("primary-2");
-            primaryContext.Properties.GetValue(secondaryKey, string.Empty).Should().BeEmpty();
+            contexts.Count.ShouldBe(1);
+            primaryContext.Properties.GetValue(primaryKey2, string.Empty).ShouldBe("primary-2");
+            primaryContext.Properties.GetValue(secondaryKey, string.Empty).ShouldBeEmpty();
         }
     }
 
@@ -473,17 +474,17 @@ public class HedgingResilienceStrategyTests : IDisposable
         var result = await strategy.ExecuteAsync(
             (context, _) =>
             {
-                primaryContext.Properties.TryGetValue(key2, out var val).Should().BeTrue();
-                val.Should().Be("my-value-2");
+                primaryContext.Properties.TryGetValue(key2, out var val).ShouldBeTrue();
+                val.ShouldBe("my-value-2");
                 context.Properties.Set(key, "my-value");
                 return new ValueTask<string>("primary");
             },
             primaryContext, "dummy");
 
         // assert
-        primaryContext.Properties.TryGetValue(key, out var val).Should().BeTrue();
-        val.Should().Be("my-value");
-        primaryContext.Properties.Should().BeSameAs(props);
+        primaryContext.Properties.TryGetValue(key, out var val).ShouldBeTrue();
+        val.ShouldBe("my-value");
+        primaryContext.Properties.ShouldBeSameAs(props);
     }
 
     [Fact]
@@ -499,8 +500,8 @@ public class HedgingResilienceStrategyTests : IDisposable
         {
             return () =>
             {
-                args.ActionContext.Properties.TryGetValue(key2, out var val).Should().BeTrue();
-                val.Should().Be("my-value-2");
+                args.ActionContext.Properties.TryGetValue(key2, out var val).ShouldBeTrue();
+                val.ShouldBe("my-value-2");
                 args.ActionContext.Properties.Set(key, "my-value");
                 return Outcome.FromResultAsValueTask(Success);
             };
@@ -511,10 +512,10 @@ public class HedgingResilienceStrategyTests : IDisposable
         var result = await strategy.ExecuteAsync((_, _) => new ValueTask<string>(Failure), primaryContext, "state");
 
         // assert
-        result.Should().Be(Success);
-        primaryContext.Properties.TryGetValue(key, out var val).Should().BeTrue();
-        primaryContext.Properties.Should().BeSameAs(storedProps);
-        val.Should().Be("my-value");
+        result.ShouldBe(Success);
+        primaryContext.Properties.TryGetValue(key, out var val).ShouldBeTrue();
+        primaryContext.Properties.ShouldBeSameAs(storedProps);
+        val.ShouldBe("my-value");
     }
 
     [Fact]
@@ -525,12 +526,10 @@ public class HedgingResilienceStrategyTests : IDisposable
         ConfigureHedging(args => () => Outcome.FromResultAsValueTask(Success));
         var strategy = Create();
 
-        // act
-        (await strategy
-            .Invoking(s => s.ExecuteAsync(_ => new ValueTask<string>(Failure)).AsTask())
-            .Should()
-            .ThrowAsync<InvalidOperationException>())
-            .WithMessage("my-exception");
+        // act and assert
+        var exception = await Should.ThrowAsync<InvalidOperationException>(
+            () => strategy.ExecuteAsync(_ => new ValueTask<string>(Failure)).AsTask());
+        exception.Message.ShouldBe("my-exception");
     }
 
     [InlineData(-1)] // Fallback mode
@@ -562,7 +561,7 @@ public class HedgingResilienceStrategyTests : IDisposable
         var actual = await Create().ExecuteAsync(Execute, _cts.Token);
 
         // assert
-        actual.Should().Be("1st");
+        actual.ShouldBe("1st");
     }
 
     [Fact]
@@ -615,10 +614,10 @@ public class HedgingResilienceStrategyTests : IDisposable
         _timeProvider.Advance(TimeSpan.FromHours(4));
         cancellationSource.Cancel();
         _timeProvider.Advance(TimeSpan.FromHours(1));
-        await task.Invoking(async t => await t).Should().ThrowAsync<OperationCanceledException>();
+        await Should.ThrowAsync<OperationCanceledException>(async () => await task);
 
-        primaryCancelled.WaitOne(AssertTimeout).Should().BeTrue();
-        secondaryCancelled.WaitOne(AssertTimeout).Should().BeTrue();
+        primaryCancelled.WaitOne(AssertTimeout).ShouldBeTrue();
+        secondaryCancelled.WaitOne(AssertTimeout).ShouldBeTrue();
     }
 
     [Fact]
@@ -639,7 +638,7 @@ public class HedgingResilienceStrategyTests : IDisposable
         await Assert.ThrowsAsync<TaskCanceledException>(() => backgroundTasks[0]);
 
         // background task is still pending
-        backgroundTasks[1].IsCompleted.Should().BeFalse();
+        backgroundTasks[1].IsCompleted.ShouldBeFalse();
 
         cts.Cancel();
 
@@ -672,7 +671,7 @@ public class HedgingResilienceStrategyTests : IDisposable
         var task = Create().ExecuteAsync(async c => (await Execute(c)).Result!, CancellationToken);
 
         // assert
-        allExecutionsReached.WaitOne(AssertTimeout).Should().BeTrue();
+        allExecutionsReached.WaitOne(AssertTimeout).ShouldBeTrue();
         _timeProvider.Advance(LongDelay);
         await task;
 
@@ -701,7 +700,7 @@ public class HedgingResilienceStrategyTests : IDisposable
         var pending = Create().ExecuteAsync(Execute, _cts.Token);
 
         // assert
-        allExecutions.WaitOne(AssertTimeout).Should().BeTrue();
+        allExecutions.WaitOne(AssertTimeout).ShouldBeTrue();
 
         async ValueTask<string> Execute(CancellationToken token)
         {
@@ -756,8 +755,8 @@ public class HedgingResilienceStrategyTests : IDisposable
         });
 
         var strategy = Create();
-        await strategy.Invoking(s => s.ExecuteAsync<string>(_ => throw new InvalidCastException()).AsTask()).Should().ThrowAsync<BadImageFormatException>();
-        attempts.Should().Be(3);
+        await Should.ThrowAsync<BadImageFormatException>(() => strategy.ExecuteAsync<string>(_ => throw new InvalidCastException()).AsTask());
+        attempts.ShouldBe(3);
     }
 
     [Fact]
@@ -788,8 +787,8 @@ public class HedgingResilienceStrategyTests : IDisposable
         });
 
         var strategy = Create();
-        await strategy.Invoking(s => s.ExecuteAsync<string>(_ => throw new InvalidCastException()).AsTask()).Should().ThrowAsync<InvalidCastException>();
-        attempts.Should().Be(3);
+        await Should.ThrowAsync<InvalidCastException>(() => strategy.ExecuteAsync<string>(_ => throw new InvalidCastException()).AsTask());
+        attempts.ShouldBe(3);
     }
 
     [Fact]
@@ -804,8 +803,8 @@ public class HedgingResilienceStrategyTests : IDisposable
         });
 
         var strategy = Create();
-        await strategy.Invoking(s => s.ExecuteAsync<string>(_ => throw new InvalidCastException()).AsTask()).Should().ThrowAsync<InvalidCastException>();
-        attempts.Should().Be(0);
+        await Should.ThrowAsync<InvalidCastException>(() => strategy.ExecuteAsync<string>(_ => throw new InvalidCastException()).AsTask());
+        attempts.ShouldBe(0);
     }
 
     [Fact]
@@ -846,7 +845,7 @@ public class HedgingResilienceStrategyTests : IDisposable
 
         var strategy = Create();
         var result = await strategy.ExecuteAsync<string>(_ => throw new InvalidCastException(), CancellationToken);
-        result.Should().Be(Success);
+        result.ShouldBe(Success);
     }
 
     [Fact]
@@ -865,8 +864,8 @@ public class HedgingResilienceStrategyTests : IDisposable
         }, CancellationToken);
 
         _timeProvider.Advance(TimeSpan.FromHours(5));
-        (await task).Should().Be(Success);
-        _timeProvider.TimerEntries.Should().Contain(e => e.Delay == delay);
+        (await task).ShouldBe(Success);
+        _timeProvider.TimerEntries.ShouldContain(e => e.Delay == delay);
     }
 
     [Fact]
@@ -876,10 +875,11 @@ public class HedgingResilienceStrategyTests : IDisposable
 
         var strategy = Create();
 
-        var exception = await strategy.Invoking(s => s.ExecuteAsync(PrimaryTaskThatThrowsError).AsTask()).Should().ThrowAsync<InvalidOperationException>();
+        var exception = await Should.ThrowAsync<InvalidOperationException>(() => strategy.ExecuteAsync(PrimaryTaskThatThrowsError).AsTask());
 
-        exception.WithMessage("Forced Error");
-        exception.And.StackTrace.Should().Contain(nameof(PrimaryTaskThatThrowsError));
+        exception.Message.ShouldBe("Forced Error");
+        exception.StackTrace.ShouldNotBeNull();
+        exception.StackTrace.ShouldContain(nameof(PrimaryTaskThatThrowsError));
 
         static ValueTask<string> PrimaryTaskThatThrowsError(CancellationToken cancellationToken) => throw new InvalidOperationException("Forced Error");
     }
@@ -894,10 +894,10 @@ public class HedgingResilienceStrategyTests : IDisposable
         var attempts = new List<int>();
         _options.OnHedging = args =>
         {
-            args.PrimaryContext.Should().Be(primaryContext);
-            args.ActionContext.Should().NotBe(args.PrimaryContext);
-            args.PrimaryContext.Properties.GetValue(key, string.Empty).Should().Be("my-value");
-            args.ActionContext.Properties.GetValue(key, string.Empty).Should().Be("my-value");
+            args.PrimaryContext.ShouldBe(primaryContext);
+            args.ActionContext.ShouldNotBe(args.PrimaryContext);
+            args.PrimaryContext.Properties.GetValue(key, string.Empty).ShouldBe("my-value");
+            args.ActionContext.Properties.GetValue(key, string.Empty).ShouldBe("my-value");
             args.ActionContext.Properties.Set(key, "new-value");
             attempts.Add(args.AttemptNumber);
             return default;
@@ -906,16 +906,16 @@ public class HedgingResilienceStrategyTests : IDisposable
         ConfigureHedging(res => res.Result == Failure,
             args => () =>
             {
-                args.ActionContext.Properties.GetValue(key, string.Empty).Should().Be("new-value");
+                args.ActionContext.Properties.GetValue(key, string.Empty).ShouldBe("new-value");
                 return Outcome.FromResultAsValueTask(Failure);
             });
 
         var strategy = Create();
         await strategy.ExecuteAsync(_ => new ValueTask<string>(Failure), primaryContext);
 
-        attempts.Should().HaveCount(_options.MaxHedgedAttempts);
-        attempts.Should().BeInAscendingOrder();
-        attempts[0].Should().Be(0);
+        attempts.Count.ShouldBe(_options.MaxHedgedAttempts);
+        attempts.OrderBy(p => p).ShouldBe(attempts);
+        attempts[0].ShouldBe(0);
     }
 
     [Fact]
@@ -928,8 +928,8 @@ public class HedgingResilienceStrategyTests : IDisposable
         var strategy = Create();
         await strategy.ExecuteAsync((_, _) => new ValueTask<string>(Failure), context, "state");
 
-        _events.Should().HaveCount(_options.MaxHedgedAttempts + 4);
-        _events.Select(v => v.Event.EventName).Distinct().Should().HaveCount(2);
+        _events.Count.ShouldBe(_options.MaxHedgedAttempts + 4);
+        _events.Select(v => v.Event.EventName).Distinct().Count().ShouldBe(2);
     }
 
     private void ConfigureHedging() =>

--- a/test/Polly.Core.Tests/Hedging/HedgingStrategyOptionsTests.cs
+++ b/test/Polly.Core.Tests/Hedging/HedgingStrategyOptionsTests.cs
@@ -11,12 +11,12 @@ public class HedgingStrategyOptionsTests
     {
         var options = new HedgingStrategyOptions<int>();
 
-        options.ShouldHandle.Should().NotBeNull();
-        options.ActionGenerator.Should().NotBeNull();
-        options.Delay.Should().Be(TimeSpan.FromSeconds(2));
-        options.MaxHedgedAttempts.Should().Be(1);
-        options.OnHedging.Should().BeNull();
-        options.Name.Should().Be("Hedging");
+        options.ShouldHandle.ShouldNotBeNull();
+        options.ActionGenerator.ShouldNotBeNull();
+        options.Delay.ShouldBe(TimeSpan.FromSeconds(2));
+        options.MaxHedgedAttempts.ShouldBe(1);
+        options.OnHedging.ShouldBeNull();
+        options.Name.ShouldBe("Hedging");
     }
 
     [InlineData(true)]
@@ -33,11 +33,11 @@ public class HedgingStrategyOptionsTests
         {
             if (synchronous)
             {
-                Thread.CurrentThread.ManagedThreadId.Should().NotBe(threadId);
+                Thread.CurrentThread.ManagedThreadId.ShouldNotBe(threadId);
             }
             else
             {
-                Thread.CurrentThread.ManagedThreadId.Should().Be(threadId);
+                Thread.CurrentThread.ManagedThreadId.ShouldBe(threadId);
             }
 
             semaphore.Release();
@@ -47,9 +47,8 @@ public class HedgingStrategyOptionsTests
         var task = action();
         semaphore
             .Wait(TimeSpan.FromSeconds(20))
-            .Should()
-            .BeTrue("The test thread failed to complete within the timeout");
-        (await task).Result.Should().Be(99);
+            .ShouldBeTrue("The test thread failed to complete within the timeout");
+        (await task).Result.ShouldBe(99);
     }
 
     [Fact]
@@ -58,9 +57,9 @@ public class HedgingStrategyOptionsTests
         var options = new HedgingStrategyOptions<int>();
         var context = ResilienceContextPool.Shared.Get();
 
-        (await options.ShouldHandle(new HedgingPredicateArguments<int>(context, Outcome.FromResult(0)))).Should().Be(false);
-        (await options.ShouldHandle(new HedgingPredicateArguments<int>(context, Outcome.FromException<int>(new OperationCanceledException())))).Should().Be(false);
-        (await options.ShouldHandle(new HedgingPredicateArguments<int>(context, Outcome.FromException<int>(new InvalidOperationException())))).Should().Be(true);
+        (await options.ShouldHandle(new HedgingPredicateArguments<int>(context, Outcome.FromResult(0)))).ShouldBe(false);
+        (await options.ShouldHandle(new HedgingPredicateArguments<int>(context, Outcome.FromException<int>(new OperationCanceledException())))).ShouldBe(false);
+        (await options.ShouldHandle(new HedgingPredicateArguments<int>(context, Outcome.FromException<int>(new InvalidOperationException())))).ShouldBe(true);
     }
 
     [Fact]
@@ -75,17 +74,14 @@ public class HedgingStrategyOptionsTests
             ActionGenerator = null!
         };
 
-        options
-            .Invoking(o => ValidationHelper.ValidateObject(new(o, "Invalid.")))
-            .Should()
-            .Throw<ValidationException>()
-            .WithMessage("""
+        var exception = Should.Throw<ValidationException>(() => ValidationHelper.ValidateObject(new(options, "Invalid.")));
+        exception.Message.Trim().ShouldBe("""
             Invalid.
-
             Validation Errors:
             The field MaxHedgedAttempts must be between 1 and 10.
             The ShouldHandle field is required.
             The ActionGenerator field is required.
-            """);
+            """,
+            StringCompareShould.IgnoreLineEndings);
     }
 }

--- a/test/Polly.Core.Tests/Hedging/OnHedgingArgumentsTests.cs
+++ b/test/Polly.Core.Tests/Hedging/OnHedgingArgumentsTests.cs
@@ -16,8 +16,8 @@ public static class OnHedgingArgumentsTests
         var args = new OnHedgingArguments<int>(primaryContext, actionContext, 1);
 
         // Assert
-        args.PrimaryContext.Should().Be(primaryContext);
-        args.ActionContext.Should().Be(actionContext);
-        args.AttemptNumber.Should().Be(1);
+        args.PrimaryContext.ShouldBe(primaryContext);
+        args.ActionContext.ShouldBe(actionContext);
+        args.AttemptNumber.ShouldBe(1);
     }
 }

--- a/test/Polly.Core.Tests/Issues/IssuesTests.CircuitBreakerStateRegistry_1828.cs
+++ b/test/Polly.Core.Tests/Issues/IssuesTests.CircuitBreakerStateRegistry_1828.cs
@@ -35,13 +35,13 @@ public partial class IssuesTests
         });
 
         // Assert
-        states.Should().HaveCount(2);
+        states.Count.ShouldBe(2);
         registry.GetPipeline("C");
-        states.Should().HaveCount(3);
+        states.Count.ShouldBe(3);
 
         foreach (var state in states)
         {
-            state.CircuitState.Should().Be(CircuitState.Closed);
+            state.CircuitState.ShouldBe(CircuitState.Closed);
         }
     }
 }

--- a/test/Polly.Core.Tests/Issues/IssuesTests.CircuitBreakerStateSharing_959.cs
+++ b/test/Polly.Core.Tests/Issues/IssuesTests.CircuitBreakerStateSharing_959.cs
@@ -34,8 +34,8 @@ public partial class IssuesTests
         }
 
         // now the circuit breaker should be open
-        strategy.Invoking(s => s.Execute(_ => 0)).Should().Throw<BrokenCircuitException>();
-        strategy.Invoking(s => s.Execute(_ => "valid-result")).Should().Throw<BrokenCircuitException>();
+        Should.Throw<BrokenCircuitException>(() => strategy.Execute(_ => 0));
+        Should.Throw<BrokenCircuitException>(() => strategy.Execute(_ => "valid-result"));
 
         // now wait for recovery
         TimeProvider.Advance(options.BreakDuration);

--- a/test/Polly.Core.Tests/Issues/IssuesTests.FlowingContext_849.cs
+++ b/test/Polly.Core.Tests/Issues/IssuesTests.FlowingContext_849.cs
@@ -16,7 +16,7 @@ public partial class IssuesTests
                 {
                     // access the context to evaluate the retry
                     ResilienceContext context = args.Context;
-                    context.Should().NotBeNull();
+                    context.ShouldNotBeNull();
                     contextChecked = true;
                     return PredicateResult.False();
                 }
@@ -26,6 +26,6 @@ public partial class IssuesTests
         // execute the retry
         strategy.Execute(_ => 0);
 
-        contextChecked.Should().BeTrue();
+        contextChecked.ShouldBeTrue();
     }
 }

--- a/test/Polly.Core.Tests/Issues/IssuesTests.HandleMultipleResults_898.cs
+++ b/test/Polly.Core.Tests/Issues/IssuesTests.HandleMultipleResults_898.cs
@@ -45,7 +45,7 @@ public partial class IssuesTests
 
             isRetry = true;
             return -1;
-        }, cancellationToken).Should().Be(0);
+        }, cancellationToken).ShouldBe(0);
 
         // check that string-based results is retried
         isRetry = false;
@@ -58,6 +58,6 @@ public partial class IssuesTests
 
             isRetry = true;
             return "error";
-        }, cancellationToken).Should().Be("no-error");
+        }, cancellationToken).ShouldBe("no-error");
     }
 }

--- a/test/Polly.Core.Tests/Issues/IssuesTests.InfiniteRetry_2163.cs
+++ b/test/Polly.Core.Tests/Issues/IssuesTests.InfiniteRetry_2163.cs
@@ -21,7 +21,7 @@ public partial class IssuesTests
             UseJitter = true,
             OnRetry = (args) =>
             {
-                args.RetryDelay.Should().BeGreaterThan(TimeSpan.Zero, $"RetryDelay is less than zero after {args.AttemptNumber} attempts");
+                args.RetryDelay.ShouldBeGreaterThan(TimeSpan.Zero, $"RetryDelay is less than zero after {args.AttemptNumber} attempts");
                 attempts++;
                 return default;
             },
@@ -54,7 +54,7 @@ public partial class IssuesTests
 
         var actual = await executing;
 
-        actual.Should().BeTrue();
-        attempts.Should().Be(succeedAfter);
+        actual.ShouldBeTrue();
+        attempts.ShouldBe(succeedAfter);
     }
 }

--- a/test/Polly.Core.Tests/OutcomeTests.cs
+++ b/test/Polly.Core.Tests/OutcomeTests.cs
@@ -5,44 +5,44 @@ public class OutcomeTests
     public void Ctor_Result_Ok()
     {
         var outcome = Outcome.FromResult(10);
-        outcome.HasResult.Should().BeTrue();
-        outcome.Exception.Should().BeNull();
-        outcome.ExceptionDispatchInfo.Should().BeNull();
-        outcome.IsVoidResult.Should().BeFalse();
-        outcome.TryGetResult(out var result).Should().BeTrue();
-        result.Should().Be(10);
-        outcome.ToString().Should().Be("10");
+        outcome.HasResult.ShouldBeTrue();
+        outcome.Exception.ShouldBeNull();
+        outcome.ExceptionDispatchInfo.ShouldBeNull();
+        outcome.IsVoidResult.ShouldBeFalse();
+        outcome.TryGetResult(out var result).ShouldBeTrue();
+        result.ShouldBe(10);
+        outcome.ToString().ShouldBe("10");
     }
 
     [Fact]
     public void Ctor_VoidResult_Ok()
     {
         var outcome = Outcome.Void;
-        outcome.HasResult.Should().BeTrue();
-        outcome.Exception.Should().BeNull();
-        outcome.IsVoidResult.Should().BeTrue();
-        outcome.TryGetResult(out var result).Should().BeFalse();
-        outcome.Result.Should().Be(VoidResult.Instance);
-        outcome.ToString().Should().Be("void");
+        outcome.HasResult.ShouldBeTrue();
+        outcome.Exception.ShouldBeNull();
+        outcome.IsVoidResult.ShouldBeTrue();
+        outcome.TryGetResult(out var result).ShouldBeFalse();
+        outcome.Result.ShouldBe(VoidResult.Instance);
+        outcome.ToString().ShouldBe("void");
     }
 
     [Fact]
     public void Ctor_Exception_Ok()
     {
         var outcome = Outcome.FromException(new InvalidOperationException("Dummy message."));
-        outcome.HasResult.Should().BeFalse();
-        outcome.Exception.Should().NotBeNull();
-        outcome.ExceptionDispatchInfo.Should().NotBeNull();
-        outcome.IsVoidResult.Should().BeFalse();
-        outcome.TryGetResult(out var result).Should().BeFalse();
-        outcome.ToString().Should().Be("Dummy message.");
+        outcome.HasResult.ShouldBeFalse();
+        outcome.Exception.ShouldNotBeNull();
+        outcome.ExceptionDispatchInfo.ShouldNotBeNull();
+        outcome.IsVoidResult.ShouldBeFalse();
+        outcome.TryGetResult(out var result).ShouldBeFalse();
+        outcome.ToString().ShouldBe("Dummy message.");
     }
 
     [Fact]
     public void ToString_NullResult_ShouldBeEmpty()
     {
         var outcome = Outcome.FromResult<object>(default);
-        outcome.ToString().Should().BeEmpty();
+        outcome.ToString().ShouldBeEmpty();
     }
 
     [Fact]
@@ -50,7 +50,7 @@ public class OutcomeTests
     {
         var outcome = Outcome.FromResult("dummy");
 
-        outcome.Invoking(o => o.ThrowIfException()).Should().NotThrow();
+        Should.NotThrow(outcome.ThrowIfException);
     }
 
     [Fact]
@@ -58,6 +58,6 @@ public class OutcomeTests
     {
         var outcome = Outcome.FromException<string>(new InvalidOperationException());
 
-        outcome.Invoking(o => o.ThrowIfException()).Should().Throw<InvalidOperationException>();
+        Should.Throw<InvalidOperationException>(outcome.ThrowIfException);
     }
 }

--- a/test/Polly.Core.Tests/Polly.Core.Tests.csproj
+++ b/test/Polly.Core.Tests/Polly.Core.Tests.csproj
@@ -12,10 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.Bcl.TimeProvider" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" />
+    <PackageReference Include="Shouldly" />
   </ItemGroup>
 
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net9.0'))">
@@ -29,8 +29,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Using Include="FluentAssertions" />
     <Using Include="Polly.Core.Tests.Helpers" />
     <Using Include="Polly.TestUtils" />
+    <Using Include="Shouldly" />
   </ItemGroup>
 </Project>

--- a/test/Polly.Core.Tests/Polly.Core.Tests.csproj
+++ b/test/Polly.Core.Tests/Polly.Core.Tests.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.Bcl.TimeProvider" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" />
@@ -28,6 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Using Include="FluentAssertions" />
     <Using Include="Polly.Core.Tests.Helpers" />
     <Using Include="Polly.TestUtils" />
   </ItemGroup>

--- a/test/Polly.Core.Tests/PredicateBuilderTests.cs
+++ b/test/Polly.Core.Tests/PredicateBuilderTests.cs
@@ -55,8 +55,8 @@ public class PredicateBuilderTests
     [Fact]
     public void Ctor_Ok()
     {
-        new PredicateBuilder().Should().NotBeNull();
-        new PredicateBuilder<string>().Should().NotBeNull();
+        new PredicateBuilder().ShouldNotBeNull();
+        new PredicateBuilder<string>().ShouldNotBeNull();
     }
 
     [Theory]
@@ -70,17 +70,14 @@ public class PredicateBuilderTests
         configure(predicate);
 
         var result = predicate.Build()(value);
-        result.Should().Be(handled);
+        result.ShouldBe(handled);
     }
 
     [Fact]
     public void CreatePredicate_NotConfigured_Throws()
     {
-        var predicate = new PredicateBuilder<string>()
-            .Invoking(b => b.Build())
-            .Should()
-            .Throw<InvalidOperationException>()
-            .WithMessage("No predicates were configured. There must be at least one predicate added.");
+        var exception = Should.Throw<InvalidOperationException>(() => new PredicateBuilder<string>().Build());
+        exception.Message.ShouldBe("No predicates were configured. There must be at least one predicate added.");
     }
 
     [Fact]
@@ -94,7 +91,7 @@ public class PredicateBuilderTests
 
         var handled = await options.ShouldHandle(new RetryPredicateArguments<string>(context, CreateOutcome("error"), 0));
 
-        handled.Should().BeTrue();
+        handled.ShouldBeTrue();
     }
 
     [Fact]
@@ -108,7 +105,7 @@ public class PredicateBuilderTests
 
         var handled = await options.ShouldHandle(new(context, CreateOutcome("error")));
 
-        handled.Should().BeTrue();
+        handled.ShouldBeTrue();
     }
 
     [Fact]
@@ -122,7 +119,7 @@ public class PredicateBuilderTests
 
         var handled = await options.ShouldHandle(new(context, CreateOutcome("error")));
 
-        handled.Should().BeTrue();
+        handled.ShouldBeTrue();
     }
 
     [Fact]
@@ -136,7 +133,7 @@ public class PredicateBuilderTests
 
         var handled = await options.ShouldHandle(new(context, CreateOutcome("error")));
 
-        handled.Should().BeTrue();
+        handled.ShouldBeTrue();
     }
 
     private static Outcome<string> CreateOutcome(Exception exception)

--- a/test/Polly.Core.Tests/PredicateResultTests.cs
+++ b/test/Polly.Core.Tests/PredicateResultTests.cs
@@ -4,9 +4,9 @@ public class PredicateResultTests
 {
     [Fact]
     public async Task True_Ok() =>
-        (await PredicateResult.True()).Should().BeTrue();
+        (await PredicateResult.True()).ShouldBeTrue();
 
     [Fact]
     public async Task False_Ok() =>
-        (await PredicateResult.False()).Should().BeFalse();
+        (await PredicateResult.False()).ShouldBeFalse();
 }

--- a/test/Polly.Core.Tests/Registry/ConfigureBuilderContextTests.cs
+++ b/test/Polly.Core.Tests/Registry/ConfigureBuilderContextTests.cs
@@ -16,6 +16,6 @@ public static class ConfigureBuilderContextTests
         source.Cancel();
         context.AddReloadToken(source.Token);
 
-        context.ReloadTokens.Should().HaveCount(1);
+        context.ReloadTokens.Count.ShouldBe(1);
     }
 }

--- a/test/Polly.Core.Tests/Registry/ResiliencePipelineProviderTests.cs
+++ b/test/Polly.Core.Tests/Registry/ResiliencePipelineProviderTests.cs
@@ -6,28 +6,26 @@ namespace Polly.Core.Tests.Registry;
 public class ResiliencePipelineProviderTests
 {
     [Fact]
-    public void Get_DoesNotExist_Throws() =>
-        new Provider()
-            .Invoking(o => o.GetPipeline("not-exists"))
-            .Should()
-            .Throw<KeyNotFoundException>()
-            .WithMessage("Unable to find a resilience pipeline associated with the key 'not-exists'. Please ensure that either the resilience pipeline or the builder is registered.");
+    public void Get_DoesNotExist_Throws()
+    {
+        var exception = Should.Throw<KeyNotFoundException>(() => new Provider().GetPipeline("not-exists"));
+        exception.Message.ShouldBe("Unable to find a resilience pipeline associated with the key 'not-exists'. Please ensure that either the resilience pipeline or the builder is registered.");
+    }
 
     [Fact]
-    public void Get_GenericDoesNotExist_Throws() =>
-        new Provider()
-            .Invoking(o => o.GetPipeline<string>("not-exists"))
-            .Should()
-            .Throw<KeyNotFoundException>()
-            .WithMessage("Unable to find a generic resilience pipeline of 'String' associated with the key 'not-exists'. " +
+    public void Get_GenericDoesNotExist_Throws()
+    {
+        var exception = Should.Throw<KeyNotFoundException>(() => new Provider().GetPipeline<string>("not-exists"));
+        exception.Message.ShouldBe("Unable to find a generic resilience pipeline of 'String' associated with the key 'not-exists'. " +
             "Please ensure that either the generic resilience pipeline or the generic builder is registered.");
+    }
 
     [Fact]
     public void Get_Exist_Ok()
     {
         var provider = new Provider { Strategy = new TestResilienceStrategy().AsPipeline() };
 
-        provider.GetPipeline("exists").Should().Be(provider.Strategy);
+        provider.GetPipeline("exists").ShouldBe(provider.Strategy);
     }
 
     [Fact]
@@ -35,7 +33,7 @@ public class ResiliencePipelineProviderTests
     {
         var provider = new Provider { GenericStrategy = ResiliencePipeline<string>.Empty };
 
-        provider.GetPipeline<string>("exists").Should().Be(provider.GenericStrategy);
+        provider.GetPipeline<string>("exists").ShouldBe(provider.GenericStrategy);
     }
 
     private class Provider : ResiliencePipelineProvider<string>

--- a/test/Polly.Core.Tests/Registry/ResiliencePipelineRegistryOptionsTests.cs
+++ b/test/Polly.Core.Tests/Registry/ResiliencePipelineRegistryOptionsTests.cs
@@ -8,10 +8,10 @@ public class ResiliencePipelineRegistryOptionsTests
     {
         ResiliencePipelineRegistryOptions<object> options = new();
 
-        options.InstanceNameFormatter.Should().BeNull();
+        options.InstanceNameFormatter.ShouldBeNull();
 
-        options.BuilderNameFormatter.Should().NotBeNull();
-        options.BuilderNameFormatter(null!).Should().Be("");
-        options.BuilderNameFormatter("ABC").Should().Be("ABC");
+        options.BuilderNameFormatter.ShouldNotBeNull();
+        options.BuilderNameFormatter(null!).ShouldBe("");
+        options.BuilderNameFormatter("ABC").ShouldBe("ABC");
     }
 }

--- a/test/Polly.Core.Tests/Registry/ResiliencePipelineRegistryTests.cs
+++ b/test/Polly.Core.Tests/Registry/ResiliencePipelineRegistryTests.cs
@@ -28,13 +28,11 @@ public class ResiliencePipelineRegistryTests
 
     [Fact]
     public void Ctor_Default_Ok() =>
-        this.Invoking(_ => new ResiliencePipelineRegistry<string>()).Should().NotThrow();
+        Should.NotThrow(() => new ResiliencePipelineRegistry<string>());
 
     [Fact]
     public void Ctor_InvalidOptions_Throws() =>
-        this.Invoking(_ => new ResiliencePipelineRegistry<string>(new ResiliencePipelineRegistryOptions<string> { BuilderFactory = null! }))
-            .Should()
-            .Throw<ArgumentNullException>();
+        Should.Throw<ArgumentNullException>(() => new ResiliencePipelineRegistry<string>(new ResiliencePipelineRegistryOptions<string> { BuilderFactory = null! }));
 
     [Fact]
     public void GetPipeline_BuilderMultiInstance_EnsureMultipleInstances()
@@ -54,7 +52,7 @@ public class ResiliencePipelineRegistryTests
             strategies.Add(registry.GetPipeline(key));
         }
 
-        strategies.Should().HaveCount(100);
+        strategies.Count.ShouldBe(100);
     }
 
     [Fact]
@@ -75,7 +73,7 @@ public class ResiliencePipelineRegistryTests
             strategies.Add(registry.GetPipeline<string>(key));
         }
 
-        strategies.Should().HaveCount(100);
+        strategies.Count.ShouldBe(100);
     }
 
     [Fact]
@@ -101,9 +99,9 @@ public class ResiliencePipelineRegistryTests
             registry.GetPipeline(key);
         }
 
-        called.Should().Be(3);
-        activatorCalls.Should().Be(3);
-        strategies.Keys.Should().HaveCount(3);
+        called.ShouldBe(3);
+        activatorCalls.ShouldBe(3);
+        strategies.Keys.Count.ShouldBe(3);
     }
 
     [Fact]
@@ -129,9 +127,9 @@ public class ResiliencePipelineRegistryTests
             registry.GetPipeline<string>(key);
         }
 
-        called.Should().Be(3);
-        activatorCalls.Should().Be(3);
-        strategies.Keys.Should().HaveCount(3);
+        called.ShouldBe(3);
+        activatorCalls.ShouldBe(3);
+        strategies.Keys.Count.ShouldBe(3);
     }
 
     [Fact]
@@ -144,17 +142,17 @@ public class ResiliencePipelineRegistryTests
         using var registry = CreateRegistry();
         registry.TryAddBuilder(StrategyId.Create("A"), (builder, context) =>
         {
-            context.BuilderName.Should().Be("A");
-            context.BuilderInstanceName.Should().Be("Instance1");
-            context.PipelineKey.Should().Be(StrategyId.Create("A", "Instance1"));
+            context.BuilderName.ShouldBe("A");
+            context.BuilderInstanceName.ShouldBe("Instance1");
+            context.PipelineKey.ShouldBe(StrategyId.Create("A", "Instance1"));
 
             builder.AddStrategy(new TestResilienceStrategy());
-            builder.Name.Should().Be("A");
+            builder.Name.ShouldBe("A");
             called = true;
         });
 
         registry.GetPipeline(StrategyId.Create("A", "Instance1"));
-        called.Should().BeTrue();
+        called.ShouldBeTrue();
     }
 
     [InlineData(false)]
@@ -167,8 +165,8 @@ public class ResiliencePipelineRegistryTests
         var called1 = false;
         var called2 = false;
 
-        AddBuilder(() => called1 = true).Should().BeTrue();
-        AddBuilder(() => called2 = true).Should().BeFalse();
+        AddBuilder(() => called1 = true).ShouldBeTrue();
+        AddBuilder(() => called2 = true).ShouldBeFalse();
 
         if (generic)
         {
@@ -179,8 +177,8 @@ public class ResiliencePipelineRegistryTests
             registry.GetPipeline("A");
         }
 
-        called1.Should().BeTrue();
-        called2.Should().BeFalse();
+        called1.ShouldBeTrue();
+        called2.ShouldBeFalse();
 
         bool AddBuilder(Action onCalled)
         {
@@ -202,8 +200,8 @@ public class ResiliencePipelineRegistryTests
         registry.TryAddBuilder<string>(StrategyId.Create("A"), (builder, _) => builder.AddStrategy(new TestResilienceStrategy()));
         registry.TryAddBuilder<int>(StrategyId.Create("A"), (builder, _) => builder.AddStrategy(new TestResilienceStrategy()));
 
-        registry.GetPipeline<string>(StrategyId.Create("A", "Instance1")).Should().BeSameAs(registry.GetPipeline<string>(StrategyId.Create("A", "Instance1")));
-        registry.GetPipeline<int>(StrategyId.Create("A", "Instance1")).Should().BeSameAs(registry.GetPipeline<int>(StrategyId.Create("A", "Instance1")));
+        registry.GetPipeline<string>(StrategyId.Create("A", "Instance1")).ShouldBeSameAs(registry.GetPipeline<string>(StrategyId.Create("A", "Instance1")));
+        registry.GetPipeline<int>(StrategyId.Create("A", "Instance1")).ShouldBeSameAs(registry.GetPipeline<int>(StrategyId.Create("A", "Instance1")));
     }
 
     [Fact]
@@ -217,13 +215,13 @@ public class ResiliencePipelineRegistryTests
         registry.TryAddBuilder<string>(StrategyId.Create("A"), (builder, _) =>
         {
             builder.AddStrategy(new TestResilienceStrategy());
-            builder.Name.Should().Be("A");
-            builder.InstanceName.Should().Be("Instance1");
+            builder.Name.ShouldBe("A");
+            builder.InstanceName.ShouldBe("Instance1");
             called = true;
         });
 
         registry.GetPipeline<string>(StrategyId.Create("A", "Instance1"));
-        called.Should().BeTrue();
+        called.ShouldBeTrue();
     }
 
     [Fact]
@@ -232,8 +230,8 @@ public class ResiliencePipelineRegistryTests
         using var registry = CreateRegistry();
         var key = StrategyId.Create("A");
 
-        registry.TryGetPipeline(key, out var strategy).Should().BeFalse();
-        strategy.Should().BeNull();
+        registry.TryGetPipeline(key, out var strategy).ShouldBeFalse();
+        strategy.ShouldBeNull();
     }
 
     [Fact]
@@ -242,8 +240,8 @@ public class ResiliencePipelineRegistryTests
         using var registry = CreateRegistry();
         var key = StrategyId.Create("A");
 
-        registry.TryGetPipeline<string>(key, out var strategy).Should().BeFalse();
-        strategy.Should().BeNull();
+        registry.TryGetPipeline<string>(key, out var strategy).ShouldBeFalse();
+        strategy.ShouldBeNull();
     }
 
     [InlineData(true)]
@@ -277,7 +275,7 @@ public class ResiliencePipelineRegistryTests
         // assert
         var tries = 0;
         strategy.Execute(() => tries++);
-        tries.Should().Be(retryCount + 1);
+        tries.ShouldBe(retryCount + 1);
 
         tries = 0;
         retryCount = 5;
@@ -292,7 +290,7 @@ public class ResiliencePipelineRegistryTests
         }
 
         strategy.Execute(() => tries++);
-        tries.Should().Be(retryCount + 1);
+        tries.ShouldBe(retryCount + 1);
     }
 
     [Fact]
@@ -315,15 +313,15 @@ public class ResiliencePipelineRegistryTests
         var strategy = registry.GetPipeline("dummy");
 
         // assert
-        disposedCalls.Should().Be(0);
+        disposedCalls.ShouldBe(0);
         strategy.Execute(() => { });
 
         changeSource.Cancel();
-        disposedCalls.Should().Be(1);
+        disposedCalls.ShouldBe(1);
         strategy.Execute(() => { });
 
         registry.Dispose();
-        disposedCalls.Should().Be(2);
+        disposedCalls.ShouldBe(2);
     }
 
     [Fact]
@@ -353,13 +351,13 @@ public class ResiliencePipelineRegistryTests
         // assert
         var tries = 0;
         strategy.Execute(() => { tries++; return "dummy"; });
-        tries.Should().Be(retryCount + 1);
+        tries.ShouldBe(retryCount + 1);
 
         tries = 0;
         retryCount = 5;
         changeSource.Cancel();
         strategy.Execute(() => { tries++; return "dummy"; });
-        tries.Should().Be(retryCount + 1);
+        tries.ShouldBe(retryCount + 1);
     }
 
     [Fact]
@@ -372,9 +370,9 @@ public class ResiliencePipelineRegistryTests
         var strategy = registry.GetOrAddPipeline(id, builder => { builder.AddTimeout(TimeSpan.FromSeconds(1)); called++; });
         var otherPipeline = registry.GetOrAddPipeline(id, builder => { builder.AddTimeout(TimeSpan.FromSeconds(1)); called++; });
 
-        strategy.GetPipelineDescriptor().FirstStrategy.StrategyInstance.Should().BeOfType<TimeoutResilienceStrategy>();
+        strategy.GetPipelineDescriptor().FirstStrategy.StrategyInstance.ShouldBeOfType<TimeoutResilienceStrategy>();
 
-        called.Should().Be(1);
+        called.ShouldBe(1);
     }
 
     [Fact]
@@ -385,10 +383,10 @@ public class ResiliencePipelineRegistryTests
         using var registry = CreateRegistry();
 
         var pipeline = registry.GetOrAddPipeline(id, builder => builder.AddTimeout(TimeSpan.FromSeconds(1)));
-        pipeline.Component.Should().BeOfType<ExecutionTrackingComponent>().Subject.Component.Should().BeOfType<CompositeComponent>();
+        pipeline.Component.ShouldBeOfType<ExecutionTrackingComponent>().Component.ShouldBeOfType<CompositeComponent>();
 
         var genericPipeline = registry.GetOrAddPipeline<string>(id, builder => builder.AddTimeout(TimeSpan.FromSeconds(1)));
-        pipeline.Component.Should().BeOfType<ExecutionTrackingComponent>().Subject.Component.Should().BeOfType<CompositeComponent>();
+        pipeline.Component.ShouldBeOfType<ExecutionTrackingComponent>().Component.ShouldBeOfType<CompositeComponent>();
     }
 
     [Fact]
@@ -401,7 +399,7 @@ public class ResiliencePipelineRegistryTests
         var strategy = registry.GetOrAddPipeline<string>(id, builder => { builder.AddTimeout(TimeSpan.FromSeconds(1)); called++; });
         var otherPipeline = registry.GetOrAddPipeline<string>(id, builder => { builder.AddTimeout(TimeSpan.FromSeconds(1)); called++; });
 
-        strategy.GetPipelineDescriptor().FirstStrategy.StrategyInstance.Should().BeOfType<TimeoutResilienceStrategy>();
+        strategy.GetPipelineDescriptor().FirstStrategy.StrategyInstance.ShouldBeOfType<TimeoutResilienceStrategy>();
     }
 
     [InlineData(true)]
@@ -429,10 +427,10 @@ public class ResiliencePipelineRegistryTests
         }
 #pragma warning restore S3966 // Objects should not be disposed more than once
 
-        pipeline1.Invoking(p => p.Execute(() => { })).Should().Throw<ObjectDisposedException>();
-        pipeline2.Invoking(p => p.Execute(() => { })).Should().Throw<ObjectDisposedException>();
-        pipeline3.Invoking(p => p.Execute(() => "dummy")).Should().Throw<ObjectDisposedException>();
-        pipeline4.Invoking(p => p.Execute(() => "dummy")).Should().Throw<ObjectDisposedException>();
+        Should.Throw<ObjectDisposedException>(() => pipeline1.Execute(() => { }));
+        Should.Throw<ObjectDisposedException>(() => pipeline2.Execute(() => { }));
+        Should.Throw<ObjectDisposedException>(() => pipeline3.Execute(() => "dummy"));
+        Should.Throw<ObjectDisposedException>(() => pipeline4.Execute(() => "dummy"));
     }
 
     [Fact]
@@ -441,8 +439,7 @@ public class ResiliencePipelineRegistryTests
         using var registry = CreateRegistry();
         var pipeline = registry.GetOrAddPipeline(StrategyId.Create("A"), builder => { builder.AddTimeout(TimeSpan.FromSeconds(1)); });
 
-        await pipeline.Invoking(p => p.DisposeHelper.DisposeAsync().AsTask()).Should().ThrowAsync<InvalidOperationException>();
-
+        await Should.ThrowAsync<InvalidOperationException>(() => pipeline.DisposeHelper.DisposeAsync().AsTask());
     }
 
     [InlineData(true)]
@@ -453,16 +450,16 @@ public class ResiliencePipelineRegistryTests
         using var registry = new ResiliencePipelineRegistry<string>();
         await DisposeHelper.TryDisposeSafeAsync(registry, !isAsync);
 
-        registry.Invoking(r => r.GetOrAddPipeline("dummy", builder => { })).Should().Throw<ObjectDisposedException>();
-        registry.Invoking(r => r.GetOrAddPipeline<string>("dummy", builder => { })).Should().Throw<ObjectDisposedException>();
-        registry.Invoking(r => r.GetOrAddPipeline("dummy", (_, _) => { })).Should().Throw<ObjectDisposedException>();
-        registry.Invoking(r => r.GetOrAddPipeline<string>("dummy", (_, _) => { })).Should().Throw<ObjectDisposedException>();
-        registry.Invoking(r => r.TryAddBuilder("dummy", (_, _) => { })).Should().Throw<ObjectDisposedException>();
-        registry.Invoking(r => r.TryAddBuilder<string>("dummy", (_, _) => { })).Should().Throw<ObjectDisposedException>();
-        registry.Invoking(r => r.GetPipeline<string>("dummy")).Should().Throw<ObjectDisposedException>();
-        registry.Invoking(r => r.GetPipeline("dummy")).Should().Throw<ObjectDisposedException>();
-        registry.Invoking(r => r.TryGetPipeline<string>("dummy", out _)).Should().Throw<ObjectDisposedException>();
-        registry.Invoking(r => r.TryGetPipeline("dummy", out _)).Should().Throw<ObjectDisposedException>();
+        Should.Throw<ObjectDisposedException>(() => registry.GetOrAddPipeline("dummy", builder => { }));
+        Should.Throw<ObjectDisposedException>(() => registry.GetOrAddPipeline<string>("dummy", builder => { }));
+        Should.Throw<ObjectDisposedException>(() => registry.GetOrAddPipeline("dummy", (_, _) => { }));
+        Should.Throw<ObjectDisposedException>(() => registry.GetOrAddPipeline<string>("dummy", (_, _) => { }));
+        Should.Throw<ObjectDisposedException>(() => registry.TryAddBuilder("dummy", (_, _) => { }));
+        Should.Throw<ObjectDisposedException>(() => registry.TryAddBuilder<string>("dummy", (_, _) => { }));
+        Should.Throw<ObjectDisposedException>(() => registry.GetPipeline<string>("dummy"));
+        Should.Throw<ObjectDisposedException>(() => registry.GetPipeline("dummy"));
+        Should.Throw<ObjectDisposedException>(() => registry.TryGetPipeline<string>("dummy", out _));
+        Should.Throw<ObjectDisposedException>(() => registry.TryGetPipeline("dummy", out _));
     }
 
     private ResiliencePipelineRegistry<StrategyId> CreateRegistry() => new(_options);

--- a/test/Polly.Core.Tests/ResilienceContextPoolTests.cs
+++ b/test/Polly.Core.Tests/ResilienceContextPoolTests.cs
@@ -4,15 +4,15 @@ public class ResilienceContextPoolTests
 {
     [Fact]
     public void Shared_NotNull() =>
-        ResilienceContextPool.Shared.Should().NotBeNull();
+        ResilienceContextPool.Shared.ShouldNotBeNull();
 
     [Fact]
     public void Shared_SameInstance() =>
-        ResilienceContextPool.Shared.Should().BeSameAs(ResilienceContextPool.Shared);
+        ResilienceContextPool.Shared.ShouldBeSameAs(ResilienceContextPool.Shared);
 
     [Fact]
     public void Get_EnsureNotNull() =>
-        ResilienceContextPool.Shared.Get().Should().NotBeNull();
+        ResilienceContextPool.Shared.Get().ShouldNotBeNull();
 
     [Fact]
     public void Get_EnsureDefaults()
@@ -30,7 +30,7 @@ public class ResilienceContextPoolTests
 
         var context = ResilienceContextPool.Shared.Get(token.Token);
 
-        context.CancellationToken.Should().Be(token.Token);
+        context.CancellationToken.ShouldBe(token.Token);
     }
 
     [Fact]
@@ -40,7 +40,7 @@ public class ResilienceContextPoolTests
 
         var context = ResilienceContextPool.Shared.Get();
 
-        context.ContinueOnCapturedContext.Should().BeFalse();
+        context.ContinueOnCapturedContext.ShouldBeFalse();
     }
 
     [Fact]
@@ -48,7 +48,7 @@ public class ResilienceContextPoolTests
     {
         var context = ResilienceContextPool.Shared.Get(true);
 
-        context.ContinueOnCapturedContext.Should().Be(true);
+        context.ContinueOnCapturedContext.ShouldBe(true);
     }
 
     [Fact]
@@ -58,9 +58,9 @@ public class ResilienceContextPoolTests
 
         var context = ResilienceContextPool.Shared.Get("dummy", true, token.Token);
 
-        context.ContinueOnCapturedContext.Should().Be(true);
-        context.OperationKey.Should().Be("dummy");
-        context.CancellationToken.Should().Be(token.Token);
+        context.ContinueOnCapturedContext.ShouldBe(true);
+        context.OperationKey.ShouldBe("dummy");
+        context.CancellationToken.ShouldBe(token.Token);
     }
 
     [InlineData(null)]
@@ -72,8 +72,8 @@ public class ResilienceContextPoolTests
         using var token = new CancellationTokenSource();
 
         var context = ResilienceContextPool.Shared.Get(key!, token.Token);
-        context.OperationKey.Should().Be(key);
-        context.CancellationToken.Should().Be(token.Token);
+        context.OperationKey.ShouldBe(key);
+        context.CancellationToken.ShouldBe(token.Token);
     }
 
     [Fact]
@@ -84,7 +84,7 @@ public class ResilienceContextPoolTests
 
             ResilienceContextPool.Shared.Return(context);
 
-            ResilienceContextPool.Shared.Get(default(CancellationToken)).Should().BeSameAs(context);
+            ResilienceContextPool.Shared.Get(default(CancellationToken)).ShouldBeSameAs(context);
         });
 
     [Fact]
@@ -99,7 +99,7 @@ public class ResilienceContextPoolTests
             var context = ResilienceContextPool.Shared.Get(CancellationToken.None);
             context.CancellationToken = cts.Token;
             context.Initialize<bool>(true);
-            context.CancellationToken.Should().Be(cts.Token);
+            context.CancellationToken.ShouldBe(cts.Token);
             context.Properties.Set(new ResiliencePropertyKey<int>("abc"), 10);
             ResilienceContextPool.Shared.Return(context);
 
@@ -108,13 +108,13 @@ public class ResilienceContextPoolTests
 
     private static void AssertDefaults(ResilienceContext context, CancellationToken expectedToken)
     {
-        context.IsInitialized.Should().BeFalse();
-        context.ContinueOnCapturedContext.Should().BeFalse();
-        context.IsVoid.Should().BeFalse();
-        context.ResultType.Name.Should().Be("UnknownResult");
-        context.IsSynchronous.Should().BeFalse();
-        context.CancellationToken.Should().Be(expectedToken);
-        context.Properties.Options.Should().BeEmpty();
-        context.OperationKey.Should().BeNull();
+        context.IsInitialized.ShouldBeFalse();
+        context.ContinueOnCapturedContext.ShouldBeFalse();
+        context.IsVoid.ShouldBeFalse();
+        context.ResultType.Name.ShouldBe("UnknownResult");
+        context.IsSynchronous.ShouldBeFalse();
+        context.CancellationToken.ShouldBe(expectedToken);
+        context.Properties.Options.ShouldBeEmpty();
+        context.OperationKey.ShouldBeNull();
     }
 }

--- a/test/Polly.Core.Tests/ResilienceContextTests.cs
+++ b/test/Polly.Core.Tests/ResilienceContextTests.cs
@@ -10,11 +10,11 @@ public class ResilienceContextTests
         var context = ResilienceContextPool.Shared.Get();
         context.Initialize<bool>(synchronous);
 
-        context.ResultType.Should().Be<bool>();
-        context.IsVoid.Should().BeFalse();
-        context.IsInitialized.Should().BeTrue();
-        context.IsSynchronous.Should().Be(synchronous);
-        context.ContinueOnCapturedContext.Should().BeFalse();
+        context.ResultType.ShouldBe(typeof(bool));
+        context.IsVoid.ShouldBeFalse();
+        context.IsInitialized.ShouldBeTrue();
+        context.IsSynchronous.ShouldBe(synchronous);
+        context.ContinueOnCapturedContext.ShouldBeFalse();
     }
 
     [Theory]
@@ -31,14 +31,14 @@ public class ResilienceContextTests
         var other = ResilienceContextPool.Shared.Get(cancellationToken);
         other.InitializeFrom(context, cancellation.Token);
 
-        other.ResultType.Should().Be<bool>();
-        other.IsVoid.Should().BeFalse();
-        other.IsInitialized.Should().BeTrue();
-        other.IsSynchronous.Should().Be(synchronous);
-        other.ContinueOnCapturedContext.Should().BeTrue();
-        other.OperationKey.Should().Be("some-key");
-        other.CancellationToken.Should().Be(cancellation.Token);
-        other.Properties.GetValue(new ResiliencePropertyKey<string>("A"), string.Empty).Should().Be("B");
+        other.ResultType.ShouldBe(typeof(bool));
+        other.IsVoid.ShouldBeFalse();
+        other.IsInitialized.ShouldBeTrue();
+        other.IsSynchronous.ShouldBe(synchronous);
+        other.ContinueOnCapturedContext.ShouldBeTrue();
+        other.OperationKey.ShouldBe("some-key");
+        other.CancellationToken.ShouldBe(cancellation.Token);
+        other.Properties.GetValue(new ResiliencePropertyKey<string>("A"), string.Empty).ShouldBe("B");
     }
 
     [InlineData(true)]
@@ -49,10 +49,10 @@ public class ResilienceContextTests
         var context = ResilienceContextPool.Shared.Get();
         context.Initialize<VoidResult>(synchronous);
 
-        context.ResultType.Should().Be<VoidResult>();
-        context.IsVoid.Should().BeTrue();
-        context.IsInitialized.Should().BeTrue();
-        context.IsSynchronous.Should().Be(synchronous);
-        context.ContinueOnCapturedContext.Should().BeFalse();
+        context.ResultType.ShouldBe(typeof(VoidResult));
+        context.IsVoid.ShouldBeTrue();
+        context.IsInitialized.ShouldBeTrue();
+        context.IsSynchronous.ShouldBe(synchronous);
+        context.ContinueOnCapturedContext.ShouldBeFalse();
     }
 }

--- a/test/Polly.Core.Tests/ResiliencePipelineBuilderTests.cs
+++ b/test/Polly.Core.Tests/ResiliencePipelineBuilderTests.cs
@@ -68,7 +68,7 @@ public class ResiliencePipelineBuilderTests
         pipeline.Execute(_ => executions.Add(2));
 
         pipeline.GetPipelineDescriptor().FirstStrategy.StrategyInstance.ShouldBeOfType<TestResilienceStrategy>();
-        executions.OrderBy(p => p).ShouldBe(executions);
+        executions.ShouldBe(executions.OrderBy(p => p));
         executions.Count.ShouldBe(3);
     }
 
@@ -110,7 +110,7 @@ public class ResiliencePipelineBuilderTests
         // assert
         strategy.Execute(_ => executions.Add(4));
 
-        executions.OrderBy(p => p).ShouldBe(executions);
+        executions.ShouldBe(executions.OrderBy(p => p));
         executions.Count.ShouldBe(7);
     }
 
@@ -195,7 +195,7 @@ public class ResiliencePipelineBuilderTests
         // assert
         strategy.Execute(_ => executions.Add(4));
 
-        executions.OrderBy(p => p).ShouldBe(executions);
+        executions.ShouldBe(executions.OrderBy(p => p));
         executions.Count.ShouldBe(7);
     }
 
@@ -330,7 +330,7 @@ public class ResiliencePipelineBuilderTests
         // assert
         strategy.Execute(_ => executions.Add(4));
 
-        executions.OrderBy(p => p).ShouldBe(executions);
+        executions.ShouldBe(executions.OrderBy(p => p));
         executions.Count.ShouldBe(7);
     }
 

--- a/test/Polly.Core.Tests/ResiliencePipelineBuilderTests.cs
+++ b/test/Polly.Core.Tests/ResiliencePipelineBuilderTests.cs
@@ -68,7 +68,7 @@ public class ResiliencePipelineBuilderTests
         pipeline.Execute(_ => executions.Add(2));
 
         pipeline.GetPipelineDescriptor().FirstStrategy.StrategyInstance.ShouldBeOfType<TestResilienceStrategy>();
-        executions.ShouldBe(executions.OrderBy(p => p));
+        executions.ShouldBeInOrder();
         executions.Count.ShouldBe(3);
     }
 
@@ -110,7 +110,7 @@ public class ResiliencePipelineBuilderTests
         // assert
         strategy.Execute(_ => executions.Add(4));
 
-        executions.ShouldBe(executions.OrderBy(p => p));
+        executions.ShouldBeInOrder();
         executions.Count.ShouldBe(7);
     }
 
@@ -195,7 +195,7 @@ public class ResiliencePipelineBuilderTests
         // assert
         strategy.Execute(_ => executions.Add(4));
 
-        executions.ShouldBe(executions.OrderBy(p => p));
+        executions.ShouldBeInOrder();
         executions.Count.ShouldBe(7);
     }
 
@@ -330,7 +330,7 @@ public class ResiliencePipelineBuilderTests
         // assert
         strategy.Execute(_ => executions.Add(4));
 
-        executions.ShouldBe(executions.OrderBy(p => p));
+        executions.ShouldBeInOrder();
         executions.Count.ShouldBe(7);
     }
 
@@ -413,8 +413,8 @@ public class ResiliencePipelineBuilderTests
         strategy.Execute(_ => executions.Add("execute"));
 
         // assert
-        executions.SequenceEqual(new[]
-        {
+        executions.SequenceEqual(
+        [
             "first-start",
             "second-start",
             "third-start",
@@ -425,7 +425,7 @@ public class ResiliencePipelineBuilderTests
             "third-end",
             "second-end",
             "first-end",
-        })
+        ])
         .ShouldBeTrue();
     }
 

--- a/test/Polly.Core.Tests/ResiliencePipelineBuilderTests.cs
+++ b/test/Polly.Core.Tests/ResiliencePipelineBuilderTests.cs
@@ -15,20 +15,20 @@ public class ResiliencePipelineBuilderTests
     {
         var builder = new ResiliencePipelineBuilder();
 
-        builder.Name.Should().BeNull();
-        builder.TimeProvider.Should().BeNull();
+        builder.Name.ShouldBeNull();
+        builder.TimeProvider.ShouldBeNull();
     }
 
     [Fact]
     public void TimeProviderInternal_Ok()
     {
         var builder = new ResiliencePipelineBuilder();
-        builder.TimeProviderInternal.Should().Be(TimeProvider.System);
+        builder.TimeProviderInternal.ShouldBe(TimeProvider.System);
 
         var timeProvider = Substitute.For<TimeProvider>();
         builder.TimeProvider = timeProvider;
 
-        builder.TimeProvider.Should().Be(timeProvider);
+        builder.TimeProvider.ShouldBe(timeProvider);
     }
 
     [Fact]
@@ -42,9 +42,9 @@ public class ResiliencePipelineBuilderTests
         };
 
         var other = new ResiliencePipelineBuilder<double>(builder);
-        other.Name.Should().Be(builder.Name);
-        other.TimeProvider.Should().Be(builder.TimeProvider);
-        other.TelemetryListener.Should().BeSameAs(builder.TelemetryListener);
+        other.Name.ShouldBe(builder.Name);
+        other.TimeProvider.ShouldBe(builder.TimeProvider);
+        other.TelemetryListener.ShouldBeSameAs(builder.TelemetryListener);
     }
 
     [Fact]
@@ -67,9 +67,9 @@ public class ResiliencePipelineBuilderTests
         // assert
         pipeline.Execute(_ => executions.Add(2));
 
-        pipeline.GetPipelineDescriptor().FirstStrategy.StrategyInstance.Should().BeOfType<TestResilienceStrategy>();
-        executions.Should().BeInAscendingOrder();
-        executions.Should().HaveCount(3);
+        pipeline.GetPipelineDescriptor().FirstStrategy.StrategyInstance.ShouldBeOfType<TestResilienceStrategy>();
+        executions.OrderBy(p => p).ShouldBe(executions);
+        executions.Count.ShouldBe(3);
     }
 
     [Fact]
@@ -102,16 +102,16 @@ public class ResiliencePipelineBuilderTests
         var strategy = builder.Build();
         strategy
             .Component
-            .Should()
-            .BeOfType<CompositeComponent>()
-            .Subject
-            .Components.Should().HaveCount(3);
+            .ShouldBeOfType<CompositeComponent>()
+            .Components
+            .Count
+            .ShouldBe(3);
 
         // assert
         strategy.Execute(_ => executions.Add(4));
 
-        executions.Should().BeInAscendingOrder();
-        executions.Should().HaveCount(7);
+        executions.OrderBy(p => p).ShouldBe(executions);
+        executions.Count.ShouldBe(7);
     }
 
     [Fact]
@@ -125,8 +125,8 @@ public class ResiliencePipelineBuilderTests
         builder
             .Build()
             .GetPipelineDescriptor()
-            .FirstStrategy.StrategyInstance.Should()
-            .BeSameAs(strategy);
+            .FirstStrategy.StrategyInstance
+            .ShouldBeSameAs(strategy);
     }
 
     [Fact]
@@ -140,8 +140,8 @@ public class ResiliencePipelineBuilderTests
         builder
             .Build()
             .GetPipelineDescriptor()
-            .FirstStrategy.StrategyInstance.Should()
-            .BeSameAs(strategy);
+            .FirstStrategy.StrategyInstance
+            .ShouldBeSameAs(strategy);
     }
 
     [Fact]
@@ -149,15 +149,14 @@ public class ResiliencePipelineBuilderTests
     {
         var builder = new ResiliencePipelineBuilder();
 
-        builder.Validator.Should().NotBeNull();
+        builder.Validator.ShouldNotBeNull();
 
         builder.Validator(new ResilienceValidationContext("ABC", "ABC"));
 
-        builder
-            .Invoking(b => b.Validator(new ResilienceValidationContext(new RetryStrategyOptions { MaxRetryAttempts = -4 }, "The primary message.")))
-            .Should()
-            .Throw<ValidationException>()
-            .WithMessage("""
+        var exception = Should.Throw<ValidationException>(
+            () => builder.Validator(new ResilienceValidationContext(new RetryStrategyOptions { MaxRetryAttempts = -4 }, "The primary message.")));
+
+        exception.Message.Trim().ShouldBe("""
             The primary message.
             Validation Errors:
             The field MaxRetryAttempts must be between 1 and 2147483647.
@@ -196,12 +195,12 @@ public class ResiliencePipelineBuilderTests
         // assert
         strategy.Execute(_ => executions.Add(4));
 
-        executions.Should().BeInAscendingOrder();
-        executions.Should().HaveCount(7);
+        executions.OrderBy(p => p).ShouldBe(executions);
+        executions.Count.ShouldBe(7);
     }
 
     [Fact]
-    public void Build_Empty_ReturnsNullResiliencePipeline() => new ResiliencePipelineBuilder().Build().Component.Should().BeSameAs(PipelineComponent.Empty);
+    public void Build_Empty_ReturnsNullResiliencePipeline() => new ResiliencePipelineBuilder().Build().Component.ShouldBeSameAs(PipelineComponent.Empty);
 
     [Fact]
     public void AddPipeline_AfterUsed_Throws()
@@ -210,11 +209,8 @@ public class ResiliencePipelineBuilderTests
 
         builder.Build();
 
-        builder
-            .Invoking(b => b.AddPipeline(ResiliencePipeline.Empty))
-            .Should()
-            .Throw<InvalidOperationException>()
-            .WithMessage("Cannot add any more resilience strategies to the builder after it has been used to build a pipeline once.");
+        var exception = Should.Throw<InvalidOperationException>(() => builder.AddPipeline(ResiliencePipeline.Empty));
+        exception.Message.ShouldBe("Cannot add any more resilience strategies to the builder after it has been used to build a pipeline once.");
     }
 
     [Fact]
@@ -222,16 +218,14 @@ public class ResiliencePipelineBuilderTests
     {
         var builder = new InvalidResiliencePipelineBuilder();
 
-        builder.Invoking(b => b.BuildPipelineComponent())
-            .Should()
-            .Throw<ValidationException>()
-            .WithMessage(
-"""
-The 'ResiliencePipelineBuilder' configuration is invalid.
-
-Validation Errors:
-The RequiredProperty field is required.
-""");
+        var exception = Should.Throw<ValidationException>(builder.BuildPipelineComponent);
+        exception.Message.Trim().ShouldBe(
+            """
+            The 'ResiliencePipelineBuilder' configuration is invalid.
+            Validation Errors:
+            The RequiredProperty field is required.
+            """,
+            StringCompareShould.IgnoreLineEndings);
     }
 
     [Fact]
@@ -239,17 +233,14 @@ The RequiredProperty field is required.
     {
         var builder = new ResiliencePipelineBuilder();
 
-        builder
-            .Invoking(b => b.AddStrategy(_ => new TestResilienceStrategy(), new InvalidResiliencePipelineOptions()))
-            .Should()
-            .Throw<ValidationException>()
-            .WithMessage(
-"""
-The 'InvalidResiliencePipelineOptions' are invalid.
-
-Validation Errors:
-The RequiredProperty field is required.
-""");
+        var exception = Should.Throw<ValidationException>(() => builder.AddStrategy(_ => new TestResilienceStrategy(), new InvalidResiliencePipelineOptions()));
+        exception.Message.Trim().ShouldBe(
+            """
+            The 'InvalidResiliencePipelineOptions' are invalid.
+            Validation Errors:
+            The RequiredProperty field is required.
+            """,
+            StringCompareShould.IgnoreLineEndings);
     }
 
     [Fact]
@@ -257,21 +248,13 @@ The RequiredProperty field is required.
     {
         var builder = new ResiliencePipelineBuilder();
 
-        builder
-            .Invoking(b => b.AddStrategy((Func<StrategyBuilderContext, ResilienceStrategy>)null!, new TestResilienceStrategyOptions()))
-            .Should()
-            .Throw<ArgumentNullException>()
-            .And.ParamName
-            .Should()
-            .Be("factory");
+        Should.Throw<ArgumentNullException>(
+            () => builder.AddStrategy((Func<StrategyBuilderContext, ResilienceStrategy>)null!, new TestResilienceStrategyOptions()))
+            .ParamName.ShouldBe("factory");
 
-        builder
-            .Invoking(b => b.AddStrategy((Func<StrategyBuilderContext, ResilienceStrategy<object>>)null!, new TestResilienceStrategyOptions()))
-            .Should()
-            .Throw<ArgumentNullException>()
-            .And.ParamName
-            .Should()
-            .Be("factory");
+        Should.Throw<ArgumentNullException>(
+            () => builder.AddStrategy((Func<StrategyBuilderContext, ResilienceStrategy<object>>)null!, new TestResilienceStrategyOptions()))
+            .ParamName.ShouldBe("factory");
     }
 
     [Fact]
@@ -347,8 +330,8 @@ The RequiredProperty field is required.
         // assert
         strategy.Execute(_ => executions.Add(4));
 
-        executions.Should().BeInAscendingOrder();
-        executions.Should().HaveCount(7);
+        executions.OrderBy(p => p).ShouldBe(executions);
+        executions.Count.ShouldBe(7);
     }
 
     [Fact]
@@ -367,10 +350,10 @@ The RequiredProperty field is required.
         builder.AddStrategy(
             context =>
             {
-                context.Telemetry.TelemetrySource.PipelineName.Should().Be("builder-name");
-                context.Telemetry.TelemetrySource.StrategyName.Should().Be("strategy_name");
-                context.Telemetry.Should().NotBeNull();
-                context.TimeProvider.Should().Be(builder.TimeProvider);
+                context.Telemetry.TelemetrySource.PipelineName.ShouldBe("builder-name");
+                context.Telemetry.TelemetrySource.StrategyName.ShouldBe("strategy_name");
+                context.Telemetry.ShouldNotBeNull();
+                context.TimeProvider.ShouldBe(builder.TimeProvider);
                 verified1 = true;
 
                 return new TestResilienceStrategy();
@@ -380,10 +363,10 @@ The RequiredProperty field is required.
         builder.AddStrategy(
             context =>
             {
-                context.Telemetry.TelemetrySource.PipelineName.Should().Be("builder-name");
-                context.Telemetry.TelemetrySource.StrategyName.Should().Be("strategy_name-2");
-                context.Telemetry.Should().NotBeNull();
-                context.TimeProvider.Should().Be(builder.TimeProvider);
+                context.Telemetry.TelemetrySource.PipelineName.ShouldBe("builder-name");
+                context.Telemetry.TelemetrySource.StrategyName.ShouldBe("strategy_name-2");
+                context.Telemetry.ShouldNotBeNull();
+                context.TimeProvider.ShouldBe(builder.TimeProvider);
                 verified2 = true;
 
                 return new TestResilienceStrategy();
@@ -394,12 +377,12 @@ The RequiredProperty field is required.
         builder.Build();
 
         // assert
-        verified1.Should().BeTrue();
-        verified2.Should().BeTrue();
+        verified1.ShouldBeTrue();
+        verified2.ShouldBeTrue();
     }
 
     [Fact]
-    public void EmptyOptions_Ok() => ResiliencePipelineBuilderExtensions.EmptyOptions.Instance.Name.Should().BeNull();
+    public void EmptyOptions_Ok() => ResiliencePipelineBuilderExtensions.EmptyOptions.Instance.Name.ShouldBeNull();
 
     [Fact]
     public void ExecuteAsync_EnsureReceivedCallbackExecutesNextStrategy()
@@ -443,8 +426,7 @@ The RequiredProperty field is required.
             "second-end",
             "first-end",
         })
-        .Should()
-        .BeTrue();
+        .ShouldBeTrue();
     }
 
     private class Strategy : ResilienceStrategy

--- a/test/Polly.Core.Tests/ResiliencePipelineTTests.Async.cs
+++ b/test/Polly.Core.Tests/ResiliencePipelineTTests.Async.cs
@@ -13,10 +13,10 @@ public partial class ResiliencePipelineTests
             (await strategy.ExecuteAsync(
                 token =>
                 {
-                    token.Should().Be(CancellationToken);
+                    token.ShouldBe(CancellationToken);
                     return new ValueTask<string>("res");
                 },
-                CancellationToken)).Should().Be("res");
+                CancellationToken)).ShouldBe("res");
         },
 
         async strategy =>
@@ -24,12 +24,12 @@ public partial class ResiliencePipelineTests
             (await strategy.ExecuteAsync(
                 (state, token) =>
                 {
-                    state.Should().Be("state");
-                    token.Should().Be(CancellationToken);
+                    state.ShouldBe("state");
+                    token.ShouldBe(CancellationToken);
                     return new ValueTask<string>("res");
                 },
                 "state",
-                CancellationToken)).Should().Be("res");
+                CancellationToken)).ShouldBe("res");
         },
 
         async strategy =>
@@ -39,12 +39,12 @@ public partial class ResiliencePipelineTests
             (await strategy.ExecuteAsync(
                 (context, state) =>
                 {
-                    state.Should().Be("state");
-                    context.Should().Be(context);
+                    state.ShouldBe("state");
+                    context.ShouldBe(context);
                     return new ValueTask<string>("res");
                 },
                 context,
-                "state")).Should().Be("res");
+                "state")).ShouldBe("res");
         },
 
         async strategy =>
@@ -54,10 +54,10 @@ public partial class ResiliencePipelineTests
             (await strategy.ExecuteAsync(
                 (context) =>
                 {
-                    context.Should().Be(context);
+                    context.ShouldBe(context);
                     return new ValueTask<string>("res");
                 },
-                context)).Should().Be("res");
+                context)).ShouldBe("res");
         },
     };
 #pragma warning restore IDE0028
@@ -72,9 +72,9 @@ public partial class ResiliencePipelineTests
         {
             Before = (c, _) =>
             {
-                c.IsSynchronous.Should().BeFalse();
-                c.ResultType.Should().Be<string>();
-                c.CancellationToken.CanBeCanceled.Should().BeTrue();
+                c.IsSynchronous.ShouldBeFalse();
+                c.ResultType.ShouldBe(typeof(string));
+                c.CancellationToken.CanBeCanceled.ShouldBeTrue();
             },
         }), DisposeBehavior.Allow, null);
 
@@ -86,14 +86,14 @@ public partial class ResiliencePipelineTests
     {
         var result = await ResiliencePipeline<int>.Empty.ExecuteOutcomeAsync((context, state) =>
         {
-            state.Should().Be("state");
-            context.IsSynchronous.Should().BeFalse();
-            context.ResultType.Should().Be<int>();
+            state.ShouldBe("state");
+            context.IsSynchronous.ShouldBeFalse();
+            context.ResultType.ShouldBe(typeof(int));
             return Outcome.FromResultAsValueTask(12345);
         },
         ResilienceContextPool.Shared.Get(CancellationToken),
         "state");
 
-        result.Result.Should().Be(12345);
+        result.Result.ShouldBe(12345);
     }
 }

--- a/test/Polly.Core.Tests/ResiliencePipelineTTests.Sync.cs
+++ b/test/Polly.Core.Tests/ResiliencePipelineTTests.Sync.cs
@@ -10,17 +10,17 @@ public partial class ResiliencePipelineTests
     {
         strategy =>
         {
-            strategy.Execute(() => "res").Should().Be("res");
+            strategy.Execute(() => "res").ShouldBe("res");
         },
 
         strategy =>
         {
             strategy.Execute(state =>
             {
-                state.Should().Be("state");
+                state.ShouldBe("state");
                 return "res";
             },
-            "state").Should().Be("res");
+            "state").ShouldBe("res");
         },
 
         strategy =>
@@ -28,10 +28,10 @@ public partial class ResiliencePipelineTests
             strategy.Execute(
                 token =>
                 {
-                    token.Should().Be(CancellationToken);
+                    token.ShouldBe(CancellationToken);
                     return "res";
                 },
-                CancellationToken).Should().Be("res");
+                CancellationToken).ShouldBe("res");
         },
 
         strategy =>
@@ -39,12 +39,12 @@ public partial class ResiliencePipelineTests
             strategy.Execute(
                 (state, token) =>
                 {
-                    state.Should().Be("state");
-                    token.Should().Be(CancellationToken);
+                    state.ShouldBe("state");
+                    token.ShouldBe(CancellationToken);
                     return "res";
                 },
                 "state",
-                CancellationToken).Should().Be("res");
+                CancellationToken).ShouldBe("res");
         },
 
         strategy =>
@@ -54,13 +54,13 @@ public partial class ResiliencePipelineTests
             strategy.Execute(
                 (context, state) =>
                 {
-                    state.Should().Be("state");
-                    context.Should().Be(context);
-                    context.CancellationToken.Should().Be(CancellationToken);
+                    state.ShouldBe("state");
+                    context.ShouldBe(context);
+                    context.CancellationToken.ShouldBe(CancellationToken);
                     return "res";
                 },
                 context,
-                "state").Should().Be("res");
+                "state").ShouldBe("res");
         },
 
         strategy =>
@@ -70,10 +70,10 @@ public partial class ResiliencePipelineTests
             strategy.Execute(
                 (context) =>
                 {
-                    context.Should().Be(context);
+                    context.ShouldBe(context);
                     return "res";
                 },
-                context).Should().Be("res");
+                context).ShouldBe("res");
         },
     };
 #pragma warning restore IDE0028
@@ -86,8 +86,8 @@ public partial class ResiliencePipelineTests
         {
             Before = (c, _) =>
             {
-                c.IsSynchronous.Should().BeTrue();
-                c.ResultType.Should().Be<string>();
+                c.IsSynchronous.ShouldBeTrue();
+                c.ResultType.ShouldBe(typeof(string));
             },
         }), DisposeBehavior.Allow, null);
 

--- a/test/Polly.Core.Tests/ResiliencePipelineTests.Async.cs
+++ b/test/Polly.Core.Tests/ResiliencePipelineTests.Async.cs
@@ -15,25 +15,25 @@ public partial class ResiliencePipelineTests
             AssertContext = AssertResilienceContext,
         };
 
-        yield return new ExecuteParameters(r => r.ExecuteAsync(async t => { t.Should().Be(CancellationToken); }, CancellationToken))
+        yield return new ExecuteParameters(r => r.ExecuteAsync(async t => { t.ShouldBe(CancellationToken); }, CancellationToken))
         {
             Caption = "ExecuteAsync_Cancellation",
             AssertContext = AssertResilienceContextAndToken,
         };
 
-        yield return new ExecuteParameters(r => r.ExecuteAsync(async (state, t) => { state.Should().Be("state"); t.Should().Be(CancellationToken); }, "state", CancellationToken))
+        yield return new ExecuteParameters(r => r.ExecuteAsync(async (state, t) => { state.ShouldBe("state"); t.ShouldBe(CancellationToken); }, "state", CancellationToken))
         {
             Caption = "ExecuteAsync_StateAndCancellation",
             AssertContext = AssertResilienceContextAndToken,
         };
 
-        yield return new ExecuteParameters(r => r.ExecuteAsync(async (state, t) => { state.Should().Be("state"); t.Should().Be(CancellationToken); }, "state", CancellationToken))
+        yield return new ExecuteParameters(r => r.ExecuteAsync(async (state, t) => { state.ShouldBe("state"); t.ShouldBe(CancellationToken); }, "state", CancellationToken))
         {
             Caption = "ExecuteAsync_StateAndCancellation",
             AssertContext = AssertResilienceContextAndToken,
         };
 
-        yield return new ExecuteParameters(r => r.ExecuteAsync(async (_, s) => { s.Should().Be("dummy-state"); }, ResilienceContextPool.Shared.Get(), "dummy-state"))
+        yield return new ExecuteParameters(r => r.ExecuteAsync(async (_, s) => { s.ShouldBe("dummy-state"); }, ResilienceContextPool.Shared.Get(), "dummy-state"))
         {
             Caption = "ExecuteAsync_ResilienceContextAndState",
             AssertContext = AssertResilienceContext,
@@ -49,18 +49,18 @@ public partial class ResiliencePipelineTests
 
         static void AssertResilienceContext(ResilienceContext context)
         {
-            context.IsSynchronous.Should().BeFalse();
-            context.IsVoid.Should().BeTrue();
-            context.ContinueOnCapturedContext.Should().BeFalse();
+            context.IsSynchronous.ShouldBeFalse();
+            context.IsVoid.ShouldBeTrue();
+            context.ContinueOnCapturedContext.ShouldBeFalse();
         }
 
         static void AssertResilienceContextAndToken(ResilienceContext context)
         {
             AssertResilienceContext(context);
-            context.CancellationToken.Should().Be(CancellationToken);
+            context.CancellationToken.ShouldBe(CancellationToken);
         }
 
-        static void AssertContextInitialized(ResilienceContext context) => context.IsInitialized.Should().BeTrue();
+        static void AssertContextInitialized(ResilienceContext context) => context.IsInitialized.ShouldBeTrue();
     }
 
     [MemberData(nameof(ExecuteAsync_EnsureCorrectBehavior_Data))]
@@ -98,15 +98,10 @@ public partial class ResiliencePipelineTests
         {
             var strategy = new TestResilienceStrategy().AsPipeline();
 
-            var error = await strategy
-                .Invoking(s =>
-                {
-                    return execute(s).AsTask();
-                })
-                .Should()
-                .ThrowAsync<FormatException>();
+            var error = await Should.ThrowAsync<FormatException>(() => execute(strategy).AsTask());
 
-            error.And.StackTrace.Should().Contain(nameof(MyThrowingMethod));
+            error.StackTrace.ShouldNotBeNull();
+            error.StackTrace.ShouldContain(nameof(MyThrowingMethod));
         }
 
         static ValueTask MyThrowingMethod() => throw new FormatException();

--- a/test/Polly.Core.Tests/ResiliencePipelineTests.AsyncT.cs
+++ b/test/Polly.Core.Tests/ResiliencePipelineTests.AsyncT.cs
@@ -17,7 +17,7 @@ public partial class ResiliencePipelineTests
             AssertContext = AssertResilienceContext,
         };
 
-        yield return new ExecuteParameters<long>(r => r.ExecuteAsync(async t => { t.Should().Be(CancellationToken); return result; }, CancellationToken), result)
+        yield return new ExecuteParameters<long>(r => r.ExecuteAsync(async t => { t.ShouldBe(CancellationToken); return result; }, CancellationToken), result)
         {
             Caption = "ExecuteAsyncT_Cancellation",
             AssertContext = AssertResilienceContextAndToken,
@@ -25,8 +25,8 @@ public partial class ResiliencePipelineTests
 
         yield return new ExecuteParameters<long>(r => r.ExecuteAsync(async (state, t) =>
         {
-            state.Should().Be("state");
-            t.Should().Be(CancellationToken);
+            state.ShouldBe("state");
+            t.ShouldBe(CancellationToken);
             return result;
         }, "state", CancellationToken), result)
         {
@@ -34,7 +34,7 @@ public partial class ResiliencePipelineTests
             AssertContext = AssertResilienceContextAndToken,
         };
 
-        yield return new ExecuteParameters<long>(r => r.ExecuteAsync(async (_, s) => { s.Should().Be("dummy-state"); return result; }, ResilienceContextPool.Shared.Get(), "dummy-state"), result)
+        yield return new ExecuteParameters<long>(r => r.ExecuteAsync(async (_, s) => { s.ShouldBe("dummy-state"); return result; }, ResilienceContextPool.Shared.Get(), "dummy-state"), result)
         {
             Caption = "ExecuteAsyncT_ResilienceContextAndState",
             AssertContext = AssertResilienceContext,
@@ -50,19 +50,19 @@ public partial class ResiliencePipelineTests
 
         static void AssertResilienceContext(ResilienceContext context)
         {
-            context.IsSynchronous.Should().BeFalse();
-            context.IsVoid.Should().BeFalse();
-            context.ResultType.Should().Be<long>();
-            context.ContinueOnCapturedContext.Should().BeFalse();
+            context.IsSynchronous.ShouldBeFalse();
+            context.IsVoid.ShouldBeFalse();
+            context.ResultType.ShouldBe(typeof(long));
+            context.ContinueOnCapturedContext.ShouldBeFalse();
         }
 
         static void AssertResilienceContextAndToken(ResilienceContext context)
         {
             AssertResilienceContext(context);
-            context.CancellationToken.Should().Be(CancellationToken);
+            context.CancellationToken.ShouldBe(CancellationToken);
         }
 
-        static void AssertContextInitialized(ResilienceContext context) => context.IsInitialized.Should().BeTrue();
+        static void AssertContextInitialized(ResilienceContext context) => context.IsInitialized.ShouldBeTrue();
     }
 
     [Theory]
@@ -102,15 +102,10 @@ public partial class ResiliencePipelineTests
         {
             var strategy = new TestResilienceStrategy().AsPipeline();
 
-            var error = await strategy
-                .Invoking(s =>
-                {
-                    return execute(s).AsTask();
-                })
-                .Should()
-                .ThrowAsync<FormatException>();
+            var error = await Should.ThrowAsync<FormatException>(() => execute(strategy).AsTask());
 
-            error.And.StackTrace.Should().Contain(nameof(MyThrowingMethod));
+            error.StackTrace.ShouldNotBeNull();
+            error.StackTrace.ShouldContain(nameof(MyThrowingMethod));
         }
 
         static ValueTask<string> MyThrowingMethod() => throw new FormatException();
@@ -121,14 +116,14 @@ public partial class ResiliencePipelineTests
     {
         var result = await ResiliencePipeline.Empty.ExecuteOutcomeAsync((context, state) =>
         {
-            state.Should().Be("state");
-            context.IsSynchronous.Should().BeFalse();
-            context.ResultType.Should().Be<int>();
+            state.ShouldBe("state");
+            context.IsSynchronous.ShouldBeFalse();
+            context.ResultType.ShouldBe(typeof(int));
             return Outcome.FromResultAsValueTask(12345);
         },
         ResilienceContextPool.Shared.Get(),
         "state");
 
-        result.Result.Should().Be(12345);
+        result.Result.ShouldBe(12345);
     }
 }

--- a/test/Polly.Core.Tests/ResiliencePipelineTests.Sync.cs
+++ b/test/Polly.Core.Tests/ResiliencePipelineTests.Sync.cs
@@ -13,13 +13,13 @@ public partial class ResiliencePipelineTests
             AssertContext = AssertResilienceContext,
         };
 
-        yield return new ExecuteParameters(r => r.Execute(t => { t.Should().Be(CancellationToken); }, CancellationToken))
+        yield return new ExecuteParameters(r => r.Execute(t => { t.ShouldBe(CancellationToken); }, CancellationToken))
         {
             Caption = "Execute_Cancellation",
             AssertContext = AssertResilienceContextAndToken,
         };
 
-        yield return new ExecuteParameters(r => r.Execute((state, t) => { state.Should().Be("state"); t.Should().Be(CancellationToken); }, "state", CancellationToken))
+        yield return new ExecuteParameters(r => r.Execute((state, t) => { state.ShouldBe("state"); t.ShouldBe(CancellationToken); }, "state", CancellationToken))
         {
             Caption = "Execute_StateAndCancellation",
             AssertContext = AssertResilienceContextAndToken,
@@ -31,7 +31,7 @@ public partial class ResiliencePipelineTests
             AssertContext = AssertResilienceContext,
         };
 
-        yield return new ExecuteParameters(r => r.Execute(state => { state.Should().Be("state"); }, "state"))
+        yield return new ExecuteParameters(r => r.Execute(state => { state.ShouldBe("state"); }, "state"))
         {
             Caption = "ExecuteAndState",
             AssertContext = AssertResilienceContext,
@@ -44,7 +44,7 @@ public partial class ResiliencePipelineTests
             AssertContextAfter = AssertContextInitialized,
         };
 
-        yield return new ExecuteParameters(r => r.Execute((_, s) => { s.Should().Be("dummy-state"); }, ResilienceContextPool.Shared.Get(CancellationToken), "dummy-state"))
+        yield return new ExecuteParameters(r => r.Execute((_, s) => { s.ShouldBe("dummy-state"); }, ResilienceContextPool.Shared.Get(CancellationToken), "dummy-state"))
         {
             Caption = "Execute_ResilienceContextAndState",
             AssertContext = AssertResilienceContext,
@@ -53,18 +53,18 @@ public partial class ResiliencePipelineTests
 
         static void AssertResilienceContext(ResilienceContext context)
         {
-            context.IsSynchronous.Should().BeTrue();
-            context.IsVoid.Should().BeTrue();
-            context.ContinueOnCapturedContext.Should().BeFalse();
+            context.IsSynchronous.ShouldBeTrue();
+            context.IsVoid.ShouldBeTrue();
+            context.ContinueOnCapturedContext.ShouldBeFalse();
         }
 
         static void AssertResilienceContextAndToken(ResilienceContext context)
         {
             AssertResilienceContext(context);
-            context.CancellationToken.Should().Be(CancellationToken);
+            context.CancellationToken.ShouldBe(CancellationToken);
         }
 
-        static void AssertContextInitialized(ResilienceContext context) => context.IsInitialized.Should().BeTrue();
+        static void AssertContextInitialized(ResilienceContext context) => context.IsInitialized.ShouldBeTrue();
     }
 
     [MemberData(nameof(Execute_EnsureCorrectBehavior_Data))]
@@ -105,12 +105,10 @@ public partial class ResiliencePipelineTests
         {
             var strategy = new TestResilienceStrategy().AsPipeline();
 
-            var error = strategy
-                .Invoking(s => execute(s))
-                .Should()
-                .Throw<FormatException>();
+            var error = Should.Throw<FormatException>(() => execute(strategy));
 
-            error.And.StackTrace.Should().Contain(nameof(MyThrowingMethod));
+            error.StackTrace.ShouldNotBeNull();
+            error.StackTrace.ShouldContain(nameof(MyThrowingMethod));
         }
 
         static void MyThrowingMethod() => throw new FormatException();

--- a/test/Polly.Core.Tests/ResiliencePipelineTests.SyncT.cs
+++ b/test/Polly.Core.Tests/ResiliencePipelineTests.SyncT.cs
@@ -15,7 +15,7 @@ public partial class ResiliencePipelineTests
             AssertContext = AssertResilienceContext,
         };
 
-        yield return new ExecuteParameters<long>(r => r.Execute(t => { t.Should().Be(CancellationToken); return result; }, CancellationToken), result)
+        yield return new ExecuteParameters<long>(r => r.Execute(t => { t.ShouldBe(CancellationToken); return result; }, CancellationToken), result)
         {
             Caption = "ExecuteT_Cancellation",
             AssertContext = AssertResilienceContextAndToken,
@@ -27,7 +27,7 @@ public partial class ResiliencePipelineTests
             AssertContext = AssertResilienceContext,
         };
 
-        yield return new ExecuteParameters<long>(r => r.Execute((state) => { state.Should().Be("state"); return result; }, "state"), result)
+        yield return new ExecuteParameters<long>(r => r.Execute((state) => { state.ShouldBe("state"); return result; }, "state"), result)
         {
             Caption = "ExecuteT_State",
             AssertContext = AssertResilienceContext,
@@ -40,13 +40,13 @@ public partial class ResiliencePipelineTests
             AssertContextAfter = AssertContextInitialized
         };
 
-        yield return new ExecuteParameters<long>(r => r.Execute((_, s) => { s.Should().Be("dummy-state"); return result; }, ResilienceContextPool.Shared.Get(CancellationToken), "dummy-state"), result)
+        yield return new ExecuteParameters<long>(r => r.Execute((_, s) => { s.ShouldBe("dummy-state"); return result; }, ResilienceContextPool.Shared.Get(CancellationToken), "dummy-state"), result)
         {
             Caption = "ExecuteT_ResilienceContext",
             AssertContext = AssertResilienceContext,
         };
 
-        yield return new ExecuteParameters<long>(r => r.Execute((state, _) => { state.Should().Be("dummy-state"); return result; }, "dummy-state", CancellationToken), result)
+        yield return new ExecuteParameters<long>(r => r.Execute((state, _) => { state.ShouldBe("dummy-state"); return result; }, "dummy-state", CancellationToken), result)
         {
             Caption = "ExecuteT_StateAndCancellation",
             AssertContext = AssertResilienceContextAndToken,
@@ -54,19 +54,19 @@ public partial class ResiliencePipelineTests
 
         static void AssertResilienceContext(ResilienceContext context)
         {
-            context.IsSynchronous.Should().BeTrue();
-            context.IsVoid.Should().BeFalse();
-            context.ResultType.Should().Be<long>();
-            context.ContinueOnCapturedContext.Should().BeFalse();
+            context.IsSynchronous.ShouldBeTrue();
+            context.IsVoid.ShouldBeFalse();
+            context.ResultType.ShouldBe(typeof(long));
+            context.ContinueOnCapturedContext.ShouldBeFalse();
         }
 
         static void AssertResilienceContextAndToken(ResilienceContext context)
         {
             AssertResilienceContext(context);
-            context.CancellationToken.Should().Be(CancellationToken);
+            context.CancellationToken.ShouldBe(CancellationToken);
         }
 
-        static void AssertContextInitialized(ResilienceContext context) => context.IsInitialized.Should().BeTrue();
+        static void AssertContextInitialized(ResilienceContext context) => context.IsInitialized.ShouldBeTrue();
     }
 
     [Theory]
@@ -109,12 +109,10 @@ public partial class ResiliencePipelineTests
         {
             var strategy = new TestResilienceStrategy().AsPipeline();
 
-            var error = strategy
-                .Invoking(s => execute(s))
-                .Should()
-                .Throw<FormatException>();
+            var error = Should.Throw<FormatException>(() => execute(strategy));
 
-            error.And.StackTrace.Should().Contain(nameof(MyThrowingMethod));
+            error.StackTrace.ShouldNotBeNull();
+            error.StackTrace.ShouldContain(nameof(MyThrowingMethod));
         }
 
         static string MyThrowingMethod() => throw new FormatException();

--- a/test/Polly.Core.Tests/ResiliencePipelineTests.cs
+++ b/test/Polly.Core.Tests/ResiliencePipelineTests.cs
@@ -22,7 +22,7 @@ public partial class ResiliencePipelineTests
         await ResiliencePipeline.Empty.DisposeHelper.DisposeAsync();
         await ResiliencePipeline.Empty.DisposeHelper.DisposeAsync();
 
-        ResiliencePipeline.Empty.Execute(() => 1).Should().Be(1);
+        ResiliencePipeline.Empty.Execute(() => 1).ShouldBe(1);
     }
 
     [Fact]
@@ -31,7 +31,7 @@ public partial class ResiliencePipelineTests
         await ResiliencePipeline<int>.Empty.DisposeHelper.DisposeAsync();
         await ResiliencePipeline<int>.Empty.DisposeHelper.DisposeAsync();
 
-        ResiliencePipeline.Empty.Execute(() => 1).Should().Be(1);
+        ResiliencePipeline.Empty.Execute(() => 1).ShouldBe(1);
     }
 
     [Fact]
@@ -40,10 +40,8 @@ public partial class ResiliencePipelineTests
         var component = Substitute.For<PipelineComponent>();
         var pipeline = new ResiliencePipeline(component, DisposeBehavior.Reject, null);
 
-        (await pipeline.Invoking(p => p.DisposeHelper.DisposeAsync().AsTask())
-            .Should()
-            .ThrowAsync<InvalidOperationException>())
-            .WithMessage("Disposing this resilience pipeline is not allowed because it is owned by the pipeline registry.");
+        var exception = await Should.ThrowAsync<InvalidOperationException>(() => pipeline.DisposeHelper.DisposeAsync().AsTask());
+        exception.Message.ShouldBe("Disposing this resilience pipeline is not allowed because it is owned by the pipeline registry.");
     }
 
     [Fact]
@@ -54,7 +52,7 @@ public partial class ResiliencePipelineTests
         await pipeline.DisposeHelper.DisposeAsync();
         await pipeline.DisposeHelper.DisposeAsync();
 
-        pipeline.Invoking(p => p.Execute(() => { })).Should().Throw<ObjectDisposedException>();
+        Should.Throw<ObjectDisposedException>(() => pipeline.Execute(() => { }));
 
         await component.Received(1).DisposeAsync();
     }
@@ -62,8 +60,8 @@ public partial class ResiliencePipelineTests
     [Fact]
     public void Null_Ok()
     {
-        ResiliencePipeline.Empty.Should().NotBeNull();
-        ResiliencePipeline<string>.Empty.Should().NotBeNull();
+        ResiliencePipeline.Empty.ShouldNotBeNull();
+        ResiliencePipeline<string>.Empty.ShouldNotBeNull();
     }
 
     [Fact]
@@ -75,7 +73,7 @@ public partial class ResiliencePipelineTests
             Substitute.For<PipelineComponent>(),
         ], null!, null!);
 
-        new CompositeComponentDebuggerProxy(pipeline).Strategies.Should().HaveCount(2);
+        new CompositeComponentDebuggerProxy(pipeline).Strategies.Count().ShouldBe(2);
     }
 
     [Fact]
@@ -86,7 +84,7 @@ public partial class ResiliencePipelineTests
         ResilienceContextPool? pool = null;
 
         var pipeline = new ResiliencePipeline(component, disposeBehavior, pool);
-        pipeline.Pool.Should().Be(ResilienceContextPool.Shared);
+        pipeline.Pool.ShouldBe(ResilienceContextPool.Shared);
     }
 
     [Fact]
@@ -97,7 +95,7 @@ public partial class ResiliencePipelineTests
         var pool = Substitute.For<ResilienceContextPool>();
 
         var pipeline = new ResiliencePipeline(component, disposeBehavior, pool);
-        pipeline.Pool.Should().Be(pool);
+        pipeline.Pool.ShouldBe(pool);
     }
 
     public class ExecuteParameters<T> : ExecuteParameters
@@ -110,7 +108,7 @@ public partial class ResiliencePipelineTests
                 return result!;
             };
 
-            AssertResult = result => result.Should().BeOfType<T>().And.Be(resultValue);
+            AssertResult = result => result.ShouldBeOfType<T>().ShouldBe(resultValue);
         }
 
         public ExecuteParameters(Func<ResiliencePipeline, ValueTask<T>> execute, T resultValue)
@@ -121,13 +119,13 @@ public partial class ResiliencePipelineTests
                 return result!;
             };
 
-            AssertResult = result => result.Should().BeOfType<T>().And.Be(resultValue);
+            AssertResult = result => result.ShouldBeOfType<T>().ShouldBe(resultValue);
         }
 
         public ExecuteParameters(Func<ResiliencePipeline, T> execute, T resultValue)
         {
             Execute = strategy => new ValueTask<object>(execute(strategy)!);
-            AssertResult = result => result.Should().BeOfType<T>().And.Be(resultValue);
+            AssertResult = result => result.ShouldBeOfType<T>().ShouldBe(resultValue);
         }
     }
 
@@ -145,7 +143,7 @@ public partial class ResiliencePipelineTests
                 return VoidResult.Instance;
             };
 
-            AssertResult = r => r.Should().Be(VoidResult.Instance);
+            AssertResult = r => r.ShouldBe(VoidResult.Instance);
         }
 
         public ExecuteParameters(Func<ResiliencePipeline, Task> execute)
@@ -156,7 +154,7 @@ public partial class ResiliencePipelineTests
                 return VoidResult.Instance;
             };
 
-            AssertResult = r => r.Should().Be(VoidResult.Instance);
+            AssertResult = r => r.ShouldBe(VoidResult.Instance);
         }
 
         public ExecuteParameters(Action<ResiliencePipeline> execute)
@@ -167,7 +165,7 @@ public partial class ResiliencePipelineTests
                 return new ValueTask<object>(VoidResult.Instance);
             };
 
-            AssertResult = r => r.Should().Be(VoidResult.Instance);
+            AssertResult = r => r.ShouldBe(VoidResult.Instance);
         }
 
         public Func<ResiliencePipeline, ValueTask<object>> Execute { get; set; } = r => new ValueTask<object>(VoidResult.Instance);

--- a/test/Polly.Core.Tests/ResiliencePropertiesTests.cs
+++ b/test/Polly.Core.Tests/ResiliencePropertiesTests.cs
@@ -10,8 +10,8 @@ public class ResiliencePropertiesTests
 
         props.Set(key, 12345);
 
-        props.TryGetValue(key, out var val).Should().Be(true);
-        val.Should().Be(12345);
+        props.TryGetValue(key, out var val).ShouldBe(true);
+        val.ShouldBe(12345);
     }
 
     [Fact]
@@ -22,8 +22,8 @@ public class ResiliencePropertiesTests
 
         props.Set(key, null);
 
-        props.TryGetValue(key, out var val).Should().Be(true);
-        val.Should().Be(null);
+        props.TryGetValue(key, out var val).ShouldBe(true);
+        val.ShouldBe(null);
     }
 
     [Fact]
@@ -32,7 +32,7 @@ public class ResiliencePropertiesTests
         var key = new ResiliencePropertyKey<long>("dummy");
         var props = new ResilienceProperties();
 
-        props.TryGetValue(key, out var val).Should().Be(false);
+        props.TryGetValue(key, out var val).ShouldBe(false);
     }
 
     [Fact]
@@ -43,7 +43,7 @@ public class ResiliencePropertiesTests
 
         props.Set(key, 12345);
 
-        props.GetValue(key, default).Should().Be(12345);
+        props.GetValue(key, default).ShouldBe(12345);
     }
 
     [Fact]
@@ -54,7 +54,7 @@ public class ResiliencePropertiesTests
 
         props.Set(key, null);
 
-        props.GetValue(key, "default").Should().Be(null);
+        props.GetValue(key, "default").ShouldBe(null);
     }
 
     [Fact]
@@ -63,7 +63,7 @@ public class ResiliencePropertiesTests
         var key = new ResiliencePropertyKey<long>("dummy");
         var props = new ResilienceProperties();
 
-        props.GetValue(key, -1).Should().Be(-1);
+        props.GetValue(key, -1).ShouldBe(-1);
     }
 
     [Fact]
@@ -76,7 +76,7 @@ public class ResiliencePropertiesTests
 
         props.Set(key1, 12345);
 
-        props.TryGetValue(key2, out var val).Should().Be(false);
+        props.TryGetValue(key2, out var val).ShouldBe(false);
     }
 
     [InlineData(true)]
@@ -99,8 +99,8 @@ public class ResiliencePropertiesTests
         otherProps.Set(key2, "B");
 
         props.AddOrReplaceProperties(otherProps);
-        props.Options.Should().HaveCount(2);
-        props.GetValue(key1, "").Should().Be("A");
-        props.GetValue(key2, "").Should().Be("B");
+        props.Options.Count.ShouldBe(2);
+        props.GetValue(key1, "").ShouldBe("A");
+        props.GetValue(key2, "").ShouldBe("B");
     }
 }

--- a/test/Polly.Core.Tests/ResiliencePropertyKeyTests.cs
+++ b/test/Polly.Core.Tests/ResiliencePropertyKeyTests.cs
@@ -7,8 +7,8 @@ public class ResiliencePropertyKeyTests
     {
         var instance = new ResiliencePropertyKey<int>("dummy");
 
-        instance.Key.Should().Be("dummy");
-        instance.ToString().Should().Be("dummy");
+        instance.Key.ShouldBe("dummy");
+        instance.ToString().ShouldBe("dummy");
     }
 
     [Fact]

--- a/test/Polly.Core.Tests/ResilienceStrategyOptionsTests.cs
+++ b/test/Polly.Core.Tests/ResilienceStrategyOptionsTests.cs
@@ -7,6 +7,6 @@ public class ResilienceStrategyOptionsTests
     {
         var options = new TestResilienceStrategyOptions();
 
-        options.Name.Should().BeNull();
+        options.Name.ShouldBeNull();
     }
 }

--- a/test/Polly.Core.Tests/Retry/OnRetryArgumentsTests.cs
+++ b/test/Polly.Core.Tests/Retry/OnRetryArgumentsTests.cs
@@ -14,10 +14,10 @@ public static class OnRetryArgumentsTests
         var args = new OnRetryArguments<int>(context, Outcome.FromResult(1), 2, TimeSpan.FromSeconds(3), TimeSpan.MaxValue);
 
         // Assert
-        args.Context.Should().Be(context);
-        args.Outcome.Result.Should().Be(1);
-        args.AttemptNumber.Should().Be(2);
-        args.RetryDelay.Should().Be(TimeSpan.FromSeconds(3));
-        args.Duration.Should().Be(TimeSpan.MaxValue);
+        args.Context.ShouldBe(context);
+        args.Outcome.Result.ShouldBe(1);
+        args.AttemptNumber.ShouldBe(2);
+        args.RetryDelay.ShouldBe(TimeSpan.FromSeconds(3));
+        args.Duration.ShouldBe(TimeSpan.MaxValue);
     }
 }

--- a/test/Polly.Core.Tests/Retry/RetryConstantsTests.cs
+++ b/test/Polly.Core.Tests/Retry/RetryConstantsTests.cs
@@ -7,10 +7,10 @@ public class RetryConstantsTests
     [Fact]
     public void EnsureDefaults()
     {
-        RetryConstants.DefaultBackoffType.Should().Be(DelayBackoffType.Constant);
-        RetryConstants.DefaultBaseDelay.Should().Be(TimeSpan.FromSeconds(2));
-        RetryConstants.DefaultRetryCount.Should().Be(3);
-        RetryConstants.MaxRetryCount.Should().Be(int.MaxValue);
-        RetryConstants.OnRetryEvent.Should().Be("OnRetry");
+        RetryConstants.DefaultBackoffType.ShouldBe(DelayBackoffType.Constant);
+        RetryConstants.DefaultBaseDelay.ShouldBe(TimeSpan.FromSeconds(2));
+        RetryConstants.DefaultRetryCount.ShouldBe(3);
+        RetryConstants.MaxRetryCount.ShouldBe(int.MaxValue);
+        RetryConstants.OnRetryEvent.ShouldBe("OnRetry");
     }
 }

--- a/test/Polly.Core.Tests/Retry/RetryDelayGeneratorArgumentsTests.cs
+++ b/test/Polly.Core.Tests/Retry/RetryDelayGeneratorArgumentsTests.cs
@@ -14,8 +14,8 @@ public static class RetryDelayGeneratorArgumentsTests
         var args = new RetryDelayGeneratorArguments<int>(context, Outcome.FromResult(1), 2);
 
         // Assert
-        args.Context.Should().Be(context);
-        args.Outcome.Result.Should().Be(1);
-        args.AttemptNumber.Should().Be(2);
+        args.Context.ShouldBe(context);
+        args.Outcome.Result.ShouldBe(1);
+        args.AttemptNumber.ShouldBe(2);
     }
 }

--- a/test/Polly.Core.Tests/Retry/RetryHelperTests.cs
+++ b/test/Polly.Core.Tests/Retry/RetryHelperTests.cs
@@ -27,11 +27,11 @@ public class RetryHelperTests
     [Fact]
     public void IsValidDelay_Ok()
     {
-        RetryHelper.IsValidDelay(TimeSpan.Zero).Should().BeTrue();
-        RetryHelper.IsValidDelay(TimeSpan.FromSeconds(1)).Should().BeTrue();
-        RetryHelper.IsValidDelay(TimeSpan.MaxValue).Should().BeTrue();
-        RetryHelper.IsValidDelay(TimeSpan.MinValue).Should().BeFalse();
-        RetryHelper.IsValidDelay(TimeSpan.FromMilliseconds(-1)).Should().BeFalse();
+        RetryHelper.IsValidDelay(TimeSpan.Zero).ShouldBeTrue();
+        RetryHelper.IsValidDelay(TimeSpan.FromSeconds(1)).ShouldBeTrue();
+        RetryHelper.IsValidDelay(TimeSpan.MaxValue).ShouldBeTrue();
+        RetryHelper.IsValidDelay(TimeSpan.MinValue).ShouldBeFalse();
+        RetryHelper.IsValidDelay(TimeSpan.FromMilliseconds(-1)).ShouldBeFalse();
     }
 
     [InlineData(true)]
@@ -53,13 +53,13 @@ public class RetryHelperTests
     {
         double state = 0;
 
-        RetryHelper.GetRetryDelay(DelayBackoffType.Constant, false, 0, TimeSpan.Zero, null, ref state, _randomizer).Should().Be(TimeSpan.Zero);
-        RetryHelper.GetRetryDelay(DelayBackoffType.Constant, false, 1, TimeSpan.Zero, null, ref state, _randomizer).Should().Be(TimeSpan.Zero);
-        RetryHelper.GetRetryDelay(DelayBackoffType.Constant, false, 2, TimeSpan.Zero, null, ref state, _randomizer).Should().Be(TimeSpan.Zero);
+        RetryHelper.GetRetryDelay(DelayBackoffType.Constant, false, 0, TimeSpan.Zero, null, ref state, _randomizer).ShouldBe(TimeSpan.Zero);
+        RetryHelper.GetRetryDelay(DelayBackoffType.Constant, false, 1, TimeSpan.Zero, null, ref state, _randomizer).ShouldBe(TimeSpan.Zero);
+        RetryHelper.GetRetryDelay(DelayBackoffType.Constant, false, 2, TimeSpan.Zero, null, ref state, _randomizer).ShouldBe(TimeSpan.Zero);
 
-        RetryHelper.GetRetryDelay(DelayBackoffType.Constant, false, 0, TimeSpan.FromSeconds(1), null, ref state, _randomizer).Should().Be(TimeSpan.FromSeconds(1));
-        RetryHelper.GetRetryDelay(DelayBackoffType.Constant, false, 1, TimeSpan.FromSeconds(1), null, ref state, _randomizer).Should().Be(TimeSpan.FromSeconds(1));
-        RetryHelper.GetRetryDelay(DelayBackoffType.Constant, false, 2, TimeSpan.FromSeconds(1), null, ref state, _randomizer).Should().Be(TimeSpan.FromSeconds(1));
+        RetryHelper.GetRetryDelay(DelayBackoffType.Constant, false, 0, TimeSpan.FromSeconds(1), null, ref state, _randomizer).ShouldBe(TimeSpan.FromSeconds(1));
+        RetryHelper.GetRetryDelay(DelayBackoffType.Constant, false, 1, TimeSpan.FromSeconds(1), null, ref state, _randomizer).ShouldBe(TimeSpan.FromSeconds(1));
+        RetryHelper.GetRetryDelay(DelayBackoffType.Constant, false, 2, TimeSpan.FromSeconds(1), null, ref state, _randomizer).ShouldBe(TimeSpan.FromSeconds(1));
     }
 
     [Fact]
@@ -67,32 +67,28 @@ public class RetryHelperTests
     {
         double state = 0;
 
-        RetryHelper.GetRetryDelay(DelayBackoffType.Constant, true, 0, TimeSpan.Zero, null, ref state, _randomizer).Should().Be(TimeSpan.Zero);
-        RetryHelper.GetRetryDelay(DelayBackoffType.Constant, true, 1, TimeSpan.Zero, null, ref state, _randomizer).Should().Be(TimeSpan.Zero);
-        RetryHelper.GetRetryDelay(DelayBackoffType.Constant, true, 2, TimeSpan.Zero, null, ref state, _randomizer).Should().Be(TimeSpan.Zero);
+        RetryHelper.GetRetryDelay(DelayBackoffType.Constant, true, 0, TimeSpan.Zero, null, ref state, _randomizer).ShouldBe(TimeSpan.Zero);
+        RetryHelper.GetRetryDelay(DelayBackoffType.Constant, true, 1, TimeSpan.Zero, null, ref state, _randomizer).ShouldBe(TimeSpan.Zero);
+        RetryHelper.GetRetryDelay(DelayBackoffType.Constant, true, 2, TimeSpan.Zero, null, ref state, _randomizer).ShouldBe(TimeSpan.Zero);
 
         _randomizer = () => 0.0;
         RetryHelper
             .GetRetryDelay(DelayBackoffType.Constant, true, 0, TimeSpan.FromSeconds(1), null, ref state, _randomizer)
-            .Should()
-            .Be(TimeSpan.FromSeconds(0.75));
+            .ShouldBe(TimeSpan.FromSeconds(0.75));
 
         _randomizer = () => 0.4;
         RetryHelper
             .GetRetryDelay(DelayBackoffType.Constant, true, 0, TimeSpan.FromSeconds(1), null, ref state, _randomizer)
-            .Should()
-            .Be(TimeSpan.FromSeconds(0.95));
+            .ShouldBe(TimeSpan.FromSeconds(0.95));
 
         _randomizer = () => 0.6;
         RetryHelper.GetRetryDelay(DelayBackoffType.Constant, true, 1, TimeSpan.FromSeconds(1), null, ref state, _randomizer)
-            .Should()
-            .Be(TimeSpan.FromSeconds(1.05));
+            .ShouldBe(TimeSpan.FromSeconds(1.05));
 
         _randomizer = () => 1.0;
         RetryHelper
             .GetRetryDelay(DelayBackoffType.Constant, true, 0, TimeSpan.FromSeconds(1), null, ref state, _randomizer)
-            .Should()
-            .Be(TimeSpan.FromSeconds(1.25));
+            .ShouldBe(TimeSpan.FromSeconds(1.25));
     }
 
     [Fact]
@@ -100,13 +96,13 @@ public class RetryHelperTests
     {
         double state = 0;
 
-        RetryHelper.GetRetryDelay(DelayBackoffType.Linear, false, 0, TimeSpan.Zero, null, ref state, _randomizer).Should().Be(TimeSpan.Zero);
-        RetryHelper.GetRetryDelay(DelayBackoffType.Linear, false, 1, TimeSpan.Zero, null, ref state, _randomizer).Should().Be(TimeSpan.Zero);
-        RetryHelper.GetRetryDelay(DelayBackoffType.Linear, false, 2, TimeSpan.Zero, null, ref state, _randomizer).Should().Be(TimeSpan.Zero);
+        RetryHelper.GetRetryDelay(DelayBackoffType.Linear, false, 0, TimeSpan.Zero, null, ref state, _randomizer).ShouldBe(TimeSpan.Zero);
+        RetryHelper.GetRetryDelay(DelayBackoffType.Linear, false, 1, TimeSpan.Zero, null, ref state, _randomizer).ShouldBe(TimeSpan.Zero);
+        RetryHelper.GetRetryDelay(DelayBackoffType.Linear, false, 2, TimeSpan.Zero, null, ref state, _randomizer).ShouldBe(TimeSpan.Zero);
 
-        RetryHelper.GetRetryDelay(DelayBackoffType.Linear, false, 0, TimeSpan.FromSeconds(1), null, ref state, _randomizer).Should().Be(TimeSpan.FromSeconds(1));
-        RetryHelper.GetRetryDelay(DelayBackoffType.Linear, false, 1, TimeSpan.FromSeconds(1), null, ref state, _randomizer).Should().Be(TimeSpan.FromSeconds(2));
-        RetryHelper.GetRetryDelay(DelayBackoffType.Linear, false, 2, TimeSpan.FromSeconds(1), null, ref state, _randomizer).Should().Be(TimeSpan.FromSeconds(3));
+        RetryHelper.GetRetryDelay(DelayBackoffType.Linear, false, 0, TimeSpan.FromSeconds(1), null, ref state, _randomizer).ShouldBe(TimeSpan.FromSeconds(1));
+        RetryHelper.GetRetryDelay(DelayBackoffType.Linear, false, 1, TimeSpan.FromSeconds(1), null, ref state, _randomizer).ShouldBe(TimeSpan.FromSeconds(2));
+        RetryHelper.GetRetryDelay(DelayBackoffType.Linear, false, 2, TimeSpan.FromSeconds(1), null, ref state, _randomizer).ShouldBe(TimeSpan.FromSeconds(3));
     }
 
     [Fact]
@@ -114,38 +110,33 @@ public class RetryHelperTests
     {
         double state = 0;
 
-        RetryHelper.GetRetryDelay(DelayBackoffType.Linear, true, 0, TimeSpan.Zero, null, ref state, _randomizer).Should().Be(TimeSpan.Zero);
-        RetryHelper.GetRetryDelay(DelayBackoffType.Linear, true, 1, TimeSpan.Zero, null, ref state, _randomizer).Should().Be(TimeSpan.Zero);
-        RetryHelper.GetRetryDelay(DelayBackoffType.Linear, true, 2, TimeSpan.Zero, null, ref state, _randomizer).Should().Be(TimeSpan.Zero);
+        RetryHelper.GetRetryDelay(DelayBackoffType.Linear, true, 0, TimeSpan.Zero, null, ref state, _randomizer).ShouldBe(TimeSpan.Zero);
+        RetryHelper.GetRetryDelay(DelayBackoffType.Linear, true, 1, TimeSpan.Zero, null, ref state, _randomizer).ShouldBe(TimeSpan.Zero);
+        RetryHelper.GetRetryDelay(DelayBackoffType.Linear, true, 2, TimeSpan.Zero, null, ref state, _randomizer).ShouldBe(TimeSpan.Zero);
 
         _randomizer = () => 0.0;
         RetryHelper
             .GetRetryDelay(DelayBackoffType.Linear, true, 2, TimeSpan.FromSeconds(1), null, ref state, _randomizer)
-            .Should()
-            .Be(TimeSpan.FromSeconds(2.25));
+            .ShouldBe(TimeSpan.FromSeconds(2.25));
 
         _randomizer = () => 0.4;
         RetryHelper
             .GetRetryDelay(DelayBackoffType.Linear, true, 2, TimeSpan.FromSeconds(1), null, ref state, _randomizer)
-            .Should()
-            .Be(TimeSpan.FromSeconds(2.85));
+            .ShouldBe(TimeSpan.FromSeconds(2.85));
 
         _randomizer = () => 0.5;
         RetryHelper
             .GetRetryDelay(DelayBackoffType.Linear, true, 2, TimeSpan.FromSeconds(1), null, ref state, _randomizer)
-            .Should()
-            .Be(TimeSpan.FromSeconds(3));
+            .ShouldBe(TimeSpan.FromSeconds(3));
 
         _randomizer = () => 0.6;
         RetryHelper.GetRetryDelay(DelayBackoffType.Linear, true, 2, TimeSpan.FromSeconds(1), null, ref state, _randomizer)
-            .Should()
-            .Be(TimeSpan.FromSeconds(3.15));
+            .ShouldBe(TimeSpan.FromSeconds(3.15));
 
         _randomizer = () => 1.0;
         RetryHelper
             .GetRetryDelay(DelayBackoffType.Linear, true, 2, TimeSpan.FromSeconds(1), null, ref state, _randomizer)
-            .Should()
-            .Be(TimeSpan.FromSeconds(3.75));
+            .ShouldBe(TimeSpan.FromSeconds(3.75));
     }
 
     [Fact]
@@ -153,13 +144,13 @@ public class RetryHelperTests
     {
         double state = 0;
 
-        RetryHelper.GetRetryDelay(DelayBackoffType.Exponential, false, 0, TimeSpan.Zero, null, ref state, _randomizer).Should().Be(TimeSpan.Zero);
-        RetryHelper.GetRetryDelay(DelayBackoffType.Exponential, false, 1, TimeSpan.Zero, null, ref state, _randomizer).Should().Be(TimeSpan.Zero);
-        RetryHelper.GetRetryDelay(DelayBackoffType.Exponential, false, 2, TimeSpan.Zero, null, ref state, _randomizer).Should().Be(TimeSpan.Zero);
+        RetryHelper.GetRetryDelay(DelayBackoffType.Exponential, false, 0, TimeSpan.Zero, null, ref state, _randomizer).ShouldBe(TimeSpan.Zero);
+        RetryHelper.GetRetryDelay(DelayBackoffType.Exponential, false, 1, TimeSpan.Zero, null, ref state, _randomizer).ShouldBe(TimeSpan.Zero);
+        RetryHelper.GetRetryDelay(DelayBackoffType.Exponential, false, 2, TimeSpan.Zero, null, ref state, _randomizer).ShouldBe(TimeSpan.Zero);
 
-        RetryHelper.GetRetryDelay(DelayBackoffType.Exponential, false, 0, TimeSpan.FromSeconds(1), null, ref state, _randomizer).Should().Be(TimeSpan.FromSeconds(1));
-        RetryHelper.GetRetryDelay(DelayBackoffType.Exponential, false, 1, TimeSpan.FromSeconds(1), null, ref state, _randomizer).Should().Be(TimeSpan.FromSeconds(2));
-        RetryHelper.GetRetryDelay(DelayBackoffType.Exponential, false, 2, TimeSpan.FromSeconds(1), null, ref state, _randomizer).Should().Be(TimeSpan.FromSeconds(4));
+        RetryHelper.GetRetryDelay(DelayBackoffType.Exponential, false, 0, TimeSpan.FromSeconds(1), null, ref state, _randomizer).ShouldBe(TimeSpan.FromSeconds(1));
+        RetryHelper.GetRetryDelay(DelayBackoffType.Exponential, false, 1, TimeSpan.FromSeconds(1), null, ref state, _randomizer).ShouldBe(TimeSpan.FromSeconds(2));
+        RetryHelper.GetRetryDelay(DelayBackoffType.Exponential, false, 2, TimeSpan.FromSeconds(1), null, ref state, _randomizer).ShouldBe(TimeSpan.FromSeconds(4));
     }
 
     [InlineData(DelayBackoffType.Linear, false)]
@@ -175,7 +166,7 @@ public class RetryHelperTests
         var expected = TimeSpan.FromSeconds(1);
         double state = 0;
 
-        RetryHelper.GetRetryDelay(type, jitter, 2, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(1), ref state, _randomizer).Should().Be(expected);
+        RetryHelper.GetRetryDelay(type, jitter, 2, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(1), ref state, _randomizer).ShouldBe(expected);
     }
 
     [Fact]
@@ -184,7 +175,7 @@ public class RetryHelperTests
         double state = 0;
         var expected = TimeSpan.FromSeconds(1);
 
-        RetryHelper.GetRetryDelay(DelayBackoffType.Constant, false, 2, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), ref state, _randomizer).Should().Be(expected);
+        RetryHelper.GetRetryDelay(DelayBackoffType.Constant, false, 2, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), ref state, _randomizer).ShouldBe(expected);
     }
 
     [Fact]
@@ -192,7 +183,7 @@ public class RetryHelperTests
     {
         double state = 0;
 
-        RetryHelper.GetRetryDelay(DelayBackoffType.Exponential, false, 1000, TimeSpan.FromDays(1), null, ref state, _randomizer).Should().Be(TimeSpan.MaxValue);
+        RetryHelper.GetRetryDelay(DelayBackoffType.Exponential, false, 1000, TimeSpan.FromDays(1), null, ref state, _randomizer).ShouldBe(TimeSpan.MaxValue);
     }
 
     [Fact]
@@ -200,7 +191,7 @@ public class RetryHelperTests
     {
         double state = 0;
 
-        RetryHelper.GetRetryDelay(DelayBackoffType.Exponential, false, 1000, TimeSpan.FromDays(1), TimeSpan.FromDays(2), ref state, _randomizer).Should().Be(TimeSpan.FromDays(2));
+        RetryHelper.GetRetryDelay(DelayBackoffType.Exponential, false, 1000, TimeSpan.FromDays(1), TimeSpan.FromDays(2), ref state, _randomizer).ShouldBe(TimeSpan.FromDays(2));
     }
 
     [Theory]
@@ -219,8 +210,8 @@ public class RetryHelperTests
         var first = RetryHelper.GetRetryDelay(type, jitter, attempt, baseDelay, maxDelay, ref state, random);
         var second = RetryHelper.GetRetryDelay(type, jitter, attempt, baseDelay, maxDelay, ref state, random);
 
-        first.Should().BePositive();
-        second.Should().BePositive();
+        first.ShouldBeGreaterThan(TimeSpan.Zero);
+        second.ShouldBeGreaterThan(TimeSpan.Zero);
     }
 
     [Theory]
@@ -239,11 +230,11 @@ public class RetryHelperTests
         var first = RetryHelper.GetRetryDelay(type, jitter, attempt, baseDelay, maxDelay, ref state, random);
         var second = RetryHelper.GetRetryDelay(type, jitter, attempt, baseDelay, maxDelay, ref state, random);
 
-        first.Should().BePositive();
-        first.Should().BeLessThanOrEqualTo(maxDelay);
+        first.ShouldBeGreaterThan(TimeSpan.Zero);
+        first.ShouldBeLessThanOrEqualTo(maxDelay);
 
-        second.Should().BePositive();
-        second.Should().BeLessThanOrEqualTo(maxDelay);
+        second.ShouldBeGreaterThan(TimeSpan.Zero);
+        second.ShouldBeLessThanOrEqualTo(maxDelay);
     }
 
     [Theory]
@@ -254,9 +245,9 @@ public class RetryHelperTests
         var oldDelays = GetExponentialWithJitterBackoff(true, delay, count);
         var newDelays = GetExponentialWithJitterBackoff(false, delay, count);
 
-        newDelays.Should().ContainInConsecutiveOrder(oldDelays);
-        newDelays.Should().HaveCount(oldDelays.Count);
-        newDelays.Should().AllSatisfy(delay => delay.Should().BePositive());
+        newDelays.ShouldBeSubsetOf(oldDelays);
+        newDelays.Count.ShouldBe(oldDelays.Count);
+        newDelays.ShouldAllBe(delay => delay > TimeSpan.Zero);
     }
 
     [Fact]
@@ -266,8 +257,8 @@ public class RetryHelperTests
         var delays1 = GetExponentialWithJitterBackoff(false, delay, 100, RandomUtil.Instance.NextDouble);
         var delays2 = GetExponentialWithJitterBackoff(false, delay, 100, RandomUtil.Instance.NextDouble);
 
-        delays1.SequenceEqual(delays2).Should().BeFalse();
-        delays1.Should().AllSatisfy(delay => delay.Should().BePositive());
+        delays1.SequenceEqual(delays2).ShouldBeFalse();
+        delays1.ShouldAllBe(delay => delay > TimeSpan.Zero);
     }
 
     private static IReadOnlyList<TimeSpan> GetExponentialWithJitterBackoff(bool contrib, TimeSpan baseDelay, int retryCount, Func<double>? randomizer = null)

--- a/test/Polly.Core.Tests/Retry/RetryResiliencePipelineBuilderExtensionsTests.cs
+++ b/test/Polly.Core.Tests/Retry/RetryResiliencePipelineBuilderExtensionsTests.cs
@@ -47,7 +47,7 @@ public class RetryResiliencePipelineBuilderExtensionsTests
     {
         var builder = new ResiliencePipelineBuilder();
 
-        builder.Invoking(b => configure(b)).Should().NotThrow();
+        Should.NotThrow(() => configure(builder));
     }
 
     [MemberData(nameof(OverloadsDataGeneric))]
@@ -56,7 +56,7 @@ public class RetryResiliencePipelineBuilderExtensionsTests
     {
         var builder = new ResiliencePipelineBuilder<int>();
 
-        builder.Invoking(b => configure(b)).Should().NotThrow();
+        Should.NotThrow(() => configure(builder));
     }
 
     [Fact]
@@ -72,11 +72,11 @@ public class RetryResiliencePipelineBuilderExtensionsTests
 
     private static void AssertStrategy(ResiliencePipelineBuilder builder, DelayBackoffType type, int retries, TimeSpan delay, Action<RetryResilienceStrategy<object>>? assert = null)
     {
-        var strategy = builder.Build().GetPipelineDescriptor().FirstStrategy.StrategyInstance.Should().BeOfType<RetryResilienceStrategy<object>>().Subject;
+        var strategy = builder.Build().GetPipelineDescriptor().FirstStrategy.StrategyInstance.ShouldBeOfType<RetryResilienceStrategy<object>>();
 
-        strategy.BackoffType.Should().Be(type);
-        strategy.RetryCount.Should().Be(retries);
-        strategy.BaseDelay.Should().Be(delay);
+        strategy.BackoffType.ShouldBe(type);
+        strategy.RetryCount.ShouldBe(retries);
+        strategy.BaseDelay.ShouldBe(delay);
 
         assert?.Invoke(strategy);
     }
@@ -88,11 +88,11 @@ public class RetryResiliencePipelineBuilderExtensionsTests
         TimeSpan delay,
         Action<RetryResilienceStrategy<T>>? assert = null)
     {
-        var strategy = builder.Build().GetPipelineDescriptor().FirstStrategy.StrategyInstance.Should().BeOfType<RetryResilienceStrategy<T>>().Subject;
+        var strategy = builder.Build().GetPipelineDescriptor().FirstStrategy.StrategyInstance.ShouldBeOfType<RetryResilienceStrategy<T>>();
 
-        strategy.BackoffType.Should().Be(type);
-        strategy.RetryCount.Should().Be(retries);
-        strategy.BaseDelay.Should().Be(delay);
+        strategy.BackoffType.ShouldBe(type);
+        strategy.RetryCount.ShouldBe(retries);
+        strategy.BaseDelay.ShouldBe(delay);
 
         assert?.Invoke(strategy);
     }
@@ -100,15 +100,8 @@ public class RetryResiliencePipelineBuilderExtensionsTests
     [Fact]
     public void AddRetry_InvalidOptions_Throws()
     {
-        new ResiliencePipelineBuilder()
-            .Invoking(b => b.AddRetry(new RetryStrategyOptions { ShouldHandle = null! }))
-            .Should()
-            .Throw<ValidationException>();
-
-        new ResiliencePipelineBuilder<int>()
-            .Invoking(b => b.AddRetry(new RetryStrategyOptions<int> { ShouldHandle = null! }))
-            .Should()
-            .Throw<ValidationException>();
+        Should.Throw<ValidationException>(() => new ResiliencePipelineBuilder().AddRetry(new RetryStrategyOptions { ShouldHandle = null! }));
+        Should.Throw<ValidationException>(() => new ResiliencePipelineBuilder<int>().AddRetry(new RetryStrategyOptions<int> { ShouldHandle = null! }));
     }
 
     [Fact]
@@ -117,7 +110,7 @@ public class RetryResiliencePipelineBuilderExtensionsTests
         var options = new RetryStrategyOptions { BackoffType = DelayBackoffType.Exponential, UseJitter = true };
 
         var delay = GetAggregatedDelay(options);
-        GetAggregatedDelay(options).Should().Be(delay);
+        GetAggregatedDelay(options).ShouldBe(delay);
     }
 
     [Fact]
@@ -125,7 +118,7 @@ public class RetryResiliencePipelineBuilderExtensionsTests
     {
         var options = new RetryStrategyOptions { BackoffType = DelayBackoffType.Constant, Delay = TimeSpan.FromSeconds(1), MaxRetryAttempts = 5 };
 
-        GetAggregatedDelay(options).Should().Be(TimeSpan.FromSeconds(5));
+        GetAggregatedDelay(options).ShouldBe(TimeSpan.FromSeconds(5));
     }
 
     private static TimeSpan GetAggregatedDelay<T>(RetryStrategyOptions<T> options)

--- a/test/Polly.Core.Tests/Retry/RetryStrategyOptionsTests.cs
+++ b/test/Polly.Core.Tests/Retry/RetryStrategyOptionsTests.cs
@@ -11,17 +11,17 @@ public class RetryStrategyOptionsTests
     {
         var options = new RetryStrategyOptions<int>();
 
-        options.ShouldHandle.Should().NotBeNull();
+        options.ShouldHandle.ShouldNotBeNull();
 
-        options.DelayGenerator.Should().BeNull();
+        options.DelayGenerator.ShouldBeNull();
 
-        options.OnRetry.Should().BeNull();
+        options.OnRetry.ShouldBeNull();
 
-        options.MaxRetryAttempts.Should().Be(3);
-        options.BackoffType.Should().Be(DelayBackoffType.Constant);
-        options.Delay.Should().Be(TimeSpan.FromSeconds(2));
-        options.Name.Should().Be("Retry");
-        options.Randomizer.Should().NotBeNull();
+        options.MaxRetryAttempts.ShouldBe(3);
+        options.BackoffType.ShouldBe(DelayBackoffType.Constant);
+        options.Delay.ShouldBe(TimeSpan.FromSeconds(2));
+        options.Name.ShouldBe("Retry");
+        options.Randomizer.ShouldNotBeNull();
     }
 
     [Fact]
@@ -30,9 +30,9 @@ public class RetryStrategyOptionsTests
         var options = new RetryStrategyOptions<int>();
         var context = ResilienceContextPool.Shared.Get();
 
-        (await options.ShouldHandle(new RetryPredicateArguments<int>(context, Outcome.FromResult(0), 0))).Should().Be(false);
-        (await options.ShouldHandle(new RetryPredicateArguments<int>(context, Outcome.FromException<int>(new OperationCanceledException()), 0))).Should().Be(false);
-        (await options.ShouldHandle(new RetryPredicateArguments<int>(context, Outcome.FromException<int>(new InvalidOperationException()), 0))).Should().Be(true);
+        (await options.ShouldHandle(new RetryPredicateArguments<int>(context, Outcome.FromResult(0), 0))).ShouldBe(false);
+        (await options.ShouldHandle(new RetryPredicateArguments<int>(context, Outcome.FromException<int>(new OperationCanceledException()), 0))).ShouldBe(false);
+        (await options.ShouldHandle(new RetryPredicateArguments<int>(context, Outcome.FromException<int>(new InvalidOperationException()), 0))).ShouldBe(true);
     }
 
     [Fact]
@@ -48,17 +48,15 @@ public class RetryStrategyOptionsTests
             MaxDelay = TimeSpan.FromSeconds(-10)
         };
 
-        options.Invoking(o => ValidationHelper.ValidateObject(new(o, "Invalid Options")))
-            .Should()
-            .Throw<ValidationException>()
-            .WithMessage("""
+        var exception = Should.Throw<ValidationException>(() => ValidationHelper.ValidateObject(new(options, "Invalid Options")));
+        exception.Message.Trim().ShouldBe("""
             Invalid Options
-            
             Validation Errors:
             The field MaxRetryAttempts must be between 1 and 2147483647.
             The field Delay must be between 00:00:00 and 1.00:00:00.
             The field MaxDelay must be between 00:00:00 and 1.00:00:00.
             The ShouldHandle field is required.
-            """);
+            """,
+            StringCompareShould.IgnoreLineEndings);
     }
 }

--- a/test/Polly.Core.Tests/Retry/ShouldRetryArgumentsTests.cs
+++ b/test/Polly.Core.Tests/Retry/ShouldRetryArgumentsTests.cs
@@ -14,8 +14,8 @@ public static class ShouldRetryArgumentsTests
         var args = new RetryPredicateArguments<int>(context, Outcome.FromResult(1), 2);
 
         // Assert
-        args.Context.Should().Be(context);
-        args.Outcome.Result.Should().Be(1);
-        args.AttemptNumber.Should().Be(2);
+        args.Context.ShouldBe(context);
+        args.Outcome.Result.ShouldBe(1);
+        args.AttemptNumber.ShouldBe(2);
     }
 }

--- a/test/Polly.Core.Tests/Simmy/Behavior/BehaviorGeneratorArgumentsTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Behavior/BehaviorGeneratorArgumentsTests.cs
@@ -14,6 +14,6 @@ public static class BehaviorGeneratorArgumentsTests
         var args = new BehaviorGeneratorArguments(context);
 
         // Assert
-        args.Context.Should().Be(context);
+        args.Context.ShouldBe(context);
     }
 }

--- a/test/Polly.Core.Tests/Simmy/Behavior/ChaosBehaviorConstantsTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Behavior/ChaosBehaviorConstantsTests.cs
@@ -7,7 +7,7 @@ public class ChaosBehaviorConstantsTests
     [Fact]
     public void EnsureDefaults()
     {
-        ChaosBehaviorConstants.DefaultName.Should().Be("Chaos.Behavior");
-        ChaosBehaviorConstants.OnBehaviorInjectedEvent.Should().Be("Chaos.OnBehavior");
+        ChaosBehaviorConstants.DefaultName.ShouldBe("Chaos.Behavior");
+        ChaosBehaviorConstants.OnBehaviorInjectedEvent.ShouldBe("Chaos.OnBehavior");
     }
 }

--- a/test/Polly.Core.Tests/Simmy/Behavior/ChaosBehaviorPipelineBuilderExtensionsTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Behavior/ChaosBehaviorPipelineBuilderExtensionsTests.cs
@@ -16,9 +16,9 @@ public class ChaosBehaviorPipelineBuilderExtensionsTests
             (ResiliencePipelineBuilder<int> builder) => { builder.AddChaosBehavior(0.5, behavior); },
             (ChaosBehaviorStrategy strategy) =>
             {
-                strategy.Behavior!.Invoke(new(context)).Preserve().GetAwaiter().IsCompleted.Should().BeTrue();
-                strategy.EnabledGenerator.Invoke(new(context)).Preserve().GetAwaiter().GetResult().Should().BeTrue();
-                strategy.InjectionRateGenerator.Invoke(new(context)).Preserve().GetAwaiter().GetResult().Should().Be(0.5);
+                strategy.Behavior!.Invoke(new(context)).Preserve().GetAwaiter().IsCompleted.ShouldBeTrue();
+                strategy.EnabledGenerator.Invoke(new(context)).Preserve().GetAwaiter().GetResult().ShouldBeTrue();
+                strategy.InjectionRateGenerator.Invoke(new(context)).Preserve().GetAwaiter().GetResult().ShouldBe(0.5);
             }
         };
     }
@@ -27,22 +27,16 @@ public class ChaosBehaviorPipelineBuilderExtensionsTests
     public void AddBehavior_Shortcut_Option_Ok()
     {
         var sut = new ResiliencePipelineBuilder().AddChaosBehavior(0.5, _ => default).Build();
-        sut.GetPipelineDescriptor().FirstStrategy.StrategyInstance.Should().BeOfType<ChaosBehaviorStrategy>();
+        sut.GetPipelineDescriptor().FirstStrategy.StrategyInstance.ShouldBeOfType<ChaosBehaviorStrategy>();
     }
 
     [Fact]
     public void AddBehavior_Shortcut_Option_Throws() =>
-        new ResiliencePipelineBuilder()
-            .Invoking(b => b.AddChaosBehavior(-1, _ => default))
-            .Should()
-            .Throw<ValidationException>();
+        Should.Throw<ValidationException>(() => new ResiliencePipelineBuilder().AddChaosBehavior(-1, _ => default));
 
     [Fact]
     public void AddBehavior_InvalidOptions_Throws() =>
-        new ResiliencePipelineBuilder()
-            .Invoking(b => b.AddChaosBehavior(new ChaosBehaviorStrategyOptions()))
-            .Should()
-            .Throw<ValidationException>();
+        Should.Throw<ValidationException>(() => new ResiliencePipelineBuilder().AddChaosBehavior(new ChaosBehaviorStrategyOptions()));
 
     [Fact]
     public void AddBehavior_Options_Ok()
@@ -55,7 +49,7 @@ public class ChaosBehaviorPipelineBuilderExtensionsTests
             })
             .Build();
 
-        sut.GetPipelineDescriptor().FirstStrategy.StrategyInstance.Should().BeOfType<ChaosBehaviorStrategy>();
+        sut.GetPipelineDescriptor().FirstStrategy.StrategyInstance.ShouldBeOfType<ChaosBehaviorStrategy>();
     }
 
     [MemberData(nameof(AddBehavior_Ok_Data))]
@@ -65,7 +59,7 @@ public class ChaosBehaviorPipelineBuilderExtensionsTests
         var builder = new ResiliencePipelineBuilder<int>();
         configure(builder);
 
-        var strategy = builder.Build().GetPipelineDescriptor().FirstStrategy.StrategyInstance.Should().BeOfType<ChaosBehaviorStrategy>().Subject;
+        var strategy = builder.Build().GetPipelineDescriptor().FirstStrategy.StrategyInstance.ShouldBeOfType<ChaosBehaviorStrategy>();
         assert(strategy);
     }
 }

--- a/test/Polly.Core.Tests/Simmy/Behavior/ChaosBehaviorStrategyOptionsTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Behavior/ChaosBehaviorStrategyOptionsTests.cs
@@ -11,13 +11,13 @@ public class ChaosBehaviorStrategyOptionsTests
     public void Ctor_Ok()
     {
         var sut = new ChaosBehaviorStrategyOptions();
-        sut.Randomizer.Should().NotBeNull();
-        sut.Enabled.Should().BeTrue();
-        sut.EnabledGenerator.Should().BeNull();
-        sut.InjectionRate.Should().Be(ChaosStrategyConstants.DefaultInjectionRate);
-        sut.InjectionRateGenerator.Should().BeNull();
-        sut.BehaviorGenerator.Should().BeNull();
-        sut.OnBehaviorInjected.Should().BeNull();
+        sut.Randomizer.ShouldNotBeNull();
+        sut.Enabled.ShouldBeTrue();
+        sut.EnabledGenerator.ShouldBeNull();
+        sut.InjectionRate.ShouldBe(ChaosStrategyConstants.DefaultInjectionRate);
+        sut.InjectionRateGenerator.ShouldBeNull();
+        sut.BehaviorGenerator.ShouldBeNull();
+        sut.OnBehaviorInjected.ShouldBeNull();
     }
 
     [Fact]
@@ -25,15 +25,12 @@ public class ChaosBehaviorStrategyOptionsTests
     {
         var sut = new ChaosBehaviorStrategyOptions();
 
-        sut
-            .Invoking(o => ValidationHelper.ValidateObject(new(o, "Invalid Options")))
-            .Should()
-            .Throw<ValidationException>()
-            .WithMessage("""
+        var exception = Should.Throw<ValidationException>(() => ValidationHelper.ValidateObject(new(sut, "Invalid Options")));
+        exception.Message.Trim().ShouldBe("""
             Invalid Options
-
             Validation Errors:
             The BehaviorGenerator field is required.
-            """);
+            """,
+            StringCompareShould.IgnoreLineEndings);
     }
 }

--- a/test/Polly.Core.Tests/Simmy/Behavior/ChaosBehaviorStrategyTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Behavior/ChaosBehaviorStrategyTests.cs
@@ -32,8 +32,8 @@ public class ChaosBehaviorStrategyTests
         var sut = CreateSut();
         sut.Execute(() => { _userDelegateExecuted = true; });
 
-        _userDelegateExecuted.Should().BeTrue();
-        _behaviorGeneratorExecuted.Should().BeFalse();
+        _userDelegateExecuted.ShouldBeTrue();
+        _behaviorGeneratorExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -46,9 +46,9 @@ public class ChaosBehaviorStrategyTests
         var sut = CreateSut();
         await sut.ExecuteAsync((_) => { _userDelegateExecuted = true; return default; });
 
-        _userDelegateExecuted.Should().BeTrue();
-        _behaviorGeneratorExecuted.Should().BeTrue();
-        _onBehaviorInjectedExecuted.Should().BeFalse();
+        _userDelegateExecuted.ShouldBeTrue();
+        _behaviorGeneratorExecuted.ShouldBeTrue();
+        _onBehaviorInjectedExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -59,8 +59,8 @@ public class ChaosBehaviorStrategyTests
         _options.BehaviorGenerator = (_) => { _behaviorGeneratorExecuted = true; return default; };
         _options.OnBehaviorInjected = args =>
         {
-            args.Context.Should().NotBeNull();
-            args.Context.CancellationToken.IsCancellationRequested.Should().BeFalse();
+            args.Context.ShouldNotBeNull();
+            args.Context.CancellationToken.IsCancellationRequested.ShouldBeFalse();
             _onBehaviorInjectedExecuted = true;
             return default;
         };
@@ -68,11 +68,11 @@ public class ChaosBehaviorStrategyTests
         var sut = CreateSut();
         await sut.ExecuteAsync((_) => { _userDelegateExecuted = true; return default; });
 
-        _onBehaviorInjectedExecuted.Should().BeTrue();
-        _userDelegateExecuted.Should().BeTrue();
-        _behaviorGeneratorExecuted.Should().BeTrue();
-        _args.Should().HaveCount(1);
-        _args[0].Arguments.Should().BeOfType<OnBehaviorInjectedArguments>();
+        _onBehaviorInjectedExecuted.ShouldBeTrue();
+        _userDelegateExecuted.ShouldBeTrue();
+        _behaviorGeneratorExecuted.ShouldBeTrue();
+        _args.Count.ShouldBe(1);
+        _args[0].Arguments.ShouldBeOfType<OnBehaviorInjectedArguments>();
     }
 
     [Fact]
@@ -86,9 +86,9 @@ public class ChaosBehaviorStrategyTests
         var sut = CreateSut();
         await sut.ExecuteAsync((_) => { _userDelegateExecuted = true; return default; });
 
-        _userDelegateExecuted.Should().BeTrue();
-        _behaviorGeneratorExecuted.Should().BeFalse();
-        _onBehaviorInjectedExecuted.Should().BeFalse();
+        _userDelegateExecuted.ShouldBeTrue();
+        _behaviorGeneratorExecuted.ShouldBeFalse();
+        _onBehaviorInjectedExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -98,7 +98,7 @@ public class ChaosBehaviorStrategyTests
         _options.Randomizer = () => 0.5;
         _options.BehaviorGenerator = (_) =>
         {
-            _userDelegateExecuted.Should().BeFalse(); // Not yet executed at the time the injected behavior runs.
+            _userDelegateExecuted.ShouldBeFalse(); // Not yet executed at the time the injected behavior runs.
             _behaviorGeneratorExecuted = true;
             return default;
         };
@@ -106,9 +106,9 @@ public class ChaosBehaviorStrategyTests
         var sut = CreateSut();
         await sut.ExecuteAsync((_) => { _userDelegateExecuted = true; return default; });
 
-        _userDelegateExecuted.Should().BeTrue();
-        _behaviorGeneratorExecuted.Should().BeTrue();
-        _onBehaviorInjectedExecuted.Should().BeFalse();
+        _userDelegateExecuted.ShouldBeTrue();
+        _behaviorGeneratorExecuted.ShouldBeTrue();
+        _onBehaviorInjectedExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -125,13 +125,11 @@ public class ChaosBehaviorStrategyTests
         };
 
         var sut = CreateSut();
-        await sut.Invoking(s => s.ExecuteAsync(async _ => { await Task.CompletedTask; }, cts.Token).AsTask())
-            .Should()
-            .ThrowAsync<OperationCanceledException>();
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.ExecuteAsync(async _ => await Task.CompletedTask, cts.Token).AsTask());
 
-        _userDelegateExecuted.Should().BeFalse();
-        _behaviorGeneratorExecuted.Should().BeTrue();
-        _onBehaviorInjectedExecuted.Should().BeFalse();
+        _userDelegateExecuted.ShouldBeFalse();
+        _behaviorGeneratorExecuted.ShouldBeTrue();
+        _onBehaviorInjectedExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -150,13 +148,11 @@ public class ChaosBehaviorStrategyTests
         };
 
         var sut = CreateSut();
-        await sut.Invoking(s => s.ExecuteAsync(async _ => { await Task.CompletedTask; }, cts.Token).AsTask())
-            .Should()
-            .ThrowAsync<OperationCanceledException>();
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.ExecuteAsync(async _ => await Task.CompletedTask, cts.Token).AsTask());
 
-        _userDelegateExecuted.Should().BeFalse();
-        enabledGeneratorExecuted.Should().BeTrue();
-        _onBehaviorInjectedExecuted.Should().BeFalse();
+        _userDelegateExecuted.ShouldBeFalse();
+        enabledGeneratorExecuted.ShouldBeTrue();
+        _onBehaviorInjectedExecuted.ShouldBeFalse();
     }
 
     private ResiliencePipeline CreateSut() => new ChaosBehaviorStrategy(_options, _telemetry).AsPipeline();

--- a/test/Polly.Core.Tests/Simmy/Behavior/OnBehaviorInjectedArgumentsTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Behavior/OnBehaviorInjectedArgumentsTests.cs
@@ -14,6 +14,6 @@ public static class OnBehaviorInjectedArgumentsTests
         var args = new OnBehaviorInjectedArguments(context);
 
         // Assert
-        args.Context.Should().Be(context);
+        args.Context.ShouldBe(context);
     }
 }

--- a/test/Polly.Core.Tests/Simmy/ChaosStrategyConstantsTests.cs
+++ b/test/Polly.Core.Tests/Simmy/ChaosStrategyConstantsTests.cs
@@ -7,9 +7,9 @@ public class ChaosStrategyConstantsTests
     [Fact]
     public void EnsureDefaults()
     {
-        ChaosStrategyConstants.MinInjectionThreshold.Should().Be(0d);
-        ChaosStrategyConstants.MaxInjectionThreshold.Should().Be(1d);
-        ChaosStrategyConstants.DefaultInjectionRate.Should().Be(0.001d);
-        ChaosStrategyConstants.DefaultEnabled.Should().BeTrue();
+        ChaosStrategyConstants.MinInjectionThreshold.ShouldBe(0d);
+        ChaosStrategyConstants.MaxInjectionThreshold.ShouldBe(1d);
+        ChaosStrategyConstants.DefaultInjectionRate.ShouldBe(0.001d);
+        ChaosStrategyConstants.DefaultEnabled.ShouldBeTrue();
     }
 }

--- a/test/Polly.Core.Tests/Simmy/ChaosStrategyOptionsTTests.cs
+++ b/test/Polly.Core.Tests/Simmy/ChaosStrategyOptionsTTests.cs
@@ -11,11 +11,11 @@ public class ChaosStrategyOptionsTTests
     {
         var sut = new TestChaosStrategyOptions<int>();
 
-        sut.Randomizer.Should().NotBeNull();
-        sut.Enabled.Should().BeTrue();
-        sut.EnabledGenerator.Should().BeNull();
-        sut.InjectionRate.Should().Be(ChaosStrategyConstants.DefaultInjectionRate);
-        sut.InjectionRateGenerator.Should().BeNull();
+        sut.Randomizer.ShouldNotBeNull();
+        sut.Enabled.ShouldBeTrue();
+        sut.EnabledGenerator.ShouldBeNull();
+        sut.InjectionRate.ShouldBe(ChaosStrategyConstants.DefaultInjectionRate);
+        sut.InjectionRateGenerator.ShouldBeNull();
     }
 
     [InlineData(-1)]
@@ -28,15 +28,12 @@ public class ChaosStrategyOptionsTTests
             InjectionRate = injectionRate,
         };
 
-        sut
-            .Invoking(o => ValidationHelper.ValidateObject(new(o, "Invalid Options")))
-            .Should()
-            .Throw<ValidationException>()
-            .WithMessage("""
+        var exception = Should.Throw<ValidationException>(() => ValidationHelper.ValidateObject(new(sut, "Invalid Options")));
+        exception.Message.Trim().ShouldBe("""
             Invalid Options
-
             Validation Errors:
             The field InjectionRate must be between 0 and 1.
-            """);
+            """,
+            StringCompareShould.IgnoreLineEndings);
     }
 }

--- a/test/Polly.Core.Tests/Simmy/ChaosStrategyOptionsTests.cs
+++ b/test/Polly.Core.Tests/Simmy/ChaosStrategyOptionsTests.cs
@@ -10,11 +10,11 @@ public class ChaosStrategyOptionsTests
     {
         var sut = new TestChaosStrategyOptions();
 
-        sut.Randomizer.Should().NotBeNull();
-        sut.Enabled.Should().BeTrue();
-        sut.EnabledGenerator.Should().BeNull();
-        sut.InjectionRate.Should().Be(ChaosStrategyConstants.DefaultInjectionRate);
-        sut.InjectionRateGenerator.Should().BeNull();
+        sut.Randomizer.ShouldNotBeNull();
+        sut.Enabled.ShouldBeTrue();
+        sut.EnabledGenerator.ShouldBeNull();
+        sut.InjectionRate.ShouldBe(ChaosStrategyConstants.DefaultInjectionRate);
+        sut.InjectionRateGenerator.ShouldBeNull();
     }
 
     [InlineData(-1)]
@@ -27,15 +27,12 @@ public class ChaosStrategyOptionsTests
             InjectionRate = injectionRate,
         };
 
-        sut
-            .Invoking(o => ValidationHelper.ValidateObject(new(o, "Invalid Options")))
-            .Should()
-            .Throw<ValidationException>()
-            .WithMessage("""
+        var exception = Should.Throw<ValidationException>(() => ValidationHelper.ValidateObject(new(sut, "Invalid Options")));
+        exception.Message.Trim().ShouldBe("""
             Invalid Options
-
             Validation Errors:
             The field InjectionRate must be between 0 and 1.
-            """);
+            """,
+            StringCompareShould.IgnoreLineEndings);
     }
 }

--- a/test/Polly.Core.Tests/Simmy/ChaosStrategyTTests.cs
+++ b/test/Polly.Core.Tests/Simmy/ChaosStrategyTTests.cs
@@ -25,10 +25,10 @@ public class ChaosStrategyTTests
             var _ = new TestChaosStrategy<int>(null);
         };
 
-        act.Should().Throw<ArgumentNullException>();
-        _wasChaosUnleashed.Should().BeFalse();
-        _enableGeneratorExecuted.Should().BeFalse();
-        _injectionRateGeneratorExecuted.Should().BeFalse();
+        act.ShouldThrow<ArgumentNullException>();
+        _wasChaosUnleashed.ShouldBeFalse();
+        _enableGeneratorExecuted.ShouldBeFalse();
+        _injectionRateGeneratorExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -40,15 +40,15 @@ public class ChaosStrategyTTests
 
         var sut = CreateSut();
 
-        sut.EnabledGenerator.Should().NotBeNull();
-        (await sut.EnabledGenerator(new(context))).Should().BeTrue();
+        sut.EnabledGenerator.ShouldNotBeNull();
+        (await sut.EnabledGenerator(new(context))).ShouldBeTrue();
 
-        sut.InjectionRateGenerator.Should().NotBeNull();
-        (await sut.InjectionRateGenerator(new(context))).Should().Be(0.5);
+        sut.InjectionRateGenerator.ShouldNotBeNull();
+        (await sut.InjectionRateGenerator(new(context))).ShouldBe(0.5);
 
-        _wasChaosUnleashed.Should().BeFalse();
-        _enableGeneratorExecuted.Should().BeFalse();
-        _injectionRateGeneratorExecuted.Should().BeFalse();
+        _wasChaosUnleashed.ShouldBeFalse();
+        _enableGeneratorExecuted.ShouldBeFalse();
+        _injectionRateGeneratorExecuted.ShouldBeFalse();
     }
 
     [InlineData(0, false)]
@@ -68,9 +68,9 @@ public class ChaosStrategyTTests
 
         await sut.AsPipeline().ExecuteAsync<int>((_) => { return default; });
 
-        _wasChaosUnleashed.Should().Be(shouldBeInjected);
-        _enableGeneratorExecuted.Should().BeFalse();
-        _injectionRateGeneratorExecuted.Should().BeFalse();
+        _wasChaosUnleashed.ShouldBe(shouldBeInjected);
+        _enableGeneratorExecuted.ShouldBeFalse();
+        _injectionRateGeneratorExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -92,13 +92,11 @@ public class ChaosStrategyTTests
         var sut = CreateSut();
         sut.Before = (_, _) => { cts.Cancel(); };
 
-        await sut.Invoking(s => s.AsPipeline().ExecuteAsync(async _ => { return await Task.FromResult(5); }, cts.Token).AsTask())
-            .Should()
-            .ThrowAsync<OperationCanceledException>();
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.AsPipeline().ExecuteAsync(async _ => await Task.FromResult(5), cts.Token).AsTask());
 
-        _wasChaosUnleashed.Should().BeFalse();
-        _enableGeneratorExecuted.Should().BeFalse();
-        _injectionRateGeneratorExecuted.Should().BeFalse();
+        _wasChaosUnleashed.ShouldBeFalse();
+        _enableGeneratorExecuted.ShouldBeFalse();
+        _injectionRateGeneratorExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -120,13 +118,11 @@ public class ChaosStrategyTTests
 
         var sut = CreateSut();
 
-        await sut.Invoking(s => s.AsPipeline().ExecuteAsync(async _ => { return await Task.FromResult(5); }, cts.Token).AsTask())
-            .Should()
-            .ThrowAsync<OperationCanceledException>();
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.AsPipeline().ExecuteAsync(async _ => await Task.FromResult(5), cts.Token).AsTask());
 
-        _wasChaosUnleashed.Should().BeFalse();
-        _enableGeneratorExecuted.Should().BeTrue();
-        _injectionRateGeneratorExecuted.Should().BeFalse();
+        _wasChaosUnleashed.ShouldBeFalse();
+        _enableGeneratorExecuted.ShouldBeTrue();
+        _injectionRateGeneratorExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -148,13 +144,11 @@ public class ChaosStrategyTTests
 
         var sut = CreateSut();
 
-        await sut.Invoking(s => s.AsPipeline().ExecuteAsync(async _ => { return await Task.FromResult(5); }, cts.Token).AsTask())
-            .Should()
-            .ThrowAsync<OperationCanceledException>();
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.AsPipeline().ExecuteAsync(async _ => await Task.FromResult(5), cts.Token).AsTask());
 
-        _wasChaosUnleashed.Should().BeFalse();
-        _enableGeneratorExecuted.Should().BeTrue();
-        _injectionRateGeneratorExecuted.Should().BeTrue();
+        _wasChaosUnleashed.ShouldBeFalse();
+        _enableGeneratorExecuted.ShouldBeTrue();
+        _injectionRateGeneratorExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -169,9 +163,9 @@ public class ChaosStrategyTTests
 
         await sut.AsPipeline().ExecuteAsync<int>((_) => { return default; });
 
-        _wasChaosUnleashed.Should().BeTrue();
-        _enableGeneratorExecuted.Should().BeFalse();
-        _injectionRateGeneratorExecuted.Should().BeFalse();
+        _wasChaosUnleashed.ShouldBeTrue();
+        _enableGeneratorExecuted.ShouldBeFalse();
+        _injectionRateGeneratorExecuted.ShouldBeFalse();
     }
 
     private TestChaosStrategy<int> CreateSut() => new(_options);

--- a/test/Polly.Core.Tests/Simmy/ChaosStrategyTests.cs
+++ b/test/Polly.Core.Tests/Simmy/ChaosStrategyTests.cs
@@ -20,16 +20,11 @@ public class ChaosStrategyTests
     [Fact]
     public void InvalidCtor()
     {
-        Action act = () =>
-        {
-            var _ = new TestChaosStrategy(null);
-        };
+        Should.Throw<ArgumentNullException>(() => new TestChaosStrategy(null));
 
-        act.Should().Throw<ArgumentNullException>();
-
-        _wasChaosUnleashed.Should().BeFalse();
-        _enableGeneratorExecuted.Should().BeFalse();
-        _injectionRateGeneratorExecuted.Should().BeFalse();
+        _wasChaosUnleashed.ShouldBeFalse();
+        _enableGeneratorExecuted.ShouldBeFalse();
+        _injectionRateGeneratorExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -41,15 +36,15 @@ public class ChaosStrategyTests
 
         var sut = CreateSut();
 
-        sut.EnabledGenerator.Should().NotBeNull();
-        (await sut.EnabledGenerator(new(context))).Should().BeTrue();
+        sut.EnabledGenerator.ShouldNotBeNull();
+        (await sut.EnabledGenerator(new(context))).ShouldBeTrue();
 
-        sut.InjectionRateGenerator.Should().NotBeNull();
-        (await sut.InjectionRateGenerator(new(context))).Should().Be(0.5);
+        sut.InjectionRateGenerator.ShouldNotBeNull();
+        (await sut.InjectionRateGenerator(new(context))).ShouldBe(0.5);
 
-        _wasChaosUnleashed.Should().BeFalse();
-        _enableGeneratorExecuted.Should().BeFalse();
-        _injectionRateGeneratorExecuted.Should().BeFalse();
+        _wasChaosUnleashed.ShouldBeFalse();
+        _enableGeneratorExecuted.ShouldBeFalse();
+        _injectionRateGeneratorExecuted.ShouldBeFalse();
     }
 
     [InlineData(0, false)]
@@ -69,9 +64,9 @@ public class ChaosStrategyTests
 
         await sut.AsPipeline().ExecuteAsync((_) => { return default; });
 
-        _wasChaosUnleashed.Should().Be(shouldBeInjected);
-        _enableGeneratorExecuted.Should().BeFalse();
-        _injectionRateGeneratorExecuted.Should().BeFalse();
+        _wasChaosUnleashed.ShouldBe(shouldBeInjected);
+        _enableGeneratorExecuted.ShouldBeFalse();
+        _injectionRateGeneratorExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -93,13 +88,11 @@ public class ChaosStrategyTests
         var sut = CreateSut();
         sut.Before = (_, _) => { cts.Cancel(); };
 
-        await sut.Invoking(s => s.AsPipeline().ExecuteAsync(async _ => { await Task.CompletedTask; }, cts.Token).AsTask())
-            .Should()
-            .ThrowAsync<OperationCanceledException>();
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.AsPipeline().ExecuteAsync(async _ => await Task.CompletedTask, cts.Token).AsTask());
 
-        _wasChaosUnleashed.Should().BeFalse();
-        _enableGeneratorExecuted.Should().BeFalse();
-        _injectionRateGeneratorExecuted.Should().BeFalse();
+        _wasChaosUnleashed.ShouldBeFalse();
+        _enableGeneratorExecuted.ShouldBeFalse();
+        _injectionRateGeneratorExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -121,13 +114,11 @@ public class ChaosStrategyTests
 
         var sut = CreateSut();
 
-        await sut.Invoking(s => s.AsPipeline().ExecuteAsync(async _ => { await Task.CompletedTask; }, cts.Token).AsTask())
-            .Should()
-            .ThrowAsync<OperationCanceledException>();
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.AsPipeline().ExecuteAsync(async _ => await Task.CompletedTask, cts.Token).AsTask());
 
-        _wasChaosUnleashed.Should().BeFalse();
-        _enableGeneratorExecuted.Should().BeTrue();
-        _injectionRateGeneratorExecuted.Should().BeFalse();
+        _wasChaosUnleashed.ShouldBeFalse();
+        _enableGeneratorExecuted.ShouldBeTrue();
+        _injectionRateGeneratorExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -149,13 +140,11 @@ public class ChaosStrategyTests
 
         var sut = CreateSut();
 
-        await sut.Invoking(s => s.AsPipeline().ExecuteAsync(async _ => { await Task.CompletedTask; }, cts.Token).AsTask())
-            .Should()
-            .ThrowAsync<OperationCanceledException>();
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.AsPipeline().ExecuteAsync(async _ => await Task.CompletedTask, cts.Token).AsTask());
 
-        _wasChaosUnleashed.Should().BeFalse();
-        _enableGeneratorExecuted.Should().BeTrue();
-        _injectionRateGeneratorExecuted.Should().BeTrue();
+        _wasChaosUnleashed.ShouldBeFalse();
+        _enableGeneratorExecuted.ShouldBeTrue();
+        _injectionRateGeneratorExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -170,9 +159,9 @@ public class ChaosStrategyTests
 
         await sut.AsPipeline().ExecuteAsync((_) => { return default; });
 
-        _wasChaosUnleashed.Should().BeTrue();
-        _enableGeneratorExecuted.Should().BeFalse();
-        _injectionRateGeneratorExecuted.Should().BeFalse();
+        _wasChaosUnleashed.ShouldBeTrue();
+        _enableGeneratorExecuted.ShouldBeFalse();
+        _injectionRateGeneratorExecuted.ShouldBeFalse();
     }
 
     private TestChaosStrategy CreateSut() => new(_options);

--- a/test/Polly.Core.Tests/Simmy/EnabledGeneratorArgumentsTests.cs
+++ b/test/Polly.Core.Tests/Simmy/EnabledGeneratorArgumentsTests.cs
@@ -14,6 +14,6 @@ public static class EnabledGeneratorArgumentsTests
         var args = new EnabledGeneratorArguments(context);
 
         // Assert
-        args.Context.Should().Be(context);
+        args.Context.ShouldBe(context);
     }
 }

--- a/test/Polly.Core.Tests/Simmy/Fault/ChaosFaultConstantsTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Fault/ChaosFaultConstantsTests.cs
@@ -7,7 +7,7 @@ public class ChaosFaultConstantsTests
     [Fact]
     public void EnsureDefaults()
     {
-        ChaosFaultConstants.DefaultName.Should().Be("Chaos.Fault");
-        ChaosFaultConstants.OnFaultInjectedEvent.Should().Be("Chaos.OnFault");
+        ChaosFaultConstants.DefaultName.ShouldBe("Chaos.Fault");
+        ChaosFaultConstants.OnFaultInjectedEvent.ShouldBe("Chaos.OnFault");
     }
 }

--- a/test/Polly.Core.Tests/Simmy/Fault/ChaosFaultPipelineBuilderExtensionsTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Fault/ChaosFaultPipelineBuilderExtensionsTests.cs
@@ -19,7 +19,7 @@ public class ChaosFaultPipelineBuilderExtensionsTests
                 FaultGenerator = _=> new ValueTask<Exception?>( new InvalidOperationException("Dummy exception."))
             });
 
-            AssertFaultStrategy<InvalidOperationException>(builder, true, 0.6).FaultGenerator.Should().NotBeNull();
+            AssertFaultStrategy<InvalidOperationException>(builder, true, 0.6).FaultGenerator.ShouldNotBeNull();
         },
     };
 #pragma warning restore IDE0028
@@ -28,22 +28,22 @@ public class ChaosFaultPipelineBuilderExtensionsTests
         where TException : Exception
     {
         var context = ResilienceContextPool.Shared.Get();
-        var strategy = builder.Build().GetPipelineDescriptor().FirstStrategy.StrategyInstance.Should().BeOfType<ChaosFaultStrategy>().Subject;
+        var strategy = builder.Build().GetPipelineDescriptor().FirstStrategy.StrategyInstance.ShouldBeOfType<ChaosFaultStrategy>();
 
-        strategy.EnabledGenerator.Invoke(new(context)).Preserve().GetAwaiter().GetResult().Should().Be(enabled);
-        strategy.InjectionRateGenerator.Invoke(new(context)).Preserve().GetAwaiter().GetResult().Should().Be(injectionRate);
-        strategy.FaultGenerator!.Invoke(new(context)).Preserve().GetAwaiter().GetResult().Should().BeOfType<TException>();
+        strategy.EnabledGenerator.Invoke(new(context)).Preserve().GetAwaiter().GetResult().ShouldBe(enabled);
+        strategy.InjectionRateGenerator.Invoke(new(context)).Preserve().GetAwaiter().GetResult().ShouldBe(injectionRate);
+        strategy.FaultGenerator!.Invoke(new(context)).Preserve().GetAwaiter().GetResult().ShouldBeOfType<TException>();
     }
 
     private static ChaosFaultStrategy AssertFaultStrategy<TException>(ResiliencePipelineBuilder builder, bool enabled, double injectionRate)
         where TException : Exception
     {
         var context = ResilienceContextPool.Shared.Get();
-        var strategy = builder.Build().GetPipelineDescriptor().FirstStrategy.StrategyInstance.Should().BeOfType<ChaosFaultStrategy>().Subject;
+        var strategy = builder.Build().GetPipelineDescriptor().FirstStrategy.StrategyInstance.ShouldBeOfType<ChaosFaultStrategy>();
 
-        strategy.EnabledGenerator.Invoke(new(context)).Preserve().GetAwaiter().GetResult().Should().Be(enabled);
-        strategy.InjectionRateGenerator.Invoke(new(context)).Preserve().GetAwaiter().GetResult().Should().Be(injectionRate);
-        strategy.FaultGenerator!.Invoke(new(context)).Preserve().GetAwaiter().GetResult().Should().BeOfType<TException>();
+        strategy.EnabledGenerator.Invoke(new(context)).Preserve().GetAwaiter().GetResult().ShouldBe(enabled);
+        strategy.InjectionRateGenerator.Invoke(new(context)).Preserve().GetAwaiter().GetResult().ShouldBe(injectionRate);
+        strategy.FaultGenerator!.Invoke(new(context)).Preserve().GetAwaiter().GetResult().ShouldBeOfType<TException>();
 
         return strategy;
     }
@@ -53,26 +53,22 @@ public class ChaosFaultPipelineBuilderExtensionsTests
     internal void AddFault_Options_Ok(Action<ResiliencePipelineBuilder> configure)
     {
         var builder = new ResiliencePipelineBuilder();
-        builder.Invoking(b => configure(b)).Should().NotThrow();
+        Should.NotThrow(() => configure(builder));
     }
 
     [Fact]
     public void AddFault_Generic_Shortcut_Generator_Option_Throws() =>
-        new ResiliencePipelineBuilder<int>()
-            .Invoking(b => b.AddChaosFault(
-                1.5,
-                () => new InvalidOperationException()))
-            .Should()
-            .Throw<ValidationException>();
+        Should.Throw<ValidationException>(
+            () =>
+                new ResiliencePipelineBuilder<int>()
+                .AddChaosFault(1.5, () => new InvalidOperationException()));
 
     [Fact]
     public void AddFault_Shortcut_Generator_Option_Throws() =>
-        new ResiliencePipelineBuilder()
-            .Invoking(b => b.AddChaosFault(
-                1.5,
-                () => new InvalidOperationException()))
-            .Should()
-            .Throw<ValidationException>();
+        Should.Throw<ValidationException>(
+            () =>
+                new ResiliencePipelineBuilder()
+                .AddChaosFault(1.5, () => new InvalidOperationException()));
 
     [Fact]
     public void AddFault_Shortcut_Generator_Option_Ok()

--- a/test/Polly.Core.Tests/Simmy/Fault/ChaosFaultStrategyOptionsTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Fault/ChaosFaultStrategyOptionsTests.cs
@@ -11,13 +11,13 @@ public class ChaosFaultStrategyOptionsTests
     public void Ctor_Ok()
     {
         var sut = new ChaosFaultStrategyOptions();
-        sut.Randomizer.Should().NotBeNull();
-        sut.Enabled.Should().BeTrue();
-        sut.EnabledGenerator.Should().BeNull();
-        sut.InjectionRate.Should().Be(ChaosStrategyConstants.DefaultInjectionRate);
-        sut.InjectionRateGenerator.Should().BeNull();
-        sut.OnFaultInjected.Should().BeNull();
-        sut.FaultGenerator.Should().BeNull();
+        sut.Randomizer.ShouldNotBeNull();
+        sut.Enabled.ShouldBeTrue();
+        sut.EnabledGenerator.ShouldBeNull();
+        sut.InjectionRate.ShouldBe(ChaosStrategyConstants.DefaultInjectionRate);
+        sut.InjectionRateGenerator.ShouldBeNull();
+        sut.OnFaultInjected.ShouldBeNull();
+        sut.FaultGenerator.ShouldBeNull();
     }
 
     [Fact]
@@ -28,14 +28,12 @@ public class ChaosFaultStrategyOptionsTests
             FaultGenerator = null!,
         };
 
-        options.Invoking(o => ValidationHelper.ValidateObject(new(o, "Invalid Options")))
-            .Should()
-            .Throw<ValidationException>()
-            .WithMessage("""
+        var exception = Should.Throw<ValidationException>(() => ValidationHelper.ValidateObject(new(options, "Invalid Options")));
+        exception.Message.Trim().ShouldBe("""
             Invalid Options
-
             Validation Errors:
             The FaultGenerator field is required.
-            """);
+            """,
+            StringCompareShould.IgnoreLineEndings);
     }
 }

--- a/test/Polly.Core.Tests/Simmy/Fault/ChaosFaultStrategyTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Fault/ChaosFaultStrategyTests.cs
@@ -69,8 +69,8 @@ public class ChaosFaultStrategyTests
         var sut = CreateSut(options);
         sut.Execute(() => { _userDelegateExecuted = true; });
 
-        _userDelegateExecuted.Should().BeTrue();
-        _onFaultInjectedExecuted.Should().BeFalse();
+        _userDelegateExecuted.ShouldBeTrue();
+        _onFaultInjectedExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -93,9 +93,9 @@ public class ChaosFaultStrategyTests
             return await Task.FromResult(HttpStatusCode.OK);
         });
 
-        response.Should().Be(HttpStatusCode.OK);
-        _userDelegateExecuted.Should().BeTrue();
-        _onFaultInjectedExecuted.Should().BeFalse();
+        response.ShouldBe(HttpStatusCode.OK);
+        _userDelegateExecuted.ShouldBeTrue();
+        _onFaultInjectedExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -111,25 +111,26 @@ public class ChaosFaultStrategyTests
             FaultGenerator = _ => new ValueTask<Exception?>(fault),
             OnFaultInjected = args =>
             {
-                args.Context.Should().NotBeNull();
-                args.Context.CancellationToken.IsCancellationRequested.Should().BeFalse();
+                args.Context.ShouldNotBeNull();
+                args.Context.CancellationToken.IsCancellationRequested.ShouldBeFalse();
                 _onFaultInjectedExecuted = true;
                 return default;
             }
         };
 
         var sut = new ResiliencePipelineBuilder<HttpStatusCode>().AddChaosFault(options).Build();
-        await sut.Invoking(s => s.ExecuteAsync(async _ =>
-        {
-            _userDelegateExecuted = true;
-            return await Task.FromResult(HttpStatusCode.OK);
-        }).AsTask())
-            .Should()
-            .ThrowAsync<InvalidOperationException>()
-            .WithMessage(exceptionMessage);
 
-        _userDelegateExecuted.Should().BeFalse();
-        _onFaultInjectedExecuted.Should().BeTrue();
+        var exception = await Should.ThrowAsync<InvalidOperationException>(
+            () => sut.ExecuteAsync(async _ =>
+            {
+                _userDelegateExecuted = true;
+                return await Task.FromResult(HttpStatusCode.OK);
+            }).AsTask());
+
+        exception.Message.ShouldBe(exceptionMessage);
+
+        _userDelegateExecuted.ShouldBeFalse();
+        _onFaultInjectedExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -145,28 +146,28 @@ public class ChaosFaultStrategyTests
             FaultGenerator = _ => new ValueTask<Exception?>(fault),
             OnFaultInjected = args =>
             {
-                args.Context.Should().NotBeNull();
-                args.Context.CancellationToken.IsCancellationRequested.Should().BeFalse();
+                args.Context.ShouldNotBeNull();
+                args.Context.CancellationToken.IsCancellationRequested.ShouldBeFalse();
                 _onFaultInjectedExecuted = true;
                 return default;
             }
         };
 
         var sut = CreateSut(options);
-        await sut.Invoking(s => s.ExecuteAsync(async _ =>
-        {
-            _userDelegateExecuted = true;
-            return await Task.FromResult(200);
-        }).AsTask())
-            .Should()
-            .ThrowAsync<InvalidOperationException>()
-            .WithMessage(exceptionMessage);
 
-        _userDelegateExecuted.Should().BeFalse();
-        _onFaultInjectedExecuted.Should().BeTrue();
-        _args.Should().HaveCount(1);
-        _args[0].Arguments.Should().BeOfType<OnFaultInjectedArguments>();
-        _args[0].Event.EventName.Should().Be(ChaosFaultConstants.OnFaultInjectedEvent);
+        var exception = await Should.ThrowAsync<InvalidOperationException>(
+            () => sut.ExecuteAsync(async _ =>
+            {
+                _userDelegateExecuted = true;
+                return await Task.FromResult(200);
+            }).AsTask());
+        exception.Message.ShouldBe(exceptionMessage);
+
+        _userDelegateExecuted.ShouldBeFalse();
+        _onFaultInjectedExecuted.ShouldBeTrue();
+        _args.Count.ShouldBe(1);
+        _args[0].Arguments.ShouldBeOfType<OnFaultInjectedArguments>();
+        _args[0].Event.EventName.ShouldBe(ChaosFaultConstants.OnFaultInjectedEvent);
     }
 
     [Fact]
@@ -188,9 +189,9 @@ public class ChaosFaultStrategyTests
             return 200;
         });
 
-        result.Should().Be(200);
-        _userDelegateExecuted.Should().BeTrue();
-        _onFaultInjectedExecuted.Should().BeFalse();
+        result.ShouldBe(200);
+        _userDelegateExecuted.ShouldBeTrue();
+        _onFaultInjectedExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -209,8 +210,8 @@ public class ChaosFaultStrategyTests
             _userDelegateExecuted = true;
         });
 
-        _userDelegateExecuted.Should().BeTrue();
-        _onFaultInjectedExecuted.Should().BeFalse();
+        _userDelegateExecuted.ShouldBeTrue();
+        _onFaultInjectedExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -232,17 +233,17 @@ public class ChaosFaultStrategyTests
         };
 
         var sut = CreateSut(options);
-        await sut.Invoking(s => s.ExecuteAsync(async _ =>
-        {
-            _userDelegateExecuted = true;
-            return await Task.FromResult(1);
-        }, cts.Token)
-        .AsTask())
-            .Should()
-            .ThrowAsync<OperationCanceledException>();
 
-        _userDelegateExecuted.Should().BeFalse();
-        _onFaultInjectedExecuted.Should().BeFalse();
+        await Should.ThrowAsync<OperationCanceledException>(
+            () => sut.ExecuteAsync(async _ =>
+            {
+                _userDelegateExecuted = true;
+                return await Task.FromResult(1);
+            }, cts.Token)
+            .AsTask());
+
+        _userDelegateExecuted.ShouldBeFalse();
+        _onFaultInjectedExecuted.ShouldBeFalse();
     }
 
     private ResiliencePipeline CreateSut(ChaosFaultStrategyOptions options) =>

--- a/test/Polly.Core.Tests/Simmy/Fault/FaultGeneratorArgumentsTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Fault/FaultGeneratorArgumentsTests.cs
@@ -14,6 +14,6 @@ public static class FaultGeneratorArgumentsTests
         var args = new FaultGeneratorArguments(context);
 
         // Assert
-        args.Context.Should().Be(context);
+        args.Context.ShouldBe(context);
     }
 }

--- a/test/Polly.Core.Tests/Simmy/Fault/FaultGeneratorTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Fault/FaultGeneratorTests.cs
@@ -11,7 +11,7 @@ public class FaultGeneratorTests
 
         generator.AddException<InvalidOperationException>();
 
-        Generate(generator).Should().BeOfType<InvalidOperationException>();
+        Generate(generator).ShouldBeOfType<InvalidOperationException>();
     }
 
     [Fact]
@@ -21,7 +21,7 @@ public class FaultGeneratorTests
 
         generator.AddException(() => new InvalidOperationException());
 
-        Generate(generator).Should().BeOfType<InvalidOperationException>();
+        Generate(generator).ShouldBeOfType<InvalidOperationException>();
     }
 
     [Fact]
@@ -31,12 +31,12 @@ public class FaultGeneratorTests
 
         generator.AddException(context =>
         {
-            context.Should().NotBeNull();
+            context.ShouldNotBeNull();
 
             return new InvalidOperationException();
         });
 
-        Generate(generator).Should().BeOfType<InvalidOperationException>();
+        Generate(generator).ShouldBeOfType<InvalidOperationException>();
     }
 
     private static Exception? Generate(FaultGenerator generator)

--- a/test/Polly.Core.Tests/Simmy/Fault/OnFaultInjectedArgumentsTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Fault/OnFaultInjectedArgumentsTests.cs
@@ -15,7 +15,7 @@ public static class OnFaultInjectedArgumentsTests
         var args = new OnFaultInjectedArguments(context, fault);
 
         // Assert
-        args.Context.Should().Be(context);
-        args.Fault.Should().Be(fault);
+        args.Context.ShouldBe(context);
+        args.Fault.ShouldBe(fault);
     }
 }

--- a/test/Polly.Core.Tests/Simmy/InjectionRateGeneratorArgumentsTests.cs
+++ b/test/Polly.Core.Tests/Simmy/InjectionRateGeneratorArgumentsTests.cs
@@ -14,6 +14,6 @@ public static class InjectionRateGeneratorArgumentsTests
         var args = new InjectionRateGeneratorArguments(context);
 
         // Assert
-        args.Context.Should().Be(context);
+        args.Context.ShouldBe(context);
     }
 }

--- a/test/Polly.Core.Tests/Simmy/Latency/ChaosLatencyConstantsTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Latency/ChaosLatencyConstantsTests.cs
@@ -7,8 +7,8 @@ public class ChaosLatencyConstantsTests
     [Fact]
     public void EnsureDefaults()
     {
-        ChaosLatencyConstants.DefaultName.Should().Be("Chaos.Latency");
-        ChaosLatencyConstants.OnLatencyInjectedEvent.Should().Be("Chaos.OnLatency");
-        ChaosLatencyConstants.DefaultLatency.Should().Be(TimeSpan.FromSeconds(30));
+        ChaosLatencyConstants.DefaultName.ShouldBe("Chaos.Latency");
+        ChaosLatencyConstants.OnLatencyInjectedEvent.ShouldBe("Chaos.OnLatency");
+        ChaosLatencyConstants.DefaultLatency.ShouldBe(TimeSpan.FromSeconds(30));
     }
 }

--- a/test/Polly.Core.Tests/Simmy/Latency/ChaosLatencyPipelineBuilderExtensionsTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Latency/ChaosLatencyPipelineBuilderExtensionsTests.cs
@@ -15,10 +15,10 @@ public class ChaosLatencyPipelineBuilderExtensionsTests
             (ResiliencePipelineBuilder<int> builder) => { builder.AddChaosLatency(0.5, TimeSpan.FromSeconds(10)); },
             (ChaosLatencyStrategy strategy) =>
             {
-                strategy.Latency.Should().Be(TimeSpan.FromSeconds(10));
-                strategy.LatencyGenerator!.Invoke(new(context)).Preserve().GetAwaiter().GetResult().Should().Be(TimeSpan.FromSeconds(10));
-                strategy.EnabledGenerator.Invoke(new(context)).Preserve().GetAwaiter().GetResult().Should().BeTrue();
-                strategy.InjectionRateGenerator.Invoke(new(context)).Preserve().GetAwaiter().GetResult().Should().Be(0.5);
+                strategy.Latency.ShouldBe(TimeSpan.FromSeconds(10));
+                strategy.LatencyGenerator!.Invoke(new(context)).Preserve().GetAwaiter().GetResult().ShouldBe(TimeSpan.FromSeconds(10));
+                strategy.EnabledGenerator.Invoke(new(context)).Preserve().GetAwaiter().GetResult().ShouldBeTrue();
+                strategy.InjectionRateGenerator.Invoke(new(context)).Preserve().GetAwaiter().GetResult().ShouldBe(0.5);
             }
         };
     }
@@ -27,7 +27,7 @@ public class ChaosLatencyPipelineBuilderExtensionsTests
     public void AddLatency_Shortcut_Option_Ok()
     {
         var sut = new ResiliencePipelineBuilder().AddChaosLatency(0.5, TimeSpan.FromSeconds(10)).Build();
-        sut.GetPipelineDescriptor().FirstStrategy.StrategyInstance.Should().BeOfType<ChaosLatencyStrategy>();
+        sut.GetPipelineDescriptor().FirstStrategy.StrategyInstance.ShouldBeOfType<ChaosLatencyStrategy>();
     }
 
     [Fact]
@@ -41,7 +41,7 @@ public class ChaosLatencyPipelineBuilderExtensionsTests
             })
             .Build();
 
-        sut.GetPipelineDescriptor().FirstStrategy.StrategyInstance.Should().BeOfType<ChaosLatencyStrategy>();
+        sut.GetPipelineDescriptor().FirstStrategy.StrategyInstance.ShouldBeOfType<ChaosLatencyStrategy>();
     }
 
     [MemberData(nameof(AddLatency_Ok_Data))]
@@ -51,7 +51,7 @@ public class ChaosLatencyPipelineBuilderExtensionsTests
         var builder = new ResiliencePipelineBuilder<int>();
         configure(builder);
 
-        var strategy = builder.Build().GetPipelineDescriptor().FirstStrategy.StrategyInstance.Should().BeOfType<ChaosLatencyStrategy>().Subject;
+        var strategy = builder.Build().GetPipelineDescriptor().FirstStrategy.StrategyInstance.ShouldBeOfType<ChaosLatencyStrategy>();
         assert(strategy);
     }
 }

--- a/test/Polly.Core.Tests/Simmy/Latency/ChaosLatencyStrategyOptionsTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Latency/ChaosLatencyStrategyOptionsTests.cs
@@ -9,13 +9,13 @@ public class ChaosLatencyStrategyOptionsTests
     public void Ctor_Ok()
     {
         var sut = new ChaosLatencyStrategyOptions();
-        sut.Randomizer.Should().NotBeNull();
-        sut.Enabled.Should().BeTrue();
-        sut.EnabledGenerator.Should().BeNull();
-        sut.InjectionRate.Should().Be(ChaosStrategyConstants.DefaultInjectionRate);
-        sut.InjectionRateGenerator.Should().BeNull();
-        sut.Latency.Should().Be(ChaosLatencyConstants.DefaultLatency);
-        sut.LatencyGenerator.Should().BeNull();
-        sut.OnLatencyInjected.Should().BeNull();
+        sut.Randomizer.ShouldNotBeNull();
+        sut.Enabled.ShouldBeTrue();
+        sut.EnabledGenerator.ShouldBeNull();
+        sut.InjectionRate.ShouldBe(ChaosStrategyConstants.DefaultInjectionRate);
+        sut.InjectionRateGenerator.ShouldBeNull();
+        sut.Latency.ShouldBe(ChaosLatencyConstants.DefaultLatency);
+        sut.LatencyGenerator.ShouldBeNull();
+        sut.OnLatencyInjected.ShouldBeNull();
     }
 }

--- a/test/Polly.Core.Tests/Simmy/Latency/ChaosLatencyStrategyTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Latency/ChaosLatencyStrategyTests.cs
@@ -34,8 +34,8 @@ public class ChaosLatencyStrategyTests : IDisposable
         _options.Randomizer = () => 0.5;
         _options.OnLatencyInjected = args =>
         {
-            args.Context.Should().NotBeNull();
-            args.Context.CancellationToken.IsCancellationRequested.Should().BeFalse();
+            args.Context.ShouldNotBeNull();
+            args.Context.CancellationToken.IsCancellationRequested.ShouldBeFalse();
             _onLatencyInjectedExecuted = true;
             return default;
         };
@@ -46,13 +46,13 @@ public class ChaosLatencyStrategyTests : IDisposable
         _timeProvider.Advance(_delay);
         await task;
 
-        _userDelegateExecuted.Should().BeTrue();
-        _onLatencyInjectedExecuted.Should().BeTrue();
+        _userDelegateExecuted.ShouldBeTrue();
+        _onLatencyInjectedExecuted.ShouldBeTrue();
         var after = _timeProvider.GetUtcNow();
-        (after - before).Should().Be(_delay);
+        (after - before).ShouldBe(_delay);
 
-        _args.Should().HaveCount(1);
-        _args[0].Arguments.Should().BeOfType<OnLatencyInjectedArguments>();
+        _args.Count.ShouldBe(1);
+        _args[0].Arguments.ShouldBeOfType<OnLatencyInjectedArguments>();
     }
 
     [Fact]
@@ -69,10 +69,10 @@ public class ChaosLatencyStrategyTests : IDisposable
         _timeProvider.Advance(_delay);
         await task;
 
-        _userDelegateExecuted.Should().BeTrue();
-        _onLatencyInjectedExecuted.Should().BeFalse();
+        _userDelegateExecuted.ShouldBeTrue();
+        _onLatencyInjectedExecuted.ShouldBeFalse();
         var after = _timeProvider.GetUtcNow();
-        (after - before).Seconds.Should().Be(0);
+        (after - before).Seconds.ShouldBe(0);
     }
 
     [Fact]
@@ -89,10 +89,10 @@ public class ChaosLatencyStrategyTests : IDisposable
         _timeProvider.Advance(_delay);
         await task;
 
-        _userDelegateExecuted.Should().BeTrue();
-        _onLatencyInjectedExecuted.Should().BeFalse();
+        _userDelegateExecuted.ShouldBeTrue();
+        _onLatencyInjectedExecuted.ShouldBeFalse();
         var after = _timeProvider.GetUtcNow();
-        (after - before).Seconds.Should().Be(0);
+        (after - before).Seconds.ShouldBe(0);
     }
 
     [InlineData(-1000)]
@@ -106,8 +106,8 @@ public class ChaosLatencyStrategyTests : IDisposable
 
         _options.OnLatencyInjected = args =>
         {
-            args.Context.Should().NotBeNull();
-            args.Context.CancellationToken.IsCancellationRequested.Should().BeFalse();
+            args.Context.ShouldNotBeNull();
+            args.Context.CancellationToken.IsCancellationRequested.ShouldBeFalse();
             _onLatencyInjectedExecuted = true;
             return default;
         };
@@ -118,10 +118,10 @@ public class ChaosLatencyStrategyTests : IDisposable
         _timeProvider.Advance(_delay);
         await task;
 
-        _userDelegateExecuted.Should().BeTrue();
-        _onLatencyInjectedExecuted.Should().BeFalse();
+        _userDelegateExecuted.ShouldBeTrue();
+        _onLatencyInjectedExecuted.ShouldBeFalse();
         var after = _timeProvider.GetUtcNow();
-        (after - before).Seconds.Should().Be(0);
+        (after - before).Seconds.ShouldBe(0);
     }
 
     [Fact]
@@ -137,12 +137,10 @@ public class ChaosLatencyStrategyTests : IDisposable
         };
 
         var sut = CreateSut();
-        await sut.Invoking(s => s.ExecuteAsync(async _ => { await Task.CompletedTask; }, cts.Token).AsTask())
-            .Should()
-            .ThrowAsync<OperationCanceledException>();
+        await Should.ThrowAsync<OperationCanceledException>(() => sut.ExecuteAsync(async _ => await Task.CompletedTask, cts.Token).AsTask());
 
-        _userDelegateExecuted.Should().BeFalse();
-        _onLatencyInjectedExecuted.Should().BeFalse();
+        _userDelegateExecuted.ShouldBeFalse();
+        _onLatencyInjectedExecuted.ShouldBeFalse();
     }
 
     private ResiliencePipeline CreateSut() => new ChaosLatencyStrategy(_options, _timeProvider, _telemetry).AsPipeline();

--- a/test/Polly.Core.Tests/Simmy/Latency/LatencyGeneratorArgumentsTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Latency/LatencyGeneratorArgumentsTests.cs
@@ -14,6 +14,6 @@ public static class LatencyGeneratorArgumentsTests
         var args = new LatencyGeneratorArguments(context);
 
         // Assert
-        args.Context.Should().NotBeNull();
+        args.Context.ShouldNotBeNull();
     }
 }

--- a/test/Polly.Core.Tests/Simmy/Latency/OnLatencyInjectedArgumentsTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Latency/OnLatencyInjectedArgumentsTests.cs
@@ -14,7 +14,7 @@ public static class OnLatencyInjectedArgumentsTests
         var args = new OnLatencyInjectedArguments(context, TimeSpan.FromSeconds(10));
 
         // Assert
-        args.Context.Should().Be(context);
-        args.Latency.Should().Be(TimeSpan.FromSeconds(10));
+        args.Context.ShouldBe(context);
+        args.Latency.ShouldBe(TimeSpan.FromSeconds(10));
     }
 }

--- a/test/Polly.Core.Tests/Simmy/Outcomes/ChaosOutcomeConstantsTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Outcomes/ChaosOutcomeConstantsTests.cs
@@ -7,7 +7,7 @@ public class ChaosOutcomeConstantsTests
     [Fact]
     public void EnsureDefaults()
     {
-        ChaosOutcomeConstants.DefaultName.Should().Be("Chaos.Outcome");
-        ChaosOutcomeConstants.OnOutcomeInjectedEvent.Should().Be("Chaos.OnOutcome");
+        ChaosOutcomeConstants.DefaultName.ShouldBe("Chaos.Outcome");
+        ChaosOutcomeConstants.OnOutcomeInjectedEvent.ShouldBe("Chaos.OnOutcome");
     }
 }

--- a/test/Polly.Core.Tests/Simmy/Outcomes/ChaosOutcomePipelineBuilderExtensionsTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Outcomes/ChaosOutcomePipelineBuilderExtensionsTests.cs
@@ -28,11 +28,11 @@ public class ChaosOutcomePipelineBuilderExtensionsTests
     private static void AssertResultStrategy<T>(ResiliencePipelineBuilder<T> builder, ChaosOutcomeStrategyOptions<T> options, bool enabled, double injectionRate, Outcome<T> outcome)
     {
         var context = ResilienceContextPool.Shared.Get();
-        var strategy = builder.Build().GetPipelineDescriptor().FirstStrategy.StrategyInstance.Should().BeOfType<ChaosOutcomeStrategy<T>>().Subject;
+        var strategy = builder.Build().GetPipelineDescriptor().FirstStrategy.StrategyInstance.ShouldBeOfType<ChaosOutcomeStrategy<T>>();
 
-        strategy.EnabledGenerator.Invoke(new(context)).Preserve().GetAwaiter().GetResult().Should().Be(enabled);
-        strategy.InjectionRateGenerator.Invoke(new(context)).Preserve().GetAwaiter().GetResult().Should().Be(injectionRate);
-        options.OutcomeGenerator!.Invoke(new(context)).Preserve().GetAwaiter().GetResult().Should().Be(outcome);
+        strategy.EnabledGenerator.Invoke(new(context)).Preserve().GetAwaiter().GetResult().ShouldBe(enabled);
+        strategy.InjectionRateGenerator.Invoke(new(context)).Preserve().GetAwaiter().GetResult().ShouldBe(injectionRate);
+        options.OutcomeGenerator!.Invoke(new(context)).Preserve().GetAwaiter().GetResult().ShouldBe(outcome);
     }
 
     [Theory]
@@ -42,7 +42,7 @@ public class ChaosOutcomePipelineBuilderExtensionsTests
     internal void AddResult_Options_Ok(Action<ResiliencePipelineBuilder<int>> configure)
     {
         var builder = new ResiliencePipelineBuilder<int>();
-        builder.Invoking(b => configure(b)).Should().NotThrow();
+        Should.NotThrow(() => configure(builder));
     }
 
     [Fact]
@@ -61,8 +61,6 @@ public class ChaosOutcomePipelineBuilderExtensionsTests
 
     [Fact]
     public void AddResult_Shortcut_Option_Throws() =>
-        new ResiliencePipelineBuilder<int>()
-            .Invoking(b => b.AddChaosOutcome(-1, () => 120))
-            .Should()
-            .Throw<ValidationException>();
+        Should.Throw<ValidationException>(
+            () => new ResiliencePipelineBuilder<int>().AddChaosOutcome(-1, () => 120));
 }

--- a/test/Polly.Core.Tests/Simmy/Outcomes/ChaosOutcomeStrategyOptionsTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Outcomes/ChaosOutcomeStrategyOptionsTests.cs
@@ -9,12 +9,12 @@ public class ChaosOutcomeStrategyOptionsTests
     public void Ctor_Ok()
     {
         var sut = new ChaosOutcomeStrategyOptions<int>();
-        sut.Randomizer.Should().NotBeNull();
-        sut.Enabled.Should().BeTrue();
-        sut.EnabledGenerator.Should().BeNull();
-        sut.InjectionRate.Should().Be(ChaosStrategyConstants.DefaultInjectionRate);
-        sut.InjectionRateGenerator.Should().BeNull();
-        sut.OnOutcomeInjected.Should().BeNull();
-        sut.OutcomeGenerator.Should().BeNull();
+        sut.Randomizer.ShouldNotBeNull();
+        sut.Enabled.ShouldBeTrue();
+        sut.EnabledGenerator.ShouldBeNull();
+        sut.InjectionRate.ShouldBe(ChaosStrategyConstants.DefaultInjectionRate);
+        sut.InjectionRateGenerator.ShouldBeNull();
+        sut.OnOutcomeInjected.ShouldBeNull();
+        sut.OutcomeGenerator.ShouldBeNull();
     }
 }

--- a/test/Polly.Core.Tests/Simmy/Outcomes/ChaosOutcomeStrategyTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Outcomes/ChaosOutcomeStrategyTests.cs
@@ -71,9 +71,9 @@ public class ChaosOutcomeStrategyTests
         var sut = CreateSut(options);
         var response = sut.Execute(() => { _userDelegateExecuted = true; return HttpStatusCode.OK; });
 
-        response.Should().Be(HttpStatusCode.OK);
-        _userDelegateExecuted.Should().BeTrue();
-        _onOutcomeInjectedExecuted.Should().BeFalse();
+        response.ShouldBe(HttpStatusCode.OK);
+        _userDelegateExecuted.ShouldBeTrue();
+        _onOutcomeInjectedExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -88,8 +88,8 @@ public class ChaosOutcomeStrategyTests
             OutcomeGenerator = _ => new ValueTask<Outcome<HttpStatusCode>?>(Outcome.FromResult(fakeResult)),
             OnOutcomeInjected = args =>
             {
-                args.Context.Should().NotBeNull();
-                args.Context.CancellationToken.IsCancellationRequested.Should().BeFalse();
+                args.Context.ShouldNotBeNull();
+                args.Context.CancellationToken.IsCancellationRequested.ShouldBeFalse();
                 _onOutcomeInjectedExecuted = true;
                 return default;
             }
@@ -102,13 +102,13 @@ public class ChaosOutcomeStrategyTests
             return new ValueTask<HttpStatusCode>(HttpStatusCode.OK);
         }, CancellationToken);
 
-        response.Should().Be(fakeResult);
-        _userDelegateExecuted.Should().BeFalse();
-        _onOutcomeInjectedExecuted.Should().BeTrue();
+        response.ShouldBe(fakeResult);
+        _userDelegateExecuted.ShouldBeFalse();
+        _onOutcomeInjectedExecuted.ShouldBeTrue();
 
-        _args.Should().HaveCount(1);
-        _args[0].Arguments.Should().BeOfType<OnOutcomeInjectedArguments<HttpStatusCode>>();
-        _args[0].Event.EventName.Should().Be(ChaosOutcomeConstants.OnOutcomeInjectedEvent);
+        _args.Count.ShouldBe(1);
+        _args[0].Arguments.ShouldBeOfType<OnOutcomeInjectedArguments<HttpStatusCode>>();
+        _args[0].Event.EventName.ShouldBe(ChaosOutcomeConstants.OnOutcomeInjectedEvent);
     }
 
     [Fact]
@@ -131,9 +131,9 @@ public class ChaosOutcomeStrategyTests
             return HttpStatusCode.OK;
         }, CancellationToken);
 
-        response.Should().Be(HttpStatusCode.OK);
-        _userDelegateExecuted.Should().BeTrue();
-        _onOutcomeInjectedExecuted.Should().BeFalse();
+        response.ShouldBe(HttpStatusCode.OK);
+        _userDelegateExecuted.ShouldBeTrue();
+        _onOutcomeInjectedExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -154,9 +154,9 @@ public class ChaosOutcomeStrategyTests
             return new ValueTask<HttpStatusCode?>(HttpStatusCode.OK);
         }, CancellationToken);
 
-        response.Should().Be(null);
-        _userDelegateExecuted.Should().BeFalse();
-        _onOutcomeInjectedExecuted.Should().BeFalse();
+        response.ShouldBe(null);
+        _userDelegateExecuted.ShouldBeFalse();
+        _onOutcomeInjectedExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -182,9 +182,9 @@ public class ChaosOutcomeStrategyTests
             return new ValueTask<int>(42);
         }, CancellationToken);
 
-        response.Should().Be(42);
-        _userDelegateExecuted.Should().BeTrue();
-        _onOutcomeInjectedExecuted.Should().BeFalse();
+        response.ShouldBe(42);
+        _userDelegateExecuted.ShouldBeTrue();
+        _onOutcomeInjectedExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -198,25 +198,25 @@ public class ChaosOutcomeStrategyTests
             OutcomeGenerator = _ => new ValueTask<Outcome<int>?>(Outcome.FromException<int>(exception)),
             OnOutcomeInjected = args =>
             {
-                args.Outcome.Result.Should().Be(default);
-                args.Outcome.Exception.Should().Be(exception);
+                args.Outcome.Result.ShouldBe(default);
+                args.Outcome.Exception.ShouldBe(exception);
                 _onOutcomeInjectedExecuted = true;
                 return default;
             }
         };
 
         var sut = CreateSut(options);
-        await sut.Invoking(s => s.ExecuteAsync(_ =>
-        {
-            _userDelegateExecuted = true;
-            return new ValueTask<int>(42);
-        }, CancellationToken)
-        .AsTask())
-            .Should()
-            .ThrowAsync<InvalidOperationException>();
 
-        _userDelegateExecuted.Should().BeFalse();
-        _onOutcomeInjectedExecuted.Should().BeTrue();
+        await Should.ThrowAsync<InvalidOperationException>(
+            () => sut.ExecuteAsync(_ =>
+            {
+                _userDelegateExecuted = true;
+                return new ValueTask<int>(42);
+            }, CancellationToken)
+            .AsTask());
+
+        _userDelegateExecuted.ShouldBeFalse();
+        _onOutcomeInjectedExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -236,17 +236,17 @@ public class ChaosOutcomeStrategyTests
         };
 
         var sut = CreateSut(options);
-        await sut.Invoking(s => s.ExecuteAsync(_ =>
-        {
-            _userDelegateExecuted = true;
-            return new ValueTask<HttpStatusCode>(HttpStatusCode.OK);
-        }, cts.Token)
-        .AsTask())
-            .Should()
-            .ThrowAsync<OperationCanceledException>();
 
-        _userDelegateExecuted.Should().BeFalse();
-        _onOutcomeInjectedExecuted.Should().BeFalse();
+        await Should.ThrowAsync<OperationCanceledException>(
+            () => sut.ExecuteAsync(_ =>
+            {
+                _userDelegateExecuted = true;
+                return new ValueTask<HttpStatusCode>(HttpStatusCode.OK);
+            }, cts.Token)
+            .AsTask());
+
+        _userDelegateExecuted.ShouldBeFalse();
+        _onOutcomeInjectedExecuted.ShouldBeFalse();
     }
 
     private ResiliencePipeline<TResult> CreateSut<TResult>(ChaosOutcomeStrategyOptions<TResult> options) =>

--- a/test/Polly.Core.Tests/Simmy/Outcomes/OnOutcomeInjectedArgumentsTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Outcomes/OnOutcomeInjectedArgumentsTests.cs
@@ -9,12 +9,13 @@ public static class OnOutcomeInjectedArgumentsTests
     {
         // Arrange
         var context = ResilienceContextPool.Shared.Get();
+        var outcome = 200;
 
         // Act
-        var args = new OnOutcomeInjectedArguments<int>(context, new(200));
+        var args = new OnOutcomeInjectedArguments<int>(context, new(outcome));
 
         // Assert
-        args.Context.Should().Be(context);
-        args.Outcome.Should().NotBeNull();
+        args.Context.ShouldBe(context);
+        args.Outcome.Result.ShouldBe(outcome);
     }
 }

--- a/test/Polly.Core.Tests/Simmy/Outcomes/OutcomeGeneratorArgumentsTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Outcomes/OutcomeGeneratorArgumentsTests.cs
@@ -14,6 +14,6 @@ public static class OutcomeGeneratorArgumentsTests
         var args = new OutcomeGeneratorArguments(context);
 
         // Assert
-        args.Context.Should().NotBeNull();
+        args.Context.ShouldNotBeNull();
     }
 }

--- a/test/Polly.Core.Tests/Simmy/Outcomes/OutcomeGeneratorTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Outcomes/OutcomeGeneratorTests.cs
@@ -11,7 +11,7 @@ public class OutcomeGeneratorTests
 
         generator.AddException<InvalidOperationException>();
 
-        Generate(generator)!.Value.Exception.Should().BeOfType<InvalidOperationException>();
+        Generate(generator)!.Value.Exception.ShouldBeOfType<InvalidOperationException>();
     }
 
     [Fact]
@@ -21,7 +21,7 @@ public class OutcomeGeneratorTests
 
         generator.AddException(() => new InvalidOperationException());
 
-        Generate(generator)!.Value.Exception.Should().BeOfType<InvalidOperationException>();
+        Generate(generator)!.Value.Exception.ShouldBeOfType<InvalidOperationException>();
     }
 
     [Fact]
@@ -31,12 +31,12 @@ public class OutcomeGeneratorTests
 
         generator.AddException(context =>
         {
-            context.Should().NotBeNull();
+            context.ShouldNotBeNull();
 
             return new InvalidOperationException();
         });
 
-        Generate(generator)!.Value.Exception.Should().BeOfType<InvalidOperationException>();
+        Generate(generator)!.Value.Exception.ShouldBeOfType<InvalidOperationException>();
     }
 
     [Fact]
@@ -49,7 +49,7 @@ public class OutcomeGeneratorTests
             return "dummy";
         });
 
-        Generate(generator)!.Value.Result.Should().Be("dummy");
+        Generate(generator)!.Value.Result.ShouldBe("dummy");
     }
 
     [Fact]
@@ -59,12 +59,12 @@ public class OutcomeGeneratorTests
 
         generator.AddResult(context =>
         {
-            context.Should().NotBeNull();
+            context.ShouldNotBeNull();
 
             return "dummy";
         });
 
-        Generate(generator)!.Value.Result.Should().Be("dummy");
+        Generate(generator)!.Value.Result.ShouldBe("dummy");
     }
 
     private static Outcome<string>? Generate(OutcomeGenerator<string> generator)

--- a/test/Polly.Core.Tests/Simmy/TestChaosStrategyOptions.TResult.cs
+++ b/test/Polly.Core.Tests/Simmy/TestChaosStrategyOptions.TResult.cs
@@ -2,6 +2,4 @@
 
 namespace Polly.Core.Tests.Simmy;
 
-public sealed class TestChaosStrategyOptions<T> : ChaosStrategyOptions
-{
-}
+public sealed class TestChaosStrategyOptions<T> : ChaosStrategyOptions;

--- a/test/Polly.Core.Tests/Simmy/TestChaosStrategyOptions.cs
+++ b/test/Polly.Core.Tests/Simmy/TestChaosStrategyOptions.cs
@@ -2,6 +2,4 @@
 
 namespace Polly.Core.Tests.Simmy;
 
-public sealed class TestChaosStrategyOptions : ChaosStrategyOptions
-{
-}
+public sealed class TestChaosStrategyOptions : ChaosStrategyOptions;

--- a/test/Polly.Core.Tests/Simmy/Utils/GeneratorHelperTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Utils/GeneratorHelperTests.cs
@@ -9,7 +9,7 @@ public class GeneratorHelperTests
     {
         var helper = new GeneratorHelper<int>(_ => 10);
 
-        helper.CreateGenerator()(ResilienceContextPool.Shared.Get()).Should().BeNull();
+        helper.CreateGenerator()(ResilienceContextPool.Shared.Get()).ShouldBeNull();
     }
 
     [Fact]
@@ -31,14 +31,14 @@ public class GeneratorHelperTests
         var generator = helper.CreateGenerator();
 
         weight = 0;
-        generator(context)!.Value.Result.Should().Be(1);
+        generator(context)!.Value.Result.ShouldBe(1);
         weight = 39;
-        generator(context)!.Value.Result.Should().Be(1);
+        generator(context)!.Value.Result.ShouldBe(1);
 
         weight = 40;
-        generator(context)!.Value.Result.Should().Be(2);
+        generator(context)!.Value.Result.ShouldBe(2);
 
-        maxWeight.Should().Be(120);
+        maxWeight.ShouldBe(120);
     }
 
     [Fact]
@@ -50,6 +50,6 @@ public class GeneratorHelperTests
         helper.AddOutcome(_ => Outcome.FromResult(1), 40);
 
         var generator = helper.CreateGenerator();
-        generator(context).Should().BeNull();
+        generator(context).ShouldBeNull();
     }
 }

--- a/test/Polly.Core.Tests/StrategyBuilderContextTests.cs
+++ b/test/Polly.Core.Tests/StrategyBuilderContextTests.cs
@@ -14,13 +14,13 @@ public class StrategyBuilderContextTests
             new ResilienceStrategyTelemetry(new ResilienceTelemetrySource("builder-name", "instance", "strategy_name"),
             Substitute.For<TelemetryListener>()), timeProvider);
 
-        context.Telemetry.TelemetrySource.PipelineName.Should().Be("builder-name");
-        context.Telemetry.TelemetrySource.PipelineInstanceName.Should().Be("instance");
-        context.Telemetry.TelemetrySource.StrategyName.Should().Be("strategy_name");
-        context.TimeProvider.Should().Be(timeProvider);
-        context.Telemetry.Should().NotBeNull();
+        context.Telemetry.TelemetrySource.PipelineName.ShouldBe("builder-name");
+        context.Telemetry.TelemetrySource.PipelineInstanceName.ShouldBe("instance");
+        context.Telemetry.TelemetrySource.StrategyName.ShouldBe("strategy_name");
+        context.TimeProvider.ShouldBe(timeProvider);
+        context.Telemetry.ShouldNotBeNull();
 
-        context.Telemetry.TelemetrySource.PipelineName.Should().Be("builder-name");
-        context.Telemetry.TelemetrySource.StrategyName.Should().Be("strategy_name");
+        context.Telemetry.TelemetrySource.PipelineName.ShouldBe("builder-name");
+        context.Telemetry.TelemetrySource.StrategyName.ShouldBe("strategy_name");
     }
 }

--- a/test/Polly.Core.Tests/Telemetry/ExecutionAttemptArgumentsTests.cs
+++ b/test/Polly.Core.Tests/Telemetry/ExecutionAttemptArgumentsTests.cs
@@ -8,8 +8,8 @@ public class ExecutionAttemptArgumentsTests
     public void Ctor_Ok()
     {
         var args = new ExecutionAttemptArguments(99, TimeSpan.MaxValue, true);
-        args.AttemptNumber.Should().Be(99);
-        args.Duration.Should().Be(TimeSpan.MaxValue);
-        args.Handled.Should().BeTrue();
+        args.AttemptNumber.ShouldBe(99);
+        args.Duration.ShouldBe(TimeSpan.MaxValue);
+        args.Handled.ShouldBeTrue();
     }
 }

--- a/test/Polly.Core.Tests/Telemetry/PipelineExecutedArgumentsTests.cs
+++ b/test/Polly.Core.Tests/Telemetry/PipelineExecutedArgumentsTests.cs
@@ -8,6 +8,6 @@ public class PipelineExecutedArgumentsTests
     public void Ctor_Ok()
     {
         var args = new PipelineExecutedArguments(TimeSpan.MaxValue);
-        args.Duration.Should().Be(TimeSpan.MaxValue);
+        args.Duration.ShouldBe(TimeSpan.MaxValue);
     }
 }

--- a/test/Polly.Core.Tests/Telemetry/ResilienceEventTests.cs
+++ b/test/Polly.Core.Tests/Telemetry/ResilienceEventTests.cs
@@ -9,7 +9,7 @@ public class ResilienceEventTests
     {
         var ev = new ResilienceEvent(ResilienceEventSeverity.Warning, "A");
 
-        ev.ToString().Should().Be("A");
-        ev.Severity.Should().Be(ResilienceEventSeverity.Warning);
+        ev.ToString().ShouldBe("A");
+        ev.Severity.ShouldBe(ResilienceEventSeverity.Warning);
     }
 }

--- a/test/Polly.Core.Tests/Telemetry/ResilienceStrategyTelemetryTests.cs
+++ b/test/Polly.Core.Tests/Telemetry/ResilienceStrategyTelemetryTests.cs
@@ -22,8 +22,8 @@ public class ResilienceStrategyTelemetryTests
     [Fact]
     public void Enabled_Ok()
     {
-        _sut.Enabled.Should().BeTrue();
-        new ResilienceStrategyTelemetry(_source, null).Enabled.Should().BeFalse();
+        _sut.Enabled.ShouldBeTrue();
+        new ResilienceStrategyTelemetry(_source, null).Enabled.ShouldBeFalse();
     }
 
     [Fact]
@@ -33,15 +33,15 @@ public class ResilienceStrategyTelemetryTests
 
         _sut.Report(new(ResilienceEventSeverity.Warning, "dummy-event"), context, new TestArguments());
 
-        _args.Should().HaveCount(1);
+        _args.Count.ShouldBe(1);
         var args = _args.Single();
-        args.Event.EventName.Should().Be("dummy-event");
-        args.Event.Severity.Should().Be(ResilienceEventSeverity.Warning);
-        args.Outcome.Should().BeNull();
-        args.Source.StrategyName.Should().Be("strategy_name");
-        args.Arguments.Should().BeOfType<TestArguments>();
-        args.Outcome.Should().BeNull();
-        args.Context.Should().Be(context);
+        args.Event.EventName.ShouldBe("dummy-event");
+        args.Event.Severity.ShouldBe(ResilienceEventSeverity.Warning);
+        args.Outcome.ShouldBeNull();
+        args.Source.StrategyName.ShouldBe("strategy_name");
+        args.Arguments.ShouldBeOfType<TestArguments>();
+        args.Outcome.ShouldBeNull();
+        args.Context.ShouldBe(context);
     }
 
     [Fact]
@@ -51,8 +51,8 @@ public class ResilienceStrategyTelemetryTests
         var sut = new ResilienceStrategyTelemetry(source, null);
         var context = ResilienceContextPool.Shared.Get();
 
-        sut.Invoking(s => s.Report(new(ResilienceEventSeverity.Warning, "dummy"), context, new TestArguments())).Should().NotThrow();
-        sut.Invoking(s => s.Report(new(ResilienceEventSeverity.Warning, "dummy"), context, Outcome.FromResult(1), new TestArguments())).Should().NotThrow();
+        Should.NotThrow(() => sut.Report(new(ResilienceEventSeverity.Warning, "dummy"), context, new TestArguments()));
+        Should.NotThrow(() => sut.Report(new(ResilienceEventSeverity.Warning, "dummy"), context, Outcome.FromResult(1), new TestArguments()));
     }
 
     [Fact]
@@ -61,15 +61,15 @@ public class ResilienceStrategyTelemetryTests
         var context = ResilienceContextPool.Shared.Get();
         _sut.Report(new(ResilienceEventSeverity.Warning, "dummy-event"), context, Outcome.FromResult(99), new TestArguments());
 
-        _args.Should().HaveCount(1);
+        _args.Count.ShouldBe(1);
         var args = _args.Single();
-        args.Event.EventName.Should().Be("dummy-event");
-        args.Event.Severity.Should().Be(ResilienceEventSeverity.Warning);
-        args.Source.StrategyName.Should().Be("strategy_name");
-        args.Arguments.Should().BeOfType<TestArguments>();
-        args.Outcome.Should().NotBeNull();
-        args.Outcome!.Value.Result.Should().Be(99);
-        args.Context.Should().NotBeNull();
+        args.Event.EventName.ShouldBe("dummy-event");
+        args.Event.Severity.ShouldBe(ResilienceEventSeverity.Warning);
+        args.Source.StrategyName.ShouldBe("strategy_name");
+        args.Arguments.ShouldBeOfType<TestArguments>();
+        args.Outcome.ShouldNotBeNull();
+        args.Outcome!.Value.Result.ShouldBe(99);
+        args.Context.ShouldNotBeNull();
     }
 
     [Fact]
@@ -79,7 +79,7 @@ public class ResilienceStrategyTelemetryTests
         _sut.Report(new(ResilienceEventSeverity.None, "dummy-event"), context, Outcome.FromResult(99), new TestArguments());
         _sut.Report(new(ResilienceEventSeverity.None, "dummy-event"), context, new TestArguments());
 
-        _args.Should().BeEmpty();
+        _args.ShouldBeEmpty();
     }
 
     [Fact]
@@ -89,13 +89,9 @@ public class ResilienceStrategyTelemetryTests
 
         var context = ResilienceContextPool.Shared.Get();
 
-        sut.Invoking(s => s.Report(new(ResilienceEventSeverity.None, "dummy-event"), context, Outcome.FromResult(99), new TestArguments()))
-           .Should()
-           .NotThrow();
+        Should.NotThrow(() => sut.Report(new(ResilienceEventSeverity.None, "dummy-event"), context, Outcome.FromResult(99), new TestArguments()));
 
-        sut.Invoking(s => s.Report(new(ResilienceEventSeverity.None, "dummy-event"), context, new TestArguments()))
-           .Should()
-           .NotThrow();
+        Should.NotThrow(() => sut.Report(new(ResilienceEventSeverity.None, "dummy-event"), context, new TestArguments()));
     }
 
     [Fact]
@@ -106,7 +102,7 @@ public class ResilienceStrategyTelemetryTests
 
         sut.SetTelemetrySource(exception);
 
-        exception.TelemetrySource.Should().Be(_source);
+        exception.TelemetrySource.ShouldBe(_source);
     }
 
     [Fact]
@@ -114,8 +110,6 @@ public class ResilienceStrategyTelemetryTests
     {
         ExecutionRejectedException? exception = null;
 
-        _sut.Invoking(s => s.SetTelemetrySource(exception!))
-            .Should()
-            .Throw<ArgumentNullException>();
+        Should.Throw<ArgumentNullException>(() => _sut.SetTelemetrySource(exception!));
     }
 }

--- a/test/Polly.Core.Tests/Telemetry/TelemetryEventArgumentsTests.cs
+++ b/test/Polly.Core.Tests/Telemetry/TelemetryEventArgumentsTests.cs
@@ -12,12 +12,12 @@ public class TelemetryEventArgumentsTests
         var context = ResilienceContextPool.Shared.Get();
         var args = new TelemetryEventArguments<string, string>(_source, new ResilienceEvent(ResilienceEventSeverity.Warning, "ev"), context, "arg", Outcome.FromResult("dummy"));
 
-        args.Outcome!.Value.Result.Should().Be("dummy");
-        args.Context.Should().Be(context);
-        args.Event.EventName.Should().Be("ev");
-        args.Event.Severity.Should().Be(ResilienceEventSeverity.Warning);
-        args.Source.Should().Be(_source);
-        args.Arguments.Should().BeEquivalentTo("arg");
-        args.Context.Should().Be(context);
+        args.Outcome!.Value.Result.ShouldBe("dummy");
+        args.Context.ShouldBe(context);
+        args.Event.EventName.ShouldBe("ev");
+        args.Event.Severity.ShouldBe(ResilienceEventSeverity.Warning);
+        args.Source.ShouldBe(_source);
+        args.Arguments.ShouldBeEquivalentTo("arg");
+        args.Context.ShouldBe(context);
     }
 }

--- a/test/Polly.Core.Tests/Telemetry/TelemetryUtilTests.cs
+++ b/test/Polly.Core.Tests/Telemetry/TelemetryUtilTests.cs
@@ -13,12 +13,12 @@ public static class TelemetryUtilTests
         var context = ResilienceContextPool.Shared.Get();
         var listener = TestUtilities.CreateResilienceTelemetry(args =>
         {
-            args.Event.Severity.Should().Be(severity);
+            args.Event.Severity.ShouldBe(severity);
             asserted = true;
         });
 
         TelemetryUtil.ReportExecutionAttempt(listener, context, Outcome.FromResult("dummy"), 0, TimeSpan.Zero, handled);
-        asserted.Should().BeTrue();
+        asserted.ShouldBeTrue();
     }
 
     [Theory]
@@ -30,11 +30,11 @@ public static class TelemetryUtilTests
         var context = ResilienceContextPool.Shared.Get();
         var listener = TestUtilities.CreateResilienceTelemetry(args =>
         {
-            args.Event.Severity.Should().Be(severity);
+            args.Event.Severity.ShouldBe(severity);
             asserted = true;
         });
 
         TelemetryUtil.ReportFinalExecutionAttempt(listener, context, Outcome.FromResult("dummy"), 1, TimeSpan.Zero, handled);
-        asserted.Should().BeTrue();
+        asserted.ShouldBeTrue();
     }
 }

--- a/test/Polly.Core.Tests/Timeout/TimeoutConstantsTests.cs
+++ b/test/Polly.Core.Tests/Timeout/TimeoutConstantsTests.cs
@@ -6,5 +6,5 @@ public class TimeoutConstantsTests
 {
     [Fact]
     public void EnsureDefaultValues() =>
-        TimeoutConstants.OnTimeoutEvent.Should().Be("OnTimeout");
+        TimeoutConstants.OnTimeoutEvent.ShouldBe("OnTimeout");
 }

--- a/test/Polly.Core.Tests/Timeout/TimeoutRejectedExceptionTests.cs
+++ b/test/Polly.Core.Tests/Timeout/TimeoutRejectedExceptionTests.cs
@@ -9,13 +9,13 @@ public class TimeoutRejectedExceptionTests
     {
         var delay = TimeSpan.FromSeconds(4);
 
-        new TimeoutRejectedException().Message.Should().Be("The operation didn't complete within the allowed timeout.");
-        new TimeoutRejectedException("dummy").Message.Should().Be("dummy");
-        new TimeoutRejectedException("dummy", new InvalidOperationException()).Message.Should().Be("dummy");
-        new TimeoutRejectedException(delay).Timeout.Should().Be(delay);
-        new TimeoutRejectedException(delay).Message.Should().Be("The operation didn't complete within the allowed timeout.");
-        new TimeoutRejectedException("dummy", delay).Timeout.Should().Be(delay);
-        new TimeoutRejectedException("dummy", delay, new InvalidOperationException()).Timeout.Should().Be(delay);
+        new TimeoutRejectedException().Message.ShouldBe("The operation didn't complete within the allowed timeout.");
+        new TimeoutRejectedException("dummy").Message.ShouldBe("dummy");
+        new TimeoutRejectedException("dummy", new InvalidOperationException()).Message.ShouldBe("dummy");
+        new TimeoutRejectedException(delay).Timeout.ShouldBe(delay);
+        new TimeoutRejectedException(delay).Message.ShouldBe("The operation didn't complete within the allowed timeout.");
+        new TimeoutRejectedException("dummy", delay).Timeout.ShouldBe(delay);
+        new TimeoutRejectedException("dummy", delay, new InvalidOperationException()).Timeout.ShouldBe(delay);
     }
 
 #if NETFRAMEWORK
@@ -26,7 +26,7 @@ public class TimeoutRejectedExceptionTests
 
         var result = BinarySerializationUtil.SerializeAndDeserializeException(new TimeoutRejectedException(timeout));
 
-        result.Timeout.Should().Be(timeout);
+        result.Timeout.ShouldBe(timeout);
     }
 #endif
 }

--- a/test/Polly.Core.Tests/Timeout/TimeoutResiliencePipelineBuilderExtensionsTests.cs
+++ b/test/Polly.Core.Tests/Timeout/TimeoutResiliencePipelineBuilderExtensionsTests.cs
@@ -13,7 +13,7 @@ public class TimeoutResiliencePipelineBuilderExtensionsTests
         {
             timeout,
             (ResiliencePipelineBuilder<int> builder) => { builder.AddTimeout(timeout); },
-            (TimeoutResilienceStrategy strategy) => { GetTimeout(strategy).Should().Be(timeout); }
+            (TimeoutResilienceStrategy strategy) => { GetTimeout(strategy).ShouldBe(timeout); }
         };
     }
 
@@ -35,9 +35,9 @@ public class TimeoutResiliencePipelineBuilderExtensionsTests
         var builder = new ResiliencePipelineBuilder<int>();
         configure(builder);
 
-        var strategy = builder.Build().GetPipelineDescriptor().FirstStrategy.StrategyInstance.Should().BeOfType<TimeoutResilienceStrategy>().Subject;
+        var strategy = builder.Build().GetPipelineDescriptor().FirstStrategy.StrategyInstance.ShouldBeOfType<TimeoutResilienceStrategy>();
         assert(strategy);
-        GetTimeout(strategy).Should().Be(timeout);
+        GetTimeout(strategy).ShouldBe(timeout);
     }
 
     [Fact]
@@ -45,15 +45,13 @@ public class TimeoutResiliencePipelineBuilderExtensionsTests
     {
         var strategy = new ResiliencePipelineBuilder().AddTimeout(new TimeoutStrategyOptions()).Build();
 
-        strategy.GetPipelineDescriptor().FirstStrategy.StrategyInstance.Should().BeOfType<TimeoutResilienceStrategy>();
+        strategy.GetPipelineDescriptor().FirstStrategy.StrategyInstance.ShouldBeOfType<TimeoutResilienceStrategy>();
     }
 
     [Fact]
     public void AddTimeout_InvalidOptions_Throws() =>
-        new ResiliencePipelineBuilder()
-            .Invoking(b => b.AddTimeout(new TimeoutStrategyOptions { Timeout = TimeSpan.Zero }))
-            .Should()
-            .Throw<ValidationException>();
+        Should.Throw<ValidationException>(
+            () => new ResiliencePipelineBuilder().AddTimeout(new TimeoutStrategyOptions { Timeout = TimeSpan.Zero }));
 
     private static TimeSpan GetTimeout(TimeoutResilienceStrategy strategy)
     {

--- a/test/Polly.Core.Tests/Timeout/TimeoutResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Timeout/TimeoutResilienceStrategyTests.cs
@@ -222,7 +222,7 @@ public class TimeoutResilienceStrategyTests : IDisposable
 
         onTimeoutCalled.ShouldBeFalse();
 
-        _args.Count.ShouldBe(0);
+        _args.ShouldBeEmpty();
     }
 
     [Fact]

--- a/test/Polly.Core.Tests/Timeout/TimeoutStrategyOptionsTests.cs
+++ b/test/Polly.Core.Tests/Timeout/TimeoutStrategyOptionsTests.cs
@@ -11,9 +11,9 @@ public class TimeoutStrategyOptionsTests
     {
         var options = new TimeoutStrategyOptions();
 
-        options.TimeoutGenerator.Should().BeNull();
-        options.OnTimeout.Should().BeNull();
-        options.Name.Should().Be("Timeout");
+        options.TimeoutGenerator.ShouldBeNull();
+        options.OnTimeout.ShouldBeNull();
+        options.Name.ShouldBe("Timeout");
     }
 
     [MemberData(nameof(TimeoutTestUtils.InvalidTimeouts), MemberType = typeof(TimeoutTestUtils))]
@@ -25,10 +25,8 @@ public class TimeoutStrategyOptionsTests
             Timeout = value
         };
 
-        options
-            .Invoking(o => ValidationHelper.ValidateObject(new(o, "Dummy message")))
-            .Should()
-            .Throw<ValidationException>();
+        Should.Throw<ValidationException>(
+            () => ValidationHelper.ValidateObject(new(options, "Dummy message")));
     }
 
     [MemberData(nameof(TimeoutTestUtils.ValidTimeouts), MemberType = typeof(TimeoutTestUtils))]
@@ -40,9 +38,7 @@ public class TimeoutStrategyOptionsTests
             Timeout = value
         };
 
-        options
-            .Invoking(o => ValidationHelper.ValidateObject(new(o, "Dummy message")))
-            .Should()
-            .NotThrow();
+        Should.NotThrow(
+            () => ValidationHelper.ValidateObject(new(options, "Dummy message")));
     }
 }

--- a/test/Polly.Core.Tests/Timeout/TimeoutUtilTests.cs
+++ b/test/Polly.Core.Tests/Timeout/TimeoutUtilTests.cs
@@ -22,5 +22,5 @@ public class TimeoutUtilTests
     [MemberData(nameof(ShouldApplyTimeoutData))]
     [Theory]
     public void ShouldApplyTimeout_Ok(TimeSpan timeSpan, bool result) =>
-        TimeoutUtil.ShouldApplyTimeout(timeSpan).Should().Be(result);
+        TimeoutUtil.ShouldApplyTimeout(timeSpan).ShouldBe(result);
 }

--- a/test/Polly.Core.Tests/Utils/CancellationTokenSourcePoolTests.cs
+++ b/test/Polly.Core.Tests/Utils/CancellationTokenSourcePoolTests.cs
@@ -18,10 +18,10 @@ public class CancellationTokenSourcePoolTests
 
         Assert.Throws<ArgumentOutOfRangeException>(() => pool.Get(TimeSpan.Zero));
         var e = Assert.Throws<ArgumentOutOfRangeException>(() => pool.Get(TimeSpan.FromMilliseconds(-2)));
-        e.Message.Should().StartWith("Invalid delay specified.");
-        e.ActualValue.Should().Be(TimeSpan.FromMilliseconds(-2));
+        e.Message.ShouldStartWith("Invalid delay specified.");
+        e.ActualValue.ShouldBe(TimeSpan.FromMilliseconds(-2));
 
-        pool.Get(System.Threading.Timeout.InfiniteTimeSpan).Should().NotBeNull();
+        pool.Get(System.Threading.Timeout.InfiniteTimeSpan).ShouldNotBeNull();
     }
 
 #pragma warning disable xUnit1042 // The member referenced by the MemberData attribute returns untyped data rows
@@ -39,14 +39,14 @@ public class CancellationTokenSourcePoolTests
 #if NET6_0_OR_GREATER
         if (timeProvider == TimeProvider.System)
         {
-            cts2.Should().BeSameAs(cts);
+            cts2.ShouldBeSameAs(cts);
         }
         else
         {
-            cts2.Should().NotBeSameAs(cts);
+            cts2.ShouldNotBeSameAs(cts);
         }
 #else
-        cts2.Should().NotBeSameAs(cts);
+        cts2.ShouldNotBeSameAs(cts);
 #endif
     }
 
@@ -61,10 +61,11 @@ public class CancellationTokenSourcePoolTests
         cts.Cancel();
         pool.Return(cts);
 
-        cts.Invoking(c => c.Token).Should().Throw<ObjectDisposedException>();
+        Should.Throw<ObjectDisposedException>(() => cts.Token);
 
         var cts2 = pool.Get(System.Threading.Timeout.InfiniteTimeSpan);
-        cts2.Token.Should().NotBeNull();
+
+        Should.NotThrow(() => cts2.Token);
     }
 
 #pragma warning disable xUnit1042 // The member referenced by the MemberData attribute returns untyped data rows
@@ -83,7 +84,7 @@ public class CancellationTokenSourcePoolTests
 
         await Task.Delay(100);
 
-        await TestUtilities.AssertWithTimeoutAsync(() => cts.IsCancellationRequested.Should().BeTrue());
+        await TestUtilities.AssertWithTimeoutAsync(() => cts.IsCancellationRequested.ShouldBeTrue());
     }
 
 #pragma warning disable xUnit1042 // The member referenced by the MemberData attribute returns untyped data rows
@@ -97,7 +98,7 @@ public class CancellationTokenSourcePoolTests
 
         await Task.Delay(20);
 
-        cts.IsCancellationRequested.Should().BeFalse();
+        cts.IsCancellationRequested.ShouldBeFalse();
     }
 
     private static TimeProvider GetTimeProvider(object timeProvider) => (TimeProvider)timeProvider;

--- a/test/Polly.Core.Tests/Utils/DisposeHelperTests.cs
+++ b/test/Polly.Core.Tests/Utils/DisposeHelperTests.cs
@@ -9,7 +9,7 @@ public class DisposeHelperTests
     [InlineData(false)]
     [Theory]
     public void Dispose_Object_Ok(bool synchronous) =>
-        DisposeHelper.TryDisposeSafeAsync(new object(), synchronous).AsTask().IsCompleted.Should().BeTrue();
+        DisposeHelper.TryDisposeSafeAsync(new object(), synchronous).AsTask().IsCompleted.ShouldBeTrue();
 
     [InlineData(true)]
     [InlineData(false)]
@@ -18,7 +18,7 @@ public class DisposeHelperTests
     {
         using var disposable = new DisposableResult();
         await DisposeHelper.TryDisposeSafeAsync(disposable, synchronous);
-        disposable.IsDisposed.Should().BeTrue();
+        disposable.IsDisposed.ShouldBeTrue();
     }
 
     [InlineData(true)]
@@ -34,7 +34,7 @@ public class DisposeHelperTests
 
         await DisposeHelper.TryDisposeSafeAsync(disposable, synchronous);
 
-        disposed.Should().BeTrue();
+        disposed.ShouldBeTrue();
     }
 
     [InlineData(true)]
@@ -45,7 +45,7 @@ public class DisposeHelperTests
         var disposable = Substitute.For<IAsyncDisposable>();
         disposable.When(async v => await v.DisposeAsync()).Do((_) => throw new InvalidOperationException());
 
-        await disposable.Invoking(async _ => await DisposeHelper.TryDisposeSafeAsync(disposable, synchronous)).Should().NotThrowAsync();
+        await Should.NotThrowAsync(async () => await DisposeHelper.TryDisposeSafeAsync(disposable, synchronous));
     }
 
     [InlineData(true)]
@@ -57,8 +57,8 @@ public class DisposeHelperTests
 
         await DisposeHelper.TryDisposeSafeAsync(disposable, synchronous);
 
-        disposable.IsDisposedAsync.Should().Be(!synchronous);
-        disposable.IsDisposed.Should().Be(synchronous);
+        disposable.IsDisposedAsync.ShouldBe(!synchronous);
+        disposable.IsDisposed.ShouldBe(synchronous);
     }
 
     private class MyDisposable : DisposableResult, IAsyncDisposable

--- a/test/Polly.Core.Tests/Utils/ExceptionUtilitiesTests.cs
+++ b/test/Polly.Core.Tests/Utils/ExceptionUtilitiesTests.cs
@@ -11,7 +11,8 @@ public class ExceptionUtilitiesTests
 
         ExceptionUtilities.TrySetStackTrace(exception);
 
-        exception.StackTrace.Should().Contain("ExceptionUtilitiesTests");
+        exception.StackTrace.ShouldNotBeNull();
+        exception.StackTrace.ShouldContain("ExceptionUtilitiesTests");
     }
 
     [Fact]
@@ -26,7 +27,8 @@ public class ExceptionUtilitiesTests
         {
             var oldTrace = e.StackTrace;
             ExceptionUtilities.TrySetStackTrace(e);
-            e.StackTrace.Should().Be(oldTrace);
+            e.StackTrace.ShouldNotBeNull();
+            e.StackTrace.ShouldBe(oldTrace);
         }
     }
 }

--- a/test/Polly.Core.Tests/Utils/LegacySupportTests.cs
+++ b/test/Polly.Core.Tests/Utils/LegacySupportTests.cs
@@ -11,7 +11,7 @@ public class LegacySupportTests
 
         resilienceProperties.SetProperties(newProps, out var oldProperties2);
 
-        resilienceProperties.Options.Should().BeSameAs(newProps);
-        oldProperties2.Should().BeSameAs(oldProps);
+        resilienceProperties.Options.ShouldBeSameAs(newProps);
+        oldProperties2.ShouldBeSameAs(oldProps);
     }
 }

--- a/test/Polly.Core.Tests/Utils/ObjectPoolTests.cs
+++ b/test/Polly.Core.Tests/Utils/ObjectPoolTests.cs
@@ -35,7 +35,7 @@ public class ObjectPoolTests
         var items2 = GetStoreReturn(pool);
 
         // Assert
-        items1.ShouldBeEquivalentTo(items2);
+        items1.ShouldBe(items2);
     }
 
     [Fact]

--- a/test/Polly.Core.Tests/Utils/ObjectPoolTests.cs
+++ b/test/Polly.Core.Tests/Utils/ObjectPoolTests.cs
@@ -22,7 +22,7 @@ public class ObjectPoolTests
 
     [Fact]
     public void MaxCapacity_Ok() =>
-        ObjectPool<object>.MaxCapacity.Should().Be((Environment.ProcessorCount * 2) - 1);
+        ObjectPool<object>.MaxCapacity.ShouldBe((Environment.ProcessorCount * 2) - 1);
 
     [Fact]
     public void MaxCapacity_Respected()
@@ -35,7 +35,7 @@ public class ObjectPoolTests
         var items2 = GetStoreReturn(pool);
 
         // Assert
-        items1.Should().BeEquivalentTo(items2);
+        items1.ShouldBeEquivalentTo(items2);
     }
 
     [Fact]
@@ -50,7 +50,7 @@ public class ObjectPoolTests
         var items2 = GetStoreReturn(pool, count);
 
         // Assert
-        items1[items1.Count - 1].Should().NotBeSameAs(items2[items2.Count - 1]);
+        items1[items1.Count - 1].ShouldNotBeSameAs(items2[items2.Count - 1]);
     }
 
     [Fact]

--- a/test/Polly.Core.Tests/Utils/Pipeline/BridgePipelineComponentTests.cs
+++ b/test/Polly.Core.Tests/Utils/Pipeline/BridgePipelineComponentTests.cs
@@ -8,7 +8,7 @@ public class BridgePipelineComponentTests
 {
     [Fact]
     public void Ctor_Ok() =>
-        new Strategy<string>(args => { }).Should().NotBeNull();
+        new Strategy<string>(args => { }).ShouldNotBeNull();
 
     [Fact]
     public void Execute_NonGeneric_Ok()
@@ -26,10 +26,10 @@ public class BridgePipelineComponentTests
         pipeline.Execute<object?>(args => null, cancellationToken);
         pipeline.Execute(args => true, cancellationToken);
 
-        values[0].Should().Be("dummy");
-        values[1].Should().Be(0);
-        values[2].Should().BeNull();
-        values[3].Should().Be(true);
+        values[0].ShouldBe("dummy");
+        values[1].ShouldBe(0);
+        values[2].ShouldBeNull();
+        values[3].ShouldBe(true);
     }
 
     [Fact]
@@ -44,8 +44,8 @@ public class BridgePipelineComponentTests
 
         pipeline.Execute(args => "dummy");
 
-        values.Should().HaveCount(1);
-        values[0].Should().Be("dummy");
+        values.Count.ShouldBe(1);
+        values[0].ShouldBe("dummy");
     }
 
     [Fact]
@@ -55,13 +55,13 @@ public class BridgePipelineComponentTests
 
         var pipeline = new ResiliencePipeline(PipelineComponentFactory.FromStrategy(new Strategy<object>(outcome =>
         {
-            outcome.Result.Should().Be(-1);
+            outcome.Result.ShouldBe(-1);
             called = true;
         })), DisposeBehavior.Allow, null);
 
         pipeline.Execute(() => -1);
 
-        called.Should().BeTrue();
+        called.ShouldBeTrue();
     }
 
 #pragma warning disable S1944 // Invalid casts should be avoided

--- a/test/Polly.Core.Tests/Utils/Pipeline/ComponentWithDisposeCallbacksTests.cs
+++ b/test/Polly.Core.Tests/Utils/Pipeline/ComponentWithDisposeCallbacksTests.cs
@@ -26,8 +26,8 @@ public class ComponentWithDisposeCallbacksTests
         await component.Received(2).DisposeAsync();
 
         // Assert
-        callbacks.Should().BeEmpty();
-        called1.Should().Be(1);
-        called2.Should().Be(1);
+        callbacks.ShouldBeEmpty();
+        called1.ShouldBe(1);
+        called2.ShouldBe(1);
     }
 }

--- a/test/Polly.Core.Tests/Utils/Pipeline/CompositePipelineComponentTests.cs
+++ b/test/Polly.Core.Tests/Utils/Pipeline/CompositePipelineComponentTests.cs
@@ -31,10 +31,10 @@ public class CompositePipelineComponentTests
 
         for (var i = 0; i < pipelines.Length; i++)
         {
-            pipeline.Components[i].Should().BeSameAs(pipelines[i]);
+            pipeline.Components[i].ShouldBeSameAs(pipelines[i]);
         }
 
-        pipeline.Components.SequenceEqual(pipelines).Should().BeTrue();
+        pipeline.Components.SequenceEqual(pipelines).ShouldBeTrue();
     }
 
     [Fact]
@@ -48,10 +48,8 @@ public class CompositePipelineComponentTests
         };
 
         var pipeline = CreateSut(components);
-        await pipeline
-            .Invoking(p => p.ExecuteCore((_, _) => Outcome.FromResultAsValueTask(10), context, "state").AsTask())
-            .Should()
-            .ThrowAsync<NotSupportedException>();
+        await Should.ThrowAsync<NotSupportedException>(
+            () => pipeline.ExecuteCore((_, _) => Outcome.FromResultAsValueTask(10), context, "state").AsTask());
     }
 
     [Fact]
@@ -69,9 +67,7 @@ public class CompositePipelineComponentTests
 
         CreateSut([PipelineComponent.Empty, pipeline]);
 
-        this.Invoking(_ => CreateSut([PipelineComponent.Empty, pipeline]))
-            .Should()
-            .NotThrow();
+        Should.NotThrow(() => CreateSut([PipelineComponent.Empty, pipeline]));
     }
 
     [Fact]
@@ -90,7 +86,7 @@ public class CompositePipelineComponentTests
         context.CancellationToken = cancellation.Token;
 
         var result = await pipeline.ExecuteOutcomeAsync((_, _) => Outcome.FromResultAsValueTask("result"), context, "state");
-        result.Exception.Should().BeOfType<OperationCanceledException>();
+        result.Exception.ShouldBeOfType<OperationCanceledException>();
     }
 
     [Fact]
@@ -108,8 +104,8 @@ public class CompositePipelineComponentTests
         context.CancellationToken = cancellation.Token;
 
         var result = await pipeline.ExecuteOutcomeAsync((_, _) => Outcome.FromResultAsValueTask("result"), context, "state");
-        result.Exception.Should().BeOfType<OperationCanceledException>();
-        executed.Should().BeTrue();
+        result.Exception.ShouldBeOfType<OperationCanceledException>();
+        executed.ShouldBeTrue();
     }
 
     [Fact]
@@ -120,9 +116,9 @@ public class CompositePipelineComponentTests
         var pipeline = new ResiliencePipeline(CreateSut([Substitute.For<PipelineComponent>()], timeProvider), DisposeBehavior.Allow, null);
         pipeline.Execute(() => { timeProvider.Advance(TimeSpan.FromHours(1)); });
 
-        _listener.Events.Should().HaveCount(2);
-        _listener.GetArgs<PipelineExecutingArguments>().Should().HaveCount(1);
-        _listener.GetArgs<PipelineExecutedArguments>().Should().HaveCount(1);
+        _listener.Events.Count.ShouldBe(2);
+        _listener.GetArgs<PipelineExecutingArguments>().Count().ShouldBe(1);
+        _listener.GetArgs<PipelineExecutedArguments>().Count().ShouldBe(1);
     }
 
     [Fact]

--- a/test/Polly.Core.Tests/Utils/Pipeline/DelegatingComponentTests.cs
+++ b/test/Polly.Core.Tests/Utils/Pipeline/DelegatingComponentTests.cs
@@ -19,8 +19,7 @@ public static class DelegatingComponentTests
             context,
             state);
 
-        actual.Should().NotBeNull();
-        actual.Result.Should().Be(2);
+        actual.Result.ShouldBe(2);
     }
 
 #if NET6_0_OR_GREATER
@@ -39,8 +38,7 @@ public static class DelegatingComponentTests
             context,
             state);
 
-        actual.Should().NotBeNull();
-        actual.Result.Should().Be(2);
+        actual.Result.ShouldBe(2);
     }
 #endif
 

--- a/test/Polly.Core.Tests/Utils/Pipeline/ExecutionTrackingComponentTests.cs
+++ b/test/Polly.Core.Tests/Utils/Pipeline/ExecutionTrackingComponentTests.cs
@@ -28,7 +28,7 @@ public class ExecutionTrackingComponentTests
 
         var disposeTask = component.DisposeAsync().AsTask();
         _timeProvider.Advance(ExecutionTrackingComponent.SleepDelay);
-        inner.Disposed.Should().BeFalse();
+        inner.Disposed.ShouldBeFalse();
         assert.Set();
 
         _timeProvider.Advance(ExecutionTrackingComponent.SleepDelay);
@@ -37,7 +37,7 @@ public class ExecutionTrackingComponentTests
         _timeProvider.Advance(ExecutionTrackingComponent.SleepDelay);
         await disposeTask;
 
-        inner.Disposed.Should().BeTrue();
+        inner.Disposed.ShouldBeTrue();
     }
 
     [Fact]
@@ -59,11 +59,11 @@ public class ExecutionTrackingComponentTests
         var execution = Task.Run(() => new ResiliencePipeline(component, Polly.Utils.DisposeBehavior.Allow, null).Execute(() => { }));
         executing.WaitOne();
 
-        component.HasPendingExecutions.Should().BeTrue();
+        component.HasPendingExecutions.ShouldBeTrue();
         assert.Set();
         await execution;
 
-        component.HasPendingExecutions.Should().BeFalse();
+        component.HasPendingExecutions.ShouldBeFalse();
     }
 
     [Fact]
@@ -86,13 +86,13 @@ public class ExecutionTrackingComponentTests
         executing.WaitOne();
 
         var disposeTask = component.DisposeAsync().AsTask();
-        inner.Disposed.Should().BeFalse();
+        inner.Disposed.ShouldBeFalse();
         _timeProvider.Advance(ExecutionTrackingComponent.Timeout - TimeSpan.FromSeconds(1));
-        inner.Disposed.Should().BeFalse();
+        inner.Disposed.ShouldBeFalse();
         _timeProvider.Advance(TimeSpan.FromSeconds(1));
         _timeProvider.Advance(TimeSpan.FromSeconds(1));
         await disposeTask;
-        inner.Disposed.Should().BeTrue();
+        inner.Disposed.ShouldBeTrue();
 
         assert.Set();
         await execution;
@@ -129,19 +129,19 @@ public class ExecutionTrackingComponentTests
 
         while (tasks.Count > 1)
         {
-            tasks.TryDequeue(out var ev).Should().BeTrue();
+            tasks.TryDequeue(out var ev).ShouldBeTrue();
             ev!.Set();
             ev.Dispose();
-            disposeTask.Wait(1).Should().BeFalse();
-            inner.Disposed.Should().BeFalse();
+            disposeTask.Wait(1).ShouldBeFalse();
+            inner.Disposed.ShouldBeFalse();
         }
 
         // last one
-        tasks.TryDequeue(out var last).Should().BeTrue();
+        tasks.TryDequeue(out var last).ShouldBeTrue();
         last!.Set();
         last.Dispose();
         await disposeTask;
-        inner.Disposed.Should().BeTrue();
+        inner.Disposed.ShouldBeTrue();
     }
 
     private class Inner : PipelineComponent

--- a/test/Polly.Core.Tests/Utils/Pipeline/PipelineComponentFactoryTests.cs
+++ b/test/Polly.Core.Tests/Utils/Pipeline/PipelineComponentFactoryTests.cs
@@ -30,7 +30,7 @@ public class PipelineComponentFactoryTests
     {
         var component = Substitute.For<PipelineComponent>();
         var result = PipelineComponentFactory.WithDisposableCallbacks(component, callbacks);
-        result.Should().BeSameAs(component);
+        result.ShouldBeSameAs(component);
     }
 
     [Theory]
@@ -43,7 +43,7 @@ public class PipelineComponentFactoryTests
 
         var result = PipelineComponentFactory.WithDisposableCallbacks(component, callbacks);
 
-        result.Should().BeOfType<ComponentWithDisposeCallbacks>();
+        result.ShouldBeOfType<ComponentWithDisposeCallbacks>();
     }
 
     private sealed class EmptyActionEnumerable : IEnumerable<Action>, IEnumerator<Action>

--- a/test/Polly.Core.Tests/Utils/Pipeline/PipelineComponentTests.cs
+++ b/test/Polly.Core.Tests/Utils/Pipeline/PipelineComponentTests.cs
@@ -8,7 +8,7 @@ public class PipelineComponentTests
     [Fact]
     public async Task Dispose_Ok()
     {
-        PipelineComponent.Empty.Should().NotBeNull();
+        PipelineComponent.Empty.ShouldNotBeNull();
         await PipelineComponent.Empty.DisposeAsync();
     }
 }

--- a/test/Polly.Core.Tests/Utils/Pipeline/ReloadablePipelineComponentTests.cs
+++ b/test/Polly.Core.Tests/Utils/Pipeline/ReloadablePipelineComponentTests.cs
@@ -24,9 +24,9 @@ public class ReloadablePipelineComponentTests : IDisposable
         var component = Substitute.For<PipelineComponent>();
         await using var sut = CreateSut(component);
 
-        sut.Component.Should().Be(component);
+        sut.Component.ShouldBe(component);
 
-        ReloadableComponent.ReloadFailedEvent.Should().Be("ReloadFailed");
+        ReloadableComponent.ReloadFailedEvent.ShouldBe("ReloadFailed");
     }
 
     [Fact]
@@ -43,12 +43,12 @@ public class ReloadablePipelineComponentTests : IDisposable
         var component = Substitute.For<PipelineComponent>();
         await using var sut = CreateSut(component);
 
-        sut.Component.Should().Be(component);
+        sut.Component.ShouldBe(component);
         _cancellationTokenSource.Cancel();
-        sut.Component.Should().NotBe(component);
+        sut.Component.ShouldNotBe(component);
 
-        _listener.Events.Where(e => e.Event.EventName == "ReloadFailed").Should().HaveCount(0);
-        _listener.Events.Where(e => e.Event.EventName == "OnReload").Should().HaveCount(1);
+        _listener.Events.Count(e => e.Event.EventName == "ReloadFailed").ShouldBe(0);
+        _listener.Events.Count(e => e.Event.EventName == "OnReload").ShouldBe(1);
     }
 
     [Fact]
@@ -76,23 +76,20 @@ public class ReloadablePipelineComponentTests : IDisposable
 
         _cancellationTokenSource.Cancel();
 
-        sut.Component.Should().Be(component);
-        _listener.Events.Should().HaveCount(2);
+        sut.Component.ShouldBe(component);
+        _listener.Events.Count.ShouldBe(2);
 
         _listener.Events[0]
             .Arguments
-            .Should()
-            .BeOfType<ReloadableComponent.OnReloadArguments>();
+            .ShouldBeOfType<ReloadableComponent.OnReloadArguments>();
 
         var args = _listener.Events[1]
             .Arguments
-            .Should()
-            .BeOfType<ReloadableComponent.ReloadFailedArguments>()
-            .Subject;
+            .ShouldBeOfType<ReloadableComponent.ReloadFailedArguments>();
 
-        args.Exception.Should().BeOfType<InvalidOperationException>();
+        args.Exception.ShouldBeOfType<InvalidOperationException>();
 
-        _synchronousFlags.Should().AllSatisfy(f => f.Should().BeTrue());
+        _synchronousFlags.ShouldAllBe(f => f);
     }
 
     [Fact]
@@ -109,24 +106,21 @@ public class ReloadablePipelineComponentTests : IDisposable
 
         _cancellationTokenSource.Cancel();
 
-        _listener.Events.Should().HaveCount(2);
+        _listener.Events.Count.ShouldBe(2);
 
         _listener.Events[0]
             .Arguments
-            .Should()
-            .BeOfType<ReloadableComponent.OnReloadArguments>();
+            .ShouldBeOfType<ReloadableComponent.OnReloadArguments>();
 
         var args = _listener.Events[1]
             .Arguments
-            .Should()
-            .BeOfType<ReloadableComponent.DisposedFailedArguments>()
-            .Subject;
+            .ShouldBeOfType<ReloadableComponent.DisposedFailedArguments>();
 
-        args.Exception.Should().BeOfType<InvalidOperationException>();
+        args.Exception.ShouldBeOfType<InvalidOperationException>();
 
-        _synchronousFlags.Should().HaveCount(2);
-        _synchronousFlags[0].Should().BeTrue();
-        _synchronousFlags[1].Should().BeFalse();
+        _synchronousFlags.Count.ShouldBe(2);
+        _synchronousFlags[0].ShouldBeTrue();
+        _synchronousFlags[1].ShouldBeFalse();
     }
 
     private ReloadableComponent CreateSut(PipelineComponent? initial = null, Func<ReloadableComponent.Entry>? factory = null)

--- a/test/Polly.Core.Tests/Utils/RandomUtilTests.cs
+++ b/test/Polly.Core.Tests/Utils/RandomUtilTests.cs
@@ -12,10 +12,10 @@ public class RandomUtilTests
     {
         var util = new RandomUtil(seed);
 
-        util.Invoking(u => u.NextDouble()).Should().NotThrow();
+        Should.NotThrow(util.NextDouble);
     }
 
     [Fact]
     public void Instance_Ok() =>
-        RandomUtil.Instance.Should().NotBeNull();
+        RandomUtil.Instance.ShouldNotBeNull();
 }

--- a/test/Polly.Core.Tests/Utils/StrategyHelperTests.cs
+++ b/test/Polly.Core.Tests/Utils/StrategyHelperTests.cs
@@ -15,7 +15,7 @@ public static class StrategyHelperTests
             ResilienceContextPool.Shared.Get(token.Token),
             "dummy");
 
-        outcome.Exception.Should().BeOfType<OperationCanceledException>();
+        outcome.Exception.ShouldBeOfType<OperationCanceledException>();
     }
 
     [Theory]
@@ -37,7 +37,7 @@ public static class StrategyHelperTests
                 ResilienceContextPool.Shared.Get(),
                 "dummy");
 
-            outcome.Exception.Should().BeOfType<InvalidOperationException>();
+            outcome.Exception.ShouldBeOfType<InvalidOperationException>();
         });
 
     [Theory]
@@ -59,7 +59,7 @@ public static class StrategyHelperTests
                 ResilienceContextPool.Shared.Get(),
                 "dummy");
 
-            outcomeTask.IsCompleted.Should().Be(!isAsync);
-            (await outcomeTask).Result.Should().Be("success");
+            outcomeTask.IsCompleted.ShouldBe(!isAsync);
+            (await outcomeTask).Result.ShouldBe("success");
         });
 }

--- a/test/Polly.Core.Tests/Utils/TaskHelperTests.cs
+++ b/test/Polly.Core.Tests/Utils/TaskHelperTests.cs
@@ -10,11 +10,11 @@ public class TaskHelperTests
     public void GetResult_ValueTaskT_Ok()
     {
         var result = TaskHelper.GetResult(new ValueTask<int>(42));
-        result.Should().Be(42);
+        result.ShouldBe(42);
 
         result = TaskHelper.GetResult(GetValue());
 
-        result.Should().Be(42);
+        result.ShouldBe(42);
 
         static async ValueTask<int> GetValue()
         {
@@ -28,7 +28,7 @@ public class TaskHelperTests
     {
         TaskHelper.GetResult(default);
 
-        this.Invoking(_ => TaskHelper.GetResult(GetValue())).Should().NotThrow();
+        Should.NotThrow(() => TaskHelper.GetResult(GetValue()));
 
         static async ValueTask<VoidResult> GetValue()
         {

--- a/test/Polly.Core.Tests/Utils/TimeProviderExtensionsTests.cs
+++ b/test/Polly.Core.Tests/Utils/TimeProviderExtensionsTests.cs
@@ -21,7 +21,7 @@ public class TimeProviderExtensionsTests
         await TestUtilities.AssertWithTimeoutAsync(async () =>
         {
             var task = timeProvider.DelayAsync(delay, context);
-            task.IsCompleted.Should().Be(synchronous);
+            task.IsCompleted.ShouldBe(synchronous);
             await task;
         });
     }
@@ -38,7 +38,7 @@ public class TimeProviderExtensionsTests
             var watch = Stopwatch.StartNew();
             await TimeProvider.System.DelayAsync(delay, context);
             var elapsed = watch.Elapsed;
-            elapsed.Should().BeGreaterThanOrEqualTo(delay);
+            elapsed.ShouldBeGreaterThanOrEqualTo(delay);
         });
     }
 
@@ -52,10 +52,8 @@ public class TimeProviderExtensionsTests
 
         await TestUtilities.AssertWithTimeoutAsync(async () =>
         {
-            await TimeProvider.System
-                .Invoking(p => p.DelayAsync(delay, context))
-                .Should()
-                .ThrowAsync<OperationCanceledException>();
+            await Should.ThrowAsync<OperationCanceledException>(
+                () => TimeProvider.System.DelayAsync(delay, context));
         });
     }
 
@@ -107,11 +105,11 @@ public class TimeProviderExtensionsTests
             context.Initialize<VoidResult>(isSynchronous: false);
 
             var delayTask = timeProvider.DelayAsync(delay, context);
-            delayTask.Wait(TimeSpan.FromMilliseconds(10)).Should().BeFalse();
+            delayTask.Wait(TimeSpan.FromMilliseconds(10)).ShouldBeFalse();
 
             cts.Cancel();
 
-            await delayTask.Invoking(t => t).Should().ThrowAsync<OperationCanceledException>();
+            await Should.ThrowAsync<OperationCanceledException>(() => delayTask);
         });
     }
 }

--- a/test/Polly.Core.Tests/Utils/TypeNameFormatterTests.cs
+++ b/test/Polly.Core.Tests/Utils/TypeNameFormatterTests.cs
@@ -5,8 +5,8 @@ public class TypeNameFormatterTests
     [Fact]
     public void AsString_Ok()
     {
-        Polly.Utils.TypeNameFormatter.Format(typeof(string)).Should().Be("String");
-        Polly.Utils.TypeNameFormatter.Format(typeof(List<string>)).Should().Be("List<String>");
-        Polly.Utils.TypeNameFormatter.Format(typeof(KeyValuePair<string, string>)).Should().Be("KeyValuePair`2");
+        Polly.Utils.TypeNameFormatter.Format(typeof(string)).ShouldBe("String");
+        Polly.Utils.TypeNameFormatter.Format(typeof(List<string>)).ShouldBe("List<String>");
+        Polly.Utils.TypeNameFormatter.Format(typeof(KeyValuePair<string, string>)).ShouldBe("KeyValuePair`2");
     }
 }

--- a/test/Polly.Core.Tests/Utils/ValidationHelperTests.cs
+++ b/test/Polly.Core.Tests/Utils/ValidationHelperTests.cs
@@ -9,27 +9,27 @@ public class ValidationHelperTests
     public void GetMemberName_Ok()
     {
         ValidationContext? context = null;
-        context.GetMemberName().Should().BeNull();
+        context.GetMemberName().ShouldBeNull();
 
         context = new ValidationContext(new object());
-        context.GetMemberName().Should().BeNull();
+        context.GetMemberName().ShouldBeNull();
 
         context = new ValidationContext(new object()) { MemberName = "X" };
-        context.GetMemberName().Should().NotBeNull();
-        context.GetMemberName()![0].Should().Be("X");
+        context.GetMemberName().ShouldNotBeNull();
+        context.GetMemberName()![0].ShouldBe("X");
     }
 
     [Fact]
     public void GetDisplayName_Ok()
     {
         ValidationContext? context = null;
-        context.GetDisplayName().Should().Be("");
+        context.GetDisplayName().ShouldBe("");
 
         context = new ValidationContext(new object());
-        context.GetDisplayName().Should().Be("Object");
+        context.GetDisplayName().ShouldBe("Object");
 
         context = new ValidationContext(new object()) { DisplayName = "X" };
-        context.GetDisplayName().Should().Be("X");
+        context.GetDisplayName().ShouldBe("X");
     }
 
     /// <summary>
@@ -41,7 +41,7 @@ public class ValidationHelperTests
         var detector = new ConcurrencyDetector();
         Parallel.For(0, 2, _ => ValidationHelper.ValidateObject(new(new TestOptions(detector), string.Empty)));
 
-        detector.InvokedConcurrently.Should().BeFalse();
+        detector.InvokedConcurrently.ShouldBeFalse();
     }
 
     private sealed class TestOptions(ConcurrencyDetector detector) : IValidatableObject

--- a/test/Polly.Extensions.Tests/DependencyInjection/PollyServiceCollectionExtensionTests.cs
+++ b/test/Polly.Extensions.Tests/DependencyInjection/PollyServiceCollectionExtensionTests.cs
@@ -58,10 +58,10 @@ public class PollyServiceCollectionExtensionTests
 
         var serviceProvider = _services.BuildServiceProvider();
 
-        serviceProvider.GetServices<ResiliencePipelineBuilder>().Should().NotBeNull();
-        serviceProvider.GetServices<ResiliencePipelineRegistry<string>>().Should().NotBeNull();
-        serviceProvider.GetServices<ResiliencePipelineProvider<string>>().Should().NotBeNull();
-        serviceProvider.GetServices<ResiliencePipelineBuilder>().Should().NotBeSameAs(serviceProvider.GetServices<ResiliencePipelineBuilder>());
+        serviceProvider.GetServices<ResiliencePipelineBuilder>().ShouldNotBeNull();
+        serviceProvider.GetServices<ResiliencePipelineRegistry<string>>().ShouldNotBeNull();
+        serviceProvider.GetServices<ResiliencePipelineProvider<string>>().ShouldNotBeNull();
+        serviceProvider.GetServices<ResiliencePipelineBuilder>().ShouldNotBeSameAs(serviceProvider.GetServices<ResiliencePipelineBuilder>());
     }
 
     [Fact]
@@ -77,13 +77,13 @@ public class PollyServiceCollectionExtensionTests
 
         var serviceProvider = _services.BuildServiceProvider();
 
-        serviceProvider.GetRequiredService<ResiliencePipelineRegistry<string>>().GetPipeline(Key).Should().NotBeNull();
-        serviceProvider.GetRequiredService<ResiliencePipelineRegistry<string>>().GetPipeline<string>(Key).Should().NotBeNull();
-        serviceProvider.GetRequiredService<ResiliencePipelineRegistry<string>>().GetPipeline<int>(Key).Should().NotBeNull();
+        serviceProvider.GetRequiredService<ResiliencePipelineRegistry<string>>().GetPipeline(Key).ShouldNotBeNull();
+        serviceProvider.GetRequiredService<ResiliencePipelineRegistry<string>>().GetPipeline<string>(Key).ShouldNotBeNull();
+        serviceProvider.GetRequiredService<ResiliencePipelineRegistry<string>>().GetPipeline<int>(Key).ShouldNotBeNull();
 
-        serviceProvider.GetRequiredService<ResiliencePipelineRegistry<int>>().GetPipeline(10).Should().NotBeNull();
-        serviceProvider.GetRequiredService<ResiliencePipelineRegistry<int>>().GetPipeline<string>(10).Should().NotBeNull();
-        serviceProvider.GetRequiredService<ResiliencePipelineRegistry<int>>().GetPipeline<int>(10).Should().NotBeNull();
+        serviceProvider.GetRequiredService<ResiliencePipelineRegistry<int>>().GetPipeline(10).ShouldNotBeNull();
+        serviceProvider.GetRequiredService<ResiliencePipelineRegistry<int>>().GetPipeline<string>(10).ShouldNotBeNull();
+        serviceProvider.GetRequiredService<ResiliencePipelineRegistry<int>>().GetPipeline<int>(10).ShouldNotBeNull();
     }
 
     [InlineData(true)]
@@ -97,11 +97,11 @@ public class PollyServiceCollectionExtensionTests
         {
             _services.AddResiliencePipeline<string, string>(Key, (builder, context) =>
             {
-                context.RegistryContext.Should().NotBeNull();
-                context.PipelineKey.Should().Be(Key);
-                builder.Name.Should().Be(Key);
-                builder.Should().NotBeNull();
-                context.ServiceProvider.Should().NotBeNull();
+                context.RegistryContext.ShouldNotBeNull();
+                context.PipelineKey.ShouldBe(Key);
+                builder.Name.ShouldBe(Key);
+                builder.ShouldNotBeNull();
+                context.ServiceProvider.ShouldNotBeNull();
                 builder.AddStrategy(new TestStrategy());
                 asserted = true;
             });
@@ -112,9 +112,9 @@ public class PollyServiceCollectionExtensionTests
         {
             _services.AddResiliencePipeline(Key, (builder, context) =>
             {
-                context.PipelineKey.Should().Be(Key);
-                builder.Should().NotBeNull();
-                context.ServiceProvider.Should().NotBeNull();
+                context.PipelineKey.ShouldBe(Key);
+                builder.ShouldNotBeNull();
+                context.ServiceProvider.ShouldNotBeNull();
                 builder.AddStrategy(new TestStrategy());
                 asserted = true;
             });
@@ -122,7 +122,7 @@ public class PollyServiceCollectionExtensionTests
             CreateProvider().GetPipeline(Key);
         }
 
-        asserted.Should().BeTrue();
+        asserted.ShouldBeTrue();
     }
 
     [InlineData(true)]
@@ -148,17 +148,17 @@ public class PollyServiceCollectionExtensionTests
         CreateProvider().GetPipeline(Key);
 
         var diagSource = telemetry!.GetType().GetProperty("Listener", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(telemetry);
-        diagSource.Should().BeOfType<TelemetryListenerImpl>();
+        diagSource.ShouldBeOfType<TelemetryListenerImpl>();
 
         var factory = _services.BuildServiceProvider().GetRequiredService<IOptions<TelemetryOptions>>().Value.LoggerFactory;
 
         if (hasLogging)
         {
-            factory.Should().NotBe(NullLoggerFactory.Instance);
+            factory.ShouldNotBe(NullLoggerFactory.Instance);
         }
         else
         {
-            factory.Should().Be(NullLoggerFactory.Instance);
+            factory.ShouldBe(NullLoggerFactory.Instance);
         }
     }
 
@@ -172,7 +172,7 @@ public class PollyServiceCollectionExtensionTests
 
         CreateProvider().GetPipeline(Key);
 
-        asserted.Should().BeTrue();
+        asserted.ShouldBeTrue();
     }
 
     [Fact]
@@ -183,7 +183,7 @@ public class PollyServiceCollectionExtensionTests
 
         AddResiliencePipeline(Key);
 
-        _services.Count.Should().Be(count + 1);
+        _services.Count.ShouldBe(count + 1);
     }
 
     [Fact]
@@ -194,7 +194,7 @@ public class PollyServiceCollectionExtensionTests
         var provider = CreateProvider();
 
         var pipeline = provider.GetPipeline(Key);
-        provider.GetPipeline("my-pipeline").Should().BeSameAs(provider.GetPipeline("my-pipeline"));
+        provider.GetPipeline("my-pipeline").ShouldBeSameAs(provider.GetPipeline("my-pipeline"));
     }
 
     [Fact]
@@ -205,9 +205,9 @@ public class PollyServiceCollectionExtensionTests
         var provider = _services.BuildServiceProvider();
 
         var pipeline = provider.GetKeyedService<ResiliencePipeline>(Key);
-        provider.GetKeyedService<ResiliencePipeline>(Key).Should().BeSameAs(pipeline);
+        provider.GetKeyedService<ResiliencePipeline>(Key).ShouldBeSameAs(pipeline);
 
-        pipeline.Should().NotBeNull();
+        pipeline.ShouldNotBeNull();
     }
 
     [Fact]
@@ -218,9 +218,9 @@ public class PollyServiceCollectionExtensionTests
         var provider = _services.BuildServiceProvider();
 
         var pipeline = provider.GetKeyedService<ResiliencePipeline<string>>(Key);
-        provider.GetKeyedService<ResiliencePipeline<string>>(Key).Should().BeSameAs(pipeline);
+        provider.GetKeyedService<ResiliencePipeline<string>>(Key).ShouldBeSameAs(pipeline);
 
-        pipeline.Should().NotBeNull();
+        pipeline.ShouldNotBeNull();
     }
 
     [Fact]
@@ -232,7 +232,7 @@ public class PollyServiceCollectionExtensionTests
 
         var provider = _services.BuildServiceProvider();
 
-        provider.GetKeyedService<ResiliencePipeline>(Key).Should().BeSameAs(pipeline);
+        provider.GetKeyedService<ResiliencePipeline>(Key).ShouldBeSameAs(pipeline);
     }
 
     [Fact]
@@ -244,7 +244,7 @@ public class PollyServiceCollectionExtensionTests
 
         var provider = _services.BuildServiceProvider();
 
-        provider.GetKeyedService<ResiliencePipeline<string>>(Key).Should().BeSameAs(pipeline);
+        provider.GetKeyedService<ResiliencePipeline<string>>(Key).ShouldBeSameAs(pipeline);
     }
 
     [InlineData(true)]
@@ -268,8 +268,8 @@ public class PollyServiceCollectionExtensionTests
             CreateProvider().GetPipeline(Key);
         }
 
-        firstCalled.Should().BeTrue();
-        secondCalled.Should().BeFalse();
+        firstCalled.ShouldBeTrue();
+        secondCalled.ShouldBeFalse();
     }
 
     [Fact]
@@ -298,8 +298,8 @@ public class PollyServiceCollectionExtensionTests
                 };
             })
             .Distinct()
-            .Should()
-            .HaveCount(30);
+            .Count()
+            .ShouldBe(30);
     }
 
     [InlineData(true)]
@@ -319,18 +319,18 @@ public class PollyServiceCollectionExtensionTests
         {
             if (timeProviderRegistered)
             {
-                builder.TimeProvider.Should().Be(timeProvider);
+                builder.TimeProvider.ShouldBe(timeProvider);
             }
             else
             {
-                builder.TimeProvider.Should().BeNull();
+                builder.TimeProvider.ShouldBeNull();
             }
 
             asserted = true;
         });
 
         CreateProvider().GetPipeline("dummy");
-        asserted.Should().BeTrue();
+        asserted.ShouldBeTrue();
     }
 
     [Fact]
@@ -338,9 +338,9 @@ public class PollyServiceCollectionExtensionTests
     {
         var provider = new ServiceCollection().AddResiliencePipelineRegistry<string>().BuildServiceProvider();
 
-        provider.GetRequiredService<ResiliencePipelineRegistry<string>>().Should().NotBeNull();
-        provider.GetRequiredService<ResiliencePipelineProvider<string>>().Should().NotBeNull();
-        provider.GetRequiredService<ResiliencePipelineBuilder>().TelemetryListener.Should().NotBeNull();
+        provider.GetRequiredService<ResiliencePipelineRegistry<string>>().ShouldNotBeNull();
+        provider.GetRequiredService<ResiliencePipelineProvider<string>>().ShouldNotBeNull();
+        provider.GetRequiredService<ResiliencePipelineBuilder>().TelemetryListener.ShouldNotBeNull();
     }
 
     [Fact]
@@ -350,9 +350,9 @@ public class PollyServiceCollectionExtensionTests
 
         var provider = new ServiceCollection().AddResiliencePipelineRegistry<string>(options => options.InstanceNameFormatter = formatter).BuildServiceProvider();
 
-        provider.GetRequiredService<ResiliencePipelineRegistry<string>>().Should().NotBeNull();
-        provider.GetRequiredService<ResiliencePipelineProvider<string>>().Should().NotBeNull();
-        provider.GetRequiredService<IOptions<ResiliencePipelineRegistryOptions<string>>>().Value.InstanceNameFormatter.Should().Be(formatter);
+        provider.GetRequiredService<ResiliencePipelineRegistry<string>>().ShouldNotBeNull();
+        provider.GetRequiredService<ResiliencePipelineProvider<string>>().ShouldNotBeNull();
+        provider.GetRequiredService<IOptions<ResiliencePipelineRegistryOptions<string>>>().Value.InstanceNameFormatter.ShouldBe(formatter);
     }
 
     [InlineData(true)]
@@ -383,17 +383,17 @@ public class PollyServiceCollectionExtensionTests
         // assert
         foreach (var ev in listener.Events)
         {
-            ev.Source.PipelineInstanceName.Should().Be("my-instance");
-            ev.Source.PipelineName.Should().Be("my-pipeline");
+            ev.Source.PipelineInstanceName.ShouldBe("my-instance");
+            ev.Source.PipelineName.ShouldBe("my-pipeline");
         }
 
         var record = loggerFactory.FakeLogger.GetRecords(new EventId(0, "ResilienceEvent")).First();
 
-        record.Message.Should().Contain("my-pipeline/my-instance");
+        record.Message.ShouldContain("my-pipeline/my-instance");
 
         static void ConfigureBuilder(ResiliencePipelineBuilder builder)
         {
-            builder.Name.Should().Be("my-pipeline");
+            builder.Name.ShouldBe("my-pipeline");
             builder.InstanceName = "my-instance";
             builder.AddRetry(new()
             {
@@ -436,8 +436,8 @@ public class PollyServiceCollectionExtensionTests
                 };
             })
             .Distinct()
-            .Should()
-            .HaveCount(30);
+            .Count()
+            .ShouldBe(30);
     }
 
     [Fact]
@@ -459,13 +459,13 @@ public class PollyServiceCollectionExtensionTests
 
         var serviceProvider = _services.BuildServiceProvider();
 
-        serviceProvider.GetRequiredService<ResiliencePipelineRegistry<string>>().GetPipeline(Key).Should().NotBeNull();
-        serviceProvider.GetRequiredService<ResiliencePipelineRegistry<string>>().GetPipeline<string>(Key).Should().NotBeNull();
-        serviceProvider.GetRequiredService<ResiliencePipelineRegistry<string>>().GetPipeline<int>(Key).Should().NotBeNull();
+        serviceProvider.GetRequiredService<ResiliencePipelineRegistry<string>>().GetPipeline(Key).ShouldNotBeNull();
+        serviceProvider.GetRequiredService<ResiliencePipelineRegistry<string>>().GetPipeline<string>(Key).ShouldNotBeNull();
+        serviceProvider.GetRequiredService<ResiliencePipelineRegistry<string>>().GetPipeline<int>(Key).ShouldNotBeNull();
 
-        serviceProvider.GetRequiredService<ResiliencePipelineRegistry<int>>().GetPipeline(10).Should().NotBeNull();
-        serviceProvider.GetRequiredService<ResiliencePipelineRegistry<int>>().GetPipeline<string>(10).Should().NotBeNull();
-        serviceProvider.GetRequiredService<ResiliencePipelineRegistry<int>>().GetPipeline<int>(10).Should().NotBeNull();
+        serviceProvider.GetRequiredService<ResiliencePipelineRegistry<int>>().GetPipeline(10).ShouldNotBeNull();
+        serviceProvider.GetRequiredService<ResiliencePipelineRegistry<int>>().GetPipeline<string>(10).ShouldNotBeNull();
+        serviceProvider.GetRequiredService<ResiliencePipelineRegistry<int>>().GetPipeline<int>(10).ShouldNotBeNull();
     }
 
     private void AddResiliencePipeline(string key, Action<StrategyBuilderContext>? onBuilding = null) =>

--- a/test/Polly.Extensions.Tests/DisposablePipelineTests.cs
+++ b/test/Polly.Extensions.Tests/DisposablePipelineTests.cs
@@ -32,15 +32,15 @@ public class DisposablePipelineTests
             })
             .BuildServiceProvider();
 
-        limiters.Should().HaveCount(0);
+        limiters.Count.ShouldBe(0);
         provider.GetRequiredService<ResiliencePipelineProvider<string>>().GetPipeline("my-pipeline");
         provider.GetRequiredService<ResiliencePipelineProvider<string>>().GetPipeline("my-pipeline");
-        limiters.Should().HaveCount(1);
-        IsDisposed(limiters[0]).Should().BeFalse();
+        limiters.Count.ShouldBe(1);
+        IsDisposed(limiters[0]).ShouldBeFalse();
 
         provider.Dispose();
-        limiters.Should().HaveCount(1);
-        IsDisposed(limiters[0]).Should().BeTrue();
+        limiters.Count.ShouldBe(1);
+        IsDisposed(limiters[0]).ShouldBeTrue();
     }
 
     [Fact]
@@ -57,15 +57,15 @@ public class DisposablePipelineTests
 
         pipeline3.Execute(() => string.Empty);
         await registry2.DisposeAsync();
-        pipeline3.Invoking(p => p.Execute(() => string.Empty)).Should().Throw<ObjectDisposedException>();
+        Should.Throw<ObjectDisposedException>(() => pipeline3.Execute(() => string.Empty));
 
         pipeline1.Execute(() => { });
         pipeline2.Execute(() => string.Empty);
 
         await registry1.DisposeAsync();
 
-        pipeline1.Invoking(p => p.Execute(() => { })).Should().Throw<ObjectDisposedException>();
-        pipeline2.Invoking(p => p.Execute(() => string.Empty)).Should().Throw<ObjectDisposedException>();
+        Should.Throw<ObjectDisposedException>(() => pipeline1.Execute(() => { }));
+        Should.Throw<ObjectDisposedException>(() => pipeline2.Execute(() => string.Empty));
     }
 
     private static bool IsDisposed(RateLimiter limiter)

--- a/test/Polly.Extensions.Tests/Issues/IssuesTests.DynamicContextPool_1687.cs
+++ b/test/Polly.Extensions.Tests/Issues/IssuesTests.DynamicContextPool_1687.cs
@@ -28,7 +28,7 @@ public partial class IssuesTests
             ResilienceContext context,
             TState state)
         {
-            context.ContinueOnCapturedContext.Should().BeTrue();
+            context.ContinueOnCapturedContext.ShouldBeTrue();
 
             HitCount++;
 
@@ -51,7 +51,7 @@ public partial class IssuesTests
 
         services.AddResiliencePipeline(key, builder =>
         {
-            builder.ContextPool.Should().Be(pool);
+            builder.ContextPool.ShouldBe(pool);
             builder.AddStrategy(strategy);
         });
 
@@ -62,6 +62,6 @@ public partial class IssuesTests
 
         await pipeline.ExecuteAsync(async ct => await default(ValueTask));
 
-        strategy.HitCount.Should().BeGreaterThan(0);
+        strategy.HitCount.ShouldBeGreaterThan(0);
     }
 }

--- a/test/Polly.Extensions.Tests/Issues/IssuesTests.OnCircuitBreakWithServiceProvider_796.cs
+++ b/test/Polly.Extensions.Tests/Issues/IssuesTests.OnCircuitBreakWithServiceProvider_796.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
 using Polly.CircuitBreaker;
-using Polly.DependencyInjection;
 using Polly.Registry;
 
 namespace Polly.Extensions.Tests.Issues;
@@ -25,7 +24,7 @@ public partial class IssuesTests
                     MinimumThroughput = 10,
                     OnOpened = async args =>
                     {
-                        args.Context.Properties.GetValue(ServiceProviderKey, null!).Should().NotBeNull();
+                        args.Context.Properties.GetValue(ServiceProviderKey, null!).ShouldNotBeNull();
                         contextChecked = true;
 
                         // do asynchronous call
@@ -50,10 +49,10 @@ public partial class IssuesTests
         }
 
         // now the circuit breaker should be open
-        await pipeline.Invoking(s => s.ExecuteAsync(_ => new ValueTask<string>("valid-result")).AsTask()).Should().ThrowAsync<BrokenCircuitException>();
+        await Should.ThrowAsync<BrokenCircuitException>(() => pipeline.ExecuteAsync(_ => new ValueTask<string>("valid-result")).AsTask());
 
         // check that service provider was received in the context
-        contextChecked.Should().BeTrue();
+        contextChecked.ShouldBeTrue();
     }
 
     private class ServiceProviderStrategy : ResilienceStrategy

--- a/test/Polly.Extensions.Tests/Issues/IssuesTests.OverrideLibraryStrategies_1072.cs
+++ b/test/Polly.Extensions.Tests/Issues/IssuesTests.OverrideLibraryStrategies_1072.cs
@@ -40,13 +40,12 @@ public partial class IssuesTests
         if (overrideStrategy)
         {
             // The library now also handles SocketException.
-            api.Invoking(a => a.ExecuteLibrary(UnstableCall)).Should().NotThrow();
-
+            Should.NotThrow(() => api.ExecuteLibrary(UnstableCall));
         }
         else
         {
             // Originally, the library pipeline only handled InvalidOperationException.
-            api.Invoking(a => a.ExecuteLibrary(UnstableCall)).Should().Throw<SocketException>();
+            Should.Throw<SocketException>(() => api.ExecuteLibrary(UnstableCall));
         }
 
         void UnstableCall()
@@ -74,11 +73,9 @@ public partial class IssuesTests
         }));
     }
 
-    public class LibraryApi
+    public class LibraryApi(ResiliencePipelineProvider<string> provider)
     {
-        private readonly ResiliencePipeline _pipeline;
-
-        public LibraryApi(ResiliencePipelineProvider<string> provider) => _pipeline = provider.GetPipeline("library-pipeline");
+        private readonly ResiliencePipeline _pipeline = provider.GetPipeline("library-pipeline");
 
         public void ExecuteLibrary(Action execute) => _pipeline.Execute(execute);
     }

--- a/test/Polly.Extensions.Tests/Issues/IssuesTests.OverrideLoggerFactory_1783.cs
+++ b/test/Polly.Extensions.Tests/Issues/IssuesTests.OverrideLoggerFactory_1783.cs
@@ -30,7 +30,7 @@ public partial class IssuesTests
 
         provider.GetPipeline("dummy").Execute(() => { });
 
-        loggerFactory1.FakeLogger.GetRecords().Should().BeEmpty();
-        loggerFactory2.FakeLogger.GetRecords().Should().NotBeEmpty();
+        loggerFactory1.FakeLogger.GetRecords().ShouldBeEmpty();
+        loggerFactory2.FakeLogger.GetRecords().ShouldNotBeEmpty();
     }
 }

--- a/test/Polly.Extensions.Tests/Issues/IssuesTests.PartitionedRateLimiter_1365.cs
+++ b/test/Polly.Extensions.Tests/Issues/IssuesTests.PartitionedRateLimiter_1365.cs
@@ -51,7 +51,7 @@ public partial class IssuesTests
         // assert admin is not limited
         using var adminAsserted = new ManualResetEvent(false);
         var task = ExecuteBatch("admin", adminAsserted);
-        task.Wait(100).Should().BeFalse();
+        task.Wait(100).ShouldBeFalse();
         adminAsserted.Set();
         await task;
 

--- a/test/Polly.Extensions.Tests/Issues/IssuesTests.StrategiesPerEndpoint_1365.cs
+++ b/test/Polly.Extensions.Tests/Issues/IssuesTests.StrategiesPerEndpoint_1365.cs
@@ -92,14 +92,14 @@ public partial class IssuesTests
         var pipeline1 = provider.GetPipeline(resource1Key);
         var pipeline2 = provider.GetPipeline(resource2Key);
 
-        pipeline1.Should().NotBe(pipeline2);
-        provider.GetPipeline(resource1Key).Should().BeSameAs(pipeline1);
-        provider.GetPipeline(resource2Key).Should().BeSameAs(pipeline2);
+        pipeline1.ShouldNotBe(pipeline2);
+        provider.GetPipeline(resource1Key).ShouldBeSameAs(pipeline1);
+        provider.GetPipeline(resource2Key).ShouldBeSameAs(pipeline2);
 
         pipeline1.Execute(() => { });
-        events.Should().HaveCount(5);
-        events[0].Tags["pipeline.name"].Should().Be("endpoint-pipeline");
-        events[0].Tags["pipeline.instance"].Should().Be("Endpoint 1/Resource 1");
+        events.Count.ShouldBe(5);
+        events[0].Tags["pipeline.name"].ShouldBe("endpoint-pipeline");
+        events[0].Tags["pipeline.instance"].ShouldBe("Endpoint 1/Resource 1");
     }
 
     public class EndpointOptions

--- a/test/Polly.Extensions.Tests/Polly.Extensions.Tests.csproj
+++ b/test/Polly.Extensions.Tests/Polly.Extensions.Tests.csproj
@@ -14,10 +14,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Using Include="FluentAssertions" />
     <Using Include="Polly.TestUtils" />
     <ProjectReference Include="..\..\src\Polly.Extensions\Polly.Extensions.csproj" />
     <ProjectReference Include="..\..\src\Polly.RateLimiting\Polly.RateLimiting.csproj" />
     <ProjectReference Include="..\Polly.TestUtils\Polly.TestUtils.csproj" />
+    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
   </ItemGroup>

--- a/test/Polly.Extensions.Tests/Polly.Extensions.Tests.csproj
+++ b/test/Polly.Extensions.Tests/Polly.Extensions.Tests.csproj
@@ -14,13 +14,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Using Include="FluentAssertions" />
     <Using Include="Polly.TestUtils" />
+    <Using Include="Shouldly" />
     <ProjectReference Include="..\..\src\Polly.Extensions\Polly.Extensions.csproj" />
     <ProjectReference Include="..\..\src\Polly.RateLimiting\Polly.RateLimiting.csproj" />
     <ProjectReference Include="..\Polly.TestUtils\Polly.TestUtils.csproj" />
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+    <PackageReference Include="Shouldly" />
+    <Reference Include="System.Net.Http" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
   </ItemGroup>
 </Project>

--- a/test/Polly.Extensions.Tests/Registry/ConfigureBuilderContextExtensionsTEsts.cs
+++ b/test/Polly.Extensions.Tests/Registry/ConfigureBuilderContextExtensionsTEsts.cs
@@ -24,10 +24,8 @@ public class ConfigureBuilderContextExtensionsTests
 
         await registry.DisposeAsync();
 
-        listener.Events.Should().BeEmpty();
+        listener.Events.ShouldBeEmpty();
     }
 
-    public class Options
-    {
-    }
+    public class Options;
 }

--- a/test/Polly.Extensions.Tests/ReloadableResiliencePipelineTests.cs
+++ b/test/Polly.Extensions.Tests/ReloadableResiliencePipelineTests.cs
@@ -44,8 +44,8 @@ public class ReloadableResiliencePipelineTests
             builder.InstanceName = "my-instance";
 
             var options = context.GetOptions<ReloadableStrategyOptions>(name);
-            options.Should().NotBeNull();
-            options.OptionsName.Should().Be(name);
+            options.ShouldNotBeNull();
+            options.OptionsName.ShouldBe(name);
 
             context.EnableReloads<ReloadableStrategyOptions>(name);
 
@@ -64,18 +64,18 @@ public class ReloadableResiliencePipelineTests
 
         // initial
         pipeline.Execute(_ => "dummy", context);
-        context.Properties.GetValue(TagKey, string.Empty).Should().Be("initial-tag");
+        context.Properties.GetValue(TagKey, string.Empty).ShouldBe("initial-tag");
 
         // reloads
         for (int i = 0; i < 10; i++)
         {
             reloadableConfig.Reload(new() { { "tag", $"reload-{i}" } });
             pipeline.Execute(_ => "dummy", context);
-            context.Properties.GetValue(TagKey, string.Empty).Should().Be($"reload-{i}");
+            context.Properties.GetValue(TagKey, string.Empty).ShouldBe($"reload-{i}");
         }
 
         // check resource disposed
-        resList.Should().HaveCount(11);
+        resList.Count.ShouldBe(11);
         for (int i = 0; i < resList.Count - 1; i++)
         {
             resList[i].Received(1).Dispose();
@@ -86,12 +86,12 @@ public class ReloadableResiliencePipelineTests
         // check disposal of service provider
         serviceProvider.Dispose();
         resList[resList.Count - 1].Received(1).Dispose();
-        pipeline.Invoking(p => p.Execute(() => { })).Should().Throw<ObjectDisposedException>();
+        Should.Throw<ObjectDisposedException>(() => pipeline.Execute(() => { }));
 
         foreach (var ev in fakeListener.Events)
         {
-            ev.Source.PipelineName.Should().Be("my-pipeline");
-            ev.Source.PipelineInstanceName.Should().Be("my-instance");
+            ev.Source.PipelineName.ShouldBe("my-pipeline");
+            ev.Source.PipelineInstanceName.ShouldBe("my-instance");
         }
     }
 

--- a/test/Polly.Extensions.Tests/Telemetry/TagsListTests.cs
+++ b/test/Polly.Extensions.Tests/Telemetry/TagsListTests.cs
@@ -13,6 +13,6 @@ public class TagsListTests
 
             TagsList.Return(context);
 
-            TagsList.Get().Should().BeSameAs(context);
+            TagsList.Get().ShouldBeSameAs(context);
         });
 }

--- a/test/Polly.Extensions.Tests/Telemetry/TelemetryListenerImplTests.cs
+++ b/test/Polly.Extensions.Tests/Telemetry/TelemetryListenerImplTests.cs
@@ -22,16 +22,16 @@ public class TelemetryListenerImplTests : IDisposable
     [Fact]
     public void Meter_Ok()
     {
-        TelemetryListenerImpl.Meter.Name.Should().Be("Polly");
-        TelemetryListenerImpl.Meter.Version.Should().Be("1.0");
+        TelemetryListenerImpl.Meter.Name.ShouldBe("Polly");
+        TelemetryListenerImpl.Meter.Version.ShouldBe("1.0");
         var source = new TelemetryListenerImpl(new TelemetryOptions());
 
-        source.Counter.Description.Should().Be("Tracks the number of resilience events that occurred in resilience strategies.");
-        source.AttemptDuration.Description.Should().Be("Tracks the duration of execution attempts.");
-        source.AttemptDuration.Unit.Should().Be("ms");
+        source.Counter.Description.ShouldBe("Tracks the number of resilience events that occurred in resilience strategies.");
+        source.AttemptDuration.Description.ShouldBe("Tracks the duration of execution attempts.");
+        source.AttemptDuration.Unit.ShouldBe("ms");
 
-        source.ExecutionDuration.Description.Should().Be("The execution duration of resilience pipelines.");
-        source.ExecutionDuration.Unit.Should().Be("ms");
+        source.ExecutionDuration.Description.ShouldBe("The execution duration of resilience pipelines.");
+        source.ExecutionDuration.Unit.ShouldBe("ms");
     }
 
     [InlineData(true)]
@@ -44,15 +44,15 @@ public class TelemetryListenerImplTests : IDisposable
         ReportEvent(telemetry, noOutcome ? null : Outcome.FromResult<object>(response));
 
         var messages = _logger.GetRecords(new EventId(0, "ResilienceEvent")).ToList();
-        messages.Should().HaveCount(1);
+        messages.Count.ShouldBe(1);
 
         if (noOutcome)
         {
-            messages[0].Message.Should().Be("Resilience event occurred. EventName: 'my-event', Source: 'my-pipeline/my-instance/my-strategy', Operation Key: 'op-key', Result: ''");
+            messages[0].Message.ShouldBe("Resilience event occurred. EventName: 'my-event', Source: 'my-pipeline/my-instance/my-strategy', Operation Key: 'op-key', Result: ''");
         }
         else
         {
-            messages[0].Message.Should().Be("Resilience event occurred. EventName: 'my-event', Source: 'my-pipeline/my-instance/my-strategy', Operation Key: 'op-key', Result: '200'");
+            messages[0].Message.ShouldBe("Resilience event occurred. EventName: 'my-event', Source: 'my-pipeline/my-instance/my-strategy', Operation Key: 'op-key', Result: '200'");
         }
     }
 
@@ -66,20 +66,20 @@ public class TelemetryListenerImplTests : IDisposable
 
         var messages = _logger.GetRecords(new EventId(0, "ResilienceEvent")).ToList();
 
-        messages.Should().HaveCount(1);
+        messages.Count.ShouldBe(1);
 
         if (!noOutcome)
         {
-            messages[0].Exception.Should().NotBeNull();
+            messages[0].Exception.ShouldNotBeNull();
         }
 
         if (noOutcome)
         {
-            messages[0].Message.Should().Be("Resilience event occurred. EventName: 'my-event', Source: 'my-pipeline/my-instance/my-strategy', Operation Key: 'op-key', Result: ''");
+            messages[0].Message.ShouldBe("Resilience event occurred. EventName: 'my-event', Source: 'my-pipeline/my-instance/my-strategy', Operation Key: 'op-key', Result: ''");
         }
         else
         {
-            messages[0].Message.Should().Be("Resilience event occurred. EventName: 'my-event', Source: 'my-pipeline/my-instance/my-strategy', Operation Key: 'op-key', Result: 'Dummy message.'");
+            messages[0].Message.ShouldBe("Resilience event occurred. EventName: 'my-event', Source: 'my-pipeline/my-instance/my-strategy', Operation Key: 'op-key', Result: 'Dummy message.'");
         }
     }
 
@@ -91,7 +91,7 @@ public class TelemetryListenerImplTests : IDisposable
 
         var messages = _logger.GetRecords(new EventId(0, "ResilienceEvent")).ToList();
 
-        messages[0].Message.Should().Be("Resilience event occurred. EventName: 'my-event', Source: 'my-pipeline/(null)/my-strategy', Operation Key: 'op-key', Result: ''");
+        messages[0].Message.ShouldBe("Resilience event occurred. EventName: 'my-event', Source: 'my-pipeline/(null)/my-strategy', Operation Key: 'op-key', Result: ''");
     }
 
     [InlineData(ResilienceEventSeverity.Error, LogLevel.Error)]
@@ -111,11 +111,11 @@ public class TelemetryListenerImplTests : IDisposable
 
         var messages = _logger.GetRecords(new EventId(0, "ResilienceEvent")).ToList();
 
-        messages[0].LogLevel.Should().Be(logLevel);
+        messages[0].LogLevel.ShouldBe(logLevel);
 
         var events = GetEvents("resilience.polly.strategy.events");
-        events.Should().HaveCount(1);
-        var ev = events[0]["event.severity"].Should().Be(severity.ToString());
+        events.Count.ShouldBe(1);
+        events[0]["event.severity"].ShouldBe(severity.ToString());
     }
 
     [Fact]
@@ -126,9 +126,9 @@ public class TelemetryListenerImplTests : IDisposable
         ReportEvent(telemetry, Outcome.FromException<object>(new InvalidOperationException("Dummy message.")), arg: new ExecutionAttemptArguments(4, TimeSpan.FromMilliseconds(123), true));
 
         var messages = _logger.GetRecords(new EventId(3, "ExecutionAttempt")).ToList();
-        messages.Should().HaveCount(1);
+        messages.Count.ShouldBe(1);
 
-        messages[0].Message.Should().Be("Execution attempt. Source: 'my-pipeline/my-instance/my-strategy', Operation Key: 'op-key', Result: 'Dummy message.', Handled: 'True', Attempt: '4', Execution Time: 123ms");
+        messages[0].Message.ShouldBe("Execution attempt. Source: 'my-pipeline/my-instance/my-strategy', Operation Key: 'op-key', Result: 'Dummy message.', Handled: 'True', Attempt: '4', Execution Time: 123ms");
     }
 
     [InlineData(true, true)]
@@ -143,19 +143,19 @@ public class TelemetryListenerImplTests : IDisposable
         ReportEvent(telemetry, noOutcome ? null : Outcome.FromResult<object>(response), arg: new ExecutionAttemptArguments(4, TimeSpan.FromMilliseconds(123), handled));
 
         var messages = _logger.GetRecords(new EventId(3, "ExecutionAttempt")).ToList();
-        messages.Should().HaveCount(1);
+        messages.Count.ShouldBe(1);
 
         if (noOutcome)
         {
             string resultString = string.Empty;
-            messages[0].Message.Should().Be($"Execution attempt. Source: 'my-pipeline/my-instance/my-strategy', Operation Key: 'op-key', Result: '{resultString}', Handled: '{handled}', Attempt: '4', Execution Time: 123ms");
+            messages[0].Message.ShouldBe($"Execution attempt. Source: 'my-pipeline/my-instance/my-strategy', Operation Key: 'op-key', Result: '{resultString}', Handled: '{handled}', Attempt: '4', Execution Time: 123ms");
         }
         else
         {
-            messages[0].Message.Should().Be($"Execution attempt. Source: 'my-pipeline/my-instance/my-strategy', Operation Key: 'op-key', Result: '200', Handled: '{handled}', Attempt: '4', Execution Time: 123ms");
+            messages[0].Message.ShouldBe($"Execution attempt. Source: 'my-pipeline/my-instance/my-strategy', Operation Key: 'op-key', Result: '200', Handled: '{handled}', Attempt: '4', Execution Time: 123ms");
         }
 
-        messages[0].LogLevel.Should().Be(LogLevel.Warning);
+        messages[0].LogLevel.ShouldBe(LogLevel.Warning);
     }
 
     [Fact]
@@ -167,7 +167,7 @@ public class TelemetryListenerImplTests : IDisposable
         ReportEvent(telemetry, null, arg: new ExecutionAttemptArguments(4, TimeSpan.FromMilliseconds(123), true));
 
         var messages = _logger.GetRecords(new EventId(3, "ExecutionAttempt")).ToList();
-        messages.Should().HaveCount(0);
+        messages.ShouldBeEmpty();
     }
 
     [InlineData(true, false)]
@@ -188,32 +188,32 @@ public class TelemetryListenerImplTests : IDisposable
         ReportEvent(telemetry, outcome, context: ResilienceContextPool.Shared.Get("op-key").WithResultType<bool>());
 
         var events = GetEvents("resilience.polly.strategy.events");
-        events.Should().HaveCount(1);
+        events.Count.ShouldBe(1);
         var ev = events[0];
 
         if (noOutcome && exception)
         {
-            ev.Count.Should().Be(7);
+            ev.Count.ShouldBe(7);
         }
         else
         {
-            ev.Count.Should().Be(6);
+            ev.Count.ShouldBe(6);
         }
 
-        ev["event.name"].Should().Be("my-event");
-        ev["event.severity"].Should().Be("Warning");
-        ev["pipeline.name"].Should().Be("my-pipeline");
-        ev["pipeline.instance"].Should().Be("my-instance");
-        ev["operation.key"].Should().Be("op-key");
-        ev["strategy.name"].Should().Be("my-strategy");
+        ev["event.name"].ShouldBe("my-event");
+        ev["event.severity"].ShouldBe("Warning");
+        ev["pipeline.name"].ShouldBe("my-pipeline");
+        ev["pipeline.instance"].ShouldBe("my-instance");
+        ev["operation.key"].ShouldBe("op-key");
+        ev["strategy.name"].ShouldBe("my-strategy");
 
         if (outcome?.Exception is not null)
         {
-            ev["exception.type"].Should().Be("System.InvalidOperationException");
+            ev["exception.type"].ShouldBe("System.InvalidOperationException");
         }
         else
         {
-            ev.Should().NotContainKey("exception.type");
+            ev.ShouldNotContainKey("exception.type");
         }
     }
 
@@ -236,37 +236,37 @@ public class TelemetryListenerImplTests : IDisposable
         ReportEvent(telemetry, outcome, context: ResilienceContextPool.Shared.Get("op-key").WithResultType<bool>(), arg: attemptArg);
 
         var events = GetEvents("resilience.polly.strategy.attempt.duration");
-        events.Should().HaveCount(1);
+        events.Count.ShouldBe(1);
         var ev = events[0];
 
         if (noOutcome && exception)
         {
-            ev.Count.Should().Be(9);
+            ev.Count.ShouldBe(9);
         }
         else
         {
-            ev.Count.Should().Be(8);
+            ev.Count.ShouldBe(8);
         }
 
-        ev["event.name"].Should().Be("my-event");
-        ev["event.severity"].Should().Be("Warning");
-        ev["pipeline.name"].Should().Be("my-pipeline");
-        ev["pipeline.instance"].Should().Be("my-instance");
-        ev["operation.key"].Should().Be("op-key");
-        ev["pipeline.name"].Should().Be("my-pipeline");
-        ev["attempt.number"].Should().Be(5);
-        ev["attempt.handled"].Should().Be(true);
+        ev["event.name"].ShouldBe("my-event");
+        ev["event.severity"].ShouldBe("Warning");
+        ev["pipeline.name"].ShouldBe("my-pipeline");
+        ev["pipeline.instance"].ShouldBe("my-instance");
+        ev["operation.key"].ShouldBe("op-key");
+        ev["pipeline.name"].ShouldBe("my-pipeline");
+        ev["attempt.number"].ShouldBe(5);
+        ev["attempt.handled"].ShouldBe(true);
 
         if (outcome?.Exception is not null)
         {
-            ev["exception.type"].Should().Be("System.InvalidOperationException");
+            ev["exception.type"].ShouldBe("System.InvalidOperationException");
         }
         else
         {
-            ev.Should().NotContainKey("exception.type");
+            ev.ShouldNotContainKey("exception.type");
         }
 
-        _events.Single(v => v.Name == "resilience.polly.strategy.attempt.duration").Measurement.Should().Be(50000);
+        _events.Single(v => v.Name == "resilience.polly.strategy.attempt.duration").Measurement.ShouldBe(50000);
     }
 
     [Fact]
@@ -279,7 +279,7 @@ public class TelemetryListenerImplTests : IDisposable
         ReportEvent(telemetry, Outcome.FromResult<object>(true), context: ResilienceContextPool.Shared.Get("op-key").WithResultType<bool>(), arg: attemptArg);
 
         var events = GetEvents("resilience.polly.strategy.attempt.duration");
-        events.Should().HaveCount(0);
+        events.ShouldBeEmpty();
     }
 
     [InlineData(1)]
@@ -311,12 +311,12 @@ public class TelemetryListenerImplTests : IDisposable
 
         var events = GetEvents("resilience.polly.strategy.events");
         var ev = events[0];
-        ev.Count.Should().Be(DefaultDimensions + count + 1);
-        ev["other"].Should().Be("other-value");
+        ev.Count.ShouldBe(DefaultDimensions + count + 1);
+        ev["other"].ShouldBe("other-value");
 
         for (int i = 0; i < count; i++)
         {
-            ev[$"custom-{i}"].Should().Be($"custom-{i}-value");
+            ev[$"custom-{i}"].ShouldBe($"custom-{i}-value");
         }
     }
 
@@ -326,7 +326,7 @@ public class TelemetryListenerImplTests : IDisposable
         using var metering = TestUtilities.EnablePollyMetering(_events);
         var telemetry = Create();
         ReportEvent(telemetry, null, instanceName: null);
-        var events = GetEvents("resilience.polly.strategy.events")[0].Should().NotContainKey("pipeline.instance");
+        GetEvents("resilience.polly.strategy.events")[0].ShouldNotContainKey("pipeline.instance");
     }
 
     [InlineData(true)]
@@ -344,7 +344,7 @@ public class TelemetryListenerImplTests : IDisposable
         var telemetry = Create();
         ReportEvent(telemetry, null, instanceName: null);
 
-        called.Should().Be(hasCallback);
+        called.ShouldBe(hasCallback);
     }
 
     [InlineData(true)]
@@ -361,12 +361,12 @@ public class TelemetryListenerImplTests : IDisposable
         ReportEvent(telemetry, outcome: outcome, arg: new PipelineExecutedArguments(TimeSpan.FromSeconds(10)), context: context);
 
         var messages = _logger.GetRecords(new EventId(1, "StrategyExecuting")).ToList();
-        messages.Should().HaveCount(1);
-        messages[0].Message.Should().Be("Resilience pipeline executing. Source: 'my-pipeline/my-instance', Operation Key: 'op-key'");
+        messages.Count.ShouldBe(1);
+        messages[0].Message.ShouldBe("Resilience pipeline executing. Source: 'my-pipeline/my-instance', Operation Key: 'op-key'");
         messages = _logger.GetRecords(new EventId(2, "StrategyExecuted")).ToList();
-        messages.Should().HaveCount(1);
-        messages[0].Message.Should().Match($"Resilience pipeline executed. Source: 'my-pipeline/my-instance', Operation Key: 'op-key', Result: '{result}', Execution Time: 10000ms");
-        messages[0].LogLevel.Should().Be(LogLevel.Debug);
+        messages.Count.ShouldBe(1);
+        messages[0].Message.ShouldMatch($"Resilience pipeline executed. Source: 'my-pipeline/my-instance', Operation Key: 'op-key', Result: '{result}', Execution Time: 10000ms");
+        messages[0].LogLevel.ShouldBe(LogLevel.Debug);
     }
 
     [Fact]
@@ -377,8 +377,8 @@ public class TelemetryListenerImplTests : IDisposable
         ReportEvent(telemetry, outcome: null, arg: default(PipelineExecutingArguments), context: context);
 
         var messages = _logger.GetRecords(new EventId(1, "StrategyExecuting")).ToList();
-        messages.Should().HaveCount(1);
-        messages[0].Message.Should().Be("Resilience pipeline executing. Source: 'my-pipeline/my-instance', Operation Key: 'op-key'");
+        messages.Count.ShouldBe(1);
+        messages[0].Message.ShouldBe("Resilience pipeline executing. Source: 'my-pipeline/my-instance', Operation Key: 'op-key'");
     }
 
     [Fact]
@@ -390,7 +390,7 @@ public class TelemetryListenerImplTests : IDisposable
         ReportEvent(telemetry, outcome: null, arg: new PipelineExecutedArguments(TimeSpan.FromSeconds(10)), context: context);
 
         var messages = _logger.GetRecords(new EventId(2, "StrategyExecuted")).ToList();
-        messages[0].Message.Should().Match($"Resilience pipeline executed. Source: 'my-pipeline/my-instance', Operation Key: 'op-key', Result: '', Execution Time: 10000ms");
+        messages[0].Message.ShouldMatch($"Resilience pipeline executed. Source: 'my-pipeline/my-instance', Operation Key: 'op-key', Result: '', Execution Time: 10000ms");
     }
 
     [InlineData(false)]
@@ -410,7 +410,7 @@ public class TelemetryListenerImplTests : IDisposable
             {
                 if (exception)
                 {
-                    context.TelemetryEvent.Outcome!.Value.Exception.Should().BeOfType<InvalidOperationException>();
+                    context.TelemetryEvent.Outcome!.Value.Exception.ShouldBeOfType<InvalidOperationException>();
                 }
 
                 context.Tags.Add(new("custom-tag", "custom-tag-value"));
@@ -421,22 +421,22 @@ public class TelemetryListenerImplTests : IDisposable
 
         var ev = _events.Single(v => v.Name == "resilience.polly.pipeline.duration").Tags;
 
-        ev.Count.Should().Be(exception ? 8 : 7);
-        ev["pipeline.instance"].Should().Be("my-instance");
-        ev["operation.key"].Should().Be("op-key");
-        ev["pipeline.name"].Should().Be("my-pipeline");
-        ev["event.name"].Should().Be("my-event");
-        ev["event.severity"].Should().Be("Warning");
-        ev["pipeline.name"].Should().Be("my-pipeline");
-        ev["custom-tag"].Should().Be("custom-tag-value");
+        ev.Count.ShouldBe(exception ? 8 : 7);
+        ev["pipeline.instance"].ShouldBe("my-instance");
+        ev["operation.key"].ShouldBe("op-key");
+        ev["pipeline.name"].ShouldBe("my-pipeline");
+        ev["event.name"].ShouldBe("my-event");
+        ev["event.severity"].ShouldBe("Warning");
+        ev["pipeline.name"].ShouldBe("my-pipeline");
+        ev["custom-tag"].ShouldBe("custom-tag-value");
 
         if (exception)
         {
-            ev["exception.type"].Should().Be("System.InvalidOperationException");
+            ev["exception.type"].ShouldBe("System.InvalidOperationException");
         }
         else
         {
-            ev.Should().NotContainKey("exception.type");
+            ev.ShouldNotContainKey("exception.type");
         }
     }
 
@@ -450,7 +450,7 @@ public class TelemetryListenerImplTests : IDisposable
         ReportEvent(telemetry, Outcome.FromResult<object>(true), context: ResilienceContextPool.Shared.Get("op-key").WithResultType<bool>(), arg: attemptArg);
 
         var events = GetEvents("resilience.polly.pipeline.duration");
-        events.Should().HaveCount(0);
+        events.ShouldBeEmpty();
     }
 
     [Fact]
@@ -462,7 +462,7 @@ public class TelemetryListenerImplTests : IDisposable
 
         var records = _logger.GetRecords();
 
-        records.Single().LogLevel.Should().Be(LogLevel.Critical);
+        records.Single().LogLevel.ShouldBe(LogLevel.Critical);
     }
 
     [Fact]
@@ -473,9 +473,9 @@ public class TelemetryListenerImplTests : IDisposable
         {
             options.SeverityProvider = args =>
             {
-                args.Event.Severity.Should().Be(ResilienceEventSeverity.Warning);
-                args.Source.Should().NotBeNull();
-                args.Context.Should().NotBeNull();
+                args.Event.Severity.ShouldBe(ResilienceEventSeverity.Warning);
+                args.Source.ShouldNotBeNull();
+                args.Context.ShouldNotBeNull();
                 called = true;
                 return ResilienceEventSeverity.Critical;
             };
@@ -485,8 +485,8 @@ public class TelemetryListenerImplTests : IDisposable
 
         var records = _logger.GetRecords();
 
-        records.Single().LogLevel.Should().Be(LogLevel.Critical);
-        called.Should().BeTrue();
+        records.Single().LogLevel.ShouldBe(LogLevel.Critical);
+        called.ShouldBeTrue();
     }
 
     private List<Dictionary<string, object?>> GetEvents(string eventName) => _events.Where(e => e.Name == eventName).Select(v => v.Tags).ToList();

--- a/test/Polly.Extensions.Tests/Telemetry/TelemetryOptionsTests.cs
+++ b/test/Polly.Extensions.Tests/Telemetry/TelemetryOptionsTests.cs
@@ -14,14 +14,14 @@ public class TelemetryOptionsTests
     {
         var options = new TelemetryOptions();
 
-        options.MeteringEnrichers.Should().BeEmpty();
-        options.LoggerFactory.Should().Be(NullLoggerFactory.Instance);
+        options.MeteringEnrichers.ShouldBeEmpty();
+        options.LoggerFactory.ShouldBe(NullLoggerFactory.Instance);
         var resilienceContext = ResilienceContextPool.Shared.Get();
-        options.ResultFormatter(resilienceContext, null).Should().BeNull();
-        options.ResultFormatter(resilienceContext, "dummy").Should().Be("dummy");
+        options.ResultFormatter(resilienceContext, null).ShouldBeNull();
+        options.ResultFormatter(resilienceContext, "dummy").ShouldBe("dummy");
 
         using var response = new HttpResponseMessage(HttpStatusCode.OK);
-        options.ResultFormatter(resilienceContext, response).Should().Be(200);
+        options.ResultFormatter(resilienceContext, response).ShouldBe(200);
     }
 
     [Fact]
@@ -39,19 +39,19 @@ public class TelemetryOptionsTests
 
         var other = new TelemetryOptions(options);
 
-        other.ResultFormatter.Should().Be(options.ResultFormatter);
-        other.LoggerFactory.Should().Be(options.LoggerFactory);
-        other.SeverityProvider.Should().Be(options.SeverityProvider);
-        other.MeteringEnrichers.Should().BeEquivalentTo(options.MeteringEnrichers);
-        other.TelemetryListeners.Should().BeEquivalentTo(options.TelemetryListeners);
-        other.TelemetryListeners.Should().NotBeSameAs(options.TelemetryListeners);
-        other.MeteringEnrichers.Should().NotBeSameAs(options.MeteringEnrichers);
+        other.ResultFormatter.ShouldBe(options.ResultFormatter);
+        other.LoggerFactory.ShouldBe(options.LoggerFactory);
+        other.SeverityProvider.ShouldBe(options.SeverityProvider);
+        other.MeteringEnrichers.ShouldBeEquivalentTo(options.MeteringEnrichers);
+        other.TelemetryListeners.ShouldBeEquivalentTo(options.TelemetryListeners);
+        other.TelemetryListeners.ShouldNotBeSameAs(options.TelemetryListeners);
+        other.MeteringEnrichers.ShouldNotBeSameAs(options.MeteringEnrichers);
 
-        typeof(TelemetryOptions).GetRuntimeProperties().Should().HaveCount(5);
+        typeof(TelemetryOptions).GetRuntimeProperties().Count().ShouldBe(5);
     }
 
     [Fact]
     public void CopyCtor_Reminder()
-        => typeof(TelemetryOptions).GetRuntimeProperties().Should()
-        .HaveCount(5, "Make sure that when you increase this number, you also update the copy constructor to assign the new property.");
+        => typeof(TelemetryOptions).GetRuntimeProperties().Count()
+        .ShouldBe(5, "Make sure that when you increase this number, you also update the copy constructor to assign the new property.");
 }

--- a/test/Polly.Extensions.Tests/Telemetry/TelemetryResiliencePipelineBuilderExtensionsTests.cs
+++ b/test/Polly.Extensions.Tests/Telemetry/TelemetryResiliencePipelineBuilderExtensionsTests.cs
@@ -12,8 +12,8 @@ public class TelemetryResiliencePipelineBuilderExtensionsTests
     public void ConfigureTelemetry_EnsureDiagnosticSourceUpdated()
     {
         _builder.ConfigureTelemetry(NullLoggerFactory.Instance);
-        _builder.TelemetryListener.Should().BeOfType<TelemetryListenerImpl>();
-        _builder.AddStrategy(new TestResilienceStrategy()).Build().Should().NotBeOfType<TestResilienceStrategy>();
+        _builder.TelemetryListener.ShouldBeOfType<TelemetryListenerImpl>();
+        _builder.AddStrategy(new TestResilienceStrategy()).Build().ShouldNotBeOfType<TestResilienceStrategy>();
     }
 
     [Fact]
@@ -24,22 +24,23 @@ public class TelemetryResiliencePipelineBuilderExtensionsTests
         _builder.ConfigureTelemetry(factory);
         _builder.AddStrategy(new TestResilienceStrategy()).Build().Execute(_ => { });
 
-        fakeLogger.GetRecords().Should().NotBeEmpty();
-        fakeLogger.GetRecords().Should().HaveCount(2);
+        fakeLogger.GetRecords().ShouldNotBeEmpty();
+        fakeLogger.GetRecords().Count().ShouldBe(2);
     }
 
     [Fact]
-    public void ConfigureTelemetry_InvalidOptions_Throws() =>
-        _builder
-            .Invoking(b => b.ConfigureTelemetry(new TelemetryOptions
+    public void ConfigureTelemetry_InvalidOptions_Throws()
+    {
+        var exception = Should.Throw<ValidationException>(() =>
+            _builder.ConfigureTelemetry(new TelemetryOptions
             {
                 LoggerFactory = null!,
-            })).Should()
-            .Throw<ValidationException>()
-            .WithMessage("""
+            }));
+        exception.Message.Trim().ShouldBe("""
             The 'TelemetryOptions' are invalid.
-
             Validation Errors:
             The LoggerFactory field is required.
-            """);
+            """,
+            StringCompareShould.IgnoreLineEndings);
+    }
 }

--- a/test/Polly.Extensions.Tests/Utils/TelemetryUtilTests.cs
+++ b/test/Polly.Extensions.Tests/Utils/TelemetryUtilTests.cs
@@ -7,8 +7,8 @@ public class TelemetryUtilTests
     [Fact]
     public void AsBoxedPool_Ok()
     {
-        TelemetryUtil.AsBoxedBool(true).Should().Be(true);
-        TelemetryUtil.AsBoxedBool(false).Should().Be(false);
+        TelemetryUtil.AsBoxedBool(true).ShouldBe(true);
+        TelemetryUtil.AsBoxedBool(false).ShouldBe(false);
     }
 
     [Fact]
@@ -18,18 +18,18 @@ public class TelemetryUtilTests
 
         for (int i = 0; i < 100; i++)
         {
-            i.AsBoxedInt().Should().BeSameAs(i.AsBoxedInt());
-            i.AsBoxedInt().Should().Be(i);
+            i.AsBoxedInt().ShouldBeSameAs(i.AsBoxedInt());
+            i.AsBoxedInt().ShouldBe(i);
         }
 
-        (-1).AsBoxedInt().Should().NotBeSameAs((-1).AsBoxedInt());
-        100.AsBoxedInt().Should().NotBeSameAs(100.AsBoxedInt());
+        (-1).AsBoxedInt().ShouldNotBeSameAs((-1).AsBoxedInt());
+        100.AsBoxedInt().ShouldNotBeSameAs(100.AsBoxedInt());
     }
 
     [Fact]
     public void GetValueOrPlaceholder_Ok()
     {
-        TelemetryUtil.GetValueOrPlaceholder("dummy").Should().Be("dummy");
-        TelemetryUtil.GetValueOrPlaceholder(null).Should().Be("(null)");
+        TelemetryUtil.GetValueOrPlaceholder("dummy").ShouldBe("dummy");
+        TelemetryUtil.GetValueOrPlaceholder(null).ShouldBe("(null)");
     }
 }

--- a/test/Polly.RateLimiting.Tests/OnRateLimiterRejectedArgumentsTests.cs
+++ b/test/Polly.RateLimiting.Tests/OnRateLimiterRejectedArgumentsTests.cs
@@ -12,7 +12,7 @@ public static class OnRateLimiterRejectedArgumentsTests
             ResilienceContextPool.Shared.Get(CancellationToken.None),
             Substitute.For<RateLimitLease>());
 
-        args.Context.Should().NotBeNull();
-        args.Lease.Should().NotBeNull();
+        args.Context.ShouldNotBeNull();
+        args.Lease.ShouldNotBeNull();
     }
 }

--- a/test/Polly.RateLimiting.Tests/Polly.RateLimiting.Tests.csproj
+++ b/test/Polly.RateLimiting.Tests/Polly.RateLimiting.Tests.csproj
@@ -16,9 +16,9 @@
     <ProjectReference Include="..\..\src\Polly.RateLimiting\Polly.RateLimiting.csproj" />
     <ProjectReference Include="..\..\src\Polly.Testing\Polly.Testing.csproj" />
     <ProjectReference Include="..\Polly.TestUtils\Polly.TestUtils.csproj" />
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Shouldly" />
   </ItemGroup>
   <ItemGroup>
-    <Using Include="FluentAssertions" />
+    <Using Include="Shouldly" />
   </ItemGroup>
 </Project>

--- a/test/Polly.RateLimiting.Tests/Polly.RateLimiting.Tests.csproj
+++ b/test/Polly.RateLimiting.Tests/Polly.RateLimiting.Tests.csproj
@@ -16,5 +16,9 @@
     <ProjectReference Include="..\..\src\Polly.RateLimiting\Polly.RateLimiting.csproj" />
     <ProjectReference Include="..\..\src\Polly.Testing\Polly.Testing.csproj" />
     <ProjectReference Include="..\Polly.TestUtils\Polly.TestUtils.csproj" />
+    <PackageReference Include="FluentAssertions" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="FluentAssertions" />
   </ItemGroup>
 </Project>

--- a/test/Polly.RateLimiting.Tests/RateLimiterConstantsTests.cs
+++ b/test/Polly.RateLimiting.Tests/RateLimiterConstantsTests.cs
@@ -4,5 +4,5 @@ public class RateLimiterConstantsTests
 {
     [Fact]
     public void Ctor_EnsureDefaults() =>
-        RateLimiterConstants.OnRateLimiterRejectedEvent.Should().Be("OnRateLimiterRejected");
+        RateLimiterConstants.OnRateLimiterRejectedEvent.ShouldBe("OnRateLimiterRejected");
 }

--- a/test/Polly.RateLimiting.Tests/RateLimiterRejectedExceptionTests.cs
+++ b/test/Polly.RateLimiting.Tests/RateLimiterRejectedExceptionTests.cs
@@ -11,60 +11,60 @@ public class RateLimiterRejectedExceptionTests
     public void Ctor_Ok()
     {
         var exception = new RateLimiterRejectedException();
-        exception.InnerException.Should().BeNull();
-        exception.Message.Should().Be("The operation could not be executed because it was rejected by the rate limiter.");
-        exception.RetryAfter.Should().BeNull();
-        exception.TelemetrySource.Should().BeNull();
+        exception.InnerException.ShouldBeNull();
+        exception.Message.ShouldBe("The operation could not be executed because it was rejected by the rate limiter.");
+        exception.RetryAfter.ShouldBeNull();
+        exception.TelemetrySource.ShouldBeNull();
     }
 
     [Fact]
     public void Ctor_RetryAfter_Ok()
     {
         var exception = new RateLimiterRejectedException(_retryAfter);
-        exception.InnerException.Should().BeNull();
-        exception.Message.Should().Be($"The operation could not be executed because it was rejected by the rate limiter. It can be retried after '00:00:04'.");
-        exception.RetryAfter.Should().Be(_retryAfter);
-        exception.TelemetrySource.Should().BeNull();
+        exception.InnerException.ShouldBeNull();
+        exception.Message.ShouldBe($"The operation could not be executed because it was rejected by the rate limiter. It can be retried after '00:00:04'.");
+        exception.RetryAfter.ShouldBe(_retryAfter);
+        exception.TelemetrySource.ShouldBeNull();
     }
 
     [Fact]
     public void Ctor_Message_Ok()
     {
         var exception = new RateLimiterRejectedException(_message);
-        exception.InnerException.Should().BeNull();
-        exception.Message.Should().Be(_message);
-        exception.RetryAfter.Should().BeNull();
-        exception.TelemetrySource.Should().BeNull();
+        exception.InnerException.ShouldBeNull();
+        exception.Message.ShouldBe(_message);
+        exception.RetryAfter.ShouldBeNull();
+        exception.TelemetrySource.ShouldBeNull();
     }
 
     [Fact]
     public void Ctor_Message_RetryAfter_Ok()
     {
         var exception = new RateLimiterRejectedException(_message, _retryAfter);
-        exception.InnerException.Should().BeNull();
-        exception.Message.Should().Be(_message);
-        exception.RetryAfter.Should().Be(_retryAfter);
-        exception.TelemetrySource.Should().BeNull();
+        exception.InnerException.ShouldBeNull();
+        exception.Message.ShouldBe(_message);
+        exception.RetryAfter.ShouldBe(_retryAfter);
+        exception.TelemetrySource.ShouldBeNull();
     }
 
     [Fact]
     public void Ctor_Message_InnerException_Ok()
     {
         var exception = new RateLimiterRejectedException(_message, new InvalidOperationException());
-        exception.InnerException.Should().BeOfType<InvalidOperationException>();
-        exception.Message.Should().Be(_message);
-        exception.RetryAfter.Should().BeNull();
-        exception.TelemetrySource.Should().BeNull();
+        exception.InnerException.ShouldBeOfType<InvalidOperationException>();
+        exception.Message.ShouldBe(_message);
+        exception.RetryAfter.ShouldBeNull();
+        exception.TelemetrySource.ShouldBeNull();
     }
 
     [Fact]
     public void Ctor_Message_RetryAfter_InnerException_Ok()
     {
         var exception = new RateLimiterRejectedException(_message, _retryAfter, new InvalidOperationException());
-        exception.InnerException.Should().BeOfType<InvalidOperationException>();
-        exception.Message.Should().Be(_message);
-        exception.RetryAfter.Should().Be(_retryAfter);
-        exception.TelemetrySource.Should().BeNull();
+        exception.InnerException.ShouldBeOfType<InvalidOperationException>();
+        exception.Message.ShouldBe(_message);
+        exception.RetryAfter.ShouldBe(_retryAfter);
+        exception.TelemetrySource.ShouldBeNull();
     }
 
 #if NETFRAMEWORK
@@ -73,10 +73,10 @@ public class RateLimiterRejectedExceptionTests
     {
         var timeout = TimeSpan.FromSeconds(4);
         var result = SerializeAndDeserializeException(new RateLimiterRejectedException(timeout));
-        result.RetryAfter.Should().Be(timeout);
+        result.RetryAfter.ShouldBe(timeout);
 
         result = SerializeAndDeserializeException(new RateLimiterRejectedException());
-        result.RetryAfter.Should().BeNull();
+        result.RetryAfter.ShouldBeNull();
     }
 
     public static T SerializeAndDeserializeException<T>(T exception)

--- a/test/Polly.RateLimiting.Tests/RateLimiterResiliencePipelineBuilderExtensionsTests.cs
+++ b/test/Polly.RateLimiting.Tests/RateLimiterResiliencePipelineBuilderExtensionsTests.cs
@@ -15,7 +15,7 @@ public class RateLimiterResiliencePipelineBuilderExtensionsTests
         builder =>
         {
             builder.AddConcurrencyLimiter(2, 2);
-            AssertRateLimiterStrategy(builder, strategy => strategy.Wrapper!.Limiter.Should().BeOfType<ConcurrencyLimiter>());
+            AssertRateLimiterStrategy(builder, strategy => strategy.Wrapper!.Limiter.ShouldBeOfType<ConcurrencyLimiter>());
         },
         builder =>
         {
@@ -26,20 +26,20 @@ public class RateLimiterResiliencePipelineBuilderExtensionsTests
                     QueueLimit = 2
                 });
 
-            AssertRateLimiterStrategy(builder, strategy => strategy.Wrapper!.Limiter.Should().BeOfType<ConcurrencyLimiter>());
+            AssertRateLimiterStrategy(builder, strategy => strategy.Wrapper!.Limiter.ShouldBeOfType<ConcurrencyLimiter>());
         },
         builder =>
         {
             var expected = Substitute.For<RateLimiter>();
             builder.AddRateLimiter(expected);
-            AssertRateLimiterStrategy(builder, strategy => strategy.Wrapper.Should().BeNull());
+            AssertRateLimiterStrategy(builder, strategy => strategy.Wrapper.ShouldBeNull());
         },
         builder =>
         {
             var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions { PermitLimit = 1 });
             builder.AddRateLimiter(limiter);
             builder.Build().Execute(() => { });
-            AssertRateLimiterStrategy(builder, strategy => strategy.Wrapper.Should().BeNull());
+            AssertRateLimiterStrategy(builder, strategy => strategy.Wrapper.ShouldBeNull());
         }
     };
 #pragma warning restore IDE0028
@@ -54,7 +54,7 @@ public class RateLimiterResiliencePipelineBuilderExtensionsTests
 
         configure(builder);
 
-        builder.Build().Should().BeOfType<RateLimiterResilienceStrategy>();
+        builder.Build().ShouldBeOfType<RateLimiterResilienceStrategy>();
     }
 
     [Fact]
@@ -100,33 +100,38 @@ public class RateLimiterResiliencePipelineBuilderExtensionsTests
             .GetPipelineDescriptor()
             .FirstStrategy
             .StrategyInstance
-            .Should()
-            .BeOfType<RateLimiterResilienceStrategy>();
+            .ShouldBeOfType<RateLimiterResilienceStrategy>();
     }
 
     [Fact]
-    public void AddRateLimiter_InvalidOptions_Throws() =>
-        new ResiliencePipelineBuilder().Invoking(b => b.AddRateLimiter(new RateLimiterStrategyOptions { DefaultRateLimiterOptions = null! }))
-            .Should()
-            .Throw<ValidationException>()
-            .WithMessage("""
-            The 'RateLimiterStrategyOptions' are invalid.
+    public void AddRateLimiter_InvalidOptions_Throws()
+    {
+        var options = new RateLimiterStrategyOptions { DefaultRateLimiterOptions = null! };
+        var builder = new ResiliencePipelineBuilder();
 
+        var exception = Should.Throw<ValidationException>(() => builder.AddRateLimiter(options));
+        exception.Message.Trim().ShouldBe("""
+            The 'RateLimiterStrategyOptions' are invalid.
             Validation Errors:
             The DefaultRateLimiterOptions field is required.
-            """);
+            """,
+            StringCompareShould.IgnoreLineEndings);
+    }
 
     [Fact]
-    public void AddGenericRateLimiter_InvalidOptions_Throws() =>
-        new ResiliencePipelineBuilder<int>().Invoking(b => b.AddRateLimiter(new RateLimiterStrategyOptions { DefaultRateLimiterOptions = null! }))
-            .Should()
-            .Throw<ValidationException>()
-            .WithMessage("""
-            The 'RateLimiterStrategyOptions' are invalid.
+    public void AddGenericRateLimiter_InvalidOptions_Throws()
+    {
+        var options = new RateLimiterStrategyOptions { DefaultRateLimiterOptions = null! };
+        var builder = new ResiliencePipelineBuilder<int>();
 
+        var exception = Should.Throw<ValidationException>(() => builder.AddRateLimiter(options));
+        exception.Message.Trim().ShouldBe("""
+            The 'RateLimiterStrategyOptions' are invalid.
             Validation Errors:
             The DefaultRateLimiterOptions field is required.
-            """);
+            """,
+            StringCompareShould.IgnoreLineEndings);
+    }
 
     [Fact]
     public void AddRateLimiter_Options_Ok()
@@ -140,8 +145,7 @@ public class RateLimiterResiliencePipelineBuilderExtensionsTests
             .GetPipelineDescriptor()
             .FirstStrategy
             .StrategyInstance
-            .Should()
-            .BeOfType<RateLimiterResilienceStrategy>();
+            .ShouldBeOfType<RateLimiterResilienceStrategy>();
     }
 
     [Fact]
@@ -154,7 +158,7 @@ public class RateLimiterResiliencePipelineBuilderExtensionsTests
 
         await registry.DisposeAsync();
 
-        strategy.AsPipeline().Invoking(p => p.Execute(() => { })).Should().Throw<ObjectDisposedException>();
+        Should.Throw<ObjectDisposedException>(() => strategy.AsPipeline().Execute(() => { }));
     }
 
     private static void AssertRateLimiterStrategy(ResiliencePipelineBuilder builder, Action<RateLimiterResilienceStrategy>? assert = null, bool hasEvents = false)
@@ -167,21 +171,20 @@ public class RateLimiterResiliencePipelineBuilderExtensionsTests
 
         if (hasEvents)
         {
-            limiterStrategy.OnLeaseRejected.Should().NotBeNull();
+            limiterStrategy.OnLeaseRejected.ShouldNotBeNull();
             limiterStrategy
                 .OnLeaseRejected!(new OnRateLimiterRejectedArguments(ResilienceContextPool.Shared.Get(), Substitute.For<RateLimitLease>()))
                 .Preserve().GetAwaiter().GetResult();
         }
         else
         {
-            limiterStrategy.OnLeaseRejected.Should().BeNull();
+            limiterStrategy.OnLeaseRejected.ShouldBeNull();
         }
 
         strategy
             .GetPipelineDescriptor()
             .FirstStrategy
             .StrategyInstance
-            .Should()
-            .BeOfType<RateLimiterResilienceStrategy>();
+            .ShouldBeOfType<RateLimiterResilienceStrategy>();
     }
 }

--- a/test/Polly.RateLimiting.Tests/RateLimiterStrategyOptionsTests.cs
+++ b/test/Polly.RateLimiting.Tests/RateLimiterStrategyOptionsTests.cs
@@ -7,10 +7,10 @@ public class RateLimiterStrategyOptionsTests
     {
         var options = new RateLimiterStrategyOptions();
 
-        options.RateLimiter.Should().BeNull();
-        options.OnRejected.Should().BeNull();
-        options.DefaultRateLimiterOptions.PermitLimit.Should().Be(1000);
-        options.DefaultRateLimiterOptions.QueueLimit.Should().Be(0);
-        options.Name.Should().Be("RateLimiter");
+        options.RateLimiter.ShouldBeNull();
+        options.OnRejected.ShouldBeNull();
+        options.DefaultRateLimiterOptions.PermitLimit.ShouldBe(1000);
+        options.DefaultRateLimiterOptions.QueueLimit.ShouldBe(0);
+        options.Name.ShouldBe("RateLimiter");
     }
 }

--- a/test/Polly.Specs/Polly.Specs.csproj
+++ b/test/Polly.Specs/Polly.Specs.csproj
@@ -33,5 +33,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Polly.TestUtils\Polly.TestUtils.csproj" />
     <ProjectReference Include="..\..\src\Polly\Polly.csproj" />
+    <PackageReference Include="FluentAssertions" />
   </ItemGroup>
 </Project>

--- a/test/Polly.Testing.Tests/Polly.Testing.Tests.csproj
+++ b/test/Polly.Testing.Tests/Polly.Testing.Tests.csproj
@@ -13,5 +13,9 @@
     <ProjectReference Include="..\..\src\Polly.Extensions\Polly.Extensions.csproj" />
     <ProjectReference Include="..\..\src\Polly.RateLimiting\Polly.RateLimiting.csproj" />
     <ProjectReference Include="..\..\src\Polly.Testing\Polly.Testing.csproj" />
+    <PackageReference Include="FluentAssertions" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="FluentAssertions" />
   </ItemGroup>
 </Project>

--- a/test/Polly.Testing.Tests/Polly.Testing.Tests.csproj
+++ b/test/Polly.Testing.Tests/Polly.Testing.Tests.csproj
@@ -13,9 +13,9 @@
     <ProjectReference Include="..\..\src\Polly.Extensions\Polly.Extensions.csproj" />
     <ProjectReference Include="..\..\src\Polly.RateLimiting\Polly.RateLimiting.csproj" />
     <ProjectReference Include="..\..\src\Polly.Testing\Polly.Testing.csproj" />
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Shouldly" />
   </ItemGroup>
   <ItemGroup>
-    <Using Include="FluentAssertions" />
+    <Using Include="Shouldly" />
   </ItemGroup>
 </Project>

--- a/test/Polly.Testing.Tests/ResiliencePipelineExtensionsTests.cs
+++ b/test/Polly.Testing.Tests/ResiliencePipelineExtensionsTests.cs
@@ -33,27 +33,26 @@ public class ResiliencePipelineExtensionsTests
         var descriptor = strategy.GetPipelineDescriptor();
 
         // assert
-        descriptor.IsReloadable.Should().BeFalse();
-        descriptor.Strategies.Should().HaveCount(7);
-        descriptor.FirstStrategy.Options.Should().BeOfType<FallbackStrategyOptions<string>>();
-        descriptor.Strategies[0].Options.Should().BeOfType<FallbackStrategyOptions<string>>();
-        descriptor.Strategies[0].StrategyInstance.GetType().FullName.Should().Contain("Fallback");
-        descriptor.Strategies[1].Options.Should().BeOfType<RetryStrategyOptions<string>>();
-        descriptor.Strategies[1].StrategyInstance.GetType().FullName.Should().Contain("Retry");
-        descriptor.Strategies[2].Options.Should().BeOfType<CircuitBreakerStrategyOptions<string>>();
-        descriptor.Strategies[2].StrategyInstance.GetType().FullName.Should().Contain("CircuitBreaker");
-        descriptor.Strategies[3].Options.Should().BeOfType<TimeoutStrategyOptions>();
-        descriptor.Strategies[3].StrategyInstance.GetType().FullName.Should().Contain("Timeout");
+        descriptor.IsReloadable.ShouldBeFalse();
+        descriptor.Strategies.Count.ShouldBe(7);
+        descriptor.FirstStrategy.Options.ShouldBeOfType<FallbackStrategyOptions<string>>();
+        descriptor.Strategies[0].Options.ShouldBeOfType<FallbackStrategyOptions<string>>();
+        descriptor.Strategies[0].StrategyInstance.GetType().FullName.ShouldNotBeNull().ShouldContain("Fallback");
+        descriptor.Strategies[1].Options.ShouldBeOfType<RetryStrategyOptions<string>>();
+        descriptor.Strategies[1].StrategyInstance.GetType().FullName.ShouldNotBeNull().ShouldContain("Retry");
+        descriptor.Strategies[2].Options.ShouldBeOfType<CircuitBreakerStrategyOptions<string>>();
+        descriptor.Strategies[2].StrategyInstance.GetType().FullName.ShouldNotBeNull().ShouldContain("CircuitBreaker");
+        descriptor.Strategies[3].Options.ShouldBeOfType<TimeoutStrategyOptions>();
+        descriptor.Strategies[3].StrategyInstance.GetType().FullName.ShouldNotBeNull().ShouldContain("Timeout");
         descriptor.Strategies[3].Options
-            .Should()
-            .BeOfType<TimeoutStrategyOptions>().Subject.Timeout
-            .Should().Be(TimeSpan.FromSeconds(1));
+            .ShouldBeOfType<TimeoutStrategyOptions>().Timeout
+            .ShouldBe(TimeSpan.FromSeconds(1));
 
-        descriptor.Strategies[4].Options.Should().BeOfType<HedgingStrategyOptions<string>>();
-        descriptor.Strategies[4].StrategyInstance.GetType().FullName.Should().Contain("Hedging");
-        descriptor.Strategies[5].Options.Should().BeOfType<RateLimiterStrategyOptions>();
-        descriptor.Strategies[5].StrategyInstance.GetType().FullName.Should().Contain("RateLimiter");
-        descriptor.Strategies[6].StrategyInstance.GetType().Should().Be<CustomStrategy>();
+        descriptor.Strategies[4].Options.ShouldBeOfType<HedgingStrategyOptions<string>>();
+        descriptor.Strategies[4].StrategyInstance.GetType().FullName.ShouldNotBeNull().ShouldContain("Hedging");
+        descriptor.Strategies[5].Options.ShouldBeOfType<RateLimiterStrategyOptions>();
+        descriptor.Strategies[5].StrategyInstance.GetType().FullName.ShouldNotBeNull().ShouldContain("RateLimiter");
+        descriptor.Strategies[6].StrategyInstance.ShouldBeOfType<CustomStrategy>();
     }
 
     [Fact]
@@ -73,22 +72,21 @@ public class ResiliencePipelineExtensionsTests
         var descriptor = strategy.GetPipelineDescriptor();
 
         // assert
-        descriptor.IsReloadable.Should().BeFalse();
-        descriptor.Strategies.Should().HaveCount(5);
-        descriptor.Strategies[0].Options.Should().BeOfType<RetryStrategyOptions>();
-        descriptor.Strategies[0].StrategyInstance.GetType().FullName.Should().Contain("Retry");
-        descriptor.Strategies[1].Options.Should().BeOfType<CircuitBreakerStrategyOptions>();
-        descriptor.Strategies[1].StrategyInstance.GetType().FullName.Should().Contain("CircuitBreaker");
-        descriptor.Strategies[2].Options.Should().BeOfType<TimeoutStrategyOptions>();
-        descriptor.Strategies[2].StrategyInstance.GetType().FullName.Should().Contain("Timeout");
+        descriptor.IsReloadable.ShouldBeFalse();
+        descriptor.Strategies.Count.ShouldBe(5);
+        descriptor.Strategies[0].Options.ShouldBeOfType<RetryStrategyOptions>();
+        descriptor.Strategies[0].StrategyInstance.GetType().FullName.ShouldNotBeNull().ShouldContain("Retry");
+        descriptor.Strategies[1].Options.ShouldBeOfType<CircuitBreakerStrategyOptions>();
+        descriptor.Strategies[1].StrategyInstance.GetType().FullName.ShouldNotBeNull().ShouldContain("CircuitBreaker");
+        descriptor.Strategies[2].Options.ShouldBeOfType<TimeoutStrategyOptions>();
+        descriptor.Strategies[2].StrategyInstance.GetType().FullName.ShouldNotBeNull().ShouldContain("Timeout");
         descriptor.Strategies[2].Options
-            .Should()
-            .BeOfType<TimeoutStrategyOptions>().Subject.Timeout
-            .Should().Be(TimeSpan.FromSeconds(1));
+            .ShouldBeOfType<TimeoutStrategyOptions>().Timeout
+            .ShouldBe(TimeSpan.FromSeconds(1));
 
-        descriptor.Strategies[3].Options.Should().BeOfType<RateLimiterStrategyOptions>();
-        descriptor.Strategies[3].StrategyInstance.GetType().FullName.Should().Contain("RateLimiter");
-        descriptor.Strategies[4].StrategyInstance.GetType().Should().Be<CustomStrategy>();
+        descriptor.Strategies[3].Options.ShouldBeOfType<RateLimiterStrategyOptions>();
+        descriptor.Strategies[3].StrategyInstance.GetType().FullName.ShouldNotBeNull().ShouldContain("RateLimiter");
+        descriptor.Strategies[4].StrategyInstance.ShouldBeOfType<CustomStrategy>();
     }
 
     [Fact]
@@ -103,9 +101,9 @@ public class ResiliencePipelineExtensionsTests
         var descriptor = strategy.GetPipelineDescriptor();
 
         // assert
-        descriptor.IsReloadable.Should().BeFalse();
-        descriptor.Strategies.Should().HaveCount(1);
-        descriptor.Strategies[0].Options.Should().BeOfType<TimeoutStrategyOptions>();
+        descriptor.IsReloadable.ShouldBeFalse();
+        descriptor.Strategies.Count.ShouldBe(1);
+        descriptor.Strategies[0].Options.ShouldBeOfType<TimeoutStrategyOptions>();
     }
 
     [Fact]
@@ -128,10 +126,10 @@ public class ResiliencePipelineExtensionsTests
         var descriptor = strategy.GetPipelineDescriptor();
 
         // assert
-        descriptor.IsReloadable.Should().BeTrue();
-        descriptor.Strategies.Should().HaveCount(2);
-        descriptor.Strategies[0].Options.Should().BeOfType<RateLimiterStrategyOptions>();
-        descriptor.Strategies[1].StrategyInstance.GetType().Should().Be<CustomStrategy>();
+        descriptor.IsReloadable.ShouldBeTrue();
+        descriptor.Strategies.Count.ShouldBe(2);
+        descriptor.Strategies[0].Options.ShouldBeOfType<RateLimiterStrategyOptions>();
+        descriptor.Strategies[1].StrategyInstance.ShouldBeOfType<CustomStrategy>();
     }
 
     [Fact]
@@ -142,8 +140,8 @@ public class ResiliencePipelineExtensionsTests
             .Build()
             .GetPipelineDescriptor();
 
-        descriptor.Strategies.Should().HaveCount(1);
-        descriptor.Strategies[0].Options.Should().BeOfType<RateLimiterStrategyOptions>();
+        descriptor.Strategies.Count.ShouldBe(1);
+        descriptor.Strategies[0].Options.ShouldBeOfType<RateLimiterStrategyOptions>();
     }
 
     private sealed class CustomStrategy : ResilienceStrategy
@@ -152,7 +150,5 @@ public class ResiliencePipelineExtensionsTests
             => throw new NotSupportedException();
     }
 
-    private class TestOptions : ResilienceStrategyOptions
-    {
-    }
+    private class TestOptions : ResilienceStrategyOptions;
 }


### PR DESCRIPTION
Migrate all test projects, except Polly.Specs, from using FluentAssertions to use Shouldly instead.

Contributes to #2450.
