### PR TITLE
Remove FluentAssertions

### DIFF
--- a/eng/Test.targets
+++ b/eng/Test.targets
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Using Include="Shouldly" />
     <Using Include="Xunit" />
   </ItemGroup>
 
@@ -15,6 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="ReportGenerator" PrivateAssets="all" />
+    <PackageReference Include="Shouldly" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
   </ItemGroup>

--- a/test/Polly.Core.Tests/Polly.Core.Tests.csproj
+++ b/test/Polly.Core.Tests/Polly.Core.Tests.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="Microsoft.Bcl.TimeProvider" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" />
-    <PackageReference Include="Shouldly" />
   </ItemGroup>
 
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net9.0'))">
@@ -31,6 +30,5 @@
   <ItemGroup>
     <Using Include="Polly.Core.Tests.Helpers" />
     <Using Include="Polly.TestUtils" />
-    <Using Include="Shouldly" />
   </ItemGroup>
 </Project>

--- a/test/Polly.Extensions.Tests/Polly.Extensions.Tests.csproj
+++ b/test/Polly.Extensions.Tests/Polly.Extensions.Tests.csproj
@@ -15,13 +15,11 @@
 
   <ItemGroup>
     <Using Include="Polly.TestUtils" />
-    <Using Include="Shouldly" />
     <ProjectReference Include="..\..\src\Polly.Extensions\Polly.Extensions.csproj" />
     <ProjectReference Include="..\..\src\Polly.RateLimiting\Polly.RateLimiting.csproj" />
     <ProjectReference Include="..\Polly.TestUtils\Polly.TestUtils.csproj" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
-    <PackageReference Include="Shouldly" />
     <Reference Include="System.Net.Http" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
   </ItemGroup>
 </Project>

--- a/test/Polly.RateLimiting.Tests/Polly.RateLimiting.Tests.csproj
+++ b/test/Polly.RateLimiting.Tests/Polly.RateLimiting.Tests.csproj
@@ -16,9 +16,5 @@
     <ProjectReference Include="..\..\src\Polly.RateLimiting\Polly.RateLimiting.csproj" />
     <ProjectReference Include="..\..\src\Polly.Testing\Polly.Testing.csproj" />
     <ProjectReference Include="..\Polly.TestUtils\Polly.TestUtils.csproj" />
-    <PackageReference Include="Shouldly" />
-  </ItemGroup>
-  <ItemGroup>
-    <Using Include="Shouldly" />
   </ItemGroup>
 </Project>

--- a/test/Polly.Specs/Bulkhead/BulkheadAsyncSpecs.cs
+++ b/test/Polly.Specs/Bulkhead/BulkheadAsyncSpecs.cs
@@ -27,10 +27,10 @@ public class BulkheadAsyncSpecs(ITestOutputHelper testOutputHelper) : BulkheadSp
 
         var func = () => generic.Invoke(instance, [action, new Context(), CancellationToken, false]);
 
-        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("action");
+        var exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>()
+            .ParamName.ShouldBe("action");
     }
 
     [Fact]
@@ -39,8 +39,8 @@ public class BulkheadAsyncSpecs(ITestOutputHelper testOutputHelper) : BulkheadSp
         Action policy = () => Policy
             .BulkheadAsync(0);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-            .ParamName.Should().Be("maxParallelization");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+            .ParamName.ShouldBe("maxParallelization");
     }
 
     [Fact]
@@ -49,8 +49,8 @@ public class BulkheadAsyncSpecs(ITestOutputHelper testOutputHelper) : BulkheadSp
         Action policy = () => Policy
             .BulkheadAsync(0, 1);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-            .ParamName.Should().Be("maxParallelization");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+            .ParamName.ShouldBe("maxParallelization");
     }
 
     [Fact]
@@ -59,8 +59,8 @@ public class BulkheadAsyncSpecs(ITestOutputHelper testOutputHelper) : BulkheadSp
         Action policy = () => Policy
             .BulkheadAsync(1, -1);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-            .ParamName.Should().Be("maxQueuingActions");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+            .ParamName.ShouldBe("maxQueuingActions");
     }
 
     [Fact]
@@ -69,8 +69,8 @@ public class BulkheadAsyncSpecs(ITestOutputHelper testOutputHelper) : BulkheadSp
         Action policy = () => Policy
             .BulkheadAsync(1, 0, null!);
 
-        policy.Should().Throw<ArgumentNullException>().And
-            .ParamName.Should().Be("onBulkheadRejectedAsync");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onBulkheadRejectedAsync");
     }
 
     #endregion
@@ -94,7 +94,8 @@ public class BulkheadAsyncSpecs(ITestOutputHelper testOutputHelper) : BulkheadSp
 
             Within(CohesionTimeLimit, () => Expect(0, () => bulkhead.BulkheadAvailableCount, nameof(bulkhead.BulkheadAvailableCount)));
 
-            await bulkhead.Awaiting(b => b.ExecuteAsync(_ => TaskHelper.EmptyTask, contextPassedToExecute)).Should().ThrowAsync<BulkheadRejectedException>();
+            await Should.ThrowAsync<BulkheadRejectedException>(
+                () => bulkhead.ExecuteAsync(_ => TaskHelper.EmptyTask, contextPassedToExecute));
 
             cancellationSource.Cancel();
 
@@ -105,9 +106,9 @@ public class BulkheadAsyncSpecs(ITestOutputHelper testOutputHelper) : BulkheadSp
 #endif
         }
 
-        contextPassedToOnRejected!.Should().NotBeNull();
-        contextPassedToOnRejected!.OperationKey.Should().Be(operationKey);
-        contextPassedToOnRejected!.Should().BeSameAs(contextPassedToExecute);
+        contextPassedToOnRejected!.ShouldNotBeNull();
+        contextPassedToOnRejected!.OperationKey.ShouldBe(operationKey);
+        contextPassedToOnRejected!.ShouldBeSameAs(contextPassedToExecute);
     }
 
     #endregion

--- a/test/Polly.Specs/Bulkhead/BulkheadSpecs.cs
+++ b/test/Polly.Specs/Bulkhead/BulkheadSpecs.cs
@@ -32,10 +32,10 @@ public class BulkheadSpecs : BulkheadSpecsBase
 
         var func = () => generic.Invoke(instance, [action, new Context(), CancellationToken]);
 
-        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("action");
+        var exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>()
+            .ParamName.ShouldBe("action");
     }
 
     [Fact]
@@ -44,8 +44,8 @@ public class BulkheadSpecs : BulkheadSpecsBase
         Action policy = () => Policy
             .Bulkhead(0);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-            .ParamName.Should().Be("maxParallelization");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+            .ParamName.ShouldBe("maxParallelization");
     }
 
     [Fact]
@@ -54,8 +54,8 @@ public class BulkheadSpecs : BulkheadSpecsBase
         Action policy = () => Policy
             .Bulkhead(0, 1);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-            .ParamName.Should().Be("maxParallelization");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+            .ParamName.ShouldBe("maxParallelization");
     }
 
     [Fact]
@@ -64,8 +64,8 @@ public class BulkheadSpecs : BulkheadSpecsBase
         Action policy = () => Policy
             .Bulkhead(1, -1);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-            .ParamName.Should().Be("maxQueuingActions");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+            .ParamName.ShouldBe("maxQueuingActions");
     }
 
     [Fact]
@@ -74,8 +74,8 @@ public class BulkheadSpecs : BulkheadSpecsBase
         Action policy = () => Policy
             .Bulkhead(1, 0, null!);
 
-        policy.Should().Throw<ArgumentNullException>().And
-            .ParamName.Should().Be("onBulkheadRejected");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onBulkheadRejected");
     }
 
     #endregion
@@ -99,8 +99,7 @@ public class BulkheadSpecs : BulkheadSpecsBase
         // Time for the other thread to kick up and take the bulkhead.
         Within(CohesionTimeLimit, () => Expect(0, () => bulkhead.BulkheadAvailableCount, nameof(bulkhead.BulkheadAvailableCount)));
 
-        bulkhead.Invoking(b => b.Execute(_ => { }, contextPassedToExecute)).Should()
-            .Throw<BulkheadRejectedException>();
+        Should.Throw<BulkheadRejectedException>(() => bulkhead.Execute(_ => { }, contextPassedToExecute));
 
 #if NET
         tcs.SetCanceled(CancellationToken);
@@ -108,9 +107,9 @@ public class BulkheadSpecs : BulkheadSpecsBase
         tcs.SetCanceled();
 #endif
 
-        contextPassedToOnRejected!.Should().NotBeNull();
-        contextPassedToOnRejected!.OperationKey.Should().Be(operationKey);
-        contextPassedToOnRejected!.Should().BeSameAs(contextPassedToExecute);
+        contextPassedToOnRejected!.ShouldNotBeNull();
+        contextPassedToOnRejected!.OperationKey.ShouldBe(operationKey);
+        contextPassedToOnRejected!.ShouldBeSameAs(contextPassedToExecute);
     }
 
     #endregion

--- a/test/Polly.Specs/Bulkhead/BulkheadSpecsBase.cs
+++ b/test/Polly.Specs/Bulkhead/BulkheadSpecsBase.cs
@@ -334,7 +334,7 @@ public abstract class BulkheadSpecsBase : IDisposable
             if (watch.Elapsed > permitted)
             {
                 TestOutputHelper.WriteLine("Failing assertion on: {0}", potentialFailure.Measure);
-                potentialFailure.Actual.Should().Be(potentialFailure.Expected, $"for '{potentialFailure.Measure}', in scenario: {Scenario}");
+                potentialFailure.Actual.ShouldBe(potentialFailure.Expected, $"for '{potentialFailure.Measure}', in scenario: {Scenario}");
                 throw new InvalidOperationException("Code should never reach here. Preceding assertion should fail.");
             }
 

--- a/test/Polly.Specs/Bulkhead/BulkheadTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/Bulkhead/BulkheadTResultAsyncSpecs.cs
@@ -1,13 +1,8 @@
 ﻿namespace Polly.Specs.Bulkhead;
 
 [Collection(Constants.ParallelThreadDependentTestCollection)]
-public class BulkheadTResultAsyncSpecs : BulkheadSpecsBase
+public class BulkheadTResultAsyncSpecs(ITestOutputHelper testOutputHelper) : BulkheadSpecsBase(testOutputHelper)
 {
-    public BulkheadTResultAsyncSpecs(ITestOutputHelper testOutputHelper)
-        : base(testOutputHelper)
-    {
-    }
-
     #region Configuration
 
     [Fact]
@@ -31,10 +26,10 @@ public class BulkheadTResultAsyncSpecs : BulkheadSpecsBase
 
         var func = () => methodInfo.Invoke(instance, [action, new Context(), CancellationToken, false]);
 
-        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("action");
+        var exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>()
+            .ParamName.ShouldBe("action");
     }
 
     [Fact]
@@ -43,8 +38,8 @@ public class BulkheadTResultAsyncSpecs : BulkheadSpecsBase
         Action policy = () => Policy
             .BulkheadAsync(0);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-            .ParamName.Should().Be("maxParallelization");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+            .ParamName.ShouldBe("maxParallelization");
     }
 
     [Fact]
@@ -53,8 +48,8 @@ public class BulkheadTResultAsyncSpecs : BulkheadSpecsBase
         Action policy = () => Policy
             .BulkheadAsync<int>(0, 1);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-            .ParamName.Should().Be("maxParallelization");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+            .ParamName.ShouldBe("maxParallelization");
     }
 
     [Fact]
@@ -63,8 +58,8 @@ public class BulkheadTResultAsyncSpecs : BulkheadSpecsBase
         Action policy = () => Policy
             .BulkheadAsync<int>(1, -1);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-            .ParamName.Should().Be("maxQueuingActions");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+            .ParamName.ShouldBe("maxQueuingActions");
     }
 
     [Fact]
@@ -73,8 +68,8 @@ public class BulkheadTResultAsyncSpecs : BulkheadSpecsBase
         Action policy = () => Policy
             .BulkheadAsync<int>(1, 0, null!);
 
-        policy.Should().Throw<ArgumentNullException>().And
-            .ParamName.Should().Be("onBulkheadRejectedAsync");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onBulkheadRejectedAsync");
     }
 
     #endregion
@@ -105,7 +100,7 @@ public class BulkheadTResultAsyncSpecs : BulkheadSpecsBase
 
             Within(CohesionTimeLimit, () => Expect(0, () => bulkhead.BulkheadAvailableCount, nameof(bulkhead.BulkheadAvailableCount)));
 
-            await bulkhead.Awaiting(b => b.ExecuteAsync(_ => Task.FromResult(1), contextPassedToExecute)).Should().ThrowAsync<BulkheadRejectedException>();
+            await Should.ThrowAsync<BulkheadRejectedException>(() => bulkhead.ExecuteAsync(_ => Task.FromResult(1), contextPassedToExecute));
 
             cancellationSource.Cancel();
 
@@ -116,9 +111,9 @@ public class BulkheadTResultAsyncSpecs : BulkheadSpecsBase
 #endif
         }
 
-        contextPassedToOnRejected!.Should().NotBeNull();
-        contextPassedToOnRejected!.OperationKey.Should().Be(operationKey);
-        contextPassedToOnRejected!.Should().BeSameAs(contextPassedToExecute);
+        contextPassedToOnRejected.ShouldNotBeNull();
+        contextPassedToOnRejected.OperationKey.ShouldBe(operationKey);
+        contextPassedToOnRejected.ShouldBeSameAs(contextPassedToExecute);
     }
 
     #endregion

--- a/test/Polly.Specs/Bulkhead/BulkheadTResultSpecs.cs
+++ b/test/Polly.Specs/Bulkhead/BulkheadTResultSpecs.cs
@@ -1,13 +1,8 @@
 ﻿namespace Polly.Specs.Bulkhead;
 
 [Collection(Constants.ParallelThreadDependentTestCollection)]
-public class BulkheadTResultSpecs : BulkheadSpecsBase
+public class BulkheadTResultSpecs(ITestOutputHelper testOutputHelper) : BulkheadSpecsBase(testOutputHelper)
 {
-    public BulkheadTResultSpecs(ITestOutputHelper testOutputHelper)
-        : base(testOutputHelper)
-    {
-    }
-
     #region Configuration
 
     [Fact]
@@ -31,10 +26,10 @@ public class BulkheadTResultSpecs : BulkheadSpecsBase
 
         var func = () => methodInfo.Invoke(instance, [action, new Context(), CancellationToken]);
 
-        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("action");
+        var exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>()
+            .ParamName.ShouldBe("action");
     }
 
     [Fact]
@@ -43,8 +38,8 @@ public class BulkheadTResultSpecs : BulkheadSpecsBase
         Action policy = () => Policy
             .Bulkhead<int>(0);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-            .ParamName.Should().Be("maxParallelization");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+            .ParamName.ShouldBe("maxParallelization");
     }
 
     [Fact]
@@ -53,8 +48,8 @@ public class BulkheadTResultSpecs : BulkheadSpecsBase
         Action policy = () => Policy
             .Bulkhead<int>(0, 1);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-            .ParamName.Should().Be("maxParallelization");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+            .ParamName.ShouldBe("maxParallelization");
     }
 
     [Fact]
@@ -63,8 +58,8 @@ public class BulkheadTResultSpecs : BulkheadSpecsBase
         Action policy = () => Policy
             .Bulkhead<int>(1, -1);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-            .ParamName.Should().Be("maxQueuingActions");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+            .ParamName.ShouldBe("maxQueuingActions");
     }
 
     [Fact]
@@ -73,8 +68,8 @@ public class BulkheadTResultSpecs : BulkheadSpecsBase
         Action policy = () => Policy
             .Bulkhead<int>(1, 0, null!);
 
-        policy.Should().Throw<ArgumentNullException>().And
-            .ParamName.Should().Be("onBulkheadRejected");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onBulkheadRejected");
     }
 
     #endregion
@@ -105,7 +100,7 @@ public class BulkheadTResultSpecs : BulkheadSpecsBase
 
             Within(CohesionTimeLimit, () => Expect(0, () => bulkhead.BulkheadAvailableCount, nameof(bulkhead.BulkheadAvailableCount)));
 
-            bulkhead.Invoking(b => b.Execute(_ => 1, contextPassedToExecute)).Should().Throw<BulkheadRejectedException>();
+            Should.Throw<BulkheadRejectedException>(() => bulkhead.Execute(_ => 1, contextPassedToExecute));
 
             cancellationSource.Cancel();
 
@@ -116,9 +111,9 @@ public class BulkheadTResultSpecs : BulkheadSpecsBase
 #endif
         }
 
-        contextPassedToOnRejected!.Should().NotBeNull();
-        contextPassedToOnRejected!.OperationKey.Should().Be(operationKey);
-        contextPassedToOnRejected!.Should().BeSameAs(contextPassedToExecute);
+        contextPassedToOnRejected!.ShouldNotBeNull();
+        contextPassedToOnRejected!.OperationKey.ShouldBe(operationKey);
+        contextPassedToOnRejected!.ShouldBeSameAs(contextPassedToExecute);
     }
 
     #endregion

--- a/test/Polly.Specs/Bulkhead/IBulkheadPolicySpecs.cs
+++ b/test/Polly.Specs/Bulkhead/IBulkheadPolicySpecs.cs
@@ -7,7 +7,7 @@ public class IBulkheadPolicySpecs
     {
         IBulkheadPolicy bulkhead = Policy.Bulkhead(20, 10);
 
-        bulkhead.BulkheadAvailableCount.Should().Be(20);
+        bulkhead.BulkheadAvailableCount.ShouldBe(20);
     }
 
     [Fact]
@@ -15,6 +15,6 @@ public class IBulkheadPolicySpecs
     {
         IBulkheadPolicy bulkhead = Policy.Bulkhead(20, 10);
 
-        bulkhead.QueueAvailableCount.Should().Be(10);
+        bulkhead.QueueAvailableCount.ShouldBe(10);
     }
 }

--- a/test/Polly.Specs/Caching/AbsoluteTtlSpecs.cs
+++ b/test/Polly.Specs/Caching/AbsoluteTtlSpecs.cs
@@ -8,7 +8,7 @@ public class AbsoluteTtlSpecs : IDisposable
     {
         Action configure = () => _ = new AbsoluteTtl(DateTimeOffset.UtcNow.Date.AddDays(1));
 
-        configure.Should().NotThrow();
+        Should.NotThrow(configure);
     }
 
     [Fact]
@@ -16,7 +16,7 @@ public class AbsoluteTtlSpecs : IDisposable
     {
         Action configure = () => _ = new AbsoluteTtl(DateTimeOffset.MaxValue);
 
-        configure.Should().NotThrow();
+        Should.NotThrow(configure);
     }
 
     [Fact]
@@ -24,7 +24,7 @@ public class AbsoluteTtlSpecs : IDisposable
     {
         Action configure = () => _ = new AbsoluteTtl(DateTimeOffset.MinValue);
 
-        configure.Should().NotThrow();
+        Should.NotThrow(configure);
     }
 
     [Fact]
@@ -32,7 +32,7 @@ public class AbsoluteTtlSpecs : IDisposable
     {
         AbsoluteTtl ttlStrategy = new AbsoluteTtl(SystemClock.DateTimeOffsetUtcNow().Subtract(TimeSpan.FromTicks(1)));
 
-        ttlStrategy.GetTtl(new Context("someOperationKey"), null).Timespan.Should().Be(TimeSpan.Zero);
+        ttlStrategy.GetTtl(new Context("someOperationKey"), null).Timespan.ShouldBe(TimeSpan.Zero);
     }
 
     [Fact]
@@ -44,7 +44,7 @@ public class AbsoluteTtlSpecs : IDisposable
         AbsoluteTtl ttlStrategy = new AbsoluteTtl(tomorrow);
 
         SystemClock.DateTimeOffsetUtcNow = () => today;
-        ttlStrategy.GetTtl(new Context("someOperationKey"), null).Timespan.Should().Be(TimeSpan.FromDays(1));
+        ttlStrategy.GetTtl(new Context("someOperationKey"), null).Timespan.ShouldBe(TimeSpan.FromDays(1));
     }
 
     public void Dispose() =>

--- a/test/Polly.Specs/Caching/AsyncSerializingCacheProviderSpecs.cs
+++ b/test/Polly.Specs/Caching/AsyncSerializingCacheProviderSpecs.cs
@@ -15,8 +15,8 @@ public class AsyncSerializingCacheProviderSpecs
 
         Action configure = () => _ = new AsyncSerializingCacheProvider<StubSerialized>(null!, stubObjectSerializer);
 
-        configure.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("wrappedCacheProvider");
+        Should.Throw<ArgumentNullException>(configure)
+            .ParamName.ShouldBe("wrappedCacheProvider");
     }
 
     [Fact]
@@ -24,8 +24,8 @@ public class AsyncSerializingCacheProviderSpecs
     {
         Action configure = () => _ = new AsyncSerializingCacheProvider<object>(new StubCacheProvider().AsyncFor<object>(), null!);
 
-        configure.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("serializer");
+        Should.Throw<ArgumentNullException>(configure)
+            .ParamName.ShouldBe("serializer");
     }
 
     [Fact]
@@ -33,8 +33,8 @@ public class AsyncSerializingCacheProviderSpecs
     {
         Action configure = () => new StubCacheProvider().AsyncFor<object>().WithSerializer(null!);
 
-        configure.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("serializer");
+        Should.Throw<ArgumentNullException>(configure)
+            .ParamName.ShouldBe("serializer");
     }
 
     [Fact]
@@ -51,13 +51,13 @@ public class AsyncSerializingCacheProviderSpecs
         AsyncSerializingCacheProvider<StubSerialized> serializingCacheProvider = new AsyncSerializingCacheProvider<StubSerialized>(stubCacheProvider.AsyncFor<StubSerialized>(), stubSerializer);
         await serializingCacheProvider.PutAsync(key, objectToCache, new Ttl(TimeSpan.FromMinutes(1)), CancellationToken, false);
 
-        serializeInvoked.Should().BeTrue();
+        serializeInvoked.ShouldBeTrue();
 
         (bool cacheHit, object? fromCache) = await stubCacheProvider.TryGetAsync(key, CancellationToken, false);
 
-        cacheHit.Should().BeTrue();
-        fromCache.Should().BeOfType<StubSerialized>()
-            .Which.Original.Should().Be(objectToCache);
+        cacheHit.ShouldBeTrue();
+        fromCache.ShouldBeOfType<StubSerialized>()
+            .Original.ShouldBe(objectToCache);
     }
 
     [Fact]
@@ -74,13 +74,13 @@ public class AsyncSerializingCacheProviderSpecs
         AsyncSerializingCacheProvider<StubSerialized> serializingCacheProvider = new AsyncSerializingCacheProvider<StubSerialized>(stubCacheProvider.AsyncFor<StubSerialized>(), stubSerializer);
         await serializingCacheProvider.PutAsync(key, objectToCache, new Ttl(TimeSpan.FromMinutes(1)), CancellationToken, false);
 
-        serializeInvoked.Should().BeTrue();
+        serializeInvoked.ShouldBeTrue();
 
         (bool cacheHit, object? fromCache) = stubCacheProvider.TryGet(key);
 
-        cacheHit.Should().BeTrue();
-        fromCache.Should().BeOfType<StubSerialized>()
-            .Which.Original.Should().Be(objectToCache);
+        cacheHit.ShouldBeTrue();
+        fromCache.ShouldBeOfType<StubSerialized>()
+            .Original.ShouldBe(objectToCache);
     }
 
     [Fact]
@@ -100,9 +100,9 @@ public class AsyncSerializingCacheProviderSpecs
         AsyncSerializingCacheProvider<StubSerialized> serializingCacheProvider = new AsyncSerializingCacheProvider<StubSerialized>(stubCacheProvider.AsyncFor<StubSerialized>(), stubSerializer);
         (bool cacheHit, object? fromCache) = await serializingCacheProvider.TryGetAsync(key, CancellationToken, false);
 
-        cacheHit.Should().BeTrue();
-        deserializeInvoked.Should().BeTrue();
-        fromCache.Should().Be(objectToCache);
+        cacheHit.ShouldBeTrue();
+        deserializeInvoked.ShouldBeTrue();
+        fromCache.ShouldBe(objectToCache);
     }
 
     [Fact]
@@ -115,14 +115,14 @@ public class AsyncSerializingCacheProviderSpecs
         var stubCacheProvider = new StubCacheProvider();
         string key = "some key";
 
-        stubCacheProvider.TryGet(key).Item1.Should().BeFalse();
+        stubCacheProvider.TryGet(key).Item1.ShouldBeFalse();
 
         AsyncSerializingCacheProvider<StubSerialized> serializingCacheProvider = new AsyncSerializingCacheProvider<StubSerialized>(stubCacheProvider.AsyncFor<StubSerialized>(), stubSerializer);
         (bool cacheHit, object? fromCache) = await serializingCacheProvider.TryGetAsync(key, CancellationToken, false);
 
-        cacheHit.Should().BeFalse();
-        deserializeInvoked.Should().BeFalse();
-        fromCache.Should().Be(default);
+        cacheHit.ShouldBeFalse();
+        deserializeInvoked.ShouldBeFalse();
+        fromCache.ShouldBe(default);
     }
 
     [Fact]
@@ -139,13 +139,13 @@ public class AsyncSerializingCacheProviderSpecs
         AsyncSerializingCacheProvider<StubSerialized> serializingCacheProvider = stubCacheProvider.AsyncFor<StubSerialized>().WithSerializer(stubSerializer);
         await serializingCacheProvider.PutAsync(key, objectToCache, new Ttl(TimeSpan.FromMinutes(1)), CancellationToken, false);
 
-        serializeInvoked.Should().BeTrue();
+        serializeInvoked.ShouldBeTrue();
 
         (bool cacheHit, object? fromCache) = await stubCacheProvider.TryGetAsync(key, CancellationToken, false);
 
-        cacheHit.Should().BeTrue();
-        fromCache.Should().BeOfType<StubSerialized>()
-            .Which.Original.Should().Be(objectToCache);
+        cacheHit.ShouldBeTrue();
+        fromCache.ShouldBeOfType<StubSerialized>()
+            .Original.ShouldBe(objectToCache);
     }
 
     [Fact]
@@ -162,13 +162,13 @@ public class AsyncSerializingCacheProviderSpecs
         AsyncSerializingCacheProvider<StubSerialized> serializingCacheProvider = stubCacheProvider.AsyncFor<StubSerialized>().WithSerializer(stubSerializer);
         await serializingCacheProvider.PutAsync(key, objectToCache, new Ttl(TimeSpan.FromMinutes(1)), CancellationToken, false);
 
-        serializeInvoked.Should().BeTrue();
+        serializeInvoked.ShouldBeTrue();
 
         (bool cacheHit, object? fromCache) = stubCacheProvider.TryGet(key);
 
-        cacheHit.Should().BeTrue();
-        fromCache.Should().BeOfType<StubSerialized>()
-            .Which.Original.Should().Be(objectToCache);
+        cacheHit.ShouldBeTrue();
+        fromCache.ShouldBeOfType<StubSerialized>()
+            .Original.ShouldBe(objectToCache);
     }
 
     [Fact]
@@ -188,9 +188,9 @@ public class AsyncSerializingCacheProviderSpecs
         AsyncSerializingCacheProvider<StubSerialized> serializingCacheProvider = stubCacheProvider.AsyncFor<StubSerialized>().WithSerializer(stubSerializer);
         (bool cacheHit, object? fromCache) = await serializingCacheProvider.TryGetAsync(key, cancellationToken, false);
 
-        cacheHit.Should().BeTrue();
-        deserializeInvoked.Should().BeTrue();
-        fromCache.Should().Be(objectToCache);
+        cacheHit.ShouldBeTrue();
+        deserializeInvoked.ShouldBeTrue();
+        fromCache.ShouldBe(objectToCache);
     }
 
     [Fact]
@@ -203,14 +203,14 @@ public class AsyncSerializingCacheProviderSpecs
         var stubCacheProvider = new StubCacheProvider();
         string key = "some key";
 
-        stubCacheProvider.TryGet(key).Item1.Should().BeFalse();
+        stubCacheProvider.TryGet(key).Item1.ShouldBeFalse();
 
         AsyncSerializingCacheProvider<StubSerialized> serializingCacheProvider = stubCacheProvider.AsyncFor<StubSerialized>().WithSerializer(stubSerializer);
         (bool cacheHit, object? fromCache) = await serializingCacheProvider.TryGetAsync(key, CancellationToken, false);
 
-        cacheHit.Should().BeFalse();
-        deserializeInvoked.Should().BeFalse();
-        fromCache.Should().Be(default);
+        cacheHit.ShouldBeFalse();
+        deserializeInvoked.ShouldBeFalse();
+        fromCache.ShouldBe(default);
     }
 
     #endregion
@@ -226,8 +226,8 @@ public class AsyncSerializingCacheProviderSpecs
 
         Action configure = () => _ = new AsyncSerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>>(null!, stubTResultSerializer);
 
-        configure.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("wrappedCacheProvider");
+        Should.Throw<ArgumentNullException>(configure)
+            .ParamName.ShouldBe("wrappedCacheProvider");
     }
 
     [Fact]
@@ -235,8 +235,8 @@ public class AsyncSerializingCacheProviderSpecs
     {
         Action configure = () => _ = new AsyncSerializingCacheProvider<object, object>(new StubCacheProvider().AsyncFor<object>(), null!);
 
-        configure.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("serializer");
+        Should.Throw<ArgumentNullException>(configure)
+            .ParamName.ShouldBe("serializer");
     }
 
     [Fact]
@@ -244,8 +244,8 @@ public class AsyncSerializingCacheProviderSpecs
     {
         Action configure = () => new StubCacheProvider().AsyncFor<object>().WithSerializer<object, object>(null!);
 
-        configure.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("serializer");
+        Should.Throw<ArgumentNullException>(configure)
+            .ParamName.ShouldBe("serializer");
     }
 
     [Fact]
@@ -262,13 +262,13 @@ public class AsyncSerializingCacheProviderSpecs
         AsyncSerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>> serializingCacheProvider = new AsyncSerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>>(stubCacheProvider.AsyncFor<StubSerialized<ResultPrimitive>>(), stubTResultSerializer);
         await serializingCacheProvider.PutAsync(key, objectToCache, new Ttl(TimeSpan.FromMinutes(1)), CancellationToken, false);
 
-        serializeInvoked.Should().BeTrue();
+        serializeInvoked.ShouldBeTrue();
 
         (bool cacheHit, object? fromCache) = await stubCacheProvider.TryGetAsync(key, CancellationToken, false);
 
-        cacheHit.Should().BeTrue();
-        fromCache.Should().BeOfType<StubSerialized<ResultPrimitive>>()
-            .Which.Original.Should().Be(objectToCache);
+        cacheHit.ShouldBeTrue();
+        fromCache.ShouldBeOfType<StubSerialized<ResultPrimitive>>()
+            .Original.ShouldBe(objectToCache);
     }
 
     [Fact]
@@ -285,13 +285,13 @@ public class AsyncSerializingCacheProviderSpecs
         AsyncSerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>> serializingCacheProvider = new AsyncSerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>>(stubCacheProvider.AsyncFor<StubSerialized<ResultPrimitive>>(), stubTResultSerializer);
         await serializingCacheProvider.PutAsync(key, objectToCache, new Ttl(TimeSpan.FromMinutes(1)), CancellationToken, false);
 
-        serializeInvoked.Should().BeTrue();
+        serializeInvoked.ShouldBeTrue();
 
         (bool cacheHit, object? fromCache) = stubCacheProvider.TryGet(key);
 
-        cacheHit.Should().BeTrue();
-        fromCache.Should().BeOfType<StubSerialized<ResultPrimitive>>()
-            .Which.Original.Should().Be(objectToCache);
+        cacheHit.ShouldBeTrue();
+        fromCache.ShouldBeOfType<StubSerialized<ResultPrimitive>>()
+            .Original.ShouldBe(objectToCache);
     }
 
     [Fact]
@@ -310,9 +310,9 @@ public class AsyncSerializingCacheProviderSpecs
         await stubCacheProvider.PutAsync(key, new StubSerialized<ResultPrimitive>(objectToCache), new Ttl(TimeSpan.FromMinutes(1)), CancellationToken, false);
         (bool cacheHit, object? fromCache) = await serializingCacheProvider.TryGetAsync(key, CancellationToken, false);
 
-        cacheHit.Should().BeTrue();
-        deserializeInvoked.Should().BeTrue();
-        fromCache.Should().Be(objectToCache);
+        cacheHit.ShouldBeTrue();
+        deserializeInvoked.ShouldBeTrue();
+        fromCache.ShouldBe(objectToCache);
     }
 
     [Fact]
@@ -325,14 +325,14 @@ public class AsyncSerializingCacheProviderSpecs
         var stubCacheProvider = new StubCacheProvider();
         string key = "some key";
 
-        stubCacheProvider.TryGet(key).Item1.Should().BeFalse();
+        stubCacheProvider.TryGet(key).Item1.ShouldBeFalse();
 
         AsyncSerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>> serializingCacheProvider = new AsyncSerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>>(stubCacheProvider.AsyncFor<StubSerialized<ResultPrimitive>>(), stubTResultSerializer);
         (bool cacheHit, ResultPrimitive? fromCache) = await serializingCacheProvider.TryGetAsync(key, CancellationToken, false);
 
-        cacheHit.Should().BeFalse();
-        deserializeInvoked.Should().BeFalse();
-        fromCache.Should().Be(default);
+        cacheHit.ShouldBeFalse();
+        deserializeInvoked.ShouldBeFalse();
+        fromCache.ShouldBe(ResultPrimitive.Undefined);
     }
 
     [Fact]
@@ -350,12 +350,12 @@ public class AsyncSerializingCacheProviderSpecs
             stubCacheProvider.AsyncFor<StubSerialized<ResultPrimitive>>().WithSerializer(stubTResultSerializer);
         await serializingCacheProvider.PutAsync(key, objectToCache, new Ttl(TimeSpan.FromMinutes(1)), CancellationToken, false);
 
-        serializeInvoked.Should().BeTrue();
+        serializeInvoked.ShouldBeTrue();
 
         (bool cacheHit, object? fromCache) = await stubCacheProvider.TryGetAsync(key, CancellationToken, false);
-        cacheHit.Should().BeTrue();
-        fromCache.Should().BeOfType<StubSerialized<ResultPrimitive>>()
-            .Which.Original.Should().Be(objectToCache);
+        cacheHit.ShouldBeTrue();
+        fromCache.ShouldBeOfType<StubSerialized<ResultPrimitive>>()
+            .Original.ShouldBe(objectToCache);
     }
 
     [Fact]
@@ -373,13 +373,13 @@ public class AsyncSerializingCacheProviderSpecs
             stubCacheProvider.AsyncFor<StubSerialized<ResultPrimitive>>().WithSerializer(stubTResultSerializer);
         await serializingCacheProvider.PutAsync(key, objectToCache, new Ttl(TimeSpan.FromMinutes(1)), CancellationToken, false);
 
-        serializeInvoked.Should().BeTrue();
+        serializeInvoked.ShouldBeTrue();
 
         (bool cacheHit, object? fromCache) = stubCacheProvider.TryGet(key);
 
-        cacheHit.Should().BeTrue();
-        fromCache.Should().BeOfType<StubSerialized<ResultPrimitive>>()
-            .Which.Original.Should().Be(objectToCache);
+        cacheHit.ShouldBeTrue();
+        fromCache.ShouldBeOfType<StubSerialized<ResultPrimitive>>()
+            .Original.ShouldBe(objectToCache);
     }
 
     [Fact]
@@ -399,9 +399,9 @@ public class AsyncSerializingCacheProviderSpecs
         await stubCacheProvider.PutAsync(key, new StubSerialized<ResultPrimitive>(objectToCache), new Ttl(TimeSpan.FromMinutes(1)), CancellationToken, false);
         (bool cacheHit, ResultPrimitive? fromCache) = await serializingCacheProvider.TryGetAsync(key, CancellationToken, false);
 
-        cacheHit.Should().BeTrue();
-        deserializeInvoked.Should().BeTrue();
-        fromCache.Should().Be(objectToCache);
+        cacheHit.ShouldBeTrue();
+        deserializeInvoked.ShouldBeTrue();
+        fromCache.ShouldBe(objectToCache);
     }
 
     [Fact]
@@ -414,15 +414,15 @@ public class AsyncSerializingCacheProviderSpecs
         var stubCacheProvider = new StubCacheProvider();
         string key = "some key";
 
-        stubCacheProvider.TryGet(key).Item1.Should().BeFalse();
+        stubCacheProvider.TryGet(key).Item1.ShouldBeFalse();
 
         AsyncSerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>> serializingCacheProvider =
             stubCacheProvider.AsyncFor<StubSerialized<ResultPrimitive>>().WithSerializer(stubTResultSerializer);
         (bool cacheHit, ResultPrimitive? fromCache) = await serializingCacheProvider.TryGetAsync(key, CancellationToken, false);
 
-        cacheHit.Should().BeFalse();
-        deserializeInvoked.Should().BeFalse();
-        fromCache.Should().Be(default);
+        cacheHit.ShouldBeFalse();
+        deserializeInvoked.ShouldBeFalse();
+        fromCache.ShouldBe(ResultPrimitive.Undefined);
     }
 
     #endregion

--- a/test/Polly.Specs/Caching/CacheAsyncSpecs.cs
+++ b/test/Polly.Specs/Caching/CacheAsyncSpecs.cs
@@ -45,19 +45,19 @@ public class CacheAsyncSpecs : IDisposable
 
         var func = () => generic.Invoke(instance, [action, new Context(), CancellationToken, false]);
 
-        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("action");
+        var exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>()
+            .ParamName.ShouldBe("action");
 
         methodInfo = methods.First(method => method is { Name: "ImplementationAsync", ReturnType.Name: "Task" });
 
         func = () => methodInfo.Invoke(instance, [actionVoid, new Context(), CancellationToken, false]);
 
-        exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("action");
+        exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>()
+            .ParamName.ShouldBe("action");
     }
 
     [Fact]
@@ -73,46 +73,46 @@ public class CacheAsyncSpecs : IDisposable
         const string CacheProviderExpected = "cacheProvider";
 
         Action action = () => Policy.CacheAsync(cacheProvider, ttl, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttlStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttl, cacheKeyStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttlStrategy, cacheKeyStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttl, cacheKeyStrategyFunc, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttlStrategy, cacheKeyStrategyFunc, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttl, onCache, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttlStrategy, onCache, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttl, cacheKeyStrategy, onCache, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttlStrategy, cacheKeyStrategy, onCache, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttl, cacheKeyStrategyFunc, onCache, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttlStrategy, cacheKeyStrategyFunc, onCache, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
     }
 
     [Fact]
     public void Should_throw_when_ttl_strategy_is_null()
     {
-        IAsyncCacheProvider cacheProvider = new StubCacheProvider();
+        var cacheProvider = new StubCacheProvider();
         ITtlStrategy ttlStrategy = null!;
         ICacheKeyStrategy cacheKeyStrategy = new StubCacheKeyStrategy(context => context.OperationKey + context["id"]);
         Func<Context, string> cacheKeyStrategyFunc = (_) => string.Empty;
@@ -121,28 +121,28 @@ public class CacheAsyncSpecs : IDisposable
         const string TtlStrategyExpected = "ttlStrategy";
 
         Action action = () => Policy.CacheAsync(cacheProvider, ttlStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttlStrategy, cacheKeyStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttlStrategy, cacheKeyStrategyFunc, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttlStrategy, onCache, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttlStrategy, cacheKeyStrategy, onCache, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttlStrategy, cacheKeyStrategyFunc, onCache, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
     }
 
     [Fact]
     public void Should_throw_when_cache_key_strategy_is_null()
     {
-        IAsyncCacheProvider cacheProvider = new StubCacheProvider();
+        var cacheProvider = new StubCacheProvider();
         var ttl = TimeSpan.MaxValue;
         ITtlStrategy ttlStrategy = new ContextualTtl();
         ICacheKeyStrategy cacheKeyStrategy = null!;
@@ -152,16 +152,16 @@ public class CacheAsyncSpecs : IDisposable
         const string CacheKeyStrategyExpected = "cacheKeyStrategy";
 
         Action action = () => Policy.CacheAsync(cacheProvider, ttl, cacheKeyStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttlStrategy, cacheKeyStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttl, cacheKeyStrategyFunc, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttlStrategy, cacheKeyStrategyFunc, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
         action = () => Policy.CacheAsync(
             cacheProvider,
@@ -172,7 +172,7 @@ public class CacheAsyncSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
         action = () => Policy.CacheAsync(
             cacheProvider,
@@ -183,7 +183,7 @@ public class CacheAsyncSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
         action = () => Policy.CacheAsync(
             cacheProvider,
@@ -194,7 +194,7 @@ public class CacheAsyncSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
         action = () => Policy.CacheAsync(
             cacheProvider,
@@ -205,13 +205,13 @@ public class CacheAsyncSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
     }
 
     [Fact]
     public void Should_throw_when_on_cache_get_is_null()
     {
-        IAsyncCacheProvider cacheProvider = new StubCacheProvider();
+        var cacheProvider = new StubCacheProvider();
         var ttl = TimeSpan.MaxValue;
         ITtlStrategy ttlStrategy = new ContextualTtl();
         ICacheKeyStrategy cacheKeyStrategy = new StubCacheKeyStrategy(context => context.OperationKey + context["id"]);
@@ -222,31 +222,31 @@ public class CacheAsyncSpecs : IDisposable
         const string OnCacheGetExpected = "onCacheGet";
 
         Action action = () => Policy.CacheAsync(cacheProvider, ttl, onCacheGet, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheGetExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheGetExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttlStrategy, onCacheGet, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheGetExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheGetExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttl, cacheKeyStrategy, onCacheGet, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheGetExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheGetExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttlStrategy, cacheKeyStrategy, onCacheGet, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheGetExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheGetExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttl, cacheKeyStrategyFunc, onCacheGet, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheGetExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheGetExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttlStrategy, cacheKeyStrategyFunc, onCacheGet, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheGetExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheGetExpected);
     }
 
     [Fact]
     public void Should_throw_when_on_cache_miss_is_null()
     {
-        IAsyncCacheProvider cacheProvider = new StubCacheProvider();
+        var cacheProvider = new StubCacheProvider();
         var ttl = TimeSpan.MaxValue;
         ITtlStrategy ttlStrategy = new ContextualTtl();
-        ICacheKeyStrategy cacheKeyStrategy = new StubCacheKeyStrategy(context => context.OperationKey + context["id"]);
+        var cacheKeyStrategy = new StubCacheKeyStrategy(context => context.OperationKey + context["id"]);
         Func<Context, string> cacheKeyStrategyFunc = (_) => string.Empty;
         Action<Context, string> onCacheMiss = null!;
         Action<Context, string> onCache = (_, _) => { };
@@ -254,22 +254,22 @@ public class CacheAsyncSpecs : IDisposable
         const string OnCacheMissExpected = "onCacheMiss";
 
         Action action = () => Policy.CacheAsync(cacheProvider, ttl, onCache, onCacheMiss, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheMissExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheMissExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttlStrategy, onCache, onCacheMiss, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheMissExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheMissExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttl, cacheKeyStrategy, onCache, onCacheMiss, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheMissExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheMissExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttlStrategy, cacheKeyStrategy, onCache, onCacheMiss, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheMissExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheMissExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttl, cacheKeyStrategyFunc, onCache, onCacheMiss, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheMissExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheMissExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttlStrategy, cacheKeyStrategyFunc, onCache, onCacheMiss, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheMissExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheMissExpected);
     }
 
     [Fact]
@@ -286,22 +286,22 @@ public class CacheAsyncSpecs : IDisposable
         const string OnCachePutExpected = "onCachePut";
 
         Action action = () => Policy.CacheAsync(cacheProvider, ttl, onCache, onCache, onCachePut, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCachePutExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCachePutExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttlStrategy, onCache, onCache, onCachePut, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCachePutExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCachePutExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttl, cacheKeyStrategy, onCache, onCache, onCachePut, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCachePutExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCachePutExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttlStrategy, cacheKeyStrategy, onCache, onCache, onCachePut, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCachePutExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCachePutExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttl, cacheKeyStrategyFunc, onCache, onCache, onCachePut, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCachePutExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCachePutExpected);
 
         action = () => Policy.CacheAsync(cacheProvider, ttlStrategy, cacheKeyStrategyFunc, onCache, onCache, onCachePut, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCachePutExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCachePutExpected);
     }
 
     [Fact]
@@ -311,10 +311,10 @@ public class CacheAsyncSpecs : IDisposable
         IAsyncPolicy<int>[] policiesGeneric = null!;
 
         Action action = () => Policy.WrapAsync(policies);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("policies");
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe("policies");
 
         action = () => Policy.WrapAsync<int>(policiesGeneric);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("policies");
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe("policies");
     }
     #endregion
 
@@ -327,7 +327,7 @@ public class CacheAsyncSpecs : IDisposable
         const string ValueToReturnFromExecution = "valueToReturnFromExecution";
         const string OperationKey = "SomeOperationKey";
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         var cache = Policy.CacheAsync(stubCacheProvider, TimeSpan.MaxValue);
         await stubCacheProvider.PutAsync(OperationKey, ValueToReturnFromCache, new Ttl(TimeSpan.MaxValue), CancellationToken, false);
 
@@ -339,9 +339,9 @@ public class CacheAsyncSpecs : IDisposable
             await TaskHelper.EmptyTask;
             return ValueToReturnFromExecution;
         }, new Context(OperationKey)))
-            .Should().Be(ValueToReturnFromCache);
+            .ShouldBe(ValueToReturnFromCache);
 
-        delegateExecuted.Should().BeFalse();
+        delegateExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -350,18 +350,18 @@ public class CacheAsyncSpecs : IDisposable
         const string ValueToReturn = "valueToReturn";
         const string OperationKey = "SomeOperationKey";
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         var cache = Policy.CacheAsync(stubCacheProvider, TimeSpan.MaxValue);
 
         (bool cacheHit1, object? fromCache1) = await stubCacheProvider.TryGetAsync(OperationKey, CancellationToken, false);
-        cacheHit1.Should().BeFalse();
-        fromCache1.Should().BeNull();
+        cacheHit1.ShouldBeFalse();
+        fromCache1.ShouldBeNull();
 
-        (await cache.ExecuteAsync(async _ => { await TaskHelper.EmptyTask; return ValueToReturn; }, new Context(OperationKey))).Should().Be(ValueToReturn);
+        (await cache.ExecuteAsync(async _ => { await TaskHelper.EmptyTask; return ValueToReturn; }, new Context(OperationKey))).ShouldBe(ValueToReturn);
 
         (bool cacheHit2, object? fromCache2) = await stubCacheProvider.TryGetAsync(OperationKey, CancellationToken, false);
-        cacheHit2.Should().BeTrue();
-        fromCache2.Should().Be(ValueToReturn);
+        cacheHit2.ShouldBeTrue();
+        fromCache2.ShouldBe(ValueToReturn);
     }
 
     [Fact]
@@ -370,13 +370,13 @@ public class CacheAsyncSpecs : IDisposable
         const string ValueToReturn = "valueToReturn";
         const string OperationKey = "SomeOperationKey";
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
-        TimeSpan ttl = TimeSpan.FromMinutes(30);
+        var stubCacheProvider = new StubCacheProvider();
+        var ttl = TimeSpan.FromMinutes(30);
         var cache = Policy.CacheAsync(stubCacheProvider, ttl);
 
         (bool cacheHit1, object? fromCache1) = await stubCacheProvider.TryGetAsync(OperationKey, CancellationToken, false);
-        cacheHit1.Should().BeFalse();
-        fromCache1.Should().BeNull();
+        cacheHit1.ShouldBeFalse();
+        fromCache1.ShouldBeNull();
 
         int delegateInvocations = 0;
         Func<Context, Task<string>> func = async _ =>
@@ -390,24 +390,24 @@ public class CacheAsyncSpecs : IDisposable
         SystemClock.DateTimeOffsetUtcNow = () => fixedTime;
 
         // First execution should execute delegate and put result in the cache.
-        (await cache.ExecuteAsync(func, new Context(OperationKey))).Should().Be(ValueToReturn);
-        delegateInvocations.Should().Be(1);
+        (await cache.ExecuteAsync(func, new Context(OperationKey))).ShouldBe(ValueToReturn);
+        delegateInvocations.ShouldBe(1);
         (bool cacheHit2, object? fromCache2) = await stubCacheProvider.TryGetAsync(OperationKey, CancellationToken, false);
-        cacheHit2.Should().BeTrue();
-        fromCache2.Should().Be(ValueToReturn);
+        cacheHit2.ShouldBeTrue();
+        fromCache2.ShouldBe(ValueToReturn);
 
         // Second execution (before cache expires) should get it from the cache - no further delegate execution.
         // (Manipulate time so just prior cache expiry).
         SystemClock.DateTimeOffsetUtcNow = () => fixedTime.Add(ttl).AddSeconds(-1);
-        (await cache.ExecuteAsync(func, new Context(OperationKey))).Should().Be(ValueToReturn);
-        delegateInvocations.Should().Be(1);
+        (await cache.ExecuteAsync(func, new Context(OperationKey))).ShouldBe(ValueToReturn);
+        delegateInvocations.ShouldBe(1);
 
         // Manipulate time to force cache expiry.
         SystemClock.DateTimeOffsetUtcNow = () => fixedTime.Add(ttl).AddSeconds(1);
 
         // Third execution (cache expired) should not get it from the cache - should cause further delegate execution.
-        (await cache.ExecuteAsync(func, new Context(OperationKey))).Should().Be(ValueToReturn);
-        delegateInvocations.Should().Be(2);
+        (await cache.ExecuteAsync(func, new Context(OperationKey))).ShouldBe(ValueToReturn);
+        delegateInvocations.ShouldBe(2);
     }
 
     [Fact]
@@ -416,18 +416,18 @@ public class CacheAsyncSpecs : IDisposable
         const string ValueToReturn = "valueToReturn";
         const string OperationKey = "SomeOperationKey";
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         var cache = Policy.CacheAsync(stubCacheProvider, TimeSpan.Zero);
 
         (bool cacheHit1, object? fromCache1) = await stubCacheProvider.TryGetAsync(OperationKey, CancellationToken, false);
-        cacheHit1.Should().BeFalse();
-        fromCache1.Should().BeNull();
+        cacheHit1.ShouldBeFalse();
+        fromCache1.ShouldBeNull();
 
-        (await cache.ExecuteAsync(async _ => { await TaskHelper.EmptyTask; return ValueToReturn; }, new Context(OperationKey))).Should().Be(ValueToReturn);
+        (await cache.ExecuteAsync(async _ => { await TaskHelper.EmptyTask; return ValueToReturn; }, new Context(OperationKey))).ShouldBe(ValueToReturn);
 
         (bool cacheHit2, object? fromCache2) = await stubCacheProvider.TryGetAsync(OperationKey, CancellationToken, false);
-        cacheHit2.Should().BeFalse();
-        fromCache2.Should().BeNull();
+        cacheHit2.ShouldBeFalse();
+        fromCache2.ShouldBeNull();
     }
 
     [Fact]
@@ -446,20 +446,20 @@ public class CacheAsyncSpecs : IDisposable
             return ValueToReturn;
         };
 
-        (await cache.ExecuteAsync(func, new Context(OperationKey))).Should().Be(ValueToReturn);
-        delegateInvocations.Should().Be(1);
+        (await cache.ExecuteAsync(func, new Context(OperationKey))).ShouldBe(ValueToReturn);
+        delegateInvocations.ShouldBe(1);
 
-        (await cache.ExecuteAsync(func, new Context(OperationKey))).Should().Be(ValueToReturn);
-        delegateInvocations.Should().Be(1);
+        (await cache.ExecuteAsync(func, new Context(OperationKey))).ShouldBe(ValueToReturn);
+        delegateInvocations.ShouldBe(1);
 
-        (await cache.ExecuteAsync(func, new Context(OperationKey))).Should().Be(ValueToReturn);
-        delegateInvocations.Should().Be(1);
+        (await cache.ExecuteAsync(func, new Context(OperationKey))).ShouldBe(ValueToReturn);
+        delegateInvocations.ShouldBe(1);
     }
 
     [Fact]
     public async Task Should_allow_custom_FuncCacheKeyStrategy()
     {
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         var cache = Policy.CacheAsync(stubCacheProvider, TimeSpan.MaxValue, context => context.OperationKey + context["id"]);
 
         object person1 = new();
@@ -470,11 +470,11 @@ public class CacheAsyncSpecs : IDisposable
         bool funcExecuted = false;
         Func<Context, Task<object>> func = async _ => { funcExecuted = true; await TaskHelper.EmptyTask; return new object(); };
 
-        (await cache.ExecuteAsync(func, new Context("person", CreateDictionary("id", "1")))).Should().BeSameAs(person1);
-        funcExecuted.Should().BeFalse();
+        (await cache.ExecuteAsync(func, new Context("person", CreateDictionary("id", "1")))).ShouldBeSameAs(person1);
+        funcExecuted.ShouldBeFalse();
 
-        (await cache.ExecuteAsync(func, new Context("person", CreateDictionary("id", "2")))).Should().BeSameAs(person2);
-        funcExecuted.Should().BeFalse();
+        (await cache.ExecuteAsync(func, new Context("person", CreateDictionary("id", "2")))).ShouldBeSameAs(person2);
+        funcExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -483,8 +483,8 @@ public class CacheAsyncSpecs : IDisposable
         Action<Context, string, Exception> noErrorHandling = (_, _, _) => { };
         Action<Context, string> emptyDelegate = (_, _) => { };
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
-        ICacheKeyStrategy cacheKeyStrategy = new StubCacheKeyStrategy(context => context.OperationKey + context["id"]);
+        var stubCacheProvider = new StubCacheProvider();
+        var cacheKeyStrategy = new StubCacheKeyStrategy(context => context.OperationKey + context["id"]);
         var cache = Policy.CacheAsync(stubCacheProvider, new RelativeTtl(TimeSpan.MaxValue), cacheKeyStrategy, emptyDelegate, emptyDelegate, emptyDelegate, noErrorHandling, noErrorHandling);
 
         object person1 = new();
@@ -495,11 +495,11 @@ public class CacheAsyncSpecs : IDisposable
         bool funcExecuted = false;
         Func<Context, Task<object>> func = async _ => { funcExecuted = true; await TaskHelper.EmptyTask; return new object(); };
 
-        (await cache.ExecuteAsync(func, new Context("person", CreateDictionary("id", "1")))).Should().BeSameAs(person1);
-        funcExecuted.Should().BeFalse();
+        (await cache.ExecuteAsync(func, new Context("person", CreateDictionary("id", "1")))).ShouldBeSameAs(person1);
+        funcExecuted.ShouldBeFalse();
 
-        (await cache.ExecuteAsync(func, new Context("person", CreateDictionary("id", "2")))).Should().BeSameAs(person2);
-        funcExecuted.Should().BeFalse();
+        (await cache.ExecuteAsync(func, new Context("person", CreateDictionary("id", "2")))).ShouldBeSameAs(person2);
+        funcExecuted.ShouldBeFalse();
     }
 
     #endregion
@@ -512,18 +512,18 @@ public class CacheAsyncSpecs : IDisposable
         ResultClass? valueToReturn = null;
         const string OperationKey = "SomeOperationKey";
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         var cache = Policy.CacheAsync(stubCacheProvider, TimeSpan.MaxValue);
 
         (bool cacheHit1, object? fromCache1) = await stubCacheProvider.TryGetAsync(OperationKey, CancellationToken, false);
-        cacheHit1.Should().BeFalse();
-        fromCache1.Should().BeNull();
+        cacheHit1.ShouldBeFalse();
+        fromCache1.ShouldBeNull();
 
-        (await cache.ExecuteAsync(async _ => { await TaskHelper.EmptyTask; return valueToReturn; }, new Context(OperationKey))).Should().Be(valueToReturn);
+        (await cache.ExecuteAsync(async _ => { await TaskHelper.EmptyTask; return valueToReturn; }, new Context(OperationKey))).ShouldBe(valueToReturn);
 
         (bool cacheHit2, object? fromCache2) = await stubCacheProvider.TryGetAsync(OperationKey, CancellationToken, false);
-        cacheHit2.Should().BeTrue();
-        fromCache2.Should().Be(valueToReturn);
+        cacheHit2.ShouldBeTrue();
+        fromCache2.ShouldBe(valueToReturn);
     }
 
     [Fact]
@@ -533,7 +533,7 @@ public class CacheAsyncSpecs : IDisposable
         ResultClass valueToReturnFromExecution = new ResultClass(ResultPrimitive.Good);
         const string OperationKey = "SomeOperationKey";
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         var cache = Policy.CacheAsync(stubCacheProvider, TimeSpan.MaxValue);
         await stubCacheProvider.PutAsync(OperationKey, valueToReturnFromCache, new Ttl(TimeSpan.MaxValue), CancellationToken, false);
 
@@ -545,9 +545,9 @@ public class CacheAsyncSpecs : IDisposable
                     await TaskHelper.EmptyTask;
                     return valueToReturnFromExecution;
                 }, new Context(OperationKey)))
-            .Should().Be(valueToReturnFromCache);
+            .ShouldBe(valueToReturnFromCache);
 
-        delegateExecuted.Should().BeFalse();
+        delegateExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -556,18 +556,18 @@ public class CacheAsyncSpecs : IDisposable
         ResultPrimitive valueToReturn = default;
         const string OperationKey = "SomeOperationKey";
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         var cache = Policy.CacheAsync(stubCacheProvider, TimeSpan.MaxValue);
 
         (bool cacheHit1, object? fromCache1) = await stubCacheProvider.TryGetAsync(OperationKey, CancellationToken, false);
-        cacheHit1.Should().BeFalse();
-        fromCache1.Should().BeNull();
+        cacheHit1.ShouldBeFalse();
+        fromCache1.ShouldBeNull();
 
-        (await cache.ExecuteAsync(async _ => { await TaskHelper.EmptyTask; return valueToReturn; }, new Context(OperationKey))).Should().Be(valueToReturn);
+        (await cache.ExecuteAsync(async _ => { await TaskHelper.EmptyTask; return valueToReturn; }, new Context(OperationKey))).ShouldBe(valueToReturn);
 
         (bool cacheHit2, object? fromCache2) = await stubCacheProvider.TryGetAsync(OperationKey, CancellationToken, false);
-        cacheHit2.Should().BeTrue();
-        fromCache2.Should().Be(valueToReturn);
+        cacheHit2.ShouldBeTrue();
+        fromCache2.ShouldBe(valueToReturn);
     }
 
     [Fact]
@@ -575,10 +575,10 @@ public class CacheAsyncSpecs : IDisposable
     {
         ResultPrimitive valueToReturnFromCache = default;
         ResultPrimitive valueToReturnFromExecution = ResultPrimitive.Good;
-        valueToReturnFromExecution.Should().NotBe(valueToReturnFromCache);
+        valueToReturnFromExecution.ShouldNotBe(valueToReturnFromCache);
         const string OperationKey = "SomeOperationKey";
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         var cache = Policy.CacheAsync(stubCacheProvider, TimeSpan.MaxValue);
         await stubCacheProvider.PutAsync(OperationKey, valueToReturnFromCache, new Ttl(TimeSpan.MaxValue), CancellationToken, false);
 
@@ -590,9 +590,9 @@ public class CacheAsyncSpecs : IDisposable
                     await TaskHelper.EmptyTask;
                     return valueToReturnFromExecution;
                 }, new Context(OperationKey)))
-            .Should().Be(valueToReturnFromCache);
+            .ShouldBe(valueToReturnFromCache);
 
-        delegateExecuted.Should().BeFalse();
+        delegateExecuted.ShouldBeFalse();
     }
 
     #endregion
@@ -606,7 +606,7 @@ public class CacheAsyncSpecs : IDisposable
         const string ValueToReturnFromExecution = "valueToReturnFromExecution";
         const string OperationKey = "SomeOperationKey";
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         var cache = Policy.CacheAsync(stubCacheProvider, TimeSpan.MaxValue);
         var noop = Policy.NoOpAsync();
         var wrap = Policy.WrapAsync(cache, noop);
@@ -621,9 +621,9 @@ public class CacheAsyncSpecs : IDisposable
             await TaskHelper.EmptyTask;
             return ValueToReturnFromExecution;
         }, new Context(OperationKey)))
-            .Should().Be(ValueToReturnFromCache);
+            .ShouldBe(ValueToReturnFromCache);
 
-        delegateExecuted.Should().BeFalse();
+        delegateExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -633,7 +633,7 @@ public class CacheAsyncSpecs : IDisposable
         const string ValueToReturnFromExecution = "valueToReturnFromExecution";
         const string OperationKey = "SomeOperationKey";
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         var cache = Policy.CacheAsync(stubCacheProvider, TimeSpan.MaxValue);
         var noop = Policy.NoOpAsync();
         var wrap = Policy.WrapAsync(noop, cache);
@@ -648,9 +648,9 @@ public class CacheAsyncSpecs : IDisposable
             await TaskHelper.EmptyTask;
             return ValueToReturnFromExecution;
         }, new Context(OperationKey)))
-            .Should().Be(ValueToReturnFromCache);
+            .ShouldBe(ValueToReturnFromCache);
 
-        delegateExecuted.Should().BeFalse();
+        delegateExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -660,7 +660,7 @@ public class CacheAsyncSpecs : IDisposable
         const string ValueToReturnFromExecution = "valueToReturnFromExecution";
         const string OperationKey = "SomeOperationKey";
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         var cache = Policy.CacheAsync(stubCacheProvider, TimeSpan.MaxValue);
         var noop = Policy.NoOpAsync();
         var wrap = Policy.WrapAsync(noop, cache, noop);
@@ -675,9 +675,9 @@ public class CacheAsyncSpecs : IDisposable
             await TaskHelper.EmptyTask;
             return ValueToReturnFromExecution;
         }, new Context(OperationKey)))
-            .Should().Be(ValueToReturnFromCache);
+            .ShouldBe(ValueToReturnFromCache);
 
-        delegateExecuted.Should().BeFalse();
+        delegateExecuted.ShouldBeFalse();
     }
 
     #endregion
@@ -699,11 +699,11 @@ public class CacheAsyncSpecs : IDisposable
             return valueToReturn;
         };
 
-        (await cache.ExecuteAsync(func /*, no operation key */)).Should().Be(valueToReturn);
-        delegateInvocations.Should().Be(1);
+        (await cache.ExecuteAsync(func /*, no operation key */)).ShouldBe(valueToReturn);
+        delegateInvocations.ShouldBe(1);
 
-        (await cache.ExecuteAsync(func /*, no operation key */)).Should().Be(valueToReturn);
-        delegateInvocations.Should().Be(2);
+        (await cache.ExecuteAsync(func /*, no operation key */)).ShouldBe(valueToReturn);
+        delegateInvocations.ShouldBe(2);
     }
 
     [Fact]
@@ -717,10 +717,10 @@ public class CacheAsyncSpecs : IDisposable
         Func<Context, Task> action = async _ => { delegateInvocations++; await TaskHelper.EmptyTask; };
 
         cache.ExecuteAsync(action, new Context(operationKey));
-        delegateInvocations.Should().Be(1);
+        delegateInvocations.ShouldBe(1);
 
         cache.ExecuteAsync(action, new Context(operationKey));
-        delegateInvocations.Should().Be(2);
+        delegateInvocations.ShouldBe(2);
     }
 
     #endregion
@@ -733,7 +733,7 @@ public class CacheAsyncSpecs : IDisposable
         const string ValueToReturn = "valueToReturn";
         const string OperationKey = "SomeOperationKey";
 
-        var cache = Policy.CacheAsync(new StubCacheProvider(), TimeSpan.MaxValue);
+        var policy = Policy.CacheAsync(new StubCacheProvider(), TimeSpan.MaxValue);
 
         int delegateInvocations = 0;
 
@@ -747,16 +747,15 @@ public class CacheAsyncSpecs : IDisposable
                 return ValueToReturn;
             };
 
-            (await cache.ExecuteAsync(func, new Context(OperationKey), tokenSource.Token)).Should().Be(ValueToReturn);
-            delegateInvocations.Should().Be(1);
+            (await policy.ExecuteAsync(func, new Context(OperationKey), tokenSource.Token)).ShouldBe(ValueToReturn);
+            delegateInvocations.ShouldBe(1);
 
             tokenSource.Cancel();
 
-            await cache.Awaiting(policy => policy.ExecuteAsync(func, new Context(OperationKey), tokenSource.Token))
-                .Should().ThrowAsync<OperationCanceledException>();
+            await Should.ThrowAsync<OperationCanceledException>(() => policy.ExecuteAsync(func, new Context(OperationKey), tokenSource.Token));
         }
 
-        delegateInvocations.Should().Be(1);
+        delegateInvocations.ShouldBe(1);
     }
 
     [Fact]
@@ -765,8 +764,8 @@ public class CacheAsyncSpecs : IDisposable
         const string ValueToReturn = "valueToReturn";
         const string OperationKey = "SomeOperationKey";
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
-        var cache = Policy.CacheAsync(stubCacheProvider, TimeSpan.MaxValue);
+        var stubCacheProvider = new StubCacheProvider();
+        var policy = Policy.CacheAsync(stubCacheProvider, TimeSpan.MaxValue);
 
         using (var tokenSource = new CancellationTokenSource())
         {
@@ -778,13 +777,12 @@ public class CacheAsyncSpecs : IDisposable
                 return ValueToReturn;
             };
 
-            await cache.Awaiting(policy => policy.ExecuteAsync(func, new Context(OperationKey), tokenSource.Token))
-                .Should().ThrowAsync<OperationCanceledException>();
+            await Should.ThrowAsync<OperationCanceledException>(() => policy.ExecuteAsync(func, new Context(OperationKey), tokenSource.Token));
         }
 
         (bool cacheHit, object? fromCache) = await stubCacheProvider.TryGetAsync(OperationKey, CancellationToken, false);
-        cacheHit.Should().BeFalse();
-        fromCache.Should().BeNull();
+        cacheHit.ShouldBeFalse();
+        fromCache.ShouldBeNull();
     }
 
     #endregion
@@ -795,7 +793,7 @@ public class CacheAsyncSpecs : IDisposable
     public async Task Should_call_onError_delegate_if_cache_get_errors()
     {
         Exception ex = new Exception();
-        IAsyncCacheProvider stubCacheProvider = new StubErroringCacheProvider(getException: ex, putException: null);
+        var stubCacheProvider = new StubErroringCacheProvider(getException: ex, putException: null);
 
         Exception? exceptionFromCacheProvider = null;
 
@@ -819,18 +817,18 @@ public class CacheAsyncSpecs : IDisposable
             return ValueToReturnFromExecution;
 
         }, new Context(OperationKey)))
-           .Should().Be(ValueToReturnFromExecution);
-        delegateExecuted.Should().BeTrue();
+           .ShouldBe(ValueToReturnFromExecution);
+        delegateExecuted.ShouldBeTrue();
 
         // And error should be captured by onError delegate.
-        exceptionFromCacheProvider.Should().Be(ex);
+        exceptionFromCacheProvider.ShouldBe(ex);
     }
 
     [Fact]
     public async Task Should_call_onError_delegate_if_cache_put_errors()
     {
-        Exception ex = new Exception();
-        IAsyncCacheProvider stubCacheProvider = new StubErroringCacheProvider(getException: null, putException: ex);
+        var ex = new Exception();
+        var stubCacheProvider = new StubErroringCacheProvider(getException: null, putException: ex);
 
         Exception? exceptionFromCacheProvider = null;
 
@@ -842,18 +840,18 @@ public class CacheAsyncSpecs : IDisposable
         var cache = Policy.CacheAsync(stubCacheProvider, TimeSpan.MaxValue, onError);
 
         (bool cacheHit1, object? fromCache1) = await stubCacheProvider.TryGetAsync(OperationKey, CancellationToken, false);
-        cacheHit1.Should().BeFalse();
-        fromCache1.Should().BeNull();
+        cacheHit1.ShouldBeFalse();
+        fromCache1.ShouldBeNull();
 
-        (await cache.ExecuteAsync(async _ => { await TaskHelper.EmptyTask; return ValueToReturn; }, new Context(OperationKey))).Should().Be(ValueToReturn);
+        (await cache.ExecuteAsync(async _ => { await TaskHelper.EmptyTask; return ValueToReturn; }, new Context(OperationKey))).ShouldBe(ValueToReturn);
 
         // error should be captured by onError delegate.
-        exceptionFromCacheProvider.Should().Be(ex);
+        exceptionFromCacheProvider.ShouldBe(ex);
 
         // failed to put it in the cache
         (bool cacheHit2, object? fromCache2) = await stubCacheProvider.TryGetAsync(OperationKey, CancellationToken, false);
-        cacheHit2.Should().BeFalse();
-        fromCache2.Should().BeNull();
+        cacheHit2.ShouldBeFalse();
+        fromCache2.ShouldBeNull();
     }
 
     [Fact]
@@ -872,7 +870,7 @@ public class CacheAsyncSpecs : IDisposable
         Action<Context, string> emptyDelegate = (_, _) => { };
         Action<Context, string> onCacheAction = (ctx, key) => { contextPassedToDelegate = ctx; keyPassedToDelegate = key; };
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         var cache = Policy.CacheAsync(stubCacheProvider, new RelativeTtl(TimeSpan.MaxValue), DefaultCacheKeyStrategy.Instance, onCacheAction, emptyDelegate, emptyDelegate, noErrorHandling, noErrorHandling);
         await stubCacheProvider.PutAsync(OperationKey, ValueToReturnFromCache, new Ttl(TimeSpan.MaxValue), CancellationToken, false);
 
@@ -883,11 +881,11 @@ public class CacheAsyncSpecs : IDisposable
                     await TaskHelper.EmptyTask;
                     return ValueToReturnFromExecution;
                 }, contextToExecute))
-            .Should().Be(ValueToReturnFromCache);
-        delegateExecuted.Should().BeFalse();
+            .ShouldBe(ValueToReturnFromCache);
+        delegateExecuted.ShouldBeFalse();
 
-        contextPassedToDelegate.Should().BeSameAs(contextToExecute);
-        keyPassedToDelegate.Should().Be(OperationKey);
+        contextPassedToDelegate.ShouldBeSameAs(contextToExecute);
+        keyPassedToDelegate.ShouldBe(OperationKey);
     }
 
     [Fact]
@@ -908,23 +906,23 @@ public class CacheAsyncSpecs : IDisposable
         Action<Context, string> onCacheMiss = (ctx, key) => { contextPassedToOnCacheMiss = ctx; keyPassedToOnCacheMiss = key; };
         Action<Context, string> onCachePut = (ctx, key) => { contextPassedToOnCachePut = ctx; keyPassedToOnCachePut = key; };
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         var cache = Policy.CacheAsync(stubCacheProvider, new RelativeTtl(TimeSpan.MaxValue), DefaultCacheKeyStrategy.Instance, emptyDelegate, onCacheMiss, onCachePut, noErrorHandling, noErrorHandling);
 
         (bool cacheHit1, object? fromCache1) = await stubCacheProvider.TryGetAsync(OperationKey, CancellationToken, false);
-        cacheHit1.Should().BeFalse();
-        fromCache1.Should().BeNull();
+        cacheHit1.ShouldBeFalse();
+        fromCache1.ShouldBeNull();
 
-        (await cache.ExecuteAsync(async _ => { await TaskHelper.EmptyTask; return ValueToReturn; }, contextToExecute)).Should().Be(ValueToReturn);
+        (await cache.ExecuteAsync(async _ => { await TaskHelper.EmptyTask; return ValueToReturn; }, contextToExecute)).ShouldBe(ValueToReturn);
 
         (bool cacheHit2, object? fromCache2) = await stubCacheProvider.TryGetAsync(OperationKey, CancellationToken, false);
-        cacheHit2.Should().BeTrue();
-        fromCache2.Should().Be(ValueToReturn);
+        cacheHit2.ShouldBeTrue();
+        fromCache2.ShouldBe(ValueToReturn);
 
-        contextPassedToOnCachePut.Should().BeSameAs(contextToExecute);
-        keyPassedToOnCachePut.Should().Be(OperationKey);
-        contextPassedToOnCacheMiss.Should().NotBeNull();
-        keyPassedToOnCacheMiss.Should().Be("SomeOperationKey");
+        contextPassedToOnCachePut.ShouldBeSameAs(contextToExecute);
+        keyPassedToOnCachePut.ShouldBe(OperationKey);
+        contextPassedToOnCacheMiss.ShouldNotBeNull();
+        keyPassedToOnCacheMiss.ShouldBe("SomeOperationKey");
     }
 
     [Fact]
@@ -945,19 +943,19 @@ public class CacheAsyncSpecs : IDisposable
         Action<Context, string> onCacheMiss = (ctx, key) => { contextPassedToOnCacheMiss = ctx; keyPassedToOnCacheMiss = key; };
         Action<Context, string> onCachePut = (ctx, key) => { contextPassedToOnCachePut = ctx; keyPassedToOnCachePut = key; };
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         var cache = Policy.CacheAsync(stubCacheProvider, new RelativeTtl(TimeSpan.Zero), DefaultCacheKeyStrategy.Instance, emptyDelegate, onCacheMiss, onCachePut, noErrorHandling, noErrorHandling);
 
         (bool cacheHit, object? fromCache) = await stubCacheProvider.TryGetAsync(OperationKey, CancellationToken, false);
-        cacheHit.Should().BeFalse();
-        fromCache.Should().BeNull();
+        cacheHit.ShouldBeFalse();
+        fromCache.ShouldBeNull();
 
-        (await cache.ExecuteAsync(async _ => { await TaskHelper.EmptyTask; return ValueToReturn; }, contextToExecute)).Should().Be(ValueToReturn);
+        (await cache.ExecuteAsync(async _ => { await TaskHelper.EmptyTask; return ValueToReturn; }, contextToExecute)).ShouldBe(ValueToReturn);
 
-        contextPassedToOnCachePut.Should().BeNull();
-        keyPassedToOnCachePut.Should().BeNull();
-        contextPassedToOnCacheMiss.Should().BeEmpty();
-        keyPassedToOnCacheMiss.Should().Be("SomeOperationKey");
+        contextPassedToOnCachePut.ShouldBeNull();
+        keyPassedToOnCachePut.ShouldBeNull();
+        contextPassedToOnCacheMiss.ShouldBeEmpty();
+        keyPassedToOnCacheMiss.ShouldBe("SomeOperationKey");
     }
 
     [Fact]
@@ -978,9 +976,9 @@ public class CacheAsyncSpecs : IDisposable
             await TaskHelper.EmptyTask;
             return valueToReturn;
         }  /*, no operation key */))
-        .Should().Be(valueToReturn);
+        .ShouldBe(valueToReturn);
 
-        onCacheMissExecuted.Should().BeFalse();
+        onCacheMissExecuted.ShouldBeFalse();
     }
 
     #endregion

--- a/test/Polly.Specs/Caching/CacheSpecs.cs
+++ b/test/Polly.Specs/Caching/CacheSpecs.cs
@@ -44,19 +44,19 @@ public class CacheSpecs : IDisposable
 
         var func = () => generic.Invoke(instance, [action, new Context(), cancellationToken]);
 
-        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("action");
+        var exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>()
+            .ParamName.ShouldBe("action");
 
         methodInfo = methods.First(method => method is { Name: "Implementation", ReturnType.Name: "Void" });
 
         func = () => methodInfo.Invoke(instance, [actionVoid, new Context(), cancellationToken]);
 
-        exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("action");
+        exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>()
+            .ParamName.ShouldBe("action");
     }
 
     [Fact]
@@ -72,40 +72,40 @@ public class CacheSpecs : IDisposable
         const string CacheProviderExpected = "cacheProvider";
 
         Action action = () => Policy.Cache(cacheProvider, ttl, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.Cache(cacheProvider, ttlStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.Cache(cacheProvider, ttl, cacheKeyStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.Cache(cacheProvider, ttlStrategy, cacheKeyStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.Cache(cacheProvider, ttl, cacheKeyStrategyFunc, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.Cache(cacheProvider, ttlStrategy, cacheKeyStrategyFunc, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.Cache(cacheProvider, ttl, onCache, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.Cache(cacheProvider, ttlStrategy, onCache, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.Cache(cacheProvider, ttl, cacheKeyStrategy, onCache, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.Cache(cacheProvider, ttlStrategy, cacheKeyStrategy, onCache, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.Cache(cacheProvider, ttl, cacheKeyStrategyFunc, onCache, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.Cache(cacheProvider, ttlStrategy, cacheKeyStrategyFunc, onCache, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
     }
 
     [Fact]
@@ -120,22 +120,22 @@ public class CacheSpecs : IDisposable
         const string TtlStrategyExpected = "ttlStrategy";
 
         Action action = () => Policy.Cache(cacheProvider, ttlStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
 
         action = () => Policy.Cache(cacheProvider, ttlStrategy, cacheKeyStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
 
         action = () => Policy.Cache(cacheProvider, ttlStrategy, cacheKeyStrategyFunc, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
 
         action = () => Policy.Cache(cacheProvider, ttlStrategy, onCache, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
 
         action = () => Policy.Cache(cacheProvider, ttlStrategy, cacheKeyStrategy, onCache, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
 
         action = () => Policy.Cache(cacheProvider, ttlStrategy, cacheKeyStrategyFunc, onCache, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
     }
 
     [Fact]
@@ -151,16 +151,16 @@ public class CacheSpecs : IDisposable
         const string CacheKeyStrategyExpected = "cacheKeyStrategy";
 
         Action action = () => Policy.Cache(cacheProvider, ttl, cacheKeyStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
         action = () => Policy.Cache(cacheProvider, ttlStrategy, cacheKeyStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
         action = () => Policy.Cache(cacheProvider, ttl, cacheKeyStrategyFunc, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
         action = () => Policy.Cache(cacheProvider, ttlStrategy, cacheKeyStrategyFunc, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
         action = () => Policy.Cache(
             cacheProvider,
@@ -171,7 +171,7 @@ public class CacheSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
         action = () => Policy.Cache(
             cacheProvider,
@@ -182,7 +182,7 @@ public class CacheSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
         action = () => Policy.Cache(
             cacheProvider,
@@ -193,7 +193,7 @@ public class CacheSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
         action = () => Policy.Cache(
             cacheProvider,
@@ -204,7 +204,7 @@ public class CacheSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
     }
 
     [Fact]
@@ -221,22 +221,22 @@ public class CacheSpecs : IDisposable
         const string OnCacheGetExpected = "onCacheGet";
 
         Action action = () => Policy.Cache(cacheProvider, ttl, onCacheGet, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheGetExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheGetExpected);
 
         action = () => Policy.Cache(cacheProvider, ttlStrategy, onCacheGet, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheGetExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheGetExpected);
 
         action = () => Policy.Cache(cacheProvider, ttl, cacheKeyStrategy, onCacheGet, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheGetExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheGetExpected);
 
         action = () => Policy.Cache(cacheProvider, ttlStrategy, cacheKeyStrategy, onCacheGet, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheGetExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheGetExpected);
 
         action = () => Policy.Cache(cacheProvider, ttl, cacheKeyStrategyFunc, onCacheGet, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheGetExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheGetExpected);
 
         action = () => Policy.Cache(cacheProvider, ttlStrategy, cacheKeyStrategyFunc, onCacheGet, onCache, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheGetExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheGetExpected);
     }
 
     [Fact]
@@ -253,22 +253,22 @@ public class CacheSpecs : IDisposable
         const string OnCacheMissExpected = "onCacheMiss";
 
         Action action = () => Policy.Cache(cacheProvider, ttl, onCache, onCacheMiss, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheMissExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheMissExpected);
 
         action = () => Policy.Cache(cacheProvider, ttlStrategy, onCache, onCacheMiss, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheMissExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheMissExpected);
 
         action = () => Policy.Cache(cacheProvider, ttl, cacheKeyStrategy, onCache, onCacheMiss, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheMissExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheMissExpected);
 
         action = () => Policy.Cache(cacheProvider, ttlStrategy, cacheKeyStrategy, onCache, onCacheMiss, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheMissExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheMissExpected);
 
         action = () => Policy.Cache(cacheProvider, ttl, cacheKeyStrategyFunc, onCache, onCacheMiss, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheMissExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheMissExpected);
 
         action = () => Policy.Cache(cacheProvider, ttlStrategy, cacheKeyStrategyFunc, onCache, onCacheMiss, onCache, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheMissExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheMissExpected);
     }
 
     [Fact]
@@ -285,22 +285,22 @@ public class CacheSpecs : IDisposable
         const string OnCachePutExpected = "onCachePut";
 
         Action action = () => Policy.Cache(cacheProvider, ttl, onCache, onCache, onCachePut, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCachePutExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCachePutExpected);
 
         action = () => Policy.Cache(cacheProvider, ttlStrategy, onCache, onCache, onCachePut, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCachePutExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCachePutExpected);
 
         action = () => Policy.Cache(cacheProvider, ttl, cacheKeyStrategy, onCache, onCache, onCachePut, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCachePutExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCachePutExpected);
 
         action = () => Policy.Cache(cacheProvider, ttlStrategy, cacheKeyStrategy, onCache, onCache, onCachePut, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCachePutExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCachePutExpected);
 
         action = () => Policy.Cache(cacheProvider, ttl, cacheKeyStrategyFunc, onCache, onCache, onCachePut, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCachePutExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCachePutExpected);
 
         action = () => Policy.Cache(cacheProvider, ttlStrategy, cacheKeyStrategyFunc, onCache, onCache, onCachePut, onCacheError, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCachePutExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCachePutExpected);
     }
 
     [Fact]
@@ -310,10 +310,10 @@ public class CacheSpecs : IDisposable
         ISyncPolicy<int>[] policiesGeneric = null!;
 
         Action action = () => Policy.Wrap(policies);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("policies");
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe("policies");
 
         action = () => Policy.Wrap<int>(policiesGeneric);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("policies");
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe("policies");
     }
 
     #endregion
@@ -327,7 +327,7 @@ public class CacheSpecs : IDisposable
         const string ValueToReturnFromExecution = "valueToReturnFromExecution";
         const string OperationKey = "SomeOperationKey";
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         CachePolicy cache = Policy.Cache(stubCacheProvider, TimeSpan.MaxValue);
         stubCacheProvider.Put(OperationKey, ValueToReturnFromCache, new Ttl(TimeSpan.MaxValue));
 
@@ -338,9 +338,9 @@ public class CacheSpecs : IDisposable
             delegateExecuted = true;
             return ValueToReturnFromExecution;
         }, new Context(OperationKey))
-            .Should().Be(ValueToReturnFromCache);
+            .ShouldBe(ValueToReturnFromCache);
 
-        delegateExecuted.Should().BeFalse();
+        delegateExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -349,18 +349,18 @@ public class CacheSpecs : IDisposable
         const string ValueToReturn = "valueToReturn";
         const string OperationKey = "SomeOperationKey";
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         CachePolicy cache = Policy.Cache(stubCacheProvider, TimeSpan.MaxValue);
 
         (bool cacheHit1, object? fromCache1) = stubCacheProvider.TryGet(OperationKey);
-        cacheHit1.Should().BeFalse();
-        fromCache1.Should().BeNull();
+        cacheHit1.ShouldBeFalse();
+        fromCache1.ShouldBeNull();
 
-        cache.Execute(_ => ValueToReturn, new Context(OperationKey)).Should().Be(ValueToReturn);
+        cache.Execute(_ => ValueToReturn, new Context(OperationKey)).ShouldBe(ValueToReturn);
 
         (bool cacheHit2, object? fromCache2) = stubCacheProvider.TryGet(OperationKey);
-        cacheHit2.Should().BeTrue();
-        fromCache2.Should().Be(ValueToReturn);
+        cacheHit2.ShouldBeTrue();
+        fromCache2.ShouldBe(ValueToReturn);
     }
 
     [Fact]
@@ -369,13 +369,13 @@ public class CacheSpecs : IDisposable
         const string ValueToReturn = "valueToReturn";
         const string OperationKey = "SomeOperationKey";
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
-        TimeSpan ttl = TimeSpan.FromMinutes(30);
+        var stubCacheProvider = new StubCacheProvider();
+        var ttl = TimeSpan.FromMinutes(30);
         CachePolicy cache = Policy.Cache(stubCacheProvider, ttl);
 
         (bool cacheHit1, object? fromCache1) = stubCacheProvider.TryGet(OperationKey);
-        cacheHit1.Should().BeFalse();
-        fromCache1.Should().BeNull();
+        cacheHit1.ShouldBeFalse();
+        fromCache1.ShouldBeNull();
 
         int delegateInvocations = 0;
         Func<Context, string> func = _ =>
@@ -388,25 +388,25 @@ public class CacheSpecs : IDisposable
         SystemClock.DateTimeOffsetUtcNow = () => fixedTime;
 
         // First execution should execute delegate and put result in the cache.
-        cache.Execute(func, new Context(OperationKey)).Should().Be(ValueToReturn);
-        delegateInvocations.Should().Be(1);
+        cache.Execute(func, new Context(OperationKey)).ShouldBe(ValueToReturn);
+        delegateInvocations.ShouldBe(1);
 
         (bool cacheHit2, object? fromCache2) = stubCacheProvider.TryGet(OperationKey);
-        cacheHit2.Should().BeTrue();
-        fromCache2.Should().Be(ValueToReturn);
+        cacheHit2.ShouldBeTrue();
+        fromCache2.ShouldBe(ValueToReturn);
 
         // Second execution (before cache expires) should get it from the cache - no further delegate execution.
         // (Manipulate time so just prior cache expiry).
         SystemClock.DateTimeOffsetUtcNow = () => fixedTime.Add(ttl).AddSeconds(-1);
-        cache.Execute(func, new Context(OperationKey)).Should().Be(ValueToReturn);
-        delegateInvocations.Should().Be(1);
+        cache.Execute(func, new Context(OperationKey)).ShouldBe(ValueToReturn);
+        delegateInvocations.ShouldBe(1);
 
         // Manipulate time to force cache expiry.
         SystemClock.DateTimeOffsetUtcNow = () => fixedTime.Add(ttl).AddSeconds(1);
 
         // Third execution (cache expired) should not get it from the cache - should cause further delegate execution.
-        cache.Execute(func, new Context(OperationKey)).Should().Be(ValueToReturn);
-        delegateInvocations.Should().Be(2);
+        cache.Execute(func, new Context(OperationKey)).ShouldBe(ValueToReturn);
+        delegateInvocations.ShouldBe(2);
     }
 
     [Fact]
@@ -415,18 +415,18 @@ public class CacheSpecs : IDisposable
         const string ValueToReturn = "valueToReturn";
         const string OperationKey = "SomeOperationKey";
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         CachePolicy cache = Policy.Cache(stubCacheProvider, TimeSpan.Zero);
 
         (bool cacheHit1, object? fromCache1) = stubCacheProvider.TryGet(OperationKey);
-        cacheHit1.Should().BeFalse();
-        fromCache1.Should().BeNull();
+        cacheHit1.ShouldBeFalse();
+        fromCache1.ShouldBeNull();
 
-        cache.Execute(_ => ValueToReturn, new Context(OperationKey)).Should().Be(ValueToReturn);
+        cache.Execute(_ => ValueToReturn, new Context(OperationKey)).ShouldBe(ValueToReturn);
 
         (bool cacheHit2, object? fromCache2) = stubCacheProvider.TryGet(OperationKey);
-        cacheHit2.Should().BeFalse();
-        fromCache2.Should().BeNull();
+        cacheHit2.ShouldBeFalse();
+        fromCache2.ShouldBeNull();
     }
 
     [Fact]
@@ -444,20 +444,20 @@ public class CacheSpecs : IDisposable
             return ValueToReturn;
         };
 
-        cache.Execute(func, new Context(OperationKey)).Should().Be(ValueToReturn);
-        delegateInvocations.Should().Be(1);
+        cache.Execute(func, new Context(OperationKey)).ShouldBe(ValueToReturn);
+        delegateInvocations.ShouldBe(1);
 
-        cache.Execute(func, new Context(OperationKey)).Should().Be(ValueToReturn);
-        delegateInvocations.Should().Be(1);
+        cache.Execute(func, new Context(OperationKey)).ShouldBe(ValueToReturn);
+        delegateInvocations.ShouldBe(1);
 
-        cache.Execute(func, new Context(OperationKey)).Should().Be(ValueToReturn);
-        delegateInvocations.Should().Be(1);
+        cache.Execute(func, new Context(OperationKey)).ShouldBe(ValueToReturn);
+        delegateInvocations.ShouldBe(1);
     }
 
     [Fact]
     public void Should_allow_custom_FuncCacheKeyStrategy()
     {
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         CachePolicy cache = Policy.Cache(stubCacheProvider, TimeSpan.MaxValue, context => context.OperationKey + context["id"]);
 
         object person1 = new();
@@ -468,11 +468,11 @@ public class CacheSpecs : IDisposable
         bool funcExecuted = false;
         Func<Context, object> func = _ => { funcExecuted = true; return new object(); };
 
-        cache.Execute(func, new Context("person", CreateDictionary("id", "1"))).Should().BeSameAs(person1);
-        funcExecuted.Should().BeFalse();
+        cache.Execute(func, new Context("person", CreateDictionary("id", "1"))).ShouldBeSameAs(person1);
+        funcExecuted.ShouldBeFalse();
 
-        cache.Execute(func, new Context("person", CreateDictionary("id", "2"))).Should().BeSameAs(person2);
-        funcExecuted.Should().BeFalse();
+        cache.Execute(func, new Context("person", CreateDictionary("id", "2"))).ShouldBeSameAs(person2);
+        funcExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -481,8 +481,8 @@ public class CacheSpecs : IDisposable
         Action<Context, string, Exception> noErrorHandling = (_, _, _) => { };
         Action<Context, string> emptyDelegate = (_, _) => { };
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
-        ICacheKeyStrategy cacheKeyStrategy = new StubCacheKeyStrategy(context => context.OperationKey + context["id"]);
+        var stubCacheProvider = new StubCacheProvider();
+        var cacheKeyStrategy = new StubCacheKeyStrategy(context => context.OperationKey + context["id"]);
         CachePolicy cache = Policy.Cache(stubCacheProvider, new RelativeTtl(TimeSpan.MaxValue), cacheKeyStrategy, emptyDelegate, emptyDelegate, emptyDelegate, noErrorHandling, noErrorHandling);
 
         object person1 = new();
@@ -493,11 +493,11 @@ public class CacheSpecs : IDisposable
         bool funcExecuted = false;
         Func<Context, object> func = _ => { funcExecuted = true; return new object(); };
 
-        cache.Execute(func, new Context("person", CreateDictionary("id", "1"))).Should().BeSameAs(person1);
-        funcExecuted.Should().BeFalse();
+        cache.Execute(func, new Context("person", CreateDictionary("id", "1"))).ShouldBeSameAs(person1);
+        funcExecuted.ShouldBeFalse();
 
-        cache.Execute(func, new Context("person", CreateDictionary("id", "2"))).Should().BeSameAs(person2);
-        funcExecuted.Should().BeFalse();
+        cache.Execute(func, new Context("person", CreateDictionary("id", "2"))).ShouldBeSameAs(person2);
+        funcExecuted.ShouldBeFalse();
     }
 
     #endregion
@@ -510,18 +510,18 @@ public class CacheSpecs : IDisposable
         ResultClass? valueToReturn = null;
         const string OperationKey = "SomeOperationKey";
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         CachePolicy cache = Policy.Cache(stubCacheProvider, TimeSpan.MaxValue);
 
         (bool cacheHit1, object? fromCache1) = stubCacheProvider.TryGet(OperationKey);
-        cacheHit1.Should().BeFalse();
-        fromCache1.Should().BeNull();
+        cacheHit1.ShouldBeFalse();
+        fromCache1.ShouldBeNull();
 
-        cache.Execute(_ => valueToReturn, new Context(OperationKey)).Should().Be(valueToReturn);
+        cache.Execute(_ => valueToReturn, new Context(OperationKey)).ShouldBe(valueToReturn);
 
         (bool cacheHit2, object? fromCache2) = stubCacheProvider.TryGet(OperationKey);
-        cacheHit2.Should().BeTrue();
-        fromCache2.Should().Be(valueToReturn);
+        cacheHit2.ShouldBeTrue();
+        fromCache2.ShouldBe(valueToReturn);
     }
 
     [Fact]
@@ -531,7 +531,7 @@ public class CacheSpecs : IDisposable
         ResultClass valueToReturnFromExecution = new ResultClass(ResultPrimitive.Good);
         const string OperationKey = "SomeOperationKey";
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         CachePolicy cache = Policy.Cache(stubCacheProvider, TimeSpan.MaxValue);
         stubCacheProvider.Put(OperationKey, valueToReturnFromCache, new Ttl(TimeSpan.MaxValue));
 
@@ -542,9 +542,9 @@ public class CacheSpecs : IDisposable
                 delegateExecuted = true;
                 return valueToReturnFromExecution;
             }, new Context(OperationKey))
-            .Should().Be(valueToReturnFromCache);
+            .ShouldBe(valueToReturnFromCache);
 
-        delegateExecuted.Should().BeFalse();
+        delegateExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -553,18 +553,18 @@ public class CacheSpecs : IDisposable
         ResultPrimitive valueToReturn = default;
         const string OperationKey = "SomeOperationKey";
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         CachePolicy cache = Policy.Cache(stubCacheProvider, TimeSpan.MaxValue);
 
         (bool cacheHit1, object? fromCache1) = stubCacheProvider.TryGet(OperationKey);
-        cacheHit1.Should().BeFalse();
-        fromCache1.Should().BeNull();
+        cacheHit1.ShouldBeFalse();
+        fromCache1.ShouldBeNull();
 
-        cache.Execute(_ => valueToReturn, new Context(OperationKey)).Should().Be(valueToReturn);
+        cache.Execute(_ => valueToReturn, new Context(OperationKey)).ShouldBe(valueToReturn);
 
         (bool cacheHit2, object? fromCache2) = stubCacheProvider.TryGet(OperationKey);
-        cacheHit2.Should().BeTrue();
-        fromCache2.Should().Be(valueToReturn);
+        cacheHit2.ShouldBeTrue();
+        fromCache2.ShouldBe(valueToReturn);
     }
 
     [Fact]
@@ -572,10 +572,10 @@ public class CacheSpecs : IDisposable
     {
         ResultPrimitive valueToReturnFromCache = default;
         ResultPrimitive valueToReturnFromExecution = ResultPrimitive.Good;
-        valueToReturnFromExecution.Should().NotBe(valueToReturnFromCache);
+        valueToReturnFromExecution.ShouldNotBe(valueToReturnFromCache);
         const string OperationKey = "SomeOperationKey";
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         CachePolicy cache = Policy.Cache(stubCacheProvider, TimeSpan.MaxValue);
         stubCacheProvider.Put(OperationKey, valueToReturnFromCache, new Ttl(TimeSpan.MaxValue));
 
@@ -586,9 +586,9 @@ public class CacheSpecs : IDisposable
                 delegateExecuted = true;
                 return valueToReturnFromExecution;
             }, new Context(OperationKey))
-            .Should().Be(valueToReturnFromCache);
+            .ShouldBe(valueToReturnFromCache);
 
-        delegateExecuted.Should().BeFalse();
+        delegateExecuted.ShouldBeFalse();
     }
 
     #endregion
@@ -602,7 +602,7 @@ public class CacheSpecs : IDisposable
         const string ValueToReturnFromExecution = "valueToReturnFromExecution";
         const string OperationKey = "SomeOperationKey";
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         CachePolicy cache = Policy.Cache(stubCacheProvider, TimeSpan.MaxValue);
         Policy noop = Policy.NoOp();
         PolicyWrap wrap = Policy.Wrap(cache, noop);
@@ -616,9 +616,9 @@ public class CacheSpecs : IDisposable
             delegateExecuted = true;
             return ValueToReturnFromExecution;
         }, new Context(OperationKey))
-            .Should().Be(ValueToReturnFromCache);
+            .ShouldBe(ValueToReturnFromCache);
 
-        delegateExecuted.Should().BeFalse();
+        delegateExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -628,7 +628,7 @@ public class CacheSpecs : IDisposable
         const string ValueToReturnFromExecution = "valueToReturnFromExecution";
         const string OperationKey = "SomeOperationKey";
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         CachePolicy cache = Policy.Cache(stubCacheProvider, TimeSpan.MaxValue);
         Policy noop = Policy.NoOp();
         PolicyWrap wrap = Policy.Wrap(noop, cache);
@@ -642,9 +642,9 @@ public class CacheSpecs : IDisposable
             delegateExecuted = true;
             return ValueToReturnFromExecution;
         }, new Context(OperationKey))
-            .Should().Be(ValueToReturnFromCache);
+            .ShouldBe(ValueToReturnFromCache);
 
-        delegateExecuted.Should().BeFalse();
+        delegateExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -654,7 +654,7 @@ public class CacheSpecs : IDisposable
         const string ValueToReturnFromExecution = "valueToReturnFromExecution";
         const string OperationKey = "SomeOperationKey";
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         CachePolicy cache = Policy.Cache(stubCacheProvider, TimeSpan.MaxValue);
         Policy noop = Policy.NoOp();
         PolicyWrap wrap = Policy.Wrap(noop, cache, noop);
@@ -668,9 +668,9 @@ public class CacheSpecs : IDisposable
             delegateExecuted = true;
             return ValueToReturnFromExecution;
         }, new Context(OperationKey))
-            .Should().Be(ValueToReturnFromCache);
+            .ShouldBe(ValueToReturnFromCache);
 
-        delegateExecuted.Should().BeFalse();
+        delegateExecuted.ShouldBeFalse();
     }
 
     #endregion
@@ -691,11 +691,11 @@ public class CacheSpecs : IDisposable
             return valueToReturn;
         };
 
-        cache.Execute(func /*, no operation key */).Should().Be(valueToReturn);
-        delegateInvocations.Should().Be(1);
+        cache.Execute(func /*, no operation key */).ShouldBe(valueToReturn);
+        delegateInvocations.ShouldBe(1);
 
-        cache.Execute(func /*, no operation key */).Should().Be(valueToReturn);
-        delegateInvocations.Should().Be(2);
+        cache.Execute(func /*, no operation key */).ShouldBe(valueToReturn);
+        delegateInvocations.ShouldBe(2);
     }
 
     [Fact]
@@ -709,10 +709,10 @@ public class CacheSpecs : IDisposable
         Action<Context> action = _ => { delegateInvocations++; };
 
         cache.Execute(action, new Context(operationKey));
-        delegateInvocations.Should().Be(1);
+        delegateInvocations.ShouldBe(1);
 
         cache.Execute(action, new Context(operationKey));
-        delegateInvocations.Should().Be(2);
+        delegateInvocations.ShouldBe(2);
     }
 
     #endregion
@@ -725,7 +725,7 @@ public class CacheSpecs : IDisposable
         const string ValueToReturn = "valueToReturn";
         const string OperationKey = "SomeOperationKey";
 
-        CachePolicy cache = Policy.Cache(new StubCacheProvider(), TimeSpan.MaxValue);
+        CachePolicy policy = Policy.Cache(new StubCacheProvider(), TimeSpan.MaxValue);
 
         int delegateInvocations = 0;
 
@@ -738,16 +738,15 @@ public class CacheSpecs : IDisposable
                 return ValueToReturn;
             };
 
-            cache.Execute(func, new Context(OperationKey), tokenSource.Token).Should().Be(ValueToReturn);
-            delegateInvocations.Should().Be(1);
+            policy.Execute(func, new Context(OperationKey), tokenSource.Token).ShouldBe(ValueToReturn);
+            delegateInvocations.ShouldBe(1);
 
             tokenSource.Cancel();
 
-            cache.Invoking(policy => policy.Execute(func, new Context(OperationKey), tokenSource.Token))
-                .Should().Throw<OperationCanceledException>();
+            Should.Throw<OperationCanceledException>(() => policy.Execute(func, new Context(OperationKey), tokenSource.Token));
         }
 
-        delegateInvocations.Should().Be(1);
+        delegateInvocations.ShouldBe(1);
     }
 
     [Fact]
@@ -756,8 +755,8 @@ public class CacheSpecs : IDisposable
         const string ValueToReturn = "valueToReturn";
         const string OperationKey = "SomeOperationKey";
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
-        CachePolicy cache = Policy.Cache(stubCacheProvider, TimeSpan.MaxValue);
+        var stubCacheProvider = new StubCacheProvider();
+        CachePolicy policy = Policy.Cache(stubCacheProvider, TimeSpan.MaxValue);
 
         using (var tokenSource = new CancellationTokenSource())
         {
@@ -768,13 +767,12 @@ public class CacheSpecs : IDisposable
                 return ValueToReturn;
             };
 
-            cache.Invoking(policy => policy.Execute(func, new Context(OperationKey), tokenSource.Token))
-                .Should().Throw<OperationCanceledException>();
+            Should.Throw<OperationCanceledException>(() => policy.Execute(func, new Context(OperationKey), tokenSource.Token));
         }
 
         (bool cacheHit, object? fromCache) = stubCacheProvider.TryGet(OperationKey);
-        cacheHit.Should().BeFalse();
-        fromCache.Should().BeNull();
+        cacheHit.ShouldBeFalse();
+        fromCache.ShouldBeNull();
     }
 
     #endregion
@@ -785,7 +783,7 @@ public class CacheSpecs : IDisposable
     public void Should_call_onError_delegate_if_cache_get_errors()
     {
         Exception ex = new Exception();
-        ISyncCacheProvider stubCacheProvider = new StubErroringCacheProvider(getException: ex, putException: null);
+        var stubCacheProvider = new StubErroringCacheProvider(getException: ex, putException: null);
 
         Exception? exceptionFromCacheProvider = null;
 
@@ -807,18 +805,18 @@ public class CacheSpecs : IDisposable
                 delegateExecuted = true;
                 return ValueToReturnFromExecution;
             }, new Context(OperationKey))
-            .Should().Be(ValueToReturnFromExecution);
-        delegateExecuted.Should().BeTrue();
+            .ShouldBe(ValueToReturnFromExecution);
+        delegateExecuted.ShouldBeTrue();
 
         // And error should be captured by onError delegate.
-        exceptionFromCacheProvider.Should().Be(ex);
+        exceptionFromCacheProvider.ShouldBe(ex);
     }
 
     [Fact]
     public void Should_call_onError_delegate_if_cache_put_errors()
     {
         Exception ex = new Exception();
-        ISyncCacheProvider stubCacheProvider = new StubErroringCacheProvider(getException: null, putException: ex);
+        var stubCacheProvider = new StubErroringCacheProvider(getException: null, putException: ex);
 
         Exception? exceptionFromCacheProvider = null;
 
@@ -830,18 +828,18 @@ public class CacheSpecs : IDisposable
         CachePolicy cache = Policy.Cache(stubCacheProvider, TimeSpan.MaxValue, onError);
 
         (bool cacheHit1, object? fromCache1) = stubCacheProvider.TryGet(OperationKey);
-        cacheHit1.Should().BeFalse();
-        fromCache1.Should().BeNull();
+        cacheHit1.ShouldBeFalse();
+        fromCache1.ShouldBeNull();
 
-        cache.Execute(_ => ValueToReturn, new Context(OperationKey)).Should().Be(ValueToReturn);
+        cache.Execute(_ => ValueToReturn, new Context(OperationKey)).ShouldBe(ValueToReturn);
 
         // error should be captured by onError delegate.
-        exceptionFromCacheProvider.Should().Be(ex);
+        exceptionFromCacheProvider.ShouldBe(ex);
 
         // failed to put it in the cache
         (bool cacheHit2, object? fromCache2) = stubCacheProvider.TryGet(OperationKey);
-        cacheHit2.Should().BeFalse();
-        fromCache2.Should().BeNull();
+        cacheHit2.ShouldBeFalse();
+        fromCache2.ShouldBeNull();
 
     }
 
@@ -861,7 +859,7 @@ public class CacheSpecs : IDisposable
         Action<Context, string> emptyDelegate = (_, _) => { };
         Action<Context, string> onCacheAction = (ctx, key) => { contextPassedToDelegate = ctx; keyPassedToDelegate = key; };
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         CachePolicy cache = Policy.Cache(stubCacheProvider, new RelativeTtl(TimeSpan.MaxValue), DefaultCacheKeyStrategy.Instance, onCacheAction, emptyDelegate, emptyDelegate, noErrorHandling, noErrorHandling);
         stubCacheProvider.Put(OperationKey, ValueToReturnFromCache, new Ttl(TimeSpan.MaxValue));
 
@@ -871,11 +869,11 @@ public class CacheSpecs : IDisposable
                 delegateExecuted = true;
                 return ValueToReturnFromExecution;
             }, contextToExecute)
-            .Should().Be(ValueToReturnFromCache);
-        delegateExecuted.Should().BeFalse();
+            .ShouldBe(ValueToReturnFromCache);
+        delegateExecuted.ShouldBeFalse();
 
-        contextPassedToDelegate.Should().BeSameAs(contextToExecute);
-        keyPassedToDelegate.Should().Be(OperationKey);
+        contextPassedToDelegate.ShouldBeSameAs(contextToExecute);
+        keyPassedToDelegate.ShouldBe(OperationKey);
     }
 
     [Fact]
@@ -896,24 +894,24 @@ public class CacheSpecs : IDisposable
         Action<Context, string> onCacheMiss = (ctx, key) => { contextPassedToOnCacheMiss = ctx; keyPassedToOnCacheMiss = key; };
         Action<Context, string> onCachePut = (ctx, key) => { contextPassedToOnCachePut = ctx; keyPassedToOnCachePut = key; };
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         CachePolicy cache = Policy.Cache(stubCacheProvider, new RelativeTtl(TimeSpan.MaxValue), DefaultCacheKeyStrategy.Instance, emptyDelegate, onCacheMiss, onCachePut, noErrorHandling, noErrorHandling);
 
         (bool cacheHit1, object? fromCache1) = stubCacheProvider.TryGet(OperationKey);
-        cacheHit1.Should().BeFalse();
-        fromCache1.Should().BeNull();
+        cacheHit1.ShouldBeFalse();
+        fromCache1.ShouldBeNull();
 
-        cache.Execute(_ => ValueToReturn, contextToExecute).Should().Be(ValueToReturn);
+        cache.Execute(_ => ValueToReturn, contextToExecute).ShouldBe(ValueToReturn);
 
         (bool cacheHit2, object? fromCache2) = stubCacheProvider.TryGet(OperationKey);
-        cacheHit2.Should().BeTrue();
-        fromCache2.Should().Be(ValueToReturn);
+        cacheHit2.ShouldBeTrue();
+        fromCache2.ShouldBe(ValueToReturn);
 
-        contextPassedToOnCacheMiss.Should().BeSameAs(contextToExecute);
-        keyPassedToOnCacheMiss.Should().Be(OperationKey);
+        contextPassedToOnCacheMiss.ShouldBeSameAs(contextToExecute);
+        keyPassedToOnCacheMiss.ShouldBe(OperationKey);
 
-        contextPassedToOnCachePut.Should().BeSameAs(contextToExecute);
-        keyPassedToOnCachePut.Should().Be(OperationKey);
+        contextPassedToOnCachePut.ShouldBeSameAs(contextToExecute);
+        keyPassedToOnCachePut.ShouldBe(OperationKey);
     }
 
     [Fact]
@@ -934,20 +932,20 @@ public class CacheSpecs : IDisposable
         Action<Context, string> onCacheMiss = (ctx, key) => { contextPassedToOnCacheMiss = ctx; keyPassedToOnCacheMiss = key; };
         Action<Context, string> onCachePut = (ctx, key) => { contextPassedToOnCachePut = ctx; keyPassedToOnCachePut = key; };
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         CachePolicy cache = Policy.Cache(stubCacheProvider, new RelativeTtl(TimeSpan.Zero), DefaultCacheKeyStrategy.Instance, emptyDelegate, onCacheMiss, onCachePut, noErrorHandling, noErrorHandling);
 
         (bool cacheHit, object? fromCache) = stubCacheProvider.TryGet(OperationKey);
-        cacheHit.Should().BeFalse();
-        fromCache.Should().BeNull();
+        cacheHit.ShouldBeFalse();
+        fromCache.ShouldBeNull();
 
-        cache.Execute(_ => ValueToReturn, contextToExecute).Should().Be(ValueToReturn);
+        cache.Execute(_ => ValueToReturn, contextToExecute).ShouldBe(ValueToReturn);
 
-        contextPassedToOnCacheMiss.Should().BeSameAs(contextToExecute);
-        keyPassedToOnCacheMiss.Should().Be(OperationKey);
+        contextPassedToOnCacheMiss.ShouldBeSameAs(contextToExecute);
+        keyPassedToOnCacheMiss.ShouldBe(OperationKey);
 
-        contextPassedToOnCachePut.Should().BeNull();
-        keyPassedToOnCachePut.Should().BeNull();
+        contextPassedToOnCachePut.ShouldBeNull();
+        keyPassedToOnCachePut.ShouldBeNull();
     }
 
     [Fact]
@@ -963,9 +961,9 @@ public class CacheSpecs : IDisposable
 
         CachePolicy cache = Policy.Cache(new StubCacheProvider(), new RelativeTtl(TimeSpan.MaxValue), DefaultCacheKeyStrategy.Instance, emptyDelegate, onCacheMiss, emptyDelegate, noErrorHandling, noErrorHandling);
 
-        cache.Execute(() => valueToReturn /*, no operation key */).Should().Be(valueToReturn);
+        cache.Execute(() => valueToReturn /*, no operation key */).ShouldBe(valueToReturn);
 
-        onCacheMissExecuted.Should().BeFalse();
+        onCacheMissExecuted.ShouldBeFalse();
     }
 
     #endregion

--- a/test/Polly.Specs/Caching/CacheTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/Caching/CacheTResultAsyncSpecs.cs
@@ -43,10 +43,10 @@ public class CacheTResultAsyncSpecs : IDisposable
 
         var func = () => methodInfo.Invoke(instance, [action, new Context(), CancellationToken, false]);
 
-        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("action");
+        var exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>()
+            .ParamName.ShouldBe("action");
     }
 
     [Fact]
@@ -54,7 +54,7 @@ public class CacheTResultAsyncSpecs : IDisposable
     {
         IAsyncCacheProvider cacheProvider = null!;
         Action action = () => Policy.CacheAsync<ResultPrimitive>(cacheProvider, TimeSpan.MaxValue);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("cacheProvider");
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe("cacheProvider");
     }
 
     [Fact]
@@ -63,15 +63,15 @@ public class CacheTResultAsyncSpecs : IDisposable
         IAsyncCacheProvider cacheProvider = new StubCacheProvider();
         ITtlStrategy ttlStrategy = null!;
         Action action = () => Policy.CacheAsync<ResultPrimitive>(cacheProvider, ttlStrategy);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("ttlStrategy");
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe("ttlStrategy");
     }
 
     [Fact]
     public void Should_throw_when_cache_key_strategy_is_null()
     {
-        IAsyncCacheProvider cacheProvider = new StubCacheProvider();
+        var cacheProvider = new StubCacheProvider();
         var ttl = TimeSpan.MaxValue;
-        ITtlStrategy ttlStrategy = new ContextualTtl();
+        var ttlStrategy = new ContextualTtl();
         ICacheKeyStrategy cacheKeyStrategy = null!;
         Func<Context, string> cacheKeyStrategyFunc = null!;
         Action<Context, string> onCacheGet = (_, _) => { };
@@ -82,42 +82,42 @@ public class CacheTResultAsyncSpecs : IDisposable
         const string CacheKeyStrategyExpected = "cacheKeyStrategy";
 
         Action action = () => Policy.CacheAsync<ResultPrimitive>(cacheProvider, ttl, cacheKeyStrategy, onCacheGetError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
         action = () => Policy.CacheAsync<ResultPrimitive>(cacheProvider, ttlStrategy, cacheKeyStrategy, onCacheGetError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
         action = () => Policy.CacheAsync<ResultPrimitive>(cacheProvider, ttl, cacheKeyStrategyFunc);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
-        action = () => Policy.CacheAsync<ResultPrimitive>(cacheProvider.AsyncFor<ResultPrimitive>(), ttl, cacheKeyStrategy);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        action = () => Policy.CacheAsync(cacheProvider.AsyncFor<ResultPrimitive>(), ttl, cacheKeyStrategy);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
-        action = () => Policy.CacheAsync<ResultPrimitive>(cacheProvider.AsyncFor<ResultPrimitive>(), ttlStrategy, cacheKeyStrategy);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        action = () => Policy.CacheAsync(cacheProvider.AsyncFor<ResultPrimitive>(), ttlStrategy, cacheKeyStrategy);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
-        action = () => Policy.CacheAsync<ResultPrimitive>(
+        action = () => Policy.CacheAsync(
             cacheProvider.AsyncFor<ResultPrimitive>(),
             ttlStrategy.For<ResultPrimitive>(),
             cacheKeyStrategy,
             onCacheGetError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
-        action = () => Policy.CacheAsync<ResultPrimitive>(
+        action = () => Policy.CacheAsync(
             cacheProvider.AsyncFor<ResultPrimitive>(),
             ttl,
             cacheKeyStrategy,
             onCacheGetError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
-        action = () => Policy.CacheAsync<ResultPrimitive>(
+        action = () => Policy.CacheAsync(
             cacheProvider.AsyncFor<ResultPrimitive>(),
             ttl,
             cacheKeyStrategy,
             onCacheGetError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
-        action = () => Policy.CacheAsync<ResultPrimitive>(
+        action = () => Policy.CacheAsync(
             cacheProvider.AsyncFor<ResultPrimitive>(),
             ttl,
             cacheKeyStrategy,
@@ -126,9 +126,9 @@ public class CacheTResultAsyncSpecs : IDisposable
             onCachePut,
             onCacheGetError,
             onCachePutError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
-        action = () => Policy.CacheAsync<ResultPrimitive>(
+        action = () => Policy.CacheAsync(
             cacheProvider.AsyncFor<ResultPrimitive>(),
             ttlStrategy,
             cacheKeyStrategy,
@@ -137,9 +137,9 @@ public class CacheTResultAsyncSpecs : IDisposable
             onCachePut,
             onCacheGetError,
             onCachePutError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
-        action = () => Policy.CacheAsync<ResultPrimitive>(
+        action = () => Policy.CacheAsync(
             cacheProvider.AsyncFor<ResultPrimitive>(),
             ttlStrategy.For<ResultPrimitive>(),
             cacheKeyStrategy,
@@ -148,7 +148,7 @@ public class CacheTResultAsyncSpecs : IDisposable
             onCachePut,
             onCacheGetError,
             onCachePutError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
     }
     #endregion
 
@@ -161,7 +161,7 @@ public class CacheTResultAsyncSpecs : IDisposable
         const string ValueToReturnFromExecution = "valueToReturnFromExecution";
         const string OperationKey = "SomeOperationKey";
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         var cache = Policy.CacheAsync<string>(stubCacheProvider, TimeSpan.MaxValue);
         await stubCacheProvider.PutAsync(OperationKey, ValueToReturnFromCache, new Ttl(TimeSpan.MaxValue), CancellationToken.None, false);
 
@@ -173,9 +173,9 @@ public class CacheTResultAsyncSpecs : IDisposable
             await TaskHelper.EmptyTask;
             return ValueToReturnFromExecution;
         }, new Context(OperationKey)))
-            .Should().Be(ValueToReturnFromCache);
+            .ShouldBe(ValueToReturnFromCache);
 
-        delegateExecuted.Should().BeFalse();
+        delegateExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -184,18 +184,18 @@ public class CacheTResultAsyncSpecs : IDisposable
         const string ValueToReturn = "valueToReturn";
         const string OperationKey = "SomeOperationKey";
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         var cache = Policy.CacheAsync<string>(stubCacheProvider, TimeSpan.MaxValue);
 
         (bool cacheHit1, object? fromCache1) = await stubCacheProvider.TryGetAsync(OperationKey, CancellationToken, false);
-        cacheHit1.Should().BeFalse();
-        fromCache1.Should().BeNull();
+        cacheHit1.ShouldBeFalse();
+        fromCache1.ShouldBeNull();
 
-        (await cache.ExecuteAsync(async _ => { await TaskHelper.EmptyTask; return ValueToReturn; }, new Context(OperationKey))).Should().Be(ValueToReturn);
+        (await cache.ExecuteAsync(async _ => { await TaskHelper.EmptyTask; return ValueToReturn; }, new Context(OperationKey))).ShouldBe(ValueToReturn);
 
         (bool cacheHit2, object? fromCache2) = await stubCacheProvider.TryGetAsync(OperationKey, CancellationToken, false);
-        cacheHit2.Should().BeTrue();
-        fromCache2.Should().Be(ValueToReturn);
+        cacheHit2.ShouldBeTrue();
+        fromCache2.ShouldBe(ValueToReturn);
     }
 
     [Fact]
@@ -204,13 +204,13 @@ public class CacheTResultAsyncSpecs : IDisposable
         const string ValueToReturn = "valueToReturn";
         const string OperationKey = "SomeOperationKey";
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         TimeSpan ttl = TimeSpan.FromMinutes(30);
         var cache = Policy.CacheAsync<string>(stubCacheProvider, ttl);
 
         (bool cacheHit1, object? fromCache1) = await stubCacheProvider.TryGetAsync(OperationKey, CancellationToken, false);
-        cacheHit1.Should().BeFalse();
-        fromCache1.Should().BeNull();
+        cacheHit1.ShouldBeFalse();
+        fromCache1.ShouldBeNull();
 
         int delegateInvocations = 0;
         Func<Context, Task<string>> func = async _ =>
@@ -224,25 +224,25 @@ public class CacheTResultAsyncSpecs : IDisposable
         SystemClock.DateTimeOffsetUtcNow = () => fixedTime;
 
         // First execution should execute delegate and put result in the cache.
-        (await cache.ExecuteAsync(func, new Context(OperationKey))).Should().Be(ValueToReturn);
-        delegateInvocations.Should().Be(1);
+        (await cache.ExecuteAsync(func, new Context(OperationKey))).ShouldBe(ValueToReturn);
+        delegateInvocations.ShouldBe(1);
 
         (bool cacheHit2, object? fromCache2) = await stubCacheProvider.TryGetAsync(OperationKey, CancellationToken, false);
-        cacheHit2.Should().BeTrue();
-        fromCache2.Should().Be(ValueToReturn);
+        cacheHit2.ShouldBeTrue();
+        fromCache2.ShouldBe(ValueToReturn);
 
         // Second execution (before cache expires) should get it from the cache - no further delegate execution.
         // (Manipulate time so just prior cache expiry).
         SystemClock.DateTimeOffsetUtcNow = () => fixedTime.Add(ttl).AddSeconds(-1);
-        (await cache.ExecuteAsync(func, new Context(OperationKey))).Should().Be(ValueToReturn);
-        delegateInvocations.Should().Be(1);
+        (await cache.ExecuteAsync(func, new Context(OperationKey))).ShouldBe(ValueToReturn);
+        delegateInvocations.ShouldBe(1);
 
         // Manipulate time to force cache expiry.
         SystemClock.DateTimeOffsetUtcNow = () => fixedTime.Add(ttl).AddSeconds(1);
 
         // Third execution (cache expired) should not get it from the cache - should cause further delegate execution.
-        (await cache.ExecuteAsync(func, new Context(OperationKey))).Should().Be(ValueToReturn);
-        delegateInvocations.Should().Be(2);
+        (await cache.ExecuteAsync(func, new Context(OperationKey))).ShouldBe(ValueToReturn);
+        delegateInvocations.ShouldBe(2);
     }
 
     [Fact]
@@ -251,18 +251,18 @@ public class CacheTResultAsyncSpecs : IDisposable
         const string ValueToReturn = "valueToReturn";
         const string OperationKey = "SomeOperationKey";
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         var cache = Policy.CacheAsync<string>(stubCacheProvider, TimeSpan.Zero);
 
         (bool cacheHit1, object? fromCache1) = await stubCacheProvider.TryGetAsync(OperationKey, CancellationToken, false);
-        cacheHit1.Should().BeFalse();
-        fromCache1.Should().BeNull();
+        cacheHit1.ShouldBeFalse();
+        fromCache1.ShouldBeNull();
 
-        (await cache.ExecuteAsync(async _ => { await TaskHelper.EmptyTask; return ValueToReturn; }, new Context(OperationKey))).Should().Be(ValueToReturn);
+        (await cache.ExecuteAsync(async _ => { await TaskHelper.EmptyTask; return ValueToReturn; }, new Context(OperationKey))).ShouldBe(ValueToReturn);
 
         (bool cacheHit2, object? fromCache2) = await stubCacheProvider.TryGetAsync(OperationKey, CancellationToken, false);
-        cacheHit2.Should().BeFalse();
-        fromCache2.Should().BeNull();
+        cacheHit2.ShouldBeFalse();
+        fromCache2.ShouldBeNull();
     }
 
     [Fact]
@@ -281,20 +281,20 @@ public class CacheTResultAsyncSpecs : IDisposable
             return ValueToReturn;
         };
 
-        (await cache.ExecuteAsync(func, new Context(OperationKey))).Should().Be(ValueToReturn);
-        delegateInvocations.Should().Be(1);
+        (await cache.ExecuteAsync(func, new Context(OperationKey))).ShouldBe(ValueToReturn);
+        delegateInvocations.ShouldBe(1);
 
-        (await cache.ExecuteAsync(func, new Context(OperationKey))).Should().Be(ValueToReturn);
-        delegateInvocations.Should().Be(1);
+        (await cache.ExecuteAsync(func, new Context(OperationKey))).ShouldBe(ValueToReturn);
+        delegateInvocations.ShouldBe(1);
 
-        (await cache.ExecuteAsync(func, new Context(OperationKey))).Should().Be(ValueToReturn);
-        delegateInvocations.Should().Be(1);
+        (await cache.ExecuteAsync(func, new Context(OperationKey))).ShouldBe(ValueToReturn);
+        delegateInvocations.ShouldBe(1);
     }
 
     [Fact]
     public async Task Should_allow_custom_FuncCacheKeyStrategy()
     {
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         var cache = Policy.CacheAsync<ResultClass>(stubCacheProvider, TimeSpan.MaxValue, context => context.OperationKey + context["id"]);
 
         object person1 = new ResultClass(ResultPrimitive.Good, "person1");
@@ -305,11 +305,11 @@ public class CacheTResultAsyncSpecs : IDisposable
         bool funcExecuted = false;
         Func<Context, Task<ResultClass>> func = async _ => { funcExecuted = true; await TaskHelper.EmptyTask; return new ResultClass(ResultPrimitive.Fault, "should never return this one"); };
 
-        (await cache.ExecuteAsync(func, new Context("person", CreateDictionary("id", "1")))).Should().BeSameAs(person1);
-        funcExecuted.Should().BeFalse();
+        (await cache.ExecuteAsync(func, new Context("person", CreateDictionary("id", "1")))).ShouldBeSameAs(person1);
+        funcExecuted.ShouldBeFalse();
 
-        (await cache.ExecuteAsync(func, new Context("person", CreateDictionary("id", "2")))).Should().BeSameAs(person2);
-        funcExecuted.Should().BeFalse();
+        (await cache.ExecuteAsync(func, new Context("person", CreateDictionary("id", "2")))).ShouldBeSameAs(person2);
+        funcExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -318,8 +318,8 @@ public class CacheTResultAsyncSpecs : IDisposable
         Action<Context, string, Exception> noErrorHandling = (_, _, _) => { };
         Action<Context, string> emptyDelegate = (_, _) => { };
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
-        ICacheKeyStrategy cacheKeyStrategy = new StubCacheKeyStrategy(context => context.OperationKey + context["id"]);
+        var stubCacheProvider = new StubCacheProvider();
+        var cacheKeyStrategy = new StubCacheKeyStrategy(context => context.OperationKey + context["id"]);
 
         var cache = Policy.CacheAsync<ResultClass>(stubCacheProvider.AsyncFor<ResultClass>(), new RelativeTtl(TimeSpan.MaxValue), cacheKeyStrategy, emptyDelegate, emptyDelegate, emptyDelegate, noErrorHandling, noErrorHandling);
 
@@ -331,11 +331,11 @@ public class CacheTResultAsyncSpecs : IDisposable
         bool funcExecuted = false;
         Func<Context, Task<ResultClass>> func = async _ => { funcExecuted = true; await TaskHelper.EmptyTask; return new ResultClass(ResultPrimitive.Fault, "should never return this one"); };
 
-        (await cache.ExecuteAsync(func, new Context("person", CreateDictionary("id", "1")))).Should().BeSameAs(person1);
-        funcExecuted.Should().BeFalse();
+        (await cache.ExecuteAsync(func, new Context("person", CreateDictionary("id", "1")))).ShouldBeSameAs(person1);
+        funcExecuted.ShouldBeFalse();
 
-        (await cache.ExecuteAsync(func, new Context("person", CreateDictionary("id", "2")))).Should().BeSameAs(person2);
-        funcExecuted.Should().BeFalse();
+        (await cache.ExecuteAsync(func, new Context("person", CreateDictionary("id", "2")))).ShouldBeSameAs(person2);
+        funcExecuted.ShouldBeFalse();
     }
 
     #endregion
@@ -348,18 +348,18 @@ public class CacheTResultAsyncSpecs : IDisposable
         ResultClass? valueToReturn = null;
         const string OperationKey = "SomeOperationKey";
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         var cache = Policy.CacheAsync<ResultClass?>(stubCacheProvider, TimeSpan.MaxValue);
 
         (bool cacheHit1, object? fromCache1) = await stubCacheProvider.TryGetAsync(OperationKey, CancellationToken, false);
-        cacheHit1.Should().BeFalse();
-        fromCache1.Should().BeNull();
+        cacheHit1.ShouldBeFalse();
+        fromCache1.ShouldBeNull();
 
-        (await cache.ExecuteAsync(async _ => { await TaskHelper.EmptyTask; return valueToReturn; }, new Context(OperationKey))).Should().Be(valueToReturn);
+        (await cache.ExecuteAsync(async _ => { await TaskHelper.EmptyTask; return valueToReturn; }, new Context(OperationKey))).ShouldBe(valueToReturn);
 
         (bool cacheHit2, object? fromCache2) = await stubCacheProvider.TryGetAsync(OperationKey, CancellationToken, false);
-        cacheHit2.Should().BeTrue();
-        fromCache2.Should().Be(valueToReturn);
+        cacheHit2.ShouldBeTrue();
+        fromCache2.ShouldBe(valueToReturn);
     }
 
     [Fact]
@@ -369,7 +369,7 @@ public class CacheTResultAsyncSpecs : IDisposable
         ResultClass valueToReturnFromExecution = new ResultClass(ResultPrimitive.Good);
         const string OperationKey = "SomeOperationKey";
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         var cache = Policy.CacheAsync<ResultClass>(stubCacheProvider, TimeSpan.MaxValue);
         await stubCacheProvider.PutAsync(OperationKey, valueToReturnFromCache, new Ttl(TimeSpan.MaxValue), CancellationToken, false);
 
@@ -381,9 +381,9 @@ public class CacheTResultAsyncSpecs : IDisposable
             await TaskHelper.EmptyTask;
             return valueToReturnFromExecution;
         }, new Context(OperationKey)))
-            .Should().Be(valueToReturnFromCache);
+            .ShouldBe(valueToReturnFromCache);
 
-        delegateExecuted.Should().BeFalse();
+        delegateExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -392,18 +392,18 @@ public class CacheTResultAsyncSpecs : IDisposable
         ResultPrimitive valueToReturn = default;
         const string OperationKey = "SomeOperationKey";
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         var cache = Policy.CacheAsync<ResultPrimitive>(stubCacheProvider, TimeSpan.MaxValue);
 
         (bool cacheHit1, object? fromCache1) = await stubCacheProvider.TryGetAsync(OperationKey, CancellationToken, false);
-        cacheHit1.Should().BeFalse();
-        fromCache1.Should().BeNull();
+        cacheHit1.ShouldBeFalse();
+        fromCache1.ShouldBeNull();
 
-        (await cache.ExecuteAsync(async _ => { await TaskHelper.EmptyTask; return valueToReturn; }, new Context(OperationKey))).Should().Be(valueToReturn);
+        (await cache.ExecuteAsync(async _ => { await TaskHelper.EmptyTask; return valueToReturn; }, new Context(OperationKey))).ShouldBe(valueToReturn);
 
         (bool cacheHit2, object? fromCache2) = await stubCacheProvider.TryGetAsync(OperationKey, CancellationToken, false);
-        cacheHit2.Should().BeTrue();
-        fromCache2.Should().Be(valueToReturn);
+        cacheHit2.ShouldBeTrue();
+        fromCache2.ShouldBe(valueToReturn);
     }
 
     [Fact]
@@ -411,10 +411,10 @@ public class CacheTResultAsyncSpecs : IDisposable
     {
         ResultPrimitive valueToReturnFromCache = default;
         ResultPrimitive valueToReturnFromExecution = ResultPrimitive.Good;
-        valueToReturnFromExecution.Should().NotBe(valueToReturnFromCache);
+        valueToReturnFromExecution.ShouldNotBe(valueToReturnFromCache);
         const string OperationKey = "SomeOperationKey";
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         var cache = Policy.CacheAsync<ResultPrimitive>(stubCacheProvider, TimeSpan.MaxValue);
         await stubCacheProvider.PutAsync(OperationKey, valueToReturnFromCache, new Ttl(TimeSpan.MaxValue), CancellationToken, false);
 
@@ -426,9 +426,9 @@ public class CacheTResultAsyncSpecs : IDisposable
             await TaskHelper.EmptyTask;
             return valueToReturnFromExecution;
         }, new Context(OperationKey)))
-            .Should().Be(valueToReturnFromCache);
+            .ShouldBe(valueToReturnFromCache);
 
-        delegateExecuted.Should().BeFalse();
+        delegateExecuted.ShouldBeFalse();
     }
 
     #endregion
@@ -442,7 +442,7 @@ public class CacheTResultAsyncSpecs : IDisposable
         const string ValueToReturnFromExecution = "valueToReturnFromExecution";
         const string OperationKey = "SomeOperationKey";
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         var cache = Policy.CacheAsync<string>(stubCacheProvider, TimeSpan.MaxValue);
         var noop = Policy.NoOpAsync();
         var wrap = cache.WrapAsync(noop);
@@ -457,9 +457,9 @@ public class CacheTResultAsyncSpecs : IDisposable
             await TaskHelper.EmptyTask;
             return ValueToReturnFromExecution;
         }, new Context(OperationKey)))
-            .Should().Be(ValueToReturnFromCache);
+            .ShouldBe(ValueToReturnFromCache);
 
-        delegateExecuted.Should().BeFalse();
+        delegateExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -469,7 +469,7 @@ public class CacheTResultAsyncSpecs : IDisposable
         const string ValueToReturnFromExecution = "valueToReturnFromExecution";
         const string OperationKey = "SomeOperationKey";
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         var cache = Policy.CacheAsync<string>(stubCacheProvider, TimeSpan.MaxValue);
         var noop = Policy.NoOpAsync();
         var wrap = noop.WrapAsync(cache);
@@ -484,9 +484,9 @@ public class CacheTResultAsyncSpecs : IDisposable
             await TaskHelper.EmptyTask;
             return ValueToReturnFromExecution;
         }, new Context(OperationKey)))
-            .Should().Be(ValueToReturnFromCache);
+            .ShouldBe(ValueToReturnFromCache);
 
-        delegateExecuted.Should().BeFalse();
+        delegateExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -496,7 +496,7 @@ public class CacheTResultAsyncSpecs : IDisposable
         const string ValueToReturnFromExecution = "valueToReturnFromExecution";
         const string OperationKey = "SomeOperationKey";
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         var cache = Policy.CacheAsync<string>(stubCacheProvider, TimeSpan.MaxValue);
         var noop = Policy.NoOpAsync<string>();
         var wrap = Policy.WrapAsync(noop, cache, noop);
@@ -511,9 +511,9 @@ public class CacheTResultAsyncSpecs : IDisposable
             await TaskHelper.EmptyTask;
             return ValueToReturnFromExecution;
         }, new Context(OperationKey)))
-            .Should().Be(ValueToReturnFromCache);
+            .ShouldBe(ValueToReturnFromCache);
 
-        delegateExecuted.Should().BeFalse();
+        delegateExecuted.ShouldBeFalse();
     }
 
     #endregion
@@ -535,11 +535,11 @@ public class CacheTResultAsyncSpecs : IDisposable
             return valueToReturn;
         };
 
-        (await cache.ExecuteAsync(func /*, no operation key */)).Should().Be(valueToReturn);
-        delegateInvocations.Should().Be(1);
+        (await cache.ExecuteAsync(func /*, no operation key */)).ShouldBe(valueToReturn);
+        delegateInvocations.ShouldBe(1);
 
-        (await cache.ExecuteAsync(func /*, no operation key */)).Should().Be(valueToReturn);
-        delegateInvocations.Should().Be(2);
+        (await cache.ExecuteAsync(func /*, no operation key */)).ShouldBe(valueToReturn);
+        delegateInvocations.ShouldBe(2);
     }
 
     #endregion
@@ -552,7 +552,7 @@ public class CacheTResultAsyncSpecs : IDisposable
         const string ValueToReturn = "valueToReturn";
         const string OperationKey = "SomeOperationKey";
 
-        var cache = Policy.CacheAsync<string>(new StubCacheProvider(), TimeSpan.MaxValue);
+        var policy = Policy.CacheAsync<string>(new StubCacheProvider(), TimeSpan.MaxValue);
 
         int delegateInvocations = 0;
 
@@ -566,16 +566,15 @@ public class CacheTResultAsyncSpecs : IDisposable
                 return ValueToReturn;
             };
 
-            (await cache.ExecuteAsync(func, new Context(OperationKey), tokenSource.Token)).Should().Be(ValueToReturn);
-            delegateInvocations.Should().Be(1);
+            (await policy.ExecuteAsync(func, new Context(OperationKey), tokenSource.Token)).ShouldBe(ValueToReturn);
+            delegateInvocations.ShouldBe(1);
 
             tokenSource.Cancel();
 
-            await cache.Awaiting(policy => policy.ExecuteAsync(func, new Context(OperationKey), tokenSource.Token))
-                .Should().ThrowAsync<OperationCanceledException>();
+            await Should.ThrowAsync<OperationCanceledException>(() => policy.ExecuteAsync(func, new Context(OperationKey), tokenSource.Token));
         }
 
-        delegateInvocations.Should().Be(1);
+        delegateInvocations.ShouldBe(1);
     }
 
     [Fact]
@@ -584,8 +583,8 @@ public class CacheTResultAsyncSpecs : IDisposable
         const string ValueToReturn = "valueToReturn";
         const string OperationKey = "SomeOperationKey";
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
-        var cache = Policy.CacheAsync<string>(stubCacheProvider, TimeSpan.MaxValue);
+        var stubCacheProvider = new StubCacheProvider();
+        var policy = Policy.CacheAsync<string>(stubCacheProvider, TimeSpan.MaxValue);
 
         using (var tokenSource = new CancellationTokenSource())
         {
@@ -597,13 +596,12 @@ public class CacheTResultAsyncSpecs : IDisposable
                 return ValueToReturn;
             };
 
-            await cache.Awaiting(policy => policy.ExecuteAsync(func, new Context(OperationKey), tokenSource.Token))
-                .Should().ThrowAsync<OperationCanceledException>();
+            await Should.ThrowAsync<OperationCanceledException>(() => policy.ExecuteAsync(func, new Context(OperationKey), tokenSource.Token));
         }
 
         (bool cacheHit, object? fromCache) = await stubCacheProvider.TryGetAsync(OperationKey, CancellationToken, false);
-        cacheHit.Should().BeFalse();
-        fromCache.Should().BeNull();
+        cacheHit.ShouldBeFalse();
+        fromCache.ShouldBeNull();
     }
 
     #endregion

--- a/test/Polly.Specs/Caching/CacheTResultSpecs.cs
+++ b/test/Polly.Specs/Caching/CacheTResultSpecs.cs
@@ -38,10 +38,10 @@ public class CacheTResultSpecs : IDisposable
 
         var func = () => methodInfo.Invoke(instance, [action, new Context(), CancellationToken.None]);
 
-        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("action");
+        var exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>()
+            .ParamName.ShouldBe("action");
     }
 
     [Fact]
@@ -50,31 +50,31 @@ public class CacheTResultSpecs : IDisposable
         ISyncCacheProvider cacheProvider = null!;
         ISyncCacheProvider<ResultPrimitive> cacheProviderGeneric = null!;
         var ttl = TimeSpan.MaxValue;
-        ITtlStrategy ttlStrategy = new ContextualTtl();
-        ITtlStrategy<ResultPrimitive> ttlStrategyGeneric = new ContextualTtl().For<ResultPrimitive>();
-        ICacheKeyStrategy cacheKeyStrategy = new StubCacheKeyStrategy(context => context.OperationKey + context["id"]);
+        var ttlStrategy = new ContextualTtl();
+        var ttlStrategyGeneric = new ContextualTtl().For<ResultPrimitive>();
+        var cacheKeyStrategy = new StubCacheKeyStrategy(context => context.OperationKey + context["id"]);
         Func<Context, string> cacheKeyStrategyFunc = (_) => string.Empty;
         Action<Context, string> onCache = (_, _) => { };
         Action<Context, string, Exception>? onCacheError = null;
         const string CacheProviderExpected = "cacheProvider";
 
         Action action = () => Policy.Cache<ResultPrimitive>(cacheProvider, ttl, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(cacheProvider, ttlStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(cacheProvider, ttl, cacheKeyStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(cacheProvider, ttlStrategy, cacheKeyStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(cacheProvider, ttl, cacheKeyStrategyFunc, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(cacheProvider, ttlStrategy, cacheKeyStrategyFunc, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(
             cacheProvider,
@@ -84,7 +84,7 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(
             cacheProvider,
@@ -94,7 +94,7 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(
             cacheProvider,
@@ -105,7 +105,7 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(
             cacheProvider,
@@ -116,7 +116,7 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(
             cacheProvider,
@@ -127,7 +127,7 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(
             cacheProvider,
@@ -138,36 +138,36 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(cacheProviderGeneric, ttl, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        action = () => Policy.Cache(cacheProviderGeneric, ttl, onCacheError);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(cacheProviderGeneric, ttlStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        action = () => Policy.Cache(cacheProviderGeneric, ttlStrategy, onCacheError);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(cacheProviderGeneric, ttlStrategyGeneric, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        action = () => Policy.Cache(cacheProviderGeneric, ttlStrategyGeneric, onCacheError);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(cacheProviderGeneric, ttl, cacheKeyStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        action = () => Policy.Cache(cacheProviderGeneric, ttl, cacheKeyStrategy, onCacheError);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(cacheProviderGeneric, ttlStrategy, cacheKeyStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        action = () => Policy.Cache(cacheProviderGeneric, ttlStrategy, cacheKeyStrategy, onCacheError);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(cacheProviderGeneric, ttlStrategyGeneric, cacheKeyStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        action = () => Policy.Cache(cacheProviderGeneric, ttlStrategyGeneric, cacheKeyStrategy, onCacheError);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(cacheProviderGeneric, ttl, cacheKeyStrategyFunc, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        action = () => Policy.Cache(cacheProviderGeneric, ttl, cacheKeyStrategyFunc, onCacheError);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(cacheProviderGeneric, ttlStrategy, cacheKeyStrategyFunc, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        action = () => Policy.Cache(cacheProviderGeneric, ttlStrategy, cacheKeyStrategyFunc, onCacheError);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(cacheProviderGeneric, ttlStrategyGeneric, cacheKeyStrategyFunc, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        action = () => Policy.Cache(cacheProviderGeneric, ttlStrategyGeneric, cacheKeyStrategyFunc, onCacheError);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttl,
             onCache,
@@ -175,9 +175,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategy,
             onCache,
@@ -185,9 +185,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategyGeneric,
             onCache,
@@ -195,9 +195,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttl,
             cacheKeyStrategy,
@@ -206,9 +206,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategy,
             cacheKeyStrategy,
@@ -217,9 +217,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategyGeneric,
             cacheKeyStrategy,
@@ -228,9 +228,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttl,
             cacheKeyStrategyFunc,
@@ -239,9 +239,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategy,
             cacheKeyStrategyFunc,
@@ -250,9 +250,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategyGeneric,
             cacheKeyStrategyFunc,
@@ -261,13 +261,13 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheProviderExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheProviderExpected);
     }
 
     [Fact]
     public void Should_throw_when_ttl_strategy_is_null()
     {
-        ISyncCacheProvider cacheProvider = new StubCacheProvider();
+        var cacheProvider = new StubCacheProvider();
         ISyncCacheProvider<ResultPrimitive> cacheProviderGeneric = new StubCacheProvider().For<ResultPrimitive>();
         ITtlStrategy ttlStrategy = null!;
         ITtlStrategy<ResultPrimitive> ttlStrategyGeneric = null!;
@@ -278,16 +278,16 @@ public class CacheTResultSpecs : IDisposable
         const string TtlStrategyExpected = "ttlStrategy";
 
         Action action = () => Policy.Cache<ResultPrimitive>(cacheProvider, ttlStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(cacheProvider, ttlStrategy, cacheKeyStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(cacheProvider, ttlStrategy, cacheKeyStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(cacheProvider, ttlStrategy, cacheKeyStrategyFunc, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(
             cacheProvider,
@@ -297,7 +297,7 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(
             cacheProvider,
@@ -308,7 +308,7 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(
             cacheProvider,
@@ -319,39 +319,39 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(cacheProviderGeneric, ttlStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        action = () => Policy.Cache(cacheProviderGeneric, ttlStrategy, onCacheError);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(cacheProviderGeneric, ttlStrategyGeneric, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        action = () => Policy.Cache(cacheProviderGeneric, ttlStrategyGeneric, onCacheError);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(cacheProviderGeneric, ttlStrategy, cacheKeyStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        action = () => Policy.Cache(cacheProviderGeneric, ttlStrategy, cacheKeyStrategy, onCacheError);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(cacheProviderGeneric, ttlStrategyGeneric, cacheKeyStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        action = () => Policy.Cache(cacheProviderGeneric, ttlStrategyGeneric, cacheKeyStrategy, onCacheError);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(cacheProviderGeneric, ttlStrategy, cacheKeyStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        action = () => Policy.Cache(cacheProviderGeneric, ttlStrategy, cacheKeyStrategy, onCacheError);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(cacheProviderGeneric, ttlStrategy, cacheKeyStrategyFunc, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        action = () => Policy.Cache(cacheProviderGeneric, ttlStrategy, cacheKeyStrategyFunc, onCacheError);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(cacheProviderGeneric, ttlStrategyGeneric, cacheKeyStrategyFunc, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        action = () => Policy.Cache(cacheProviderGeneric, ttlStrategyGeneric, cacheKeyStrategyFunc, onCacheError);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategy, onCache,
             onCache,
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategyGeneric,
             onCache,
@@ -359,9 +359,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategy,
             cacheKeyStrategy,
@@ -370,9 +370,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategyGeneric,
             cacheKeyStrategy,
@@ -381,9 +381,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategy,
             cacheKeyStrategyFunc,
@@ -392,9 +392,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategyGeneric,
             cacheKeyStrategyFunc,
@@ -403,13 +403,13 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(TtlStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(TtlStrategyExpected);
     }
 
     [Fact]
     public void Should_throw_when_cache_key_strategy_is_null()
     {
-        ISyncCacheProvider cacheProvider = new StubCacheProvider();
+        var cacheProvider = new StubCacheProvider();
         ISyncCacheProvider<ResultPrimitive> cacheProviderGeneric = new StubCacheProvider().For<ResultPrimitive>();
         var ttl = TimeSpan.MaxValue;
         ITtlStrategy ttlStrategy = new ContextualTtl();
@@ -421,16 +421,16 @@ public class CacheTResultSpecs : IDisposable
         const string CacheKeyStrategyExpected = "cacheKeyStrategy";
 
         Action action = () => Policy.Cache<ResultPrimitive>(cacheProvider, ttl, cacheKeyStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(cacheProvider, ttlStrategy, cacheKeyStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(cacheProvider, ttl, cacheKeyStrategyFunc, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(cacheProvider, ttlStrategy, cacheKeyStrategyFunc, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(
             cacheProvider,
@@ -441,7 +441,7 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(
             cacheProvider,
@@ -452,7 +452,7 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(cacheProvider,
             ttl,
@@ -462,7 +462,7 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(
             cacheProvider,
@@ -473,27 +473,27 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(cacheProviderGeneric, ttl, cacheKeyStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        action = () => Policy.Cache(cacheProviderGeneric, ttl, cacheKeyStrategy, onCacheError);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(cacheProviderGeneric, ttlStrategy, cacheKeyStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        action = () => Policy.Cache(cacheProviderGeneric, ttlStrategy, cacheKeyStrategy, onCacheError);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(cacheProviderGeneric, ttlStrategyGeneric, cacheKeyStrategy, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        action = () => Policy.Cache(cacheProviderGeneric, ttlStrategyGeneric, cacheKeyStrategy, onCacheError);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(cacheProviderGeneric, ttl, cacheKeyStrategyFunc, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        action = () => Policy.Cache(cacheProviderGeneric, ttl, cacheKeyStrategyFunc, onCacheError);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(cacheProviderGeneric, ttlStrategy, cacheKeyStrategyFunc, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        action = () => Policy.Cache(cacheProviderGeneric, ttlStrategy, cacheKeyStrategyFunc, onCacheError);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(cacheProviderGeneric, ttlStrategyGeneric, cacheKeyStrategyFunc, onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        action = () => Policy.Cache(cacheProviderGeneric, ttlStrategyGeneric, cacheKeyStrategyFunc, onCacheError);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttl,
             cacheKeyStrategy,
@@ -502,9 +502,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategy,
             cacheKeyStrategy,
@@ -513,9 +513,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategyGeneric,
             cacheKeyStrategy,
@@ -524,9 +524,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttl,
             cacheKeyStrategyFunc,
@@ -535,9 +535,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategy,
             cacheKeyStrategyFunc,
@@ -546,9 +546,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategyGeneric,
             cacheKeyStrategyFunc,
@@ -557,13 +557,13 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(CacheKeyStrategyExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(CacheKeyStrategyExpected);
     }
 
     [Fact]
     public void Should_throw_when_on_cache_get_is_null()
     {
-        ISyncCacheProvider cacheProvider = new StubCacheProvider();
+        var cacheProvider = new StubCacheProvider();
         ISyncCacheProvider<ResultPrimitive> cacheProviderGeneric = new StubCacheProvider().For<ResultPrimitive>();
         var ttl = TimeSpan.MaxValue;
         ITtlStrategy ttlStrategy = new ContextualTtl();
@@ -583,7 +583,7 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheGetExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheGetExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(
             cacheProvider,
@@ -593,7 +593,7 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheGetExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheGetExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(
             cacheProvider,
@@ -604,7 +604,7 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheGetExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheGetExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(
             cacheProvider,
@@ -615,7 +615,7 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheGetExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheGetExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(
             cacheProvider,
@@ -626,7 +626,7 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheGetExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheGetExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(
             cacheProvider,
@@ -637,9 +637,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheGetExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheGetExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttl,
             onCacheGet,
@@ -647,9 +647,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheGetExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheGetExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategy,
             onCacheGet,
@@ -657,9 +657,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheGetExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheGetExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategyGeneric,
             onCacheGet,
@@ -667,9 +667,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheGetExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheGetExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttl,
             cacheKeyStrategy,
@@ -678,9 +678,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheGetExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheGetExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategy,
             cacheKeyStrategy,
@@ -689,9 +689,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheGetExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheGetExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategyGeneric,
             cacheKeyStrategy,
@@ -700,9 +700,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheGetExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheGetExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttl,
             cacheKeyStrategyFunc,
@@ -711,9 +711,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheGetExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheGetExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategy,
             cacheKeyStrategyFunc,
@@ -722,9 +722,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheGetExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheGetExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategyGeneric,
             cacheKeyStrategyFunc,
@@ -733,13 +733,13 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheGetExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheGetExpected);
     }
 
     [Fact]
     public void Should_throw_when_on_cache_miss_is_null()
     {
-        ISyncCacheProvider cacheProvider = new StubCacheProvider();
+        var cacheProvider = new StubCacheProvider();
         ISyncCacheProvider<ResultPrimitive> cacheProviderGeneric = new StubCacheProvider().For<ResultPrimitive>();
         var ttl = TimeSpan.MaxValue;
         ITtlStrategy ttlStrategy = new ContextualTtl();
@@ -759,7 +759,7 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheMissExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheMissExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(
             cacheProvider,
@@ -769,7 +769,7 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheMissExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheMissExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(
             cacheProvider,
@@ -780,7 +780,7 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheMissExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheMissExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(
             cacheProvider,
@@ -791,7 +791,7 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheMissExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheMissExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(
             cacheProvider,
@@ -802,7 +802,7 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheMissExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheMissExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(
             cacheProvider,
@@ -813,9 +813,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheMissExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheMissExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttl,
             onCache,
@@ -823,9 +823,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheMissExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheMissExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategy,
             onCache,
@@ -833,9 +833,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheMissExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheMissExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategyGeneric,
             onCache,
@@ -843,9 +843,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheMissExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheMissExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttl,
             cacheKeyStrategy,
@@ -854,9 +854,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheMissExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheMissExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategy,
             cacheKeyStrategy,
@@ -865,9 +865,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheMissExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheMissExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategyGeneric,
             cacheKeyStrategy,
@@ -876,9 +876,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheMissExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheMissExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttl,
             cacheKeyStrategyFunc,
@@ -887,9 +887,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheMissExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheMissExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategy,
             cacheKeyStrategyFunc,
@@ -898,9 +898,9 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheMissExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheMissExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategyGeneric,
             cacheKeyStrategyFunc,
@@ -909,13 +909,13 @@ public class CacheTResultSpecs : IDisposable
             onCache,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCacheMissExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCacheMissExpected);
     }
 
     [Fact]
     public void Should_throw_when_on_cache_put_is_null()
     {
-        ISyncCacheProvider cacheProvider = new StubCacheProvider();
+        var cacheProvider = new StubCacheProvider();
         ISyncCacheProvider<ResultPrimitive> cacheProviderGeneric = new StubCacheProvider().For<ResultPrimitive>();
         var ttl = TimeSpan.MaxValue;
         ITtlStrategy ttlStrategy = new ContextualTtl();
@@ -935,7 +935,7 @@ public class CacheTResultSpecs : IDisposable
             onCachePut,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCachePutExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCachePutExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(
             cacheProvider,
@@ -945,7 +945,7 @@ public class CacheTResultSpecs : IDisposable
             onCachePut,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCachePutExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCachePutExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(
             cacheProvider,
@@ -956,7 +956,7 @@ public class CacheTResultSpecs : IDisposable
             onCachePut,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCachePutExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCachePutExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(
             cacheProvider,
@@ -967,7 +967,7 @@ public class CacheTResultSpecs : IDisposable
             onCachePut,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCachePutExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCachePutExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(
             cacheProvider,
@@ -978,7 +978,7 @@ public class CacheTResultSpecs : IDisposable
             onCachePut,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCachePutExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCachePutExpected);
 
         action = () => Policy.Cache<ResultPrimitive>(
             cacheProvider,
@@ -989,9 +989,9 @@ public class CacheTResultSpecs : IDisposable
             onCachePut,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCachePutExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCachePutExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttl,
             onCache,
@@ -999,9 +999,9 @@ public class CacheTResultSpecs : IDisposable
             onCachePut,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCachePutExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCachePutExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategy,
             onCache,
@@ -1009,9 +1009,9 @@ public class CacheTResultSpecs : IDisposable
             onCachePut,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCachePutExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCachePutExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategyGeneric,
             onCache,
@@ -1019,9 +1019,9 @@ public class CacheTResultSpecs : IDisposable
             onCachePut,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCachePutExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCachePutExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttl,
             cacheKeyStrategy,
@@ -1030,9 +1030,9 @@ public class CacheTResultSpecs : IDisposable
             onCachePut,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCachePutExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCachePutExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategy,
             cacheKeyStrategy,
@@ -1041,9 +1041,9 @@ public class CacheTResultSpecs : IDisposable
             onCachePut,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCachePutExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCachePutExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategyGeneric,
             cacheKeyStrategy,
@@ -1052,9 +1052,9 @@ public class CacheTResultSpecs : IDisposable
             onCachePut,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCachePutExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCachePutExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttl,
             cacheKeyStrategyFunc,
@@ -1063,9 +1063,9 @@ public class CacheTResultSpecs : IDisposable
             onCachePut,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCachePutExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCachePutExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategy,
             cacheKeyStrategyFunc,
@@ -1074,9 +1074,9 @@ public class CacheTResultSpecs : IDisposable
             onCachePut,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCachePutExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCachePutExpected);
 
-        action = () => Policy.Cache<ResultPrimitive>(
+        action = () => Policy.Cache(
             cacheProviderGeneric,
             ttlStrategyGeneric,
             cacheKeyStrategyFunc,
@@ -1085,7 +1085,7 @@ public class CacheTResultSpecs : IDisposable
             onCachePut,
             onCacheError,
             onCacheError);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be(OnCachePutExpected);
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe(OnCachePutExpected);
     }
 
     #endregion
@@ -1099,7 +1099,7 @@ public class CacheTResultSpecs : IDisposable
         const string ValueToReturnFromExecution = "valueToReturnFromExecution";
         const string OperationKey = "SomeOperationKey";
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         CachePolicy<string> cache = Policy.Cache<string>(stubCacheProvider, TimeSpan.MaxValue);
         stubCacheProvider.Put(OperationKey, ValueToReturnFromCache, new Ttl(TimeSpan.MaxValue));
 
@@ -1110,9 +1110,9 @@ public class CacheTResultSpecs : IDisposable
             delegateExecuted = true;
             return ValueToReturnFromExecution;
         }, new Context(OperationKey))
-            .Should().Be(ValueToReturnFromCache);
+            .ShouldBe(ValueToReturnFromCache);
 
-        delegateExecuted.Should().BeFalse();
+        delegateExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -1121,18 +1121,18 @@ public class CacheTResultSpecs : IDisposable
         const string ValueToReturn = "valueToReturn";
         const string OperationKey = "SomeOperationKey";
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         CachePolicy<string> cache = Policy.Cache<string>(stubCacheProvider, TimeSpan.MaxValue);
 
         (bool cacheHit1, object? fromCache1) = stubCacheProvider.TryGet(OperationKey);
-        cacheHit1.Should().BeFalse();
-        fromCache1.Should().BeNull();
+        cacheHit1.ShouldBeFalse();
+        fromCache1.ShouldBeNull();
 
-        cache.Execute(_ => ValueToReturn, new Context(OperationKey)).Should().Be(ValueToReturn);
+        cache.Execute(_ => ValueToReturn, new Context(OperationKey)).ShouldBe(ValueToReturn);
 
         (bool cacheHit2, object? fromCache2) = stubCacheProvider.TryGet(OperationKey);
-        cacheHit2.Should().BeTrue();
-        fromCache2.Should().Be(ValueToReturn);
+        cacheHit2.ShouldBeTrue();
+        fromCache2.ShouldBe(ValueToReturn);
     }
 
     [Fact]
@@ -1141,13 +1141,13 @@ public class CacheTResultSpecs : IDisposable
         const string ValueToReturn = "valueToReturn";
         const string OperationKey = "SomeOperationKey";
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
-        TimeSpan ttl = TimeSpan.FromMinutes(30);
+        var stubCacheProvider = new StubCacheProvider();
+        var ttl = TimeSpan.FromMinutes(30);
         CachePolicy<string> cache = Policy.Cache<string>(stubCacheProvider, ttl);
 
         (bool cacheHit1, object? fromCache1) = stubCacheProvider.TryGet(OperationKey);
-        cacheHit1.Should().BeFalse();
-        fromCache1.Should().BeNull();
+        cacheHit1.ShouldBeFalse();
+        fromCache1.ShouldBeNull();
 
         int delegateInvocations = 0;
         Func<Context, string> func = _ =>
@@ -1160,25 +1160,25 @@ public class CacheTResultSpecs : IDisposable
         SystemClock.DateTimeOffsetUtcNow = () => fixedTime;
 
         // First execution should execute delegate and put result in the cache.
-        cache.Execute(func, new Context(OperationKey)).Should().Be(ValueToReturn);
-        delegateInvocations.Should().Be(1);
+        cache.Execute(func, new Context(OperationKey)).ShouldBe(ValueToReturn);
+        delegateInvocations.ShouldBe(1);
 
         (bool cacheHit2, object? fromCache2) = stubCacheProvider.TryGet(OperationKey);
-        cacheHit2.Should().BeTrue();
-        fromCache2.Should().Be(ValueToReturn);
+        cacheHit2.ShouldBeTrue();
+        fromCache2.ShouldBe(ValueToReturn);
 
         // Second execution (before cache expires) should get it from the cache - no further delegate execution.
         // (Manipulate time so just prior cache expiry).
         SystemClock.DateTimeOffsetUtcNow = () => fixedTime.Add(ttl).AddSeconds(-1);
-        cache.Execute(func, new Context(OperationKey)).Should().Be(ValueToReturn);
-        delegateInvocations.Should().Be(1);
+        cache.Execute(func, new Context(OperationKey)).ShouldBe(ValueToReturn);
+        delegateInvocations.ShouldBe(1);
 
         // Manipulate time to force cache expiry.
         SystemClock.DateTimeOffsetUtcNow = () => fixedTime.Add(ttl).AddSeconds(1);
 
         // Third execution (cache expired) should not get it from the cache - should cause further delegate execution.
-        cache.Execute(func, new Context(OperationKey)).Should().Be(ValueToReturn);
-        delegateInvocations.Should().Be(2);
+        cache.Execute(func, new Context(OperationKey)).ShouldBe(ValueToReturn);
+        delegateInvocations.ShouldBe(2);
     }
 
     [Fact]
@@ -1187,18 +1187,18 @@ public class CacheTResultSpecs : IDisposable
         const string ValueToReturn = "valueToReturn";
         const string OperationKey = "SomeOperationKey";
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         CachePolicy<string> cache = Policy.Cache<string>(stubCacheProvider, TimeSpan.Zero);
 
         (bool cacheHit1, object? fromCache1) = stubCacheProvider.TryGet(OperationKey);
-        cacheHit1.Should().BeFalse();
-        fromCache1.Should().BeNull();
+        cacheHit1.ShouldBeFalse();
+        fromCache1.ShouldBeNull();
 
-        cache.Execute(_ => ValueToReturn, new Context(OperationKey)).Should().Be(ValueToReturn);
+        cache.Execute(_ => ValueToReturn, new Context(OperationKey)).ShouldBe(ValueToReturn);
 
         (bool cacheHit2, object? fromCache2) = stubCacheProvider.TryGet(OperationKey);
-        cacheHit2.Should().BeFalse();
-        fromCache2.Should().BeNull();
+        cacheHit2.ShouldBeFalse();
+        fromCache2.ShouldBeNull();
     }
 
     [Fact]
@@ -1216,20 +1216,20 @@ public class CacheTResultSpecs : IDisposable
             return ValueToReturn;
         };
 
-        cache.Execute(func, new Context(OperationKey)).Should().Be(ValueToReturn);
-        delegateInvocations.Should().Be(1);
+        cache.Execute(func, new Context(OperationKey)).ShouldBe(ValueToReturn);
+        delegateInvocations.ShouldBe(1);
 
-        cache.Execute(func, new Context(OperationKey)).Should().Be(ValueToReturn);
-        delegateInvocations.Should().Be(1);
+        cache.Execute(func, new Context(OperationKey)).ShouldBe(ValueToReturn);
+        delegateInvocations.ShouldBe(1);
 
-        cache.Execute(func, new Context(OperationKey)).Should().Be(ValueToReturn);
-        delegateInvocations.Should().Be(1);
+        cache.Execute(func, new Context(OperationKey)).ShouldBe(ValueToReturn);
+        delegateInvocations.ShouldBe(1);
     }
 
     [Fact]
     public void Should_allow_custom_FuncICacheKeyStrategy()
     {
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         CachePolicy<ResultClass> cache = Policy.Cache<ResultClass>(stubCacheProvider, TimeSpan.MaxValue, context => context.OperationKey + context["id"]);
 
         object person1 = new ResultClass(ResultPrimitive.Good, "person1");
@@ -1240,11 +1240,11 @@ public class CacheTResultSpecs : IDisposable
         bool funcExecuted = false;
         Func<Context, ResultClass> func = _ => { funcExecuted = true; return new ResultClass(ResultPrimitive.Fault, "should never return this one"); };
 
-        cache.Execute(func, new Context("person", CreateDictionary("id", "1"))).Should().BeSameAs(person1);
-        funcExecuted.Should().BeFalse();
+        cache.Execute(func, new Context("person", CreateDictionary("id", "1"))).ShouldBeSameAs(person1);
+        funcExecuted.ShouldBeFalse();
 
-        cache.Execute(func, new Context("person", CreateDictionary("id", "2"))).Should().BeSameAs(person2);
-        funcExecuted.Should().BeFalse();
+        cache.Execute(func, new Context("person", CreateDictionary("id", "2"))).ShouldBeSameAs(person2);
+        funcExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -1253,9 +1253,9 @@ public class CacheTResultSpecs : IDisposable
         Action<Context, string, Exception> noErrorHandling = (_, _, _) => { };
         Action<Context, string> emptyDelegate = (_, _) => { };
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         ICacheKeyStrategy cacheKeyStrategy = new StubCacheKeyStrategy(context => context.OperationKey + context["id"]);
-        CachePolicy<ResultClass> cache = Policy.Cache<ResultClass>(stubCacheProvider.For<ResultClass>(), new RelativeTtl(TimeSpan.MaxValue), cacheKeyStrategy, emptyDelegate, emptyDelegate, emptyDelegate, noErrorHandling, noErrorHandling);
+        CachePolicy<ResultClass> cache = Policy.Cache(stubCacheProvider.For<ResultClass>(), new RelativeTtl(TimeSpan.MaxValue), cacheKeyStrategy, emptyDelegate, emptyDelegate, emptyDelegate, noErrorHandling, noErrorHandling);
 
         object person1 = new ResultClass(ResultPrimitive.Good, "person1");
         stubCacheProvider.Put("person1", person1, new Ttl(TimeSpan.MaxValue));
@@ -1265,11 +1265,11 @@ public class CacheTResultSpecs : IDisposable
         bool funcExecuted = false;
         Func<Context, ResultClass> func = _ => { funcExecuted = true; return new ResultClass(ResultPrimitive.Fault, "should never return this one"); };
 
-        cache.Execute(func, new Context("person", CreateDictionary("id", "1"))).Should().BeSameAs(person1);
-        funcExecuted.Should().BeFalse();
+        cache.Execute(func, new Context("person", CreateDictionary("id", "1"))).ShouldBeSameAs(person1);
+        funcExecuted.ShouldBeFalse();
 
-        cache.Execute(func, new Context("person", CreateDictionary("id", "2"))).Should().BeSameAs(person2);
-        funcExecuted.Should().BeFalse();
+        cache.Execute(func, new Context("person", CreateDictionary("id", "2"))).ShouldBeSameAs(person2);
+        funcExecuted.ShouldBeFalse();
     }
 
     #endregion
@@ -1282,18 +1282,18 @@ public class CacheTResultSpecs : IDisposable
         ResultClass? valueToReturn = null;
         const string OperationKey = "SomeOperationKey";
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         CachePolicy<ResultClass?> cache = Policy.Cache<ResultClass?>(stubCacheProvider, TimeSpan.MaxValue);
 
         (bool cacheHit1, object? fromCache1) = stubCacheProvider.TryGet(OperationKey);
-        cacheHit1.Should().BeFalse();
-        fromCache1.Should().BeNull();
+        cacheHit1.ShouldBeFalse();
+        fromCache1.ShouldBeNull();
 
-        cache.Execute(_ => valueToReturn, new Context(OperationKey)).Should().Be(valueToReturn);
+        cache.Execute(_ => valueToReturn, new Context(OperationKey)).ShouldBe(valueToReturn);
 
         (bool cacheHit2, object? fromCache2) = stubCacheProvider.TryGet(OperationKey);
-        cacheHit2.Should().BeTrue();
-        fromCache2.Should().Be(valueToReturn);
+        cacheHit2.ShouldBeTrue();
+        fromCache2.ShouldBe(valueToReturn);
     }
 
     [Fact]
@@ -1303,7 +1303,7 @@ public class CacheTResultSpecs : IDisposable
         ResultClass valueToReturnFromExecution = new ResultClass(ResultPrimitive.Good);
         const string OperationKey = "SomeOperationKey";
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         CachePolicy<ResultClass> cache = Policy.Cache<ResultClass>(stubCacheProvider, TimeSpan.MaxValue);
         stubCacheProvider.Put(OperationKey, valueToReturnFromCache, new Ttl(TimeSpan.MaxValue));
 
@@ -1314,9 +1314,9 @@ public class CacheTResultSpecs : IDisposable
             delegateExecuted = true;
             return valueToReturnFromExecution;
         }, new Context(OperationKey))
-            .Should().Be(valueToReturnFromCache);
+            .ShouldBe(valueToReturnFromCache);
 
-        delegateExecuted.Should().BeFalse();
+        delegateExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -1325,18 +1325,18 @@ public class CacheTResultSpecs : IDisposable
         ResultPrimitive valueToReturn = default;
         const string OperationKey = "SomeOperationKey";
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         CachePolicy<ResultPrimitive> cache = Policy.Cache<ResultPrimitive>(stubCacheProvider, TimeSpan.MaxValue);
 
         (bool cacheHit1, object? fromCache1) = stubCacheProvider.TryGet(OperationKey);
-        cacheHit1.Should().BeFalse();
-        fromCache1.Should().BeNull();
+        cacheHit1.ShouldBeFalse();
+        fromCache1.ShouldBeNull();
 
-        cache.Execute(_ => valueToReturn, new Context(OperationKey)).Should().Be(valueToReturn);
+        cache.Execute(_ => valueToReturn, new Context(OperationKey)).ShouldBe(valueToReturn);
 
         (bool cacheHit2, object? fromCache2) = stubCacheProvider.TryGet(OperationKey);
-        cacheHit2.Should().BeTrue();
-        fromCache2.Should().Be(valueToReturn);
+        cacheHit2.ShouldBeTrue();
+        fromCache2.ShouldBe(valueToReturn);
     }
 
     [Fact]
@@ -1344,10 +1344,10 @@ public class CacheTResultSpecs : IDisposable
     {
         ResultPrimitive valueToReturnFromCache = default;
         ResultPrimitive valueToReturnFromExecution = ResultPrimitive.Good;
-        valueToReturnFromExecution.Should().NotBe(valueToReturnFromCache);
+        valueToReturnFromExecution.ShouldNotBe(valueToReturnFromCache);
         const string OperationKey = "SomeOperationKey";
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         CachePolicy<ResultPrimitive> cache = Policy.Cache<ResultPrimitive>(stubCacheProvider, TimeSpan.MaxValue);
         stubCacheProvider.Put(OperationKey, valueToReturnFromCache, new Ttl(TimeSpan.MaxValue));
 
@@ -1358,9 +1358,9 @@ public class CacheTResultSpecs : IDisposable
             delegateExecuted = true;
             return valueToReturnFromExecution;
         }, new Context(OperationKey))
-            .Should().Be(valueToReturnFromCache);
+            .ShouldBe(valueToReturnFromCache);
 
-        delegateExecuted.Should().BeFalse();
+        delegateExecuted.ShouldBeFalse();
     }
 
     #endregion
@@ -1374,7 +1374,7 @@ public class CacheTResultSpecs : IDisposable
         const string ValueToReturnFromExecution = "valueToReturnFromExecution";
         const string OperationKey = "SomeOperationKey";
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         CachePolicy<string> cache = Policy.Cache<string>(stubCacheProvider, TimeSpan.MaxValue);
         Policy noop = Policy.NoOp();
         PolicyWrap<string> wrap = cache.Wrap(noop);
@@ -1388,9 +1388,9 @@ public class CacheTResultSpecs : IDisposable
             delegateExecuted = true;
             return ValueToReturnFromExecution;
         }, new Context(OperationKey))
-            .Should().Be(ValueToReturnFromCache);
+            .ShouldBe(ValueToReturnFromCache);
 
-        delegateExecuted.Should().BeFalse();
+        delegateExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -1400,7 +1400,7 @@ public class CacheTResultSpecs : IDisposable
         const string ValueToReturnFromExecution = "valueToReturnFromExecution";
         const string OperationKey = "SomeOperationKey";
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         CachePolicy<string> cache = Policy.Cache<string>(stubCacheProvider, TimeSpan.MaxValue);
         Policy noop = Policy.NoOp();
         PolicyWrap<string> wrap = noop.Wrap(cache);
@@ -1414,9 +1414,9 @@ public class CacheTResultSpecs : IDisposable
             delegateExecuted = true;
             return ValueToReturnFromExecution;
         }, new Context(OperationKey))
-            .Should().Be(ValueToReturnFromCache);
+            .ShouldBe(ValueToReturnFromCache);
 
-        delegateExecuted.Should().BeFalse();
+        delegateExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -1426,7 +1426,7 @@ public class CacheTResultSpecs : IDisposable
         const string ValueToReturnFromExecution = "valueToReturnFromExecution";
         const string OperationKey = "SomeOperationKey";
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         CachePolicy<string> cache = Policy.Cache<string>(stubCacheProvider, TimeSpan.MaxValue);
         Policy<string> noop = Policy.NoOp<string>();
         PolicyWrap<string> wrap = Policy.Wrap(noop, cache, noop);
@@ -1440,9 +1440,9 @@ public class CacheTResultSpecs : IDisposable
             delegateExecuted = true;
             return ValueToReturnFromExecution;
         }, new Context(OperationKey))
-            .Should().Be(ValueToReturnFromCache);
+            .ShouldBe(ValueToReturnFromCache);
 
-        delegateExecuted.Should().BeFalse();
+        delegateExecuted.ShouldBeFalse();
     }
 
     #endregion
@@ -1463,11 +1463,11 @@ public class CacheTResultSpecs : IDisposable
             return valueToReturn;
         };
 
-        cache.Execute(func /*, no operation key */).Should().Be(valueToReturn);
-        delegateInvocations.Should().Be(1);
+        cache.Execute(func /*, no operation key */).ShouldBe(valueToReturn);
+        delegateInvocations.ShouldBe(1);
 
-        cache.Execute(func /*, no operation key */).Should().Be(valueToReturn);
-        delegateInvocations.Should().Be(2);
+        cache.Execute(func /*, no operation key */).ShouldBe(valueToReturn);
+        delegateInvocations.ShouldBe(2);
     }
 
     #endregion
@@ -1480,7 +1480,7 @@ public class CacheTResultSpecs : IDisposable
         const string ValueToReturn = "valueToReturn";
         const string OperationKey = "SomeOperationKey";
 
-        CachePolicy<string> cache = Policy.Cache<string>(new StubCacheProvider(), TimeSpan.MaxValue);
+        CachePolicy<string> policy = Policy.Cache<string>(new StubCacheProvider(), TimeSpan.MaxValue);
 
         int delegateInvocations = 0;
 
@@ -1493,16 +1493,15 @@ public class CacheTResultSpecs : IDisposable
                 return ValueToReturn;
             };
 
-            cache.Execute(func, new Context(OperationKey), tokenSource.Token).Should().Be(ValueToReturn);
-            delegateInvocations.Should().Be(1);
+            policy.Execute(func, new Context(OperationKey), tokenSource.Token).ShouldBe(ValueToReturn);
+            delegateInvocations.ShouldBe(1);
 
             tokenSource.Cancel();
 
-            cache.Invoking(policy => policy.Execute(func, new Context(OperationKey), tokenSource.Token))
-                .Should().Throw<OperationCanceledException>();
+            Should.Throw<OperationCanceledException>(() => policy.Execute(func, new Context(OperationKey), tokenSource.Token));
         }
 
-        delegateInvocations.Should().Be(1);
+        delegateInvocations.ShouldBe(1);
     }
 
     [Fact]
@@ -1511,8 +1510,8 @@ public class CacheTResultSpecs : IDisposable
         const string ValueToReturn = "valueToReturn";
         const string OperationKey = "SomeOperationKey";
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
-        CachePolicy<string> cache = Policy.Cache<string>(stubCacheProvider, TimeSpan.MaxValue);
+        var stubCacheProvider = new StubCacheProvider();
+        CachePolicy<string> policy = Policy.Cache<string>(stubCacheProvider, TimeSpan.MaxValue);
 
         using (var tokenSource = new CancellationTokenSource())
         {
@@ -1523,13 +1522,12 @@ public class CacheTResultSpecs : IDisposable
                 return ValueToReturn;
             };
 
-            cache.Invoking(policy => policy.Execute(func, new Context(OperationKey), tokenSource.Token))
-                .Should().Throw<OperationCanceledException>();
+            Should.Throw<OperationCanceledException>(() => policy.Execute(func, new Context(OperationKey), tokenSource.Token));
         }
 
         (bool cacheHit, object? fromCache) = stubCacheProvider.TryGet(OperationKey);
-        cacheHit.Should().BeFalse();
-        fromCache.Should().BeNull();
+        cacheHit.ShouldBeFalse();
+        fromCache.ShouldBeNull();
     }
 
     #endregion

--- a/test/Polly.Specs/Caching/ContextualTtlSpecs.cs
+++ b/test/Polly.Specs/Caching/ContextualTtlSpecs.cs
@@ -7,12 +7,12 @@ public class ContextualTtlSpecs
     {
         Context context = null!;
         Action action = () => new ContextualTtl().GetTtl(context, null);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("context");
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe("context");
     }
 
     [Fact]
     public void Should_return_zero_if_no_value_set_on_context() =>
-        new ContextualTtl().GetTtl(new Context("someOperationKey"), null).Timespan.Should().Be(TimeSpan.Zero);
+        new ContextualTtl().GetTtl(new Context("someOperationKey"), null).Timespan.ShouldBe(TimeSpan.Zero);
 
     [Fact]
     public void Should_return_zero_if_invalid_value_set_on_context()
@@ -23,7 +23,7 @@ public class ContextualTtlSpecs
         };
 
         Context context = new Context(string.Empty, contextData);
-        new ContextualTtl().GetTtl(context, null).Timespan.Should().Be(TimeSpan.Zero);
+        new ContextualTtl().GetTtl(context, null).Timespan.ShouldBe(TimeSpan.Zero);
     }
 
     [Fact]
@@ -37,8 +37,8 @@ public class ContextualTtlSpecs
 
         Context context = new Context(string.Empty, contextData);
         Ttl gotTtl = new ContextualTtl().GetTtl(context, null);
-        gotTtl.Timespan.Should().Be(ttl);
-        gotTtl.SlidingExpiration.Should().BeFalse();
+        gotTtl.Timespan.ShouldBe(ttl);
+        gotTtl.SlidingExpiration.ShouldBeFalse();
     }
 
     [Fact]
@@ -52,8 +52,8 @@ public class ContextualTtlSpecs
 
         Context context = new Context(string.Empty, contextData);
         Ttl gotTtl = new ContextualTtl().GetTtl(context, null);
-        gotTtl.Timespan.Should().Be(ttl);
-        gotTtl.SlidingExpiration.Should().BeFalse();
+        gotTtl.Timespan.ShouldBe(ttl);
+        gotTtl.SlidingExpiration.ShouldBeFalse();
     }
 
     [Fact]
@@ -65,7 +65,7 @@ public class ContextualTtlSpecs
         };
 
         Context context = new Context(string.Empty, contextData);
-        new ContextualTtl().GetTtl(context, null).Timespan.Should().Be(TimeSpan.Zero);
+        new ContextualTtl().GetTtl(context, null).Timespan.ShouldBe(TimeSpan.Zero);
     }
 
     [Fact]
@@ -80,8 +80,8 @@ public class ContextualTtlSpecs
 
         var context = new Context(string.Empty, contextData);
         var gotTtl = new ContextualTtl().GetTtl(context, null);
-        gotTtl.Timespan.Should().Be(ttl);
-        gotTtl.SlidingExpiration.Should().BeTrue();
+        gotTtl.Timespan.ShouldBe(ttl);
+        gotTtl.SlidingExpiration.ShouldBeTrue();
     }
 
     [Fact]
@@ -96,8 +96,8 @@ public class ContextualTtlSpecs
 
         var context = new Context(string.Empty, contextData);
         var gotTtl = new ContextualTtl().GetTtl(context, null);
-        gotTtl.Timespan.Should().Be(ttl);
-        gotTtl.SlidingExpiration.Should().BeFalse();
+        gotTtl.Timespan.ShouldBe(ttl);
+        gotTtl.SlidingExpiration.ShouldBeFalse();
     }
 
     [Fact]
@@ -112,7 +112,7 @@ public class ContextualTtlSpecs
 
         var context = new Context(string.Empty, contextData);
         var gotTtl = new ContextualTtl().GetTtl(context, null);
-        gotTtl.Timespan.Should().Be(ttl);
-        gotTtl.SlidingExpiration.Should().BeFalse();
+        gotTtl.Timespan.ShouldBe(ttl);
+        gotTtl.SlidingExpiration.ShouldBeFalse();
     }
 }

--- a/test/Polly.Specs/Caching/DefaultCacheKeyStrategySpecs.cs
+++ b/test/Polly.Specs/Caching/DefaultCacheKeyStrategySpecs.cs
@@ -7,7 +7,7 @@ public class DefaultCacheKeyStrategySpecs
     {
         Context context = null!;
         Action action = () => DefaultCacheKeyStrategy.Instance.GetCacheKey(context);
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("context");
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe("context");
     }
 
     [Fact]
@@ -18,6 +18,6 @@ public class DefaultCacheKeyStrategySpecs
         Context context = new Context(operationKey);
 
         DefaultCacheKeyStrategy.Instance.GetCacheKey(context)
-            .Should().Be(operationKey);
+            .ShouldBe(operationKey);
     }
 }

--- a/test/Polly.Specs/Caching/GenericCacheProviderAsyncSpecs.cs
+++ b/test/Polly.Specs/Caching/GenericCacheProviderAsyncSpecs.cs
@@ -15,8 +15,8 @@ public class GenericCacheProviderAsyncSpecs : IDisposable
         var cache = Policy.CacheAsync(stubCacheProvider, TimeSpan.MaxValue, onError);
 
         (bool cacheHit, object? fromCache) = await stubCacheProvider.TryGetAsync(OperationKey, CancellationToken.None, false);
-        cacheHit.Should().BeFalse();
-        fromCache.Should().BeNull();
+        cacheHit.ShouldBeFalse();
+        fromCache.ShouldBeNull();
 
         ResultPrimitive result = await cache.ExecuteAsync(async _ =>
         {
@@ -24,7 +24,7 @@ public class GenericCacheProviderAsyncSpecs : IDisposable
             return ResultPrimitive.Substitute;
         }, new Context(OperationKey));
 
-        onErrorCalled.Should().BeFalse();
+        onErrorCalled.ShouldBeFalse();
     }
 
     [Fact]
@@ -38,18 +38,18 @@ public class GenericCacheProviderAsyncSpecs : IDisposable
         var cache = Policy.CacheAsync(stubCacheProvider, TimeSpan.MaxValue);
 
         (bool cacheHit1, object? fromCache1) = await stubCacheProvider.TryGetAsync(OperationKey, cancellationToken, false);
-        cacheHit1.Should().BeFalse();
-        fromCache1.Should().BeNull();
+        cacheHit1.ShouldBeFalse();
+        fromCache1.ShouldBeNull();
 
         (await cache.ExecuteAsync(async _ =>
         {
             await TaskHelper.EmptyTask;
             return ResultPrimitive.Substitute;
-        }, new Context(OperationKey))).Should().Be(ValueToReturn);
+        }, new Context(OperationKey))).ShouldBe(ValueToReturn);
 
         (bool cacheHit2, object? fromCache2) = await stubCacheProvider.TryGetAsync(OperationKey, cancellationToken, false);
-        cacheHit2.Should().BeTrue();
-        fromCache2.Should().Be(ValueToReturn);
+        cacheHit2.ShouldBeTrue();
+        fromCache2.ShouldBe(ValueToReturn);
     }
 
     public void Dispose() =>

--- a/test/Polly.Specs/Caching/GenericCacheProviderSpecs.cs
+++ b/test/Polly.Specs/Caching/GenericCacheProviderSpecs.cs
@@ -15,12 +15,12 @@ public class GenericCacheProviderSpecs : IDisposable
         CachePolicy cache = Policy.Cache(stubCacheProvider, TimeSpan.MaxValue, onError);
 
         (bool cacheHit, object? fromCache) = stubCacheProvider.TryGet(OperationKey);
-        cacheHit.Should().BeFalse();
-        fromCache.Should().BeNull();
+        cacheHit.ShouldBeFalse();
+        fromCache.ShouldBeNull();
 
         ResultPrimitive result = cache.Execute(_ => ResultPrimitive.Substitute, new Context(OperationKey));
 
-        onErrorCalled.Should().BeFalse();
+        onErrorCalled.ShouldBeFalse();
     }
 
     [Fact]
@@ -34,15 +34,15 @@ public class GenericCacheProviderSpecs : IDisposable
 
         (bool cacheHit1, object? fromCache1) = stubCacheProvider.TryGet(OperationKey);
 
-        cacheHit1.Should().BeFalse();
-        fromCache1.Should().BeNull();
+        cacheHit1.ShouldBeFalse();
+        fromCache1.ShouldBeNull();
 
-        cache.Execute(_ => ValueToReturn, new Context(OperationKey)).Should().Be(ValueToReturn);
+        cache.Execute(_ => ValueToReturn, new Context(OperationKey)).ShouldBe(ValueToReturn);
 
         (bool cacheHit2, object? fromCache2) = stubCacheProvider.TryGet(OperationKey);
 
-        cacheHit2.Should().BeTrue();
-        fromCache2.Should().Be(ValueToReturn);
+        cacheHit2.ShouldBeTrue();
+        fromCache2.ShouldBe(ValueToReturn);
     }
 
     public void Dispose() =>

--- a/test/Polly.Specs/Caching/RelativeTtlSpecs.cs
+++ b/test/Polly.Specs/Caching/RelativeTtlSpecs.cs
@@ -7,7 +7,7 @@ public class RelativeTtlSpecs
     {
         Action configure = () => _ = new RelativeTtl(TimeSpan.FromMilliseconds(-1));
 
-        configure.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("ttl");
+        Should.Throw<ArgumentOutOfRangeException>(configure).ParamName.ShouldBe("ttl");
     }
 
     [Fact]
@@ -15,7 +15,7 @@ public class RelativeTtlSpecs
     {
         Action configure = () => _ = new RelativeTtl(TimeSpan.Zero);
 
-        configure.Should().NotThrow();
+        Should.NotThrow(configure);
     }
 
     [Fact]
@@ -23,7 +23,7 @@ public class RelativeTtlSpecs
     {
         Action configure = () => _ = new RelativeTtl(TimeSpan.MaxValue);
 
-        configure.Should().NotThrow();
+        Should.NotThrow(configure);
     }
 
     [Fact]
@@ -34,8 +34,8 @@ public class RelativeTtlSpecs
         RelativeTtl ttlStrategy = new RelativeTtl(ttl);
 
         Ttl retrieved = ttlStrategy.GetTtl(new Context("someOperationKey"), null);
-        retrieved.Timespan.Should().BeCloseTo(ttl, TimeSpan.Zero);
-        retrieved.SlidingExpiration.Should().BeFalse();
+        retrieved.Timespan.ShouldBe(ttl);
+        retrieved.SlidingExpiration.ShouldBeFalse();
     }
 
     [Fact]
@@ -50,7 +50,7 @@ public class RelativeTtlSpecs
         SystemClock.DateTimeOffsetUtcNow = () => fixedTime.Add(delay);
 
         Ttl retrieved = ttlStrategy.GetTtl(new Context("someOperationKey"), null);
-        retrieved.Timespan.Should().BeCloseTo(ttl, TimeSpan.Zero);
-        retrieved.SlidingExpiration.Should().BeFalse();
+        retrieved.Timespan.ShouldBe(ttl);
+        retrieved.SlidingExpiration.ShouldBeFalse();
     }
 }

--- a/test/Polly.Specs/Caching/ResultTtlSpecs.cs
+++ b/test/Polly.Specs/Caching/ResultTtlSpecs.cs
@@ -7,7 +7,7 @@ public class ResultTtlSpecs
     {
         Action configure = () => _ = new ResultTtl<object>((Func<object?, Ttl>)null!);
 
-        configure.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("ttlFunc");
+        Should.Throw<ArgumentNullException>(configure).ParamName.ShouldBe("ttlFunc");
     }
 
     [Fact]
@@ -15,7 +15,7 @@ public class ResultTtlSpecs
     {
         Action configure = () => _ = new ResultTtl<object>((Func<Context, object?, Ttl>)null!);
 
-        configure.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("ttlFunc");
+        Should.Throw<ArgumentNullException>(configure).ParamName.ShouldBe("ttlFunc");
     }
 
     [Fact]
@@ -23,7 +23,7 @@ public class ResultTtlSpecs
     {
         Action configure = () => _ = new ResultTtl<object>(_ => default);
 
-        configure.Should().NotThrow();
+        Should.NotThrow(configure);
     }
 
     [Fact]
@@ -31,7 +31,7 @@ public class ResultTtlSpecs
     {
         Action configure = () => _ = new ResultTtl<object>((_, _) => default);
 
-        configure.Should().NotThrow();
+        Should.NotThrow(configure);
     }
 
     [Fact]
@@ -43,8 +43,8 @@ public class ResultTtlSpecs
         ResultTtl<dynamic> ttlStrategy = new ResultTtl<dynamic>(func);
 
         Ttl retrieved = ttlStrategy.GetTtl(new Context("someOperationKey"), new { Ttl = ttl });
-        retrieved.Timespan.Should().Be(ttl);
-        retrieved.SlidingExpiration.Should().BeFalse();
+        retrieved.Timespan.ShouldBe(ttl);
+        retrieved.SlidingExpiration.ShouldBeFalse();
     }
 
     [Fact]
@@ -57,7 +57,7 @@ public class ResultTtlSpecs
 
         ResultTtl<dynamic> ttlStrategy = new ResultTtl<dynamic>(func);
 
-        ttlStrategy.GetTtl(new Context("someOperationKey"), new { Ttl = ttl }).Timespan.Should().Be(ttl);
-        ttlStrategy.GetTtl(new Context(SpecialKey), new { Ttl = ttl }).Timespan.Should().Be(TimeSpan.Zero);
+        ttlStrategy.GetTtl(new Context("someOperationKey"), new { Ttl = ttl }).Timespan.ShouldBe(ttl);
+        ttlStrategy.GetTtl(new Context(SpecialKey), new { Ttl = ttl }).Timespan.ShouldBe(TimeSpan.Zero);
     }
 }

--- a/test/Polly.Specs/Caching/SerializingCacheProviderSpecs.cs
+++ b/test/Polly.Specs/Caching/SerializingCacheProviderSpecs.cs
@@ -13,8 +13,8 @@ public class SerializingCacheProviderSpecs
 
         Action configure = () => _ = new SerializingCacheProvider<StubSerialized>(null!, stubObjectSerializer);
 
-        configure.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("wrappedCacheProvider");
+        Should.Throw<ArgumentNullException>(configure)
+            .ParamName.ShouldBe("wrappedCacheProvider");
     }
 
     [Fact]
@@ -22,8 +22,8 @@ public class SerializingCacheProviderSpecs
     {
         Action configure = () => _ = new SerializingCacheProvider<object>(new StubCacheProvider().For<object>(), null!);
 
-        configure.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("serializer");
+        Should.Throw<ArgumentNullException>(configure)
+            .ParamName.ShouldBe("serializer");
     }
 
     [Fact]
@@ -31,8 +31,8 @@ public class SerializingCacheProviderSpecs
     {
         Action configure = () => new StubCacheProvider().For<object>().WithSerializer(null!);
 
-        configure.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("serializer");
+        Should.Throw<ArgumentNullException>(configure)
+            .ParamName.ShouldBe("serializer");
     }
 
     [Fact]
@@ -49,13 +49,13 @@ public class SerializingCacheProviderSpecs
         SerializingCacheProvider<StubSerialized> serializingCacheProvider = new SerializingCacheProvider<StubSerialized>(stubCacheProvider.For<StubSerialized>(), stubSerializer);
         serializingCacheProvider.Put(key, objectToCache, new Ttl(TimeSpan.FromMinutes(1)));
 
-        serializeInvoked.Should().BeTrue();
+        serializeInvoked.ShouldBeTrue();
 
         (bool cacheHit, object? fromCache) = stubCacheProvider.TryGet(key);
 
-        cacheHit.Should().BeTrue();
-        fromCache.Should().BeOfType<StubSerialized>()
-            .Which.Original.Should().Be(objectToCache);
+        cacheHit.ShouldBeTrue();
+        fromCache.ShouldBeOfType<StubSerialized>()
+            .Original.ShouldBe(objectToCache);
     }
 
     [Fact]
@@ -72,13 +72,13 @@ public class SerializingCacheProviderSpecs
         SerializingCacheProvider<StubSerialized> serializingCacheProvider = new SerializingCacheProvider<StubSerialized>(stubCacheProvider.For<StubSerialized>(), stubSerializer);
         serializingCacheProvider.Put(key, objectToCache, new Ttl(TimeSpan.FromMinutes(1)));
 
-        serializeInvoked.Should().BeTrue();
+        serializeInvoked.ShouldBeTrue();
 
         (bool cacheHit, object? fromCache) = stubCacheProvider.TryGet(key);
 
-        cacheHit.Should().BeTrue();
-        fromCache.Should().BeOfType<StubSerialized>()
-            .Which.Original.Should().Be(objectToCache);
+        cacheHit.ShouldBeTrue();
+        fromCache.ShouldBeOfType<StubSerialized>()
+            .Original.ShouldBe(objectToCache);
     }
 
     [Fact]
@@ -98,9 +98,9 @@ public class SerializingCacheProviderSpecs
         SerializingCacheProvider<StubSerialized> serializingCacheProvider = new SerializingCacheProvider<StubSerialized>(stubCacheProvider.For<StubSerialized>(), stubSerializer);
         (bool cacheHit, object? fromCache) = serializingCacheProvider.TryGet(key);
 
-        cacheHit.Should().BeTrue();
-        deserializeInvoked.Should().BeTrue();
-        fromCache.Should().Be(objectToCache);
+        cacheHit.ShouldBeTrue();
+        deserializeInvoked.ShouldBeTrue();
+        fromCache.ShouldBe(objectToCache);
     }
 
     [Fact]
@@ -113,14 +113,14 @@ public class SerializingCacheProviderSpecs
         var stubCacheProvider = new StubCacheProvider();
         string key = "some key";
 
-        stubCacheProvider.TryGet(key).Item1.Should().BeFalse();
+        stubCacheProvider.TryGet(key).Item1.ShouldBeFalse();
 
         SerializingCacheProvider<StubSerialized> serializingCacheProvider = new SerializingCacheProvider<StubSerialized>(stubCacheProvider.For<StubSerialized>(), stubSerializer);
         (bool cacheHit, object? fromCache) = serializingCacheProvider.TryGet(key);
 
-        cacheHit.Should().BeFalse();
-        deserializeInvoked.Should().BeFalse();
-        fromCache.Should().Be(default);
+        cacheHit.ShouldBeFalse();
+        deserializeInvoked.ShouldBeFalse();
+        fromCache.ShouldBe(default);
     }
 
     [Fact]
@@ -137,13 +137,13 @@ public class SerializingCacheProviderSpecs
         SerializingCacheProvider<StubSerialized> serializingCacheProvider = stubCacheProvider.For<StubSerialized>().WithSerializer(stubSerializer);
         serializingCacheProvider.Put(key, objectToCache, new Ttl(TimeSpan.FromMinutes(1)));
 
-        serializeInvoked.Should().BeTrue();
+        serializeInvoked.ShouldBeTrue();
 
         (bool cacheHit, object? fromCache) = stubCacheProvider.TryGet(key);
 
-        cacheHit.Should().BeTrue();
-        fromCache.Should().BeOfType<StubSerialized>()
-            .Which.Original.Should().Be(objectToCache);
+        cacheHit.ShouldBeTrue();
+        fromCache.ShouldBeOfType<StubSerialized>()
+            .Original.ShouldBe(objectToCache);
     }
 
     [Fact]
@@ -160,13 +160,13 @@ public class SerializingCacheProviderSpecs
         SerializingCacheProvider<StubSerialized> serializingCacheProvider = stubCacheProvider.For<StubSerialized>().WithSerializer(stubSerializer);
         serializingCacheProvider.Put(key, objectToCache, new Ttl(TimeSpan.FromMinutes(1)));
 
-        serializeInvoked.Should().BeTrue();
+        serializeInvoked.ShouldBeTrue();
 
         (bool cacheHit, object? fromCache) = stubCacheProvider.TryGet(key);
 
-        cacheHit.Should().BeTrue();
-        fromCache.Should().BeOfType<StubSerialized>()
-            .Which.Original.Should().Be(objectToCache);
+        cacheHit.ShouldBeTrue();
+        fromCache.ShouldBeOfType<StubSerialized>()
+            .Original.ShouldBe(objectToCache);
     }
 
     [Fact]
@@ -185,9 +185,9 @@ public class SerializingCacheProviderSpecs
         SerializingCacheProvider<StubSerialized> serializingCacheProvider = stubCacheProvider.For<StubSerialized>().WithSerializer(stubSerializer);
         (bool cacheHit, object? fromCache) = serializingCacheProvider.TryGet(key);
 
-        cacheHit.Should().BeTrue();
-        deserializeInvoked.Should().BeTrue();
-        fromCache.Should().Be(objectToCache);
+        cacheHit.ShouldBeTrue();
+        deserializeInvoked.ShouldBeTrue();
+        fromCache.ShouldBe(objectToCache);
     }
 
     [Fact]
@@ -200,14 +200,14 @@ public class SerializingCacheProviderSpecs
         var stubCacheProvider = new StubCacheProvider();
         string key = "some key";
 
-        stubCacheProvider.TryGet(key).Item1.Should().BeFalse();
+        stubCacheProvider.TryGet(key).Item1.ShouldBeFalse();
 
         SerializingCacheProvider<StubSerialized> serializingCacheProvider = stubCacheProvider.For<StubSerialized>().WithSerializer(stubSerializer);
         (bool cacheHit, object? fromCache) = serializingCacheProvider.TryGet(key);
 
-        cacheHit.Should().BeFalse();
-        deserializeInvoked.Should().BeFalse();
-        fromCache.Should().Be(default);
+        cacheHit.ShouldBeFalse();
+        deserializeInvoked.ShouldBeFalse();
+        fromCache.ShouldBe(default);
     }
 
     #endregion
@@ -223,8 +223,8 @@ public class SerializingCacheProviderSpecs
 
         Action configure = () => _ = new SerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>>(null!, stubTResultSerializer);
 
-        configure.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("wrappedCacheProvider");
+        Should.Throw<ArgumentNullException>(configure)
+            .ParamName.ShouldBe("wrappedCacheProvider");
     }
 
     [Fact]
@@ -232,8 +232,8 @@ public class SerializingCacheProviderSpecs
     {
         Action configure = () => _ = new SerializingCacheProvider<object, object>(new StubCacheProvider().For<object>(), null!);
 
-        configure.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("serializer");
+        Should.Throw<ArgumentNullException>(configure)
+            .ParamName.ShouldBe("serializer");
     }
 
     [Fact]
@@ -241,8 +241,8 @@ public class SerializingCacheProviderSpecs
     {
         Action configure = () => new StubCacheProvider().For<object>().WithSerializer<object, object>(null!);
 
-        configure.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("serializer");
+        Should.Throw<ArgumentNullException>(configure)
+            .ParamName.ShouldBe("serializer");
     }
 
     [Fact]
@@ -259,13 +259,13 @@ public class SerializingCacheProviderSpecs
         SerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>> serializingCacheProvider = new SerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>>(stubCacheProvider.For<StubSerialized<ResultPrimitive>>(), stubTResultSerializer);
         serializingCacheProvider.Put(key, objectToCache, new Ttl(TimeSpan.FromMinutes(1)));
 
-        serializeInvoked.Should().BeTrue();
+        serializeInvoked.ShouldBeTrue();
 
         (bool cacheHit, object? fromCache) = stubCacheProvider.TryGet(key);
 
-        cacheHit.Should().BeTrue();
-        fromCache.Should().BeOfType<StubSerialized<ResultPrimitive>>()
-            .Which.Original.Should().Be(objectToCache);
+        cacheHit.ShouldBeTrue();
+        fromCache.ShouldBeOfType<StubSerialized<ResultPrimitive>>()
+            .Original.ShouldBe(objectToCache);
     }
 
     [Fact]
@@ -282,13 +282,13 @@ public class SerializingCacheProviderSpecs
         SerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>> serializingCacheProvider = new SerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>>(stubCacheProvider.For<StubSerialized<ResultPrimitive>>(), stubTResultSerializer);
         serializingCacheProvider.Put(key, objectToCache, new Ttl(TimeSpan.FromMinutes(1)));
 
-        serializeInvoked.Should().BeTrue();
+        serializeInvoked.ShouldBeTrue();
 
         (bool cacheHit, object? fromCache) = stubCacheProvider.TryGet(key);
 
-        cacheHit.Should().BeTrue();
-        fromCache.Should().BeOfType<StubSerialized<ResultPrimitive>>()
-            .Which.Original.Should().Be(objectToCache);
+        cacheHit.ShouldBeTrue();
+        fromCache.ShouldBeOfType<StubSerialized<ResultPrimitive>>()
+            .Original.ShouldBe(objectToCache);
     }
 
     [Fact]
@@ -307,9 +307,9 @@ public class SerializingCacheProviderSpecs
         stubCacheProvider.Put(key, new StubSerialized<ResultPrimitive>(objectToCache), new Ttl(TimeSpan.FromMinutes(1)));
         (bool cacheHit, object fromCache) = serializingCacheProvider.TryGet(key);
 
-        cacheHit.Should().BeTrue();
-        deserializeInvoked.Should().BeTrue();
-        fromCache.Should().Be(objectToCache);
+        cacheHit.ShouldBeTrue();
+        deserializeInvoked.ShouldBeTrue();
+        fromCache.ShouldBe(objectToCache);
     }
 
     [Fact]
@@ -322,14 +322,14 @@ public class SerializingCacheProviderSpecs
         var stubCacheProvider = new StubCacheProvider();
         string key = "some key";
 
-        stubCacheProvider.TryGet(key).Item1.Should().BeFalse();
+        stubCacheProvider.TryGet(key).Item1.ShouldBeFalse();
 
         SerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>> serializingCacheProvider = new SerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>>(stubCacheProvider.For<StubSerialized<ResultPrimitive>>(), stubTResultSerializer);
         (bool cacheHit, ResultPrimitive fromCache) = serializingCacheProvider.TryGet(key);
 
-        cacheHit.Should().BeFalse();
-        deserializeInvoked.Should().BeFalse();
-        fromCache.Should().Be(default);
+        cacheHit.ShouldBeFalse();
+        deserializeInvoked.ShouldBeFalse();
+        fromCache.ShouldBe(default);
     }
 
     [Fact]
@@ -347,13 +347,13 @@ public class SerializingCacheProviderSpecs
             stubCacheProvider.For<StubSerialized<ResultPrimitive>>().WithSerializer(stubTResultSerializer);
         serializingCacheProvider.Put(key, objectToCache, new Ttl(TimeSpan.FromMinutes(1)));
 
-        serializeInvoked.Should().BeTrue();
+        serializeInvoked.ShouldBeTrue();
 
         (bool cacheHit, object? fromCache) = stubCacheProvider.TryGet(key);
 
-        cacheHit.Should().BeTrue();
-        fromCache.Should().BeOfType<StubSerialized<ResultPrimitive>>()
-            .Which.Original.Should().Be(objectToCache);
+        cacheHit.ShouldBeTrue();
+        fromCache.ShouldBeOfType<StubSerialized<ResultPrimitive>>()
+            .Original.ShouldBe(objectToCache);
     }
 
     [Fact]
@@ -372,13 +372,13 @@ public class SerializingCacheProviderSpecs
 
         serializingCacheProvider.Put(key, objectToCache, new Ttl(TimeSpan.FromMinutes(1)));
 
-        serializeInvoked.Should().BeTrue();
+        serializeInvoked.ShouldBeTrue();
 
         (bool cacheHit, object? fromCache) = stubCacheProvider.TryGet(key);
 
-        cacheHit.Should().BeTrue();
-        fromCache.Should().BeOfType<StubSerialized<ResultPrimitive>>()
-            .Which.Original.Should().Be(objectToCache);
+        cacheHit.ShouldBeTrue();
+        fromCache.ShouldBeOfType<StubSerialized<ResultPrimitive>>()
+            .Original.ShouldBe(objectToCache);
     }
 
     [Fact]
@@ -398,9 +398,9 @@ public class SerializingCacheProviderSpecs
         stubCacheProvider.Put(key, new StubSerialized<ResultPrimitive>(objectToCache), new Ttl(TimeSpan.FromMinutes(1)));
         (bool cacheHit, ResultPrimitive? fromCache) = serializingCacheProvider.TryGet(key);
 
-        cacheHit.Should().BeTrue();
-        deserializeInvoked.Should().BeTrue();
-        fromCache.Should().Be(objectToCache);
+        cacheHit.ShouldBeTrue();
+        deserializeInvoked.ShouldBeTrue();
+        fromCache.ShouldBe(objectToCache);
     }
 
     [Fact]
@@ -413,15 +413,15 @@ public class SerializingCacheProviderSpecs
         var stubCacheProvider = new StubCacheProvider();
         string key = "some key";
 
-        stubCacheProvider.TryGet(key).Item2.Should().BeNull();
+        stubCacheProvider.TryGet(key).Item2.ShouldBeNull();
 
         SerializingCacheProvider<ResultPrimitive, StubSerialized<ResultPrimitive>> serializingCacheProvider =
             stubCacheProvider.For<StubSerialized<ResultPrimitive>>().WithSerializer(stubTResultSerializer);
         (bool cacheHit, ResultPrimitive? fromCache) = serializingCacheProvider.TryGet(key);
 
-        cacheHit.Should().BeFalse();
-        deserializeInvoked.Should().BeFalse();
-        fromCache.Should().Be(default);
+        cacheHit.ShouldBeFalse();
+        deserializeInvoked.ShouldBeFalse();
+        fromCache.ShouldBe(ResultPrimitive.Undefined);
     }
 
     #endregion

--- a/test/Polly.Specs/Caching/SlidingTtlSpecs.cs
+++ b/test/Polly.Specs/Caching/SlidingTtlSpecs.cs
@@ -7,7 +7,7 @@ public class SlidingTtlSpecs
     {
         Action configure = () => _ = new SlidingTtl(TimeSpan.FromMilliseconds(-1));
 
-        configure.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("slidingTtl");
+        Should.Throw<ArgumentOutOfRangeException>(configure).ParamName.ShouldBe("slidingTtl");
     }
 
     [Fact]
@@ -15,7 +15,7 @@ public class SlidingTtlSpecs
     {
         Action configure = () => _ = new SlidingTtl(TimeSpan.Zero);
 
-        configure.Should().NotThrow();
+        Should.NotThrow(configure);
     }
 
     [Fact]
@@ -23,7 +23,7 @@ public class SlidingTtlSpecs
     {
         Action configure = () => _ = new SlidingTtl(TimeSpan.MaxValue);
 
-        configure.Should().NotThrow();
+        Should.NotThrow(configure);
     }
 
     [Fact]
@@ -34,7 +34,7 @@ public class SlidingTtlSpecs
         SlidingTtl ttlStrategy = new SlidingTtl(ttl);
 
         Ttl retrieved = ttlStrategy.GetTtl(new Context("someOperationKey"), null);
-        retrieved.Timespan.Should().Be(ttl);
-        retrieved.SlidingExpiration.Should().BeTrue();
+        retrieved.Timespan.ShouldBe(ttl);
+        retrieved.SlidingExpiration.ShouldBeTrue();
     }
 }

--- a/test/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerAsyncSpecs.cs
+++ b/test/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerAsyncSpecs.cs
@@ -14,8 +14,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreakerAsync(0.5, TimeSpan.FromSeconds(10), 4, TimeSpan.MaxValue);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
     }
 
     [Fact]
@@ -25,9 +24,8 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreakerAsync(0, TimeSpan.FromSeconds(10), 4, TimeSpan.FromSeconds(30));
 
-        action.Should().Throw<ArgumentOutOfRangeException>()
-            .And.ParamName.Should()
-            .Be("failureThreshold");
+        Should.Throw<ArgumentOutOfRangeException>(action)
+            .ParamName.ShouldBe("failureThreshold");
     }
 
     [Fact]
@@ -37,9 +35,8 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreakerAsync(-0.5, TimeSpan.FromSeconds(10), 4, TimeSpan.FromSeconds(30));
 
-        action.Should().Throw<ArgumentOutOfRangeException>()
-            .And.ParamName.Should()
-            .Be("failureThreshold");
+        Should.Throw<ArgumentOutOfRangeException>(action)
+            .ParamName.ShouldBe("failureThreshold");
     }
 
     [Fact]
@@ -49,7 +46,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreakerAsync(1.0, TimeSpan.FromSeconds(10), 4, TimeSpan.FromSeconds(30));
 
-        action.Should().NotThrow();
+        Should.NotThrow(action);
     }
 
     [Fact]
@@ -59,9 +56,8 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreakerAsync(1.01, TimeSpan.FromSeconds(10), 4, TimeSpan.FromSeconds(30));
 
-        action.Should().Throw<ArgumentOutOfRangeException>()
-            .And.ParamName.Should()
-            .Be("failureThreshold");
+        Should.Throw<ArgumentOutOfRangeException>(action)
+            .ParamName.ShouldBe("failureThreshold");
     }
 
     [Fact]
@@ -75,9 +71,8 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 4,
                 TimeSpan.FromSeconds(30));
 
-        action.Should().Throw<ArgumentOutOfRangeException>()
-            .And.ParamName.Should()
-            .Be("samplingDuration");
+        Should.Throw<ArgumentOutOfRangeException>(action)
+            .ParamName.ShouldBe("samplingDuration");
     }
 
     [Fact]
@@ -87,7 +82,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreakerAsync(0.5, TimeSpan.FromMilliseconds(20), 4, TimeSpan.FromSeconds(30));
 
-        action.Should().NotThrow<ArgumentOutOfRangeException>();
+        Should.NotThrow(action);
     }
 
     [Fact]
@@ -97,9 +92,8 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreakerAsync(0.5, TimeSpan.FromSeconds(10), 1, TimeSpan.FromSeconds(30));
 
-        action.Should().Throw<ArgumentOutOfRangeException>()
-            .And.ParamName.Should()
-            .Be("minimumThroughput");
+        Should.Throw<ArgumentOutOfRangeException>(action)
+            .ParamName.ShouldBe("minimumThroughput");
     }
 
     [Fact]
@@ -109,9 +103,8 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreakerAsync(0.5, TimeSpan.FromSeconds(10), 0, TimeSpan.FromSeconds(30));
 
-        action.Should().Throw<ArgumentOutOfRangeException>()
-            .And.ParamName.Should()
-            .Be("minimumThroughput");
+        Should.Throw<ArgumentOutOfRangeException>(action)
+            .ParamName.ShouldBe("minimumThroughput");
     }
 
     [Fact]
@@ -121,9 +114,8 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreakerAsync(0.5, TimeSpan.FromSeconds(10), 4, -TimeSpan.FromSeconds(1));
 
-        action.Should().Throw<ArgumentOutOfRangeException>()
-            .And.ParamName.Should()
-            .Be("durationOfBreak");
+        Should.Throw<ArgumentOutOfRangeException>(action)
+            .ParamName.ShouldBe("durationOfBreak");
     }
 
     [Fact]
@@ -133,7 +125,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreakerAsync(0.5, TimeSpan.FromSeconds(10), 4, TimeSpan.Zero);
 
-        action.Should().NotThrow();
+        Should.NotThrow(action);
     }
 
     [Fact]
@@ -143,7 +135,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreakerAsync(0.5, TimeSpan.FromSeconds(10), 4, TimeSpan.FromSeconds(30));
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     #endregion
@@ -161,7 +153,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
     [Fact]
     public async Task Should_not_open_circuit_if_failure_threshold_and_minimum_threshold_is_equalled_but_last_call_is_success()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var breaker = Policy
@@ -173,24 +165,20 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Three of three actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Failure threshold exceeded, but throughput threshold not yet.
 
         // Throughput threshold will be exceeded by the below successful call, but we never break on a successful call; hence don't break on this.
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
     }
@@ -198,7 +186,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
     [Fact]
     public async Task Should_not_open_circuit_if_exceptions_raised_are_not_one_of_the_specified_exceptions()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var breaker = Policy
@@ -211,21 +199,11 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Four of four actions in this test throw unhandled failures.
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<ArgumentNullException>())
-            .Should().ThrowAsync<ArgumentNullException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<ArgumentNullException>())
-            .Should().ThrowAsync<ArgumentNullException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<ArgumentNullException>())
-            .Should().ThrowAsync<ArgumentNullException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<ArgumentNullException>())
-            .Should().ThrowAsync<ArgumentNullException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        for (int i = 0; i < 4; i++)
+        {
+            await Should.ThrowAsync<ArgumentNullException>(() => breaker.RaiseExceptionAsync<ArgumentNullException>());
+            breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        }
     }
 
     #endregion
@@ -241,7 +219,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
     [Fact]
     public async Task Should_open_circuit_blocking_executions_and_noting_the_last_raised_exception_if_failure_threshold_exceeded_and_throughput_threshold_equalled_within_timeslice_in_same_window()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var breaker = Policy
@@ -253,38 +231,31 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Four of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
-
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         bool delegateExecutedWhenBroken = false;
-        var ex = await breaker.Awaiting(x => x.ExecuteAsync(() => { delegateExecutedWhenBroken = true; return TaskHelper.EmptyTask; }))
-            .Should().ThrowAsync<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.");
-        ex.WithInnerException<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        delegateExecutedWhenBroken.Should().BeFalse();
-
+        var ex = await Should.ThrowAsync<BrokenCircuitException>(() => breaker.ExecuteAsync(() => { delegateExecutedWhenBroken = true; return TaskHelper.EmptyTask; }));
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        delegateExecutedWhenBroken.ShouldBeFalse();
     }
 
     [Fact]
     public async Task Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_exceeded_and_throughput_threshold_equalled_within_timeslice_in_different_windows()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var samplingDuration = TimeSpan.FromSeconds(10);
@@ -298,39 +269,33 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Four of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Placing the rest of the invocations ('samplingDuration' / 2) + 1 seconds later
         // ensures that even if there are only two windows, then the invocations are placed in the second.
         // They are still placed within same timeslice.
         SystemClock.UtcNow = () => time.AddSeconds((samplingDuration.Seconds / 2d) + 1);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        var ex = await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.");
-        ex.WithInnerException<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
+        var ex = await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
     public async Task Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_exceeded_though_not_all_are_failures_and_throughput_threshold_equalled_within_timeslice_in_same_window()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var breaker = Policy
@@ -342,36 +307,29 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Three of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
-
-        var ex = await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.");
-        ex.WithInnerException<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
+        var ex = await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
     public async Task Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_exceeded_though_not_all_are_failures_and_throughput_threshold_equalled_within_timeslice_in_different_windows()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var samplingDuration = TimeSpan.FromSeconds(10);
@@ -385,39 +343,33 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Three of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // Placing the rest of the invocations ('samplingDuration' / 2) + 1 seconds later
         // ensures that even if there are only two windows, then the invocations are placed in the second.
         // They are still placed within same timeslice
         SystemClock.UtcNow = () => time.AddSeconds((samplingDuration.Seconds / 2d) + 1);
 
-        var ex = await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.");
-        ex.WithInnerException<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
+        var ex = await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
     public async Task Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_equalled_and_throughput_threshold_equalled_within_timeslice_in_same_window()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var breaker = Policy
@@ -429,36 +381,29 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Two of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
-
-        var ex = await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.");
-        ex.WithInnerException<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
+        var ex = await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
     public async Task Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_equalled_and_throughput_threshold_equalled_within_timeslice_in_different_windows()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var samplingDuration = TimeSpan.FromSeconds(10);
@@ -472,39 +417,33 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Two of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // Placing the rest of the invocations ('samplingDuration' / 2) + 1 seconds later
         // ensures that even if there are only two windows, then the invocations are placed in the second.
         // They are still placed within same timeslice
         SystemClock.UtcNow = () => time.AddSeconds((samplingDuration.Seconds / 2d) + 1);
 
-        var ex = await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.");
-        ex.WithInnerException<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
+        var ex = await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
     public async Task Should_not_open_circuit_if_failure_threshold_exceeded_but_throughput_threshold_not_met_before_timeslice_expires()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var samplingDuration = TimeSpan.FromSeconds(10);
@@ -518,31 +457,26 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Four of four actions in this test throw handled failures; but only the first three within the timeslice.
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Adjust SystemClock so that timeslice (clearly) expires; fourth exception thrown in next-recorded timeslice.
         SystemClock.UtcNow = () => time.Add(samplingDuration).Add(samplingDuration);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
     public async Task Should_not_open_circuit_if_failure_threshold_exceeded_but_throughput_threshold_not_met_before_timeslice_expires_even_if_timeslice_expires_only_exactly()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var samplingDuration = TimeSpan.FromSeconds(10);
@@ -556,31 +490,26 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Four of four actions in this test throw handled failures; but only the first three within the timeslice.
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Adjust SystemClock so that timeslice (just) expires; fourth exception thrown in following timeslice.
         SystemClock.UtcNow = () => time.Add(samplingDuration);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
     public async Task Should_not_open_circuit_if_failure_threshold_exceeded_but_throughput_threshold_not_met_before_timeslice_expires_even_if_error_occurring_just_at_the_end_of_the_duration()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var samplingDuration = TimeSpan.FromSeconds(10);
@@ -596,34 +525,29 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         // Four of four actions in this test throw handled failures; but only the first three within the original timeslice.
 
         // Two actions at the start of the original timeslice.
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Creates a new window right at the end of the original timeslice.
         SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Adjust SystemClock so that timeslice (just) expires; fourth exception thrown in following timeslice.  If timeslice/window rollover is precisely defined, this should cause first two actions to be forgotten from statistics (rolled out of the window of relevance), and thus the circuit not to break.
         SystemClock.UtcNow = () => time.Add(samplingDuration);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
     public async Task Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_equalled_and_throughput_threshold_equalled_even_if_only_just_within_timeslice()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var samplingDuration = TimeSpan.FromSeconds(10);
@@ -637,37 +561,31 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Four of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Adjust SystemClock so that timeslice doesn't quite expire; fourth exception thrown in same timeslice.
         SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        var ex = await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.");
-        ex.WithInnerException<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
+        var ex = await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
     public async Task Should_not_open_circuit_if_failure_threshold_not_met_and_throughput_threshold_not_met()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var breaker = Policy
@@ -679,25 +597,20 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // One of three actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-
-        // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
     public async Task Should_not_open_circuit_if_failure_threshold_not_met_but_throughput_threshold_met_before_timeslice_expires()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var breaker = Policy
@@ -709,29 +622,23 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // One of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-
-        // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
     public async Task Should_open_circuit_if_failures_at_end_of_last_timeslice_below_failure_threshold_and_failures_in_beginning_of_new_timeslice_where_total_equals_failure_threshold()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var samplingDuration = TimeSpan.FromSeconds(10);
@@ -746,26 +653,22 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
 
         // Executing a single invocation to ensure timeslice is created
         // This invocation is not be counted against the threshold
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // The time is set to just at the end of the sampling duration ensuring
         // the invocations are within the timeslice, but only barely.
         SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
 
         // Three of four actions in this test occur within the first timeslice.
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Setting the time to just barely into the new timeslice
         SystemClock.UtcNow = () => time.Add(samplingDuration);
@@ -773,15 +676,14 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         // This failure opens the circuit, because it is the second failure of four calls
         // equalling the failure threshold. The minimum threshold within the defined
         // sampling duration is met, when using rolling windows.
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
     public async Task Should_not_open_circuit_if_failures_at_end_of_last_timeslice_and_failures_in_beginning_of_new_timeslice_when_below_minimum_throughput_threshold()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var samplingDuration = TimeSpan.FromSeconds(10);
@@ -796,22 +698,19 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
 
         // Executing a single invocation to ensure timeslice is created
         // This invocation is not be counted against the threshold
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // The time is set to just at the end of the sampling duration ensuring
         // the invocations are within the timeslice, but only barely.
         SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
 
         // Two of three actions in this test occur within the first timeslice.
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Setting the time to just barely into the new timeslice
         SystemClock.UtcNow = () => time.Add(samplingDuration);
@@ -819,15 +718,14 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         // A third failure occurs just at the beginning of the new timeslice making
         // the number of failures above the failure threshold. However, the throughput is
         // below the minimum threshold as to open the circuit.
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
     public async Task Should_open_circuit_if_failures_in_second_window_of_last_timeslice_and_failures_in_first_window_in_next_timeslice_exceeds_failure_threshold_and_minimum_threshold()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var samplingDuration = TimeSpan.FromSeconds(10);
@@ -843,32 +741,27 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
 
         // Executing a single invocation to ensure timeslice is created
         // This invocation is not be counted against the threshold
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Setting the time to the second window in the rolling metrics
         SystemClock.UtcNow = () => time.AddSeconds(samplingDuration.Seconds / (double)numberOfWindowsDefinedInCircuitBreaker);
 
         // Three actions occur in the second window of the first timeslice
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Setting the time to just barely into the new timeslice
         SystemClock.UtcNow = () => time.Add(samplingDuration);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     #endregion
@@ -884,7 +777,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
     [Fact]
     public async Task Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_exceeded_and_throughput_threshold_equalled_within_timeslice_low_sampling_duration()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var breaker = Policy
@@ -896,36 +789,29 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Four of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
-        var ex = await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.");
-        ex.WithInnerException<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
+        var ex = await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
     public async Task Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_exceeded_though_not_all_are_failures_and_throughput_threshold_equalled_within_timeslice_low_sampling_duration()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var breaker = Policy
@@ -937,36 +823,29 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Three of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
-
-        var ex = await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.");
-        ex.WithInnerException<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
+        var ex = await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
     public async Task Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_equalled_and_throughput_threshold_equalled_within_timeslice_low_sampling_duration()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var breaker = Policy
@@ -978,36 +857,29 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Two of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
-
-        var ex = await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.");
-        ex.WithInnerException<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
+        var ex = await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
     public async Task Should_not_open_circuit_if_failure_threshold_exceeded_but_throughput_threshold_not_met_before_timeslice_expires_low_sampling_duration()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var samplingDuration = TimeSpan.FromMilliseconds(199);
@@ -1021,31 +893,26 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Four of four actions in this test throw handled failures; but only the first within the timeslice.
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Adjust SystemClock so that timeslice (clearly) expires; fourth exception thrown in next-recorded timeslice.
         SystemClock.UtcNow = () => time.Add(samplingDuration).Add(samplingDuration);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
     public async Task Should_not_open_circuit_if_failure_threshold_exceeded_but_throughput_threshold_not_met_before_timeslice_expires_even_if_timeslice_expires_only_exactly_low_sampling_duration()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var samplingDuration = TimeSpan.FromMilliseconds(199);
@@ -1059,31 +926,26 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Two of four actions in this test throw handled failures; but only the first within the timeslice.
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Adjust SystemClock so that timeslice (just) expires; fourth exception thrown in following timeslice.
         SystemClock.UtcNow = () => time.Add(samplingDuration);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
     public async Task Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_equalled_and_throughput_threshold_equalled_even_if_only_just_within_timeslice_low_sampling_duration()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var samplingDuration = TimeSpan.FromMilliseconds(199);
@@ -1097,37 +959,31 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Four of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Adjust SystemClock so that timeslice doesn't quite expire; fourth exception thrown in same timeslice.
         SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        var ex = await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.");
-        ex.WithInnerException<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
+        var ex = await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
     public async Task Should_not_open_circuit_if_failure_threshold_not_met_and_throughput_threshold_not_met_low_sampling_duration()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var breaker = Policy
@@ -1139,25 +995,20 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // One of three actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-
-        // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
     public async Task Should_not_open_circuit_if_failure_threshold_not_met_but_throughput_threshold_met_before_timeslice_expires_low_sampling_duration()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var breaker = Policy
@@ -1169,29 +1020,23 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // One of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-
-        // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
     public async Task Should_not_open_circuit_if_failures_at_end_of_last_timeslice_below_failure_threshold_and_failures_in_beginning_of_new_timeslice_where_total_equals_failure_threshold_low_sampling_duration()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var samplingDuration = TimeSpan.FromMilliseconds(199);
@@ -1206,35 +1051,30 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
 
         // Executing a single invocation to ensure timeslice is created
         // This invocation is not be counted against the threshold
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // The time is set to just at the end of the sampling duration ensuring
         // the invocations are within the timeslice, but only barely.
         SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
 
         // Three of four actions in this test occur within the first timeslice.
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Setting the time to just barely into the new timeslice
         SystemClock.UtcNow = () => time.Add(samplingDuration);
 
         // This failure does not open the circuit, because a new duration should have
         // started and with such low sampling duration, windows should not be used.
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     #endregion
@@ -1246,7 +1086,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
     [Fact]
     public async Task Should_halfopen_circuit_after_the_specified_duration_has_passed_with_failures_in_same_window()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -1260,35 +1100,29 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 durationOfBreak: durationOfBreak);
 
         // Four of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
     }
 
     [Fact]
     public async Task Should_halfopen_circuit_after_the_specified_duration_has_passed_with_failures_in_different_windows()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -1303,17 +1137,14 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 durationOfBreak: durationOfBreak);
 
         // Four of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Placing the rest of the invocations ('samplingDuration' / 2) + 1 seconds later
         // ensures that even if there are only two windows, then the invocations are placed in the second.
@@ -1321,28 +1152,25 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         var anotherWindowDuration = (samplingDuration.Seconds / 2d) + 1;
         SystemClock.UtcNow = () => time.AddSeconds(anotherWindowDuration);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // Since the call that opened the circuit occurred in a later window, then the
         // break duration must be simulated as from that call.
         SystemClock.UtcNow = () => time.Add(durationOfBreak).AddSeconds(anotherWindowDuration);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
     }
 
     [Fact]
     public async Task Should_open_circuit_again_after_the_specified_duration_has_passed_if_the_next_call_raises_an_exception()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -1356,41 +1184,33 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 durationOfBreak: durationOfBreak);
 
         // Four of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // first call after duration raises an exception, so circuit should open again
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<BrokenCircuitException>();
-
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
     }
 
     [Fact]
     public async Task Should_reset_circuit_after_the_specified_duration_has_passed_if_the_next_call_does_not_raise_an_exception()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -1404,37 +1224,32 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 durationOfBreak: durationOfBreak);
 
         // Four of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // first call after duration is successful, so circuit should reset
         await breaker.ExecuteAsync(() => TaskHelper.EmptyTask);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
     public async Task Should_only_allow_single_execution_on_first_entering_halfopen_state__test_execution_permit_directly()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1446,31 +1261,29 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 minimumThroughput: 2,
                 durationOfBreak: durationOfBreak);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
 
         // exception raised, circuit is now open.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // break duration passes, circuit now half open
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution. (tho still in half-open condition).
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.Throw<BrokenCircuitException>(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
     }
 
     [Fact]
     public async Task Should_allow_single_execution_per_break_duration_in_halfopen_state__test_execution_permit_directly()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1482,39 +1295,37 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 minimumThroughput: 2,
                 durationOfBreak: durationOfBreak);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
 
         // exception raised, circuit is now open.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // break duration passes, circuit now half open
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution. (tho still in half-open condition).
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.Throw<BrokenCircuitException>(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // Allow another time window to pass (breaker should still be HalfOpen).
         SystemClock.UtcNow = () => time.Add(durationOfBreak).Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should now permit another trial execution.
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
     }
 
     [Fact]
     public async Task Should_only_allow_single_execution_on_first_entering_halfopen_state__integration_test()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1526,17 +1337,15 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 minimumThroughput: 2,
                 durationOfBreak: durationOfBreak);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
 
         // exceptions raised, circuit is now open.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // break duration passes, circuit now half open
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // Start one execution during the HalfOpen state, and request a second execution before the first has completed (ie still during the HalfOpen state).
         // The second execution should be rejected due to the halfopen state.
@@ -1553,7 +1362,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         // First execution in HalfOpen state: we should be able to verify state is HalfOpen as it executes.
         Task firstExecution = Task.Factory.StartNew(async () =>
         {
-            await breaker.Awaiting(x => x.ExecuteAsync(async () =>
+            await Should.NotThrowAsync(() => breaker.ExecuteAsync(async () =>
             {
                 firstDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
 
@@ -1566,7 +1375,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 await TaskHelper.EmptyTask;
                 firstExecutionActive = false;
 
-            })).Should().NotThrowAsync();
+            }));
         }, TaskCreationOptions.LongRunning);
 
         // Attempt a second execution, signalled by the first execution to ensure they overlap: we should be able to verify it doesn't execute, and is rejected by a breaker in a HalfOpen state.
@@ -1575,8 +1384,8 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         Task secondExecution = Task.Factory.StartNew(async () =>
         {
             // Validation of correct sequencing and overlapping of tasks in test (guard against erroneous test refactorings/operation).
-            firstExecutionActive.Should().BeTrue();
-            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+            firstExecutionActive.ShouldBeTrue();
+            breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
             try
             {
@@ -1600,7 +1409,11 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. This validates the test ran as expected (and background delegates are complete) before we assert on outcomes.
         permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
         permitFirstExecutionEnd.Set();
-        Task.WaitAll(new[] { firstExecution, secondExecution }, testTimeoutToExposeDeadlocks).Should().BeTrue();
+
+#pragma warning disable xUnit1031 // Do not use blocking task operations in test method
+        Task.WaitAll([firstExecution, secondExecution], testTimeoutToExposeDeadlocks).ShouldBeTrue();
+#pragma warning restore xUnit1031 // Do not use blocking task operations in test method
+
         if (firstExecution.IsFaulted)
         {
             throw firstExecution!.Exception!;
@@ -1611,22 +1424,25 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
             throw secondExecution!.Exception!;
         }
 
-        firstExecution.Status.Should().Be(TaskStatus.RanToCompletion);
-        secondExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+        firstExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
+        secondExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
 
         // Assert:
         // - First execution should have been permitted and executed under a HalfOpen state
         // - Second overlapping execution in halfopen state should not have been permitted.
         // - Second execution attempt should have been rejected with HalfOpen state as cause.
-        firstDelegateExecutedInHalfOpenState.Should().BeTrue();
-        secondDelegateExecutedInHalfOpenState.Should().BeFalse();
-        secondDelegateRejectedInHalfOpenState.Should().BeTrue();
+        firstDelegateExecutedInHalfOpenState.ShouldNotBeNull();
+        firstDelegateExecutedInHalfOpenState.Value.ShouldBeTrue();
+        secondDelegateExecutedInHalfOpenState.ShouldNotBeNull();
+        secondDelegateExecutedInHalfOpenState.Value.ShouldBeFalse();
+        secondDelegateRejectedInHalfOpenState.ShouldNotBeNull();
+        secondDelegateRejectedInHalfOpenState.Value.ShouldBeTrue();
     }
 
     [Fact]
     public async Task Should_allow_single_execution_per_break_duration_in_halfopen_state__integration_test()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1638,17 +1454,15 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 minimumThroughput: 2,
                 durationOfBreak: durationOfBreak);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
 
         // exception raised, circuit is now open.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // break duration passes, circuit now half open
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // Start one execution during the HalfOpen state.
         // Request a second execution while the first is still in flight (not completed), while still during the HalfOpen state, but after one breakDuration later.
@@ -1666,7 +1480,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         // First execution in HalfOpen state: we should be able to verify state is HalfOpen as it executes.
         Task firstExecution = Task.Factory.StartNew(async () =>
         {
-            await breaker.Awaiting(x => x.ExecuteAsync(async () =>
+            await Should.NotThrowAsync(() => breaker.ExecuteAsync(async () =>
             {
                 firstDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
 
@@ -1678,7 +1492,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
                 await TaskHelper.EmptyTask;
                 firstExecutionActive = false;
-            })).Should().NotThrowAsync();
+            }));
         }, TaskCreationOptions.LongRunning);
 
         // Attempt a second execution, signalled by the first execution to ensure they overlap; start it one breakDuration later.  We should be able to verify it does execute, though the breaker is still in a HalfOpen state.
@@ -1687,8 +1501,8 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         Task secondExecution = Task.Factory.StartNew(async () =>
         {
             // Validation of correct sequencing and overlapping of tasks in test (guard against erroneous test refactorings/operation).
-            firstExecutionActive.Should().BeTrue();
-            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+            firstExecutionActive.ShouldBeTrue();
+            breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
             try
             {
@@ -1715,7 +1529,11 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. This validates the test ran as expected (and background delegates are complete) before we assert on outcomes.
         permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
         permitFirstExecutionEnd.Set();
-        Task.WaitAll(new[] { firstExecution, secondExecution }, testTimeoutToExposeDeadlocks).Should().BeTrue();
+
+#pragma warning disable xUnit1031 // Do not use blocking task operations in test method
+        Task.WaitAll([firstExecution, secondExecution], testTimeoutToExposeDeadlocks).ShouldBeTrue();
+#pragma warning restore xUnit1031 // Do not use blocking task operations in test method
+
         if (firstExecution.IsFaulted)
         {
             throw firstExecution!.Exception!;
@@ -1726,15 +1544,18 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
             throw secondExecution!.Exception!;
         }
 
-        firstExecution.Status.Should().Be(TaskStatus.RanToCompletion);
-        secondExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+        firstExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
+        secondExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
 
         // Assert:
         // - First execution should have been permitted and executed under a HalfOpen state
         // - Second overlapping execution in halfopen state should have been permitted, one breakDuration later.
-        firstDelegateExecutedInHalfOpenState.Should().BeTrue();
-        secondDelegateExecutedInHalfOpenState.Should().BeTrue();
-        secondDelegateRejectedInHalfOpenState.Should().BeFalse();
+        firstDelegateExecutedInHalfOpenState.ShouldNotBeNull();
+        firstDelegateExecutedInHalfOpenState.Value.ShouldBeTrue();
+        secondDelegateExecutedInHalfOpenState.ShouldNotBeNull();
+        secondDelegateExecutedInHalfOpenState.Value.ShouldBeTrue();
+        secondDelegateRejectedInHalfOpenState.ShouldNotBeNull();
+        secondDelegateRejectedInHalfOpenState.Value.ShouldBeFalse();
     }
 
     #endregion
@@ -1747,72 +1568,68 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         var breaker = Policy
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreakerAsync(0.5, TimeSpan.FromSeconds(10), 4, TimeSpan.FromSeconds(30));
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // manually break circuit
         breaker.Isolate();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
 
         // circuit manually broken: execution should be blocked; even non-exception-throwing executions should not reset circuit
         bool delegateExecutedWhenBroken = false;
-        await breaker.Awaiting(x => x.ExecuteAsync(() => { delegateExecutedWhenBroken = true; return TaskHelper.EmptyTask; }))
-            .Should().ThrowAsync<IsolatedCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
-        breaker.LastException.Should().BeOfType<IsolatedCircuitException>();
-        delegateExecutedWhenBroken.Should().BeFalse();
+        await Should.ThrowAsync<IsolatedCircuitException>(() => breaker.ExecuteAsync(() => { delegateExecutedWhenBroken = true; return TaskHelper.EmptyTask; }));
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
+        breaker.LastException.ShouldBeOfType<IsolatedCircuitException>();
+        delegateExecutedWhenBroken.ShouldBeFalse();
     }
 
     [Fact]
     public async Task Should_hold_circuit_open_despite_elapsed_time_if_manual_override_open()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
         var breaker = Policy
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreakerAsync(0.5, TimeSpan.FromSeconds(10), 4, durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.Isolate();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
 
         bool delegateExecutedWhenBroken = false;
-        await breaker.Awaiting(x => x.ExecuteAsync(() => { delegateExecutedWhenBroken = true; return TaskHelper.EmptyTask; }))
-            .Should().ThrowAsync<IsolatedCircuitException>();
-        delegateExecutedWhenBroken.Should().BeFalse();
+        await Should.ThrowAsync<IsolatedCircuitException>(() => breaker.ExecuteAsync(() => { delegateExecutedWhenBroken = true; return TaskHelper.EmptyTask; }));
+        delegateExecutedWhenBroken.ShouldBeFalse();
     }
 
     [Fact]
     public async Task Should_close_circuit_again_on_reset_after_manual_override()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
         var breaker = Policy
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreakerAsync(0.5, TimeSpan.FromSeconds(10), 4, durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.Isolate();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().ThrowAsync<IsolatedCircuitException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
+        await Should.ThrowAsync<IsolatedCircuitException>(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
 
         breaker.Reset();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
     }
 
     [Fact]
     public async Task Should_be_able_to_reset_automatically_opened_circuit_without_specified_duration_passing()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -1826,28 +1643,23 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 durationOfBreak: durationOfBreak);
 
         // Four of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // reset circuit, with no time having passed
         breaker.Reset();
-        SystemClock.UtcNow().Should().Be(time);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
+        SystemClock.UtcNow().ShouldBe(time);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
     }
 
     #endregion
@@ -1866,7 +1678,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreakerAsync(0.5, TimeSpan.FromSeconds(10), 4, durationOfBreak, onBreak, onReset);
 
-        onResetCalled.Should().BeFalse();
+        onResetCalled.ShouldBeFalse();
     }
 
     [Fact]
@@ -1876,7 +1688,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled = true; };
         Action onReset = () => { };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var breaker = Policy
@@ -1890,32 +1702,27 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 onReset: onReset);
 
         // Four of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
-        onBreakCalled.Should().BeTrue();
+        onBreakCalled.ShouldBeTrue();
     }
 
     [Fact]
     public void Should_call_onbreak_when_breaking_circuit_manually()
     {
         bool onBreakCalled = false;
-        Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled = true; };
+        Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled = true;
         Action onReset = () => { };
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -1923,21 +1730,21 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreakerAsync(0.5, TimeSpan.FromSeconds(10), 4, durationOfBreak, onBreak, onReset);
 
-        onBreakCalled.Should().BeFalse();
+        onBreakCalled.ShouldBeFalse();
 
         breaker.Isolate();
 
-        onBreakCalled.Should().BeTrue();
+        onBreakCalled.ShouldBeTrue();
     }
 
     [Fact]
     public async Task Should_call_onbreak_when_breaking_circuit_first_time_but_not_for_subsequent_calls_placed_through_open_circuit()
     {
         int onBreakCalled = 0;
-        Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
+        Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled++;
         Action onReset = () => { };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var breaker = Policy
@@ -1951,35 +1758,27 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 onReset: onReset);
 
         // Four of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().Be(0);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBe(0);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().Be(0);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBe(0);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().Be(0);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBe(0);
 
         // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
-
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
-        onBreakCalled.Should().Be(1);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
 
         // call through circuit when already broken - should not retrigger onBreak
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<BrokenCircuitException>();
-
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
     }
 
     [Fact]
@@ -2006,9 +1805,10 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         using ManualResetEvent permitMainThreadToOpenCircuit = new ManualResetEvent(false);
         Task longRunningExecution = Task.Factory.StartNew(async () =>
         {
-            breaker.CircuitState.Should().Be(CircuitState.Closed);
+            breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-            await breaker.Awaiting(x => x.ExecuteAsync(async () =>
+            // However, since execution started when circuit was closed, BrokenCircuitException will not have been thrown on entry; the original exception will still be thrown.
+            await Should.ThrowAsync<DivideByZeroException>(() => breaker.ExecuteAsync(async () =>
             {
                 await TaskHelper.EmptyTask;
 
@@ -2018,44 +1818,44 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 permitLongRunningExecutionToReturnItsFailure.WaitOne(testTimeoutToExposeDeadlocks);
 
                 // Throw a further failure when rest of test has already broken the circuit.
-                breaker.CircuitState.Should().Be(CircuitState.Open);
+                breaker.CircuitState.ShouldBe(CircuitState.Open);
                 throw new DivideByZeroException();
 
-            })).Should().ThrowAsync<DivideByZeroException>(); // However, since execution started when circuit was closed, BrokenCircuitException will not have been thrown on entry; the original exception will still be thrown.
+            }));
         }, TaskCreationOptions.LongRunning);
 
-        permitMainThreadToOpenCircuit.WaitOne(testTimeoutToExposeDeadlocks).Should().BeTrue();
+        permitMainThreadToOpenCircuit.WaitOne(testTimeoutToExposeDeadlocks).ShouldBeTrue();
 
         // Break circuit in the normal manner: onBreak() should be called once.
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().Be(0);
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBe(0);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
 
         // Permit the second (long-running) execution to hit the open circuit with its failure.
         permitLongRunningExecutionToReturnItsFailure.Set();
 
+#pragma warning disable xUnit1031 // Do not use blocking task operations in test method
         // Graceful cleanup: allow executions time to end naturally; timeout if any deadlocks; expose any execution faults.  This validates the test ran as expected (and background delegates are complete) before we assert on outcomes.
 #if NET
-        longRunningExecution.Wait(testTimeoutToExposeDeadlocks, CancellationToken.None).Should().BeTrue();
+        longRunningExecution.Wait(testTimeoutToExposeDeadlocks, CancellationToken.None).ShouldBeTrue();
 #else
-        longRunningExecution.Wait(testTimeoutToExposeDeadlocks).Should().BeTrue();
+        longRunningExecution.Wait(testTimeoutToExposeDeadlocks).ShouldBeTrue();
 #endif
+#pragma warning restore xUnit1031 // Do not use blocking task operations in test method
 
         if (longRunningExecution.IsFaulted)
         {
             throw longRunningExecution!.Exception!;
         }
 
-        longRunningExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+        longRunningExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
 
         // onBreak() should still only have been called once.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
     }
 
     [Fact]
@@ -2066,7 +1866,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
         Action onReset = () => { onResetCalled++; };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -2082,38 +1882,33 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 onReset: onReset);
 
         // Four of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
-        onBreakCalled.Should().Be(1);
+        onBreakCalled.ShouldBe(1);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // but not yet reset
-        onResetCalled.Should().Be(0);
+        onResetCalled.ShouldBe(0);
 
         // first call after duration is successful, so circuit should reset
         await breaker.ExecuteAsync(() => TaskHelper.EmptyTask);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onResetCalled.Should().Be(1);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onResetCalled.ShouldBe(1);
     }
 
     [Fact]
@@ -2128,15 +1923,15 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreakerAsync(0.5, TimeSpan.FromSeconds(10), 4, durationOfBreak, onBreak, onReset);
 
-        onResetCalled.Should().BeFalse();
+        onResetCalled.ShouldBeFalse();
 
         await breaker.ExecuteAsync(() => TaskHelper.EmptyTask);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onResetCalled.Should().BeFalse();
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onResetCalled.ShouldBeFalse();
 
         await breaker.ExecuteAsync(() => TaskHelper.EmptyTask);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onResetCalled.Should().BeFalse();
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onResetCalled.ShouldBeFalse();
     }
 
     [Fact]
@@ -2145,11 +1940,11 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         int onBreakCalled = 0;
         int onResetCalled = 0;
         int onHalfOpenCalled = 0;
-        Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
-        Action onReset = () => { onResetCalled++; };
-        Action onHalfOpen = () => { onHalfOpenCalled++; };
+        Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled++;
+        Action onReset = () => onResetCalled++;
+        Action onHalfOpen = () => onHalfOpenCalled++;
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -2166,39 +1961,33 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 onHalfOpen: onHalfOpen);
 
         // Four of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().Be(0);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBe(0);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().Be(0);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBe(0);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().Be(0);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBe(0);
 
         // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
-
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
-        onBreakCalled.Should().Be(1);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        onHalfOpenCalled.Should().Be(0); // not yet transitioned to half-open, because we have not queried state
+        onHalfOpenCalled.ShouldBe(0); // not yet transitioned to half-open, because we have not queried state
 
         // first call after duration is successful, so circuit should reset
         await breaker.ExecuteAsync(() => TaskHelper.EmptyTask);
-        onHalfOpenCalled.Should().Be(1); // called as action was placed for execution
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onResetCalled.Should().Be(1); // called after action succeeded
+        onHalfOpenCalled.ShouldBe(1); // called as action was placed for execution
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onResetCalled.ShouldBe(1); // called after action succeeded
     }
 
     [Fact]
@@ -2207,11 +1996,11 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         int onBreakCalled = 0;
         int onResetCalled = 0;
         int onHalfOpenCalled = 0;
-        Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
-        Action onReset = () => { onResetCalled++; };
-        Action onHalfOpen = () => { onHalfOpenCalled++; };
+        Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled++;
+        Action onReset = () => onResetCalled++;
+        Action onHalfOpen = () => onHalfOpenCalled++;
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -2228,35 +2017,30 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 onHalfOpen: onHalfOpen);
 
         // Four of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().Be(0);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBe(0);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().Be(0);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBe(0);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().Be(0);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBe(0);
 
         // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
-        onBreakCalled.Should().Be(1);
+        onBreakCalled.ShouldBe(1);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
-        onHalfOpenCalled.Should().Be(1);
-        onResetCalled.Should().Be(0);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
+        onHalfOpenCalled.ShouldBe(1);
+        onResetCalled.ShouldBe(0);
     }
 
     [Fact]
@@ -2264,10 +2048,10 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
     {
         int onBreakCalled = 0;
         int onResetCalled = 0;
-        Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
+        Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled++;
         Action onReset = () => { onResetCalled++; };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -2275,21 +2059,19 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreakerAsync(0.5, TimeSpan.FromSeconds(10), 4, durationOfBreak, onBreak, onReset);
 
-        onBreakCalled.Should().Be(0);
+        onBreakCalled.ShouldBe(0);
         breaker.Isolate();
-        onBreakCalled.Should().Be(1);
+        onBreakCalled.ShouldBe(1);
 
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().ThrowAsync<IsolatedCircuitException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
+        await Should.ThrowAsync<IsolatedCircuitException>(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
 
-        onResetCalled.Should().Be(0);
+        onResetCalled.ShouldBe(0);
         breaker.Reset();
-        onResetCalled.Should().Be(1);
+        onResetCalled.ShouldBe(1);
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().NotThrowAsync();
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
     }
 
     #region Tests of supplied parameters to onBreak delegate
@@ -2313,25 +2095,20 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 onReset: onReset);
 
         // Four of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
-        passedException?.Should().BeOfType<DivideByZeroException>();
+        passedException?.ShouldBeOfType<DivideByZeroException>();
     }
 
     [Fact]
@@ -2339,7 +2116,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
     {
         CircuitState? transitionedState = null;
 
-        Action<Exception, CircuitState, TimeSpan, Context> onBreak = (_, state, _, _) => { transitionedState = state; };
+        Action<Exception, CircuitState, TimeSpan, Context> onBreak = (_, state, _, _) => transitionedState = state;
         Action<Context> onReset = _ => { };
         Action onHalfOpen = () => { };
 
@@ -2354,25 +2131,20 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 onReset: onReset,
                 onHalfOpen: onHalfOpen);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
-        transitionedState?.Should().Be(CircuitState.Closed);
+        transitionedState?.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
@@ -2384,7 +2156,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         Action<Context> onReset = _ => { };
         Action onHalfOpen = () => { };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -2401,37 +2173,31 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 onHalfOpen: onHalfOpen);
 
         // Four of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // first call after duration raises an exception, so circuit should open again
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<BrokenCircuitException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        transitionedStates[0].Should().Be(CircuitState.Closed);
-        transitionedStates[1].Should().Be(CircuitState.HalfOpen);
+        await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+
+        transitionedStates[0].ShouldBe(CircuitState.Closed);
+        transitionedStates[1].ShouldBe(CircuitState.HalfOpen);
     }
 
     [Fact]
@@ -2439,7 +2205,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
     {
         TimeSpan? passedBreakTimespan = null;
 
-        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => { passedBreakTimespan = timespan; };
+        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => passedBreakTimespan = timespan;
         Action<Context> onReset = _ => { };
 
         TimeSpan durationOfBreak = TimeSpan.FromMinutes(1);
@@ -2455,35 +2221,30 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 onReset: onReset);
 
         // Four of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
-        passedBreakTimespan.Should().Be(durationOfBreak);
+        passedBreakTimespan.ShouldBe(durationOfBreak);
     }
 
     [Fact]
     public void Should_open_circuit_with_timespan_maxvalue_if_manual_override_open()
     {
         TimeSpan? passedBreakTimespan = null;
-        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => { passedBreakTimespan = timespan; };
+        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => passedBreakTimespan = timespan;
         Action<Context> onReset = _ => { };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var breaker = Policy
@@ -2495,22 +2256,22 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromMinutes(1),
                 onBreak: onBreak,
                 onReset: onReset);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // manually break circuit
         breaker.Isolate();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
 
-        passedBreakTimespan.Should().Be(TimeSpan.MaxValue);
+        passedBreakTimespan.ShouldBe(TimeSpan.MaxValue);
     }
 
     [Fact]
     public void Should_throw_when_failureThreshold_is_less_or_equals_than_zero()
     {
-        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => { _ = timespan; };
+        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => _ = timespan;
         Action<Context> onReset = _ => { };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         Action action = () => Policy
@@ -2523,7 +2284,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 onBreak: onBreak,
                 onReset: onReset);
 
-        action.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("failureThreshold");
+        Should.Throw<ArgumentOutOfRangeException>(action).ParamName.ShouldBe("failureThreshold");
     }
 
     [Fact]
@@ -2532,7 +2293,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => { _ = timespan; };
         Action<Context> onReset = _ => { };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         Action action = () => Policy
@@ -2545,7 +2306,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 onBreak: onBreak,
                 onReset: onReset);
 
-        action.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("failureThreshold");
+        Should.Throw<ArgumentOutOfRangeException>(action).ParamName.ShouldBe("failureThreshold");
     }
 
     [Fact]
@@ -2554,7 +2315,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => { _ = timespan; };
         Action<Context> onReset = _ => { };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         Action action = () => Policy
@@ -2567,7 +2328,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 onBreak: onBreak,
                 onReset: onReset);
 
-        action.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("samplingDuration");
+        Should.Throw<ArgumentOutOfRangeException>(action).ParamName.ShouldBe("samplingDuration");
     }
 
     [Fact]
@@ -2576,7 +2337,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => { _ = timespan; };
         Action<Context> onReset = _ => { };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         Action action = () => Policy
@@ -2589,7 +2350,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 onBreak: onBreak,
                 onReset: onReset);
 
-        action.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("minimumThroughput");
+        Should.Throw<ArgumentOutOfRangeException>(action).ParamName.ShouldBe("minimumThroughput");
     }
 
     [Fact]
@@ -2598,7 +2359,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => { _ = timespan; };
         Action<Context> onReset = _ => { };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         Action action = () => Policy
@@ -2611,7 +2372,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 onBreak: onBreak,
                 onReset: onReset);
 
-        action.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("durationOfBreak");
+        Should.Throw<ArgumentOutOfRangeException>(action).ParamName.ShouldBe("durationOfBreak");
     }
 
     [Fact]
@@ -2619,7 +2380,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
     {
         Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => { _ = timespan; };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         Action action = () => Policy
@@ -2632,7 +2393,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 onBreak: onBreak,
                 onReset: null);
 
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("onReset");
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe("onReset");
     }
 
     [Fact]
@@ -2641,7 +2402,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => { _ = timespan; };
         Action<Context> onReset = _ => { };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         Action action = () => Policy
@@ -2655,7 +2416,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 onReset: onReset,
                 onHalfOpen: null);
 
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("onHalfOpen");
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe("onHalfOpen");
     }
 
     #endregion
@@ -2670,7 +2431,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         Action<Exception, TimeSpan, Context> onBreak = (_, _, context) => { contextData = context; };
         Action<Context> onReset = _ => { };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var breaker = Policy
@@ -2684,25 +2445,24 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 onReset: onReset);
 
         // Four of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>(
-            CreateDictionary("key1", "value1", "key2", "value2"))).Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(
+            () =>
+                breaker.RaiseExceptionAsync<DivideByZeroException>(
+                    CreateDictionary("key1", "value1", "key2", "value2")));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -2713,7 +2473,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         Action<Exception, TimeSpan, Context> onBreak = (_, _, _) => { };
         Action<Context> onReset = context => { contextData = context; };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -2729,33 +2489,28 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 onReset: onReset);
 
         // Four of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // first call after duration should invoke onReset, with context
         await breaker.ExecuteAsync(_ => TaskHelper.EmptyTask, CreateDictionary("key1", "value1", "key2", "value2"));
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -2766,7 +2521,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         Action<Exception, TimeSpan, Context> onBreak = (_, _, context) => { contextData = context; };
         Action<Context> onReset = _ => { };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var breaker = Policy
@@ -2780,24 +2535,19 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 onReset: onReset);
 
         // Four of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
-        contextData.Should().BeEmpty();
+        contextData.ShouldBeEmpty();
     }
 
     [Fact]
@@ -2810,7 +2560,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         Action<Context> onReset =
             context => { contextValue = context.ContainsKey("key") ? context["key"].ToString() : null; };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -2826,35 +2576,31 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 onReset: onReset);
 
         // Four of four actions in this test throw handled failures.
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>(CreateDictionary("key", "original_value")))
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        contextValue.Should().Be("original_value");
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>(CreateDictionary("key", "original_value")));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        contextValue.ShouldBe("original_value");
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // but not yet reset
 
         // first call after duration is successful, so circuit should reset
         await breaker.ExecuteAsync(_ => TaskHelper.EmptyTask, CreateDictionary("key", "new_value"));
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        contextValue.Should().Be("new_value");
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        contextValue.ShouldBe("new_value");
     }
 
     #endregion
@@ -2874,7 +2620,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 minimumThroughput: 2,
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
-        breaker.LastException.Should().BeNull();
+        breaker.LastException.ShouldBeNull();
     }
 
     [Fact]
@@ -2888,11 +2634,10 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 minimumThroughput: 2,
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.LastException.Should().BeOfType<DivideByZeroException>();
+        breaker.LastException.ShouldBeOfType<DivideByZeroException>();
     }
 
     [Fact]
@@ -2906,15 +2651,13 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 minimumThroughput: 2,
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.LastException.Should().BeOfType<DivideByZeroException>();
+        breaker.LastException.ShouldBeOfType<DivideByZeroException>();
     }
 
     [Fact]
@@ -2928,19 +2671,17 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
                 minimumThroughput: 2,
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.LastException.Should().BeOfType<DivideByZeroException>();
+        breaker.LastException.ShouldBeOfType<DivideByZeroException>();
 
         breaker.Reset();
 
-        breaker.LastException.Should().BeNull();
+        breaker.LastException.ShouldBeNull();
     }
 
     #endregion
@@ -2966,11 +2707,10 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
 
         using (var cancellationTokenSource = new CancellationTokenSource())
         {
-            await breaker.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().NotThrowAsync();
+            await Should.NotThrowAsync(() => breaker.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -2995,12 +2735,11 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             cancellationTokenSource.Cancel();
 
-            var ex = await breaker.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => breaker.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(0);
+        attemptsInvoked.ShouldBe(0);
     }
 
     [Fact]
@@ -3025,12 +2764,11 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await breaker.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => breaker.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -3055,12 +2793,11 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await breaker.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => breaker.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -3083,11 +2820,10 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
 
         using (var cancellationTokenSource = new CancellationTokenSource())
         {
-            await breaker.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().ThrowAsync<DivideByZeroException>();
+            await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -3098,16 +2834,12 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreakerAsync(0.5, TimeSpan.FromSeconds(10), 2, durationOfBreak);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
-
-        var ex = await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.");
-        ex.WithInnerException<DivideByZeroException>();
+        var ex = await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<DivideByZeroException>();
 
         // Circuit is now broken.
 
@@ -3126,19 +2858,18 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             cancellationTokenSource.Cancel();
 
-            var ex2 = await breaker.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().ThrowAsync<OperationCanceledException>();
-            ex2.And.CancellationToken.Should().Be(cancellationToken);
+            var ex2 = await Should.ThrowAsync<OperationCanceledException>(() => breaker.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex2.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(0);
+        attemptsInvoked.ShouldBe(0);
     }
 
     [Fact]
     public async Task Should_honour_different_cancellationToken_captured_implicitly_by_action()
     {
-        // Before CancellationToken support was built in to Polly, users of the library may have implicitly captured a CancellationToken and used it to cancel actions.  For backwards compatibility, Polly should not confuse these with its own CancellationToken; it should distinguish TaskCanceledExceptions thrown with different CancellationTokens.
-
+        // Before CancellationToken support was built in to Polly, users of the library may have implicitly captured a CancellationToken and used it to cancel actions.
+        // For backwards compatibility, Polly should not confuse these with its own CancellationToken; it should distinguish TaskCanceledExceptions thrown with different CancellationTokens.
         var durationOfBreak = TimeSpan.FromMinutes(1);
         var breaker = Policy
             .Handle<DivideByZeroException>()
@@ -3154,18 +2885,17 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
 
             implicitlyCapturedActionCancellationTokenSource.Cancel();
 
-            var ex = await breaker.Awaiting(x => x.ExecuteAsync(async _ =>
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => breaker.ExecuteAsync(async _ =>
             {
                 attemptsInvoked++;
                 await TaskHelper.EmptyTask;
                 implicitlyCapturedActionCancellationToken.ThrowIfCancellationRequested();
-            }, policyCancellationToken))
-                .Should().ThrowAsync<OperationCanceledException>();
+            }, policyCancellationToken));
 
-            ex.And.CancellationToken.Should().Be(implicitlyCapturedActionCancellationToken);
+            ex.CancellationToken.ShouldBe(implicitlyCapturedActionCancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -3191,14 +2921,13 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            Func<AsyncCircuitBreakerPolicy, Task> action = async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true);
-            await breaker.Awaiting(action)
-                .Should().NotThrowAsync();
+            await Should.NotThrowAsync(async () => result = await breaker.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true));
         }
 
-        result.Should().BeTrue();
+        result.ShouldNotBeNull();
+        result.Value.ShouldBeTrue();
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -3225,15 +2954,13 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            Func<AsyncCircuitBreakerPolicy, Task> action = async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true);
-            var ex = await breaker.Awaiting(action)
-                .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(async () => result = await breaker.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        result.Should().Be(null);
+        result.ShouldBeNull();
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     #endregion

--- a/test/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerSpecs.cs
+++ b/test/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerSpecs.cs
@@ -14,8 +14,7 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreaker(0.5, TimeSpan.FromSeconds(10), 4, TimeSpan.MaxValue);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
     }
 
     [Fact]
@@ -25,9 +24,8 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreaker(0, TimeSpan.FromSeconds(10), 4, TimeSpan.FromSeconds(30));
 
-        action.Should().Throw<ArgumentOutOfRangeException>()
-            .And.ParamName.Should()
-            .Be("failureThreshold");
+        Should.Throw<ArgumentOutOfRangeException>(action)
+            .ParamName.ShouldBe("failureThreshold");
     }
 
     [Fact]
@@ -37,9 +35,8 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreaker(-0.5, TimeSpan.FromSeconds(10), 4, TimeSpan.FromSeconds(30));
 
-        action.Should().Throw<ArgumentOutOfRangeException>()
-            .And.ParamName.Should()
-            .Be("failureThreshold");
+        Should.Throw<ArgumentOutOfRangeException>(action)
+            .ParamName.ShouldBe("failureThreshold");
     }
 
     [Fact]
@@ -49,7 +46,7 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreaker(1.0, TimeSpan.FromSeconds(10), 4, TimeSpan.FromSeconds(30));
 
-        action.Should().NotThrow();
+        Should.NotThrow(action);
     }
 
     [Fact]
@@ -59,9 +56,8 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreaker(1.01, TimeSpan.FromSeconds(10), 4, TimeSpan.FromSeconds(30));
 
-        action.Should().Throw<ArgumentOutOfRangeException>()
-            .And.ParamName.Should()
-            .Be("failureThreshold");
+        Should.Throw<ArgumentOutOfRangeException>(action)
+            .ParamName.ShouldBe("failureThreshold");
     }
 
     [Fact]
@@ -75,9 +71,8 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 4,
                 TimeSpan.FromSeconds(30));
 
-        action.Should().Throw<ArgumentOutOfRangeException>()
-            .And.ParamName.Should()
-            .Be("samplingDuration");
+        Should.Throw<ArgumentOutOfRangeException>(action)
+            .ParamName.ShouldBe("samplingDuration");
     }
 
     [Fact]
@@ -87,7 +82,7 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreaker(0.5, TimeSpan.FromMilliseconds(20), 4, TimeSpan.FromSeconds(30));
 
-        action.Should().NotThrow<ArgumentOutOfRangeException>();
+        Should.NotThrow(action);
     }
 
     [Fact]
@@ -97,9 +92,8 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreaker(0.5, TimeSpan.FromSeconds(10), 1, TimeSpan.FromSeconds(30));
 
-        action.Should().Throw<ArgumentOutOfRangeException>()
-            .And.ParamName.Should()
-            .Be("minimumThroughput");
+        Should.Throw<ArgumentOutOfRangeException>(action)
+            .ParamName.ShouldBe("minimumThroughput");
     }
 
     [Fact]
@@ -109,9 +103,8 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreaker(0.5, TimeSpan.FromSeconds(10), 0, TimeSpan.FromSeconds(30));
 
-        action.Should().Throw<ArgumentOutOfRangeException>()
-            .And.ParamName.Should()
-            .Be("minimumThroughput");
+        Should.Throw<ArgumentOutOfRangeException>(action)
+            .ParamName.ShouldBe("minimumThroughput");
     }
 
     [Fact]
@@ -121,9 +114,8 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreaker(0.5, TimeSpan.FromSeconds(10), 4, -TimeSpan.FromSeconds(1));
 
-        action.Should().Throw<ArgumentOutOfRangeException>()
-            .And.ParamName.Should()
-            .Be("durationOfBreak");
+        Should.Throw<ArgumentOutOfRangeException>(action)
+            .ParamName.ShouldBe("durationOfBreak");
     }
 
     [Fact]
@@ -133,7 +125,7 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreaker(0.5, TimeSpan.FromSeconds(10), 4, TimeSpan.Zero);
 
-        action.Should().NotThrow();
+        Should.NotThrow(action);
     }
 
     [Fact]
@@ -143,7 +135,7 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreaker(0.5, TimeSpan.FromSeconds(10), 4, TimeSpan.FromSeconds(30));
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     #endregion
@@ -161,7 +153,7 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
     [Fact]
     public void Should_not_open_circuit_if_failure_threshold_and_minimum_threshold_is_equalled_but_last_call_is_success()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         CircuitBreakerPolicy breaker = Policy
@@ -173,32 +165,26 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Three of three actions in this test throw handled failures.
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Failure threshold exceeded, but throughput threshold not yet.
 
         // Throughput threshold will be exceeded by the below successful call, but we never break on a successful call; hence don't break on this.
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-
-        // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
     public void Should_not_open_circuit_if_exceptions_raised_are_not_one_of_the_specified_exceptions()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         CircuitBreakerPolicy breaker = Policy
@@ -211,21 +197,17 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Four of four actions in this test throw unhandled failures.
-        breaker.Invoking(x => x.RaiseException<ArgumentNullException>())
-            .Should().Throw<ArgumentNullException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<ArgumentNullException>(() => breaker.RaiseException<ArgumentNullException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<ArgumentNullException>())
-            .Should().Throw<ArgumentNullException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<ArgumentNullException>(() => breaker.RaiseException<ArgumentNullException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<ArgumentNullException>())
-            .Should().Throw<ArgumentNullException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<ArgumentNullException>(() => breaker.RaiseException<ArgumentNullException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<ArgumentNullException>())
-            .Should().Throw<ArgumentNullException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<ArgumentNullException>(() => breaker.RaiseException<ArgumentNullException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     #endregion
@@ -241,7 +223,7 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
     [Fact]
     public void Should_open_circuit_blocking_executions_and_noting_the_last_raised_exception_if_failure_threshold_exceeded_and_throughput_threshold_equalled_within_timeslice_in_same_window()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         CircuitBreakerPolicy breaker = Policy
@@ -253,38 +235,31 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Four of four actions in this test throw handled failures.
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
-
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         bool delegateExecutedWhenBroken = false;
-        breaker.Invoking(x => x.Execute(() => delegateExecutedWhenBroken = true))
-            .Should().Throw<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.")
-            .WithInnerException<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        delegateExecutedWhenBroken.Should().BeFalse();
-
+        var ex = Should.Throw<BrokenCircuitException>(() => breaker.Execute(() => delegateExecutedWhenBroken = true));
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        delegateExecutedWhenBroken.ShouldBeFalse();
     }
 
     [Fact]
     public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_exceeded_and_throughput_threshold_equalled_within_timeslice_in_different_windows()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var samplingDuration = TimeSpan.FromSeconds(10);
@@ -298,39 +273,33 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Four of four actions in this test throw handled failures.
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Placing the rest of the invocations ('samplingDuration' / 2) + 1 seconds later
         // ensures that even if there are only two windows, then the invocations are placed in the second.
         // They are still placed within same timeslice.
         SystemClock.UtcNow = () => time.AddSeconds((samplingDuration.Seconds / 2d) + 1);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.")
-            .WithInnerException<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
+        var ex = Should.Throw<BrokenCircuitException>(() => breaker.RaiseException<DivideByZeroException>());
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
     public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_exceeded_though_not_all_are_failures_and_throughput_threshold_equalled_within_timeslice_in_same_window()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         CircuitBreakerPolicy breaker = Policy
@@ -342,36 +311,29 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Three of four actions in this test throw handled failures.
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
-
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.")
-            .WithInnerException<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
+        var ex = Should.Throw<BrokenCircuitException>(() => breaker.RaiseException<DivideByZeroException>());
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
     public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_exceeded_though_not_all_are_failures_and_throughput_threshold_equalled_within_timeslice_in_different_windows()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var samplingDuration = TimeSpan.FromSeconds(10);
@@ -385,39 +347,33 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Three of four actions in this test throw handled failures.
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // Placing the rest of the invocations ('samplingDuration' / 2) + 1 seconds later
         // ensures that even if there are only two windows, then the invocations are placed in the second.
         // They are still placed within same timeslice
         SystemClock.UtcNow = () => time.AddSeconds((samplingDuration.Seconds / 2d) + 1);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.")
-            .WithInnerException<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
+        var ex = Should.Throw<BrokenCircuitException>(() => breaker.RaiseException<DivideByZeroException>());
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
     public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_equalled_and_throughput_threshold_equalled_within_timeslice_in_same_window()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         CircuitBreakerPolicy breaker = Policy
@@ -429,36 +385,29 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Two of four actions in this test throw handled failures.
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
-
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.")
-            .WithInnerException<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
+        var ex = Should.Throw<BrokenCircuitException>(() => breaker.RaiseException<DivideByZeroException>());
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
     public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_equalled_and_throughput_threshold_equalled_within_timeslice_in_different_windows()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var samplingDuration = TimeSpan.FromSeconds(10);
@@ -472,39 +421,33 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Two of four actions in this test throw handled failures.
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // Placing the rest of the invocations ('samplingDuration' / 2) + 1 seconds later
         // ensures that even if there are only two windows, then the invocations are placed in the second.
         // They are still placed within same timeslice
         SystemClock.UtcNow = () => time.AddSeconds((samplingDuration.Seconds / 2d) + 1);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.")
-            .WithInnerException<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
+        var ex = Should.Throw<BrokenCircuitException>(() => breaker.RaiseException<DivideByZeroException>());
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
     public void Should_not_open_circuit_if_failure_threshold_exceeded_but_throughput_threshold_not_met_before_timeslice_expires()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var samplingDuration = TimeSpan.FromSeconds(10);
@@ -518,31 +461,26 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Four of four actions in this test throw handled failures; but only the first three within the timeslice.
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Adjust SystemClock so that timeslice (clearly) expires; fourth exception thrown in next-recorded timeslice.
         SystemClock.UtcNow = () => time.Add(samplingDuration).Add(samplingDuration);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
     public void Should_not_open_circuit_if_failure_threshold_exceeded_but_throughput_threshold_not_met_before_timeslice_expires_even_if_timeslice_expires_only_exactly()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var samplingDuration = TimeSpan.FromSeconds(10);
@@ -556,31 +494,26 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Four of four actions in this test throw handled failures; but only the first three within the timeslice.
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Adjust SystemClock so that timeslice (just) expires; fourth exception thrown in following timeslice.
         SystemClock.UtcNow = () => time.Add(samplingDuration);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
     public void Should_not_open_circuit_if_failure_threshold_exceeded_but_throughput_threshold_not_met_before_timeslice_expires_even_if_error_occurring_just_at_the_end_of_the_duration()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var samplingDuration = TimeSpan.FromSeconds(10);
@@ -596,34 +529,29 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
         // Four of four actions in this test throw handled failures; but only the first three within the original timeslice.
 
         // Two actions at the start of the original timeslice.
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Creates a new window right at the end of the original timeslice.
         SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Adjust SystemClock so that timeslice (just) expires; fourth exception thrown in following timeslice.  If timeslice/window rollover is precisely defined, this should cause first two actions to be forgotten from statistics (rolled out of the window of relevance), and thus the circuit not to break.
         SystemClock.UtcNow = () => time.Add(samplingDuration);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
     public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_equalled_and_throughput_threshold_equalled_even_if_only_just_within_timeslice()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var samplingDuration = TimeSpan.FromSeconds(10);
@@ -637,37 +565,31 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Four of four actions in this test throw handled failures.
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Adjust SystemClock so that timeslice doesn't quite expire; fourth exception thrown in same timeslice.
         SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.")
-            .WithInnerException<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
+        var ex = Should.Throw<BrokenCircuitException>(() => breaker.RaiseException<DivideByZeroException>());
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
     public void Should_not_open_circuit_if_failure_threshold_not_met_and_throughput_threshold_not_met()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         CircuitBreakerPolicy breaker = Policy
@@ -679,25 +601,20 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // One of three actions in this test throw handled failures.
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-
-        // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
     public void Should_not_open_circuit_if_failure_threshold_not_met_but_throughput_threshold_met_before_timeslice_expires()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         CircuitBreakerPolicy breaker = Policy
@@ -709,29 +626,23 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // One of four actions in this test throw handled failures.
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-
-        // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
     public void Should_open_circuit_if_failures_at_end_of_last_timeslice_below_failure_threshold_and_failures_in_beginning_of_new_timeslice_where_total_equals_failure_threshold()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var samplingDuration = TimeSpan.FromSeconds(10);
@@ -746,26 +657,22 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
 
         // Executing a single invocation to ensure timeslice is created
         // This invocation is not be counted against the threshold
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // The time is set to just at the end of the sampling duration ensuring
         // the invocations are within the timeslice, but only barely.
         SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
 
         // Three of four actions in this test occur within the first timeslice.
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Setting the time to just barely into the new timeslice
         SystemClock.UtcNow = () => time.Add(samplingDuration);
@@ -773,15 +680,14 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
         // This failure opens the circuit, because it is the second failure of four calls
         // equalling the failure threshold. The minimum threshold within the defined
         // sampling duration is met, when using rolling windows.
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
     public void Should_not_open_circuit_if_failures_at_end_of_last_timeslice_and_failures_in_beginning_of_new_timeslice_when_below_minimum_throughput_threshold()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var samplingDuration = TimeSpan.FromSeconds(10);
@@ -796,22 +702,19 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
 
         // Executing a single invocation to ensure timeslice is created
         // This invocation is not be counted against the threshold
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // The time is set to just at the end of the sampling duration ensuring
         // the invocations are within the timeslice, but only barely.
         SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
 
         // Two of three actions in this test occur within the first timeslice.
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Setting the time to just barely into the new timeslice
         SystemClock.UtcNow = () => time.Add(samplingDuration);
@@ -819,15 +722,14 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
         // A third failure occurs just at the beginning of the new timeslice making
         // the number of failures above the failure threshold. However, the throughput is
         // below the minimum threshold as to open the circuit.
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
     public void Should_open_circuit_if_failures_in_second_window_of_last_timeslice_and_failures_in_first_window_in_next_timeslice_exceeds_failure_threshold_and_minimum_threshold()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var samplingDuration = TimeSpan.FromSeconds(10);
@@ -843,32 +745,27 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
 
         // Executing a single invocation to ensure timeslice is created
         // This invocation is not be counted against the threshold
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Setting the time to the second window in the rolling metrics
         SystemClock.UtcNow = () => time.AddSeconds(samplingDuration.Seconds / (double)numberOfWindowsDefinedInCircuitBreaker);
 
         // Three actions occur in the second window of the first timeslice
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Setting the time to just barely into the new timeslice
         SystemClock.UtcNow = () => time.Add(samplingDuration);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     #endregion
@@ -884,7 +781,7 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
     [Fact]
     public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_exceeded_and_throughput_threshold_equalled_within_timeslice_low_sampling_duration()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         CircuitBreakerPolicy breaker = Policy
@@ -896,36 +793,29 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Four of four actions in this test throw handled failures.
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.")
-            .WithInnerException<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
+        var ex = Should.Throw<BrokenCircuitException>(() => breaker.RaiseException<DivideByZeroException>());
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
     public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_exceeded_though_not_all_are_failures_and_throughput_threshold_equalled_within_timeslice_low_sampling_duration()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         CircuitBreakerPolicy breaker = Policy
@@ -937,36 +827,29 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Three of four actions in this test throw handled failures.
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
-
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.")
-            .WithInnerException<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
+        var ex = Should.Throw<BrokenCircuitException>(() => breaker.RaiseException<DivideByZeroException>());
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
     public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_equalled_and_throughput_threshold_equalled_within_timeslice_low_sampling_duration()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         CircuitBreakerPolicy breaker = Policy
@@ -978,36 +861,29 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Two of four actions in this test throw handled failures.
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
-
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.")
-            .WithInnerException<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
+        var ex = Should.Throw<BrokenCircuitException>(() => breaker.RaiseException<DivideByZeroException>());
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
     public void Should_not_open_circuit_if_failure_threshold_exceeded_but_throughput_threshold_not_met_before_timeslice_expires_low_sampling_duration()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var samplingDuration = TimeSpan.FromMilliseconds(199);
@@ -1021,31 +897,26 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Four of four actions in this test throw handled failures; but only the first within the timeslice.
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Adjust SystemClock so that timeslice (clearly) expires; fourth exception thrown in next-recorded timeslice.
         SystemClock.UtcNow = () => time.Add(samplingDuration).Add(samplingDuration);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
     public void Should_not_open_circuit_if_failure_threshold_exceeded_but_throughput_threshold_not_met_before_timeslice_expires_even_if_timeslice_expires_only_exactly_low_sampling_duration()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var samplingDuration = TimeSpan.FromMilliseconds(199);
@@ -1059,31 +930,26 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Two of four actions in this test throw handled failures; but only the first within the timeslice.
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Adjust SystemClock so that timeslice (just) expires; fourth exception thrown in following timeslice.
         SystemClock.UtcNow = () => time.Add(samplingDuration);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
     public void Should_open_circuit_with_the_last_raised_exception_if_failure_threshold_equalled_and_throughput_threshold_equalled_even_if_only_just_within_timeslice_low_sampling_duration()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var samplingDuration = TimeSpan.FromMilliseconds(199);
@@ -1097,37 +963,31 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // Four of four actions in this test throw handled failures.
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Adjust SystemClock so that timeslice doesn't quite expire; fourth exception thrown in same timeslice.
         SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.")
-            .WithInnerException<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
+        var ex = Should.Throw<BrokenCircuitException>(() => breaker.RaiseException<DivideByZeroException>());
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
     public void Should_not_open_circuit_if_failure_threshold_not_met_and_throughput_threshold_not_met_low_sampling_duration()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         CircuitBreakerPolicy breaker = Policy
@@ -1139,25 +999,20 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // One of three actions in this test throw handled failures.
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-
-        // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
     public void Should_not_open_circuit_if_failure_threshold_not_met_but_throughput_threshold_met_before_timeslice_expires_low_sampling_duration()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         CircuitBreakerPolicy breaker = Policy
@@ -1169,29 +1024,23 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
         // One of four actions in this test throw handled failures.
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-
-        // No adjustment to SystemClock.UtcNow, so all exceptions were raised within same timeslice
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
     public void Should_not_open_circuit_if_failures_at_end_of_last_timeslice_below_failure_threshold_and_failures_in_beginning_of_new_timeslice_where_total_equals_failure_threshold_low_sampling_duration()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var samplingDuration = TimeSpan.FromMilliseconds(199);
@@ -1206,35 +1055,30 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
 
         // Executing a single invocation to ensure timeslice is created
         // This invocation is not be counted against the threshold
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // The time is set to just at the end of the sampling duration ensuring
         // the invocations are within the timeslice, but only barely.
         SystemClock.UtcNow = () => time.AddTicks(samplingDuration.Ticks - 1);
 
         // Three of four actions in this test occur within the first timeslice.
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Setting the time to just barely into the new timeslice
         SystemClock.UtcNow = () => time.Add(samplingDuration);
 
         // This failure does not open the circuit, because a new duration should have
         // started and with such low sampling duration, windows should not be used.
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     #endregion
@@ -1246,7 +1090,7 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
     [Fact]
     public void Should_halfopen_circuit_after_the_specified_duration_has_passed_with_failures_in_same_window()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -1260,35 +1104,29 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 durationOfBreak: durationOfBreak);
 
         // Four of four actions in this test throw handled failures.
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
     }
 
     [Fact]
     public void Should_halfopen_circuit_after_the_specified_duration_has_passed_with_failures_in_different_windows()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -1303,17 +1141,14 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 durationOfBreak: durationOfBreak);
 
         // Four of four actions in this test throw handled failures.
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // Placing the rest of the invocations ('samplingDuration' / 2) + 1 seconds later
         // ensures that even if there are only two windows, then the invocations are placed in the second.
@@ -1321,28 +1156,25 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
         var anotherWindowDuration = (samplingDuration.Seconds / 2d) + 1;
         SystemClock.UtcNow = () => time.AddSeconds(anotherWindowDuration);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // Since the call that opened the circuit occurred in a later window, then the
         // break duration must be simulated as from that call.
         SystemClock.UtcNow = () => time.Add(durationOfBreak).AddSeconds(anotherWindowDuration);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
     }
 
     [Fact]
     public void Should_open_circuit_again_after_the_specified_duration_has_passed_if_the_next_call_raises_an_exception()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -1356,39 +1188,32 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 durationOfBreak: durationOfBreak);
 
         // Four of four actions in this test throw handled failures.
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // first call after duration raises an exception, so circuit should open again
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
     public void Should_reset_circuit_after_the_specified_duration_has_passed_if_the_next_call_does_not_raise_an_exception()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -1402,37 +1227,32 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 durationOfBreak: durationOfBreak);
 
         // Four of four actions in this test throw handled failures.
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // first call after duration is successful, so circuit should reset
         breaker.Execute(() => { });
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
     public void Should_only_allow_single_execution_on_first_entering_halfopen_state__test_execution_permit_directly()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -1445,31 +1265,29 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 minimumThroughput: 2,
                 durationOfBreak: durationOfBreak);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
 
         // exception raised, circuit is now open.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // break duration passes, circuit now half open
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution.
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.Throw<BrokenCircuitException>(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
     }
 
     [Fact]
     public void Should_allow_single_execution_per_break_duration_in_halfopen_state__test_execution_permit_directly()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -1482,39 +1300,37 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 minimumThroughput: 2,
                 durationOfBreak: durationOfBreak);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
 
         // exception raised, circuit is now open.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // break duration passes, circuit now half open
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution.
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.Throw<BrokenCircuitException>(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // Allow another time window to pass (breaker should still be HalfOpen).
         SystemClock.UtcNow = () => time.Add(durationOfBreak).Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should now permit another trial execution.
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
     }
 
     [Fact]
     public void Should_only_allow_single_execution_on_first_entering_halfopen_state__integration_test()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -1527,17 +1343,15 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 minimumThroughput: 2,
                 durationOfBreak: durationOfBreak);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
 
         // exceptions raised, circuit is now open.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // break duration passes, circuit now half open
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // Start one execution during the HalfOpen state, and request a second execution before the first has completed (ie still during the HalfOpen state).
         // The second execution should be rejected due to the halfopen state.
@@ -1554,7 +1368,7 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
         // First execution in HalfOpen state: we should be able to verify state is HalfOpen as it executes.
         Task firstExecution = Task.Factory.StartNew(() =>
         {
-            breaker.Invoking(x => x.Execute(() =>
+            Should.NotThrow(() => breaker.Execute(() =>
             {
                 firstDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
 
@@ -1566,7 +1380,7 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
                 firstExecutionActive = false;
 
-            })).Should().NotThrow();
+            }));
         }, TaskCreationOptions.LongRunning);
 
         // Attempt a second execution, signalled by the first execution to ensure they overlap: we should be able to verify it doesn't execute, and is rejected by a breaker in a HalfOpen state.
@@ -1575,8 +1389,8 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
         Task secondExecution = Task.Factory.StartNew(() =>
         {
             // Validation of correct sequencing and overlapping of tasks in test (guard against erroneous test refactorings/operation).
-            firstExecutionActive.Should().BeTrue();
-            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+            firstExecutionActive.ShouldBeTrue();
+            breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
             try
             {
@@ -1601,7 +1415,7 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
         permitFirstExecutionEnd.Set();
 
 #pragma warning disable xUnit1031 // Do not use blocking task operations in test method
-        Task.WaitAll([firstExecution, secondExecution], testTimeoutToExposeDeadlocks).Should().BeTrue();
+        Task.WaitAll([firstExecution, secondExecution], testTimeoutToExposeDeadlocks).ShouldBeTrue();
 #pragma warning restore xUnit1031 // Do not use blocking task operations in test method
 
         if (firstExecution.IsFaulted)
@@ -1614,22 +1428,25 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
             throw secondExecution!.Exception!;
         }
 
-        firstExecution.Status.Should().Be(TaskStatus.RanToCompletion);
-        secondExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+        firstExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
+        secondExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
 
         // Assert:
         // - First execution should have been permitted and executed under a HalfOpen state
         // - Second overlapping execution in halfopen state should not have been permitted.
         // - Second execution attempt should have been rejected with HalfOpen state as cause.
-        firstDelegateExecutedInHalfOpenState.Should().BeTrue();
-        secondDelegateExecutedInHalfOpenState.Should().BeFalse();
-        secondDelegateRejectedInHalfOpenState.Should().BeTrue();
+        firstDelegateExecutedInHalfOpenState.ShouldNotBeNull();
+        firstDelegateExecutedInHalfOpenState.Value.ShouldBeTrue();
+        secondDelegateExecutedInHalfOpenState.ShouldNotBeNull();
+        secondDelegateExecutedInHalfOpenState.Value.ShouldBeFalse();
+        secondDelegateRejectedInHalfOpenState.ShouldNotBeNull();
+        secondDelegateRejectedInHalfOpenState.Value.ShouldBeTrue();
     }
 
     [Fact]
     public void Should_allow_single_execution_per_break_duration_in_halfopen_state__integration_test()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -1642,17 +1459,15 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 minimumThroughput: 2,
                 durationOfBreak: durationOfBreak);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
 
         // exception raised, circuit is now open.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // break duration passes, circuit now half open
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // Start one execution during the HalfOpen state.
         // Request a second execution while the first is still in flight (not completed), while still during the HalfOpen state, but after one breakDuration later.
@@ -1670,7 +1485,7 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
         // First execution in HalfOpen state: we should be able to verify state is HalfOpen as it executes.
         Task firstExecution = Task.Factory.StartNew(() =>
         {
-            breaker.Invoking(x => x.Execute(() =>
+            Should.NotThrow(() => breaker.Execute(() =>
             {
                 firstDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
 
@@ -1682,7 +1497,7 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
                 firstExecutionActive = false;
 
-            })).Should().NotThrow();
+            }));
         }, TaskCreationOptions.LongRunning);
 
         // Attempt a second execution, signalled by the first execution to ensure they overlap; start it one breakDuration later.  We should be able to verify it does execute, though the breaker is still in a HalfOpen state.
@@ -1691,8 +1506,8 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
         Task secondExecution = Task.Factory.StartNew(() =>
         {
             // Validation of correct sequencing and overlapping of tasks in test (guard against erroneous test refactorings/operation).
-            firstExecutionActive.Should().BeTrue();
-            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+            firstExecutionActive.ShouldBeTrue();
+            breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
             try
             {
@@ -1719,7 +1534,7 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
         permitFirstExecutionEnd.Set();
 
 #pragma warning disable xUnit1031 // Do not use blocking task operations in test method
-        Task.WaitAll([firstExecution, secondExecution], testTimeoutToExposeDeadlocks).Should().BeTrue();
+        Task.WaitAll([firstExecution, secondExecution], testTimeoutToExposeDeadlocks).ShouldBeTrue();
 #pragma warning restore xUnit1031 // Do not use blocking task operations in test method
 
         if (firstExecution.IsFaulted)
@@ -1732,15 +1547,18 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
             throw secondExecution!.Exception!;
         }
 
-        firstExecution.Status.Should().Be(TaskStatus.RanToCompletion);
-        secondExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+        firstExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
+        secondExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
 
         // Assert:
         // - First execution should have been permitted and executed under a HalfOpen state
         // - Second overlapping execution in half-open state should have been permitted, one breakDuration later.
-        firstDelegateExecutedInHalfOpenState.Should().BeTrue();
-        secondDelegateExecutedInHalfOpenState.Should().BeTrue();
-        secondDelegateRejectedInHalfOpenState.Should().BeFalse();
+        firstDelegateExecutedInHalfOpenState.ShouldNotBeNull();
+        firstDelegateExecutedInHalfOpenState.Value.ShouldBeTrue();
+        secondDelegateExecutedInHalfOpenState.ShouldNotBeNull();
+        secondDelegateExecutedInHalfOpenState.Value.ShouldBeTrue();
+        secondDelegateRejectedInHalfOpenState.ShouldNotBeNull();
+        secondDelegateRejectedInHalfOpenState.Value.ShouldBeFalse();
     }
 
     #endregion
@@ -1753,71 +1571,68 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
         CircuitBreakerPolicy breaker = Policy
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreaker(0.5, TimeSpan.FromSeconds(10), 4, TimeSpan.FromSeconds(30));
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // manually break circuit
         breaker.Isolate();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
 
         // circuit manually broken: execution should be blocked; even non-exception-throwing executions should not reset circuit
         bool delegateExecutedWhenBroken = false;
-        breaker.Invoking(x => x.Execute(() => delegateExecutedWhenBroken = true))
-            .Should().Throw<IsolatedCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
-        breaker.LastException.Should().BeOfType<IsolatedCircuitException>();
-        delegateExecutedWhenBroken.Should().BeFalse();
+        Should.Throw<IsolatedCircuitException>(() => breaker.Execute(() => delegateExecutedWhenBroken = true));
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
+        breaker.LastException.ShouldBeOfType<IsolatedCircuitException>();
+        delegateExecutedWhenBroken.ShouldBeFalse();
     }
 
     [Fact]
     public void Should_hold_circuit_open_despite_elapsed_time_if_manual_override_open()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
         CircuitBreakerPolicy breaker = Policy
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreaker(0.5, TimeSpan.FromSeconds(10), 4, durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.Isolate();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
 
         bool delegateExecutedWhenBroken = false;
-        breaker.Invoking(x => x.Execute(() => delegateExecutedWhenBroken = true))
-            .Should().Throw<IsolatedCircuitException>();
-        delegateExecutedWhenBroken.Should().BeFalse();
+        Should.Throw<IsolatedCircuitException>(() => breaker.Execute(() => delegateExecutedWhenBroken = true));
+        delegateExecutedWhenBroken.ShouldBeFalse();
     }
 
     [Fact]
     public void Should_close_circuit_again_on_reset_after_manual_override()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
         CircuitBreakerPolicy breaker = Policy
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreaker(0.5, TimeSpan.FromSeconds(10), 4, durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.Isolate();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().Throw<IsolatedCircuitException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
+        Should.Throw<IsolatedCircuitException>(() => breaker.Execute(() => { }));
 
         breaker.Reset();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        breaker.Invoking(x => x.Execute(() => { })).Should().NotThrow();
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
     }
 
     [Fact]
     public void Should_be_able_to_reset_automatically_opened_circuit_without_specified_duration_passing()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -1831,27 +1646,23 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 durationOfBreak: durationOfBreak);
 
         // Four of four actions in this test throw handled failures.
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // reset circuit, with no time having passed
         breaker.Reset();
-        SystemClock.UtcNow().Should().Be(time);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        breaker.Invoking(x => x.Execute(() => { })).Should().NotThrow();
+        SystemClock.UtcNow().ShouldBe(time);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
     }
 
     #endregion
@@ -1863,24 +1674,24 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
     {
         Action<Exception, TimeSpan> onBreak = (_, _) => { };
         bool onResetCalled = false;
-        Action onReset = () => { onResetCalled = true; };
+        Action onReset = () => onResetCalled = true;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
         Policy
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreaker(0.5, TimeSpan.FromSeconds(10), 4, durationOfBreak, onBreak, onReset);
 
-        onResetCalled.Should().BeFalse();
+        onResetCalled.ShouldBeFalse();
     }
 
     [Fact]
     public void Should_call_onbreak_when_breaking_circuit_automatically()
     {
         bool onBreakCalled = false;
-        Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled = true; };
+        Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled = true;
         Action onReset = () => { };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         CircuitBreakerPolicy breaker = Policy
@@ -1894,32 +1705,27 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 onReset: onReset);
 
         // Four of four actions in this test throw handled failures.
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
-        onBreakCalled.Should().BeTrue();
+        onBreakCalled.ShouldBeTrue();
     }
 
     [Fact]
     public void Should_call_onbreak_when_breaking_circuit_manually()
     {
         bool onBreakCalled = false;
-        Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled = true; };
+        Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled = true;
         Action onReset = () => { };
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -1927,21 +1733,21 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreaker(0.5, TimeSpan.FromSeconds(10), 4, durationOfBreak, onBreak, onReset);
 
-        onBreakCalled.Should().BeFalse();
+        onBreakCalled.ShouldBeFalse();
 
         breaker.Isolate();
 
-        onBreakCalled.Should().BeTrue();
+        onBreakCalled.ShouldBeTrue();
     }
 
     [Fact]
     public void Should_call_onbreak_when_breaking_circuit_first_time_but_not_for_subsequent_calls_placed_through_open_circuit()
     {
         int onBreakCalled = 0;
-        Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
+        Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled++;
         Action onReset = () => { };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         CircuitBreakerPolicy breaker = Policy
@@ -1955,42 +1761,36 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 onReset: onReset);
 
         // Four of four actions in this test throw handled failures.
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().Be(0);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBe(0);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().Be(0);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBe(0);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().Be(0);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBe(0);
 
         // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
-        onBreakCalled.Should().Be(1);
+        onBreakCalled.ShouldBe(1);
 
         // call through circuit when already broken - should not retrigger onBreak
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<BrokenCircuitException>();
+        Should.Throw<BrokenCircuitException>(() => breaker.RaiseException<DivideByZeroException>());
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
     }
 
     [Fact]
     public void Should_call_onbreak_when_breaking_circuit_first_time_but_not_for_subsequent_call_failure_which_arrives_on_open_state_though_started_on_closed_state()
     {
         int onBreakCalled = 0;
-        Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
+        Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled++;
         Action onReset = () => { };
 
         CircuitBreakerPolicy breaker = Policy
@@ -2009,9 +1809,10 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
         using ManualResetEvent permitMainThreadToOpenCircuit = new ManualResetEvent(false);
         Task longRunningExecution = Task.Factory.StartNew(() =>
         {
-            breaker.CircuitState.Should().Be(CircuitState.Closed);
+            breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-            breaker.Invoking(x => x.Execute(() =>
+            // However, since execution started when circuit was closed, BrokenCircuitException will not have been thrown on entry; the original exception will still be thrown.
+            Should.Throw<DivideByZeroException>(() => breaker.Execute(() =>
             {
                 permitMainThreadToOpenCircuit.Set();
 
@@ -2019,23 +1820,21 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 permitLongRunningExecutionToReturnItsFailure.WaitOne(testTimeoutToExposeDeadlocks);
 
                 // Throw a further failure when rest of test has already broken the circuit.
-                breaker.CircuitState.Should().Be(CircuitState.Open);
+                breaker.CircuitState.ShouldBe(CircuitState.Open);
                 throw new DivideByZeroException();
 
-            })).Should().Throw<DivideByZeroException>(); // However, since execution started when circuit was closed, BrokenCircuitException will not have been thrown on entry; the original exception will still be thrown.
+            }));
         }, TaskCreationOptions.LongRunning);
 
-        permitMainThreadToOpenCircuit.WaitOne(testTimeoutToExposeDeadlocks).Should().BeTrue();
+        permitMainThreadToOpenCircuit.WaitOne(testTimeoutToExposeDeadlocks).ShouldBeTrue();
 
         // Break circuit in the normal manner: onBreak() should be called once.
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().Be(0);
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBe(0);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
 
         // Permit the second (long-running) execution to hit the open circuit with its failure.
         permitLongRunningExecutionToReturnItsFailure.Set();
@@ -2043,9 +1842,9 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
         // Graceful cleanup: allow executions time to end naturally; timeout if any deadlocks; expose any execution faults.  This validates the test ran as expected (and background delegates are complete) before we assert on outcomes.
 #pragma warning disable xUnit1031 // Do not use blocking task operations in test method
 #if NET
-        longRunningExecution.Wait(testTimeoutToExposeDeadlocks, CancellationToken.None).Should().BeTrue();
+        longRunningExecution.Wait(testTimeoutToExposeDeadlocks, CancellationToken.None).ShouldBeTrue();
 #else
-        longRunningExecution.Wait(testTimeoutToExposeDeadlocks).Should().BeTrue();
+        longRunningExecution.Wait(testTimeoutToExposeDeadlocks).ShouldBeTrue();
 #endif
 #pragma warning restore xUnit1031 // Do not use blocking task operations in test method
 
@@ -2054,11 +1853,11 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
             throw longRunningExecution!.Exception!;
         }
 
-        longRunningExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+        longRunningExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
 
         // onBreak() should still only have been called once.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
     }
 
     [Fact]
@@ -2066,10 +1865,10 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
     {
         int onBreakCalled = 0;
         int onResetCalled = 0;
-        Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
-        Action onReset = () => { onResetCalled++; };
+        Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled++;
+        Action onReset = () => onResetCalled++;
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -2085,38 +1884,33 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 onReset: onReset);
 
         // Four of four actions in this test throw handled failures.
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
-        onBreakCalled.Should().Be(1);
+        onBreakCalled.ShouldBe(1);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // but not yet reset
-        onResetCalled.Should().Be(0);
+        onResetCalled.ShouldBe(0);
 
         // first call after duration is successful, so circuit should reset
         breaker.Execute(() => { });
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onResetCalled.Should().Be(1);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onResetCalled.ShouldBe(1);
     }
 
     [Fact]
@@ -2124,22 +1918,22 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
     {
         Action<Exception, TimeSpan> onBreak = (_, _) => { };
         bool onResetCalled = false;
-        Action onReset = () => { onResetCalled = true; };
+        Action onReset = () => onResetCalled = true;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
         CircuitBreakerPolicy breaker = Policy
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreaker(0.5, TimeSpan.FromSeconds(10), 4, durationOfBreak, onBreak, onReset);
 
-        onResetCalled.Should().BeFalse();
+        onResetCalled.ShouldBeFalse();
 
         breaker.Execute(() => { });
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onResetCalled.Should().BeFalse();
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onResetCalled.ShouldBeFalse();
 
         breaker.Execute(() => { });
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onResetCalled.Should().BeFalse();
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onResetCalled.ShouldBeFalse();
     }
 
     [Fact]
@@ -2148,11 +1942,11 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
         int onBreakCalled = 0;
         int onResetCalled = 0;
         int onHalfOpenCalled = 0;
-        Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
-        Action onReset = () => { onResetCalled++; };
-        Action onHalfOpen = () => { onHalfOpenCalled++; };
+        Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled++;
+        Action onReset = () => onResetCalled++;
+        Action onHalfOpen = () => onHalfOpenCalled++;
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -2169,39 +1963,34 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 onHalfOpen: onHalfOpen);
 
         // Four of four actions in this test throw handled failures.
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().Be(0);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBe(0);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().Be(0);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBe(0);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().Be(0);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBe(0);
 
         // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
-        onBreakCalled.Should().Be(1);
+        onBreakCalled.ShouldBe(1);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        onHalfOpenCalled.Should().Be(0); // not yet transitioned to half-open, because we have not queried state
+        onHalfOpenCalled.ShouldBe(0); // not yet transitioned to half-open, because we have not queried state
 
         // first call after duration is successful, so circuit should reset
         breaker.Execute(() => { });
-        onHalfOpenCalled.Should().Be(1); // called as action was placed for execution
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onResetCalled.Should().Be(1); // called after action succeeded
+        onHalfOpenCalled.ShouldBe(1); // called as action was placed for execution
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onResetCalled.ShouldBe(1); // called after action succeeded
     }
 
     [Fact]
@@ -2210,11 +1999,11 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
         int onBreakCalled = 0;
         int onResetCalled = 0;
         int onHalfOpenCalled = 0;
-        Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
-        Action onReset = () => { onResetCalled++; };
-        Action onHalfOpen = () => { onHalfOpenCalled++; };
+        Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled++;
+        Action onReset = () => onResetCalled++;
+        Action onHalfOpen = () => onHalfOpenCalled++;
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -2231,35 +2020,30 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 onHalfOpen: onHalfOpen);
 
         // Four of four actions in this test throw handled failures.
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().Be(0);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBe(0);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().Be(0);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBe(0);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().Be(0);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBe(0);
 
         // No adjustment to SystemClock.UtcNow, so all exceptions raised within same timeslice
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
-        onBreakCalled.Should().Be(1);
+        onBreakCalled.ShouldBe(1);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
-        onHalfOpenCalled.Should().Be(1);
-        onResetCalled.Should().Be(0);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
+        onHalfOpenCalled.ShouldBe(1);
+        onResetCalled.ShouldBe(0);
     }
 
     [Fact]
@@ -2267,10 +2051,10 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
     {
         int onBreakCalled = 0;
         int onResetCalled = 0;
-        Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
-        Action onReset = () => { onResetCalled++; };
+        Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled++;
+        Action onReset = () => onResetCalled++;
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -2278,20 +2062,19 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreaker(0.5, TimeSpan.FromSeconds(10), 4, durationOfBreak, onBreak, onReset);
 
-        onBreakCalled.Should().Be(0);
+        onBreakCalled.ShouldBe(0);
         breaker.Isolate();
-        onBreakCalled.Should().Be(1);
+        onBreakCalled.ShouldBe(1);
 
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().Throw<IsolatedCircuitException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
+        Should.Throw<IsolatedCircuitException>(() => breaker.Execute(() => { }));
 
-        onResetCalled.Should().Be(0);
+        onResetCalled.ShouldBe(0);
         breaker.Reset();
-        onResetCalled.Should().Be(1);
+        onResetCalled.ShouldBe(1);
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        breaker.Invoking(x => x.Execute(() => { })).Should().NotThrow();
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
     }
 
     #region Tests of supplied parameters to onBreak delegate
@@ -2301,7 +2084,7 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
     {
         Exception? passedException = null;
 
-        Action<Exception, TimeSpan, Context> onBreak = (exception, _, _) => { passedException = exception; };
+        Action<Exception, TimeSpan, Context> onBreak = (exception, _, _) => passedException = exception;
         Action<Context> onReset = _ => { };
 
         CircuitBreakerPolicy breaker = Policy
@@ -2314,23 +2097,19 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 onBreak: onBreak,
                 onReset: onReset);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        passedException?.Should().BeOfType<DivideByZeroException>();
+        passedException?.ShouldBeOfType<DivideByZeroException>();
     }
 
     [Fact]
@@ -2338,7 +2117,7 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
     {
         CircuitState? transitionedState = null;
 
-        Action<Exception, CircuitState, TimeSpan, Context> onBreak = (_, state, _, _) => { transitionedState = state; };
+        Action<Exception, CircuitState, TimeSpan, Context> onBreak = (_, state, _, _) => transitionedState = state;
         Action<Context> onReset = _ => { };
         Action onHalfOpen = () => { };
 
@@ -2353,23 +2132,19 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 onReset: onReset,
                 onHalfOpen: onHalfOpen);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        transitionedState?.Should().Be(CircuitState.Closed);
+        transitionedState?.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
@@ -2381,7 +2156,7 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
         Action<Context> onReset = _ => { };
         Action onHalfOpen = () => { };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -2398,35 +2173,29 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 onHalfOpen: onHalfOpen);
 
         // Four of four actions in this test throw handled failures.
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // first call after duration raises an exception, so circuit should open again
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        transitionedStates[0].Should().Be(CircuitState.Closed);
-        transitionedStates[1].Should().Be(CircuitState.HalfOpen);
+        transitionedStates[0].ShouldBe(CircuitState.Closed);
+        transitionedStates[1].ShouldBe(CircuitState.HalfOpen);
     }
 
     [Fact]
@@ -2434,7 +2203,7 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
     {
         TimeSpan? passedBreakTimespan = null;
 
-        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => { passedBreakTimespan = timespan; };
+        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => passedBreakTimespan = timespan;
         Action<Context> onReset = _ => { };
 
         TimeSpan durationOfBreak = TimeSpan.FromSeconds(30);
@@ -2449,33 +2218,29 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 onBreak: onBreak,
                 onReset: onReset);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        passedBreakTimespan.Should().Be(durationOfBreak);
+        passedBreakTimespan.ShouldBe(durationOfBreak);
     }
 
     [Fact]
     public void Should_open_circuit_with_timespan_maxvalue_if_manual_override_open()
     {
         TimeSpan? passedBreakTimespan = null;
-        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => { passedBreakTimespan = timespan; };
+        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => passedBreakTimespan = timespan;
         Action<Context> onReset = _ => { };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         CircuitBreakerPolicy breaker = Policy
@@ -2487,13 +2252,13 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 durationOfBreak: TimeSpan.FromSeconds(30),
                 onBreak: onBreak,
                 onReset: onReset);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // manually break circuit
         breaker.Isolate();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
 
-        passedBreakTimespan.Should().Be(TimeSpan.MaxValue);
+        passedBreakTimespan.ShouldBe(TimeSpan.MaxValue);
     }
 
     #endregion
@@ -2505,10 +2270,10 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
     {
         IDictionary<string, object>? contextData = null;
 
-        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) => { contextData = context; };
+        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) => contextData = context;
         Action<Context> onReset = _ => { };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         CircuitBreakerPolicy breaker = Policy
@@ -2522,25 +2287,24 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 onReset: onReset);
 
         // Four of four actions in this test throw handled failures.
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>(
-            CreateDictionary("key1", "value1", "key2", "value2"))).Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(
+            () =>
+                breaker.RaiseException<DivideByZeroException>(
+                    CreateDictionary("key1", "value1", "key2", "value2")));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -2549,9 +2313,9 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
         IDictionary<string, object>? contextData = null;
 
         Action<Exception, TimeSpan, Context> onBreak = (_, _, _) => { };
-        Action<Context> onReset = context => { contextData = context; };
+        Action<Context> onReset = context => contextData = context;
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -2567,33 +2331,28 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 onReset: onReset);
 
         // Four of four actions in this test throw handled failures.
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // first call after duration should invoke onReset, with context
         breaker.Execute(_ => { }, CreateDictionary("key1", "value1", "key2", "value2"));
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -2601,10 +2360,10 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
     {
         IDictionary<string, object> contextData = CreateDictionary("key1", "value1", "key2", "value2");
 
-        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) => { contextData = context; };
+        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) => contextData = context;
         Action<Context> onReset = _ => { };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         CircuitBreakerPolicy breaker = Policy
@@ -2618,24 +2377,19 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 onReset: onReset);
 
         // Four of four actions in this test throw handled failures.
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
-        contextData.Should().BeEmpty();
+        contextData.ShouldBeEmpty();
     }
 
     [Fact]
@@ -2648,7 +2402,7 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
         Action<Context> onReset =
             context => { contextValue = context.ContainsKey("key") ? context["key"].ToString() : null; };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
@@ -2664,34 +2418,30 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 onReset: onReset);
 
         // Four of four actions in this test throw handled failures.
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>(CreateDictionary("key", "original_value")))
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        contextValue.Should().Be("original_value");
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>(CreateDictionary("key", "original_value")));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        contextValue.ShouldBe("original_value");
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // but not yet reset
 
         // first call after duration is successful, so circuit should reset
         breaker.Execute(_ => { }, CreateDictionary("key", "new_value"));
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        contextValue.Should().Be("new_value");
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        contextValue.ShouldBe("new_value");
     }
 
     #endregion
@@ -2711,7 +2461,7 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 minimumThroughput: 2,
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
-        breaker.LastException.Should().BeNull();
+        breaker.LastException.ShouldBeNull();
     }
 
     [Fact]
@@ -2725,11 +2475,10 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 minimumThroughput: 2,
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.LastException.Should().BeOfType<DivideByZeroException>();
+        breaker.LastException.ShouldBeOfType<DivideByZeroException>();
     }
 
     [Fact]
@@ -2743,15 +2492,13 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 minimumThroughput: 2,
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.LastException.Should().BeOfType<DivideByZeroException>();
+        breaker.LastException.ShouldBeOfType<DivideByZeroException>();
     }
 
     [Fact]
@@ -2765,19 +2512,17 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
                 minimumThroughput: 2,
                 durationOfBreak: TimeSpan.FromSeconds(30));
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.LastException.Should().BeOfType<DivideByZeroException>();
+        breaker.LastException.ShouldBeOfType<DivideByZeroException>();
 
         breaker.Reset();
 
-        breaker.LastException.Should().BeNull();
+        breaker.LastException.ShouldBeNull();
     }
 
     #endregion
@@ -2803,11 +2548,10 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
 
         using (var cancellationTokenSource = new CancellationTokenSource())
         {
-            breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().NotThrow();
+            Should.NotThrow(() => breaker.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -2832,12 +2576,11 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             cancellationTokenSource.Cancel();
 
-            breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<OperationCanceledException>()
-                .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => breaker.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(0);
+        attemptsInvoked.ShouldBe(0);
     }
 
     [Fact]
@@ -2862,12 +2605,11 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<OperationCanceledException>()
-                .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => breaker.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -2892,12 +2634,11 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<OperationCanceledException>()
-                .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => breaker.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -2920,11 +2661,10 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
 
         using (var cancellationTokenSource = new CancellationTokenSource())
         {
-            breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<DivideByZeroException>();
+            Should.Throw<DivideByZeroException>(() => breaker.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -2935,19 +2675,14 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .AdvancedCircuitBreaker(0.5, TimeSpan.FromSeconds(10), 2, durationOfBreak);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.")
-            .WithInnerException<DivideByZeroException>();
+        var ex = Should.Throw<BrokenCircuitException>(() => breaker.RaiseException<DivideByZeroException>());
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<DivideByZeroException>();
 
         // Circuit is now broken.
-
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
 
@@ -2963,12 +2698,11 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             cancellationTokenSource.Cancel();
 
-            breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<OperationCanceledException>()
-                .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => breaker.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(0);
+        attemptsInvoked.ShouldBe(0);
     }
 
     [Fact]
@@ -2991,16 +2725,15 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
 
             implicitlyCapturedActionCancellationTokenSource.Cancel();
 
-            breaker.Invoking(x => x.Execute(_ =>
+            Should.Throw<OperationCanceledException>(() => breaker.Execute(_ =>
             {
                 attemptsInvoked++;
                 implicitlyCapturedActionCancellationToken.ThrowIfCancellationRequested();
             }, policyCancellationToken))
-                .Should().Throw<OperationCanceledException>()
-                .And.CancellationToken.Should().Be(implicitlyCapturedActionCancellationToken);
+                .CancellationToken.ShouldBe(implicitlyCapturedActionCancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -3025,13 +2758,13 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            breaker.Invoking(x => result = x.RaiseExceptionAndOrCancellation<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true))
-                .Should().NotThrow();
+            Should.NotThrow(() => result = breaker.RaiseExceptionAndOrCancellation<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true));
         }
 
-        result.Should().BeTrue();
+        result.ShouldNotBeNull();
+        result.Value.ShouldBeTrue();
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -3058,13 +2791,13 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            breaker.Invoking(x => result = x.RaiseExceptionAndOrCancellation<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true))
-                .Should().Throw<OperationCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => result = breaker.RaiseExceptionAndOrCancellation<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        result.Should().Be(null);
+        result.ShouldBeNull();
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     #endregion

--- a/test/Polly.Specs/CircuitBreaker/CircuitBreakerAsyncSpecs.cs
+++ b/test/Polly.Specs/CircuitBreaker/CircuitBreakerAsyncSpecs.cs
@@ -14,8 +14,7 @@ public class CircuitBreakerAsyncSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreakerAsync(1, TimeSpan.MaxValue);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
     }
 
     [Fact]
@@ -25,9 +24,8 @@ public class CircuitBreakerAsyncSpecs : IDisposable
                                  .Handle<DivideByZeroException>()
                                  .CircuitBreakerAsync(0, TimeSpan.FromSeconds(10));
 
-        action.Should().Throw<ArgumentOutOfRangeException>()
-              .And.ParamName.Should()
-              .Be("exceptionsAllowedBeforeBreaking");
+        Should.Throw<ArgumentOutOfRangeException>(action)
+              .ParamName.ShouldBe("exceptionsAllowedBeforeBreaking");
     }
 
     [Fact]
@@ -37,9 +35,8 @@ public class CircuitBreakerAsyncSpecs : IDisposable
                                  .Handle<DivideByZeroException>()
                                  .CircuitBreakerAsync(1, -TimeSpan.FromSeconds(1));
 
-        action.Should().Throw<ArgumentOutOfRangeException>()
-            .And.ParamName.Should()
-            .Be("durationOfBreak");
+        Should.Throw<ArgumentOutOfRangeException>(action)
+            .ParamName.ShouldBe("durationOfBreak");
     }
 
     [Fact]
@@ -48,7 +45,7 @@ public class CircuitBreakerAsyncSpecs : IDisposable
         Action action = () => Policy
                                  .Handle<DivideByZeroException>()
                                  .CircuitBreakerAsync(1, TimeSpan.Zero);
-        action.Should().NotThrow();
+        Should.NotThrow(action);
     }
 
     [Fact]
@@ -60,7 +57,7 @@ public class CircuitBreakerAsyncSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .CircuitBreakerAsync(2, durationOfBreak);
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     #endregion
@@ -74,16 +71,14 @@ public class CircuitBreakerAsyncSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(b => b.ExecuteAsync(() => TaskHelper.EmptyTask)).Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
@@ -93,22 +88,18 @@ public class CircuitBreakerAsyncSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         bool delegateExecutedWhenBroken = false;
-        var ex = await breaker.Awaiting(x => x.ExecuteAsync(() => { delegateExecutedWhenBroken = true; return TaskHelper.EmptyTask; }))
-              .Should().ThrowAsync<BrokenCircuitException>()
-              .WithMessage("The circuit is now open and is not allowing calls.");
-        ex.WithInnerException<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        delegateExecutedWhenBroken.Should().BeFalse();
-
+        var ex = await Should.ThrowAsync<BrokenCircuitException>(() => breaker.ExecuteAsync(() => { delegateExecutedWhenBroken = true; return TaskHelper.EmptyTask; }));
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        delegateExecutedWhenBroken.ShouldBeFalse();
     }
 
     [Fact]
@@ -119,22 +110,19 @@ public class CircuitBreakerAsyncSpecs : IDisposable
                         .Or<ArgumentOutOfRangeException>()
                         .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<ArgumentOutOfRangeException>())
-              .Should().ThrowAsync<ArgumentOutOfRangeException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<ArgumentOutOfRangeException>(() => breaker.RaiseExceptionAsync<ArgumentOutOfRangeException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 2 exception raised, circuit is now open
         bool delegateExecutedWhenBroken = false;
-        var ex = await breaker.Awaiting(x => x.ExecuteAsync(() => { delegateExecutedWhenBroken = true; return TaskHelper.EmptyTask; }))
-              .Should().ThrowAsync<BrokenCircuitException>()
-              .WithMessage("The circuit is now open and is not allowing calls.");
-        ex.WithInnerException<ArgumentOutOfRangeException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        delegateExecutedWhenBroken.Should().BeFalse();
+        var ex = await Should.ThrowAsync<BrokenCircuitException>(() => breaker.ExecuteAsync(() => { delegateExecutedWhenBroken = true; return TaskHelper.EmptyTask; }));
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<ArgumentOutOfRangeException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        delegateExecutedWhenBroken.ShouldBeFalse();
     }
 
     [Fact]
@@ -144,17 +132,14 @@ public class CircuitBreakerAsyncSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<ArgumentNullException>())
-              .Should().ThrowAsync<ArgumentNullException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<ArgumentNullException>(() => breaker.RaiseExceptionAsync<ArgumentNullException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<ArgumentNullException>())
-              .Should().ThrowAsync<ArgumentNullException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<ArgumentNullException>(() => breaker.RaiseExceptionAsync<ArgumentNullException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<ArgumentNullException>())
-              .Should().ThrowAsync<ArgumentNullException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<ArgumentNullException>(() => breaker.RaiseExceptionAsync<ArgumentNullException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
@@ -165,17 +150,14 @@ public class CircuitBreakerAsyncSpecs : IDisposable
                         .Or<ArgumentOutOfRangeException>()
                         .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<ArgumentNullException>())
-              .Should().ThrowAsync<ArgumentNullException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<ArgumentNullException>(() => breaker.RaiseExceptionAsync<ArgumentNullException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<ArgumentNullException>())
-              .Should().ThrowAsync<ArgumentNullException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<ArgumentNullException>(() => breaker.RaiseExceptionAsync<ArgumentNullException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<ArgumentNullException>())
-              .Should().ThrowAsync<ArgumentNullException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<ArgumentNullException>(() => breaker.RaiseExceptionAsync<ArgumentNullException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     #endregion
@@ -185,7 +167,7 @@ public class CircuitBreakerAsyncSpecs : IDisposable
     [Fact]
     public async Task Should_halfopen_circuit_after_the_specified_duration_has_passed()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -194,31 +176,27 @@ public class CircuitBreakerAsyncSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreakerAsync(2, durationOfBreak);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 2 exception raised, circuit is now open
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
     }
 
     [Fact]
     public async Task Should_open_circuit_again_after_the_specified_duration_has_passed_if_the_next_call_raises_an_exception()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -227,36 +205,31 @@ public class CircuitBreakerAsyncSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreakerAsync(2, durationOfBreak);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 2 exception raised, circuit is now open
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // first call after duration raises an exception, so circuit should break again
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<BrokenCircuitException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
     }
 
     [Fact]
     public async Task Should_reset_circuit_after_the_specified_duration_has_passed_if_the_next_call_does_not_raise_an_exception()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -265,46 +238,40 @@ public class CircuitBreakerAsyncSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreakerAsync(2, durationOfBreak);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 2 exception raised, circuit is now open
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // first call after duration is successful, so circuit should reset
         await breaker.ExecuteAsync(() => TaskHelper.EmptyTask);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // circuit has been reset so should once again allow 2 exceptions to be raised before breaking
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
     public async Task Should_only_allow_single_execution_on_first_entering_halfopen_state__test_execution_permit_directly()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -312,29 +279,28 @@ public class CircuitBreakerAsyncSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreakerAsync(1, durationOfBreak);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
 
         // exception raised, circuit is now open.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // break duration passes, circuit now half open
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution.
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.Throw<BrokenCircuitException>(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
     }
 
     [Fact]
     public async Task Should_allow_single_execution_per_break_duration_in_halfopen_state__test_execution_permit_directly()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -342,37 +308,36 @@ public class CircuitBreakerAsyncSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreakerAsync(1, durationOfBreak);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
 
         // exception raised, circuit is now open.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // break duration passes, circuit now half open
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution.
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.Throw<BrokenCircuitException>(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // Allow another time window to pass (breaker should still be HalfOpen).
         SystemClock.UtcNow = () => time.Add(durationOfBreak).Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should now permit another trial execution.
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
     }
 
     [Fact]
     public async Task Should_only_allow_single_execution_on_first_entering_halfopen_state__integration_test()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -380,15 +345,14 @@ public class CircuitBreakerAsyncSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreakerAsync(1, durationOfBreak);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
 
         // exception raised, circuit is now open.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // break duration passes, circuit now half open
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // Start one execution during the HalfOpen state, and request a second execution before the first has completed (ie still during the HalfOpen state).
         // The second execution should be rejected due to the halfopen state.
@@ -405,7 +369,7 @@ public class CircuitBreakerAsyncSpecs : IDisposable
         // First execution in HalfOpen state: we should be able to verify state is HalfOpen as it executes.
         Task firstExecution = Task.Factory.StartNew(async () =>
         {
-            await breaker.Awaiting(x => x.ExecuteAsync(async () =>
+            await Should.NotThrowAsync(() => breaker.ExecuteAsync(async () =>
             {
                 firstDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
 
@@ -417,8 +381,7 @@ public class CircuitBreakerAsyncSpecs : IDisposable
                 permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
                 await TaskHelper.EmptyTask;
                 firstExecutionActive = false;
-
-            })).Should().NotThrowAsync();
+            }));
         }, TaskCreationOptions.LongRunning);
 
         // Attempt a second execution, signalled by the first execution to ensure they overlap: we should be able to verify it doesn't execute, and is rejected by a breaker in a HalfOpen state.
@@ -427,8 +390,8 @@ public class CircuitBreakerAsyncSpecs : IDisposable
         Task secondExecution = Task.Factory.StartNew(async () =>
         {
             // Validation of correct sequencing and overlapping of tasks in test (guard against erroneous test refactorings/operation).
-            firstExecutionActive.Should().BeTrue();
-            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+            firstExecutionActive.ShouldBeTrue();
+            breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
             try
             {
@@ -452,7 +415,11 @@ public class CircuitBreakerAsyncSpecs : IDisposable
         // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. This validates the test ran as expected (and background delegates are complete) before we assert on outcomes.
         permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
         permitFirstExecutionEnd.Set();
-        Task.WaitAll(new[] { firstExecution, secondExecution }, testTimeoutToExposeDeadlocks).Should().BeTrue();
+
+#pragma warning disable xUnit1031 // Do not use blocking task operations in test method
+        Task.WaitAll([firstExecution, secondExecution], testTimeoutToExposeDeadlocks).ShouldBeTrue();
+#pragma warning restore xUnit1031 // Do not use blocking task operations in test method
+
         if (firstExecution.IsFaulted)
         {
             throw firstExecution!.Exception!;
@@ -463,22 +430,25 @@ public class CircuitBreakerAsyncSpecs : IDisposable
             throw secondExecution!.Exception!;
         }
 
-        firstExecution.Status.Should().Be(TaskStatus.RanToCompletion);
-        secondExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+        firstExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
+        secondExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
 
         // Assert:
         // - First execution should have been permitted and executed under a HalfOpen state
         // - Second overlapping execution in halfopen state should not have been permitted.
         // - Second execution attempt should have been rejected with HalfOpen state as cause.
-        firstDelegateExecutedInHalfOpenState.Should().BeTrue();
-        secondDelegateExecutedInHalfOpenState.Should().BeFalse();
-        secondDelegateRejectedInHalfOpenState.Should().BeTrue();
+        firstDelegateExecutedInHalfOpenState.ShouldNotBeNull();
+        firstDelegateExecutedInHalfOpenState.Value.ShouldBeTrue();
+        secondDelegateExecutedInHalfOpenState.ShouldNotBeNull();
+        secondDelegateExecutedInHalfOpenState.Value.ShouldBeFalse();
+        secondDelegateRejectedInHalfOpenState.ShouldNotBeNull();
+        secondDelegateRejectedInHalfOpenState.Value.ShouldBeTrue();
     }
 
     [Fact]
     public async Task Should_allow_single_execution_per_break_duration_in_halfopen_state__integration_test()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -486,15 +456,14 @@ public class CircuitBreakerAsyncSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreakerAsync(1, durationOfBreak);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
 
         // exception raised, circuit is now open.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // break duration passes, circuit now half open
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // Start one execution during the HalfOpen state.
         // Request a second execution while the first is still in flight (not completed), while still during the HalfOpen state, but after one breakDuration later.
@@ -512,7 +481,7 @@ public class CircuitBreakerAsyncSpecs : IDisposable
         // First execution in HalfOpen state: we should be able to verify state is HalfOpen as it executes.
         Task firstExecution = Task.Factory.StartNew(async () =>
         {
-            await breaker.Awaiting(x => x.ExecuteAsync(async () =>
+            await Should.NotThrowAsync(() => breaker.ExecuteAsync(async () =>
             {
                 firstDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
 
@@ -524,7 +493,7 @@ public class CircuitBreakerAsyncSpecs : IDisposable
                 permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
                 await TaskHelper.EmptyTask;
                 firstExecutionActive = false;
-            })).Should().NotThrowAsync();
+            }));
         }, TaskCreationOptions.LongRunning);
 
         // Attempt a second execution, signalled by the first execution to ensure they overlap; start it one breakDuration later.  We should be able to verify it does execute, though the breaker is still in a HalfOpen state.
@@ -533,8 +502,8 @@ public class CircuitBreakerAsyncSpecs : IDisposable
         Task secondExecution = Task.Factory.StartNew(async () =>
         {
             // Validation of correct sequencing and overlapping of tasks in test (guard against erroneous test refactorings/operation).
-            firstExecutionActive.Should().BeTrue();
-            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+            firstExecutionActive.ShouldBeTrue();
+            breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
             try
             {
@@ -561,7 +530,11 @@ public class CircuitBreakerAsyncSpecs : IDisposable
         // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. This validates the test ran as expected (and background delegates are complete) before we assert on outcomes.
         permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
         permitFirstExecutionEnd.Set();
-        Task.WaitAll(new[] { firstExecution, secondExecution }, testTimeoutToExposeDeadlocks).Should().BeTrue();
+
+#pragma warning disable xUnit1031 // Do not use blocking task operations in test method
+        Task.WaitAll([firstExecution, secondExecution], testTimeoutToExposeDeadlocks).ShouldBeTrue();
+#pragma warning restore xUnit1031 // Do not use blocking task operations in test method
+
         if (firstExecution.IsFaulted)
         {
             throw firstExecution!.Exception!;
@@ -572,15 +545,18 @@ public class CircuitBreakerAsyncSpecs : IDisposable
             throw secondExecution!.Exception!;
         }
 
-        firstExecution.Status.Should().Be(TaskStatus.RanToCompletion);
-        secondExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+        firstExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
+        secondExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
 
         // Assert:
         // - First execution should have been permitted and executed under a HalfOpen state
         // - Second overlapping execution in halfopen state should have been permitted, one breakDuration later.
-        firstDelegateExecutedInHalfOpenState.Should().BeTrue();
-        secondDelegateExecutedInHalfOpenState.Should().BeTrue();
-        secondDelegateRejectedInHalfOpenState.Should().BeFalse();
+        firstDelegateExecutedInHalfOpenState.ShouldNotBeNull();
+        firstDelegateExecutedInHalfOpenState.Value.ShouldBeTrue();
+        secondDelegateExecutedInHalfOpenState.ShouldNotBeNull();
+        secondDelegateExecutedInHalfOpenState.Value.ShouldBeTrue();
+        secondDelegateRejectedInHalfOpenState.ShouldNotBeNull();
+        secondDelegateRejectedInHalfOpenState.Value.ShouldBeFalse();
     }
 
     #endregion
@@ -590,7 +566,7 @@ public class CircuitBreakerAsyncSpecs : IDisposable
     [Fact]
     public async Task Should_open_circuit_and_block_calls_if_manual_override_open()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -598,26 +574,25 @@ public class CircuitBreakerAsyncSpecs : IDisposable
         var breaker = Policy
             .Handle<DivideByZeroException>()
             .CircuitBreakerAsync(2, durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // manually break circuit
         breaker.Isolate();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
 
         // circuit manually broken: execution should be blocked; even non-exception-throwing executions should not reset circuit
         bool delegateExecutedWhenBroken = false;
-        await breaker.Awaiting(x => x.ExecuteAsync(() => { delegateExecutedWhenBroken = true; return TaskHelper.EmptyTask; }))
-            .Should().ThrowAsync<IsolatedCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
-        breaker.LastException.Should().BeOfType<IsolatedCircuitException>();
-        delegateExecutedWhenBroken.Should().BeFalse();
+        await Should.ThrowAsync<IsolatedCircuitException>(() => breaker.ExecuteAsync(() => { delegateExecutedWhenBroken = true; return TaskHelper.EmptyTask; }));
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
+        breaker.LastException.ShouldBeOfType<IsolatedCircuitException>();
+        delegateExecutedWhenBroken.ShouldBeFalse();
 
     }
 
     [Fact]
     public async Task Should_hold_circuit_open_despite_elapsed_time_if_manual_override_open()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -625,23 +600,22 @@ public class CircuitBreakerAsyncSpecs : IDisposable
         var breaker = Policy
             .Handle<DivideByZeroException>()
             .CircuitBreakerAsync(2, durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.Isolate();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
         bool delegateExecutedWhenBroken = false;
-        await breaker.Awaiting(x => x.ExecuteAsync(() => { delegateExecutedWhenBroken = true; return TaskHelper.EmptyTask; }))
-            .Should().ThrowAsync<IsolatedCircuitException>();
-        delegateExecutedWhenBroken.Should().BeFalse();
+        await Should.ThrowAsync<IsolatedCircuitException>(() => breaker.ExecuteAsync(() => { delegateExecutedWhenBroken = true; return TaskHelper.EmptyTask; }));
+        delegateExecutedWhenBroken.ShouldBeFalse();
     }
 
     [Fact]
     public async Task Should_close_circuit_again_on_reset_after_manual_override()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -649,22 +623,21 @@ public class CircuitBreakerAsyncSpecs : IDisposable
         var breaker = Policy
             .Handle<DivideByZeroException>()
             .CircuitBreakerAsync(2, durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.Isolate();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().ThrowAsync<IsolatedCircuitException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
+        await Should.ThrowAsync<IsolatedCircuitException>(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
 
         breaker.Reset();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask)).Should().NotThrowAsync();
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
     }
 
     [Fact]
     public async Task Should_be_able_to_reset_automatically_opened_circuit_without_specified_duration_passing()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -673,24 +646,21 @@ public class CircuitBreakerAsyncSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreakerAsync(2, durationOfBreak);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 2 exception raised, circuit is now open
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // reset circuit, with no time having passed
         breaker.Reset();
-        SystemClock.UtcNow().Should().Be(time);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask)).Should().NotThrowAsync();
+        SystemClock.UtcNow().ShouldBe(time);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
     }
 
     #endregion
@@ -708,7 +678,7 @@ public class CircuitBreakerAsyncSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
-        onResetCalled.Should().BeFalse();
+        onResetCalled.ShouldBeFalse();
     }
 
     [Fact]
@@ -722,17 +692,15 @@ public class CircuitBreakerAsyncSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().BeFalse();
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBeFalse();
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().BeTrue();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBeTrue();
     }
 
     [Fact]
@@ -745,42 +713,39 @@ public class CircuitBreakerAsyncSpecs : IDisposable
         var breaker = Policy
             .Handle<DivideByZeroException>()
             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset);
-        onBreakCalled.Should().BeFalse();
+        onBreakCalled.ShouldBeFalse();
 
         breaker.Isolate();
 
-        onBreakCalled.Should().BeTrue();
+        onBreakCalled.ShouldBeTrue();
     }
 
     [Fact]
     public async Task Should_call_onbreak_when_breaking_circuit_first_time_but_not_for_subsequent_calls_placed_through_open_circuit()
     {
         int onBreakCalled = 0;
-        Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
+        Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled++;
         Action onReset = () => { };
 
         var breaker = Policy
                         .Handle<DivideByZeroException>()
                         .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().Be(0);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBe(0);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
 
         // call through circuit when already broken - should not retrigger onBreak
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<BrokenCircuitException>();
+        await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
     }
 
     [Fact]
@@ -800,9 +765,10 @@ public class CircuitBreakerAsyncSpecs : IDisposable
         using ManualResetEvent permitMainThreadToOpenCircuit = new ManualResetEvent(false);
         Task longRunningExecution = Task.Factory.StartNew(async () =>
         {
-            breaker.CircuitState.Should().Be(CircuitState.Closed);
+            breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-            await breaker.Awaiting(x => x.ExecuteAsync(async () =>
+            // However, since execution started when circuit was closed, BrokenCircuitException will not have been thrown on entry; the original exception will still be thrown.
+            await Should.ThrowAsync<DivideByZeroException>(() => breaker.ExecuteAsync(async () =>
             {
                 await TaskHelper.EmptyTask;
 
@@ -812,42 +778,43 @@ public class CircuitBreakerAsyncSpecs : IDisposable
                 permitLongRunningExecutionToReturnItsFailure.WaitOne(testTimeoutToExposeDeadlocks);
 
                 // Throw a further failure when rest of test has already broken the circuit.
-                breaker.CircuitState.Should().Be(CircuitState.Open);
+                breaker.CircuitState.ShouldBe(CircuitState.Open);
                 throw new DivideByZeroException();
 
-            })).Should().ThrowAsync<DivideByZeroException>(); // However, since execution started when circuit was closed, BrokenCircuitException will not have been thrown on entry; the original exception will still be thrown.
+            }));
         }, TaskCreationOptions.LongRunning);
 
-        permitMainThreadToOpenCircuit.WaitOne(testTimeoutToExposeDeadlocks).Should().BeTrue();
+        permitMainThreadToOpenCircuit.WaitOne(testTimeoutToExposeDeadlocks).ShouldBeTrue();
 
         // Break circuit in the normal manner: onBreak() should be called once.
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().Be(0);
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBe(0);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
 
         // Permit the second (long-running) execution to hit the open circuit with its failure.
         permitLongRunningExecutionToReturnItsFailure.Set();
 
+#pragma warning disable xUnit1031 // Do not use blocking task operations in test method
         // Graceful cleanup: allow executions time to end naturally; timeout if any deadlocks; expose any execution faults.  This validates the test ran as expected (and background delegates are complete) before we assert on outcomes.
 #if NET
-        longRunningExecution.Wait(testTimeoutToExposeDeadlocks, CancellationToken.None).Should().BeTrue();
+        longRunningExecution.Wait(testTimeoutToExposeDeadlocks, CancellationToken.None).ShouldBeTrue();
 #else
-        longRunningExecution.Wait(testTimeoutToExposeDeadlocks).Should().BeTrue();
+        longRunningExecution.Wait(testTimeoutToExposeDeadlocks).ShouldBeTrue();
 #endif
+#pragma warning restore xUnit1031 // Do not use blocking task operations in test method
 
         if (longRunningExecution.IsFaulted)
         {
             throw longRunningExecution!.Exception!;
         }
 
-        longRunningExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+        longRunningExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
 
         // onBreak() should still only have been called once.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
     }
 
     [Fact]
@@ -855,10 +822,10 @@ public class CircuitBreakerAsyncSpecs : IDisposable
     {
         int onBreakCalled = 0;
         int onResetCalled = 0;
-        Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
-        Action onReset = () => { onResetCalled++; };
+        Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled++;
+        Action onReset = () => onResetCalled++;
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -867,34 +834,31 @@ public class CircuitBreakerAsyncSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreakerAsync(2, durationOfBreak, onBreak, onReset);
 
-        onBreakCalled.Should().Be(0);
+        onBreakCalled.ShouldBe(0);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        onBreakCalled.Should().Be(0);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        onBreakCalled.ShouldBe(0);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        onBreakCalled.Should().Be(1);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        onBreakCalled.ShouldBe(1);
 
         // 2 exception raised, circuit is now open
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // but not yet reset
-        onResetCalled.Should().Be(0);
+        onResetCalled.ShouldBe(0);
 
         // first call after duration is successful, so circuit should reset
         await breaker.ExecuteAsync(() => TaskHelper.EmptyTask);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onResetCalled.Should().Be(1);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onResetCalled.ShouldBe(1);
     }
 
     [Fact]
@@ -908,15 +872,15 @@ public class CircuitBreakerAsyncSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
-        onResetCalled.Should().BeFalse();
+        onResetCalled.ShouldBeFalse();
 
         await breaker.ExecuteAsync(() => TaskHelper.EmptyTask);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onResetCalled.Should().BeFalse();
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onResetCalled.ShouldBeFalse();
 
         await breaker.ExecuteAsync(() => TaskHelper.EmptyTask);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onResetCalled.Should().BeFalse();
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onResetCalled.ShouldBeFalse();
     }
 
     [Fact]
@@ -925,11 +889,11 @@ public class CircuitBreakerAsyncSpecs : IDisposable
         int onBreakCalled = 0;
         int onResetCalled = 0;
         int onHalfOpenCalled = 0;
-        Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
-        Action onReset = () => { onResetCalled++; };
+        Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled++;
+        Action onReset = () => onResetCalled++;
         Action onHalfOpen = () => { onHalfOpenCalled++; };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -938,32 +902,29 @@ public class CircuitBreakerAsyncSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreakerAsync(2, durationOfBreak, onBreak, onReset, onHalfOpen);
 
-        onBreakCalled.Should().Be(0);
+        onBreakCalled.ShouldBe(0);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        onBreakCalled.Should().Be(0);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        onBreakCalled.ShouldBe(0);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        onBreakCalled.Should().Be(1);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        onBreakCalled.ShouldBe(1);
 
         // 2 exception raised, circuit is now open
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        onHalfOpenCalled.Should().Be(0); // not yet transitioned to half-open, because we have not queried state
+        onHalfOpenCalled.ShouldBe(0); // not yet transitioned to half-open, because we have not queried state
 
         // first call after duration is successful, so circuit should reset
         await breaker.ExecuteAsync(() => TaskHelper.EmptyTask);
-        onHalfOpenCalled.Should().Be(1);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onResetCalled.Should().Be(1);
+        onHalfOpenCalled.ShouldBe(1);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onResetCalled.ShouldBe(1);
     }
 
     [Fact]
@@ -972,11 +933,11 @@ public class CircuitBreakerAsyncSpecs : IDisposable
         int onBreakCalled = 0;
         int onResetCalled = 0;
         int onHalfOpenCalled = 0;
-        Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
-        Action onReset = () => { onResetCalled++; };
-        Action onHalfOpen = () => { onHalfOpenCalled++; };
+        Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled++;
+        Action onReset = () => onResetCalled++;
+        Action onHalfOpen = () => onHalfOpenCalled++;
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -985,28 +946,25 @@ public class CircuitBreakerAsyncSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreakerAsync(2, durationOfBreak, onBreak, onReset, onHalfOpen);
 
-        onBreakCalled.Should().Be(0);
+        onBreakCalled.ShouldBe(0);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        onBreakCalled.Should().Be(0);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        onBreakCalled.ShouldBe(0);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        onBreakCalled.Should().Be(1);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        onBreakCalled.ShouldBe(1);
 
         // 2 exception raised, circuit is now open
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
-        onHalfOpenCalled.Should().Be(1);
-        onResetCalled.Should().Be(0);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
+        onHalfOpenCalled.ShouldBe(1);
+        onResetCalled.ShouldBe(0);
     }
 
     [Fact]
@@ -1014,10 +972,10 @@ public class CircuitBreakerAsyncSpecs : IDisposable
     {
         int onBreakCalled = 0;
         int onResetCalled = 0;
-        Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
-        Action onReset = () => { onResetCalled++; };
+        Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled++;
+        Action onReset = () => onResetCalled++;
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1026,20 +984,19 @@ public class CircuitBreakerAsyncSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreakerAsync(2, durationOfBreak, onBreak, onReset);
 
-        onBreakCalled.Should().Be(0);
+        onBreakCalled.ShouldBe(0);
         breaker.Isolate();
-        onBreakCalled.Should().Be(1);
+        onBreakCalled.ShouldBe(1);
 
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask))
-            .Should().ThrowAsync<IsolatedCircuitException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
+        await Should.ThrowAsync<IsolatedCircuitException>(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
 
-        onResetCalled.Should().Be(0);
+        onResetCalled.ShouldBe(0);
         breaker.Reset();
-        onResetCalled.Should().Be(1);
+        onResetCalled.ShouldBe(1);
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        await breaker.Awaiting(x => x.ExecuteAsync(() => TaskHelper.EmptyTask)).Should().NotThrowAsync();
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => TaskHelper.EmptyTask));
     }
 
     #region Tests of supplied parameters to onBreak delegate
@@ -1049,22 +1006,20 @@ public class CircuitBreakerAsyncSpecs : IDisposable
     {
         Exception? passedException = null;
 
-        Action<Exception, TimeSpan, Context> onBreak = (exception, _, _) => { passedException = exception; };
+        Action<Exception, TimeSpan, Context> onBreak = (exception, _, _) => passedException = exception;
         Action<Context> onReset = _ => { };
 
         var breaker = Policy
                         .Handle<DivideByZeroException>()
                         .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        passedException?.Should().BeOfType<DivideByZeroException>();
+        passedException?.ShouldBeOfType<DivideByZeroException>();
     }
 
     [Fact]
@@ -1072,7 +1027,7 @@ public class CircuitBreakerAsyncSpecs : IDisposable
     {
         CircuitState? transitionedState = null;
 
-        Action<Exception, CircuitState, TimeSpan, Context> onBreak = (_, state, _, _) => { transitionedState = state; };
+        Action<Exception, CircuitState, TimeSpan, Context> onBreak = (_, state, _, _) => transitionedState = state;
         Action<Context> onReset = _ => { };
         Action onHalfOpen = () => { };
 
@@ -1080,15 +1035,13 @@ public class CircuitBreakerAsyncSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset, onHalfOpen);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        transitionedState?.Should().Be(CircuitState.Closed);
+        transitionedState?.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
@@ -1096,11 +1049,11 @@ public class CircuitBreakerAsyncSpecs : IDisposable
     {
         List<CircuitState> transitionedStates = [];
 
-        Action<Exception, CircuitState, TimeSpan, Context> onBreak = (_, state, _, _) => { transitionedStates.Add(state); };
+        Action<Exception, CircuitState, TimeSpan, Context> onBreak = (_, state, _, _) => transitionedStates.Add(state);
         Action<Context> onReset = _ => { };
         Action onHalfOpen = () => { };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1109,33 +1062,28 @@ public class CircuitBreakerAsyncSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset, onHalfOpen);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 2 exception raised, circuit is now open
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // first call after duration raises an exception, so circuit should break again
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<BrokenCircuitException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
 
-        transitionedStates[0].Should().Be(CircuitState.Closed);
-        transitionedStates[1].Should().Be(CircuitState.HalfOpen);
+        transitionedStates[0].ShouldBe(CircuitState.Closed);
+        transitionedStates[1].ShouldBe(CircuitState.HalfOpen);
     }
 
     [Fact]
@@ -1143,7 +1091,7 @@ public class CircuitBreakerAsyncSpecs : IDisposable
     {
         Exception? passedException = null;
 
-        Action<Exception, TimeSpan, Context> onBreak = (exception, _, _) => { passedException = exception; };
+        Action<Exception, TimeSpan, Context> onBreak = (exception, _, _) => passedException = exception;
         Action<Context> onReset = _ => { };
 
         TimeSpan durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1156,16 +1104,14 @@ public class CircuitBreakerAsyncSpecs : IDisposable
         Exception toRaiseAsInner = new DivideByZeroException();
         Exception withInner = new AggregateException(toRaiseAsInner);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
 
-        var ex = await breaker.Awaiting(x => x.RaiseExceptionAsync(withInner))
-            .Should().ThrowAsync<DivideByZeroException>();
-        ex.Which.Should().BeSameAs(toRaiseAsInner);
+        var ex = await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync(withInner));
+        ex.ShouldBeSameAs(toRaiseAsInner);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        passedException?.Should().BeSameAs(toRaiseAsInner);
+        passedException?.ShouldBeSameAs(toRaiseAsInner);
     }
 
     [Fact]
@@ -1182,37 +1128,35 @@ public class CircuitBreakerAsyncSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreakerAsync(2, durationOfBreak, onBreak, onReset);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        passedBreakTimespan.Should().Be(durationOfBreak);
+        passedBreakTimespan.ShouldBe(durationOfBreak);
     }
 
     [Fact]
     public void Should_open_circuit_with_timespan_maxvalue_if_manual_override_open()
     {
         TimeSpan? passedBreakTimespan = null;
-        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => { passedBreakTimespan = timespan; };
+        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => passedBreakTimespan = timespan;
         Action<Context> onReset = _ => { };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var breaker = Policy
                         .Handle<DivideByZeroException>()
                         .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // manually break circuit
         breaker.Isolate();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
 
-        passedBreakTimespan.Should().Be(TimeSpan.MaxValue);
+        passedBreakTimespan.ShouldBe(TimeSpan.MaxValue);
     }
 
     #endregion
@@ -1224,24 +1168,23 @@ public class CircuitBreakerAsyncSpecs : IDisposable
     {
         IDictionary<string, object>? contextData = null;
 
-        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) => { contextData = context; };
+        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) => contextData = context;
         Action<Context> onReset = _ => { };
 
         var breaker = Policy
                         .Handle<DivideByZeroException>()
                         .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>(
-            CreateDictionary("key1", "value1", "key2", "value2"))).Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(
+            () => breaker.RaiseExceptionAsync<DivideByZeroException>(CreateDictionary("key1", "value1", "key2", "value2")));
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -1250,9 +1193,9 @@ public class CircuitBreakerAsyncSpecs : IDisposable
         IDictionary<string, object>? contextData = null;
 
         Action<Exception, TimeSpan, Context> onBreak = (_, _, _) => { };
-        Action<Context> onReset = context => { contextData = context; };
+        Action<Context> onReset = context => contextData = context;
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1261,21 +1204,19 @@ public class CircuitBreakerAsyncSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreakerAsync(2, durationOfBreak, onBreak, onReset);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // first call after duration should invoke onReset, with context
         await breaker.ExecuteAsync(_ => TaskHelper.EmptyTask, CreateDictionary("key1", "value1", "key2", "value2"));
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -1283,22 +1224,19 @@ public class CircuitBreakerAsyncSpecs : IDisposable
     {
         IDictionary<string, object> contextData = CreateDictionary("key1", "value1", "key2", "value2");
 
-        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) => { contextData = context; };
+        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) => contextData = context;
         Action<Context> onReset = _ => { };
 
         var breaker = Policy
                         .Handle<DivideByZeroException>()
                         .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
-        contextData.Should().BeEmpty();
+        contextData.ShouldBeEmpty();
     }
 
     [Fact]
@@ -1313,31 +1251,29 @@ public class CircuitBreakerAsyncSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
 
         // 2 exception raised, circuit is now open
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>(CreateDictionary("key", "original_value")))
-              .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        contextValue.Should().Be("original_value");
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>(CreateDictionary("key", "original_value")));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        contextValue.ShouldBe("original_value");
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // but not yet reset
 
         // first call after duration is successful, so circuit should reset
         await breaker.ExecuteAsync(_ => TaskHelper.EmptyTask, CreateDictionary("key", "new_value"));
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        contextValue.Should().Be("new_value");
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        contextValue.ShouldBe("new_value");
     }
 
     #endregion
@@ -1353,7 +1289,7 @@ public class CircuitBreakerAsyncSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
 
-        breaker.LastException.Should().BeNull();
+        breaker.LastException.ShouldBeNull();
     }
 
     [Fact]
@@ -1363,12 +1299,11 @@ public class CircuitBreakerAsyncSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.LastException.Should().BeOfType<DivideByZeroException>();
+        breaker.LastException.ShouldBeOfType<DivideByZeroException>();
     }
 
     [Fact]
@@ -1381,13 +1316,12 @@ public class CircuitBreakerAsyncSpecs : IDisposable
         Exception toRaiseAsInner = new DivideByZeroException();
         Exception withInner = new AggregateException(toRaiseAsInner);
 
-        var ex = await breaker.Awaiting(x => x.RaiseExceptionAsync(withInner))
-            .Should().ThrowAsync<DivideByZeroException>();
-        ex.Which.Should().BeSameAs(toRaiseAsInner);
+        var ex = await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync(withInner));
+        ex.ShouldBeSameAs(toRaiseAsInner);
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.LastException.Should().BeSameAs(toRaiseAsInner);
+        breaker.LastException.ShouldBeSameAs(toRaiseAsInner);
     }
 
     [Fact]
@@ -1397,15 +1331,12 @@ public class CircuitBreakerAsyncSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
-        breaker.LastException.Should().BeOfType<DivideByZeroException>();
+        breaker.LastException.ShouldBeOfType<DivideByZeroException>();
     }
 
     [Fact]
@@ -1415,19 +1346,16 @@ public class CircuitBreakerAsyncSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
-        breaker.LastException.Should().BeOfType<DivideByZeroException>();
+        breaker.LastException.ShouldBeOfType<DivideByZeroException>();
 
         breaker.Reset();
 
-        breaker.LastException.Should().BeNull();
+        breaker.LastException.ShouldBeNull();
     }
 
     #endregion
@@ -1453,11 +1381,10 @@ public class CircuitBreakerAsyncSpecs : IDisposable
 
         using (var cancellationTokenSource = new CancellationTokenSource())
         {
-            await breaker.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().NotThrowAsync();
+            await Should.NotThrowAsync(() => breaker.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -1482,12 +1409,11 @@ public class CircuitBreakerAsyncSpecs : IDisposable
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             cancellationTokenSource.Cancel();
 
-            var ex = await breaker.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => breaker.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(0);
+        attemptsInvoked.ShouldBe(0);
     }
 
     [Fact]
@@ -1512,12 +1438,11 @@ public class CircuitBreakerAsyncSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await breaker.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => breaker.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -1542,12 +1467,11 @@ public class CircuitBreakerAsyncSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await breaker.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => breaker.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -1570,11 +1494,10 @@ public class CircuitBreakerAsyncSpecs : IDisposable
 
         using (var cancellationTokenSource = new CancellationTokenSource())
         {
-            await breaker.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().ThrowAsync<DivideByZeroException>();
+            await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -1584,13 +1507,11 @@ public class CircuitBreakerAsyncSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .CircuitBreakerAsync(1, TimeSpan.FromMinutes(1));
 
-        await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
 
-        var ex = await breaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-            .Should().ThrowAsync<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.");
-        ex.WithInnerException<DivideByZeroException>();
+        var ex = await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseExceptionAsync<DivideByZeroException>());
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<DivideByZeroException>();
 
         // Circuit is now broken.
 
@@ -1609,12 +1530,11 @@ public class CircuitBreakerAsyncSpecs : IDisposable
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             cancellationTokenSource.Cancel();
 
-            var ex2 = await breaker.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().ThrowAsync<OperationCanceledException>();
-            ex2.And.CancellationToken.Should().Be(cancellationToken);
+            var ex2 = await Should.ThrowAsync<OperationCanceledException>(() => breaker.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex2.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(0);
+        attemptsInvoked.ShouldBe(0);
     }
 
     [Fact]
@@ -1637,17 +1557,16 @@ public class CircuitBreakerAsyncSpecs : IDisposable
 
             implicitlyCapturedActionCancellationTokenSource.Cancel();
 
-            var ex = await breaker.Awaiting(x => x.ExecuteAsync(async _ =>
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => breaker.ExecuteAsync(async _ =>
             {
                 attemptsInvoked++;
                 await TaskHelper.EmptyTask;
                 implicitlyCapturedActionCancellationToken.ThrowIfCancellationRequested();
-            }, policyCancellationToken))
-                .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(implicitlyCapturedActionCancellationToken);
+            }, policyCancellationToken));
+            ex.CancellationToken.ShouldBe(implicitlyCapturedActionCancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -1672,14 +1591,14 @@ public class CircuitBreakerAsyncSpecs : IDisposable
         using (var cancellationTokenSource = new CancellationTokenSource())
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
-            Func<AsyncCircuitBreakerPolicy, Task> action = async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true);
-            await breaker.Awaiting(action)
-                .Should().NotThrowAsync();
+            Func<Task> action = async () => result = await breaker.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true);
+            await Should.NotThrowAsync(action);
         }
 
-        result.Should().BeTrue();
+        result.ShouldNotBeNull();
+        result.Value.ShouldBeTrue();
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -1705,15 +1624,14 @@ public class CircuitBreakerAsyncSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            Func<AsyncCircuitBreakerPolicy, Task> action = async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true);
-            var ex = await breaker.Awaiting(action)
-                .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            Func<Task> action = async () => result = await breaker.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(action);
+            ex.CancellationToken.ShouldBe(cancellationToken);
 
-            result.Should().Be(null);
+            result.ShouldBeNull();
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     #endregion

--- a/test/Polly.Specs/CircuitBreaker/CircuitBreakerSpecs.cs
+++ b/test/Polly.Specs/CircuitBreaker/CircuitBreakerSpecs.cs
@@ -12,8 +12,7 @@ public class CircuitBreakerSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreaker(1, TimeSpan.MaxValue);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
     }
 
     [Fact]
@@ -23,9 +22,8 @@ public class CircuitBreakerSpecs : IDisposable
                                  .Handle<DivideByZeroException>()
                                  .CircuitBreaker(0, TimeSpan.FromSeconds(10));
 
-        action.Should().Throw<ArgumentOutOfRangeException>()
-              .And.ParamName.Should()
-              .Be("exceptionsAllowedBeforeBreaking");
+        Should.Throw<ArgumentOutOfRangeException>(action)
+              .ParamName.ShouldBe("exceptionsAllowedBeforeBreaking");
     }
 
     [Fact]
@@ -35,9 +33,8 @@ public class CircuitBreakerSpecs : IDisposable
                                  .Handle<DivideByZeroException>()
                                  .CircuitBreaker(1, -TimeSpan.FromSeconds(1));
 
-        action.Should().Throw<ArgumentOutOfRangeException>()
-            .And.ParamName.Should()
-            .Be("durationOfBreak");
+        Should.Throw<ArgumentOutOfRangeException>(action)
+            .ParamName.ShouldBe("durationOfBreak");
     }
 
     [Fact]
@@ -46,7 +43,7 @@ public class CircuitBreakerSpecs : IDisposable
         Action action = () => Policy
                                  .Handle<DivideByZeroException>()
                                  .CircuitBreaker(1, TimeSpan.Zero);
-        action.Should().NotThrow();
+        Should.NotThrow(action);
     }
 
     [Fact]
@@ -58,7 +55,7 @@ public class CircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .CircuitBreaker(2, durationOfBreak);
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     #endregion
@@ -72,16 +69,14 @@ public class CircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(b => b.Execute(() => { })).Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
@@ -91,21 +86,18 @@ public class CircuitBreakerSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         bool delegateExecutedWhenBroken = false;
-        breaker.Invoking(x => x.Execute(() => delegateExecutedWhenBroken = true))
-              .Should().Throw<BrokenCircuitException>()
-              .WithMessage("The circuit is now open and is not allowing calls.")
-              .WithInnerException<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        delegateExecutedWhenBroken.Should().BeFalse();
+        var ex = Should.Throw<BrokenCircuitException>(() => breaker.Execute(() => delegateExecutedWhenBroken = true));
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        delegateExecutedWhenBroken.ShouldBeFalse();
     }
 
     [Fact]
@@ -116,22 +108,19 @@ public class CircuitBreakerSpecs : IDisposable
                         .Or<ArgumentOutOfRangeException>()
                         .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<ArgumentOutOfRangeException>())
-              .Should().Throw<ArgumentOutOfRangeException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<ArgumentOutOfRangeException>(() => breaker.RaiseException<ArgumentOutOfRangeException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 2 exception raised, circuit is now open
         bool delegateExecutedWhenBroken = false;
-        breaker.Invoking(x => x.Execute(() => delegateExecutedWhenBroken = true))
-              .Should().Throw<BrokenCircuitException>()
-              .WithMessage("The circuit is now open and is not allowing calls.")
-              .WithInnerException<ArgumentOutOfRangeException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        delegateExecutedWhenBroken.Should().BeFalse();
+        var ex = Should.Throw<BrokenCircuitException>(() => breaker.Execute(() => delegateExecutedWhenBroken = true));
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<ArgumentOutOfRangeException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        delegateExecutedWhenBroken.ShouldBeFalse();
     }
 
     [Fact]
@@ -141,17 +130,14 @@ public class CircuitBreakerSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
-        breaker.Invoking(x => x.RaiseException<ArgumentNullException>())
-              .Should().Throw<ArgumentNullException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<ArgumentNullException>())
-              .Should().Throw<ArgumentNullException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<ArgumentNullException>(() => breaker.RaiseException<ArgumentNullException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<ArgumentNullException>())
-              .Should().Throw<ArgumentNullException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<ArgumentNullException>(() => breaker.RaiseException<ArgumentNullException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
@@ -162,17 +148,14 @@ public class CircuitBreakerSpecs : IDisposable
                         .Or<ArgumentOutOfRangeException>()
                         .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
-        breaker.Invoking(x => x.RaiseException<ArgumentNullException>())
-              .Should().Throw<ArgumentNullException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<ArgumentNullException>(() => breaker.RaiseException<ArgumentNullException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<ArgumentNullException>())
-              .Should().Throw<ArgumentNullException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<ArgumentNullException>(() => breaker.RaiseException<ArgumentNullException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<ArgumentNullException>())
-              .Should().Throw<ArgumentNullException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<ArgumentNullException>(() => breaker.RaiseException<ArgumentNullException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     #endregion
@@ -182,7 +165,7 @@ public class CircuitBreakerSpecs : IDisposable
     [Fact]
     public void Should_halfopen_circuit_after_the_specified_duration_has_passed()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -191,31 +174,27 @@ public class CircuitBreakerSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreaker(2, durationOfBreak);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 2 exception raised, circuit is now open
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<BrokenCircuitException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
     }
 
     [Fact]
     public void Should_open_circuit_again_after_the_specified_duration_has_passed_if_the_next_call_raises_an_exception()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -224,37 +203,31 @@ public class CircuitBreakerSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreaker(2, durationOfBreak);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 2 exception raised, circuit is now open
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<BrokenCircuitException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // first call after duration raises an exception, so circuit should break again
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<BrokenCircuitException>();
-
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        Should.Throw<BrokenCircuitException>(() => breaker.RaiseException<DivideByZeroException>());
     }
 
     [Fact]
     public void Should_reset_circuit_after_the_specified_duration_has_passed_if_the_next_call_does_not_raise_an_exception()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -263,46 +236,40 @@ public class CircuitBreakerSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreaker(2, durationOfBreak);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 2 exception raised, circuit is now open
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<BrokenCircuitException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // first call after duration is successful, so circuit should reset
         breaker.Execute(() => { });
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // circuit has been reset so should once again allow 2 exceptions to be raised before breaking
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<BrokenCircuitException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
     public void Should_only_allow_single_execution_on_first_entering_halfopen_state__test_execution_permit_directly()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -310,29 +277,28 @@ public class CircuitBreakerSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreaker(1, durationOfBreak);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
 
         // exception raised, circuit is now open.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // break duration passes, circuit now half open
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution.
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.Throw<BrokenCircuitException>(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
     }
 
     [Fact]
     public void Should_allow_single_execution_per_break_duration_in_halfopen_state__test_execution_permit_directly()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -340,37 +306,36 @@ public class CircuitBreakerSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreaker(1, durationOfBreak);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
 
         // exception raised, circuit is now open.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // break duration passes, circuit now half open
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution in the same time window.
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.Throw<BrokenCircuitException>(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // Allow another time window to pass (breaker should still be HalfOpen).
         SystemClock.UtcNow = () => time.Add(durationOfBreak).Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should now permit another trial execution.
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
     }
 
     [Fact]
     public void Should_only_allow_single_execution_on_first_entering_halfopen_state__integration_test()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -378,15 +343,14 @@ public class CircuitBreakerSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreaker(1, durationOfBreak);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
 
         // exception raised, circuit is now open.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // break duration passes, circuit now half open
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // Start one execution during the HalfOpen state, and request a second execution before the first has completed (ie still during the HalfOpen state).
         // The second execution should be rejected due to the halfopen state.
@@ -403,7 +367,7 @@ public class CircuitBreakerSpecs : IDisposable
         // First execution in HalfOpen state: we should be able to verify state is HalfOpen as it executes.
         Task firstExecution = Task.Factory.StartNew(() =>
         {
-            breaker.Invoking(x => x.Execute(() =>
+            Should.NotThrow(() => breaker.Execute(() =>
             {
                 firstDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
 
@@ -415,7 +379,7 @@ public class CircuitBreakerSpecs : IDisposable
                 permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
                 firstExecutionActive = false;
 
-            })).Should().NotThrow();
+            }));
         }, TaskCreationOptions.LongRunning);
 
         // Attempt a second execution, signalled by the first execution to ensure they overlap: we should be able to verify it doesn't execute, and is rejected by a breaker in a HalfOpen state.
@@ -424,8 +388,8 @@ public class CircuitBreakerSpecs : IDisposable
         Task secondExecution = Task.Factory.StartNew(() =>
         {
             // Validation of correct sequencing and overlapping of tasks in test (guard against erroneous test refactorings/operation).
-            firstExecutionActive.Should().BeTrue();
-            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+            firstExecutionActive.ShouldBeTrue();
+            breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
             try
             {
@@ -448,7 +412,11 @@ public class CircuitBreakerSpecs : IDisposable
         // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. This validates the test ran as expected (and background delegates are complete) before we assert on outcomes.
         permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
         permitFirstExecutionEnd.Set();
-        Task.WaitAll(new[] { firstExecution, secondExecution }, testTimeoutToExposeDeadlocks).Should().BeTrue();
+
+#pragma warning disable xUnit1031 // Do not use blocking task operations in test method
+        Task.WaitAll([firstExecution, secondExecution], testTimeoutToExposeDeadlocks).ShouldBeTrue();
+#pragma warning restore xUnit1031 // Do not use blocking task operations in test method
+
         if (firstExecution.IsFaulted)
         {
             throw firstExecution!.Exception!;
@@ -459,22 +427,25 @@ public class CircuitBreakerSpecs : IDisposable
             throw secondExecution!.Exception!;
         }
 
-        firstExecution.Status.Should().Be(TaskStatus.RanToCompletion);
-        secondExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+        firstExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
+        secondExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
 
         // Assert:
         // - First execution should have been permitted and executed under a HalfOpen state
         // - Second overlapping execution in halfopen state should not have been permitted.
         // - Second execution attempt should have been rejected with HalfOpen state as cause.
-        firstDelegateExecutedInHalfOpenState.Should().BeTrue();
-        secondDelegateExecutedInHalfOpenState.Should().BeFalse();
-        secondDelegateRejectedInHalfOpenState.Should().BeTrue();
+        firstDelegateExecutedInHalfOpenState.ShouldNotBeNull();
+        firstDelegateExecutedInHalfOpenState.Value.ShouldBeTrue();
+        secondDelegateExecutedInHalfOpenState.ShouldNotBeNull();
+        secondDelegateExecutedInHalfOpenState.Value.ShouldBeFalse();
+        secondDelegateRejectedInHalfOpenState.ShouldNotBeNull();
+        secondDelegateRejectedInHalfOpenState.Value.ShouldBeTrue();
     }
 
     [Fact]
     public void Should_allow_single_execution_per_break_duration_in_halfopen_state__integration_test()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -482,15 +453,14 @@ public class CircuitBreakerSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreaker(1, durationOfBreak);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
 
         // exception raised, circuit is now open.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // break duration passes, circuit now half open
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // Start one execution during the HalfOpen state.
         // Request a second execution while the first is still in flight (not completed), while still during the HalfOpen state, but after one breakDuration later.
@@ -508,7 +478,7 @@ public class CircuitBreakerSpecs : IDisposable
         // First execution in HalfOpen state: we should be able to verify state is HalfOpen as it executes.
         Task firstExecution = Task.Factory.StartNew(() =>
         {
-            breaker.Invoking(x => x.Execute(() =>
+            Should.NotThrow(() => breaker.Execute(() =>
             {
                 firstDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
 
@@ -520,7 +490,7 @@ public class CircuitBreakerSpecs : IDisposable
                 permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
                 firstExecutionActive = false;
 
-            })).Should().NotThrow();
+            }));
         }, TaskCreationOptions.LongRunning);
 
         // Attempt a second execution, signalled by the first execution to ensure they overlap; start it one breakDuration later.  We should be able to verify it does execute, though the breaker is still in a HalfOpen state.
@@ -529,8 +499,8 @@ public class CircuitBreakerSpecs : IDisposable
         Task secondExecution = Task.Factory.StartNew(() =>
         {
             // Validation of correct sequencing and overlapping of tasks in test (guard against erroneous test refactorings/operation).
-            firstExecutionActive.Should().BeTrue();
-            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+            firstExecutionActive.ShouldBeTrue();
+            breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
             try
             {
@@ -555,7 +525,11 @@ public class CircuitBreakerSpecs : IDisposable
         // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. This validates the test ran as expected (and background delegates are complete) before we assert on outcomes.
         permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
         permitFirstExecutionEnd.Set();
-        Task.WaitAll(new[] { firstExecution, secondExecution }, testTimeoutToExposeDeadlocks).Should().BeTrue();
+
+#pragma warning disable xUnit1031 // Do not use blocking task operations in test method
+        Task.WaitAll([firstExecution, secondExecution], testTimeoutToExposeDeadlocks).ShouldBeTrue();
+#pragma warning restore xUnit1031 // Do not use blocking task operations in test method
+
         if (firstExecution.IsFaulted)
         {
             throw firstExecution!.Exception!;
@@ -566,15 +540,18 @@ public class CircuitBreakerSpecs : IDisposable
             throw secondExecution!.Exception!;
         }
 
-        firstExecution.Status.Should().Be(TaskStatus.RanToCompletion);
-        secondExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+        firstExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
+        secondExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
 
         // Assert:
         // - First execution should have been permitted and executed under a HalfOpen state
         // - Second overlapping execution in halfopen state should have been permitted, one breakDuration later.
-        firstDelegateExecutedInHalfOpenState.Should().BeTrue();
-        secondDelegateExecutedInHalfOpenState.Should().BeTrue();
-        secondDelegateRejectedInHalfOpenState.Should().BeFalse();
+        firstDelegateExecutedInHalfOpenState.ShouldNotBeNull();
+        firstDelegateExecutedInHalfOpenState.Value.ShouldBeTrue();
+        secondDelegateExecutedInHalfOpenState.ShouldNotBeNull();
+        secondDelegateExecutedInHalfOpenState.Value.ShouldBeTrue();
+        secondDelegateRejectedInHalfOpenState.ShouldNotBeNull();
+        secondDelegateRejectedInHalfOpenState.Value.ShouldBeFalse();
     }
 
     #endregion
@@ -584,7 +561,7 @@ public class CircuitBreakerSpecs : IDisposable
     [Fact]
     public void Should_open_circuit_and_block_calls_if_manual_override_open()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -592,25 +569,24 @@ public class CircuitBreakerSpecs : IDisposable
         CircuitBreakerPolicy breaker = Policy
             .Handle<DivideByZeroException>()
             .CircuitBreaker(2, durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // manually break circuit
         breaker.Isolate();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
 
         // circuit manually broken: execution should be blocked; even non-exception-throwing executions should not reset circuit
         bool delegateExecutedWhenBroken = false;
-        breaker.Invoking(x => x.Execute(() => delegateExecutedWhenBroken = true))
-            .Should().Throw<IsolatedCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
-        breaker.LastException.Should().BeOfType<IsolatedCircuitException>();
-        delegateExecutedWhenBroken.Should().BeFalse();
+        Should.Throw<IsolatedCircuitException>(() => breaker.Execute(() => delegateExecutedWhenBroken = true));
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
+        breaker.LastException.ShouldBeOfType<IsolatedCircuitException>();
+        delegateExecutedWhenBroken.ShouldBeFalse();
     }
 
     [Fact]
     public void Should_hold_circuit_open_despite_elapsed_time_if_manual_override_open()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -618,23 +594,22 @@ public class CircuitBreakerSpecs : IDisposable
         CircuitBreakerPolicy breaker = Policy
             .Handle<DivideByZeroException>()
             .CircuitBreaker(2, durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.Isolate();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
         bool delegateExecutedWhenBroken = false;
-        breaker.Invoking(x => x.Execute(() => { delegateExecutedWhenBroken = true; return ResultPrimitive.Good; }))
-            .Should().Throw<IsolatedCircuitException>();
-        delegateExecutedWhenBroken.Should().BeFalse();
+        Should.Throw<IsolatedCircuitException>(() => breaker.Execute(() => { delegateExecutedWhenBroken = true; return ResultPrimitive.Good; }));
+        delegateExecutedWhenBroken.ShouldBeFalse();
     }
 
     [Fact]
     public void Should_close_circuit_again_on_reset_after_manual_override()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -642,22 +617,21 @@ public class CircuitBreakerSpecs : IDisposable
         CircuitBreakerPolicy breaker = Policy
             .Handle<DivideByZeroException>()
             .CircuitBreaker(2, durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.Isolate();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().Throw<IsolatedCircuitException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
+        Should.Throw<IsolatedCircuitException>(() => breaker.Execute(() => { }));
 
         breaker.Reset();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        breaker.Invoking(x => x.Execute(() => { })).Should().NotThrow();
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
     }
 
     [Fact]
     public void Should_be_able_to_reset_automatically_opened_circuit_without_specified_duration_passing()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -666,24 +640,21 @@ public class CircuitBreakerSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreaker(2, durationOfBreak);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 2 exception raised, circuit is now open
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<BrokenCircuitException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // reset circuit, with no time having passed
         breaker.Reset();
-        SystemClock.UtcNow().Should().Be(time);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        breaker.Invoking(x => x.Execute(() => { })).Should().NotThrow();
+        SystemClock.UtcNow().ShouldBe(time);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
     }
 
     #endregion
@@ -701,7 +672,7 @@ public class CircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .CircuitBreaker(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
-        onResetCalled.Should().BeFalse();
+        onResetCalled.ShouldBeFalse();
     }
 
     [Fact]
@@ -715,17 +686,15 @@ public class CircuitBreakerSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreaker(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().BeFalse();
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBeFalse();
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().BeTrue();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBeTrue();
     }
 
     [Fact]
@@ -738,11 +707,11 @@ public class CircuitBreakerSpecs : IDisposable
         CircuitBreakerPolicy breaker = Policy
             .Handle<DivideByZeroException>()
             .CircuitBreaker(2, TimeSpan.FromMinutes(1), onBreak, onReset);
-        onBreakCalled.Should().BeFalse();
+        onBreakCalled.ShouldBeFalse();
 
         breaker.Isolate();
 
-        onBreakCalled.Should().BeTrue();
+        onBreakCalled.ShouldBeTrue();
     }
 
     [Fact]
@@ -756,24 +725,21 @@ public class CircuitBreakerSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreaker(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().Be(0);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBe(0);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
 
         // call through circuit when already broken - should not retrigger onBreak
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<BrokenCircuitException>();
+        Should.Throw<BrokenCircuitException>(() => breaker.RaiseException<DivideByZeroException>());
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
     }
 
     [Fact]
@@ -793,9 +759,10 @@ public class CircuitBreakerSpecs : IDisposable
         using ManualResetEvent permitMainThreadToOpenCircuit = new ManualResetEvent(false);
         Task longRunningExecution = Task.Factory.StartNew(() =>
         {
-            breaker.CircuitState.Should().Be(CircuitState.Closed);
+            breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-            breaker.Invoking(x => x.Execute(() =>
+            // However, since execution started when circuit was closed, BrokenCircuitException will not have been thrown on entry; the original exception will still be thrown.
+            Should.Throw<DivideByZeroException>(() => breaker.Execute(() =>
             {
                 permitMainThreadToOpenCircuit.Set();
 
@@ -803,41 +770,43 @@ public class CircuitBreakerSpecs : IDisposable
                 permitLongRunningExecutionToReturnItsFailure.WaitOne(testTimeoutToExposeDeadlocks);
 
                 // Throw a further failure when rest of test has already broken the circuit.
-                breaker.CircuitState.Should().Be(CircuitState.Open);
+                breaker.CircuitState.ShouldBe(CircuitState.Open);
                 throw new DivideByZeroException();
 
-            })).Should().Throw<DivideByZeroException>(); // However, since execution started when circuit was closed, BrokenCircuitException will not have been thrown on entry; the original exception will still be thrown.
+            }));
         }, TaskCreationOptions.LongRunning);
 
-        permitMainThreadToOpenCircuit.WaitOne(testTimeoutToExposeDeadlocks).Should().BeTrue();
+        permitMainThreadToOpenCircuit.WaitOne(testTimeoutToExposeDeadlocks).ShouldBeTrue();
 
         // Break circuit in the normal manner: onBreak() should be called once.
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().Be(0);
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBe(0);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
 
         // Permit the second (long-running) execution to hit the open circuit with its failure.
         permitLongRunningExecutionToReturnItsFailure.Set();
 
+#pragma warning disable xUnit1031 // Do not use blocking task operations in test method
         // Graceful cleanup: allow executions time to end naturally; timeout if any deadlocks; expose any execution faults.  This validates the test ran as expected (and background delegates are complete) before we assert on outcomes.
 #if NET
-        longRunningExecution.Wait(testTimeoutToExposeDeadlocks, CancellationToken.None).Should().BeTrue();
+        longRunningExecution.Wait(testTimeoutToExposeDeadlocks, CancellationToken.None).ShouldBeTrue();
 #else
-        longRunningExecution.Wait(testTimeoutToExposeDeadlocks).Should().BeTrue();
+        longRunningExecution.Wait(testTimeoutToExposeDeadlocks).ShouldBeTrue();
 #endif
+#pragma warning restore xUnit1031 // Do not use blocking task operations in test method
+
         if (longRunningExecution.IsFaulted)
         {
             throw longRunningExecution!.Exception!;
         }
 
-        longRunningExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+        longRunningExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
 
         // onBreak() should still only have been called once.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
     }
 
     [Fact]
@@ -848,7 +817,7 @@ public class CircuitBreakerSpecs : IDisposable
         Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
         Action onReset = () => { onResetCalled++; };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -857,34 +826,31 @@ public class CircuitBreakerSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreaker(2, durationOfBreak, onBreak, onReset);
 
-        onBreakCalled.Should().Be(0);
+        onBreakCalled.ShouldBe(0);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
-        onBreakCalled.Should().Be(0);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        onBreakCalled.ShouldBe(0);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
-        onBreakCalled.Should().Be(1);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        onBreakCalled.ShouldBe(1);
 
         // 2 exception raised, circuit is now open
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        Should.Throw<BrokenCircuitException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // but not yet reset
-        onResetCalled.Should().Be(0);
+        onResetCalled.ShouldBe(0);
 
         // first call after duration is successful, so circuit should reset
         breaker.Execute(() => { });
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onResetCalled.Should().Be(1);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onResetCalled.ShouldBe(1);
     }
 
     [Fact]
@@ -898,15 +864,15 @@ public class CircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .CircuitBreaker(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
-        onResetCalled.Should().BeFalse();
+        onResetCalled.ShouldBeFalse();
 
         breaker.Execute(() => { });
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onResetCalled.Should().BeFalse();
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onResetCalled.ShouldBeFalse();
 
         breaker.Execute(() => { });
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onResetCalled.Should().BeFalse();
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onResetCalled.ShouldBeFalse();
     }
 
     [Fact]
@@ -919,7 +885,7 @@ public class CircuitBreakerSpecs : IDisposable
         Action onReset = () => { onResetCalled++; };
         Action onHalfOpen = () => { onHalfOpenCalled++; };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -928,32 +894,29 @@ public class CircuitBreakerSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreaker(2, durationOfBreak, onBreak, onReset, onHalfOpen);
 
-        onBreakCalled.Should().Be(0);
+        onBreakCalled.ShouldBe(0);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
-        onBreakCalled.Should().Be(0);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        onBreakCalled.ShouldBe(0);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
-        onBreakCalled.Should().Be(1);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        onBreakCalled.ShouldBe(1);
 
         // 2 exception raised, circuit is now open
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        Should.Throw<BrokenCircuitException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        onHalfOpenCalled.Should().Be(0); // not yet transitioned to half-open, because we have not queried state
+        onHalfOpenCalled.ShouldBe(0); // not yet transitioned to half-open, because we have not queried state
 
         // first call after duration is successful, so circuit should reset
         breaker.Execute(() => { });
-        onHalfOpenCalled.Should().Be(1);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onResetCalled.Should().Be(1);
+        onHalfOpenCalled.ShouldBe(1);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onResetCalled.ShouldBe(1);
     }
 
     [Fact]
@@ -966,7 +929,7 @@ public class CircuitBreakerSpecs : IDisposable
         Action onReset = () => { onResetCalled++; };
         Action onHalfOpen = () => { onHalfOpenCalled++; };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -975,28 +938,25 @@ public class CircuitBreakerSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreaker(2, durationOfBreak, onBreak, onReset, onHalfOpen);
 
-        onBreakCalled.Should().Be(0);
+        onBreakCalled.ShouldBe(0);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
-        onBreakCalled.Should().Be(0);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        onBreakCalled.ShouldBe(0);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
-        onBreakCalled.Should().Be(1);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        onBreakCalled.ShouldBe(1);
 
         // 2 exception raised, circuit is now open
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        Should.Throw<BrokenCircuitException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
-        onHalfOpenCalled.Should().Be(1);
-        onResetCalled.Should().Be(0);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
+        onHalfOpenCalled.ShouldBe(1);
+        onResetCalled.ShouldBe(0);
     }
 
     [Fact]
@@ -1007,7 +967,7 @@ public class CircuitBreakerSpecs : IDisposable
         Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
         Action onReset = () => { onResetCalled++; };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1016,20 +976,19 @@ public class CircuitBreakerSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreaker(2, durationOfBreak, onBreak, onReset);
 
-        onBreakCalled.Should().Be(0);
+        onBreakCalled.ShouldBe(0);
         breaker.Isolate();
-        onBreakCalled.Should().Be(1);
+        onBreakCalled.ShouldBe(1);
 
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
-        breaker.Invoking(x => x.Execute(() => { }))
-            .Should().Throw<IsolatedCircuitException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
+        Should.Throw<IsolatedCircuitException>(() => breaker.Execute(() => { }));
 
-        onResetCalled.Should().Be(0);
+        onResetCalled.ShouldBe(0);
         breaker.Reset();
-        onResetCalled.Should().Be(1);
+        onResetCalled.ShouldBe(1);
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        breaker.Invoking(x => x.Execute(() => { })).Should().NotThrow();
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => { }));
     }
 
     #region Tests of supplied parameters to onBreak delegate
@@ -1048,15 +1007,12 @@ public class CircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .CircuitBreaker(2, durationOfBreak, onBreak, onReset);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
-        passedException?.Should().BeOfType<DivideByZeroException>();
+        passedException?.ShouldBeOfType<DivideByZeroException>();
     }
 
     [Fact]
@@ -1072,15 +1028,12 @@ public class CircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .CircuitBreaker(2, TimeSpan.FromMinutes(1), onBreak, onReset, onHalfOpen);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
-        transitionedState?.Should().Be(CircuitState.Closed);
+        transitionedState?.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
@@ -1088,11 +1041,11 @@ public class CircuitBreakerSpecs : IDisposable
     {
         List<CircuitState> transitionedStates = [];
 
-        Action<Exception, CircuitState, TimeSpan, Context> onBreak = (_, state, _, _) => { transitionedStates.Add(state); };
+        Action<Exception, CircuitState, TimeSpan, Context> onBreak = (_, state, _, _) => transitionedStates.Add(state);
         Action<Context> onReset = _ => { };
         Action onHalfOpen = () => { };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1101,33 +1054,28 @@ public class CircuitBreakerSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreaker(2, TimeSpan.FromMinutes(1), onBreak, onReset, onHalfOpen);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 2 exception raised, circuit is now open
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<BrokenCircuitException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // first call after duration raises an exception, so circuit should break again
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<BrokenCircuitException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        Should.Throw<BrokenCircuitException>(() => breaker.RaiseException<DivideByZeroException>());
 
-        transitionedStates[0].Should().Be(CircuitState.Closed);
-        transitionedStates[1].Should().Be(CircuitState.HalfOpen);
+        transitionedStates[0].ShouldBe(CircuitState.Closed);
+        transitionedStates[1].ShouldBe(CircuitState.HalfOpen);
     }
 
     [Fact]
@@ -1148,15 +1096,14 @@ public class CircuitBreakerSpecs : IDisposable
         Exception toRaiseAsInner = new DivideByZeroException();
         Exception withInner = new AggregateException(toRaiseAsInner);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
 
-        breaker.Invoking(x => x.RaiseException(withInner))
-            .Should().Throw<DivideByZeroException>().Which.Should().BeSameAs(toRaiseAsInner);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException(withInner))
+            .ShouldBeSameAs(toRaiseAsInner);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        passedException?.Should().BeSameAs(toRaiseAsInner);
+        passedException?.ShouldBeSameAs(toRaiseAsInner);
     }
 
     [Fact]
@@ -1173,15 +1120,12 @@ public class CircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .CircuitBreaker(2, durationOfBreak, onBreak, onReset);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
-        passedBreakTimespan.Should().Be(durationOfBreak);
+        passedBreakTimespan.ShouldBe(durationOfBreak);
     }
 
     [Fact]
@@ -1191,7 +1135,7 @@ public class CircuitBreakerSpecs : IDisposable
         Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => { passedBreakTimespan = timespan; };
         Action<Context> onReset = _ => { };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1199,13 +1143,13 @@ public class CircuitBreakerSpecs : IDisposable
         CircuitBreakerPolicy breaker = Policy
             .Handle<DivideByZeroException>()
             .CircuitBreaker(2, durationOfBreak, onBreak, onReset);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // manually break circuit
         breaker.Isolate();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
 
-        passedBreakTimespan.Should().Be(TimeSpan.MaxValue);
+        passedBreakTimespan.ShouldBe(TimeSpan.MaxValue);
     }
 
     #endregion
@@ -1224,17 +1168,15 @@ public class CircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .CircuitBreaker(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>(
-            CreateDictionary("key1", "value1", "key2", "value2"))).Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>(CreateDictionary("key1", "value1", "key2", "value2")));
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -1245,7 +1187,7 @@ public class CircuitBreakerSpecs : IDisposable
         Action<Exception, TimeSpan, Context> onBreak = (_, _, _) => { };
         Action<Context> onReset = context => { contextData = context; };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1254,21 +1196,19 @@ public class CircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .CircuitBreaker(2, durationOfBreak, onBreak, onReset);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // first call after duration should invoke onReset, with context
         breaker.Execute(_ => { }, CreateDictionary("key1", "value1", "key2", "value2"));
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -1283,15 +1223,12 @@ public class CircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .CircuitBreaker(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
-        contextData.Should().BeEmpty();
+        contextData.ShouldBeEmpty();
     }
 
     [Fact]
@@ -1306,31 +1243,29 @@ public class CircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .CircuitBreaker(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
 
         // 2 exception raised, circuit is now open
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>(CreateDictionary("key", "original_value")))
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        contextValue.Should().Be("original_value");
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>(CreateDictionary("key", "original_value")));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        contextValue.ShouldBe("original_value");
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // but not yet reset
 
         // first call after duration is successful, so circuit should reset
         breaker.Execute(_ => { }, CreateDictionary("key", "new_value"));
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        contextValue.Should().Be("new_value");
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        contextValue.ShouldBe("new_value");
     }
 
     #endregion
@@ -1346,7 +1281,7 @@ public class CircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
-        breaker.LastException.Should().BeNull();
+        breaker.LastException.ShouldBeNull();
     }
 
     [Fact]
@@ -1356,12 +1291,11 @@ public class CircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.LastException.Should().BeOfType<DivideByZeroException>();
+        breaker.LastException.ShouldBeOfType<DivideByZeroException>();
     }
 
     [Fact]
@@ -1374,12 +1308,12 @@ public class CircuitBreakerSpecs : IDisposable
         Exception toRaiseAsInner = new DivideByZeroException();
         Exception withInner = new AggregateException(toRaiseAsInner);
 
-        breaker.Invoking(x => x.RaiseException(withInner))
-            .Should().Throw<DivideByZeroException>().Which.Should().BeSameAs(toRaiseAsInner);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException(withInner))
+            .ShouldBeSameAs(toRaiseAsInner);
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.LastException.Should().BeSameAs(toRaiseAsInner);
+        breaker.LastException.ShouldBeSameAs(toRaiseAsInner);
     }
 
     [Fact]
@@ -1389,15 +1323,12 @@ public class CircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
-        breaker.LastException.Should().BeOfType<DivideByZeroException>();
+        breaker.LastException.ShouldBeOfType<DivideByZeroException>();
     }
 
     [Fact]
@@ -1407,19 +1338,16 @@ public class CircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-
-        breaker.LastException.Should().BeOfType<DivideByZeroException>();
+        breaker.LastException.ShouldBeOfType<DivideByZeroException>();
 
         breaker.Reset();
 
-        breaker.LastException.Should().BeNull();
+        breaker.LastException.ShouldBeNull();
     }
 
     #endregion
@@ -1438,8 +1366,8 @@ public class CircuitBreakerSpecs : IDisposable
 
         PolicyResult policyResult = breaker.ExecuteAndCapture(() => throw withInner);
 
-        policyResult.ExceptionType.Should().Be(ExceptionType.HandledByThisPolicy);
-        policyResult.FinalException.Should().BeSameAs(toRaiseAsInner);
+        policyResult.ExceptionType.ShouldBe(ExceptionType.HandledByThisPolicy);
+        policyResult.FinalException.ShouldBeSameAs(toRaiseAsInner);
     }
 
     #endregion
@@ -1465,11 +1393,10 @@ public class CircuitBreakerSpecs : IDisposable
 
         using (var cancellationTokenSource = new CancellationTokenSource())
         {
-            breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().NotThrow();
+            Should.NotThrow(() => breaker.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -1494,12 +1421,11 @@ public class CircuitBreakerSpecs : IDisposable
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             cancellationTokenSource.Cancel();
 
-            breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<OperationCanceledException>()
-                .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => breaker.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(0);
+        attemptsInvoked.ShouldBe(0);
     }
 
     [Fact]
@@ -1524,12 +1450,11 @@ public class CircuitBreakerSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<OperationCanceledException>()
-                .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => breaker.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -1554,12 +1479,11 @@ public class CircuitBreakerSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<OperationCanceledException>()
-                .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => breaker.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -1582,11 +1506,10 @@ public class CircuitBreakerSpecs : IDisposable
 
         using (var cancellationTokenSource = new CancellationTokenSource())
         {
-            breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<DivideByZeroException>();
+            Should.Throw<DivideByZeroException>(() => breaker.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -1596,13 +1519,11 @@ public class CircuitBreakerSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .CircuitBreaker(1, TimeSpan.FromMinutes(1));
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseException<DivideByZeroException>());
 
-        breaker.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().Throw<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.")
-            .WithInnerException<DivideByZeroException>();
+        var ex = Should.Throw<BrokenCircuitException>(() => breaker.RaiseException<DivideByZeroException>());
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.InnerException.ShouldBeOfType<DivideByZeroException>();
 
         // Circuit is now broken.
 
@@ -1621,12 +1542,11 @@ public class CircuitBreakerSpecs : IDisposable
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             cancellationTokenSource.Cancel();
 
-            breaker.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<OperationCanceledException>()
-                .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => breaker.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(0);
+        attemptsInvoked.ShouldBe(0);
     }
 
     [Fact]
@@ -1649,16 +1569,15 @@ public class CircuitBreakerSpecs : IDisposable
 
             implicitlyCapturedActionCancellationTokenSource.Cancel();
 
-            breaker.Invoking(x => x.Execute(_ =>
+            Should.Throw<OperationCanceledException>(() => breaker.Execute(_ =>
             {
                 attemptsInvoked++;
                 implicitlyCapturedActionCancellationToken.ThrowIfCancellationRequested();
             }, policyCancellationToken))
-                .Should().Throw<OperationCanceledException>()
-                .And.CancellationToken.Should().Be(implicitlyCapturedActionCancellationToken);
+                .CancellationToken.ShouldBe(implicitlyCapturedActionCancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -1684,13 +1603,13 @@ public class CircuitBreakerSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            breaker.Invoking(x => result = x.RaiseExceptionAndOrCancellation<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true))
-                .Should().NotThrow();
+            Should.NotThrow(() => result = breaker.RaiseExceptionAndOrCancellation<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true));
         }
 
-        result.Should().BeTrue();
+        result.ShouldNotBeNull();
+        result.Value.ShouldBeTrue();
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -1715,13 +1634,13 @@ public class CircuitBreakerSpecs : IDisposable
         using (var cancellationTokenSource = new CancellationTokenSource())
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
-            breaker.Invoking(x => result = x.RaiseExceptionAndOrCancellation<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true))
-                .Should().Throw<OperationCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => result = breaker.RaiseExceptionAndOrCancellation<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        result.Should().Be(null);
+        result.ShouldBeNull();
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     #endregion

--- a/test/Polly.Specs/CircuitBreaker/CircuitBreakerTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/CircuitBreaker/CircuitBreakerTResultAsyncSpecs.cs
@@ -38,10 +38,10 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
 
         var func = () => methodInfo.Invoke(instance, [action, new Context(), CancellationToken.None, false]);
 
-        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("action");
+        var exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>()
+            .ParamName.ShouldBe("action");
     }
 
     [Fact]
@@ -52,7 +52,7 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
                         .CircuitBreakerAsync(1, TimeSpan.MaxValue);
 
         var result = await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault);
-        result.Should().Be(ResultPrimitive.Fault);
+        result.ShouldBe(ResultPrimitive.Fault);
     }
 
     [Fact]
@@ -62,9 +62,8 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
                                  .HandleResult(ResultPrimitive.Fault)
                                  .CircuitBreakerAsync(0, TimeSpan.FromSeconds(10));
 
-        action.Should().Throw<ArgumentOutOfRangeException>()
-              .And.ParamName.Should()
-              .Be("handledEventsAllowedBeforeBreaking");
+        Should.Throw<ArgumentOutOfRangeException>(action)
+              .ParamName.ShouldBe("handledEventsAllowedBeforeBreaking");
     }
 
     [Fact]
@@ -74,9 +73,8 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
                                  .HandleResult(ResultPrimitive.Fault)
                                  .CircuitBreakerAsync(1, -TimeSpan.FromSeconds(1));
 
-        action.Should().Throw<ArgumentOutOfRangeException>()
-            .And.ParamName.Should()
-            .Be("durationOfBreak");
+        Should.Throw<ArgumentOutOfRangeException>(action)
+            .ParamName.ShouldBe("durationOfBreak");
     }
 
     [Fact]
@@ -85,7 +83,7 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
         Action action = () => Policy
                                  .HandleResult(ResultPrimitive.Fault)
                                  .CircuitBreakerAsync(1, TimeSpan.Zero);
-        action.Should().NotThrow();
+        Should.NotThrow(action);
     }
 
     [Fact]
@@ -97,7 +95,7 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
             .HandleResult(ResultPrimitive.Fault)
             .CircuitBreakerAsync(2, durationOfBreak);
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     #endregion
@@ -112,16 +110,16 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
                         .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Good))
-              .Should().Be(ResultPrimitive.Good);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.Good);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
@@ -132,19 +130,18 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
                         .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        await breaker.Awaiting(b => b.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-            .Should().ThrowAsync<BrokenCircuitException<ResultPrimitive>>()
-            .WithMessage("The circuit is now open and is not allowing calls.")
-            .Where(e => e.Result == ResultPrimitive.Fault);
+        var ex = await Should.ThrowAsync<BrokenCircuitException<ResultPrimitive>>(() => breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault));
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.Result.ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
@@ -156,19 +153,18 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
                         .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.FaultAgain))
-              .Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+              .ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 2 exception or fault raised, circuit is now open
-        await breaker.Awaiting(b => b.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-            .Should().ThrowAsync<BrokenCircuitException<ResultPrimitive>>()
-            .WithMessage("The circuit is now open and is not allowing calls.")
-            .Where(e => e.Result == ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        var ex = await Should.ThrowAsync<BrokenCircuitException<ResultPrimitive>>(() => breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault));
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.Result.ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
@@ -179,19 +175,18 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
                         .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
 
         (await breaker.RaiseResultSequenceAsync(new ResultClass(ResultPrimitive.Fault)))
-              .ResultCode.Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ResultCode.ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         (await breaker.RaiseResultSequenceAsync(new ResultClass(ResultPrimitive.Fault)))
-              .ResultCode.Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+              .ResultCode.ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        await breaker.Awaiting(b => b.RaiseResultSequenceAsync(new ResultClass(ResultPrimitive.Good)))
-            .Should().ThrowAsync<BrokenCircuitException<ResultClass>>()
-            .WithMessage("The circuit is now open and is not allowing calls.")
-            .Where(e => e.Result.ResultCode == ResultPrimitive.Fault);
+        var ex = await Should.ThrowAsync<BrokenCircuitException<ResultClass>>(() => breaker.RaiseResultSequenceAsync(new ResultClass(ResultPrimitive.Good)));
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        ex.Result.ResultCode.ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
@@ -202,16 +197,16 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
                         .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.FaultAgain))
-              .Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.FaultAgain))
-              .Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.FaultAgain))
-              .Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
@@ -223,16 +218,16 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
                         .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.FaultAgain))
-            .Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+            .ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.FaultAgain))
-            .Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+            .ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.FaultAgain))
-            .Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+            .ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
@@ -243,16 +238,16 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
                         .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
 
         (await breaker.RaiseResultSequenceAsync(new ResultClass(ResultPrimitive.FaultAgain)))
-            .ResultCode.Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+            .ResultCode.ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         (await breaker.RaiseResultSequenceAsync(new ResultClass(ResultPrimitive.FaultAgain)))
-            .ResultCode.Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+            .ResultCode.ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         (await breaker.RaiseResultSequenceAsync(new ResultClass(ResultPrimitive.FaultAgain)))
-            .ResultCode.Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+            .ResultCode.ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
@@ -264,16 +259,16 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
 
         (await breaker.RaiseResultSequenceAsync(new ResultClass(ResultPrimitive.FaultAgain)))
-            .ResultCode.Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+            .ResultCode.ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         (await breaker.RaiseResultSequenceAsync(new ResultClass(ResultPrimitive.FaultAgain)))
-            .ResultCode.Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+            .ResultCode.ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         (await breaker.RaiseResultSequenceAsync(new ResultClass(ResultPrimitive.FaultAgain)))
-            .ResultCode.Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+            .ResultCode.ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     #endregion
@@ -283,7 +278,7 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
     [Fact]
     public async Task Should_halfopen_circuit_after_the_specified_duration_has_passed()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -293,30 +288,29 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
                         .CircuitBreakerAsync(2, durationOfBreak);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 2 exception or fault raised, circuit is now open
-        await breaker.Awaiting(b => b.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-            .Should().ThrowAsync<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
+              .ShouldBe(ResultPrimitive.Fault);
     }
 
     [Fact]
     public async Task Should_open_circuit_again_after_the_specified_duration_has_passed_if_the_next_call_raises_a_fault()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -326,35 +320,33 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
                         .CircuitBreakerAsync(2, durationOfBreak);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 2 exception or fault raised, circuit is now open
-        await breaker.Awaiting(b => b.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().ThrowAsync<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // first call after duration returns a fault, so circuit should break again
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        await breaker.Awaiting(b => b.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().ThrowAsync<BrokenCircuitException>();
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault));
     }
 
     [Fact]
     public async Task Should_reset_circuit_after_the_specified_duration_has_passed_if_the_next_call_does_not_return_a_fault()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -364,46 +356,44 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
                         .CircuitBreakerAsync(2, durationOfBreak);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 2 exception or fault raised, circuit is now open
-        await breaker.Awaiting(b => b.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().ThrowAsync<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // first call after duration is successful, so circuit should reset
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Good))
-            .Should().Be(ResultPrimitive.Good);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+            .ShouldBe(ResultPrimitive.Good);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // circuit has been reset so should once again allow 2 faults to be raised before breaking
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        await breaker.Awaiting(b => b.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().ThrowAsync<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
     public async Task Should_only_allow_single_execution_on_first_entering_halfopen_state__test_execution_permit_directly()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -412,28 +402,28 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
             .CircuitBreakerAsync(1, durationOfBreak);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
+              .ShouldBe(ResultPrimitive.Fault);
 
         // exception raised, circuit is now open.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // break duration passes, circuit now half open
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution.
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.Throw<BrokenCircuitException>(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
     }
 
     [Fact]
     public async Task Should_allow_single_execution_per_break_duration_in_halfopen_state__test_execution_permit_directly()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -442,36 +432,36 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
             .CircuitBreakerAsync(1, durationOfBreak);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
+              .ShouldBe(ResultPrimitive.Fault);
 
         // exception raised, circuit is now open.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // break duration passes, circuit now half open
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution.
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.Throw<BrokenCircuitException>(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // Allow another time window to pass (breaker should still be HalfOpen).
         SystemClock.UtcNow = () => time.Add(durationOfBreak).Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should now permit another trial execution.
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
     }
 
     [Fact]
     public async Task Should_only_allow_single_execution_on_first_entering_halfopen_state__integration_test()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -480,14 +470,14 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
             .CircuitBreakerAsync(1, durationOfBreak);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
+              .ShouldBe(ResultPrimitive.Fault);
 
         // exception raised, circuit is now open.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // break duration passes, circuit now half open
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // Start one execution during the HalfOpen state, and request a second execution before the first has completed (ie still during the HalfOpen state).
         // The second execution should be rejected due to the halfopen state.
@@ -504,7 +494,7 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
         // First execution in HalfOpen state: we should be able to verify state is HalfOpen as it executes.
         Task firstExecution = Task.Factory.StartNew(async () =>
         {
-            await breaker.Awaiting(x => x.ExecuteAsync(async () =>
+            await Should.NotThrowAsync(() => breaker.ExecuteAsync(async () =>
             {
                 firstDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
 
@@ -513,22 +503,22 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
                 permitSecondExecutionAttempt.Set();
 
                 // Hold first execution open until second indicates it is no longer needed, or time out.
-                permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks).Should().BeTrue();
+                permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks).ShouldBeTrue();
                 await TaskHelper.EmptyTask;
                 firstExecutionActive = false;
 
                 return ResultPrimitive.Good;
-            })).Should().NotThrowAsync();
+            }));
         }, TaskCreationOptions.LongRunning);
 
         // Attempt a second execution, signalled by the first execution to ensure they overlap: we should be able to verify it doesn't execute, and is rejected by a breaker in a HalfOpen state.
-        permitSecondExecutionAttempt.WaitOne(testTimeoutToExposeDeadlocks).Should().BeTrue();
+        permitSecondExecutionAttempt.WaitOne(testTimeoutToExposeDeadlocks).ShouldBeTrue();
 
         Task secondExecution = Task.Factory.StartNew(async () =>
         {
             // Validation of correct sequencing and overlapping of tasks in test (guard against erroneous test refactorings/operation).
-            firstExecutionActive.Should().BeTrue();
-            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+            firstExecutionActive.ShouldBeTrue();
+            breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
             try
             {
@@ -557,7 +547,7 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
         permitFirstExecutionEnd.Set();
 
 #pragma warning disable xUnit1031
-        Task.WaitAll([firstExecution, secondExecution], testTimeoutToExposeDeadlocks).Should().BeTrue();
+        Task.WaitAll([firstExecution, secondExecution], testTimeoutToExposeDeadlocks).ShouldBeTrue();
 #pragma warning restore xUnit1031
 
         if (firstExecution.IsFaulted)
@@ -570,22 +560,25 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
             throw secondExecution!.Exception!;
         }
 
-        firstExecution.Status.Should().Be(TaskStatus.RanToCompletion);
-        secondExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+        firstExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
+        secondExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
 
         // Assert:
         // - First execution should have been permitted and executed under a HalfOpen state
         // - Second overlapping execution in halfopen state should not have been permitted.
         // - Second execution attempt should have been rejected with HalfOpen state as cause.
-        firstDelegateExecutedInHalfOpenState.Should().BeTrue();
-        secondDelegateExecutedInHalfOpenState.Should().BeFalse();
-        secondDelegateRejectedInHalfOpenState.Should().BeTrue();
+        firstDelegateExecutedInHalfOpenState.ShouldNotBeNull();
+        firstDelegateExecutedInHalfOpenState.Value.ShouldBeTrue();
+        secondDelegateExecutedInHalfOpenState.ShouldNotBeNull();
+        secondDelegateExecutedInHalfOpenState.Value.ShouldBeFalse();
+        secondDelegateRejectedInHalfOpenState.ShouldNotBeNull();
+        secondDelegateRejectedInHalfOpenState.Value.ShouldBeTrue();
     }
 
     [Fact]
     public async Task Should_allow_single_execution_per_break_duration_in_halfopen_state__integration_test()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -594,14 +587,14 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
             .CircuitBreakerAsync(1, durationOfBreak);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
+              .ShouldBe(ResultPrimitive.Fault);
 
         // exception raised, circuit is now open.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // break duration passes, circuit now half open
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // Start one execution during the HalfOpen state.
         // Request a second execution while the first is still in flight (not completed), while still during the HalfOpen state, but after one breakDuration later.
@@ -619,7 +612,7 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
         // First execution in HalfOpen state: we should be able to verify state is HalfOpen as it executes.
         Task firstExecution = Task.Factory.StartNew(async () =>
         {
-            await breaker.Awaiting(x => x.ExecuteAsync(async () =>
+            await Should.NotThrowAsync(() => breaker.ExecuteAsync(async () =>
             {
                 firstDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
 
@@ -633,7 +626,7 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
                 firstExecutionActive = false;
 
                 return ResultPrimitive.Good;
-            })).Should().NotThrowAsync();
+            }));
         }, TaskCreationOptions.LongRunning);
 
         // Attempt a second execution, signalled by the first execution to ensure they overlap; start it one breakDuration later.  We should be able to verify it does execute, though the breaker is still in a HalfOpen state.
@@ -642,8 +635,8 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
         Task secondExecution = Task.Factory.StartNew(async () =>
         {
             // Validation of correct sequencing and overlapping of tasks in test (guard against erroneous test refactorings/operation).
-            firstExecutionActive.Should().BeTrue();
-            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+            firstExecutionActive.ShouldBeTrue();
+            breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
             try
             {
@@ -674,7 +667,7 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
         permitFirstExecutionEnd.Set();
 
 #pragma warning disable xUnit1031
-        Task.WaitAll([firstExecution, secondExecution], testTimeoutToExposeDeadlocks).Should().BeTrue();
+        Task.WaitAll([firstExecution, secondExecution], testTimeoutToExposeDeadlocks).ShouldBeTrue();
 #pragma warning restore xUnit1031
 
         if (firstExecution.IsFaulted)
@@ -687,15 +680,18 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
             throw secondExecution!.Exception!;
         }
 
-        firstExecution.Status.Should().Be(TaskStatus.RanToCompletion);
-        secondExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+        firstExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
+        secondExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
 
         // Assert:
         // - First execution should have been permitted and executed under a HalfOpen state
         // - Second overlapping execution in halfopen state should have been permitted, one breakDuration later.
-        firstDelegateExecutedInHalfOpenState.Should().BeTrue();
-        secondDelegateExecutedInHalfOpenState.Should().BeTrue();
-        secondDelegateRejectedInHalfOpenState.Should().BeFalse();
+        firstDelegateExecutedInHalfOpenState.ShouldNotBeNull();
+        firstDelegateExecutedInHalfOpenState.Value.ShouldBeTrue();
+        secondDelegateExecutedInHalfOpenState.ShouldNotBeNull();
+        secondDelegateExecutedInHalfOpenState.Value.ShouldBeTrue();
+        secondDelegateRejectedInHalfOpenState.ShouldNotBeNull();
+        secondDelegateRejectedInHalfOpenState.Value.ShouldBeFalse();
     }
 
     #endregion
@@ -705,7 +701,7 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
     [Fact]
     public async Task Should_open_circuit_and_block_calls_if_manual_override_open()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -713,26 +709,25 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
         var breaker = Policy
             .HandleResult(ResultPrimitive.Fault)
             .CircuitBreakerAsync(2, durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // manually break circuit
         breaker.Isolate();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
 
         // circuit manually broken: execution should be blocked; even non-fault-returning executions should not reset circuit
         bool delegateExecutedWhenBroken = false;
-        await breaker.Awaiting(b => b.ExecuteAsync(() => { delegateExecutedWhenBroken = true; return Task.FromResult(ResultPrimitive.Good); }))
-            .Should().ThrowAsync<IsolatedCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
-        breaker.LastException.Should().BeOfType<IsolatedCircuitException>();
-        delegateExecutedWhenBroken.Should().BeFalse();
+        await Should.ThrowAsync<IsolatedCircuitException>(() => breaker.ExecuteAsync(() => { delegateExecutedWhenBroken = true; return Task.FromResult(ResultPrimitive.Good); }));
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
+        breaker.LastException.ShouldBeOfType<IsolatedCircuitException>();
+        delegateExecutedWhenBroken.ShouldBeFalse();
 
     }
 
     [Fact]
     public async Task Should_hold_circuit_open_despite_elapsed_time_if_manual_override_open()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -740,24 +735,23 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
         var breaker = Policy
             .HandleResult(ResultPrimitive.Fault)
             .CircuitBreakerAsync(2, durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.Isolate();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
 
         bool delegateExecutedWhenBroken = false;
-        await breaker.Awaiting(x => x.ExecuteAsync(() => { delegateExecutedWhenBroken = true; return Task.FromResult(ResultPrimitive.Good); }))
-            .Should().ThrowAsync<IsolatedCircuitException>();
-        delegateExecutedWhenBroken.Should().BeFalse();
+        await Should.ThrowAsync<IsolatedCircuitException>(() => breaker.ExecuteAsync(() => { delegateExecutedWhenBroken = true; return Task.FromResult(ResultPrimitive.Good); }));
+        delegateExecutedWhenBroken.ShouldBeFalse();
     }
 
     [Fact]
     public async Task Should_close_circuit_again_on_reset_after_manual_override()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -765,22 +759,21 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
         var breaker = Policy
             .HandleResult(ResultPrimitive.Fault)
             .CircuitBreakerAsync(2, durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.Isolate();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
-        await breaker.Awaiting(x => x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)))
-            .Should().ThrowAsync<IsolatedCircuitException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
+        await Should.ThrowAsync<IsolatedCircuitException>(() => breaker.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)));
 
         breaker.Reset();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        await breaker.Awaiting(x => x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good))).Should().NotThrowAsync();
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)));
     }
 
     [Fact]
     public async Task Should_be_able_to_reset_automatically_opened_circuit_without_specified_duration_passing()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -790,23 +783,22 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
                         .CircuitBreakerAsync(2, durationOfBreak);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 2 exception or fault raised, circuit is now open
-        await breaker.Awaiting(x => x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)))
-              .Should().ThrowAsync<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<BrokenCircuitException>(() => breaker.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // reset circuit, with no time having passed
         breaker.Reset();
-        SystemClock.UtcNow().Should().Be(time);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        await breaker.Awaiting(x => x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good))).Should().NotThrowAsync();
+        SystemClock.UtcNow().ShouldBe(time);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)));
     }
 
     #endregion
@@ -818,20 +810,20 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
     {
         Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => { };
         bool onResetCalled = false;
-        Action onReset = () => { onResetCalled = true; };
+        Action onReset = () => onResetCalled = true;
 
         Policy
             .HandleResult(ResultPrimitive.Fault)
             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
-        onResetCalled.Should().BeFalse();
+        onResetCalled.ShouldBeFalse();
     }
 
     [Fact]
     public async Task Should_call_onbreak_when_breaking_circuit_automatically()
     {
         bool onBreakCalled = false;
-        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => { onBreakCalled = true; };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => onBreakCalled = true;
         Action onReset = () => { };
 
         var breaker = Policy
@@ -839,40 +831,40 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
                         .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
+              .ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().BeFalse();
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBeFalse();
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
+              .ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().BeTrue();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBeTrue();
     }
 
     [Fact]
     public void Should_call_onbreak_when_breaking_circuit_manually()
     {
         bool onBreakCalled = false;
-        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => { onBreakCalled = true; };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => onBreakCalled = true;
         Action onReset = () => { };
 
         var breaker = Policy
             .HandleResult(ResultPrimitive.Fault)
             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset);
-        onBreakCalled.Should().BeFalse();
+        onBreakCalled.ShouldBeFalse();
 
         breaker.Isolate();
 
-        onBreakCalled.Should().BeTrue();
+        onBreakCalled.ShouldBeTrue();
     }
 
     [Fact]
     public async Task Should_call_onbreak_when_breaking_circuit_first_time_but_not_for_subsequent_calls_placed_through_open_circuit()
     {
         int onBreakCalled = 0;
-        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => onBreakCalled++;
         Action onReset = () => { };
 
         var breaker = Policy
@@ -880,30 +872,29 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
                         .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
+              .ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().Be(0);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBe(0);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
+              .ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
 
         // call through circuit when already broken - should not retrigger onBreak
-        await breaker.Awaiting(x => x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)))
-                     .Should().ThrowAsync<BrokenCircuitException>();
+        await Should.ThrowAsync<BrokenCircuitException>(() => breaker.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)));
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
     }
 
     [Fact]
     public async Task Should_call_onbreak_when_breaking_circuit_first_time_but_not_for_subsequent_call_failure_which_arrives_on_open_state_though_started_on_closed_state()
     {
         int onBreakCalled = 0;
-        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => onBreakCalled++;
         Action onReset = () => { };
 
         var breaker = Policy
@@ -916,7 +907,7 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
         using ManualResetEvent permitMainThreadToOpenCircuit = new ManualResetEvent(false);
         Task longRunningExecution = Task.Factory.StartNew(async () =>
         {
-            breaker.CircuitState.Should().Be(CircuitState.Closed);
+            breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
             (await breaker.ExecuteAsync(async () =>
             {
@@ -928,21 +919,21 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
                 permitLongRunningExecutionToReturnItsFailure.WaitOne(testTimeoutToExposeDeadlocks);
 
                 // Throw a further failure when rest of test has already broken the circuit.
-                breaker.CircuitState.Should().Be(CircuitState.Open);
+                breaker.CircuitState.ShouldBe(CircuitState.Open);
                 return ResultPrimitive.Fault;
 
-            })).Should().Be(ResultPrimitive.Fault); // However, since execution started when circuit was closed, BrokenCircuitException will not have been thrown on entry; the original fault should still be returned.
+            })).ShouldBe(ResultPrimitive.Fault); // However, since execution started when circuit was closed, BrokenCircuitException will not have been thrown on entry; the original fault should still be returned.
         }, TaskCreationOptions.LongRunning);
 
-        permitMainThreadToOpenCircuit.WaitOne(testTimeoutToExposeDeadlocks).Should().BeTrue();
+        permitMainThreadToOpenCircuit.WaitOne(testTimeoutToExposeDeadlocks).ShouldBeTrue();
 
         // Break circuit in the normal manner: onBreak() should be called once.
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().Be(0);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBe(0);
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
 
         // Permit the second (long-running) execution to hit the open circuit with its failure.
         permitLongRunningExecutionToReturnItsFailure.Set();
@@ -950,9 +941,9 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
 #pragma warning disable xUnit1031
         // Graceful cleanup: allow executions time to end naturally; timeout if any deadlocks; expose any execution faults.  This validates the test ran as expected (and background delegates are complete) before we assert on outcomes.
 #if NET
-        longRunningExecution.Wait(testTimeoutToExposeDeadlocks, CancellationToken.None).Should().BeTrue();
+        longRunningExecution.Wait(testTimeoutToExposeDeadlocks, CancellationToken.None).ShouldBeTrue();
 #else
-        longRunningExecution.Wait(testTimeoutToExposeDeadlocks).Should().BeTrue();
+        longRunningExecution.Wait(testTimeoutToExposeDeadlocks).ShouldBeTrue();
 #endif
 #pragma warning restore xUnit1031
 
@@ -961,11 +952,11 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
             throw longRunningExecution!.Exception!;
         }
 
-        longRunningExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+        longRunningExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
 
         // onBreak() should still only have been called once.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
     }
 
     [Fact]
@@ -973,10 +964,10 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
     {
         int onBreakCalled = 0;
         int onResetCalled = 0;
-        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
-        Action onReset = () => { onResetCalled++; };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => onBreakCalled++;
+        Action onReset = () => onResetCalled++;
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -985,34 +976,33 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
                         .HandleResult(ResultPrimitive.Fault)
                         .CircuitBreakerAsync(2, durationOfBreak, onBreak, onReset);
 
-        onBreakCalled.Should().Be(0);
+        onBreakCalled.ShouldBe(0);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
-        onBreakCalled.Should().Be(0);
+              .ShouldBe(ResultPrimitive.Fault);
+        onBreakCalled.ShouldBe(0);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
-        onBreakCalled.Should().Be(1);
+              .ShouldBe(ResultPrimitive.Fault);
+        onBreakCalled.ShouldBe(1);
 
         // 2 exception or fault raised, circuit is now open
-        await breaker.Awaiting(x => x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)))
-              .Should().ThrowAsync<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        await Should.ThrowAsync<BrokenCircuitException>(() => breaker.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // but not yet reset
-        onResetCalled.Should().Be(0);
+        onResetCalled.ShouldBe(0);
 
         // first call after duration is successful, so circuit should reset
-        await breaker.Awaiting(x => x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good))).Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onResetCalled.Should().Be(1);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onResetCalled.ShouldBe(1);
     }
 
     [Fact]
@@ -1026,15 +1016,15 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
             .HandleResult(ResultPrimitive.Fault)
             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
-        onResetCalled.Should().BeFalse();
+        onResetCalled.ShouldBeFalse();
 
-        await breaker.Awaiting(x => x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good))).Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onResetCalled.Should().BeFalse();
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onResetCalled.ShouldBeFalse();
 
-        await breaker.Awaiting(x => x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good))).Should().NotThrowAsync();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onResetCalled.Should().BeFalse();
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onResetCalled.ShouldBeFalse();
     }
 
     [Fact]
@@ -1043,11 +1033,11 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
         int onBreakCalled = 0;
         int onResetCalled = 0;
         int onHalfOpenCalled = 0;
-        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
-        Action onReset = () => { onResetCalled++; };
-        Action onHalfOpen = () => { onHalfOpenCalled++; };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => onBreakCalled++;
+        Action onReset = () => onResetCalled++;
+        Action onHalfOpen = () => onHalfOpenCalled++;
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1056,33 +1046,31 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
                         .HandleResult(ResultPrimitive.Fault)
                         .CircuitBreakerAsync(2, durationOfBreak, onBreak, onReset, onHalfOpen);
 
-        onBreakCalled.Should().Be(0);
+        onBreakCalled.ShouldBe(0);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
-        onBreakCalled.Should().Be(0);
+              .ShouldBe(ResultPrimitive.Fault);
+        onBreakCalled.ShouldBe(0);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
-        onBreakCalled.Should().Be(1);
+              .ShouldBe(ResultPrimitive.Fault);
+        onBreakCalled.ShouldBe(1);
 
         // 2 exception or fault raised, circuit is now open
-        await breaker.Awaiting(x => x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)))
-                     .Should().ThrowAsync<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        await Should.ThrowAsync<BrokenCircuitException>(() => breaker.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        onHalfOpenCalled.Should().Be(0); // not yet transitioned to half-open, because we have not queried state
+        onHalfOpenCalled.ShouldBe(0); // not yet transitioned to half-open, because we have not queried state
 
         // first call after duration is successful, so circuit should reset
-        await breaker.Awaiting(x => x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)))
-                     .Should().NotThrowAsync();
-        onHalfOpenCalled.Should().Be(1);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onResetCalled.Should().Be(1);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)));
+        onHalfOpenCalled.ShouldBe(1);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onResetCalled.ShouldBe(1);
     }
 
     [Fact]
@@ -1091,11 +1079,11 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
         int onBreakCalled = 0;
         int onResetCalled = 0;
         int onHalfOpenCalled = 0;
-        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
-        Action onReset = () => { onResetCalled++; };
-        Action onHalfOpen = () => { onHalfOpenCalled++; };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => onBreakCalled++;
+        Action onReset = () => onResetCalled++;
+        Action onHalfOpen = () => onHalfOpenCalled++;
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1104,28 +1092,27 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
                         .HandleResult(ResultPrimitive.Fault)
                         .CircuitBreakerAsync(2, durationOfBreak, onBreak, onReset, onHalfOpen);
 
-        onBreakCalled.Should().Be(0);
+        onBreakCalled.ShouldBe(0);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
-        onBreakCalled.Should().Be(0);
+              .ShouldBe(ResultPrimitive.Fault);
+        onBreakCalled.ShouldBe(0);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
-        onBreakCalled.Should().Be(1);
+              .ShouldBe(ResultPrimitive.Fault);
+        onBreakCalled.ShouldBe(1);
 
         // 2 exception or fault raised, circuit is now open
-        await breaker.Awaiting(x => x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)))
-                     .Should().ThrowAsync<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        await Should.ThrowAsync<BrokenCircuitException>(() => breaker.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
-        onHalfOpenCalled.Should().Be(1);
-        onResetCalled.Should().Be(0);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
+        onHalfOpenCalled.ShouldBe(1);
+        onResetCalled.ShouldBe(0);
     }
 
     [Fact]
@@ -1133,10 +1120,10 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
     {
         int onBreakCalled = 0;
         int onResetCalled = 0;
-        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
-        Action onReset = () => { onResetCalled++; };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => onBreakCalled++;
+        Action onReset = () => onResetCalled++;
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1145,21 +1132,19 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
                         .HandleResult(ResultPrimitive.Fault)
                         .CircuitBreakerAsync(2, durationOfBreak, onBreak, onReset);
 
-        onBreakCalled.Should().Be(0);
+        onBreakCalled.ShouldBe(0);
         breaker.Isolate();
-        onBreakCalled.Should().Be(1);
+        onBreakCalled.ShouldBe(1);
 
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
-        await breaker.Awaiting(x => x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)))
-            .Should().ThrowAsync<IsolatedCircuitException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
+        await Should.ThrowAsync<IsolatedCircuitException>(() => breaker.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)));
 
-        onResetCalled.Should().Be(0);
+        onResetCalled.ShouldBe(0);
         breaker.Reset();
-        onResetCalled.Should().Be(1);
+        onResetCalled.ShouldBe(1);
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        await breaker.Awaiting(x => x.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)))
-            .Should().NotThrowAsync();
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        await Should.NotThrowAsync(() => breaker.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good)));
     }
 
     #region Tests of supplied parameters to onBreak delegate
@@ -1169,7 +1154,7 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
     {
         ResultPrimitive? handledResult = null;
 
-        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (outcome, _, _) => { handledResult = outcome.Result; };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (outcome, _, _) => handledResult = outcome.Result;
         Action<Context> onReset = _ => { };
 
         TimeSpan durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1179,14 +1164,14 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
             .CircuitBreakerAsync(2, durationOfBreak, onBreak, onReset);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        handledResult?.Should().Be(ResultPrimitive.Fault);
+        handledResult?.ShouldBe(ResultPrimitive.Fault);
     }
 
     [Fact]
@@ -1194,7 +1179,7 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
     {
         TimeSpan? passedBreakTimespan = null;
 
-        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (_, timespan, _) => { passedBreakTimespan = timespan; };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (_, timespan, _) => passedBreakTimespan = timespan;
         Action<Context> onReset = _ => { };
 
         TimeSpan durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1204,24 +1189,24 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
             .CircuitBreakerAsync(2, durationOfBreak, onBreak, onReset);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        passedBreakTimespan.Should().Be(durationOfBreak);
+        passedBreakTimespan.ShouldBe(durationOfBreak);
     }
 
     [Fact]
     public void Should_open_circuit_with_timespan_maxvalue_if_manual_override_open()
     {
         TimeSpan? passedBreakTimespan = null;
-        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (_, timespan, _) => { passedBreakTimespan = timespan; };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (_, timespan, _) => passedBreakTimespan = timespan;
         Action<Context> onReset = _ => { };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1229,13 +1214,13 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
         var breaker = Policy
             .HandleResult(ResultPrimitive.Fault)
             .CircuitBreakerAsync(2, durationOfBreak, onBreak, onReset);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // manually break circuit
         breaker.Isolate();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
 
-        passedBreakTimespan.Should().Be(TimeSpan.MaxValue);
+        passedBreakTimespan.ShouldBe(TimeSpan.MaxValue);
     }
 
     #endregion
@@ -1247,7 +1232,7 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
     {
         IDictionary<string, object>? contextData = null;
 
-        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (_, _, context) => { contextData = context; };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (_, _, context) => contextData = context;
         Action<Context> onReset = _ => { };
 
         var breaker = Policy
@@ -1255,17 +1240,17 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
         (await breaker.RaiseResultSequenceAsync(CreateDictionary("key1", "value1", "key2", "value2"),
             ResultPrimitive.Fault))
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -1274,9 +1259,9 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
         IDictionary<string, object>? contextData = null;
 
         Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (_, _, _) => { };
-        Action<Context> onReset = context => { contextData = context; };
+        Action<Context> onReset = context => contextData = context;
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1286,20 +1271,20 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
             .CircuitBreakerAsync(2, durationOfBreak, onBreak, onReset);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-            .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+            .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // first call after duration should invoke onReset, with context
         await breaker.ExecuteAsync(_ => Task.FromResult(ResultPrimitive.Good), CreateDictionary("key1", "value1", "key2", "value2"));
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -1307,7 +1292,7 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
     {
         IDictionary<string, object> contextData = CreateDictionary("key1", "value1", "key2", "value2");
 
-        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (_, _, context) => { contextData = context; };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (_, _, context) => contextData = context;
         Action<Context> onReset = _ => { };
 
         var breaker = Policy
@@ -1315,14 +1300,14 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        contextData.Should().BeEmpty();
+        contextData.ShouldBeEmpty();
     }
 
     [Fact]
@@ -1337,31 +1322,31 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
             .HandleResult(ResultPrimitive.Fault)
             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
         // 2 exception or fault raised, circuit is now open
         (await breaker.RaiseResultSequenceAsync(CreateDictionary("key", "original_value"), ResultPrimitive.Fault))
-            .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        contextValue.Should().Be("original_value");
+            .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        contextValue.ShouldBe("original_value");
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // but not yet reset
 
         // first call after duration is successful, so circuit should reset
         await breaker.ExecuteAsync(_ => Task.FromResult(ResultPrimitive.Good), CreateDictionary("key", "new_value"));
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        contextValue.Should().Be("new_value");
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        contextValue.ShouldBe("new_value");
     }
 
     #endregion
@@ -1377,8 +1362,8 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
             .HandleResult(ResultPrimitive.Fault)
             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
 
-        breaker.LastHandledResult.Should().Be(default);
-        breaker.LastException.Should().BeNull();
+        breaker.LastHandledResult.ShouldBe(default);
+        breaker.LastException.ShouldBeNull();
     }
 
     [Fact]
@@ -1389,12 +1374,12 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.LastHandledResult.Should().Be(ResultPrimitive.Fault);
-        breaker.LastException.Should().BeNull();
+        breaker.LastHandledResult.ShouldBe(ResultPrimitive.Fault);
+        breaker.LastException.ShouldBeNull();
     }
 
     [Fact]
@@ -1405,15 +1390,15 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.LastHandledResult.Should().Be(ResultPrimitive.Fault);
-        breaker.LastException.Should().BeNull();
+        breaker.LastHandledResult.ShouldBe(ResultPrimitive.Fault);
+        breaker.LastException.ShouldBeNull();
     }
 
     [Fact]
@@ -1424,20 +1409,20 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
             .CircuitBreakerAsync(2, TimeSpan.FromMinutes(1));
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.LastHandledResult.Should().Be(ResultPrimitive.Fault);
-        breaker.LastException.Should().BeNull();
+        breaker.LastHandledResult.ShouldBe(ResultPrimitive.Fault);
+        breaker.LastException.ShouldBeNull();
 
         breaker.Reset();
 
-        breaker.LastHandledResult.Should().Be(default);
-        breaker.LastException.Should().BeNull();
+        breaker.LastHandledResult.ShouldBe(default);
+        breaker.LastException.ShouldBeNull();
     }
 
     #endregion
@@ -1465,10 +1450,10 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             (await breaker.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute,
                 ResultPrimitive.Good))
-                .Should().Be(ResultPrimitive.Good);
+                .ShouldBe(ResultPrimitive.Good);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -1492,15 +1477,18 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             cancellationTokenSource.Cancel();
 
-            var ex = await breaker.Awaiting(x => x.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Good))
-            .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(
+                () => breaker.RaiseResultSequenceAndOrCancellationAsync(
+                    scenario,
+                    cancellationTokenSource,
+                    onExecute,
+                    ResultPrimitive.Fault,
+                    ResultPrimitive.Fault,
+                    ResultPrimitive.Good));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(0);
+        attemptsInvoked.ShouldBe(0);
     }
 
     [Fact]
@@ -1524,14 +1512,17 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await breaker.Awaiting(x => x.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute,
-                   ResultPrimitive.Good,
-                   ResultPrimitive.Good))
-                .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(
+                () => breaker.RaiseResultSequenceAndOrCancellationAsync(
+                    scenario,
+                    cancellationTokenSource,
+                    onExecute,
+                    ResultPrimitive.Good,
+                    ResultPrimitive.Good));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -1555,14 +1546,17 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await breaker.Awaiting(x => x.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute,
-                   ResultPrimitive.Fault,
-                   ResultPrimitive.Good))
-                .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(
+                () => breaker.RaiseResultSequenceAndOrCancellationAsync(
+                    scenario,
+                    cancellationTokenSource,
+                    onExecute,
+                    ResultPrimitive.Fault,
+                    ResultPrimitive.Good));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -1587,10 +1581,10 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
             (await breaker.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute, ResultPrimitive.Fault))
-                            .Should().Be(ResultPrimitive.Fault);
+                            .ShouldBe(ResultPrimitive.Fault);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -1601,11 +1595,10 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
             .CircuitBreakerAsync(1, TimeSpan.FromMinutes(1));
 
         (await breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
-        var ex = await breaker.Awaiting(x => x.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-            .Should().ThrowAsync<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.");
+        var ex = await Should.ThrowAsync<BrokenCircuitException>(() => breaker.RaiseResultSequenceAsync(ResultPrimitive.Fault));
+        ex.Message.ShouldBe("The circuit is now open and is not allowing calls.");
 
         // Circuit is now broken.
 
@@ -1623,14 +1616,13 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             cancellationTokenSource.Cancel();
 
-            var ex2 = await breaker.Awaiting(x => x.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute,
+            var ex2 = await Should.ThrowAsync<OperationCanceledException>(() => breaker.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute,
                    ResultPrimitive.Fault,
-                   ResultPrimitive.Good))
-                .Should().ThrowAsync<OperationCanceledException>();
-            ex2.And.CancellationToken.Should().Be(cancellationToken);
+                   ResultPrimitive.Good));
+            ex2.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(0);
+        attemptsInvoked.ShouldBe(0);
     }
 
     [Fact]
@@ -1653,18 +1645,17 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
 
             implicitlyCapturedActionCancellationTokenSource.Cancel();
 
-            var ex = await breaker.Awaiting(x => x.ExecuteAsync(async _ =>
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => breaker.ExecuteAsync(async _ =>
             {
                 attemptsInvoked++;
                 await TaskHelper.EmptyTask;
                 implicitlyCapturedActionCancellationToken.ThrowIfCancellationRequested();
                 return ResultPrimitive.Good;
-            }, policyCancellationToken))
-                .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(implicitlyCapturedActionCancellationToken);
+            }, policyCancellationToken));
+            ex.CancellationToken.ShouldBe(implicitlyCapturedActionCancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     #endregion

--- a/test/Polly.Specs/CircuitBreaker/CircuitBreakerTResultMixedResultExceptionSpecs.cs
+++ b/test/Polly.Specs/CircuitBreaker/CircuitBreakerTResultMixedResultExceptionSpecs.cs
@@ -12,20 +12,17 @@ public class CircuitBreakerTResultMixedResultExceptionSpecs : IDisposable
                         .Handle<DivideByZeroException>()
                         .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
-        breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseResultAndOrExceptionSequence(new DivideByZeroException()));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseResultAndOrExceptionSequence(new DivideByZeroException()));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Good))
-            .Should().Throw<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.")
-            .WithInnerException<DivideByZeroException>();
+        var exception = Should.Throw<BrokenCircuitException>(() => breaker.RaiseResultSequence(ResultPrimitive.Good));
+        exception.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        exception.InnerException.ShouldBeOfType<DivideByZeroException>();
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
@@ -37,20 +34,18 @@ public class CircuitBreakerTResultMixedResultExceptionSpecs : IDisposable
                         .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseResultAndOrExceptionSequence(new DivideByZeroException()));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 2 exception raised, circuit is now open
-        breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Good))
-            .Should().Throw<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.")
-            .WithInnerException<DivideByZeroException>();
+        var exception = Should.Throw<BrokenCircuitException>(() => breaker.RaiseResultSequence(ResultPrimitive.Good));
+        exception.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        exception.InnerException.ShouldBeOfType<DivideByZeroException>();
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
@@ -61,21 +56,19 @@ public class CircuitBreakerTResultMixedResultExceptionSpecs : IDisposable
                         .Or<DivideByZeroException>()
                         .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
-        breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseResultAndOrExceptionSequence(new DivideByZeroException()));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 2 exception raised, circuit is now open
-        breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Good))
-            .Should().Throw<BrokenCircuitException<ResultPrimitive>>()
-            .WithMessage("The circuit is now open and is not allowing calls.")
-            .Where(e => e.Result == ResultPrimitive.Fault);
+        var exception = Should.Throw<BrokenCircuitException<ResultPrimitive>>(() => breaker.RaiseResultSequence(ResultPrimitive.Good));
+        exception.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        exception.Result.ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
@@ -87,20 +80,18 @@ public class CircuitBreakerTResultMixedResultExceptionSpecs : IDisposable
             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseResultAndOrExceptionSequence(new DivideByZeroException()));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 2 exception raised, circuit is now open
-        breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Good))
-            .Should().Throw<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.")
-            .WithInnerException<DivideByZeroException>();
+        var exception = Should.Throw<BrokenCircuitException>(() => breaker.RaiseResultSequence(ResultPrimitive.Good));
+        exception.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        exception.InnerException.ShouldBeOfType<DivideByZeroException>();
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
@@ -111,21 +102,19 @@ public class CircuitBreakerTResultMixedResultExceptionSpecs : IDisposable
             .OrResult(ResultPrimitive.Fault)
             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
-        breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseResultAndOrExceptionSequence(new DivideByZeroException()));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 2 exception raised, circuit is now open
-        breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Good))
-            .Should().Throw<BrokenCircuitException<ResultPrimitive>>()
-            .WithMessage("The circuit is now open and is not allowing calls.")
-            .Where(e => e.Result == ResultPrimitive.Fault);
+        var exception = Should.Throw<BrokenCircuitException<ResultPrimitive>>(() => breaker.RaiseResultSequence(ResultPrimitive.Good));
+        exception.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        exception.Result.ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
@@ -136,21 +125,19 @@ public class CircuitBreakerTResultMixedResultExceptionSpecs : IDisposable
             .OrResult<ResultClass>(r => r.ResultCode == ResultPrimitive.Fault)
             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
-        breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new ArgumentException("message", "key")))
-            .Should().Throw<ArgumentException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<ArgumentException>(() => breaker.RaiseResultAndOrExceptionSequence(new ArgumentException("message", "key")));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.RaiseResultSequence(new ResultClass(ResultPrimitive.Fault))
-              .ResultCode.Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+              .ResultCode.ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 2 exception raised, circuit is now open
-        breaker.Invoking(b => b.RaiseResultSequence(new ResultClass(ResultPrimitive.Good)))
-            .Should().Throw<BrokenCircuitException<ResultClass>>()
-            .WithMessage("The circuit is now open and is not allowing calls.")
-            .Where(e => e.Result.ResultCode == ResultPrimitive.Fault);
+        var exception = Should.Throw<BrokenCircuitException<ResultClass>>(() => breaker.RaiseResultSequence(new ResultClass(ResultPrimitive.Good)));
+        exception.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        exception.Result.ResultCode.ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
@@ -162,16 +149,16 @@ public class CircuitBreakerTResultMixedResultExceptionSpecs : IDisposable
             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
         breaker.RaiseResultSequence(ResultPrimitive.FaultAgain)
-              .Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+               .ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.RaiseResultSequence(ResultPrimitive.FaultAgain)
-              .Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+               .ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.RaiseResultSequence(ResultPrimitive.FaultAgain)
-              .Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+               .ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
@@ -182,17 +169,14 @@ public class CircuitBreakerTResultMixedResultExceptionSpecs : IDisposable
             .OrResult(ResultPrimitive.Fault)
             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
-        breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new ArgumentException()))
-            .Should().Throw<ArgumentException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<ArgumentException>(() => breaker.RaiseResultAndOrExceptionSequence(new ArgumentException()));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new ArgumentException()))
-            .Should().Throw<ArgumentException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<ArgumentException>(() => breaker.RaiseResultAndOrExceptionSequence(new ArgumentException()));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new ArgumentException()))
-            .Should().Throw<ArgumentException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<ArgumentException>(() => breaker.RaiseResultAndOrExceptionSequence(new ArgumentException()));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
@@ -205,29 +189,26 @@ public class CircuitBreakerTResultMixedResultExceptionSpecs : IDisposable
 
         // non-matched result predicate
         breaker.RaiseResultSequence(new ResultClass(ResultPrimitive.FaultAgain))
-              .ResultCode.Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ResultCode.ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.RaiseResultSequence(new ResultClass(ResultPrimitive.FaultAgain))
-              .ResultCode.Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ResultCode.ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.RaiseResultSequence(new ResultClass(ResultPrimitive.FaultAgain))
-              .ResultCode.Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ResultCode.ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // non-matched exception predicate
-        breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new ArgumentException("message", "value")))
-            .Should().Throw<ArgumentException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<ArgumentException>(() => breaker.RaiseResultAndOrExceptionSequence(new ArgumentException("message", "value")));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new ArgumentException("message", "value")))
-            .Should().Throw<ArgumentException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<ArgumentException>(() => breaker.RaiseResultAndOrExceptionSequence(new ArgumentException("message", "value")));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new ArgumentException("message", "value")))
-            .Should().Throw<ArgumentException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<ArgumentException>(() => breaker.RaiseResultAndOrExceptionSequence(new ArgumentException("message", "value")));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
@@ -240,29 +221,24 @@ public class CircuitBreakerTResultMixedResultExceptionSpecs : IDisposable
             .OrResult(ResultPrimitive.FaultAgain)
             .CircuitBreaker(4, TimeSpan.FromMinutes(1));
 
-        breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.RaiseResultSequence(ResultPrimitive.Fault).ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseResultAndOrExceptionSequence(new DivideByZeroException()));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.RaiseResultSequence(ResultPrimitive.FaultAgain)
-              .Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.RaiseResultSequence(ResultPrimitive.FaultAgain).ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new ArgumentException()))
-            .Should().Throw<ArgumentException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<ArgumentException>(() => breaker.RaiseResultAndOrExceptionSequence(new ArgumentException()));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 4 exception raised, circuit is now open
-        breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Good))
-            .Should().Throw<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.")
-            .WithInnerException<ArgumentException>();
+        var exception = Should.Throw<BrokenCircuitException>(() => breaker.RaiseResultSequence(ResultPrimitive.Good));
+        exception.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        exception.InnerException.ShouldBeOfType<ArgumentException>();
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
@@ -275,29 +251,26 @@ public class CircuitBreakerTResultMixedResultExceptionSpecs : IDisposable
             .OrResult(ResultPrimitive.FaultAgain)
             .CircuitBreaker(4, TimeSpan.FromMinutes(1));
 
-        breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseResultAndOrExceptionSequence(new DivideByZeroException()));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new ArgumentException()))
-            .Should().Throw<ArgumentException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<ArgumentException>(() => breaker.RaiseResultAndOrExceptionSequence(new ArgumentException()));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.RaiseResultSequence(ResultPrimitive.FaultAgain)
-              .Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+              .ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 4 exception raised, circuit is now open
-        breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Good))
-            .Should().Throw<BrokenCircuitException<ResultPrimitive>>()
-            .WithMessage("The circuit is now open and is not allowing calls.")
-            .Where(e => e.Result == ResultPrimitive.FaultAgain);
+        var exception = Should.Throw<BrokenCircuitException<ResultPrimitive>>(() => breaker.RaiseResultSequence(ResultPrimitive.Good));
+        exception.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        exception.Result.ShouldBe(ResultPrimitive.FaultAgain);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
@@ -309,20 +282,18 @@ public class CircuitBreakerTResultMixedResultExceptionSpecs : IDisposable
                         .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
         breaker.RaiseResultSequence(ResultPrimitive.FaultAgain)
-              .Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new ArgumentException()))
-            .Should().Throw<ArgumentException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<ArgumentException>(() => breaker.RaiseResultAndOrExceptionSequence(new ArgumentException()));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.RaiseResultSequence(ResultPrimitive.FaultAgain)
-              .Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new ArgumentException()))
-            .Should().Throw<ArgumentException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<ArgumentException>(() => breaker.RaiseResultAndOrExceptionSequence(new ArgumentException()));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     #endregion
@@ -332,7 +303,7 @@ public class CircuitBreakerTResultMixedResultExceptionSpecs : IDisposable
     [Fact]
     public void Should_open_circuit_again_after_the_specified_duration_has_passed_if_the_next_call_raises_a_fault()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -343,36 +314,32 @@ public class CircuitBreakerTResultMixedResultExceptionSpecs : IDisposable
                         .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseResultAndOrExceptionSequence(new DivideByZeroException()));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 2 exception raised, circuit is now open
-        breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Fault))
-              .Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<BrokenCircuitException>(() => breaker.RaiseResultSequence(ResultPrimitive.Fault));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // first call after duration returns a fault, so circuit should break again
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Fault))
-              .Should().Throw<BrokenCircuitException>();
-
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        Should.Throw<BrokenCircuitException>(() => breaker.RaiseResultSequence(ResultPrimitive.Fault));
     }
 
     [Fact]
     public void Should_open_circuit_again_after_the_specified_duration_has_passed_if_the_next_call_raises_an_exception()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -383,29 +350,25 @@ public class CircuitBreakerTResultMixedResultExceptionSpecs : IDisposable
                         .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseResultAndOrExceptionSequence(new DivideByZeroException()));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 2 exception raised, circuit is now open
-        breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Fault))
-              .Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<BrokenCircuitException>(() => breaker.RaiseResultSequence(ResultPrimitive.Fault));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // first call after duration returns a fault, so circuit should break again
-        breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Fault))
-              .Should().Throw<BrokenCircuitException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseResultAndOrExceptionSequence(new DivideByZeroException()));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        Should.Throw<BrokenCircuitException>(() => breaker.RaiseResultSequence(ResultPrimitive.Fault));
 
     }
 
@@ -420,7 +383,7 @@ public class CircuitBreakerTResultMixedResultExceptionSpecs : IDisposable
     {
         ResultPrimitive? handledResult = null;
 
-        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (outcome, _, _) => { handledResult = outcome.Result; };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (outcome, _, _) => handledResult = outcome.Result;
         Action<Context> onReset = _ => { };
 
         TimeSpan durationOfBreak = TimeSpan.FromMinutes(1);
@@ -430,15 +393,14 @@ public class CircuitBreakerTResultMixedResultExceptionSpecs : IDisposable
             .OrResult(ResultPrimitive.Fault)
             .CircuitBreaker(2, durationOfBreak, onBreak, onReset);
 
-        breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-            .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseResultAndOrExceptionSequence(new DivideByZeroException()));
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        handledResult?.Should().Be(ResultPrimitive.Fault);
+        handledResult?.ShouldBe(ResultPrimitive.Fault);
     }
 
     [Fact]
@@ -446,7 +408,7 @@ public class CircuitBreakerTResultMixedResultExceptionSpecs : IDisposable
     {
         Exception? lastException = null;
 
-        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (outcome, _, _) => { lastException = outcome.Exception; };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (outcome, _, _) => lastException = outcome.Exception;
         Action<Context> onReset = _ => { };
 
         TimeSpan durationOfBreak = TimeSpan.FromMinutes(1);
@@ -457,14 +419,13 @@ public class CircuitBreakerTResultMixedResultExceptionSpecs : IDisposable
             .CircuitBreaker(2, durationOfBreak, onBreak, onReset);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
-        breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-            .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseResultAndOrExceptionSequence(new DivideByZeroException()));
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        lastException.Should().BeOfType<DivideByZeroException>();
+        lastException.ShouldBeOfType<DivideByZeroException>();
     }
 
     #endregion
@@ -481,8 +442,8 @@ public class CircuitBreakerTResultMixedResultExceptionSpecs : IDisposable
             .OrResult(ResultPrimitive.Fault)
             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
-        breaker.LastHandledResult.Should().Be(default);
-        breaker.LastException.Should().BeNull();
+        breaker.LastHandledResult.ShouldBe(default);
+        breaker.LastException.ShouldBeNull();
     }
 
     [Fact]
@@ -494,12 +455,12 @@ public class CircuitBreakerTResultMixedResultExceptionSpecs : IDisposable
             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.LastHandledResult.Should().Be(ResultPrimitive.Fault);
-        breaker.LastException.Should().BeNull();
+        breaker.LastHandledResult.ShouldBe(ResultPrimitive.Fault);
+        breaker.LastException.ShouldBeNull();
     }
 
     [Fact]
@@ -510,13 +471,12 @@ public class CircuitBreakerTResultMixedResultExceptionSpecs : IDisposable
             .OrResult(ResultPrimitive.Fault)
             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
-        breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-            .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseResultAndOrExceptionSequence(new DivideByZeroException()));
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.LastHandledResult.Should().Be(default);
-        breaker.LastException.Should().BeOfType<DivideByZeroException>();
+        breaker.LastHandledResult.ShouldBe(default);
+        breaker.LastException.ShouldBeOfType<DivideByZeroException>();
     }
 
     [Fact]
@@ -527,16 +487,15 @@ public class CircuitBreakerTResultMixedResultExceptionSpecs : IDisposable
             .OrResult(ResultPrimitive.Fault)
             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
-        breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-            .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseResultAndOrExceptionSequence(new DivideByZeroException()));
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.LastHandledResult.Should().Be(ResultPrimitive.Fault);
-        breaker.LastException.Should().BeNull();
+        breaker.LastHandledResult.ShouldBe(ResultPrimitive.Fault);
+        breaker.LastException.ShouldBeNull();
     }
 
     [Fact]
@@ -548,15 +507,14 @@ public class CircuitBreakerTResultMixedResultExceptionSpecs : IDisposable
             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
-        breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-            .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseResultAndOrExceptionSequence(new DivideByZeroException()));
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.LastHandledResult.Should().Be(default);
-        breaker.LastException.Should().BeOfType<DivideByZeroException>();
+        breaker.LastHandledResult.ShouldBe(default);
+        breaker.LastException.ShouldBeOfType<DivideByZeroException>();
     }
 
     [Fact]
@@ -567,21 +525,20 @@ public class CircuitBreakerTResultMixedResultExceptionSpecs : IDisposable
             .OrResult(ResultPrimitive.Fault)
             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
-        breaker.Invoking(b => b.RaiseResultAndOrExceptionSequence(new DivideByZeroException()))
-            .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => breaker.RaiseResultAndOrExceptionSequence(new DivideByZeroException()));
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.LastHandledResult.Should().Be(ResultPrimitive.Fault);
-        breaker.LastException.Should().BeNull();
+        breaker.LastHandledResult.ShouldBe(ResultPrimitive.Fault);
+        breaker.LastException.ShouldBeNull();
 
         breaker.Reset();
 
-        breaker.LastHandledResult.Should().Be(default);
-        breaker.LastException.Should().BeNull();
+        breaker.LastHandledResult.ShouldBe(default);
+        breaker.LastException.ShouldBeNull();
     }
 
     #endregion

--- a/test/Polly.Specs/CircuitBreaker/CircuitBreakerTResultSpecs.cs
+++ b/test/Polly.Specs/CircuitBreaker/CircuitBreakerTResultSpecs.cs
@@ -38,10 +38,10 @@ public class CircuitBreakerTResultSpecs : IDisposable
 
         var func = () => methodInfo.Invoke(instance, [action, new Context(), CancellationToken.None]);
 
-        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("action");
+        var exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>()
+            .ParamName.ShouldBe("action");
     }
 
     [Fact]
@@ -52,7 +52,7 @@ public class CircuitBreakerTResultSpecs : IDisposable
                         .CircuitBreaker(1, TimeSpan.MaxValue);
 
         var result = breaker.RaiseResultSequence(ResultPrimitive.Fault);
-        result.Should().Be(ResultPrimitive.Fault);
+        result.ShouldBe(ResultPrimitive.Fault);
     }
 
     [Fact]
@@ -62,9 +62,8 @@ public class CircuitBreakerTResultSpecs : IDisposable
                                  .HandleResult(ResultPrimitive.Fault)
                                  .CircuitBreaker(0, TimeSpan.FromSeconds(10));
 
-        action.Should().Throw<ArgumentOutOfRangeException>()
-              .And.ParamName.Should()
-              .Be("handledEventsAllowedBeforeBreaking");
+        Should.Throw<ArgumentOutOfRangeException>(action)
+              .ParamName.ShouldBe("handledEventsAllowedBeforeBreaking");
     }
 
     [Fact]
@@ -74,9 +73,8 @@ public class CircuitBreakerTResultSpecs : IDisposable
                                  .HandleResult(ResultPrimitive.Fault)
                                  .CircuitBreaker(1, -TimeSpan.FromSeconds(1));
 
-        action.Should().Throw<ArgumentOutOfRangeException>()
-            .And.ParamName.Should()
-            .Be("durationOfBreak");
+        Should.Throw<ArgumentOutOfRangeException>(action)
+            .ParamName.ShouldBe("durationOfBreak");
     }
 
     [Fact]
@@ -85,7 +83,7 @@ public class CircuitBreakerTResultSpecs : IDisposable
         Action action = () => Policy
                                  .HandleResult(ResultPrimitive.Fault)
                                  .CircuitBreaker(1, TimeSpan.Zero);
-        action.Should().NotThrow();
+        Should.NotThrow(action);
     }
 
     [Fact]
@@ -97,7 +95,7 @@ public class CircuitBreakerTResultSpecs : IDisposable
             .HandleResult(ResultPrimitive.Fault)
             .CircuitBreaker(2, durationOfBreak);
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     #endregion
@@ -112,16 +110,16 @@ public class CircuitBreakerTResultSpecs : IDisposable
                         .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+               .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.RaiseResultSequence(ResultPrimitive.Good)
-              .Should().Be(ResultPrimitive.Good);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+               .ShouldBe(ResultPrimitive.Good);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+               .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
@@ -132,19 +130,18 @@ public class CircuitBreakerTResultSpecs : IDisposable
                         .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+               .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+               .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Fault))
-            .Should().Throw<BrokenCircuitException<ResultPrimitive>>()
-            .WithMessage("The circuit is now open and is not allowing calls.")
-            .Where(e => e.Result == ResultPrimitive.Fault);
+        var exception = Should.Throw<BrokenCircuitException<ResultPrimitive>>(() => breaker.RaiseResultSequence(ResultPrimitive.Fault));
+        exception.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        exception.Result.ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
@@ -156,19 +153,18 @@ public class CircuitBreakerTResultSpecs : IDisposable
                         .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+               .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.RaiseResultSequence(ResultPrimitive.FaultAgain)
-              .Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+               .ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 2 exception raised, circuit is now open
-        breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Fault))
-            .Should().Throw<BrokenCircuitException<ResultPrimitive>>()
-            .WithMessage("The circuit is now open and is not allowing calls.")
-            .Where(e => e.Result == ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        var exception = Should.Throw<BrokenCircuitException<ResultPrimitive>>(() => breaker.RaiseResultSequence(ResultPrimitive.Fault));
+        exception.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        exception.Result.ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
@@ -179,19 +175,18 @@ public class CircuitBreakerTResultSpecs : IDisposable
             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
         breaker.RaiseResultSequence(new ResultClass(ResultPrimitive.Fault))
-            .ResultCode.Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+            .ResultCode.ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.RaiseResultSequence(new ResultClass(ResultPrimitive.Fault))
-            .ResultCode.Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+            .ResultCode.ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.Invoking(b => b.RaiseResultSequence(new ResultClass(ResultPrimitive.Good)))
-            .Should().Throw<BrokenCircuitException<ResultClass>>()
-            .WithMessage("The circuit is now open and is not allowing calls.")
-            .Where(e => e.Result.ResultCode == ResultPrimitive.Fault);
+        var exception = Should.Throw<BrokenCircuitException<ResultClass>>(() => breaker.RaiseResultSequence(new ResultClass(ResultPrimitive.Good)));
+        exception.Message.ShouldBe("The circuit is now open and is not allowing calls.");
+        exception.Result.ResultCode.ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
@@ -202,16 +197,16 @@ public class CircuitBreakerTResultSpecs : IDisposable
                         .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
         breaker.RaiseResultSequence(ResultPrimitive.FaultAgain)
-              .Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.RaiseResultSequence(ResultPrimitive.FaultAgain)
-              .Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.RaiseResultSequence(ResultPrimitive.FaultAgain)
-              .Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
@@ -223,16 +218,16 @@ public class CircuitBreakerTResultSpecs : IDisposable
                         .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
         breaker.RaiseResultSequence(ResultPrimitive.FaultAgain)
-              .Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.RaiseResultSequence(ResultPrimitive.FaultAgain)
-              .Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.RaiseResultSequence(ResultPrimitive.FaultAgain)
-              .Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
@@ -243,16 +238,16 @@ public class CircuitBreakerTResultSpecs : IDisposable
                         .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
         breaker.RaiseResultSequence(new ResultClass(ResultPrimitive.FaultAgain))
-              .ResultCode.Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ResultCode.ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.RaiseResultSequence(new ResultClass(ResultPrimitive.FaultAgain))
-              .ResultCode.Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ResultCode.ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.RaiseResultSequence(new ResultClass(ResultPrimitive.FaultAgain))
-              .ResultCode.Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ResultCode.ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
@@ -264,16 +259,16 @@ public class CircuitBreakerTResultSpecs : IDisposable
             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
         breaker.RaiseResultSequence(new ResultClass(ResultPrimitive.FaultAgain))
-              .ResultCode.Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+               .ResultCode.ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.RaiseResultSequence(new ResultClass(ResultPrimitive.FaultAgain))
-              .ResultCode.Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+               .ResultCode.ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.RaiseResultSequence(new ResultClass(ResultPrimitive.FaultAgain))
-              .ResultCode.Should().Be(ResultPrimitive.FaultAgain);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+               .ResultCode.ShouldBe(ResultPrimitive.FaultAgain);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     #endregion
@@ -283,7 +278,7 @@ public class CircuitBreakerTResultSpecs : IDisposable
     [Fact]
     public void Should_halfopen_circuit_after_the_specified_duration_has_passed()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -293,30 +288,29 @@ public class CircuitBreakerTResultSpecs : IDisposable
                         .CircuitBreaker(2, durationOfBreak);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+               .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+               .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 2 exception raised, circuit is now open
-        breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Fault))
-            .Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<BrokenCircuitException>(() => breaker.RaiseResultSequence(ResultPrimitive.Fault));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
+               .ShouldBe(ResultPrimitive.Fault);
     }
 
     [Fact]
     public void Should_open_circuit_again_after_the_specified_duration_has_passed_if_the_next_call_raises_a_fault()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -326,36 +320,33 @@ public class CircuitBreakerTResultSpecs : IDisposable
                         .CircuitBreaker(2, durationOfBreak);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+               .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 2 exception raised, circuit is now open
-        breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Fault))
-              .Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<BrokenCircuitException>(() => breaker.RaiseResultSequence(ResultPrimitive.Fault));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // first call after duration returns a fault, so circuit should break again
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Fault))
-              .Should().Throw<BrokenCircuitException>();
-
+               .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        Should.Throw<BrokenCircuitException>(() => breaker.RaiseResultSequence(ResultPrimitive.Fault));
     }
 
     [Fact]
     public void Should_reset_circuit_after_the_specified_duration_has_passed_if_the_next_call_does_not_return_a_fault()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -365,45 +356,43 @@ public class CircuitBreakerTResultSpecs : IDisposable
                         .CircuitBreaker(2, durationOfBreak);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 2 exception raised, circuit is now open
-        breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Fault))
-              .Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<BrokenCircuitException>(() => breaker.RaiseResultSequence(ResultPrimitive.Fault));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // first call after duration is successful, so circuit should reset
         breaker.Execute(() => ResultPrimitive.Good);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // circuit has been reset so should once again allow 2 faults to be raised before breaking
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.Invoking(b => b.RaiseResultSequence(ResultPrimitive.Fault))
-              .Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<BrokenCircuitException>(() => breaker.RaiseResultSequence(ResultPrimitive.Fault));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
     }
 
     [Fact]
     public void Should_only_allow_single_execution_on_first_entering_halfopen_state__test_execution_permit_directly()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -412,28 +401,28 @@ public class CircuitBreakerTResultSpecs : IDisposable
             .CircuitBreaker(1, durationOfBreak);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
         // exception raised, circuit is now open.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // break duration passes, circuit now half open
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution.
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.Throw<BrokenCircuitException>(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
     }
 
     [Fact]
     public void Should_allow_single_execution_per_break_duration_in_halfopen_state__test_execution_permit_directly()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -442,36 +431,36 @@ public class CircuitBreakerTResultSpecs : IDisposable
             .CircuitBreaker(1, durationOfBreak);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
         // exception raised, circuit is now open.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // break duration passes, circuit now half open
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution.
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.Throw<BrokenCircuitException>(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // Allow another time window to pass (breaker should still be HalfOpen).
         SystemClock.UtcNow = () => time.Add(durationOfBreak).Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should now permit another trial execution.
-        breaker.BreakerController.Invoking(c => c.OnActionPreExecute()).Should().NotThrow();
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
     }
 
     [Fact]
     public void Should_only_allow_single_execution_on_first_entering_halfopen_state__integration_test()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -480,14 +469,14 @@ public class CircuitBreakerTResultSpecs : IDisposable
             .CircuitBreaker(1, durationOfBreak);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
+              .ShouldBe(ResultPrimitive.Fault);
 
         // exception raised, circuit is now open.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // break duration passes, circuit now half open
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // Start one execution during the HalfOpen state, and request a second execution before the first has completed (ie still during the HalfOpen state).
         // The second execution should be rejected due to the halfopen state.
@@ -504,7 +493,7 @@ public class CircuitBreakerTResultSpecs : IDisposable
         // First execution in HalfOpen state: we should be able to verify state is HalfOpen as it executes.
         Task firstExecution = Task.Factory.StartNew(() =>
         {
-            breaker.Invoking(x => x.Execute(() =>
+            Should.NotThrow(() => breaker.Execute(() =>
             {
                 firstDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
 
@@ -517,7 +506,7 @@ public class CircuitBreakerTResultSpecs : IDisposable
                 firstExecutionActive = false;
 
                 return ResultPrimitive.Good;
-            })).Should().NotThrow();
+            }));
         }, TaskCreationOptions.LongRunning);
 
         // Attempt a second execution, signalled by the first execution to ensure they overlap: we should be able to verify it doesn't execute, and is rejected by a breaker in a HalfOpen state.
@@ -526,8 +515,8 @@ public class CircuitBreakerTResultSpecs : IDisposable
         Task secondExecution = Task.Factory.StartNew(() =>
         {
             // Validation of correct sequencing and overlapping of tasks in test (guard against erroneous test refactorings/operation).
-            firstExecutionActive.Should().BeTrue();
-            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+            firstExecutionActive.ShouldBeTrue();
+            breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
             try
             {
@@ -552,7 +541,11 @@ public class CircuitBreakerTResultSpecs : IDisposable
         // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. This validates the test ran as expected (and background delegates are complete) before we assert on outcomes.
         permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
         permitFirstExecutionEnd.Set();
-        Task.WaitAll(new[] { firstExecution, secondExecution }, testTimeoutToExposeDeadlocks).Should().BeTrue();
+
+#pragma warning disable xUnit1031 // Do not use blocking task operations in test method
+        Task.WaitAll([firstExecution, secondExecution], testTimeoutToExposeDeadlocks).ShouldBeTrue();
+#pragma warning restore xUnit1031 // Do not use blocking task operations in test method
+
         if (firstExecution.IsFaulted)
         {
             throw firstExecution!.Exception!;
@@ -563,22 +556,25 @@ public class CircuitBreakerTResultSpecs : IDisposable
             throw secondExecution!.Exception!;
         }
 
-        firstExecution.Status.Should().Be(TaskStatus.RanToCompletion);
-        secondExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+        firstExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
+        secondExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
 
         // Assert:
         // - First execution should have been permitted and executed under a HalfOpen state
         // - Second overlapping execution in halfopen state should not have been permitted.
         // - Second execution attempt should have been rejected with HalfOpen state as cause.
-        firstDelegateExecutedInHalfOpenState.Should().BeTrue();
-        secondDelegateExecutedInHalfOpenState.Should().BeFalse();
-        secondDelegateRejectedInHalfOpenState.Should().BeTrue();
+        firstDelegateExecutedInHalfOpenState.ShouldNotBeNull();
+        firstDelegateExecutedInHalfOpenState.Value.ShouldBeTrue();
+        secondDelegateExecutedInHalfOpenState.ShouldNotBeNull();
+        secondDelegateExecutedInHalfOpenState.Value.ShouldBeFalse();
+        secondDelegateRejectedInHalfOpenState.ShouldNotBeNull();
+        secondDelegateRejectedInHalfOpenState.Value.ShouldBeTrue();
     }
 
     [Fact]
     public void Should_allow_single_execution_per_break_duration_in_halfopen_state__integration_test()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -587,14 +583,14 @@ public class CircuitBreakerTResultSpecs : IDisposable
             .CircuitBreaker(1, durationOfBreak);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
+               .ShouldBe(ResultPrimitive.Fault);
 
         // exception raised, circuit is now open.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // break duration passes, circuit now half open
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // Start one execution during the HalfOpen state.
         // Request a second execution while the first is still in flight (not completed), while still during the HalfOpen state, but after one breakDuration later.
@@ -612,7 +608,7 @@ public class CircuitBreakerTResultSpecs : IDisposable
         // First execution in HalfOpen state: we should be able to verify state is HalfOpen as it executes.
         Task firstExecution = Task.Factory.StartNew(() =>
         {
-            breaker.Invoking(x => x.Execute(() =>
+            Should.NotThrow(() => breaker.Execute(() =>
             {
                 firstDelegateExecutedInHalfOpenState = breaker.CircuitState == CircuitState.HalfOpen; // For readability of test results, we assert on this at test end rather than nested in Task and breaker here.
 
@@ -625,7 +621,7 @@ public class CircuitBreakerTResultSpecs : IDisposable
                 firstExecutionActive = false;
 
                 return ResultPrimitive.Good;
-            })).Should().NotThrow();
+            }));
         }, TaskCreationOptions.LongRunning);
 
         // Attempt a second execution, signalled by the first execution to ensure they overlap; start it one breakDuration later.  We should be able to verify it does execute, though the breaker is still in a HalfOpen state.
@@ -634,8 +630,8 @@ public class CircuitBreakerTResultSpecs : IDisposable
         Task secondExecution = Task.Factory.StartNew(() =>
         {
             // Validation of correct sequencing and overlapping of tasks in test (guard against erroneous test refactorings/operation).
-            firstExecutionActive.Should().BeTrue();
-            breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+            firstExecutionActive.ShouldBeTrue();
+            breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
             try
             {
@@ -662,7 +658,11 @@ public class CircuitBreakerTResultSpecs : IDisposable
         // Graceful cleanup: allow executions time to end naturally; signal them to end if not; timeout any deadlocks; expose any execution faults. This validates the test ran as expected (and background delegates are complete) before we assert on outcomes.
         permitFirstExecutionEnd.WaitOne(testTimeoutToExposeDeadlocks);
         permitFirstExecutionEnd.Set();
-        Task.WaitAll(new[] { firstExecution, secondExecution }, testTimeoutToExposeDeadlocks).Should().BeTrue();
+
+#pragma warning disable xUnit1031 // Do not use blocking task operations in test method
+        Task.WaitAll([firstExecution, secondExecution], testTimeoutToExposeDeadlocks).ShouldBeTrue();
+#pragma warning restore xUnit1031 // Do not use blocking task operations in test method
+
         if (firstExecution.IsFaulted)
         {
             throw firstExecution!.Exception!;
@@ -673,15 +673,18 @@ public class CircuitBreakerTResultSpecs : IDisposable
             throw secondExecution!.Exception!;
         }
 
-        firstExecution.Status.Should().Be(TaskStatus.RanToCompletion);
-        secondExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+        firstExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
+        secondExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
 
         // Assert:
         // - First execution should have been permitted and executed under a HalfOpen state
         // - Second overlapping execution in halfopen state should have been permitted, one breakDuration later.
-        firstDelegateExecutedInHalfOpenState.Should().BeTrue();
-        secondDelegateExecutedInHalfOpenState.Should().BeTrue();
-        secondDelegateRejectedInHalfOpenState.Should().BeFalse();
+        firstDelegateExecutedInHalfOpenState.ShouldNotBeNull();
+        firstDelegateExecutedInHalfOpenState.Value.ShouldBeTrue();
+        secondDelegateExecutedInHalfOpenState.ShouldNotBeNull();
+        secondDelegateExecutedInHalfOpenState.Value.ShouldBeTrue();
+        secondDelegateRejectedInHalfOpenState.ShouldNotBeNull();
+        secondDelegateRejectedInHalfOpenState.Value.ShouldBeFalse();
     }
 
     #endregion
@@ -691,7 +694,7 @@ public class CircuitBreakerTResultSpecs : IDisposable
     [Fact]
     public void Should_open_circuit_and_block_calls_if_manual_override_open()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -699,26 +702,25 @@ public class CircuitBreakerTResultSpecs : IDisposable
         CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
             .HandleResult(ResultPrimitive.Fault)
             .CircuitBreaker(2, durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // manually break circuit
         breaker.Isolate();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
 
         // circuit manually broken: execution should be blocked; even non-fault-returning executions should not reset circuit
         bool delegateExecutedWhenBroken = false;
-        breaker.Invoking(x => x.Execute(() => { delegateExecutedWhenBroken = true; return ResultPrimitive.Good; }))
-            .Should().Throw<IsolatedCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
-        breaker.LastException.Should().BeOfType<IsolatedCircuitException>();
-        delegateExecutedWhenBroken.Should().BeFalse();
+        Should.Throw<IsolatedCircuitException>(() => breaker.Execute(() => { delegateExecutedWhenBroken = true; return ResultPrimitive.Good; }));
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
+        breaker.LastException.ShouldBeOfType<IsolatedCircuitException>();
+        delegateExecutedWhenBroken.ShouldBeFalse();
 
     }
 
     [Fact]
     public void Should_hold_circuit_open_despite_elapsed_time_if_manual_override_open()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -726,24 +728,23 @@ public class CircuitBreakerTResultSpecs : IDisposable
         CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
             .HandleResult(ResultPrimitive.Fault)
             .CircuitBreaker(2, durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.Isolate();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
 
         bool delegateExecutedWhenBroken = false;
-        breaker.Invoking(x => x.Execute(() => { delegateExecutedWhenBroken = true; return ResultPrimitive.Good; }))
-            .Should().Throw<IsolatedCircuitException>();
-        delegateExecutedWhenBroken.Should().BeFalse();
+        Should.Throw<IsolatedCircuitException>(() => breaker.Execute(() => { delegateExecutedWhenBroken = true; return ResultPrimitive.Good; }));
+        delegateExecutedWhenBroken.ShouldBeFalse();
     }
 
     [Fact]
     public void Should_close_circuit_again_on_reset_after_manual_override()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -751,22 +752,21 @@ public class CircuitBreakerTResultSpecs : IDisposable
         CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
             .HandleResult(ResultPrimitive.Fault)
             .CircuitBreaker(2, durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.Isolate();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
-        breaker.Invoking(x => x.Execute(() => ResultPrimitive.Good))
-            .Should().Throw<IsolatedCircuitException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
+        Should.Throw<IsolatedCircuitException>(() => breaker.Execute(() => ResultPrimitive.Good));
 
         breaker.Reset();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        breaker.Invoking(x => x.Execute(() => ResultPrimitive.Good)).Should().NotThrow();
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => ResultPrimitive.Good));
     }
 
     [Fact]
     public void Should_be_able_to_reset_automatically_opened_circuit_without_specified_duration_passing()
     {
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -776,23 +776,22 @@ public class CircuitBreakerTResultSpecs : IDisposable
                         .CircuitBreaker(2, durationOfBreak);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // 2 exception raised, circuit is now open
-        breaker.Invoking(x => x.Execute(() => ResultPrimitive.Good))
-              .Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<BrokenCircuitException>(() => breaker.Execute(() => ResultPrimitive.Good));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // reset circuit, with no time having passed
         breaker.Reset();
-        SystemClock.UtcNow().Should().Be(time);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        breaker.Invoking(x => x.Execute(() => ResultPrimitive.Good)).Should().NotThrow();
+        SystemClock.UtcNow().ShouldBe(time);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => ResultPrimitive.Good));
     }
 
     #endregion
@@ -804,13 +803,13 @@ public class CircuitBreakerTResultSpecs : IDisposable
     {
         Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => { };
         bool onResetCalled = false;
-        Action onReset = () => { onResetCalled = true; };
+        Action onReset = () => onResetCalled = true;
 
         Policy
             .HandleResult(ResultPrimitive.Fault)
             .CircuitBreaker(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
-        onResetCalled.Should().BeFalse();
+        onResetCalled.ShouldBeFalse();
     }
 
     [Fact]
@@ -825,16 +824,16 @@ public class CircuitBreakerTResultSpecs : IDisposable
                         .CircuitBreaker(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
+              .ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().BeFalse();
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBeFalse();
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
+              .ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().BeTrue();
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBeTrue();
     }
 
     [Fact]
@@ -847,11 +846,11 @@ public class CircuitBreakerTResultSpecs : IDisposable
         CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
             .HandleResult(ResultPrimitive.Fault)
             .CircuitBreaker(2, TimeSpan.FromMinutes(1), onBreak, onReset);
-        onBreakCalled.Should().BeFalse();
+        onBreakCalled.ShouldBeFalse();
 
         breaker.Isolate();
 
-        onBreakCalled.Should().BeTrue();
+        onBreakCalled.ShouldBeTrue();
     }
 
     [Fact]
@@ -866,23 +865,22 @@ public class CircuitBreakerTResultSpecs : IDisposable
                         .CircuitBreaker(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
+              .ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().Be(0);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBe(0);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
+              .ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
 
         // call through circuit when already broken - should not retrigger onBreak
-        breaker.Invoking(x => x.Execute(() => ResultPrimitive.Good))
-              .Should().Throw<BrokenCircuitException>();
+        Should.Throw<BrokenCircuitException>(() => breaker.Execute(() => ResultPrimitive.Good));
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
     }
 
     [Fact]
@@ -902,7 +900,7 @@ public class CircuitBreakerTResultSpecs : IDisposable
         using ManualResetEvent permitMainThreadToOpenCircuit = new ManualResetEvent(false);
         Task longRunningExecution = Task.Factory.StartNew(() =>
         {
-            breaker.CircuitState.Should().Be(CircuitState.Closed);
+            breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
             breaker.Execute(() =>
             {
@@ -912,42 +910,44 @@ public class CircuitBreakerTResultSpecs : IDisposable
                 permitLongRunningExecutionToReturnItsFailure.WaitOne(testTimeoutToExposeDeadlocks);
 
                 // Throw a further failure when rest of test has already broken the circuit.
-                breaker.CircuitState.Should().Be(CircuitState.Open);
+                breaker.CircuitState.ShouldBe(CircuitState.Open);
                 return ResultPrimitive.Fault;
 
-            }).Should().Be(ResultPrimitive.Fault); // However, since execution started when circuit was closed, BrokenCircuitException will not have been thrown on entry; the original fault should still be returned.
+            }).ShouldBe(ResultPrimitive.Fault); // However, since execution started when circuit was closed, BrokenCircuitException will not have been thrown on entry; the original fault should still be returned.
         }, TaskCreationOptions.LongRunning);
 
-        permitMainThreadToOpenCircuit.WaitOne(testTimeoutToExposeDeadlocks).Should().BeTrue();
+        permitMainThreadToOpenCircuit.WaitOne(testTimeoutToExposeDeadlocks).ShouldBeTrue();
 
         // Break circuit in the normal manner: onBreak() should be called once.
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onBreakCalled.Should().Be(0);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onBreakCalled.ShouldBe(0);
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
 
         // Permit the second (long-running) execution to hit the open circuit with its failure.
         permitLongRunningExecutionToReturnItsFailure.Set();
 
+#pragma warning disable xUnit1031 // Do not use blocking task operations in test method
         // Graceful cleanup: allow executions time to end naturally; timeout if any deadlocks; expose any execution faults.  This validates the test ran as expected (and background delegates are complete) before we assert on outcomes.
 #if NET
-        longRunningExecution.Wait(testTimeoutToExposeDeadlocks, CancellationToken.None).Should().BeTrue();
+        longRunningExecution.Wait(testTimeoutToExposeDeadlocks, CancellationToken.None).ShouldBeTrue();
 #else
-        longRunningExecution.Wait(testTimeoutToExposeDeadlocks).Should().BeTrue();
+        longRunningExecution.Wait(testTimeoutToExposeDeadlocks).ShouldBeTrue();
 #endif
+#pragma warning restore xUnit1031 // Do not use blocking task operations in test method
 
         if (longRunningExecution.IsFaulted)
         {
             throw longRunningExecution!.Exception!;
         }
 
-        longRunningExecution.Status.Should().Be(TaskStatus.RanToCompletion);
+        longRunningExecution.Status.ShouldBe(TaskStatus.RanToCompletion);
 
         // onBreak() should still only have been called once.
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
     }
 
     [Fact]
@@ -958,7 +958,7 @@ public class CircuitBreakerTResultSpecs : IDisposable
         Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
         Action onReset = () => { onResetCalled++; };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -967,34 +967,33 @@ public class CircuitBreakerTResultSpecs : IDisposable
                         .HandleResult(ResultPrimitive.Fault)
                         .CircuitBreaker(2, durationOfBreak, onBreak, onReset);
 
-        onBreakCalled.Should().Be(0);
+        onBreakCalled.ShouldBe(0);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        onBreakCalled.Should().Be(0);
+              .ShouldBe(ResultPrimitive.Fault);
+        onBreakCalled.ShouldBe(0);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        onBreakCalled.Should().Be(1);
+              .ShouldBe(ResultPrimitive.Fault);
+        onBreakCalled.ShouldBe(1);
 
         // 2 exception raised, circuit is now open
-        breaker.Invoking(x => x.Execute(() => ResultPrimitive.Good))
-              .Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        Should.Throw<BrokenCircuitException>(() => breaker.Execute(() => ResultPrimitive.Good));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // but not yet reset
-        onResetCalled.Should().Be(0);
+        onResetCalled.ShouldBe(0);
 
         // first call after duration is successful, so circuit should reset
         breaker.Execute(() => ResultPrimitive.Good);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onResetCalled.Should().Be(1);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onResetCalled.ShouldBe(1);
     }
 
     [Fact]
@@ -1002,21 +1001,21 @@ public class CircuitBreakerTResultSpecs : IDisposable
     {
         Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => { };
         bool onResetCalled = false;
-        Action onReset = () => { onResetCalled = true; };
+        Action onReset = () => onResetCalled = true;
 
         CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
             .HandleResult(ResultPrimitive.Fault)
             .CircuitBreaker(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
-        onResetCalled.Should().BeFalse();
+        onResetCalled.ShouldBeFalse();
 
         breaker.Execute(() => ResultPrimitive.Good);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onResetCalled.Should().BeFalse();
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onResetCalled.ShouldBeFalse();
 
         breaker.Execute(() => ResultPrimitive.Good);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onResetCalled.Should().BeFalse();
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onResetCalled.ShouldBeFalse();
     }
 
     [Fact]
@@ -1025,11 +1024,11 @@ public class CircuitBreakerTResultSpecs : IDisposable
         int onBreakCalled = 0;
         int onResetCalled = 0;
         int onHalfOpenCalled = 0;
-        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
-        Action onReset = () => { onResetCalled++; };
-        Action onHalfOpen = () => { onHalfOpenCalled++; };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => onBreakCalled++;
+        Action onReset = () => onResetCalled++;
+        Action onHalfOpen = () => onHalfOpenCalled++;
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1038,32 +1037,31 @@ public class CircuitBreakerTResultSpecs : IDisposable
                         .HandleResult(ResultPrimitive.Fault)
                         .CircuitBreaker(2, durationOfBreak, onBreak, onReset, onHalfOpen);
 
-        onBreakCalled.Should().Be(0);
+        onBreakCalled.ShouldBe(0);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        onBreakCalled.Should().Be(0);
+              .ShouldBe(ResultPrimitive.Fault);
+        onBreakCalled.ShouldBe(0);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        onBreakCalled.Should().Be(1);
+              .ShouldBe(ResultPrimitive.Fault);
+        onBreakCalled.ShouldBe(1);
 
         // 2 exception raised, circuit is now open
-        breaker.Invoking(x => x.Execute(() => ResultPrimitive.Good))
-              .Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        Should.Throw<BrokenCircuitException>(() => breaker.Execute(() => ResultPrimitive.Good));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        onHalfOpenCalled.Should().Be(0); // not yet transitioned to half-open, because we have not queried state
+        onHalfOpenCalled.ShouldBe(0); // not yet transitioned to half-open, because we have not queried state
 
         // first call after duration is successful, so circuit should reset
         breaker.Execute(() => ResultPrimitive.Good);
-        onHalfOpenCalled.Should().Be(1);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        onResetCalled.Should().Be(1);
+        onHalfOpenCalled.ShouldBe(1);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        onResetCalled.ShouldBe(1);
     }
 
     [Fact]
@@ -1076,7 +1074,7 @@ public class CircuitBreakerTResultSpecs : IDisposable
         Action onReset = () => { onResetCalled++; };
         Action onHalfOpen = () => { onHalfOpenCalled++; };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1085,28 +1083,27 @@ public class CircuitBreakerTResultSpecs : IDisposable
                         .HandleResult(ResultPrimitive.Fault)
                         .CircuitBreaker(2, durationOfBreak, onBreak, onReset, onHalfOpen);
 
-        onBreakCalled.Should().Be(0);
+        onBreakCalled.ShouldBe(0);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        onBreakCalled.Should().Be(0);
+              .ShouldBe(ResultPrimitive.Fault);
+        onBreakCalled.ShouldBe(0);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        onBreakCalled.Should().Be(1);
+              .ShouldBe(ResultPrimitive.Fault);
+        onBreakCalled.ShouldBe(1);
 
         // 2 exception raised, circuit is now open
-        breaker.Invoking(x => x.Execute(() => ResultPrimitive.Good))
-              .Should().Throw<BrokenCircuitException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        onBreakCalled.Should().Be(1);
+        Should.Throw<BrokenCircuitException>(() => breaker.Execute(() => ResultPrimitive.Good));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        onBreakCalled.ShouldBe(1);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
-        onHalfOpenCalled.Should().Be(1);
-        onResetCalled.Should().Be(0);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
+        onHalfOpenCalled.ShouldBe(1);
+        onResetCalled.ShouldBe(0);
     }
 
     [Fact]
@@ -1117,7 +1114,7 @@ public class CircuitBreakerTResultSpecs : IDisposable
         Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
         Action onReset = () => { onResetCalled++; };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1126,20 +1123,19 @@ public class CircuitBreakerTResultSpecs : IDisposable
                         .HandleResult(ResultPrimitive.Fault)
                         .CircuitBreaker(2, durationOfBreak, onBreak, onReset);
 
-        onBreakCalled.Should().Be(0);
+        onBreakCalled.ShouldBe(0);
         breaker.Isolate();
-        onBreakCalled.Should().Be(1);
+        onBreakCalled.ShouldBe(1);
 
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
-        breaker.Invoking(x => x.Execute(() => ResultPrimitive.Good))
-            .Should().Throw<IsolatedCircuitException>();
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
+        Should.Throw<IsolatedCircuitException>(() => breaker.Execute(() => ResultPrimitive.Good));
 
-        onResetCalled.Should().Be(0);
+        onResetCalled.ShouldBe(0);
         breaker.Reset();
-        onResetCalled.Should().Be(1);
+        onResetCalled.ShouldBe(1);
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        breaker.Invoking(x => x.Execute(() => ResultPrimitive.Good)).Should().NotThrow();
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        Should.NotThrow(() => breaker.Execute(() => ResultPrimitive.Good));
     }
 
     #region Tests of supplied parameters to onBreak delegate
@@ -1149,7 +1145,7 @@ public class CircuitBreakerTResultSpecs : IDisposable
     {
         ResultPrimitive? handledResult = null;
 
-        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (outcome, _, _) => { handledResult = outcome.Result; };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (outcome, _, _) => handledResult = outcome.Result;
         Action<Context> onReset = _ => { };
 
         TimeSpan durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1159,14 +1155,14 @@ public class CircuitBreakerTResultSpecs : IDisposable
             .CircuitBreaker(2, durationOfBreak, onBreak, onReset);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        handledResult?.Should().Be(ResultPrimitive.Fault);
+        handledResult?.ShouldBe(ResultPrimitive.Fault);
     }
 
     [Fact]
@@ -1174,7 +1170,7 @@ public class CircuitBreakerTResultSpecs : IDisposable
     {
         TimeSpan? passedBreakTimespan = null;
 
-        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (_, timespan, _) => { passedBreakTimespan = timespan; };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (_, timespan, _) => passedBreakTimespan = timespan;
         Action<Context> onReset = _ => { };
 
         TimeSpan durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1184,24 +1180,24 @@ public class CircuitBreakerTResultSpecs : IDisposable
             .CircuitBreaker(2, durationOfBreak, onBreak, onReset);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        passedBreakTimespan.Should().Be(durationOfBreak);
+        passedBreakTimespan.ShouldBe(durationOfBreak);
     }
 
     [Fact]
     public void Should_open_circuit_with_timespan_maxvalue_if_manual_override_open()
     {
         TimeSpan? passedBreakTimespan = null;
-        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (_, timespan, _) => { passedBreakTimespan = timespan; };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (_, timespan, _) => passedBreakTimespan = timespan;
         Action<Context> onReset = _ => { };
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1209,13 +1205,13 @@ public class CircuitBreakerTResultSpecs : IDisposable
         CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
             .HandleResult(ResultPrimitive.Fault)
             .CircuitBreaker(2, durationOfBreak, onBreak, onReset);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
         // manually break circuit
         breaker.Isolate();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
 
-        passedBreakTimespan.Should().Be(TimeSpan.MaxValue);
+        passedBreakTimespan.ShouldBe(TimeSpan.MaxValue);
     }
 
     #endregion
@@ -1227,7 +1223,7 @@ public class CircuitBreakerTResultSpecs : IDisposable
     {
         IDictionary<string, object>? contextData = null;
 
-        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (_, _, context) => { contextData = context; };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (_, _, context) => contextData = context;
         Action<Context> onReset = _ => { };
 
         CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
@@ -1235,17 +1231,17 @@ public class CircuitBreakerTResultSpecs : IDisposable
             .CircuitBreaker(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
         breaker.RaiseResultSequence(CreateDictionary("key1", "value1", "key2", "value2"),
             ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -1254,9 +1250,9 @@ public class CircuitBreakerTResultSpecs : IDisposable
         IDictionary<string, object>? contextData = null;
 
         Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (_, _, _) => { };
-        Action<Context> onReset = context => { contextData = context; };
+        Action<Context> onReset = context => contextData = context;
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1266,20 +1262,20 @@ public class CircuitBreakerTResultSpecs : IDisposable
             .CircuitBreaker(2, durationOfBreak, onBreak, onReset);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+            .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // first call after duration should invoke onReset, with context
         breaker.Execute(_ => ResultPrimitive.Good, CreateDictionary("key1", "value1", "key2", "value2"));
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -1287,7 +1283,7 @@ public class CircuitBreakerTResultSpecs : IDisposable
     {
         IDictionary<string, object> contextData = CreateDictionary("key1", "value1", "key2", "value2");
 
-        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (_, _, context) => { contextData = context; };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (_, _, context) => contextData = context;
         Action<Context> onReset = _ => { };
 
         CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
@@ -1295,14 +1291,14 @@ public class CircuitBreakerTResultSpecs : IDisposable
             .CircuitBreaker(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        contextData.Should().BeEmpty();
+        contextData.ShouldBeEmpty();
     }
 
     [Fact]
@@ -1317,31 +1313,31 @@ public class CircuitBreakerTResultSpecs : IDisposable
             .HandleResult(ResultPrimitive.Fault)
             .CircuitBreaker(2, TimeSpan.FromMinutes(1), onBreak, onReset);
 
-        var time = 1.January(2000);
+        var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
 
         var durationOfBreak = TimeSpan.FromMinutes(1);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
         // 2 exception raised, circuit is now open
         breaker.RaiseResultSequence(CreateDictionary("key", "original_value"), ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
-        contextValue.Should().Be("original_value");
+            .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
+        contextValue.ShouldBe("original_value");
 
         SystemClock.UtcNow = () => time.Add(durationOfBreak);
 
         // duration has passed, circuit now half open
-        breaker.CircuitState.Should().Be(CircuitState.HalfOpen);
+        breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // but not yet reset
 
         // first call after duration is successful, so circuit should reset
         breaker.Execute(_ => ResultPrimitive.Good, CreateDictionary("key", "new_value"));
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
-        contextValue.Should().Be("new_value");
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
+        contextValue.ShouldBe("new_value");
     }
 
     #endregion
@@ -1357,8 +1353,8 @@ public class CircuitBreakerTResultSpecs : IDisposable
             .HandleResult(ResultPrimitive.Fault)
             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
-        breaker.LastHandledResult.Should().Be(default);
-        breaker.LastException.Should().BeNull();
+        breaker.LastHandledResult.ShouldBe(default);
+        breaker.LastException.ShouldBeNull();
     }
 
     [Fact]
@@ -1369,12 +1365,12 @@ public class CircuitBreakerTResultSpecs : IDisposable
             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
-        breaker.LastHandledResult.Should().Be(ResultPrimitive.Fault);
-        breaker.LastException.Should().BeNull();
+        breaker.LastHandledResult.ShouldBe(ResultPrimitive.Fault);
+        breaker.LastException.ShouldBeNull();
     }
 
     [Fact]
@@ -1385,15 +1381,15 @@ public class CircuitBreakerTResultSpecs : IDisposable
             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.LastHandledResult.Should().Be(ResultPrimitive.Fault);
-        breaker.LastException.Should().BeNull();
+        breaker.LastHandledResult.ShouldBe(ResultPrimitive.Fault);
+        breaker.LastException.ShouldBeNull();
     }
 
     [Fact]
@@ -1404,20 +1400,20 @@ public class CircuitBreakerTResultSpecs : IDisposable
             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
-        breaker.LastHandledResult.Should().Be(ResultPrimitive.Fault);
-        breaker.LastException.Should().BeNull();
+        breaker.LastHandledResult.ShouldBe(ResultPrimitive.Fault);
+        breaker.LastException.ShouldBeNull();
 
         breaker.Reset();
 
-        breaker.LastHandledResult.Should().Be(default);
-        breaker.LastException.Should().BeNull();
+        breaker.LastHandledResult.ShouldBe(default);
+        breaker.LastException.ShouldBeNull();
     }
 
     #endregion
@@ -1444,10 +1440,10 @@ public class CircuitBreakerTResultSpecs : IDisposable
         {
             breaker.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute,
                 ResultPrimitive.Good)
-                .Should().Be(ResultPrimitive.Good);
+                .ShouldBe(ResultPrimitive.Good);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -1471,15 +1467,18 @@ public class CircuitBreakerTResultSpecs : IDisposable
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             cancellationTokenSource.Cancel();
 
-            breaker.Invoking(x => x.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Good))
-            .Should().Throw<OperationCanceledException>()
-            .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(
+                () => breaker.RaiseResultSequenceAndOrCancellation(
+                    scenario,
+                    cancellationTokenSource,
+                    onExecute,
+                    ResultPrimitive.Fault,
+                    ResultPrimitive.Fault,
+                    ResultPrimitive.Good))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(0);
+        attemptsInvoked.ShouldBe(0);
     }
 
     [Fact]
@@ -1502,14 +1501,17 @@ public class CircuitBreakerTResultSpecs : IDisposable
         using (var cancellationTokenSource = new CancellationTokenSource())
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
-            breaker.Invoking(x => x.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute,
-                   ResultPrimitive.Good,
-                   ResultPrimitive.Good))
-                .Should().Throw<OperationCanceledException>()
-                .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(
+                () => breaker.RaiseResultSequenceAndOrCancellation(
+                    scenario,
+                    cancellationTokenSource,
+                    onExecute,
+                    ResultPrimitive.Good,
+                    ResultPrimitive.Good))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -1532,14 +1534,17 @@ public class CircuitBreakerTResultSpecs : IDisposable
         using (var cancellationTokenSource = new CancellationTokenSource())
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
-            breaker.Invoking(x => x.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute,
-                   ResultPrimitive.Fault,
-                   ResultPrimitive.Good))
-                .Should().Throw<OperationCanceledException>()
-                .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(
+                () => breaker.RaiseResultSequenceAndOrCancellation(
+                    scenario,
+                    cancellationTokenSource,
+                    onExecute,
+                    ResultPrimitive.Fault,
+                    ResultPrimitive.Good))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -1562,10 +1567,10 @@ public class CircuitBreakerTResultSpecs : IDisposable
         using (var cancellationTokenSource = new CancellationTokenSource())
         {
             breaker.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute, ResultPrimitive.Fault)
-                            .Should().Be(ResultPrimitive.Fault);
+                            .ShouldBe(ResultPrimitive.Fault);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -1576,11 +1581,10 @@ public class CircuitBreakerTResultSpecs : IDisposable
             .CircuitBreaker(1, TimeSpan.FromMinutes(1));
 
         breaker.RaiseResultSequence(ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
-        breaker.Invoking(x => x.RaiseResultSequence(ResultPrimitive.Fault))
-            .Should().Throw<BrokenCircuitException>()
-            .WithMessage("The circuit is now open and is not allowing calls.");
+        var exception = Should.Throw<BrokenCircuitException>(() => breaker.RaiseResultSequence(ResultPrimitive.Fault));
+        exception.Message.ShouldBe("The circuit is now open and is not allowing calls.");
 
         // Circuit is now broken.
         int attemptsInvoked = 0;
@@ -1597,14 +1601,17 @@ public class CircuitBreakerTResultSpecs : IDisposable
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             cancellationTokenSource.Cancel();
 
-            breaker.Invoking(x => x.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute,
-                   ResultPrimitive.Fault,
-                   ResultPrimitive.Good))
-                .Should().Throw<OperationCanceledException>()
-                .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(
+                () => breaker.RaiseResultSequenceAndOrCancellation(
+                    scenario,
+                    cancellationTokenSource,
+                    onExecute,
+                    ResultPrimitive.Fault,
+                    ResultPrimitive.Good))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(0);
+        attemptsInvoked.ShouldBe(0);
     }
 
     [Fact]
@@ -1627,17 +1634,16 @@ public class CircuitBreakerTResultSpecs : IDisposable
 
             implicitlyCapturedActionCancellationTokenSource.Cancel();
 
-            breaker.Invoking(x => x.Execute(_ =>
+            Should.Throw<OperationCanceledException>(() => breaker.Execute(_ =>
             {
                 attemptsInvoked++;
                 implicitlyCapturedActionCancellationToken.ThrowIfCancellationRequested();
                 return ResultPrimitive.Good;
             }, policyCancellationToken))
-                .Should().Throw<OperationCanceledException>()
-                .And.CancellationToken.Should().Be(implicitlyCapturedActionCancellationToken);
+                .CancellationToken.ShouldBe(implicitlyCapturedActionCancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     #endregion

--- a/test/Polly.Specs/CircuitBreaker/ICircuitBreakerPolicySpecs.cs
+++ b/test/Polly.Specs/CircuitBreaker/ICircuitBreakerPolicySpecs.cs
@@ -9,7 +9,7 @@ public class ICircuitBreakerPolicySpecs
             .Handle<DivideByZeroException>()
             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
 
     }
 
@@ -21,7 +21,7 @@ public class ICircuitBreakerPolicySpecs
             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
         breaker.Isolate();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
     }
 
     [Fact]
@@ -32,10 +32,10 @@ public class ICircuitBreakerPolicySpecs
             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
         breaker.Isolate();
-        breaker.CircuitState.Should().Be(CircuitState.Isolated);
+        breaker.CircuitState.ShouldBe(CircuitState.Isolated);
 
         breaker.Reset();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
@@ -45,6 +45,6 @@ public class ICircuitBreakerPolicySpecs
             .Handle<DivideByZeroException>()
             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
-        breaker.LastException.Should().BeNull();
+        breaker.LastException.ShouldBeNull();
     }
 }

--- a/test/Polly.Specs/CircuitBreaker/ICircuitBreakerTResultPolicySpecs.cs
+++ b/test/Polly.Specs/CircuitBreaker/ICircuitBreakerTResultPolicySpecs.cs
@@ -9,6 +9,6 @@ public class ICircuitBreakerTResultPolicySpecs
             .HandleResult(ResultPrimitive.Fault)
             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 
-        breaker.LastHandledResult.Should().Be(default);
+        breaker.LastHandledResult.ShouldBe(default);
     }
 }

--- a/test/Polly.Specs/ContextSpecs.cs
+++ b/test/Polly.Specs/ContextSpecs.cs
@@ -7,9 +7,9 @@ public class ContextSpecs
     {
         Context context = new Context("SomeKey");
 
-        context.OperationKey.Should().Be("SomeKey");
+        context.OperationKey.ShouldBe("SomeKey");
 
-        context.Keys.Count.Should().Be(0);
+        context.Keys.Count.ShouldBe(0);
     }
 
     [Fact]
@@ -17,9 +17,9 @@ public class ContextSpecs
     {
         Context context = new Context("SomeKey", CreateDictionary("key1", "value1", "key2", "value2"));
 
-        context.OperationKey.Should().Be("SomeKey");
-        context["key1"].Should().Be("value1");
-        context["key2"].Should().Be("value2");
+        context.OperationKey.ShouldBe("SomeKey");
+        context["key1"].ShouldBe("value1");
+        context["key2"].ShouldBe("value2");
     }
 
     [Fact]
@@ -27,7 +27,7 @@ public class ContextSpecs
     {
         Context context = [];
 
-        context.OperationKey.Should().BeNull();
+        context.OperationKey.ShouldBeNull();
     }
 
     [Fact]
@@ -35,7 +35,7 @@ public class ContextSpecs
     {
         Context context = new Context("SomeKey");
 
-        context.CorrelationId.Should().NotBeEmpty();
+        context.OperationKey.ShouldBe("SomeKey");
     }
 
     [Fact]
@@ -46,6 +46,6 @@ public class ContextSpecs
         Guid retrieved1 = context.CorrelationId;
         Guid retrieved2 = context.CorrelationId;
 
-        retrieved1.Should().Be(retrieved2);
+        retrieved1.ShouldBe(retrieved2);
     }
 }

--- a/test/Polly.Specs/Custom/CustomAsyncSpecs.cs
+++ b/test/Polly.Specs/Custom/CustomAsyncSpecs.cs
@@ -9,13 +9,12 @@ public class CustomAsyncSpecs
         {
             AsyncPreExecutePolicy policy = AsyncPreExecutePolicy.CreateAsync(async () =>
             {
-                // Placeholder for more substantive async work.
                 Console.WriteLine("Do something");
                 await Task.CompletedTask;
             });
         };
 
-        construct.Should().NotThrow();
+        Should.NotThrow(construct);
     }
 
     [Fact]
@@ -26,11 +25,10 @@ public class CustomAsyncSpecs
 
         bool executed = false;
 
-        await policy.Awaiting(x => x.ExecuteAsync(() => { executed = true; return Task.CompletedTask; }))
-            .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.ExecuteAsync(() => { executed = true; return Task.CompletedTask; }));
 
-        executed.Should().BeTrue();
-        preExecuted.Should().BeTrue();
+        executed.ShouldBeTrue();
+        preExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -40,13 +38,12 @@ public class CustomAsyncSpecs
         {
             AsyncAddBehaviourIfHandlePolicy policy = Policy.Handle<Exception>().WithBehaviourAsync(async ex =>
             {
-                // Placeholder for more substantive async work.
                 Console.WriteLine("Handling " + ex.Message);
                 await Task.CompletedTask;
             });
         };
 
-        construct.Should().NotThrow();
+        Should.NotThrow(construct);
     }
 
     [Fact]
@@ -58,16 +55,15 @@ public class CustomAsyncSpecs
         Exception toThrow = new InvalidOperationException();
         bool executed = false;
 
-        var ex = await policy.Awaiting(x => x.ExecuteAsync(() =>
+        var ex = await Should.ThrowAsync<Exception>(() => policy.ExecuteAsync(() =>
         {
             executed = true;
             throw toThrow;
-        }))
-            .Should().ThrowAsync<Exception>();
-        ex.Which.Should().Be(toThrow);
+        }));
+        ex.ShouldBe(toThrow);
 
-        executed.Should().BeTrue();
-        handled.Should().Be(toThrow);
+        executed.ShouldBeTrue();
+        handled.ShouldBe(toThrow);
     }
 
     [Fact]
@@ -79,15 +75,14 @@ public class CustomAsyncSpecs
         Exception toThrow = new NotImplementedException();
         bool executed = false;
 
-        var ex = await policy.Awaiting(x => x.ExecuteAsync(() =>
-            {
-                executed = true;
-                throw toThrow;
-            }))
-            .Should().ThrowAsync<Exception>();
-        ex.Which.Should().Be(toThrow);
+        var ex = await Should.ThrowAsync<Exception>(() => policy.ExecuteAsync(() =>
+        {
+            executed = true;
+            throw toThrow;
+        }));
+        ex.ShouldBe(toThrow);
 
-        executed.Should().BeTrue();
-        handled.Should().Be(null);
+        executed.ShouldBeTrue();
+        handled.ShouldBe(null);
     }
 }

--- a/test/Polly.Specs/Custom/CustomSpecs.cs
+++ b/test/Polly.Specs/Custom/CustomSpecs.cs
@@ -10,7 +10,7 @@ public class CustomSpecs
             PreExecutePolicy policy = PreExecutePolicy.Create(() => Console.WriteLine("Do something"));
         };
 
-        construct.Should().NotThrow();
+        Should.NotThrow(construct);
     }
 
     [Fact]
@@ -21,11 +21,10 @@ public class CustomSpecs
 
         bool executed = false;
 
-        policy.Invoking(x => x.Execute(() => { executed = true; }))
-            .Should().NotThrow();
+        Should.NotThrow(() => policy.Execute(() => executed = true));
 
-        executed.Should().BeTrue();
-        preExecuted.Should().BeTrue();
+        executed.ShouldBeTrue();
+        preExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -36,7 +35,7 @@ public class CustomSpecs
             AddBehaviourIfHandlePolicy policy = Policy.Handle<Exception>().WithBehaviour(ex => Console.WriteLine("Handling " + ex.Message));
         };
 
-        construct.Should().NotThrow();
+        Should.NotThrow(construct);
     }
 
     [Fact]
@@ -48,15 +47,14 @@ public class CustomSpecs
         Exception toThrow = new InvalidOperationException();
         bool executed = false;
 
-        policy.Invoking(x => x.Execute(() =>
+        Should.Throw<Exception>(() => policy.Execute(() =>
         {
             executed = true;
             throw toThrow;
-        }))
-            .Should().Throw<Exception>().Which.Should().Be(toThrow);
+        })).ShouldBe(toThrow);
 
-        executed.Should().BeTrue();
-        handled.Should().Be(toThrow);
+        executed.ShouldBeTrue();
+        handled.ShouldBe(toThrow);
     }
 
     [Fact]
@@ -68,14 +66,13 @@ public class CustomSpecs
         Exception toThrow = new NotImplementedException();
         bool executed = false;
 
-        policy.Invoking(x => x.Execute(() =>
+        Should.Throw<Exception>(() => policy.Execute(() =>
         {
             executed = true;
             throw toThrow;
-        }))
-            .Should().Throw<Exception>().Which.Should().Be(toThrow);
+        })).ShouldBe(toThrow);
 
-        executed.Should().BeTrue();
-        handled.Should().Be(null);
+        executed.ShouldBeTrue();
+        handled.ShouldBeNull();
     }
 }

--- a/test/Polly.Specs/Custom/CustomTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/Custom/CustomTResultAsyncSpecs.cs
@@ -15,7 +15,7 @@ public class CustomTResultAsyncSpecs
             });
         };
 
-        construct.Should().NotThrow();
+        Should.NotThrow(construct);
     }
 
     [Fact]
@@ -25,11 +25,10 @@ public class CustomTResultAsyncSpecs
         AsyncPreExecutePolicy<ResultPrimitive> policy = AsyncPreExecutePolicy<ResultPrimitive>.CreateAsync(() => { preExecuted = true; return Task.CompletedTask; });
 
         bool executed = false;
-        await policy.Awaiting(x => x.ExecuteAsync(async () => { executed = true; await Task.CompletedTask; return ResultPrimitive.Undefined; }))
-            .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.ExecuteAsync(async () => { executed = true; await Task.CompletedTask; return ResultPrimitive.Undefined; }));
 
-        executed.Should().BeTrue();
-        preExecuted.Should().BeTrue();
+        executed.ShouldBeTrue();
+        preExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -45,7 +44,7 @@ public class CustomTResultAsyncSpecs
             });
         };
 
-        construct.Should().NotThrow();
+        Should.NotThrow(construct);
     }
 
     [Fact]
@@ -65,10 +64,10 @@ public class CustomTResultAsyncSpecs
                 await Task.CompletedTask;
                 return toReturn;
             }))
-            .Should().Be(toReturn);
+            .ShouldBe(toReturn);
 
-        executed.Should().BeTrue();
-        handled.Should().Be(toReturn);
+        executed.ShouldBeTrue();
+        handled.ShouldBe(toReturn);
     }
 
     [Fact]
@@ -88,9 +87,9 @@ public class CustomTResultAsyncSpecs
                 await Task.CompletedTask;
                 return toReturn;
             }))
-            .Should().Be(toReturn);
+            .ShouldBe(toReturn);
 
-        executed.Should().BeTrue();
-        handled.Should().Be(null);
+        executed.ShouldBeTrue();
+        handled.ShouldBe(null);
     }
 }

--- a/test/Polly.Specs/Custom/CustomTResultSpecs.cs
+++ b/test/Polly.Specs/Custom/CustomTResultSpecs.cs
@@ -10,7 +10,7 @@ public class CustomTResultSpecs
             PreExecutePolicy<ResultPrimitive> policy = PreExecutePolicy<ResultPrimitive>.Create(() => Console.WriteLine("Do something"));
         };
 
-        construct.Should().NotThrow();
+        Should.NotThrow(construct);
     }
 
     [Fact]
@@ -21,15 +21,14 @@ public class CustomTResultSpecs
 
         bool executed = false;
 
-        policy.Invoking(x => x.Execute(() =>
+        Should.NotThrow(() => policy.Execute(() =>
         {
             executed = true;
             return ResultPrimitive.Undefined;
-        }))
-            .Should().NotThrow();
+        }));
 
-        executed.Should().BeTrue();
-        preExecuted.Should().BeTrue();
+        executed.ShouldBeTrue();
+        preExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -40,7 +39,7 @@ public class CustomTResultSpecs
             AddBehaviourIfHandlePolicy<ResultPrimitive> policy = Policy.HandleResult<ResultPrimitive>(ResultPrimitive.Fault).WithBehaviour(outcome => Console.WriteLine("Handling " + outcome.Result));
         };
 
-        construct.Should().NotThrow();
+        Should.NotThrow(construct);
     }
 
     [Fact]
@@ -57,10 +56,10 @@ public class CustomTResultSpecs
                 executed = true;
                 return toReturn;
             })
-            .Should().Be(toReturn);
+            .ShouldBe(toReturn);
 
-        executed.Should().BeTrue();
-        handled.Should().Be(toReturn);
+        executed.ShouldBeTrue();
+        handled.ShouldBe(toReturn);
     }
 
     [Fact]
@@ -77,9 +76,9 @@ public class CustomTResultSpecs
                 executed = true;
                 return toReturn;
             })
-            .Should().Be(toReturn);
+            .ShouldBe(toReturn);
 
-        executed.Should().BeTrue();
-        handled.Should().Be(null);
+        executed.ShouldBeTrue();
+        handled.ShouldBe(null);
     }
 }

--- a/test/Polly.Specs/Fallback/FallbackAsyncSpecs.cs
+++ b/test/Polly.Specs/Fallback/FallbackAsyncSpecs.cs
@@ -15,8 +15,8 @@ public class FallbackAsyncSpecs
             .Handle<DivideByZeroException>()
             .FallbackAsync(fallbackActionAsync);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("fallbackAction");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("fallbackAction");
     }
 
     [Fact]
@@ -29,8 +29,8 @@ public class FallbackAsyncSpecs
             .Handle<DivideByZeroException>()
             .FallbackAsync(fallbackActionAsync, onFallbackAsync);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("fallbackAction");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("fallbackAction");
     }
 
     [Fact]
@@ -43,8 +43,8 @@ public class FallbackAsyncSpecs
                                 .Handle<DivideByZeroException>()
                                 .FallbackAsync(fallbackActionAsync, onFallbackAsync);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("fallbackAction");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("fallbackAction");
     }
 
     [Fact]
@@ -57,8 +57,8 @@ public class FallbackAsyncSpecs
                                 .Handle<DivideByZeroException>()
                                 .FallbackAsync(fallbackActionAsync, onFallbackAsync);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onFallbackAsync");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onFallbackAsync");
     }
 
     [Fact]
@@ -71,8 +71,8 @@ public class FallbackAsyncSpecs
                                 .Handle<DivideByZeroException>()
                                 .FallbackAsync(fallbackActionAsync, onFallbackAsync);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onFallbackAsync");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onFallbackAsync");
     }
 
     #endregion
@@ -91,7 +91,7 @@ public class FallbackAsyncSpecs
 
         await fallbackPolicy.ExecuteAsync(() => TaskHelper.EmptyTask);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -104,9 +104,9 @@ public class FallbackAsyncSpecs
                                 .Handle<DivideByZeroException>()
                                 .FallbackAsync(fallbackActionAsync);
 
-        await fallbackPolicy.Awaiting(x => x.RaiseExceptionAsync<ArgumentNullException>()).Should().ThrowAsync<ArgumentNullException>();
+        await Should.ThrowAsync<ArgumentNullException>(() => fallbackPolicy.RaiseExceptionAsync<ArgumentNullException>());
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -119,9 +119,9 @@ public class FallbackAsyncSpecs
                                 .Handle<DivideByZeroException>()
                                 .FallbackAsync(fallbackActionAsync);
 
-        await fallbackPolicy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>()).Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => fallbackPolicy.RaiseExceptionAsync<DivideByZeroException>());
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -135,9 +135,9 @@ public class FallbackAsyncSpecs
                                 .Or<ArgumentException>()
                                 .FallbackAsync(fallbackActionAsync);
 
-        await fallbackPolicy.Awaiting(x => x.RaiseExceptionAsync<ArgumentException>()).Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => fallbackPolicy.RaiseExceptionAsync<ArgumentException>());
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -151,9 +151,9 @@ public class FallbackAsyncSpecs
                                 .Or<NullReferenceException>()
                                 .FallbackAsync(fallbackActionAsync);
 
-        await fallbackPolicy.Awaiting(x => x.RaiseExceptionAsync<ArgumentNullException>()).Should().ThrowAsync<ArgumentNullException>();
+        await Should.ThrowAsync<ArgumentNullException>(() => fallbackPolicy.RaiseExceptionAsync<ArgumentNullException>());
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -166,9 +166,9 @@ public class FallbackAsyncSpecs
                                 .Handle<DivideByZeroException>(_ => false)
                                 .FallbackAsync(fallbackActionAsync);
 
-        await fallbackPolicy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>()).Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => fallbackPolicy.RaiseExceptionAsync<DivideByZeroException>());
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -182,9 +182,9 @@ public class FallbackAsyncSpecs
                                 .Or<ArgumentNullException>(_ => false)
                                 .FallbackAsync(fallbackActionAsync);
 
-        await fallbackPolicy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>()).Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => fallbackPolicy.RaiseExceptionAsync<DivideByZeroException>());
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -197,9 +197,9 @@ public class FallbackAsyncSpecs
                                 .Handle<DivideByZeroException>(_ => true)
                                 .FallbackAsync(fallbackActionAsync);
 
-        await fallbackPolicy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>()).Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => fallbackPolicy.RaiseExceptionAsync<DivideByZeroException>());
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -213,9 +213,9 @@ public class FallbackAsyncSpecs
                                 .Or<ArgumentNullException>()
                                 .FallbackAsync(fallbackActionAsync);
 
-        await fallbackPolicy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>()).Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => fallbackPolicy.RaiseExceptionAsync<DivideByZeroException>());
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -232,11 +232,10 @@ public class FallbackAsyncSpecs
             .Handle<DivideByZeroException>()
             .FallbackAsync(fallbackActionAsync);
 
-        var ex = await fallbackPolicy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>((e, _) => e.HelpLink = "FromExecuteDelegate"))
-            .Should().ThrowAsync<DivideByZeroException>();
-        ex.And.HelpLink.Should().Be("FromFallbackAction");
+        var ex = await Should.ThrowAsync<DivideByZeroException>(() => fallbackPolicy.RaiseExceptionAsync<DivideByZeroException>((e, _) => e.HelpLink = "FromExecuteDelegate"));
+        ex.HelpLink.ShouldBe("FromFallbackAction");
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -246,7 +245,7 @@ public class FallbackAsyncSpecs
             .Handle<DivideByZeroException>()
             .FallbackAsync(_ => TaskHelper.EmptyTask);
 
-        await fallbackPolicy.Awaiting(p => p.ExecuteAsync<int>(() => Task.FromResult(0))).Should().ThrowAsync<InvalidOperationException>();
+        await Should.ThrowAsync<InvalidOperationException>(() => fallbackPolicy.ExecuteAsync<int>(() => Task.FromResult(0)));
     }
 
     #endregion
@@ -269,9 +268,9 @@ public class FallbackAsyncSpecs
         Exception instanceToThrow = new ArgumentNullException("myParam");
         await fallbackPolicy.RaiseExceptionAsync(instanceToThrow);
 
-        fallbackActionExecuted.Should().BeTrue();
-        exceptionPassedToOnFallback.Should().BeOfType<ArgumentNullException>();
-        exceptionPassedToOnFallback.Should().Be(instanceToThrow);
+        fallbackActionExecuted.ShouldBeTrue();
+        exceptionPassedToOnFallback.ShouldBeOfType<ArgumentNullException>();
+        exceptionPassedToOnFallback.ShouldBe(instanceToThrow);
     }
 
     [Fact]
@@ -288,7 +287,7 @@ public class FallbackAsyncSpecs
 
         await fallbackPolicy.ExecuteAsync(() => TaskHelper.EmptyTask);
 
-        onFallbackExecuted.Should().BeFalse();
+        onFallbackExecuted.ShouldBeFalse();
     }
 
     #endregion
@@ -308,13 +307,15 @@ public class FallbackAsyncSpecs
             .Handle<ArgumentNullException>()
             .FallbackAsync(fallbackActionAsync, onFallbackAsync);
 
-        await fallbackPolicy.Awaiting(p => p.ExecuteAsync(_ => throw new ArgumentNullException(),
-            CreateDictionary("key1", "value1", "key2", "value2")))
-            .Should().NotThrowAsync();
+        await Should.NotThrowAsync(
+            () =>
+                fallbackPolicy.ExecuteAsync(
+                    _ => throw new ArgumentNullException(),
+                    CreateDictionary("key1", "value1", "key2", "value2")));
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -330,13 +331,15 @@ public class FallbackAsyncSpecs
             .Handle<ArgumentNullException>()
             .FallbackAsync(fallbackActionAsync, onFallbackAsync);
 
-        await fallbackPolicy.Awaiting(p => p.ExecuteAndCaptureAsync(_ => throw new ArgumentNullException(),
-            CreateDictionary("key1", "value1", "key2", "value2")))
-            .Should().NotThrowAsync();
+        await Should.NotThrowAsync(
+            () =>
+                fallbackPolicy.ExecuteAndCaptureAsync(
+                    _ => throw new ArgumentNullException(),
+                    CreateDictionary("key1", "value1", "key2", "value2")));
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -344,7 +347,7 @@ public class FallbackAsyncSpecs
     {
         Func<Context, CancellationToken, Task> fallbackActionAsync = (_, _) => TaskHelper.EmptyTask;
 
-        IDictionary<Type, object> contextData = new Dictionary<Type, object>();
+        var contextData = new Dictionary<Type, object>();
 
         Func<Exception, Context, Task> onFallbackAsync = (ex, ctx) => { contextData[ex.GetType()] = ctx["key"]; return TaskHelper.EmptyTask; };
 
@@ -353,18 +356,13 @@ public class FallbackAsyncSpecs
             .Or<DivideByZeroException>()
             .FallbackAsync(fallbackActionAsync, onFallbackAsync);
 
-        await fallbackPolicy.Awaiting(p => p.ExecuteAsync(_ => throw new ArgumentNullException(), CreateDictionary("key", "value1")))
-            .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => fallbackPolicy.ExecuteAsync(_ => throw new ArgumentNullException(), CreateDictionary("key", "value1")));
+        await Should.NotThrowAsync(() => fallbackPolicy.ExecuteAsync(_ => throw new DivideByZeroException(), CreateDictionary("key", "value2")));
 
-        await fallbackPolicy.Awaiting(p => p.ExecuteAsync(_ => throw new DivideByZeroException(), CreateDictionary("key", "value2")))
-            .Should().NotThrowAsync();
-
-        contextData.Count.Should().Be(2);
-        contextData.Keys.Should().Contain(typeof(ArgumentNullException));
-        contextData.Keys.Should().Contain(typeof(DivideByZeroException));
-        contextData[typeof(ArgumentNullException)].Should().Be("value1");
-        contextData[typeof(DivideByZeroException)].Should().Be("value2");
-
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue(typeof(ArgumentNullException), "value1");
+        contextData.ShouldContainKeyAndValue(typeof(DivideByZeroException), "value2");
+        contextData.Count.ShouldBe(2);
     }
 
     [Fact]
@@ -383,8 +381,8 @@ public class FallbackAsyncSpecs
 
         await fallbackPolicy.RaiseExceptionAsync<DivideByZeroException>();
 
-        onFallbackExecuted.Should().BeTrue();
-        capturedContext.Should().BeEmpty();
+        onFallbackExecuted.ShouldBeTrue();
+        capturedContext.ShouldBeEmpty();
     }
 
     [Fact]
@@ -400,13 +398,15 @@ public class FallbackAsyncSpecs
             .Handle<ArgumentNullException>()
             .FallbackAsync(fallbackActionAsync, onFallbackAsync);
 
-        await fallbackPolicy.Awaiting(p => p.ExecuteAsync(_ => throw new ArgumentNullException(),
-                CreateDictionary("key1", "value1", "key2", "value2")))
-            .Should().NotThrowAsync();
+        await Should.NotThrowAsync(
+            () =>
+                fallbackPolicy.ExecuteAsync(
+                    _ => throw new ArgumentNullException(),
+                    CreateDictionary("key1", "value1", "key2", "value2")));
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -422,13 +422,15 @@ public class FallbackAsyncSpecs
             .Handle<ArgumentNullException>()
             .FallbackAsync(fallbackActionAsync, onFallbackAsync);
 
-        await fallbackPolicy.Awaiting(p => p.ExecuteAndCaptureAsync(_ => throw new ArgumentNullException(),
-                CreateDictionary("key1", "value1", "key2", "value2")))
-            .Should().NotThrowAsync();
+        await Should.NotThrowAsync(
+            () =>
+                fallbackPolicy.ExecuteAndCaptureAsync(
+                    _ => throw new ArgumentNullException(),
+                    CreateDictionary("key1", "value1", "key2", "value2")));
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -448,8 +450,8 @@ public class FallbackAsyncSpecs
 
         await fallbackPolicy.RaiseExceptionAsync<DivideByZeroException>();
 
-        fallbackExecuted.Should().BeTrue();
-        capturedContext.Should().BeEmpty();
+        fallbackExecuted.ShouldBeTrue();
+        capturedContext.ShouldBeEmpty();
     }
 
     #endregion
@@ -470,10 +472,9 @@ public class FallbackAsyncSpecs
             .FallbackAsync(fallbackFunc, onFallback);
 
         Exception instanceToThrow = new ArgumentNullException("myParam");
-        await fallbackPolicy.Awaiting(p => p.RaiseExceptionAsync(instanceToThrow))
-            .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => fallbackPolicy.RaiseExceptionAsync(instanceToThrow));
 
-        fallbackException.Should().Be(instanceToThrow);
+        fallbackException.ShouldBe(instanceToThrow);
     }
 
     [Fact]
@@ -489,11 +490,10 @@ public class FallbackAsyncSpecs
             .Handle<ArgumentNullException>()
             .FallbackAsync(fallbackFunc, onFallback);
 
-        await fallbackPolicy.Awaiting(p => p.ExecuteAndCaptureAsync(() => throw new ArgumentNullException()))
-            .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => fallbackPolicy.ExecuteAndCaptureAsync(() => throw new ArgumentNullException()));
 
-        fallbackException.Should().NotBeNull()
-            .And.BeOfType<ArgumentNullException>();
+        fallbackException.ShouldNotBeNull()
+            .ShouldBeOfType<ArgumentNullException>();
     }
 
     [Fact]
@@ -511,10 +511,9 @@ public class FallbackAsyncSpecs
 
         Exception instanceToCapture = new ArgumentNullException("myParam");
         Exception instanceToThrow = new Exception(string.Empty, instanceToCapture);
-        await fallbackPolicy.Awaiting(p => p.RaiseExceptionAsync(instanceToThrow))
-            .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => fallbackPolicy.RaiseExceptionAsync(instanceToThrow));
 
-        fallbackException.Should().Be(instanceToCapture);
+        fallbackException.ShouldBe(instanceToCapture);
     }
 
     [Fact]
@@ -532,10 +531,9 @@ public class FallbackAsyncSpecs
 
         Exception instanceToCapture = new ArgumentNullException("myParam");
         Exception instanceToThrow = new AggregateException(instanceToCapture);
-        await fallbackPolicy.Awaiting(p => p.RaiseExceptionAsync(instanceToThrow))
-            .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => fallbackPolicy.RaiseExceptionAsync(instanceToThrow));
 
-        fallbackException.Should().Be(instanceToCapture);
+        fallbackException.ShouldBe(instanceToCapture);
     }
 
     [Fact]
@@ -551,10 +549,9 @@ public class FallbackAsyncSpecs
             .Handle<DivideByZeroException>()
             .FallbackAsync(fallbackFunc, onFallback);
 
-        await fallbackPolicy.Awaiting(p => p.ExecuteAsync(() => throw new ArgumentNullException()))
-            .Should().ThrowAsync<ArgumentNullException>();
+        await Should.ThrowAsync<ArgumentNullException>(() => fallbackPolicy.ExecuteAsync(() => throw new ArgumentNullException()));
 
-        fallbackException.Should().BeNull();
+        fallbackException.ShouldBeNull();
     }
 
     #endregion
@@ -567,9 +564,8 @@ public class FallbackAsyncSpecs
         bool fallbackActionExecuted = false;
         Func<CancellationToken, Task> fallbackActionAsync = _ => { fallbackActionExecuted = true; return TaskHelper.EmptyTask; };
 
-        var policy = Policy
-                                .Handle<DivideByZeroException>()
-                                .FallbackAsync(fallbackActionAsync);
+        var policy = Policy.Handle<DivideByZeroException>()
+                           .FallbackAsync(fallbackActionAsync);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -583,13 +579,12 @@ public class FallbackAsyncSpecs
         using (var cancellationTokenSource = new CancellationTokenSource())
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
-            await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().NotThrowAsync();
+            await Should.NotThrowAsync(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -598,9 +593,8 @@ public class FallbackAsyncSpecs
         bool fallbackActionExecuted = false;
         Func<CancellationToken, Task> fallbackActionAsync = _ => { fallbackActionExecuted = true; return TaskHelper.EmptyTask; };
 
-        var policy = Policy
-                                .Handle<DivideByZeroException>()
-                                .FallbackAsync(fallbackActionAsync);
+        var policy = Policy.Handle<DivideByZeroException>()
+                           .FallbackAsync(fallbackActionAsync);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -614,13 +608,12 @@ public class FallbackAsyncSpecs
         using (var cancellationTokenSource = new CancellationTokenSource())
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
-            await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().NotThrowAsync();
+            await Should.NotThrowAsync(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -629,9 +622,8 @@ public class FallbackAsyncSpecs
         bool fallbackActionExecuted = false;
         Func<CancellationToken, Task> fallbackActionAsync = _ => { fallbackActionExecuted = true; return TaskHelper.EmptyTask; };
 
-        var policy = Policy
-                                .Handle<DivideByZeroException>()
-                                .FallbackAsync(fallbackActionAsync);
+        var policy = Policy.Handle<DivideByZeroException>()
+                           .FallbackAsync(fallbackActionAsync);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -647,14 +639,13 @@ public class FallbackAsyncSpecs
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             cancellationTokenSource.Cancel();
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(0);
+        attemptsInvoked.ShouldBe(0);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -663,9 +654,8 @@ public class FallbackAsyncSpecs
         bool fallbackActionExecuted = false;
         Func<CancellationToken, Task> fallbackActionAsync = _ => { fallbackActionExecuted = true; return TaskHelper.EmptyTask; };
 
-        var policy = Policy
-                                .Handle<DivideByZeroException>()
-                                .FallbackAsync(fallbackActionAsync);
+        var policy = Policy.Handle<DivideByZeroException>()
+                           .FallbackAsync(fallbackActionAsync);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -681,14 +671,13 @@ public class FallbackAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -697,10 +686,9 @@ public class FallbackAsyncSpecs
         bool fallbackActionExecuted = false;
         Func<CancellationToken, Task> fallbackActionAsync = _ => { fallbackActionExecuted = true; return TaskHelper.EmptyTask; };
 
-        var policy = Policy
-                                .Handle<DivideByZeroException>()
-                                .Or<OperationCanceledException>()
-                                .FallbackAsync(fallbackActionAsync);
+        var policy = Policy.Handle<DivideByZeroException>()
+                           .Or<OperationCanceledException>()
+                           .FallbackAsync(fallbackActionAsync);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -716,13 +704,12 @@ public class FallbackAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().NotThrowAsync();
+            await Should.NotThrowAsync(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -731,9 +718,8 @@ public class FallbackAsyncSpecs
         bool fallbackActionExecuted = false;
         Func<CancellationToken, Task> fallbackActionAsync = _ => { fallbackActionExecuted = true; return TaskHelper.EmptyTask; };
 
-        var policy = Policy
-                                .Handle<DivideByZeroException>()
-                                .FallbackAsync(fallbackActionAsync);
+        var policy = Policy.Handle<DivideByZeroException>()
+                           .FallbackAsync(fallbackActionAsync);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -749,13 +735,12 @@ public class FallbackAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().NotThrowAsync();
+            await Should.NotThrowAsync(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -764,9 +749,8 @@ public class FallbackAsyncSpecs
         bool fallbackActionExecuted = false;
         Func<CancellationToken, Task> fallbackActionAsync = _ => { fallbackActionExecuted = true; return TaskHelper.EmptyTask; };
 
-        var policy = Policy
-                                .Handle<DivideByZeroException>()
-                                .FallbackAsync(fallbackActionAsync);
+        var policy = Policy.Handle<DivideByZeroException>()
+                           .FallbackAsync(fallbackActionAsync);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -782,13 +766,12 @@ public class FallbackAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<NullReferenceException>(scenario, cancellationTokenSource, onExecute))
-                .Should().ThrowAsync<NullReferenceException>();
+            await Should.ThrowAsync<NullReferenceException>(() => policy.RaiseExceptionAndOrCancellationAsync<NullReferenceException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -797,9 +780,8 @@ public class FallbackAsyncSpecs
         bool fallbackActionExecuted = false;
         Func<CancellationToken, Task> fallbackActionAsync = _ => { fallbackActionExecuted = true; return TaskHelper.EmptyTask; };
 
-        var policy = Policy
-                                .Handle<DivideByZeroException>()
-                                .FallbackAsync(fallbackActionAsync);
+        var policy = Policy.Handle<DivideByZeroException>()
+                           .FallbackAsync(fallbackActionAsync);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -815,13 +797,12 @@ public class FallbackAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().NotThrowAsync();
+            await Should.NotThrowAsync(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     #endregion

--- a/test/Polly.Specs/Fallback/FallbackSpecs.cs
+++ b/test/Polly.Specs/Fallback/FallbackSpecs.cs
@@ -12,11 +12,11 @@ public class FallbackSpecs
         Action fallbackAction = null!;
 
         Action policy = () => Policy
-                                .Handle<DivideByZeroException>()
-                                .Fallback(fallbackAction);
+            .Handle<DivideByZeroException>()
+            .Fallback(fallbackAction);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("fallbackAction");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("fallbackAction");
     }
 
     [Fact]
@@ -28,8 +28,8 @@ public class FallbackSpecs
             .Handle<DivideByZeroException>()
             .Fallback(fallbackAction);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("fallbackAction");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("fallbackAction");
     }
 
     [Fact]
@@ -39,11 +39,11 @@ public class FallbackSpecs
         Action<Exception> onFallback = _ => { };
 
         Action policy = () => Policy
-                                .Handle<DivideByZeroException>()
-                                .Fallback(fallbackAction, onFallback);
+            .Handle<DivideByZeroException>()
+            .Fallback(fallbackAction, onFallback);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("fallbackAction");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("fallbackAction");
     }
 
     [Fact]
@@ -56,8 +56,8 @@ public class FallbackSpecs
             .Handle<DivideByZeroException>()
             .Fallback(fallbackAction, onFallback);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("fallbackAction");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("fallbackAction");
     }
 
     [Fact]
@@ -67,11 +67,11 @@ public class FallbackSpecs
         Action<Exception, Context> onFallback = (_, _) => { };
 
         Action policy = () => Policy
-                                .Handle<DivideByZeroException>()
-                                .Fallback(fallbackAction, onFallback);
+            .Handle<DivideByZeroException>()
+            .Fallback(fallbackAction, onFallback);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("fallbackAction");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("fallbackAction");
     }
 
     [Fact]
@@ -81,11 +81,11 @@ public class FallbackSpecs
         Action<Exception, Context> onFallback = (_, _) => { };
 
         Action policy = () => Policy
-                                .Handle<DivideByZeroException>()
-                                .Fallback(fallbackAction, onFallback);
+            .Handle<DivideByZeroException>()
+            .Fallback(fallbackAction, onFallback);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("fallbackAction");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("fallbackAction");
     }
 
     [Fact]
@@ -95,11 +95,11 @@ public class FallbackSpecs
         Action<Exception> onFallback = null!;
 
         Action policy = () => Policy
-                                .Handle<DivideByZeroException>()
-                                .Fallback(fallbackAction, onFallback);
+            .Handle<DivideByZeroException>()
+            .Fallback(fallbackAction, onFallback);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onFallback");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onFallback");
     }
 
     [Fact]
@@ -112,8 +112,8 @@ public class FallbackSpecs
             .Handle<DivideByZeroException>()
             .Fallback(fallbackAction, onFallback);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onFallback");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onFallback");
     }
 
     [Fact]
@@ -123,11 +123,11 @@ public class FallbackSpecs
         Action<Exception, Context> onFallback = null!;
 
         Action policy = () => Policy
-                                .Handle<DivideByZeroException>()
-                                .Fallback(fallbackAction, onFallback);
+            .Handle<DivideByZeroException>()
+            .Fallback(fallbackAction, onFallback);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onFallback");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onFallback");
     }
 
     [Fact]
@@ -137,11 +137,11 @@ public class FallbackSpecs
         Action<Exception, Context> onFallback = null!;
 
         Action policy = () => Policy
-                                .Handle<DivideByZeroException>()
-                                .Fallback(fallbackAction, onFallback);
+            .Handle<DivideByZeroException>()
+            .Fallback(fallbackAction, onFallback);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onFallback");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onFallback");
     }
 
     #endregion
@@ -152,139 +152,139 @@ public class FallbackSpecs
     public void Should_not_execute_fallback_when_executed_delegate_does_not_throw()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
-                                .Handle<DivideByZeroException>()
-                                .Fallback(fallbackAction);
+            .Handle<DivideByZeroException>()
+            .Fallback(fallbackAction);
 
         fallbackPolicy.Execute(() => { });
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
     public void Should_not_execute_fallback_when_executed_delegate_throws_exception_not_handled_by_policy()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
-                                .Handle<DivideByZeroException>()
-                                .Fallback(fallbackAction);
+            .Handle<DivideByZeroException>()
+            .Fallback(fallbackAction);
 
-        fallbackPolicy.Invoking(x => x.RaiseException<ArgumentNullException>()).Should().Throw<ArgumentNullException>();
+        Should.Throw<ArgumentNullException>(() => fallbackPolicy.RaiseException<ArgumentNullException>());
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
     public void Should_execute_fallback_when_executed_delegate_throws_exception_handled_by_policy()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
             .Handle<DivideByZeroException>()
             .Fallback(fallbackAction);
 
-        fallbackPolicy.Invoking(x => x.RaiseException<DivideByZeroException>()).Should().NotThrow();
+        Should.NotThrow(() => fallbackPolicy.RaiseException<DivideByZeroException>());
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
     public void Should_execute_fallback_when_executed_delegate_throws_one_of_exceptions_handled_by_policy()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
             .Handle<DivideByZeroException>()
             .Or<ArgumentException>()
             .Fallback(fallbackAction);
 
-        fallbackPolicy.Invoking(x => x.RaiseException<ArgumentException>()).Should().NotThrow();
+        Should.NotThrow(() => fallbackPolicy.RaiseException<ArgumentException>());
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
     public void Should_not_execute_fallback_when_executed_delegate_throws_exception_not_one_of_exceptions_handled_by_policy()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
-                                .Handle<DivideByZeroException>()
-                                .Or<NullReferenceException>()
-                                .Fallback(fallbackAction);
+            .Handle<DivideByZeroException>()
+            .Or<NullReferenceException>()
+            .Fallback(fallbackAction);
 
-        fallbackPolicy.Invoking(x => x.RaiseException<ArgumentNullException>()).Should().Throw<ArgumentNullException>();
+        Should.Throw<ArgumentNullException>(() => fallbackPolicy.RaiseException<ArgumentNullException>());
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
     public void Should_not_execute_fallback_when_exception_thrown_does_not_match_handling_predicates()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
-                                .Handle<DivideByZeroException>(_ => false)
-                                .Fallback(fallbackAction);
+            .Handle<DivideByZeroException>(_ => false)
+            .Fallback(fallbackAction);
 
-        fallbackPolicy.Invoking(x => x.RaiseException<DivideByZeroException>()).Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => fallbackPolicy.RaiseException<DivideByZeroException>());
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
     public void Should_not_execute_fallback_when_exception_thrown_does_not_match_any_of_handling_predicates()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
-                                .Handle<DivideByZeroException>(_ => false)
-                                .Or<ArgumentNullException>(_ => false)
-                                .Fallback(fallbackAction);
+            .Handle<DivideByZeroException>(_ => false)
+            .Or<ArgumentNullException>(_ => false)
+            .Fallback(fallbackAction);
 
-        fallbackPolicy.Invoking(x => x.RaiseException<DivideByZeroException>()).Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => fallbackPolicy.RaiseException<DivideByZeroException>());
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
     public void Should_execute_fallback_when_exception_thrown_matches_handling_predicates()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
             .Handle<DivideByZeroException>(_ => true)
             .Fallback(fallbackAction);
 
-        fallbackPolicy.Invoking(x => x.RaiseException<DivideByZeroException>()).Should().NotThrow();
+        Should.NotThrow(() => fallbackPolicy.RaiseException<DivideByZeroException>());
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
     public void Should_execute_fallback_when_exception_thrown_matches_one_of_handling_predicates()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
             .Handle<DivideByZeroException>(_ => true)
             .Or<ArgumentNullException>()
             .Fallback(fallbackAction);
 
-        fallbackPolicy.Invoking(x => x.RaiseException<DivideByZeroException>()).Should().NotThrow();
+        Should.NotThrow(() => fallbackPolicy.RaiseException<DivideByZeroException>());
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -301,10 +301,10 @@ public class FallbackSpecs
             .Handle<DivideByZeroException>()
             .Fallback(fallbackAction);
 
-        fallbackPolicy.Invoking(x => x.RaiseException<DivideByZeroException>((e, _) => e.HelpLink = "FromExecuteDelegate"))
-            .Should().Throw<DivideByZeroException>().And.HelpLink.Should().Be("FromFallbackAction");
+        Should.Throw<DivideByZeroException>(() => fallbackPolicy.RaiseException<DivideByZeroException>((e, _) => e.HelpLink = "FromExecuteDelegate"))
+            .HelpLink.ShouldBe("FromFallbackAction");
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -314,7 +314,7 @@ public class FallbackSpecs
             .Handle<DivideByZeroException>()
             .Fallback(() => { });
 
-        fallbackPolicy.Invoking(p => p.Execute<int>(() => 0)).Should().Throw<InvalidOperationException>();
+        Should.Throw<InvalidOperationException>(() => fallbackPolicy.Execute(() => 0));
     }
 
     #endregion
@@ -325,7 +325,7 @@ public class FallbackSpecs
     public void Should_not_execute_fallback_when_executed_delegate_throws_inner_exception_where_policy_doesnt_handle_inner()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
             .Handle<DivideByZeroException>()
@@ -333,16 +333,16 @@ public class FallbackSpecs
 
         Exception withInner = new Exception(string.Empty, new DivideByZeroException());
 
-        fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().Throw<Exception>().And.InnerException.Should().BeOfType<DivideByZeroException>();
+        Should.Throw<Exception>(() => fallbackPolicy.RaiseException(withInner)).InnerException.ShouldBeOfType<DivideByZeroException>();
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
     public void Should_execute_fallback_when_policy_handles_inner_and_executed_delegate_throws_as_non_inner()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
             .HandleInner<DivideByZeroException>()
@@ -350,16 +350,16 @@ public class FallbackSpecs
 
         Exception nonInner = new DivideByZeroException();
 
-        fallbackPolicy.Invoking(x => x.RaiseException(nonInner)).Should().NotThrow();
+        Should.NotThrow(() => fallbackPolicy.RaiseException(nonInner));
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
     public void Should_execute_fallback_when_executed_delegate_throws_inner_exception_handled_by_policy()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
             .HandleInner<DivideByZeroException>()
@@ -367,16 +367,16 @@ public class FallbackSpecs
 
         Exception withInner = new Exception(string.Empty, new DivideByZeroException());
 
-        fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().NotThrow();
+        Should.NotThrow(() => fallbackPolicy.RaiseException(withInner));
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
     public void Should_execute_fallback_when_executed_delegate_throws_one_of_inner_exceptions_handled_by_policy()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
             .Handle<DivideByZeroException>()
@@ -385,16 +385,16 @@ public class FallbackSpecs
 
         Exception withInner = new Exception(string.Empty, new ArgumentException());
 
-        fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().NotThrow();
+        Should.NotThrow(() => fallbackPolicy.RaiseException(withInner));
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
     public void Should_execute_fallback_when_executed_delegate_throws_nested_inner_exception_handled_by_policy()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
             .HandleInner<DivideByZeroException>()
@@ -402,33 +402,33 @@ public class FallbackSpecs
 
         Exception withInner = new Exception(string.Empty, new Exception(string.Empty, new Exception(string.Empty, new DivideByZeroException())));
 
-        fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().NotThrow();
+        Should.NotThrow(() => fallbackPolicy.RaiseException(withInner));
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
     public void Should_not_execute_fallback_when_executed_delegate_throws_inner_exception_not_handled_by_policy()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
-                                .HandleInner<DivideByZeroException>()
-                                .Fallback(fallbackAction);
+            .HandleInner<DivideByZeroException>()
+            .Fallback(fallbackAction);
 
         Exception withInner = new Exception(string.Empty, new ArgumentException());
 
-        fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().Throw<Exception>().And.InnerException.Should().BeOfType<ArgumentException>();
+        Should.Throw<Exception>(() => fallbackPolicy.RaiseException(withInner)).InnerException.ShouldBeOfType<ArgumentException>();
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
     public void Should_execute_fallback_when_inner_exception_thrown_matches_handling_predicates()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
             .HandleInner<DivideByZeroException>(_ => true)
@@ -436,16 +436,16 @@ public class FallbackSpecs
 
         Exception withInner = new Exception(string.Empty, new DivideByZeroException());
 
-        fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().NotThrow();
+        Should.NotThrow(() => fallbackPolicy.RaiseException(withInner));
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
     public void Should_execute_fallback_when_inner_nested_exception_thrown_matches_handling_predicates()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
             .HandleInner<DivideByZeroException>(_ => true)
@@ -453,16 +453,16 @@ public class FallbackSpecs
 
         Exception withInner = new Exception(string.Empty, new Exception(string.Empty, new Exception(string.Empty, new DivideByZeroException())));
 
-        fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().NotThrow();
+        Should.NotThrow(() => fallbackPolicy.RaiseException(withInner));
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
     public void Should_execute_fallback_when_inner_exception_thrown_matches_one_of_handling_predicates()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
             .HandleInner<DivideByZeroException>(_ => true)
@@ -471,44 +471,44 @@ public class FallbackSpecs
 
         Exception withInner = new Exception(string.Empty, new ArgumentNullException());
 
-        fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().NotThrow();
+        Should.NotThrow(() => fallbackPolicy.RaiseException(withInner));
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
     public void Should_not_execute_fallback_when_inner_exception_thrown_does_not_match_handling_predicates()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
-                                .HandleInner<DivideByZeroException>(_ => false)
-                                .Fallback(fallbackAction);
+            .HandleInner<DivideByZeroException>(_ => false)
+            .Fallback(fallbackAction);
 
         Exception withInner = new Exception(string.Empty, new DivideByZeroException());
 
-        fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().Throw<Exception>().And.InnerException.Should().BeOfType<DivideByZeroException>();
+        Should.Throw<Exception>(() => fallbackPolicy.RaiseException(withInner)).InnerException.ShouldBeOfType<DivideByZeroException>();
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
     public void Should_not_execute_fallback_when_inner_exception_thrown_does_not_match_any_of_handling_predicates()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
-                                .HandleInner<DivideByZeroException>(_ => false)
-                                .OrInner<ArgumentNullException>(_ => false)
-                                .Fallback(fallbackAction);
+            .HandleInner<DivideByZeroException>(_ => false)
+            .OrInner<ArgumentNullException>(_ => false)
+            .Fallback(fallbackAction);
 
         Exception withInner = new Exception(string.Empty, new ArgumentNullException());
 
-        fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().Throw<Exception>().And.InnerException.Should().BeOfType<ArgumentNullException>();
+        Should.Throw<Exception>(() => fallbackPolicy.RaiseException(withInner)).InnerException.ShouldBeOfType<ArgumentNullException>();
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     #endregion
@@ -519,7 +519,7 @@ public class FallbackSpecs
     public void Should_not_execute_fallback_when_executed_delegate_throws_inner_of_aggregate_exception_where_policy_doesnt_handle_inner()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
             .Handle<DivideByZeroException>()
@@ -527,16 +527,16 @@ public class FallbackSpecs
 
         Exception withInner = new AggregateException(new DivideByZeroException());
 
-        fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().Throw<AggregateException>().And.InnerExceptions.Should().ContainSingle(e => e is DivideByZeroException);
+        Should.Throw<AggregateException>(() => fallbackPolicy.RaiseException(withInner)).InnerExceptions.Count(e => e is DivideByZeroException).ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
     public void Should_execute_fallback_when_executed_delegate_throws_inner_of_aggregate_exception_handled_by_policy()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
             .HandleInner<DivideByZeroException>()
@@ -544,16 +544,16 @@ public class FallbackSpecs
 
         Exception withInner = new AggregateException(new DivideByZeroException());
 
-        fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().NotThrow();
+        Should.NotThrow(() => fallbackPolicy.RaiseException(withInner));
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
     public void Should_execute_fallback_when_executed_delegate_throws_one_of_inner_of_aggregate_exceptions_handled_by_policy()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
             .Handle<DivideByZeroException>()
@@ -562,16 +562,16 @@ public class FallbackSpecs
 
         Exception withInner = new AggregateException(new ArgumentException());
 
-        fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().NotThrow();
+        Should.NotThrow(() => fallbackPolicy.RaiseException(withInner));
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
     public void Should_execute_fallback_when_executed_delegate_throws_aggregate_exception_with_inner_handled_by_policy_amongst_other_inners()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
             .HandleInner<DivideByZeroException>()
@@ -579,16 +579,16 @@ public class FallbackSpecs
 
         Exception withInner = new AggregateException(new ArgumentException(), new DivideByZeroException(), new ArgumentNullException());
 
-        fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().NotThrow();
+        Should.NotThrow(() => fallbackPolicy.RaiseException(withInner));
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
     public void Should_execute_fallback_when_executed_delegate_throws_nested_inner_of_aggregate_exception_handled_by_policy()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
             .HandleInner<DivideByZeroException>()
@@ -596,33 +596,35 @@ public class FallbackSpecs
 
         Exception withInner = new AggregateException(new AggregateException(new DivideByZeroException()));
 
-        fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().NotThrow();
+        Should.NotThrow(() => fallbackPolicy.RaiseException(withInner));
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
     public void Should_not_execute_fallback_when_executed_delegate_throws_inner_of_aggregate_exception_not_handled_by_policy()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
-                                .HandleInner<DivideByZeroException>()
-                                .Fallback(fallbackAction);
+            .HandleInner<DivideByZeroException>()
+            .Fallback(fallbackAction);
 
         Exception withInner = new AggregateException(new ArgumentException());
 
-        fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().Throw<AggregateException>().And.InnerExceptions.Should().ContainSingle(e => e is ArgumentException);
+        Should.Throw<AggregateException>(() => fallbackPolicy.RaiseException(withInner)).InnerExceptions
+            .Count(e => e is ArgumentException)
+            .ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
     public void Should_execute_fallback_when_inner_of_aggregate_exception_thrown_matches_handling_predicates()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
             .HandleInner<DivideByZeroException>(_ => true)
@@ -630,16 +632,16 @@ public class FallbackSpecs
 
         Exception withInner = new AggregateException(new DivideByZeroException());
 
-        fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().NotThrow();
+        Should.NotThrow(() => fallbackPolicy.RaiseException(withInner));
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
     public void Should_execute_fallback_when_inner_of_aggregate_nested_exception_thrown_matches_handling_predicates()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
             .HandleInner<DivideByZeroException>(_ => true)
@@ -647,16 +649,16 @@ public class FallbackSpecs
 
         Exception withInner = new AggregateException(new AggregateException(new DivideByZeroException()));
 
-        fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().NotThrow();
+        Should.NotThrow(() => fallbackPolicy.RaiseException(withInner));
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
     public void Should_execute_fallback_when_inner_of_aggregate_exception_thrown_matches_one_of_handling_predicates()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
             .HandleInner<DivideByZeroException>(_ => true)
@@ -665,44 +667,44 @@ public class FallbackSpecs
 
         Exception withInner = new AggregateException(new ArgumentNullException());
 
-        fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().NotThrow();
+        Should.NotThrow(() => fallbackPolicy.RaiseException(withInner));
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
     public void Should_not_execute_fallback_when_inner_of_aggregate_exception_thrown_does_not_match_handling_predicates()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
-                                .HandleInner<DivideByZeroException>(_ => false)
-                                .Fallback(fallbackAction);
+            .HandleInner<DivideByZeroException>(_ => false)
+            .Fallback(fallbackAction);
 
         Exception withInner = new AggregateException(new DivideByZeroException());
 
-        fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().Throw<AggregateException>().And.InnerExceptions.Should().ContainSingle(e => e is DivideByZeroException);
+        Should.Throw<AggregateException>(() => fallbackPolicy.RaiseException(withInner)).InnerExceptions.Count(e => e is DivideByZeroException).ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
     public void Should_not_execute_fallback_when_inner_of_aggregate_exception_thrown_does_not_match_any_of_handling_predicates()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
-                                .HandleInner<DivideByZeroException>(_ => false)
-                                .OrInner<ArgumentNullException>(_ => false)
-                                .Fallback(fallbackAction);
+            .HandleInner<DivideByZeroException>(_ => false)
+            .OrInner<ArgumentNullException>(_ => false)
+            .Fallback(fallbackAction);
 
         Exception withInner = new AggregateException(new ArgumentNullException());
 
-        fallbackPolicy.Invoking(x => x.RaiseException(withInner)).Should().Throw<AggregateException>().And.InnerExceptions.Should().ContainSingle(e => e is ArgumentNullException);
+        Should.Throw<AggregateException>(() => fallbackPolicy.RaiseException(withInner)).InnerExceptions.Count(e => e is ArgumentNullException).ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     #endregion
@@ -713,10 +715,10 @@ public class FallbackSpecs
     public void Should_call_onFallback_passing_exception_triggering_fallback()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         Exception? exceptionPassedToOnFallback = null;
-        Action<Exception> onFallback = ex => { exceptionPassedToOnFallback = ex; };
+        Action<Exception> onFallback = ex => exceptionPassedToOnFallback = ex;
 
         FallbackPolicy fallbackPolicy = Policy
             .Handle<ArgumentNullException>()
@@ -725,9 +727,9 @@ public class FallbackSpecs
         Exception instanceToThrow = new ArgumentNullException("myParam");
         fallbackPolicy.RaiseException(instanceToThrow);
 
-        fallbackActionExecuted.Should().BeTrue();
-        exceptionPassedToOnFallback.Should().BeOfType<ArgumentNullException>();
-        exceptionPassedToOnFallback.Should().Be(instanceToThrow);
+        fallbackActionExecuted.ShouldBeTrue();
+        exceptionPassedToOnFallback.ShouldBeOfType<ArgumentNullException>();
+        exceptionPassedToOnFallback.ShouldBe(instanceToThrow);
     }
 
     [Fact]
@@ -736,7 +738,7 @@ public class FallbackSpecs
         Action fallbackAction = () => { };
 
         bool onFallbackExecuted = false;
-        Action<Exception> onFallback = _ => { onFallbackExecuted = true; };
+        Action<Exception> onFallback = _ => onFallbackExecuted = true;
 
         FallbackPolicy fallbackPolicy = Policy
             .Handle<DivideByZeroException>()
@@ -744,7 +746,7 @@ public class FallbackSpecs
 
         fallbackPolicy.Execute(() => { });
 
-        onFallbackExecuted.Should().BeFalse();
+        onFallbackExecuted.ShouldBeFalse();
     }
 
     #endregion
@@ -758,19 +760,21 @@ public class FallbackSpecs
 
         IDictionary<string, object>? contextData = null;
 
-        Action<Exception, Context> onFallback = (_, ctx) => { contextData = ctx; };
+        Action<Exception, Context> onFallback = (_, ctx) => contextData = ctx;
 
         FallbackPolicy fallbackPolicy = Policy
             .Handle<ArgumentNullException>()
             .Fallback(fallbackAction, onFallback);
 
-        fallbackPolicy.Invoking(p => p.Execute(_ => throw new ArgumentNullException(),
-            CreateDictionary("key1", "value1", "key2", "value2")))
-            .Should().NotThrow();
+        Should.NotThrow(
+            () =>
+                fallbackPolicy.Execute(
+                    _ => throw new ArgumentNullException(),
+                    CreateDictionary("key1", "value1", "key2", "value2")));
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -780,19 +784,21 @@ public class FallbackSpecs
 
         IDictionary<string, object>? contextData = null;
 
-        Action<Exception, Context> onFallback = (_, ctx) => { contextData = ctx; };
+        Action<Exception, Context> onFallback = (_, ctx) => contextData = ctx;
 
         FallbackPolicy fallbackPolicy = Policy
             .Handle<ArgumentNullException>()
             .Fallback(fallbackAction, onFallback);
 
-        fallbackPolicy.Invoking(p => p.ExecuteAndCapture(_ => throw new ArgumentNullException(),
-            CreateDictionary("key1", "value1", "key2", "value2")))
-            .Should().NotThrow();
+        Should.NotThrow(
+            () =>
+                fallbackPolicy.ExecuteAndCapture(
+                    _ => throw new ArgumentNullException(),
+                    CreateDictionary("key1", "value1", "key2", "value2")));
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -802,26 +808,21 @@ public class FallbackSpecs
 
         IDictionary<Type, object> contextData = new Dictionary<Type, object>();
 
-        Action<Exception, Context> onFallback = (ex, ctx) => { contextData[ex.GetType()] = ctx["key"]; };
+        Action<Exception, Context> onFallback = (ex, ctx) => contextData[ex.GetType()] = ctx["key"];
 
         FallbackPolicy fallbackPolicy = Policy
             .Handle<ArgumentNullException>()
             .Or<DivideByZeroException>()
             .Fallback(fallbackAction, onFallback);
 
-        fallbackPolicy.Invoking(
-            p => p.Execute(_ => throw new ArgumentNullException(), CreateDictionary("key", "value1")))
-            .Should().NotThrow();
+        Should.NotThrow(() => fallbackPolicy.Execute(_ => throw new ArgumentNullException(), CreateDictionary("key", "value1")));
+        Should.NotThrow(() => fallbackPolicy.Execute(_ => throw new DivideByZeroException(), CreateDictionary("key", "value2")));
 
-        fallbackPolicy.Invoking(
-            p => p.Execute(_ => throw new DivideByZeroException(), CreateDictionary("key", "value2")))
-            .Should().NotThrow();
-
-        contextData.Count.Should().Be(2);
-        contextData.Keys.Should().Contain(typeof(ArgumentNullException));
-        contextData.Keys.Should().Contain(typeof(DivideByZeroException));
-        contextData[typeof(ArgumentNullException)].Should().Be("value1");
-        contextData[typeof(DivideByZeroException)].Should().Be("value2");
+        contextData.Count.ShouldBe(2);
+        contextData.Keys.ShouldContain(typeof(ArgumentNullException));
+        contextData.Keys.ShouldContain(typeof(DivideByZeroException));
+        contextData[typeof(ArgumentNullException)].ShouldBe("value1");
+        contextData[typeof(DivideByZeroException)].ShouldBe("value2");
 
     }
 
@@ -841,8 +842,8 @@ public class FallbackSpecs
 
         fallbackPolicy.RaiseException<DivideByZeroException>();
 
-        onFallbackExecuted.Should().BeTrue();
-        capturedContext.Should().BeEmpty();
+        onFallbackExecuted.ShouldBeTrue();
+        capturedContext.ShouldBeEmpty();
     }
 
     [Fact]
@@ -850,7 +851,7 @@ public class FallbackSpecs
     {
         IDictionary<string, object>? contextData = null;
 
-        Action<Context, CancellationToken> fallbackAction = (ctx, _) => { contextData = ctx; };
+        Action<Context, CancellationToken> fallbackAction = (ctx, _) => contextData = ctx;
 
         Action<Exception, Context> onFallback = (_, _) => { };
 
@@ -858,13 +859,15 @@ public class FallbackSpecs
             .Handle<ArgumentNullException>()
             .Fallback(fallbackAction, onFallback);
 
-        fallbackPolicy.Invoking(p => p.Execute(_ => throw new ArgumentNullException(),
-                CreateDictionary("key1", "value1", "key2", "value2")))
-            .Should().NotThrow();
+        Should.NotThrow(
+            () =>
+                fallbackPolicy.Execute(
+                    _ => throw new ArgumentNullException(),
+                    CreateDictionary("key1", "value1", "key2", "value2")));
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -872,7 +875,7 @@ public class FallbackSpecs
     {
         IDictionary<string, object>? contextData = null;
 
-        Action<Context, CancellationToken> fallbackAction = (ctx, _) => { contextData = ctx; };
+        Action<Context, CancellationToken> fallbackAction = (ctx, _) => contextData = ctx;
 
         Action<Exception, Context> onFallback = (_, _) => { };
 
@@ -880,13 +883,15 @@ public class FallbackSpecs
             .Handle<ArgumentNullException>()
             .Fallback(fallbackAction, onFallback);
 
-        fallbackPolicy.Invoking(p => p.ExecuteAndCapture(_ => throw new ArgumentNullException(),
-                CreateDictionary("key1", "value1", "key2", "value2")))
-            .Should().NotThrow();
+        Should.NotThrow(
+            () =>
+                fallbackPolicy.ExecuteAndCapture(
+                    _ => throw new ArgumentNullException(),
+                    CreateDictionary("key1", "value1", "key2", "value2")));
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -905,8 +910,8 @@ public class FallbackSpecs
 
         fallbackPolicy.RaiseException<DivideByZeroException>();
 
-        fallbackExecuted.Should().BeTrue();
-        capturedContext.Should().BeEmpty();
+        fallbackExecuted.ShouldBeTrue();
+        capturedContext.ShouldBeEmpty();
     }
 
     #endregion
@@ -918,7 +923,7 @@ public class FallbackSpecs
     {
         Exception? fallbackException = null;
 
-        Action<Exception, Context, CancellationToken> fallbackAction = (ex, _, _) => { fallbackException = ex; };
+        Action<Exception, Context, CancellationToken> fallbackAction = (ex, _, _) => fallbackException = ex;
 
         Action<Exception, Context> onFallback = (_, _) => { };
 
@@ -927,10 +932,9 @@ public class FallbackSpecs
             .Fallback(fallbackAction, onFallback);
 
         Exception instanceToThrow = new ArgumentNullException("myParam");
-        fallbackPolicy.Invoking(p => p.RaiseException(instanceToThrow))
-            .Should().NotThrow();
+        Should.NotThrow(() => fallbackPolicy.RaiseException(instanceToThrow));
 
-        fallbackException.Should().Be(instanceToThrow);
+        fallbackException.ShouldBe(instanceToThrow);
     }
 
     [Fact]
@@ -938,18 +942,18 @@ public class FallbackSpecs
     {
         Exception? fallbackException = null;
 
-        Action<Exception, Context, CancellationToken> fallbackAction = (ex, _, _) => { fallbackException = ex; };
+        Action<Exception, Context, CancellationToken> fallbackAction = (ex, _, _) => fallbackException = ex;
 
         Action<Exception, Context> onFallback = (_, _) => { };
 
         FallbackPolicy fallbackPolicy = Policy
             .Handle<ArgumentNullException>()
             .Fallback(fallbackAction, onFallback);
-        fallbackPolicy.Invoking(p => p.ExecuteAndCapture(() => throw new ArgumentNullException()))
-            .Should().NotThrow();
 
-        fallbackException.Should().NotBeNull()
-            .And.BeOfType<ArgumentNullException>();
+        Should.NotThrow(() => fallbackPolicy.ExecuteAndCapture(() => throw new ArgumentNullException()));
+
+        fallbackException.ShouldNotBeNull()
+            .ShouldBeOfType<ArgumentNullException>();
     }
 
     [Fact]
@@ -957,7 +961,7 @@ public class FallbackSpecs
     {
         Exception? fallbackException = null;
 
-        Action<Exception, Context, CancellationToken> fallbackAction = (ex, _, _) => { fallbackException = ex; };
+        Action<Exception, Context, CancellationToken> fallbackAction = (ex, _, _) => fallbackException = ex;
 
         Action<Exception, Context> onFallback = (_, _) => { };
 
@@ -967,10 +971,9 @@ public class FallbackSpecs
 
         Exception instanceToCapture = new ArgumentNullException("myParam");
         Exception instanceToThrow = new Exception(string.Empty, instanceToCapture);
-        fallbackPolicy.Invoking(p => p.RaiseException(instanceToThrow))
-            .Should().NotThrow();
+        Should.NotThrow(() => fallbackPolicy.RaiseException(instanceToThrow));
 
-        fallbackException.Should().Be(instanceToCapture);
+        fallbackException.ShouldBe(instanceToCapture);
     }
 
     [Fact]
@@ -978,7 +981,7 @@ public class FallbackSpecs
     {
         Exception? fallbackException = null;
 
-        Action<Exception, Context, CancellationToken> fallbackAction = (ex, _, _) => { fallbackException = ex; };
+        Action<Exception, Context, CancellationToken> fallbackAction = (ex, _, _) => fallbackException = ex;
 
         Action<Exception, Context> onFallback = (_, _) => { };
 
@@ -988,10 +991,9 @@ public class FallbackSpecs
 
         Exception instanceToCapture = new ArgumentNullException("myParam");
         Exception instanceToThrow = new AggregateException(instanceToCapture);
-        fallbackPolicy.Invoking(p => p.RaiseException(instanceToThrow))
-            .Should().NotThrow();
+        Should.NotThrow(() => fallbackPolicy.RaiseException(instanceToThrow));
 
-        fallbackException.Should().Be(instanceToCapture);
+        fallbackException.ShouldBe(instanceToCapture);
     }
 
     [Fact]
@@ -1010,10 +1012,9 @@ public class FallbackSpecs
             .Handle<DivideByZeroException>()
             .Fallback(fallbackAction, onFallback);
 
-        fallbackPolicy.Invoking(p => p.Execute(() => throw new ArgumentNullException()))
-            .Should().Throw<ArgumentNullException>();
+        Should.Throw<ArgumentNullException>(() => fallbackPolicy.Execute(() => throw new ArgumentNullException()));
 
-        fallbackException.Should().BeNull();
+        fallbackException.ShouldBeNull();
     }
 
     #endregion
@@ -1027,8 +1028,8 @@ public class FallbackSpecs
         Action fallbackAction = () => { fallbackActionExecuted = true; };
 
         FallbackPolicy policy = Policy
-                                .Handle<DivideByZeroException>()
-                                .Fallback(fallbackAction);
+            .Handle<DivideByZeroException>()
+            .Fallback(fallbackAction);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -1041,13 +1042,12 @@ public class FallbackSpecs
 
         using (var cancellationTokenSource = new CancellationTokenSource())
         {
-            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().NotThrow();
+            Should.NotThrow(() => policy.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -1057,8 +1057,8 @@ public class FallbackSpecs
         Action fallbackAction = () => { fallbackActionExecuted = true; };
 
         FallbackPolicy policy = Policy
-                                .Handle<DivideByZeroException>()
-                                .Fallback(fallbackAction);
+            .Handle<DivideByZeroException>()
+            .Fallback(fallbackAction);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -1071,13 +1071,12 @@ public class FallbackSpecs
 
         using (var cancellationTokenSource = new CancellationTokenSource())
         {
-            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().NotThrow();
+            Should.NotThrow(() => policy.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -1087,8 +1086,8 @@ public class FallbackSpecs
         Action fallbackAction = () => { fallbackActionExecuted = true; };
 
         FallbackPolicy policy = Policy
-                                .Handle<DivideByZeroException>()
-                                .Fallback(fallbackAction);
+            .Handle<DivideByZeroException>()
+            .Fallback(fallbackAction);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -1105,14 +1104,13 @@ public class FallbackSpecs
 
             cancellationTokenSource.Cancel();
 
-            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<OperationCanceledException>()
-                .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(0);
+        attemptsInvoked.ShouldBe(0);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
 
     }
 
@@ -1120,11 +1118,11 @@ public class FallbackSpecs
     public void Should_report_cancellation_and_not_execute_fallback_during_otherwise_non_faulting_action_execution_when_user_delegate_observes_cancellationToken_and_fallback_does_not_handle_cancellations()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy policy = Policy
-                                .Handle<DivideByZeroException>()
-                                .Fallback(fallbackAction);
+            .Handle<DivideByZeroException>()
+            .Fallback(fallbackAction);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -1139,26 +1137,25 @@ public class FallbackSpecs
         using (var cancellationTokenSource = new CancellationTokenSource())
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
-            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<OperationCanceledException>()
-                .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
     public void Should_handle_cancellation_and_execute_fallback_during_otherwise_non_faulting_action_execution_when_user_delegate_observes_cancellationToken_and_fallback_handles_cancellations()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy policy = Policy
-                                .Handle<DivideByZeroException>()
-                                .Or<OperationCanceledException>()
-                                .Fallback(fallbackAction);
+            .Handle<DivideByZeroException>()
+            .Or<OperationCanceledException>()
+            .Fallback(fallbackAction);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -1172,24 +1169,23 @@ public class FallbackSpecs
 
         using (var cancellationTokenSource = new CancellationTokenSource())
         {
-            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().NotThrow();
+            Should.NotThrow(() => policy.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
     public void Should_not_report_cancellation_and_not_execute_fallback_if_non_faulting_action_execution_completes_and_user_delegate_does_not_observe_the_set_cancellationToken()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy policy = Policy
-                                .Handle<DivideByZeroException>()
-                                .Fallback(fallbackAction);
+            .Handle<DivideByZeroException>()
+            .Fallback(fallbackAction);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -1203,23 +1199,22 @@ public class FallbackSpecs
 
         using (var cancellationTokenSource = new CancellationTokenSource())
         {
-            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().NotThrow();
+            Should.NotThrow(() => policy.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1);
-        fallbackActionExecuted.Should().BeFalse();
+        attemptsInvoked.ShouldBe(1);
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
     public void Should_report_unhandled_fault_and_not_execute_fallback_if_action_execution_raises_unhandled_fault_and_user_delegate_does_not_observe_the_set_cancellationToken()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy policy = Policy
-                                .Handle<DivideByZeroException>()
-                                .Fallback(fallbackAction);
+            .Handle<DivideByZeroException>()
+            .Fallback(fallbackAction);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -1233,24 +1228,23 @@ public class FallbackSpecs
 
         using (var cancellationTokenSource = new CancellationTokenSource())
         {
-            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<NullReferenceException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<NullReferenceException>();
+            Should.Throw<NullReferenceException>(() => policy.RaiseExceptionAndOrCancellation<NullReferenceException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
     public void Should_handle_handled_fault_and_execute_fallback_following_faulting_action_execution_when_user_delegate_does_not_observe_cancellationToken()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy policy = Policy
-                                .Handle<DivideByZeroException>()
-                                .Fallback(fallbackAction);
+            .Handle<DivideByZeroException>()
+            .Fallback(fallbackAction);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -1264,13 +1258,12 @@ public class FallbackSpecs
 
         using (var cancellationTokenSource = new CancellationTokenSource())
         {
-            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().NotThrow();
+            Should.NotThrow(() => policy.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     #endregion

--- a/test/Polly.Specs/Fallback/FallbackTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/Fallback/FallbackTResultAsyncSpecs.cs
@@ -27,10 +27,10 @@ public class FallbackTResultAsyncSpecs
 
         var func = () => methodInfo.Invoke(instance, [action, new Context(), CancellationToken.None, false]);
 
-        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("action");
+        var exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>()
+            .ParamName.ShouldBe("action");
     }
 
     [Fact]
@@ -39,11 +39,11 @@ public class FallbackTResultAsyncSpecs
         Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = null!;
 
         Action policy = () => Policy
-                                .HandleResult(ResultPrimitive.Fault)
-                                .FallbackAsync(fallbackAction);
+            .HandleResult(ResultPrimitive.Fault)
+            .FallbackAsync(fallbackAction);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("fallbackAction");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("fallbackAction");
     }
 
     [Fact]
@@ -53,11 +53,11 @@ public class FallbackTResultAsyncSpecs
         Func<DelegateResult<ResultPrimitive>, Task> onFallbackAsync = _ => TaskHelper.EmptyTask;
 
         Action policy = () => Policy
-                                .HandleResult(ResultPrimitive.Fault)
-                                .FallbackAsync(fallbackAction, onFallbackAsync);
+            .HandleResult(ResultPrimitive.Fault)
+            .FallbackAsync(fallbackAction, onFallbackAsync);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("fallbackAction");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("fallbackAction");
     }
 
     [Fact]
@@ -67,11 +67,11 @@ public class FallbackTResultAsyncSpecs
         Func<DelegateResult<ResultPrimitive>, Context, Task> onFallbackAsync = (_, _) => TaskHelper.EmptyTask;
 
         Action policy = () => Policy
-                                .HandleResult(ResultPrimitive.Fault)
-                                .FallbackAsync(fallbackAction, onFallbackAsync);
+            .HandleResult(ResultPrimitive.Fault)
+            .FallbackAsync(fallbackAction, onFallbackAsync);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("fallbackAction");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("fallbackAction");
     }
 
     [Fact]
@@ -81,11 +81,11 @@ public class FallbackTResultAsyncSpecs
         Func<DelegateResult<ResultPrimitive>, Task> onFallbackAsync = null!;
 
         Action policy = () => Policy
-                                .HandleResult(ResultPrimitive.Fault)
-                                .FallbackAsync(fallbackAction, onFallbackAsync);
+            .HandleResult(ResultPrimitive.Fault)
+            .FallbackAsync(fallbackAction, onFallbackAsync);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onFallbackAsync");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onFallbackAsync");
     }
 
     [Fact]
@@ -95,11 +95,11 @@ public class FallbackTResultAsyncSpecs
         Func<DelegateResult<ResultPrimitive>, Context, Task> onFallbackAsync = null!;
 
         Action policy = () => Policy
-                                .HandleResult(ResultPrimitive.Fault)
-                                .FallbackAsync(fallbackAction, onFallbackAsync);
+            .HandleResult(ResultPrimitive.Fault)
+            .FallbackAsync(fallbackAction, onFallbackAsync);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onFallbackAsync");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onFallbackAsync");
     }
 
     #endregion
@@ -113,12 +113,12 @@ public class FallbackTResultAsyncSpecs
         Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = _ => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };
 
         var fallbackPolicy = Policy
-                                .HandleResult(ResultPrimitive.Fault)
-                                .FallbackAsync(fallbackAction);
+            .HandleResult(ResultPrimitive.Fault)
+            .FallbackAsync(fallbackAction);
 
         await fallbackPolicy.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good));
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -128,24 +128,24 @@ public class FallbackTResultAsyncSpecs
         Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = _ => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };
 
         var fallbackPolicy = Policy
-                                .HandleResult(ResultPrimitive.Fault)
-                                .FallbackAsync(fallbackAction);
+            .HandleResult(ResultPrimitive.Fault)
+            .FallbackAsync(fallbackAction);
 
         (await fallbackPolicy.RaiseResultSequenceAsync(ResultPrimitive.FaultAgain))
-            .Should().Be(ResultPrimitive.FaultAgain);
+            .ShouldBe(ResultPrimitive.FaultAgain);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
     public async Task Should_return_fallback_value_when_executed_delegate_raises_fault_handled_by_policy()
     {
         var fallbackPolicy = Policy
-                                .HandleResult(ResultPrimitive.Fault)
-                                .FallbackAsync(ResultPrimitive.Substitute);
+            .HandleResult(ResultPrimitive.Fault)
+            .FallbackAsync(ResultPrimitive.Substitute);
 
         (await fallbackPolicy.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-            .Should().Be(ResultPrimitive.Substitute);
+            .ShouldBe(ResultPrimitive.Substitute);
     }
 
     [Fact]
@@ -155,13 +155,13 @@ public class FallbackTResultAsyncSpecs
         Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = _ => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };
 
         var fallbackPolicy = Policy
-                                .HandleResult(ResultPrimitive.Fault)
-                                .FallbackAsync(fallbackAction);
+            .HandleResult(ResultPrimitive.Fault)
+            .FallbackAsync(fallbackAction);
 
         (await fallbackPolicy.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-            .Should().Be(ResultPrimitive.Substitute);
+            .ShouldBe(ResultPrimitive.Substitute);
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -171,14 +171,14 @@ public class FallbackTResultAsyncSpecs
         Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = _ => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };
 
         var fallbackPolicy = Policy
-                                .HandleResult(ResultPrimitive.Fault)
-                                .OrResult(ResultPrimitive.FaultAgain)
-                                .FallbackAsync(fallbackAction);
+            .HandleResult(ResultPrimitive.Fault)
+            .OrResult(ResultPrimitive.FaultAgain)
+            .FallbackAsync(fallbackAction);
 
         (await fallbackPolicy.RaiseResultSequenceAsync(ResultPrimitive.FaultAgain))
-            .Should().Be(ResultPrimitive.Substitute);
+            .ShouldBe(ResultPrimitive.Substitute);
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -188,14 +188,14 @@ public class FallbackTResultAsyncSpecs
         Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = _ => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };
 
         var fallbackPolicy = Policy
-                                .HandleResult(ResultPrimitive.Fault)
-                                .OrResult(ResultPrimitive.FaultAgain)
-                                .FallbackAsync(fallbackAction);
+            .HandleResult(ResultPrimitive.Fault)
+            .OrResult(ResultPrimitive.FaultAgain)
+            .FallbackAsync(fallbackAction);
 
         (await fallbackPolicy.RaiseResultSequenceAsync(ResultPrimitive.FaultYetAgain))
-            .Should().Be(ResultPrimitive.FaultYetAgain);
+            .ShouldBe(ResultPrimitive.FaultYetAgain);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -205,13 +205,13 @@ public class FallbackTResultAsyncSpecs
         Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = _ => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };
 
         var fallbackPolicy = Policy
-                                .HandleResult<ResultPrimitive>(_ => false)
-                                .FallbackAsync(fallbackAction);
+            .HandleResult<ResultPrimitive>(_ => false)
+            .FallbackAsync(fallbackAction);
 
         (await fallbackPolicy.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-            .Should().Be(ResultPrimitive.Fault);
+            .ShouldBe(ResultPrimitive.Fault);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -221,14 +221,14 @@ public class FallbackTResultAsyncSpecs
         Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = _ => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };
 
         var fallbackPolicy = Policy
-                                .HandleResult<ResultPrimitive>(r => r == ResultPrimitive.Fault)
-                                .OrResult(r => r == ResultPrimitive.FaultAgain)
-                                .FallbackAsync(fallbackAction);
+            .HandleResult<ResultPrimitive>(r => r == ResultPrimitive.Fault)
+            .OrResult(r => r == ResultPrimitive.FaultAgain)
+            .FallbackAsync(fallbackAction);
 
         (await fallbackPolicy.RaiseResultSequenceAsync(ResultPrimitive.FaultYetAgain))
-            .Should().Be(ResultPrimitive.FaultYetAgain);
+            .ShouldBe(ResultPrimitive.FaultYetAgain);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -238,13 +238,13 @@ public class FallbackTResultAsyncSpecs
         Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = _ => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };
 
         var fallbackPolicy = Policy
-                                .HandleResult<ResultPrimitive>(_ => true)
-                                .FallbackAsync(fallbackAction);
+            .HandleResult<ResultPrimitive>(_ => true)
+            .FallbackAsync(fallbackAction);
 
         (await fallbackPolicy.RaiseResultSequenceAsync(ResultPrimitive.Undefined))
-            .Should().Be(ResultPrimitive.Substitute);
+            .ShouldBe(ResultPrimitive.Substitute);
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -254,14 +254,14 @@ public class FallbackTResultAsyncSpecs
         Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = _ => { fallbackActionExecuted = true; return Task.FromResult(ResultPrimitive.Substitute); };
 
         var fallbackPolicy = Policy
-                                .HandleResult<ResultPrimitive>(_ => true)
-                                .OrResult(ResultPrimitive.FaultAgain)
-                                .FallbackAsync(fallbackAction);
+            .HandleResult<ResultPrimitive>(_ => true)
+            .OrResult(ResultPrimitive.FaultAgain)
+            .FallbackAsync(fallbackAction);
 
         (await fallbackPolicy.RaiseResultSequenceAsync(ResultPrimitive.Undefined))
-            .Should().Be(ResultPrimitive.Substitute);
+            .ShouldBe(ResultPrimitive.Substitute);
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -278,10 +278,11 @@ public class FallbackTResultAsyncSpecs
             .HandleResult<ResultClass>(r => r.ResultCode == ResultPrimitive.Fault)
             .FallbackAsync(fallbackAction);
 
-        (await fallbackPolicy.RaiseResultSequenceAsync(new ResultClass(ResultPrimitive.Fault, "FromExecuteDelegate")))
-            .Should().Match<ResultClass>(r => r.ResultCode == ResultPrimitive.Fault && r.SomeString == "FromFallbackAction");
+        var result = await fallbackPolicy.RaiseResultSequenceAsync(new ResultClass(ResultPrimitive.Fault, "FromExecuteDelegate"));
+        result.ResultCode.ShouldBe(ResultPrimitive.Fault);
+        result.SomeString.ShouldBe("FromFallbackAction");
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     #endregion
@@ -304,9 +305,9 @@ public class FallbackTResultAsyncSpecs
         ResultClass resultFromDelegate = new ResultClass(ResultPrimitive.Fault);
         await fallbackPolicy.ExecuteAsync(() => Task.FromResult(resultFromDelegate));
 
-        fallbackActionExecuted.Should().BeTrue();
-        resultPassedToOnFallback.Should().NotBeNull();
-        resultPassedToOnFallback.Should().Be(resultFromDelegate);
+        fallbackActionExecuted.ShouldBeTrue();
+        resultPassedToOnFallback.ShouldNotBeNull();
+        resultPassedToOnFallback.ShouldBe(resultFromDelegate);
     }
 
     [Fact]
@@ -323,7 +324,7 @@ public class FallbackTResultAsyncSpecs
 
         await fallbackPolicy.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good));
 
-        onFallbackExecuted.Should().BeFalse();
+        onFallbackExecuted.ShouldBeFalse();
     }
 
     #endregion
@@ -331,7 +332,7 @@ public class FallbackTResultAsyncSpecs
     #region Context passing tests
 
     [Fact]
-    public void Should_call_onFallback_with_the_passed_context()
+    public async Task Should_call_onFallback_with_the_passed_context()
     {
         Func<Context, CancellationToken, Task<ResultPrimitive>> fallbackAction = (_, _) => Task.FromResult(ResultPrimitive.Substitute);
 
@@ -343,14 +344,11 @@ public class FallbackTResultAsyncSpecs
             .HandleResult(ResultPrimitive.Fault)
             .FallbackAsync(fallbackAction, onFallbackAsync);
 
-        fallbackPolicy.ExecuteAsync(_ => Task.FromResult(ResultPrimitive.Fault),
-            CreateDictionary("key1", "value1", "key2", "value2"))
-            .Result
-            .Should().Be(ResultPrimitive.Substitute);
+        (await fallbackPolicy.ExecuteAsync(_ => Task.FromResult(ResultPrimitive.Fault), CreateDictionary("key1", "value1", "key2", "value2"))).ShouldBe(ResultPrimitive.Substitute);
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -366,21 +364,20 @@ public class FallbackTResultAsyncSpecs
             .HandleResult(ResultPrimitive.Fault)
             .FallbackAsync(fallbackAction, onFallbackAsync);
 
-        (await fallbackPolicy.ExecuteAndCaptureAsync(_ => Task.FromResult(ResultPrimitive.Fault),
-            CreateDictionary("key1", "value1", "key2", "value2")))
-            .Result.Should().Be(ResultPrimitive.Substitute);
+        (await fallbackPolicy.ExecuteAndCaptureAsync(_ => Task.FromResult(ResultPrimitive.Fault), CreateDictionary("key1", "value1", "key2", "value2")))
+            .Result.ShouldBe(ResultPrimitive.Substitute);
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
-    public void Should_call_onFallback_with_independent_context_for_independent_calls()
+    public async Task Should_call_onFallback_with_independent_context_for_independent_calls()
     {
         Func<Context, CancellationToken, Task<ResultPrimitive>> fallbackAction = (_, _) => Task.FromResult(ResultPrimitive.Substitute);
 
-        IDictionary<ResultPrimitive, object> contextData = new Dictionary<ResultPrimitive, object>();
+        var contextData = new Dictionary<ResultPrimitive, object>();
 
         Func<DelegateResult<ResultPrimitive>, Context, Task> onFallbackAsync = (dr, ctx) => { contextData[dr.Result] = ctx["key"]; return TaskHelper.EmptyTask; };
 
@@ -389,19 +386,16 @@ public class FallbackTResultAsyncSpecs
             .OrResult(ResultPrimitive.FaultAgain)
             .FallbackAsync(fallbackAction, onFallbackAsync);
 
-        fallbackPolicy.ExecuteAsync(_ => Task.FromResult(ResultPrimitive.Fault), CreateDictionary("key", "value1"))
-            .Result
-            .Should().Be(ResultPrimitive.Substitute);
+        (await fallbackPolicy.ExecuteAsync(_ => Task.FromResult(ResultPrimitive.Fault), CreateDictionary("key", "value1")))
+            .ShouldBe(ResultPrimitive.Substitute);
 
-        fallbackPolicy.ExecuteAsync(_ => Task.FromResult(ResultPrimitive.FaultAgain), CreateDictionary("key", "value2"))
-            .Result
-            .Should().Be(ResultPrimitive.Substitute);
+        (await fallbackPolicy.ExecuteAsync(_ => Task.FromResult(ResultPrimitive.FaultAgain), CreateDictionary("key", "value2")))
+            .ShouldBe(ResultPrimitive.Substitute);
 
-        contextData.Count.Should().Be(2);
-        contextData.Keys.Should().Contain(ResultPrimitive.Fault);
-        contextData.Keys.Should().Contain(ResultPrimitive.FaultAgain);
-        contextData[ResultPrimitive.Fault].Should().Be("value1");
-        contextData[ResultPrimitive.FaultAgain].Should().Be("value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue(ResultPrimitive.Fault, "value1");
+        contextData.ShouldContainKeyAndValue(ResultPrimitive.FaultAgain, "value2");
+        contextData.Count.ShouldBe(2);
     }
 
     [Fact]
@@ -419,14 +413,14 @@ public class FallbackTResultAsyncSpecs
             .FallbackAsync(fallbackAction, onFallbackAsync);
 
         (await fallbackPolicy.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-            .Should().Be(ResultPrimitive.Substitute);
+            .ShouldBe(ResultPrimitive.Substitute);
 
-        onFallbackExecuted.Should().BeTrue();
-        capturedContext.Should().BeEmpty();
+        onFallbackExecuted.ShouldBeTrue();
+        capturedContext.ShouldBeEmpty();
     }
 
     [Fact]
-    public void Should_call_fallbackAction_with_the_passed_context()
+    public async Task Should_call_fallbackAction_with_the_passed_context()
     {
         IDictionary<string, object>? contextData = null;
 
@@ -438,14 +432,12 @@ public class FallbackTResultAsyncSpecs
             .HandleResult(ResultPrimitive.Fault)
             .FallbackAsync(fallbackActionAsync, onFallbackAsync);
 
-        fallbackPolicy.ExecuteAsync(_ => Task.FromResult(ResultPrimitive.Fault),
-                CreateDictionary("key1", "value1", "key2", "value2"))
-            .Result
-            .Should().Be(ResultPrimitive.Substitute);
+        (await fallbackPolicy.ExecuteAsync(_ => Task.FromResult(ResultPrimitive.Fault), CreateDictionary("key1", "value1", "key2", "value2")))
+            .ShouldBe(ResultPrimitive.Substitute);
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -461,13 +453,15 @@ public class FallbackTResultAsyncSpecs
             .HandleResult(ResultPrimitive.Fault)
             .FallbackAsync(fallbackActionAsync, onFallbackAsync);
 
-        await fallbackPolicy.Awaiting(p => p.ExecuteAndCaptureAsync(_ => Task.FromResult(ResultPrimitive.Fault),
-                CreateDictionary("key1", "value1", "key2", "value2")))
-            .Should().NotThrowAsync();
+        await Should.NotThrowAsync(
+            () =>
+                fallbackPolicy.ExecuteAndCaptureAsync(
+                    _ => Task.FromResult(ResultPrimitive.Fault),
+                    CreateDictionary("key1", "value1", "key2", "value2")));
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -490,10 +484,10 @@ public class FallbackTResultAsyncSpecs
             .FallbackAsync(fallbackActionAsync, onFallbackAsync);
 
         (await fallbackPolicy.RaiseResultSequenceAsync(ResultPrimitive.Fault))
-            .Should().Be(ResultPrimitive.Substitute);
+            .ShouldBe(ResultPrimitive.Substitute);
 
-        fallbackExecuted.Should().BeTrue();
-        capturedContext.Should().BeEmpty();
+        fallbackExecuted.ShouldBeTrue();
+        capturedContext.ShouldBeEmpty();
     }
     #endregion
 
@@ -514,11 +508,11 @@ public class FallbackTResultAsyncSpecs
             .FallbackAsync(fallbackAction, onFallback);
 
         var result = await fallbackPolicy.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Fault));
-        result.Should().Be(ResultPrimitive.Substitute);
+        result.ShouldBe(ResultPrimitive.Substitute);
 
-        fallbackOutcome!.Should().NotBeNull();
-        fallbackOutcome!.Exception.Should().BeNull();
-        fallbackOutcome!.Result.Should().Be(ResultPrimitive.Fault);
+        fallbackOutcome!.ShouldNotBeNull();
+        fallbackOutcome!.Exception.ShouldBeNull();
+        fallbackOutcome!.Result.ShouldBe(ResultPrimitive.Fault);
     }
 
     [Fact]
@@ -536,12 +530,12 @@ public class FallbackTResultAsyncSpecs
             .FallbackAsync(fallbackAction, onFallback);
 
         var result = await fallbackPolicy.ExecuteAndCaptureAsync(() => Task.FromResult(ResultPrimitive.Fault));
-        result.Should().NotBeNull();
-        result.Result.Should().Be(ResultPrimitive.Substitute);
+        result.ShouldNotBeNull();
+        result.Result.ShouldBe(ResultPrimitive.Substitute);
 
-        fallbackOutcome!.Should().NotBeNull();
-        fallbackOutcome!.Exception.Should().BeNull();
-        fallbackOutcome!.Result.Should().Be(ResultPrimitive.Fault);
+        fallbackOutcome!.ShouldNotBeNull();
+        fallbackOutcome!.Exception.ShouldBeNull();
+        fallbackOutcome!.Result.ShouldBe(ResultPrimitive.Fault);
     }
 
     [Fact]
@@ -559,9 +553,9 @@ public class FallbackTResultAsyncSpecs
             .FallbackAsync(fallbackAction, onFallback);
 
         var result = await fallbackPolicy.ExecuteAsync(() => Task.FromResult(ResultPrimitive.FaultAgain));
-        result.Should().Be(ResultPrimitive.FaultAgain);
+        result.ShouldBe(ResultPrimitive.FaultAgain);
 
-        fallbackOutcome.Should().BeNull();
+        fallbackOutcome.ShouldBeNull();
     }
 
     #endregion
@@ -592,12 +586,12 @@ public class FallbackTResultAsyncSpecs
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
             (await policy.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute, ResultPrimitive.Good))
-                .Should().Be(ResultPrimitive.Good);
+                .ShouldBe(ResultPrimitive.Good);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -624,12 +618,12 @@ public class FallbackTResultAsyncSpecs
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
             (await policy.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute, ResultPrimitive.Fault))
-                .Should().Be(ResultPrimitive.Substitute);
+                .ShouldBe(ResultPrimitive.Substitute);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -656,15 +650,14 @@ public class FallbackTResultAsyncSpecs
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             cancellationTokenSource.Cancel();
 
-            var ex = await policy.Awaiting(x => x.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute, ResultPrimitive.Fault))
-                .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute, ResultPrimitive.Fault));
+            ex.CancellationToken.ShouldBe(cancellationToken);
 
         }
 
-        attemptsInvoked.Should().Be(0);
+        attemptsInvoked.ShouldBe(0);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
 
     }
 
@@ -692,14 +685,13 @@ public class FallbackTResultAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await policy.Awaiting(x => x.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute, ResultPrimitive.Good))
-                .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute, ResultPrimitive.Good));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -728,12 +720,12 @@ public class FallbackTResultAsyncSpecs
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
             (await policy.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute, ResultPrimitive.Good))
-                .Should().Be(ResultPrimitive.Substitute);
+                .ShouldBe(ResultPrimitive.Substitute);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -761,12 +753,12 @@ public class FallbackTResultAsyncSpecs
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
             (await policy.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute, ResultPrimitive.Good))
-                .Should().Be(ResultPrimitive.Good);
+                .ShouldBe(ResultPrimitive.Good);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -794,12 +786,12 @@ public class FallbackTResultAsyncSpecs
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
             (await policy.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute, ResultPrimitive.FaultYetAgain))
-                .Should().Be(ResultPrimitive.FaultYetAgain);
+                .ShouldBe(ResultPrimitive.FaultYetAgain);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -827,12 +819,12 @@ public class FallbackTResultAsyncSpecs
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
             (await policy.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute, ResultPrimitive.Fault))
-                .Should().Be(ResultPrimitive.Substitute);
+                .ShouldBe(ResultPrimitive.Substitute);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     #endregion

--- a/test/Polly.Specs/Fallback/FallbackTResultSpecs.cs
+++ b/test/Polly.Specs/Fallback/FallbackTResultSpecs.cs
@@ -27,10 +27,10 @@ public class FallbackTResultSpecs
 
         var func = () => methodInfo.Invoke(instance, [action, new Context(), CancellationToken.None]);
 
-        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("action");
+        var exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>()
+            .ParamName.ShouldBe("action");
     }
 
     [Fact]
@@ -42,8 +42,8 @@ public class FallbackTResultSpecs
                                 .HandleResult(ResultPrimitive.Fault)
                                 .Fallback(fallbackAction);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("fallbackAction");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("fallbackAction");
     }
 
     [Fact]
@@ -55,8 +55,8 @@ public class FallbackTResultSpecs
             .HandleResult(ResultPrimitive.Fault)
             .Fallback(fallbackAction);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("fallbackAction");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("fallbackAction");
     }
 
     [Fact]
@@ -69,8 +69,8 @@ public class FallbackTResultSpecs
                                 .HandleResult(ResultPrimitive.Fault)
                                 .Fallback(fallbackAction, onFallback);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("fallbackAction");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("fallbackAction");
     }
 
     [Fact]
@@ -83,8 +83,8 @@ public class FallbackTResultSpecs
             .HandleResult(ResultPrimitive.Fault)
             .Fallback(fallbackAction, onFallback);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("fallbackAction");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("fallbackAction");
     }
 
     [Fact]
@@ -97,8 +97,8 @@ public class FallbackTResultSpecs
                                 .HandleResult(ResultPrimitive.Fault)
                                 .Fallback(fallbackAction, onFallback);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("fallbackAction");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("fallbackAction");
     }
 
     [Fact]
@@ -111,8 +111,8 @@ public class FallbackTResultSpecs
                                 .HandleResult(ResultPrimitive.Fault)
                                 .Fallback(fallbackAction, onFallback);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("fallbackAction");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("fallbackAction");
     }
 
     [Fact]
@@ -125,8 +125,8 @@ public class FallbackTResultSpecs
                                 .HandleResult(ResultPrimitive.Fault)
                                 .Fallback(fallbackAction, onFallback);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onFallback");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onFallback");
     }
 
     [Fact]
@@ -139,8 +139,8 @@ public class FallbackTResultSpecs
             .HandleResult(ResultPrimitive.Fault)
             .Fallback(fallbackAction, onFallback);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onFallback");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onFallback");
     }
 
     [Fact]
@@ -153,8 +153,8 @@ public class FallbackTResultSpecs
                                 .HandleResult(ResultPrimitive.Fault)
                                 .Fallback(fallbackAction, onFallback);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onFallback");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onFallback");
     }
 
     [Fact]
@@ -167,8 +167,8 @@ public class FallbackTResultSpecs
                                 .HandleResult(ResultPrimitive.Fault)
                                 .Fallback(fallbackAction, onFallback);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onFallback");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onFallback");
     }
 
     #endregion
@@ -187,7 +187,7 @@ public class FallbackTResultSpecs
 
         fallbackPolicy.Execute(() => ResultPrimitive.Good);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -200,9 +200,9 @@ public class FallbackTResultSpecs
                                 .HandleResult(ResultPrimitive.Fault)
                                 .Fallback(fallbackAction);
 
-        fallbackPolicy.RaiseResultSequence(ResultPrimitive.FaultAgain).Should().Be(ResultPrimitive.FaultAgain);
+        fallbackPolicy.RaiseResultSequence(ResultPrimitive.FaultAgain).ShouldBe(ResultPrimitive.FaultAgain);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -212,7 +212,7 @@ public class FallbackTResultSpecs
                                 .HandleResult(ResultPrimitive.Fault)
                                 .Fallback(ResultPrimitive.Substitute);
 
-        fallbackPolicy.RaiseResultSequence(ResultPrimitive.Fault).Should().Be(ResultPrimitive.Substitute);
+        fallbackPolicy.RaiseResultSequence(ResultPrimitive.Fault).ShouldBe(ResultPrimitive.Substitute);
     }
 
     [Fact]
@@ -225,9 +225,9 @@ public class FallbackTResultSpecs
                                 .HandleResult(ResultPrimitive.Fault)
                                 .Fallback(fallbackAction);
 
-        fallbackPolicy.RaiseResultSequence(ResultPrimitive.Fault).Should().Be(ResultPrimitive.Substitute);
+        fallbackPolicy.RaiseResultSequence(ResultPrimitive.Fault).ShouldBe(ResultPrimitive.Substitute);
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -241,9 +241,9 @@ public class FallbackTResultSpecs
                                 .OrResult(ResultPrimitive.FaultAgain)
                                 .Fallback(fallbackAction);
 
-        fallbackPolicy.RaiseResultSequence(ResultPrimitive.FaultAgain).Should().Be(ResultPrimitive.Substitute);
+        fallbackPolicy.RaiseResultSequence(ResultPrimitive.FaultAgain).ShouldBe(ResultPrimitive.Substitute);
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -257,9 +257,9 @@ public class FallbackTResultSpecs
                                 .OrResult(ResultPrimitive.FaultAgain)
                                 .Fallback(fallbackAction);
 
-        fallbackPolicy.RaiseResultSequence(ResultPrimitive.FaultYetAgain).Should().Be(ResultPrimitive.FaultYetAgain);
+        fallbackPolicy.RaiseResultSequence(ResultPrimitive.FaultYetAgain).ShouldBe(ResultPrimitive.FaultYetAgain);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -272,9 +272,9 @@ public class FallbackTResultSpecs
                                 .HandleResult<ResultPrimitive>(_ => false)
                                 .Fallback(fallbackAction);
 
-        fallbackPolicy.RaiseResultSequence(ResultPrimitive.Fault).Should().Be(ResultPrimitive.Fault);
+        fallbackPolicy.RaiseResultSequence(ResultPrimitive.Fault).ShouldBe(ResultPrimitive.Fault);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -288,9 +288,9 @@ public class FallbackTResultSpecs
                                 .OrResult(r => r == ResultPrimitive.FaultAgain)
                                 .Fallback(fallbackAction);
 
-        fallbackPolicy.RaiseResultSequence(ResultPrimitive.FaultYetAgain).Should().Be(ResultPrimitive.FaultYetAgain);
+        fallbackPolicy.RaiseResultSequence(ResultPrimitive.FaultYetAgain).ShouldBe(ResultPrimitive.FaultYetAgain);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -303,9 +303,9 @@ public class FallbackTResultSpecs
                                 .HandleResult<ResultPrimitive>(_ => true)
                                 .Fallback(fallbackAction);
 
-        fallbackPolicy.RaiseResultSequence(ResultPrimitive.Undefined).Should().Be(ResultPrimitive.Substitute);
+        fallbackPolicy.RaiseResultSequence(ResultPrimitive.Undefined).ShouldBe(ResultPrimitive.Substitute);
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -319,9 +319,9 @@ public class FallbackTResultSpecs
                                 .OrResult(ResultPrimitive.FaultAgain)
                                 .Fallback(fallbackAction);
 
-        fallbackPolicy.RaiseResultSequence(ResultPrimitive.Undefined).Should().Be(ResultPrimitive.Substitute);
+        fallbackPolicy.RaiseResultSequence(ResultPrimitive.Undefined).ShouldBe(ResultPrimitive.Substitute);
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -338,10 +338,12 @@ public class FallbackTResultSpecs
             .HandleResult<ResultClass>(r => r.ResultCode == ResultPrimitive.Fault)
             .Fallback(fallbackAction);
 
-        fallbackPolicy.RaiseResultSequence(new ResultClass(ResultPrimitive.Fault, "FromExecuteDelegate"))
-            .Should().Match<ResultClass>(r => r.ResultCode == ResultPrimitive.Fault && r.SomeString == "FromFallbackAction");
+        var result = fallbackPolicy.RaiseResultSequence(new ResultClass(ResultPrimitive.Fault, "FromExecuteDelegate"));
 
-        fallbackActionExecuted.Should().BeTrue();
+        result.ShouldNotBeNull();
+        result.ResultCode.ShouldBe(ResultPrimitive.Fault);
+        result.SomeString.ShouldBe("FromFallbackAction");
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     #endregion
@@ -364,9 +366,9 @@ public class FallbackTResultSpecs
         ResultClass resultFromDelegate = new ResultClass(ResultPrimitive.Fault);
         fallbackPolicy.Execute(() => resultFromDelegate);
 
-        fallbackActionExecuted.Should().BeTrue();
-        resultPassedToOnFallback.Should().NotBeNull();
-        resultPassedToOnFallback.Should().Be(resultFromDelegate);
+        fallbackActionExecuted.ShouldBeTrue();
+        resultPassedToOnFallback.ShouldNotBeNull();
+        resultPassedToOnFallback.ShouldBe(resultFromDelegate);
     }
 
     [Fact]
@@ -383,7 +385,7 @@ public class FallbackTResultSpecs
 
         fallbackPolicy.Execute(() => ResultPrimitive.Good);
 
-        onFallbackExecuted.Should().BeFalse();
+        onFallbackExecuted.ShouldBeFalse();
     }
 
     #endregion
@@ -405,11 +407,11 @@ public class FallbackTResultSpecs
 
         fallbackPolicy.Execute(_ => ResultPrimitive.Fault,
             CreateDictionary("key1", "value1", "key2", "value2"))
-            .Should().Be(ResultPrimitive.Substitute);
+            .ShouldBe(ResultPrimitive.Substitute);
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -427,11 +429,11 @@ public class FallbackTResultSpecs
 
         fallbackPolicy.ExecuteAndCapture(_ => ResultPrimitive.Fault,
             CreateDictionary("key1", "value1", "key2", "value2"))
-            .Result.Should().Be(ResultPrimitive.Substitute);
+            .Result.ShouldBe(ResultPrimitive.Substitute);
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -449,16 +451,16 @@ public class FallbackTResultSpecs
             .Fallback(fallbackAction, onFallback);
 
         fallbackPolicy.Execute(_ => ResultPrimitive.Fault, CreateDictionary("key", "value1"))
-            .Should().Be(ResultPrimitive.Substitute);
+            .ShouldBe(ResultPrimitive.Substitute);
 
         fallbackPolicy.Execute(_ => ResultPrimitive.FaultAgain, CreateDictionary("key", "value2"))
-            .Should().Be(ResultPrimitive.Substitute);
+            .ShouldBe(ResultPrimitive.Substitute);
 
-        contextData.Count.Should().Be(2);
-        contextData.Keys.Should().Contain(ResultPrimitive.Fault);
-        contextData.Keys.Should().Contain(ResultPrimitive.FaultAgain);
-        contextData[ResultPrimitive.Fault].Should().Be("value1");
-        contextData[ResultPrimitive.FaultAgain].Should().Be("value2");
+        contextData.Count.ShouldBe(2);
+        contextData.Keys.ShouldContain(ResultPrimitive.Fault);
+        contextData.Keys.ShouldContain(ResultPrimitive.FaultAgain);
+        contextData[ResultPrimitive.Fault].ShouldBe("value1");
+        contextData[ResultPrimitive.FaultAgain].ShouldBe("value2");
     }
 
     [Fact]
@@ -477,8 +479,8 @@ public class FallbackTResultSpecs
 
         fallbackPolicy.RaiseResultSequence(ResultPrimitive.Fault);
 
-        onFallbackExecuted.Should().BeTrue();
-        capturedContext.Should().BeEmpty();
+        onFallbackExecuted.ShouldBeTrue();
+        capturedContext.ShouldBeEmpty();
     }
 
     [Fact]
@@ -496,11 +498,11 @@ public class FallbackTResultSpecs
 
         fallbackPolicy.Execute(_ => ResultPrimitive.Fault,
                 CreateDictionary("key1", "value1", "key2", "value2"))
-            .Should().Be(ResultPrimitive.Substitute);
+            .ShouldBe(ResultPrimitive.Substitute);
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -518,11 +520,11 @@ public class FallbackTResultSpecs
 
         fallbackPolicy.ExecuteAndCapture(_ => ResultPrimitive.Fault,
                 CreateDictionary("key1", "value1", "key2", "value2"))
-            .Result.Should().Be(ResultPrimitive.Substitute);
+            .Result.ShouldBe(ResultPrimitive.Substitute);
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -542,8 +544,8 @@ public class FallbackTResultSpecs
 
         fallbackPolicy.RaiseResultSequence(ResultPrimitive.Fault);
 
-        fallbackExecuted.Should().BeTrue();
-        capturedContext.Should().BeEmpty();
+        fallbackExecuted.ShouldBeTrue();
+        capturedContext.ShouldBeEmpty();
     }
     #endregion
 
@@ -564,11 +566,11 @@ public class FallbackTResultSpecs
             .Fallback(fallbackAction, onFallback);
 
         fallbackPolicy.Execute(() => ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Substitute);
+            .ShouldBe(ResultPrimitive.Substitute);
 
-        fallbackOutcome!.Should().NotBeNull();
-        fallbackOutcome!.Exception.Should().BeNull();
-        fallbackOutcome!.Result.Should().Be(ResultPrimitive.Fault);
+        fallbackOutcome!.ShouldNotBeNull();
+        fallbackOutcome!.Exception.ShouldBeNull();
+        fallbackOutcome!.Result.ShouldBe(ResultPrimitive.Fault);
     }
 
     [Fact]
@@ -586,12 +588,12 @@ public class FallbackTResultSpecs
             .Fallback(fallbackAction, onFallback);
 
         var result = fallbackPolicy.ExecuteAndCapture(() => ResultPrimitive.Fault);
-        result.Should().NotBeNull();
-        result.Result.Should().Be(ResultPrimitive.Substitute);
+        result.ShouldNotBeNull();
+        result.Result.ShouldBe(ResultPrimitive.Substitute);
 
-        fallbackOutcome!.Should().NotBeNull();
-        fallbackOutcome!.Exception.Should().BeNull();
-        fallbackOutcome!.Result.Should().Be(ResultPrimitive.Fault);
+        fallbackOutcome!.ShouldNotBeNull();
+        fallbackOutcome!.Exception.ShouldBeNull();
+        fallbackOutcome!.Result.ShouldBe(ResultPrimitive.Fault);
     }
 
     [Fact]
@@ -609,9 +611,9 @@ public class FallbackTResultSpecs
             .Fallback(fallbackAction, onFallback);
 
         fallbackPolicy.Execute(() => ResultPrimitive.FaultAgain)
-            .Should().Be(ResultPrimitive.FaultAgain);
+            .ShouldBe(ResultPrimitive.FaultAgain);
 
-        fallbackOutcome.Should().BeNull();
+        fallbackOutcome.ShouldBeNull();
     }
 
     #endregion
@@ -640,12 +642,12 @@ public class FallbackTResultSpecs
         using (var cancellationTokenSource = new CancellationTokenSource())
         {
             policy.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute, ResultPrimitive.Good)
-                .Should().Be(ResultPrimitive.Good);
+                .ShouldBe(ResultPrimitive.Good);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -670,12 +672,12 @@ public class FallbackTResultSpecs
         using (var cancellationTokenSource = new CancellationTokenSource())
         {
             policy.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute, ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Substitute);
+            .ShouldBe(ResultPrimitive.Substitute);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -702,14 +704,13 @@ public class FallbackTResultSpecs
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             cancellationTokenSource.Cancel();
 
-            policy.Invoking(x => x.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute, ResultPrimitive.Fault))
-                .Should().Throw<OperationCanceledException>()
-                .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => policy.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute, ResultPrimitive.Fault))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(0);
+        attemptsInvoked.ShouldBe(0);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
 
     }
 
@@ -737,14 +738,13 @@ public class FallbackTResultSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            policy.Invoking(x => x.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute, ResultPrimitive.Good))
-            .Should().Throw<OperationCanceledException>()
-            .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => policy.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute, ResultPrimitive.Good))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -772,12 +772,12 @@ public class FallbackTResultSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             policy.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute, ResultPrimitive.Good)
-            .Should().Be(ResultPrimitive.Substitute);
+            .ShouldBe(ResultPrimitive.Substitute);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     [Fact]
@@ -805,12 +805,12 @@ public class FallbackTResultSpecs
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
             policy.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute, ResultPrimitive.Good)
-            .Should().Be(ResultPrimitive.Good);
+            .ShouldBe(ResultPrimitive.Good);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -837,12 +837,12 @@ public class FallbackTResultSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             policy.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute, ResultPrimitive.FaultYetAgain)
-            .Should().Be(ResultPrimitive.FaultYetAgain);
+            .ShouldBe(ResultPrimitive.FaultYetAgain);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeFalse();
+        fallbackActionExecuted.ShouldBeFalse();
     }
 
     [Fact]
@@ -870,12 +870,12 @@ public class FallbackTResultSpecs
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
             policy.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute, ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Substitute);
+            .ShouldBe(ResultPrimitive.Substitute);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
 
-        fallbackActionExecuted.Should().BeTrue();
+        fallbackActionExecuted.ShouldBeTrue();
     }
 
     #endregion

--- a/test/Polly.Specs/Helpers/RateLimit/IRateLimiterExtensions.cs
+++ b/test/Polly.Specs/Helpers/RateLimit/IRateLimiterExtensions.cs
@@ -6,8 +6,8 @@ internal static class IRateLimiterExtensions
     {
         (bool PermitExecution, TimeSpan RetryAfter) canExecute = rateLimiter.PermitExecution();
 
-        canExecute.PermitExecution.Should().BeTrue();
-        canExecute.RetryAfter.Should().Be(TimeSpan.Zero);
+        canExecute.PermitExecution.ShouldBeTrue();
+        canExecute.RetryAfter.ShouldBe(TimeSpan.Zero);
     }
 
     public static void ShouldPermitNExecutions(this IRateLimiter rateLimiter, long numberOfExecutions)
@@ -22,14 +22,14 @@ internal static class IRateLimiterExtensions
     {
         (bool PermitExecution, TimeSpan RetryAfter) canExecute = rateLimiter.PermitExecution();
 
-        canExecute.PermitExecution.Should().BeFalse();
+        canExecute.PermitExecution.ShouldBeFalse();
         if (retryAfter == null)
         {
-            canExecute.RetryAfter.Should().BeGreaterThan(TimeSpan.Zero);
+            canExecute.RetryAfter.ShouldBeGreaterThan(TimeSpan.Zero);
         }
         else
         {
-            canExecute.RetryAfter.Should().Be(retryAfter.Value);
+            canExecute.RetryAfter.ShouldBe(retryAfter.Value);
         }
     }
 }

--- a/test/Polly.Specs/IAsyncPolicyExtensionsSpecs.cs
+++ b/test/Polly.Specs/IAsyncPolicyExtensionsSpecs.cs
@@ -8,7 +8,7 @@ public class IAsyncPolicyExtensionsSpecs
         IAsyncPolicy nonGenericPolicy = Policy.TimeoutAsync(10);
         var genericPolicy = nonGenericPolicy.AsAsyncPolicy<ResultClass>();
 
-        genericPolicy.Should().BeAssignableTo<IAsyncPolicy<ResultClass>>();
+        genericPolicy.ShouldBeAssignableTo<IAsyncPolicy<ResultClass>>();
     }
 
     [Fact]
@@ -21,9 +21,9 @@ public class IAsyncPolicyExtensionsSpecs
         var genericPolicy = nonGenericPolicy.AsAsyncPolicy<ResultPrimitive>();
         Func<Task<ResultPrimitive>> deleg = () => Task.FromResult(ResultPrimitive.Good);
 
-        (await genericPolicy.ExecuteAsync(deleg)).Should().Be(ResultPrimitive.Good);
+        (await genericPolicy.ExecuteAsync(deleg)).ShouldBe(ResultPrimitive.Good);
         breaker.Isolate();
-        await genericPolicy.Awaiting(p => p.ExecuteAsync(deleg)).Should().ThrowAsync<BrokenCircuitException>();
+        await Should.ThrowAsync<BrokenCircuitException>(() => genericPolicy.ExecuteAsync(deleg));
     }
 }
 

--- a/test/Polly.Specs/ISyncPolicyExtensionsSpecs.cs
+++ b/test/Polly.Specs/ISyncPolicyExtensionsSpecs.cs
@@ -8,7 +8,7 @@ public class ISyncPolicyExtensionsSpecs
         ISyncPolicy nonGenericPolicy = Policy.Timeout(10);
         var genericPolicy = nonGenericPolicy.AsPolicy<ResultClass>();
 
-        genericPolicy.Should().BeAssignableTo<ISyncPolicy<ResultClass>>();
+        genericPolicy.ShouldBeAssignableTo<ISyncPolicy<ResultClass>>();
     }
 
     [Fact]
@@ -21,9 +21,9 @@ public class ISyncPolicyExtensionsSpecs
         var genericPolicy = nonGenericPolicy.AsPolicy<ResultPrimitive>();
         Func<ResultPrimitive> deleg = () => ResultPrimitive.Good;
 
-        genericPolicy.Execute(deleg).Should().Be(ResultPrimitive.Good);
+        genericPolicy.Execute(deleg).ShouldBe(ResultPrimitive.Good);
         breaker.Isolate();
-        genericPolicy.Invoking(p => p.Execute(deleg)).Should().Throw<BrokenCircuitException>();
+        Should.Throw<BrokenCircuitException>(() => genericPolicy.Execute(deleg));
     }
 }
 

--- a/test/Polly.Specs/NoOp/NoOpAsyncSpecs.cs
+++ b/test/Polly.Specs/NoOp/NoOpAsyncSpecs.cs
@@ -16,9 +16,9 @@ public class NoOpAsyncSpecs
 
         var func = () => generic.Invoke(instance, [action, new Context(), CancellationToken.None, false]);
 
-        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.WithInnerException<ArgumentNullException>("action");
+        var exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>().ParamName.ShouldBe("action");
     }
 
     [Fact]
@@ -27,10 +27,9 @@ public class NoOpAsyncSpecs
         var policy = Policy.NoOpAsync();
         bool executed = false;
 
-        await policy.Awaiting(p => p.ExecuteAsync(() => { executed = true; return TaskHelper.EmptyTask; }))
-            .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.ExecuteAsync(() => { executed = true; return TaskHelper.EmptyTask; }));
 
-        executed.Should().BeTrue();
+        executed.ShouldBeTrue();
     }
 
     [Fact]
@@ -44,11 +43,10 @@ public class NoOpAsyncSpecs
         {
             cts.Cancel();
 
-            await policy.Awaiting(p => p.ExecuteAsync(
-                _ => { executed = true; return TaskHelper.EmptyTask; }, cts.Token))
-                .Should().NotThrowAsync();
+            await Should.NotThrowAsync(() => policy.ExecuteAsync(
+                _ => { executed = true; return TaskHelper.EmptyTask; }, cts.Token));
         }
 
-        executed.Should().BeTrue();
+        executed.ShouldBeTrue();
     }
 }

--- a/test/Polly.Specs/NoOp/NoOpSpecs.cs
+++ b/test/Polly.Specs/NoOp/NoOpSpecs.cs
@@ -16,10 +16,10 @@ public class NoOpSpecs
         var generic = methodInfo.MakeGenericMethod(typeof(EmptyStruct));
         var func = () => generic.Invoke(instance, [action, new Context(), CancellationToken.None]);
 
-        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("action");
+        var exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>()
+            .ParamName.ShouldBe("action");
     }
 
     [Fact]
@@ -28,10 +28,9 @@ public class NoOpSpecs
         NoOpPolicy policy = Policy.NoOp();
         bool executed = false;
 
-        policy.Invoking(x => x.Execute(() => { executed = true; }))
-            .Should().NotThrow();
+        Should.NotThrow(() => policy.Execute(() => executed = true));
 
-        executed.Should().BeTrue();
+        executed.ShouldBeTrue();
     }
 
     [Fact]
@@ -44,10 +43,9 @@ public class NoOpSpecs
         {
             cts.Cancel();
 
-            policy.Invoking(p => p.Execute(_ => { executed = true; }, cts.Token))
-                .Should().NotThrow();
+            Should.NotThrow(() => policy.Execute(_ => executed = true, cts.Token));
         }
 
-        executed.Should().BeTrue();
+        executed.ShouldBeTrue();
     }
 }

--- a/test/Polly.Specs/NoOp/NoOpTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/NoOp/NoOpTResultAsyncSpecs.cs
@@ -15,10 +15,10 @@ public class NoOpTResultAsyncSpecs
 
         var func = () => methodInfo.Invoke(instance, [action, new Context(), CancellationToken.None, false]);
 
-        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("action");
+        var exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>()
+            .ParamName.ShouldBe("action");
     }
 
     [Fact]
@@ -27,12 +27,10 @@ public class NoOpTResultAsyncSpecs
         var policy = Policy.NoOpAsync<int?>();
         int? result = null;
 
-        Func<AsyncNoOpPolicy<int?>, Task> action = async p => result = await p.ExecuteAsync(() => Task.FromResult((int?)10));
-        await policy.Awaiting(action)
-            .Should().NotThrowAsync();
+        await Should.NotThrowAsync(async () => result = await policy.ExecuteAsync(() => Task.FromResult((int?)10)));
 
-        result.HasValue.Should().BeTrue();
-        result.Should().Be(10);
+        result.HasValue.ShouldBeTrue();
+        result.ShouldBe(10);
     }
 
     [Fact]
@@ -45,12 +43,10 @@ public class NoOpTResultAsyncSpecs
         {
             cts.Cancel();
 
-            Func<AsyncNoOpPolicy<int?>, Task> action = async p => result = await p.ExecuteAsync(_ => Task.FromResult((int?)10), cts.Token);
-            await policy.Awaiting(action)
-                .Should().NotThrowAsync();
+            await Should.NotThrowAsync(async () => result = await policy.ExecuteAsync(_ => Task.FromResult((int?)10), cts.Token));
         }
 
-        result.HasValue.Should().BeTrue();
-        result.Should().Be(10);
+        result.HasValue.ShouldBeTrue();
+        result.ShouldBe(10);
     }
 }

--- a/test/Polly.Specs/NoOp/NoOpTResultSpecs.cs
+++ b/test/Polly.Specs/NoOp/NoOpTResultSpecs.cs
@@ -14,9 +14,9 @@ public class NoOpTResultSpecs
         var methodInfo = methods.First(method => method is { Name: "Implementation", ReturnType.Name: "EmptyStruct" });
         var func = () => methodInfo.Invoke(instance, [action, new Context(), CancellationToken.None]);
 
-        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.WithInnerException<ArgumentNullException>("action");
+        var exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>().ParamName.ShouldBe("action");
     }
 
     [Fact]
@@ -25,11 +25,10 @@ public class NoOpTResultSpecs
         NoOpPolicy<int> policy = Policy.NoOp<int>();
         int? result = null;
 
-        policy.Invoking(x => result = x.Execute(() => 10))
-            .Should().NotThrow();
+        Should.NotThrow(() => result = policy.Execute(() => 10));
 
-        result.HasValue.Should().BeTrue();
-        result.Should().Be(10);
+        result.HasValue.ShouldBeTrue();
+        result.ShouldBe(10);
     }
 
     [Fact]
@@ -42,11 +41,10 @@ public class NoOpTResultSpecs
         {
             cts.Cancel();
 
-            policy.Invoking(p => result = p.Execute(_ => 10, cts.Token))
-               .Should().NotThrow();
+            Should.NotThrow(() => result = policy.Execute(_ => 10, cts.Token));
         }
 
-        result.HasValue.Should().BeTrue();
-        result.Should().Be(10);
+        result.HasValue.ShouldBeTrue();
+        result.ShouldBe(10);
     }
 }

--- a/test/Polly.Specs/PolicyAsyncSpecs.cs
+++ b/test/Polly.Specs/PolicyAsyncSpecs.cs
@@ -19,8 +19,7 @@ public class PolicyAsyncSpecs
             return TaskHelper.EmptyTask;
         });
 
-        executed.Should()
-            .BeTrue();
+        executed.ShouldBeTrue();
     }
 
     [Fact]
@@ -32,8 +31,7 @@ public class PolicyAsyncSpecs
 
         int result = await policy.ExecuteAsync(() => Task.FromResult(2));
 
-        result.Should()
-            .Be(2);
+        result.ShouldBe(2);
     }
 
     #endregion
@@ -48,12 +46,10 @@ public class PolicyAsyncSpecs
             .RetryAsync((_, _) => { })
             .ExecuteAndCaptureAsync(() => TaskHelper.EmptyTask);
 
-        result.Should().BeEquivalentTo(new
-        {
-            Outcome = OutcomeType.Successful,
-            FinalException = (Exception?)null,
-            ExceptionType = (ExceptionType?)null,
-        });
+        result.ShouldNotBeNull();
+        result.Outcome.ShouldBe(OutcomeType.Successful);
+        result.FinalException.ShouldBeNull();
+        result.ExceptionType.ShouldBeNull();
     }
 
     [Fact]
@@ -66,12 +62,10 @@ public class PolicyAsyncSpecs
             .RetryAsync((_, _) => { })
             .ExecuteAndCaptureAsync(() => throw handledException);
 
-        result.Should().BeEquivalentTo(new
-        {
-            Outcome = OutcomeType.Failure,
-            FinalException = handledException,
-            ExceptionType = ExceptionType.HandledByThisPolicy,
-        });
+        result.ShouldNotBeNull();
+        result.Outcome.ShouldBe(OutcomeType.Failure);
+        result.FinalException.ShouldBe(handledException);
+        result.ExceptionType.ShouldBe(ExceptionType.HandledByThisPolicy);
     }
 
     [Fact]
@@ -84,12 +78,10 @@ public class PolicyAsyncSpecs
             .RetryAsync((_, _) => { })
             .ExecuteAndCaptureAsync(() => throw unhandledException);
 
-        result.Should().BeEquivalentTo(new
-        {
-            Outcome = OutcomeType.Failure,
-            FinalException = unhandledException,
-            ExceptionType = ExceptionType.Unhandled
-        });
+        result.ShouldNotBeNull();
+        result.Outcome.ShouldBe(OutcomeType.Failure);
+        result.FinalException.ShouldBe(unhandledException);
+        result.ExceptionType.ShouldBe(ExceptionType.Unhandled);
     }
 
     [Fact]
@@ -100,15 +92,13 @@ public class PolicyAsyncSpecs
             .RetryAsync((_, _) => { })
             .ExecuteAndCaptureAsync(() => Task.FromResult(int.MaxValue));
 
-        result.Should().BeEquivalentTo(new
-        {
-            Outcome = OutcomeType.Successful,
-            FinalException = (Exception?)null,
-            ExceptionType = (ExceptionType?)null,
-            FaultType = (FaultType?)null,
-            FinalHandledResult = default(int),
-            Result = int.MaxValue
-        });
+        result.ShouldNotBeNull();
+        result.Outcome.ShouldBe(OutcomeType.Successful);
+        result.FinalException.ShouldBeNull();
+        result.ExceptionType.ShouldBeNull();
+        result.FaultType.ShouldBeNull();
+        result.FinalHandledResult.ShouldBe(default);
+        result.Result.ShouldBe(int.MaxValue);
     }
 
     [Fact]
@@ -121,15 +111,13 @@ public class PolicyAsyncSpecs
             .RetryAsync((_, _) => { })
             .ExecuteAndCaptureAsync<int>(() => throw handledException);
 
-        result.Should().BeEquivalentTo(new
-        {
-            Outcome = OutcomeType.Failure,
-            FinalException = handledException,
-            ExceptionType = ExceptionType.HandledByThisPolicy,
-            FaultType = FaultType.ExceptionHandledByThisPolicy,
-            FinalHandledResult = default(int),
-            Result = default(int)
-        });
+        result.ShouldNotBeNull();
+        result.Outcome.ShouldBe(OutcomeType.Failure);
+        result.FinalException.ShouldBe(handledException);
+        result.ExceptionType.ShouldBe(ExceptionType.HandledByThisPolicy);
+        result.FaultType.ShouldBe(FaultType.ExceptionHandledByThisPolicy);
+        result.FinalHandledResult.ShouldBe(default);
+        result.Result.ShouldBe(default);
     }
 
     [Fact]
@@ -142,15 +130,13 @@ public class PolicyAsyncSpecs
             .RetryAsync((_, _) => { })
             .ExecuteAndCaptureAsync<int>(() => throw unhandledException);
 
-        result.Should().BeEquivalentTo(new
-        {
-            Outcome = OutcomeType.Failure,
-            FinalException = unhandledException,
-            ExceptionType = ExceptionType.Unhandled,
-            FaultType = FaultType.UnhandledException,
-            FinalHandledResult = default(int),
-            Result = default(int)
-        });
+        result.ShouldNotBeNull();
+        result.Outcome.ShouldBe(OutcomeType.Failure);
+        result.FinalException.ShouldBe(unhandledException);
+        result.ExceptionType.ShouldBe(ExceptionType.Unhandled);
+        result.FaultType.ShouldBe(FaultType.UnhandledException);
+        result.FinalHandledResult.ShouldBe(default);
+        result.Result.ShouldBe(default);
     }
 
     #endregion
@@ -164,8 +150,7 @@ public class PolicyAsyncSpecs
             .Handle<DivideByZeroException>()
             .RetryAsync((_, _, _) => { });
 
-        await policy.Awaiting(p => p.ExecuteAsync(_ => TaskHelper.EmptyTask, (IDictionary<string, object>)null!))
-              .Should().ThrowAsync<ArgumentNullException>();
+        await Should.ThrowAsync<ArgumentNullException>(() => policy.ExecuteAsync(_ => TaskHelper.EmptyTask, (IDictionary<string, object>)null!));
     }
 
     [Fact]
@@ -175,9 +160,8 @@ public class PolicyAsyncSpecs
             .Handle<DivideByZeroException>()
             .RetryAsync((_, _, _) => { });
 
-        var ex = await policy.Awaiting(p => p.ExecuteAsync(_ => TaskHelper.EmptyTask, null!))
-            .Should().ThrowAsync<ArgumentNullException>();
-        ex.And.ParamName.Should().Be("context");
+        var ex = await Should.ThrowAsync<ArgumentNullException>(() => policy.ExecuteAsync(_ => TaskHelper.EmptyTask, null!));
+        ex.ParamName.ShouldBe("context");
     }
 
     [Fact]
@@ -187,8 +171,7 @@ public class PolicyAsyncSpecs
             .Handle<DivideByZeroException>()
             .RetryAsync((_, _, _) => { });
 
-        await policy.Awaiting(p => p.ExecuteAsync(_ => Task.FromResult(2), (IDictionary<string, object>)null!))
-              .Should().ThrowAsync<ArgumentNullException>();
+        await Should.ThrowAsync<ArgumentNullException>(() => policy.ExecuteAsync(_ => Task.FromResult(2), (IDictionary<string, object>)null!));
     }
 
     [Fact]
@@ -198,9 +181,8 @@ public class PolicyAsyncSpecs
             .Handle<DivideByZeroException>()
             .RetryAsync((_, _, _) => { });
 
-        var ex = await policy.Awaiting(p => p.ExecuteAsync(_ => Task.FromResult(2), null!))
-              .Should().ThrowAsync<ArgumentNullException>();
-        ex.And.ParamName.Should().Be("context");
+        var ex = await Should.ThrowAsync<ArgumentNullException>(() => policy.ExecuteAsync(_ => Task.FromResult(2), null!));
+        ex.ParamName.ShouldBe("context");
     }
 
     [Fact]
@@ -214,7 +196,7 @@ public class PolicyAsyncSpecs
 
         await policy.ExecuteAsync(context => { capturedContext = context; return TaskHelper.EmptyTask; }, executionContext);
 
-        capturedContext.Should().BeSameAs(executionContext);
+        capturedContext.ShouldBeSameAs(executionContext);
     }
 
     [Fact]
@@ -224,8 +206,7 @@ public class PolicyAsyncSpecs
             .Handle<DivideByZeroException>()
             .RetryAsync((_, _, _) => { });
 
-        await policy.Awaiting(p => p.ExecuteAndCaptureAsync(_ => TaskHelper.EmptyTask, (IDictionary<string, object>)null!))
-              .Should().ThrowAsync<ArgumentNullException>();
+        await Should.ThrowAsync<ArgumentNullException>(() => policy.ExecuteAndCaptureAsync(_ => TaskHelper.EmptyTask, (IDictionary<string, object>)null!));
     }
 
     [Fact]
@@ -235,9 +216,8 @@ public class PolicyAsyncSpecs
             .Handle<DivideByZeroException>()
             .RetryAsync((_, _, _) => { });
 
-        var ex = await policy.Awaiting(p => p.ExecuteAndCaptureAsync(_ => TaskHelper.EmptyTask, null!))
-            .Should().ThrowAsync<ArgumentNullException>();
-        ex.And.ParamName.Should().Be("context");
+        var ex = await Should.ThrowAsync<ArgumentNullException>(() => policy.ExecuteAndCaptureAsync(_ => TaskHelper.EmptyTask, null!));
+        ex.ParamName.ShouldBe("context");
     }
 
     [Fact]
@@ -247,8 +227,7 @@ public class PolicyAsyncSpecs
             .Handle<DivideByZeroException>()
             .RetryAsync((_, _, _) => { });
 
-        await policy.Awaiting(p => p.ExecuteAndCaptureAsync(_ => Task.FromResult(2), (IDictionary<string, object>)null!))
-              .Should().ThrowAsync<ArgumentNullException>();
+        await Should.ThrowAsync<ArgumentNullException>(() => policy.ExecuteAndCaptureAsync(_ => Task.FromResult(2), (IDictionary<string, object>)null!));
     }
 
     [Fact]
@@ -258,9 +237,8 @@ public class PolicyAsyncSpecs
             .Handle<DivideByZeroException>()
             .RetryAsync((_, _, _) => { });
 
-        var ex = await policy.Awaiting(p => p.ExecuteAndCaptureAsync(_ => Task.FromResult(2), null!))
-              .Should().ThrowAsync<ArgumentNullException>();
-        ex.And.ParamName.Should().Be("context");
+        var ex = await Should.ThrowAsync<ArgumentNullException>(() => policy.ExecuteAndCaptureAsync(_ => Task.FromResult(2), null!));
+        ex.ParamName.ShouldBe("context");
     }
 
     [Fact]
@@ -274,7 +252,7 @@ public class PolicyAsyncSpecs
 
         await policy.ExecuteAndCaptureAsync(context => { capturedContext = context; return TaskHelper.EmptyTask; }, executionContext);
 
-        capturedContext.Should().BeSameAs(executionContext);
+        capturedContext.ShouldBeSameAs(executionContext);
     }
 
     [Fact]
@@ -286,7 +264,7 @@ public class PolicyAsyncSpecs
         var policy = Policy.NoOpAsync();
 
         (await policy.ExecuteAndCaptureAsync(_ => TaskHelper.EmptyTask, executionContext))
-            .Context.Should().BeSameAs(executionContext);
+            .Context.ShouldBeSameAs(executionContext);
     }
 
     #endregion

--- a/test/Polly.Specs/PolicyKeyAsyncSpecs.cs
+++ b/test/Polly.Specs/PolicyKeyAsyncSpecs.cs
@@ -9,7 +9,7 @@ public class PolicyKeyAsyncSpecs
     {
         var policy = Policy.Handle<Exception>().RetryAsync().WithPolicyKey(Guid.NewGuid().ToString());
 
-        policy.Should().BeAssignableTo<AsyncPolicy>();
+        policy.ShouldBeAssignableTo<AsyncPolicy>();
     }
 
     [Fact]
@@ -18,7 +18,7 @@ public class PolicyKeyAsyncSpecs
         IAsyncPolicy policyAsInterface = Policy.Handle<Exception>().RetryAsync();
         var policyAsInterfaceAfterWithPolicyKey = policyAsInterface.WithPolicyKey(Guid.NewGuid().ToString());
 
-        policyAsInterfaceAfterWithPolicyKey.Should().BeAssignableTo<IAsyncPolicy>();
+        policyAsInterfaceAfterWithPolicyKey.ShouldBeAssignableTo<IAsyncPolicy>();
     }
 
     [Fact]
@@ -28,7 +28,7 @@ public class PolicyKeyAsyncSpecs
 
         var policy = Policy.Handle<Exception>().RetryAsync().WithPolicyKey(Key);
 
-        policy.PolicyKey.Should().Be(Key);
+        policy.PolicyKey.ShouldBe(Key);
     }
 
     [Fact]
@@ -38,9 +38,9 @@ public class PolicyKeyAsyncSpecs
 
         Action configure = () => policy.WithPolicyKey(Guid.NewGuid().ToString());
 
-        configure.Should().NotThrow();
+        Should.NotThrow(configure);
 
-        configure.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policyKey");
+        Should.Throw<ArgumentException>(configure).ParamName.ShouldBe("policyKey");
     }
 
     [Fact]
@@ -50,9 +50,9 @@ public class PolicyKeyAsyncSpecs
 
         Action configure = () => policyAsInterface.WithPolicyKey(Guid.NewGuid().ToString());
 
-        configure.Should().NotThrow();
+        Should.NotThrow(configure);
 
-        configure.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policyKey");
+        Should.Throw<ArgumentException>(configure).ParamName.ShouldBe("policyKey");
     }
 
     [Fact]
@@ -60,7 +60,7 @@ public class PolicyKeyAsyncSpecs
     {
         var policy = Policy.Handle<Exception>().RetryAsync();
 
-        policy.PolicyKey.Should().NotBeNullOrEmpty();
+        policy.PolicyKey.ShouldNotBeNullOrEmpty();
     }
 
     [Fact]
@@ -68,7 +68,7 @@ public class PolicyKeyAsyncSpecs
     {
         var policy = Policy.Handle<Exception>().RetryAsync();
 
-        policy.PolicyKey.Should().StartWith("AsyncRetry");
+        policy.PolicyKey.ShouldStartWith("AsyncRetry");
     }
 
     [Fact]
@@ -77,7 +77,7 @@ public class PolicyKeyAsyncSpecs
         var policy1 = Policy.Handle<Exception>().RetryAsync();
         var policy2 = Policy.Handle<Exception>().RetryAsync();
 
-        policy1.PolicyKey.Should().NotBe(policy2.PolicyKey);
+        policy1.PolicyKey.ShouldNotBe(policy2.PolicyKey);
     }
 
     [Fact]
@@ -88,7 +88,7 @@ public class PolicyKeyAsyncSpecs
         var keyRetrievedFirst = policy.PolicyKey;
         var keyRetrievedSecond = policy.PolicyKey;
 
-        keyRetrievedSecond.Should().Be(keyRetrievedFirst);
+        keyRetrievedSecond.ShouldBe(keyRetrievedFirst);
     }
 
     [Fact]
@@ -100,7 +100,7 @@ public class PolicyKeyAsyncSpecs
 
         Action configure = () => policy.WithPolicyKey(Guid.NewGuid().ToString());
 
-        configure.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policyKey");
+        Should.Throw<ArgumentException>(configure).ParamName.ShouldBe("policyKey");
     }
 
     [Fact]
@@ -125,7 +125,7 @@ public class PolicyKeyAsyncSpecs
 
         await retry.RaiseExceptionAsync<Exception>(1);
 
-        policyKeySetOnExecutionContext.Should().Be(policyKey);
+        policyKeySetOnExecutionContext.ShouldBe(policyKey);
     }
 
     [Fact]
@@ -148,7 +148,7 @@ public class PolicyKeyAsyncSpecs
             }
         }, new Context(operationKey));
 
-        operationKeySetOnContext.Should().Be(operationKey);
+        operationKeySetOnContext.ShouldBe(operationKey);
     }
 
     [Fact]
@@ -173,7 +173,7 @@ public class PolicyKeyAsyncSpecs
             return 0;
         });
 
-        policyKeySetOnExecutionContext.Should().Be(policyKey);
+        policyKeySetOnExecutionContext.ShouldBe(policyKey);
     }
 
     [Fact]
@@ -186,7 +186,7 @@ public class PolicyKeyAsyncSpecs
         var retry = Policy.Handle<Exception>().RetryAsync(1, onRetry);
 
         bool firstExecution = true;
-        await retry.ExecuteAsync<int>(async _ =>
+        await retry.ExecuteAsync(async _ =>
         {
             await TaskHelper.EmptyTask;
             if (firstExecution)
@@ -198,7 +198,7 @@ public class PolicyKeyAsyncSpecs
             return 0;
         }, new Context(operationKey));
 
-        operationKeySetOnContext.Should().Be(operationKey);
+        operationKeySetOnContext.ShouldBe(operationKey);
     }
     #endregion
 }

--- a/test/Polly.Specs/PolicyKeySpecs.cs
+++ b/test/Polly.Specs/PolicyKeySpecs.cs
@@ -9,7 +9,7 @@ public class PolicyKeySpecs
     {
         var policy = Policy.Handle<Exception>().Retry().WithPolicyKey(Guid.NewGuid().ToString());
 
-        policy.Should().BeAssignableTo<Policy>();
+        policy.ShouldBeAssignableTo<Policy>();
     }
 
     [Fact]
@@ -18,7 +18,7 @@ public class PolicyKeySpecs
         ISyncPolicy policyAsInterface = Policy.Handle<Exception>().Retry();
         var policyAsInterfaceAfterWithPolicyKey = policyAsInterface.WithPolicyKey(Guid.NewGuid().ToString());
 
-        policyAsInterfaceAfterWithPolicyKey.Should().BeAssignableTo<ISyncPolicy>();
+        policyAsInterfaceAfterWithPolicyKey.ShouldBeAssignableTo<ISyncPolicy>();
     }
 
     [Fact]
@@ -28,7 +28,7 @@ public class PolicyKeySpecs
 
         var policy = Policy.Handle<Exception>().Retry().WithPolicyKey(Key);
 
-        policy.PolicyKey.Should().Be(Key);
+        policy.PolicyKey.ShouldBe(Key);
     }
 
     [Fact]
@@ -38,9 +38,9 @@ public class PolicyKeySpecs
 
         Action configure = () => policy.WithPolicyKey(Guid.NewGuid().ToString());
 
-        configure.Should().NotThrow();
+        Should.NotThrow(configure);
 
-        configure.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policyKey");
+        Should.Throw<ArgumentException>(configure).ParamName.ShouldBe("policyKey");
     }
 
     [Fact]
@@ -48,7 +48,7 @@ public class PolicyKeySpecs
     {
         var policy = Policy.Handle<Exception>().Retry();
 
-        policy.PolicyKey.Should().NotBeNullOrEmpty();
+        policy.PolicyKey.ShouldNotBeNullOrEmpty();
     }
 
     [Fact]
@@ -56,7 +56,7 @@ public class PolicyKeySpecs
     {
         var policy = Policy.Handle<Exception>().Retry();
 
-        policy.PolicyKey.Should().StartWith("Retry");
+        policy.PolicyKey.ShouldStartWith("Retry");
     }
 
     [Fact]
@@ -65,7 +65,7 @@ public class PolicyKeySpecs
         var policy1 = Policy.Handle<Exception>().Retry();
         var policy2 = Policy.Handle<Exception>().Retry();
 
-        policy1.PolicyKey.Should().NotBe(policy2.PolicyKey);
+        policy1.PolicyKey.ShouldNotBe(policy2.PolicyKey);
     }
 
     [Fact]
@@ -76,7 +76,7 @@ public class PolicyKeySpecs
         var keyRetrievedFirst = policy.PolicyKey;
         var keyRetrievedSecond = policy.PolicyKey;
 
-        keyRetrievedSecond.Should().Be(keyRetrievedFirst);
+        keyRetrievedSecond.ShouldBe(keyRetrievedFirst);
     }
 
     [Fact]
@@ -88,7 +88,7 @@ public class PolicyKeySpecs
 
         Action configure = () => policy.WithPolicyKey(Guid.NewGuid().ToString());
 
-        configure.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policyKey");
+        Should.Throw<ArgumentException>(configure).ParamName.ShouldBe("policyKey");
     }
 
     #endregion
@@ -106,7 +106,7 @@ public class PolicyKeySpecs
 
         retry.RaiseException<Exception>(1);
 
-        policyKeySetOnExecutionContext.Should().Be(policyKey);
+        policyKeySetOnExecutionContext.ShouldBe(policyKey);
     }
 
     [Fact]
@@ -128,7 +128,7 @@ public class PolicyKeySpecs
             }
         }, new Context(operationKey));
 
-        operationKeySetOnContext.Should().Be(operationKey);
+        operationKeySetOnContext.ShouldBe(operationKey);
     }
 
     [Fact]
@@ -152,7 +152,7 @@ public class PolicyKeySpecs
             return 0;
         });
 
-        policyKeySetOnExecutionContext.Should().Be(policyKey);
+        policyKeySetOnExecutionContext.ShouldBe(policyKey);
     }
 
     [Fact]
@@ -176,7 +176,7 @@ public class PolicyKeySpecs
             return 0;
         }, new Context(operationKey));
 
-        operationKeySetOnContext.Should().Be(operationKey);
+        operationKeySetOnContext.ShouldBe(operationKey);
     }
     #endregion
 }

--- a/test/Polly.Specs/PolicySpecs.cs
+++ b/test/Polly.Specs/PolicySpecs.cs
@@ -15,8 +15,7 @@ public class PolicySpecs
 
         policy.Execute(() => executed = true);
 
-        executed.Should()
-            .BeTrue();
+        executed.ShouldBeTrue();
     }
 
     [Fact]
@@ -28,8 +27,7 @@ public class PolicySpecs
 
         var result = policy.Execute(() => 2);
 
-        result.Should()
-            .Be(2);
+        result.ShouldBe(2);
     }
 
     #endregion
@@ -44,12 +42,10 @@ public class PolicySpecs
             .Retry((_, _) => { })
             .ExecuteAndCapture(() => { });
 
-        result.Should().BeEquivalentTo(new
-        {
-            Outcome = OutcomeType.Successful,
-            FinalException = (Exception?)null,
-            ExceptionType = (ExceptionType?)null,
-        });
+        result.ShouldNotBeNull();
+        result.Outcome.ShouldBe(OutcomeType.Successful);
+        result.FinalException.ShouldBeNull();
+        result.ExceptionType.ShouldBeNull();
     }
 
     [Fact]
@@ -62,12 +58,10 @@ public class PolicySpecs
             .Retry((_, _) => { })
             .ExecuteAndCapture(() => throw handledException);
 
-        result.Should().BeEquivalentTo(new
-        {
-            Outcome = OutcomeType.Failure,
-            FinalException = handledException,
-            ExceptionType = ExceptionType.HandledByThisPolicy
-        });
+        result.ShouldNotBeNull();
+        result.Outcome.ShouldBe(OutcomeType.Failure);
+        result.FinalException.ShouldBeSameAs(handledException);
+        result.ExceptionType.ShouldBe(ExceptionType.HandledByThisPolicy);
     }
 
     [Fact]
@@ -80,12 +74,10 @@ public class PolicySpecs
             .Retry((_, _) => { })
             .ExecuteAndCapture(() => throw unhandledException);
 
-        result.Should().BeEquivalentTo(new
-        {
-            Outcome = OutcomeType.Failure,
-            FinalException = unhandledException,
-            ExceptionType = ExceptionType.Unhandled
-        });
+        result.ShouldNotBeNull();
+        result.Outcome.ShouldBe(OutcomeType.Failure);
+        result.FinalException.ShouldBeSameAs(unhandledException);
+        result.ExceptionType.ShouldBe(ExceptionType.Unhandled);
     }
 
     [Fact]
@@ -96,15 +88,13 @@ public class PolicySpecs
             .Retry((_, _) => { })
             .ExecuteAndCapture(() => int.MaxValue);
 
-        result.Should().BeEquivalentTo(new
-        {
-            Outcome = OutcomeType.Successful,
-            FinalException = (Exception?)null,
-            ExceptionType = (ExceptionType?)null,
-            FaultType = (FaultType?)null,
-            FinalHandledResult = default(int),
-            Result = int.MaxValue
-        });
+        result.ShouldNotBeNull();
+        result.Outcome.ShouldBe(OutcomeType.Successful);
+        result.FinalException.ShouldBeNull();
+        result.ExceptionType.ShouldBeNull();
+        result.FaultType.ShouldBeNull();
+        result.FinalHandledResult.ShouldBe(default);
+        result.Result.ShouldBe(int.MaxValue);
     }
 
     [Fact]
@@ -117,15 +107,13 @@ public class PolicySpecs
             .Retry((_, _) => { })
             .ExecuteAndCapture<int>(() => throw handledException);
 
-        result.Should().BeEquivalentTo(new
-        {
-            Outcome = OutcomeType.Failure,
-            FinalException = handledException,
-            ExceptionType = ExceptionType.HandledByThisPolicy,
-            FaultType = FaultType.ExceptionHandledByThisPolicy,
-            FinalHandledResult = default(int),
-            Result = default(int)
-        });
+        result.ShouldNotBeNull();
+        result.Outcome.ShouldBe(OutcomeType.Failure);
+        result.FinalException.ShouldBeSameAs(handledException);
+        result.ExceptionType.ShouldBe(ExceptionType.HandledByThisPolicy);
+        result.FaultType.ShouldBe(FaultType.ExceptionHandledByThisPolicy);
+        result.FinalHandledResult.ShouldBe(default);
+        result.Result.ShouldBe(default);
     }
 
     [Fact]
@@ -138,15 +126,13 @@ public class PolicySpecs
             .Retry((_, _) => { })
             .ExecuteAndCapture<int>(() => throw unhandledException);
 
-        result.Should().BeEquivalentTo(new
-        {
-            Outcome = OutcomeType.Failure,
-            FinalException = unhandledException,
-            ExceptionType = ExceptionType.Unhandled,
-            FaultType = FaultType.UnhandledException,
-            FinalHandledResult = default(int),
-            Result = default(int)
-        });
+        result.ShouldNotBeNull();
+        result.Outcome.ShouldBe(OutcomeType.Failure);
+        result.FinalException.ShouldBeSameAs(unhandledException);
+        result.ExceptionType.ShouldBe(ExceptionType.Unhandled);
+        result.FaultType.ShouldBe(FaultType.UnhandledException);
+        result.FinalHandledResult.ShouldBe(default);
+        result.Result.ShouldBe(default);
     }
 
     #endregion
@@ -160,8 +146,7 @@ public class PolicySpecs
             .Handle<DivideByZeroException>()
             .Retry((_, _, _) => { });
 
-        policy.Invoking(p => p.Execute(_ => { }, (IDictionary<string, object>)null!))
-              .Should().Throw<ArgumentNullException>();
+        Should.Throw<ArgumentNullException>(() => policy.Execute(_ => { }, (IDictionary<string, object>)null!));
     }
 
     [Fact]
@@ -171,9 +156,8 @@ public class PolicySpecs
             .Handle<DivideByZeroException>()
             .Retry((_, _, _) => { });
 
-        policy.Invoking(p => p.Execute(_ => { }, null!))
-            .Should().Throw<ArgumentNullException>().And
-            .ParamName.Should().Be("context");
+        Should.Throw<ArgumentNullException>(() => policy.Execute(_ => { }, null!))
+            .ParamName.ShouldBe("context");
     }
 
     [Fact]
@@ -183,8 +167,7 @@ public class PolicySpecs
             .Handle<DivideByZeroException>()
             .Retry((_, _, _) => { });
 
-        policy.Invoking(p => p.Execute(_ => 2, (IDictionary<string, object>)null!))
-            .Should().Throw<ArgumentNullException>();
+        Should.Throw<ArgumentNullException>(() => policy.Execute(_ => 2, (IDictionary<string, object>)null!));
     }
 
     [Fact]
@@ -194,9 +177,8 @@ public class PolicySpecs
             .Handle<DivideByZeroException>()
             .Retry((_, _, _) => { });
 
-        policy.Invoking(p => p.Execute(_ => 2, null!))
-            .Should().Throw<ArgumentNullException>().And
-            .ParamName.Should().Be("context");
+        Should.Throw<ArgumentNullException>(() => policy.Execute(_ => 2, null!))
+            .ParamName.ShouldBe("context");
     }
 
     [Fact]
@@ -208,9 +190,9 @@ public class PolicySpecs
 
         Policy policy = Policy.NoOp();
 
-        policy.Execute(context => { capturedContext = context; }, executionContext);
+        policy.Execute(context => capturedContext = context, executionContext);
 
-        capturedContext.Should().BeSameAs(executionContext);
+        capturedContext.ShouldBeSameAs(executionContext);
     }
 
     [Fact]
@@ -220,8 +202,7 @@ public class PolicySpecs
             .Handle<DivideByZeroException>()
             .Retry((_, _, _) => { });
 
-        policy.Invoking(p => p.ExecuteAndCapture(_ => { }, (IDictionary<string, object>)null!))
-              .Should().Throw<ArgumentNullException>();
+        Should.Throw<ArgumentNullException>(() => policy.ExecuteAndCapture(_ => { }, (IDictionary<string, object>)null!));
     }
 
     [Fact]
@@ -231,9 +212,8 @@ public class PolicySpecs
             .Handle<DivideByZeroException>()
             .Retry((_, _, _) => { });
 
-        policy.Invoking(p => p.ExecuteAndCapture(_ => { }, null!))
-            .Should().Throw<ArgumentNullException>().And
-            .ParamName.Should().Be("context");
+        Should.Throw<ArgumentNullException>(() => policy.ExecuteAndCapture(_ => { }, null!))
+            .ParamName.ShouldBe("context");
     }
 
     [Fact]
@@ -243,8 +223,7 @@ public class PolicySpecs
             .Handle<DivideByZeroException>()
             .Retry((_, _, _) => { });
 
-        policy.Invoking(p => p.ExecuteAndCapture(_ => 2, (IDictionary<string, object>)null!))
-              .Should().Throw<ArgumentNullException>();
+        Should.Throw<ArgumentNullException>(() => policy.ExecuteAndCapture(_ => 2, (IDictionary<string, object>)null!));
     }
 
     [Fact]
@@ -254,9 +233,8 @@ public class PolicySpecs
             .Handle<DivideByZeroException>()
             .Retry((_, _, _) => { });
 
-        policy.Invoking(p => p.ExecuteAndCapture(_ => 2, null!))
-              .Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("context");
+        Should.Throw<ArgumentNullException>(() => policy.ExecuteAndCapture(_ => 2, null!))
+              .ParamName.ShouldBe("context");
     }
 
     [Fact]
@@ -270,7 +248,7 @@ public class PolicySpecs
 
         policy.ExecuteAndCapture(context => { capturedContext = context; }, executionContext);
 
-        capturedContext.Should().BeSameAs(executionContext);
+        capturedContext.ShouldBeSameAs(executionContext);
     }
 
     [Fact]
@@ -282,7 +260,7 @@ public class PolicySpecs
         Policy policy = Policy.NoOp();
 
         policy.ExecuteAndCapture(_ => { }, executionContext)
-            .Context.Should().BeSameAs(executionContext);
+            .Context.ShouldBeSameAs(executionContext);
     }
 
     #endregion

--- a/test/Polly.Specs/PolicyTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/PolicyTResultAsyncSpecs.cs
@@ -13,8 +13,7 @@ public class PolicyTResultAsyncSpecs
 
         var result = await policy.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good));
 
-        result.Should()
-            .Be(ResultPrimitive.Good);
+        result.ShouldBe(ResultPrimitive.Good);
     }
 
     #endregion
@@ -29,15 +28,13 @@ public class PolicyTResultAsyncSpecs
             .RetryAsync((_, _) => { })
             .ExecuteAndCaptureAsync(() => Task.FromResult(ResultPrimitive.Good));
 
-        result.Should().BeEquivalentTo(new
-        {
-            Outcome = OutcomeType.Successful,
-            FinalException = (Exception?)null,
-            ExceptionType = (ExceptionType?)null,
-            Result = ResultPrimitive.Good,
-            FinalHandledResult = default(ResultPrimitive),
-            FaultType = (FaultType?)null
-        });
+        result.ShouldNotBeNull();
+        result.Outcome.ShouldBe(OutcomeType.Successful);
+        result.FinalException.ShouldBeNull();
+        result.ExceptionType.ShouldBeNull();
+        result.Result.ShouldBe(ResultPrimitive.Good);
+        result.FinalHandledResult.ShouldBe(default);
+        result.FaultType.ShouldBeNull();
     }
 
     [Fact]
@@ -50,15 +47,13 @@ public class PolicyTResultAsyncSpecs
             .RetryAsync((_, _) => { })
             .ExecuteAndCaptureAsync(() => Task.FromResult(handledResult));
 
-        result.Should().BeEquivalentTo(new
-        {
-            Outcome = OutcomeType.Failure,
-            FinalException = (Exception?)null,
-            ExceptionType = (ExceptionType?)null,
-            FaultType = FaultType.ResultHandledByThisPolicy,
-            FinalHandledResult = handledResult,
-            Result = default(ResultPrimitive)
-        });
+        result.ShouldNotBeNull();
+        result.Outcome.ShouldBe(OutcomeType.Failure);
+        result.FinalException.ShouldBeNull();
+        result.ExceptionType.ShouldBeNull();
+        result.FaultType.ShouldBe(FaultType.ResultHandledByThisPolicy);
+        result.FinalHandledResult.ShouldBe(handledResult);
+        result.Result.ShouldBe(default);
     }
 
     [Fact]
@@ -72,15 +67,13 @@ public class PolicyTResultAsyncSpecs
             .RetryAsync((_, _) => { })
             .ExecuteAndCaptureAsync(() => Task.FromResult(unhandledResult));
 
-        result.Should().BeEquivalentTo(new
-        {
-            Outcome = OutcomeType.Successful,
-            FinalException = (Exception?)null,
-            ExceptionType = (ExceptionType?)null,
-            Result = unhandledResult,
-            FinalHandledResult = default(ResultPrimitive),
-            FaultType = (FaultType?)null
-        });
+        result.ShouldNotBeNull();
+        result.Outcome.ShouldBe(OutcomeType.Successful);
+        result.FinalException.ShouldBeNull();
+        result.ExceptionType.ShouldBeNull();
+        result.Result.ShouldBe(unhandledResult);
+        result.FaultType.ShouldBeNull();
+        result.FinalHandledResult.ShouldBe(default);
     }
 
     #endregion
@@ -94,8 +87,7 @@ public class PolicyTResultAsyncSpecs
             .HandleResult(ResultPrimitive.Fault)
             .RetryAsync((_, _, _) => { });
 
-        await policy.Awaiting(p => p.ExecuteAsync(_ => Task.FromResult(ResultPrimitive.Good), (IDictionary<string, object>)null!))
-              .Should().ThrowAsync<ArgumentNullException>();
+        await Should.ThrowAsync<ArgumentNullException>(() => policy.ExecuteAsync(_ => Task.FromResult(ResultPrimitive.Good), (IDictionary<string, object>)null!));
     }
 
     [Fact]
@@ -105,9 +97,8 @@ public class PolicyTResultAsyncSpecs
             .HandleResult(ResultPrimitive.Fault)
             .RetryAsync((_, _, _) => { });
 
-        var ex = await policy.Awaiting(p => p.ExecuteAsync(_ => Task.FromResult(ResultPrimitive.Good), null!))
-              .Should().ThrowAsync<ArgumentNullException>();
-        ex.And.ParamName.Should().Be("context");
+        var ex = await Should.ThrowAsync<ArgumentNullException>(() => policy.ExecuteAsync(_ => Task.FromResult(ResultPrimitive.Good), null!));
+        ex.ParamName.ShouldBe("context");
     }
 
     [Fact]
@@ -121,7 +112,7 @@ public class PolicyTResultAsyncSpecs
 
         await policy.ExecuteAsync(context => { capturedContext = context; return Task.FromResult(ResultPrimitive.Good); }, executionContext);
 
-        capturedContext.Should().BeSameAs(executionContext);
+        capturedContext.ShouldBeSameAs(executionContext);
     }
 
     [Fact]
@@ -131,9 +122,8 @@ public class PolicyTResultAsyncSpecs
             .HandleResult(ResultPrimitive.Fault)
             .RetryAsync((_, _, _) => { });
 
-        var ex = await policy.Awaiting(p => p.ExecuteAndCaptureAsync(_ => Task.FromResult(ResultPrimitive.Good), null!))
-              .Should().ThrowAsync<ArgumentNullException>();
-        ex.And.ParamName.Should().Be("context");
+        var ex = await Should.ThrowAsync<ArgumentNullException>(() => policy.ExecuteAndCaptureAsync(_ => Task.FromResult(ResultPrimitive.Good), null!));
+        ex.ParamName.ShouldBe("context");
     }
 
     [Fact]
@@ -147,7 +137,7 @@ public class PolicyTResultAsyncSpecs
 
         await policy.ExecuteAndCaptureAsync(context => { capturedContext = context; return Task.FromResult(ResultPrimitive.Good); }, executionContext);
 
-        capturedContext.Should().BeSameAs(executionContext);
+        capturedContext.ShouldBeSameAs(executionContext);
     }
 
     [Fact]
@@ -159,7 +149,7 @@ public class PolicyTResultAsyncSpecs
         var policy = Policy.NoOpAsync<ResultPrimitive>();
 
         (await policy.ExecuteAndCaptureAsync(_ => Task.FromResult(ResultPrimitive.Good), executionContext))
-            .Context.Should().BeSameAs(executionContext);
+            .Context.ShouldBeSameAs(executionContext);
     }
 
     #endregion

--- a/test/Polly.Specs/PolicyTResultKeyAsyncSpecs.cs
+++ b/test/Polly.Specs/PolicyTResultKeyAsyncSpecs.cs
@@ -9,7 +9,7 @@ public class PolicyTResultKeyAsyncSpecs
     {
         var policy = Policy.HandleResult<int>(0).RetryAsync().WithPolicyKey(Guid.NewGuid().ToString());
 
-        policy.Should().BeAssignableTo<AsyncPolicy<int>>();
+        policy.ShouldBeAssignableTo<AsyncPolicy<int>>();
     }
 
     [Fact]
@@ -18,7 +18,7 @@ public class PolicyTResultKeyAsyncSpecs
         IAsyncPolicy<int> policyAsInterface = Policy.HandleResult<int>(0).RetryAsync();
         var policyAsInterfaceAfterWithPolicyKey = policyAsInterface.WithPolicyKey(Guid.NewGuid().ToString());
 
-        policyAsInterfaceAfterWithPolicyKey.Should().BeAssignableTo<IAsyncPolicy<int>>();
+        policyAsInterfaceAfterWithPolicyKey.ShouldBeAssignableTo<IAsyncPolicy<int>>();
     }
 
     [Fact]
@@ -28,7 +28,7 @@ public class PolicyTResultKeyAsyncSpecs
 
         var policy = Policy.HandleResult(0).RetryAsync().WithPolicyKey(Key);
 
-        policy.PolicyKey.Should().Be(Key);
+        policy.PolicyKey.ShouldBe(Key);
     }
 
     [Fact]
@@ -38,9 +38,9 @@ public class PolicyTResultKeyAsyncSpecs
 
         Action configure = () => policy.WithPolicyKey(Guid.NewGuid().ToString());
 
-        configure.Should().NotThrow();
+        Should.NotThrow(configure);
 
-        configure.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policyKey");
+        Should.Throw<ArgumentException>(configure).ParamName.ShouldBe("policyKey");
     }
 
     [Fact]
@@ -49,9 +49,9 @@ public class PolicyTResultKeyAsyncSpecs
         IAsyncPolicy<int> policyAsInterface = Policy.HandleResult(0).RetryAsync();
         Action configure = () => policyAsInterface.WithPolicyKey(Guid.NewGuid().ToString());
 
-        configure.Should().NotThrow();
+        Should.NotThrow(configure);
 
-        configure.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policyKey");
+        Should.Throw<ArgumentException>(configure).ParamName.ShouldBe("policyKey");
     }
 
     [Fact]
@@ -59,7 +59,7 @@ public class PolicyTResultKeyAsyncSpecs
     {
         var policy = Policy.HandleResult(0).RetryAsync();
 
-        policy.PolicyKey.Should().NotBeNullOrEmpty();
+        policy.PolicyKey.ShouldNotBeNullOrEmpty();
     }
 
     [Fact]
@@ -67,7 +67,7 @@ public class PolicyTResultKeyAsyncSpecs
     {
         var policy = Policy.HandleResult(0).RetryAsync();
 
-        policy.PolicyKey.Should().StartWith("AsyncRetry");
+        policy.PolicyKey.ShouldStartWith("AsyncRetry");
     }
 
     [Fact]
@@ -76,7 +76,7 @@ public class PolicyTResultKeyAsyncSpecs
         var policy1 = Policy.HandleResult(0).RetryAsync();
         var policy2 = Policy.HandleResult(0).RetryAsync();
 
-        policy1.PolicyKey.Should().NotBe(policy2.PolicyKey);
+        policy1.PolicyKey.ShouldNotBe(policy2.PolicyKey);
     }
 
     [Fact]
@@ -87,7 +87,7 @@ public class PolicyTResultKeyAsyncSpecs
         var keyRetrievedFirst = policy.PolicyKey;
         var keyRetrievedSecond = policy.PolicyKey;
 
-        keyRetrievedSecond.Should().Be(keyRetrievedFirst);
+        keyRetrievedSecond.ShouldBe(keyRetrievedFirst);
     }
 
     [Fact]
@@ -99,7 +99,7 @@ public class PolicyTResultKeyAsyncSpecs
 
         Action configure = () => policy.WithPolicyKey(Guid.NewGuid().ToString());
 
-        configure.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policyKey");
+        Should.Throw<ArgumentException>(configure).ParamName.ShouldBe("policyKey");
     }
 
     #endregion
@@ -117,7 +117,7 @@ public class PolicyTResultKeyAsyncSpecs
 
         await retry.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Good);
 
-        policyKeySetOnExecutionContext.Should().Be(policyKey);
+        policyKeySetOnExecutionContext.ShouldBe(policyKey);
     }
 
     [Fact]
@@ -142,7 +142,7 @@ public class PolicyTResultKeyAsyncSpecs
             return ResultPrimitive.Good;
         }, new Context(operationKey));
 
-        operationKeySetOnContext.Should().Be(operationKey);
+        operationKeySetOnContext.ShouldBe(operationKey);
     }
 
     #endregion

--- a/test/Polly.Specs/PolicyTResultKeySpecs.cs
+++ b/test/Polly.Specs/PolicyTResultKeySpecs.cs
@@ -9,7 +9,7 @@ public class PolicyTResultKeySpecs
     {
         var policy = Policy.HandleResult<int>(0).Retry().WithPolicyKey(Guid.NewGuid().ToString());
 
-        policy.Should().BeAssignableTo<Policy<int>>();
+        policy.ShouldBeAssignableTo<Policy<int>>();
     }
 
     [Fact]
@@ -18,7 +18,7 @@ public class PolicyTResultKeySpecs
         ISyncPolicy<int> policyAsInterface = Policy.HandleResult<int>(0).Retry();
         var policyAsInterfaceAfterWithPolicyKey = policyAsInterface.WithPolicyKey(Guid.NewGuid().ToString());
 
-        policyAsInterfaceAfterWithPolicyKey.Should().BeAssignableTo<ISyncPolicy<int>>();
+        policyAsInterfaceAfterWithPolicyKey.ShouldBeAssignableTo<ISyncPolicy<int>>();
     }
 
     [Fact]
@@ -28,7 +28,7 @@ public class PolicyTResultKeySpecs
 
         var policy = Policy.HandleResult(0).Retry().WithPolicyKey(Key);
 
-        policy.PolicyKey.Should().Be(Key);
+        policy.PolicyKey.ShouldBe(Key);
     }
 
     [Fact]
@@ -38,9 +38,9 @@ public class PolicyTResultKeySpecs
 
         Action configure = () => policy.WithPolicyKey(Guid.NewGuid().ToString());
 
-        configure.Should().NotThrow();
+        Should.NotThrow(configure);
 
-        configure.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policyKey");
+        Should.Throw<ArgumentException>(configure).ParamName.ShouldBe("policyKey");
     }
 
     [Fact]
@@ -48,7 +48,7 @@ public class PolicyTResultKeySpecs
     {
         var policy = Policy.HandleResult(0).Retry();
 
-        policy.PolicyKey.Should().NotBeNullOrEmpty();
+        policy.PolicyKey.ShouldNotBeNullOrEmpty();
     }
 
     [Fact]
@@ -56,7 +56,7 @@ public class PolicyTResultKeySpecs
     {
         var policy = Policy.HandleResult(0).Retry();
 
-        policy.PolicyKey.Should().StartWith("Retry");
+        policy.PolicyKey.ShouldStartWith("Retry");
     }
 
     [Fact]
@@ -65,7 +65,7 @@ public class PolicyTResultKeySpecs
         var policy1 = Policy.HandleResult(0).Retry();
         var policy2 = Policy.HandleResult(0).Retry();
 
-        policy1.PolicyKey.Should().NotBe(policy2.PolicyKey);
+        policy1.PolicyKey.ShouldNotBe(policy2.PolicyKey);
     }
 
     [Fact]
@@ -76,7 +76,7 @@ public class PolicyTResultKeySpecs
         var keyRetrievedFirst = policy.PolicyKey;
         var keyRetrievedSecond = policy.PolicyKey;
 
-        keyRetrievedSecond.Should().Be(keyRetrievedFirst);
+        keyRetrievedSecond.ShouldBe(keyRetrievedFirst);
     }
 
     [Fact]
@@ -88,7 +88,7 @@ public class PolicyTResultKeySpecs
 
         Action configure = () => policy.WithPolicyKey(Guid.NewGuid().ToString());
 
-        configure.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policyKey");
+        Should.Throw<ArgumentException>(configure).ParamName.ShouldBe("policyKey");
     }
 
     #endregion
@@ -106,7 +106,7 @@ public class PolicyTResultKeySpecs
 
         retry.RaiseResultSequence(ResultPrimitive.Fault, ResultPrimitive.Good);
 
-        policyKeySetOnExecutionContext.Should().Be(policyKey);
+        policyKeySetOnExecutionContext.ShouldBe(policyKey);
     }
 
     [Fact]
@@ -130,7 +130,7 @@ public class PolicyTResultKeySpecs
             return ResultPrimitive.Good;
         }, new Context(operationKey));
 
-        operationKeySetOnContext.Should().Be(operationKey);
+        operationKeySetOnContext.ShouldBe(operationKey);
     }
 
     #endregion

--- a/test/Polly.Specs/PolicyTResultSpecs.cs
+++ b/test/Polly.Specs/PolicyTResultSpecs.cs
@@ -13,8 +13,7 @@ public class PolicyTResultSpecs
 
         var result = policy.Execute(() => ResultPrimitive.Good);
 
-        result.Should()
-            .Be(ResultPrimitive.Good);
+        result.ShouldBe(ResultPrimitive.Good);
     }
 
     #endregion
@@ -29,15 +28,13 @@ public class PolicyTResultSpecs
             .Retry((_, _) => { })
             .ExecuteAndCapture(() => ResultPrimitive.Good);
 
-        result.Should().BeEquivalentTo(new
-        {
-            Outcome = OutcomeType.Successful,
-            FinalException = (Exception?)null,
-            ExceptionType = (ExceptionType?)null,
-            Result = ResultPrimitive.Good,
-            FinalHandledResult = default(ResultPrimitive),
-            FaultType = (FaultType?)null
-        });
+        result.ShouldNotBeNull();
+        result.Outcome.ShouldBe(OutcomeType.Successful);
+        result.FinalException.ShouldBeNull();
+        result.ExceptionType.ShouldBeNull();
+        result.Result.ShouldBe(ResultPrimitive.Good);
+        result.FinalHandledResult.ShouldBe(default);
+        result.FaultType.ShouldBeNull();
     }
 
     [Fact]
@@ -50,15 +47,13 @@ public class PolicyTResultSpecs
             .Retry((_, _) => { })
             .ExecuteAndCapture(() => handledResult);
 
-        result.Should().BeEquivalentTo(new
-        {
-            Outcome = OutcomeType.Failure,
-            FinalException = (Exception?)null,
-            ExceptionType = (ExceptionType?)null,
-            FaultType = FaultType.ResultHandledByThisPolicy,
-            FinalHandledResult = handledResult,
-            Result = default(ResultPrimitive)
-        });
+        result.ShouldNotBeNull();
+        result.Outcome.ShouldBe(OutcomeType.Failure);
+        result.FinalException.ShouldBeNull();
+        result.ExceptionType.ShouldBeNull();
+        result.FaultType.ShouldBe(FaultType.ResultHandledByThisPolicy);
+        result.FinalHandledResult.ShouldBe(handledResult);
+        result.Result.ShouldBe(default);
     }
 
     [Fact]
@@ -72,15 +67,13 @@ public class PolicyTResultSpecs
             .Retry((_, _) => { })
             .ExecuteAndCapture(() => unhandledResult);
 
-        result.Should().BeEquivalentTo(new
-        {
-            Outcome = OutcomeType.Successful,
-            FinalException = (Exception?)null,
-            ExceptionType = (ExceptionType?)null,
-            Result = unhandledResult,
-            FinalHandledResult = default(ResultPrimitive),
-            FaultType = (FaultType?)null
-        });
+        result.ShouldNotBeNull();
+        result.Outcome.ShouldBe(OutcomeType.Successful);
+        result.FinalException.ShouldBeNull();
+        result.ExceptionType.ShouldBeNull();
+        result.Result.ShouldBe(unhandledResult);
+        result.FinalHandledResult.ShouldBe(default);
+        result.FaultType.ShouldBeNull();
     }
 
     #endregion
@@ -94,8 +87,7 @@ public class PolicyTResultSpecs
             .HandleResult(ResultPrimitive.Fault)
             .Retry((_, _, _) => { });
 
-        policy.Invoking(p => p.Execute(_ => ResultPrimitive.Good, (IDictionary<string, object>)null!))
-            .Should().Throw<ArgumentNullException>();
+        Should.Throw<ArgumentNullException>(() => policy.Execute(_ => ResultPrimitive.Good, (IDictionary<string, object>)null!));
     }
 
     [Fact]
@@ -105,9 +97,8 @@ public class PolicyTResultSpecs
             .HandleResult(ResultPrimitive.Fault)
             .Retry((_, _, _) => { });
 
-        policy.Invoking(p => p.Execute(_ => ResultPrimitive.Good, null!))
-            .Should().Throw<ArgumentNullException>().And
-            .ParamName.Should().Be("context");
+        Should.Throw<ArgumentNullException>(() => policy.Execute(_ => ResultPrimitive.Good, null!))
+            .ParamName.ShouldBe("context");
     }
 
     [Fact]
@@ -121,7 +112,8 @@ public class PolicyTResultSpecs
 
         policy.Execute(context => { capturedContext = context; return ResultPrimitive.Good; }, executionContext);
 
-        capturedContext.Should().BeSameAs(executionContext);
+        capturedContext.ShouldNotBeNull();
+        capturedContext.ShouldBeSameAs(executionContext);
     }
 
     [Fact]
@@ -131,8 +123,7 @@ public class PolicyTResultSpecs
             .HandleResult(ResultPrimitive.Fault)
             .Retry((_, _, _) => { });
 
-        policy.Invoking(p => p.ExecuteAndCapture(_ => ResultPrimitive.Good, (IDictionary<string, object>)null!))
-              .Should().Throw<ArgumentNullException>();
+        Should.Throw<ArgumentNullException>(() => policy.ExecuteAndCapture(_ => ResultPrimitive.Good, (IDictionary<string, object>)null!));
     }
 
     [Fact]
@@ -142,9 +133,8 @@ public class PolicyTResultSpecs
             .HandleResult(ResultPrimitive.Fault)
             .Retry((_, _, _) => { });
 
-        policy.Invoking(p => p.ExecuteAndCapture(_ => ResultPrimitive.Good, null!))
-              .Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("context");
+        Should.Throw<ArgumentNullException>(() => policy.ExecuteAndCapture(_ => ResultPrimitive.Good, null!))
+              .ParamName.ShouldBe("context");
     }
 
     [Fact]
@@ -158,7 +148,8 @@ public class PolicyTResultSpecs
 
         policy.ExecuteAndCapture(context => { capturedContext = context; return ResultPrimitive.Good; }, executionContext);
 
-        capturedContext.Should().BeSameAs(executionContext);
+        capturedContext.ShouldNotBeNull();
+        capturedContext.ShouldBeSameAs(executionContext);
     }
 
     [Fact]
@@ -170,7 +161,7 @@ public class PolicyTResultSpecs
         Policy<ResultPrimitive> policy = Policy.NoOp<ResultPrimitive>();
 
         policy.ExecuteAndCapture(_ => ResultPrimitive.Good, executionContext)
-            .Context.Should().BeSameAs(executionContext);
+            .Context.ShouldBeSameAs(executionContext);
     }
 
     #endregion

--- a/test/Polly.Specs/Polly.Specs.csproj
+++ b/test/Polly.Specs/Polly.Specs.csproj
@@ -14,9 +14,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Using Include="FluentAssertions" />
-    <Using Include="FluentAssertions.Execution" />
-    <Using Include="FluentAssertions.Extensions" />
     <Using Include="NSubstitute" />
     <Using Include="Polly.Specs.DictionaryHelpers" Static="true" />
     <Using Include="Polly.Specs.Helpers" />
@@ -33,6 +30,5 @@
   <ItemGroup>
     <ProjectReference Include="..\Polly.TestUtils\Polly.TestUtils.csproj" />
     <ProjectReference Include="..\..\src\Polly\Polly.csproj" />
-    <PackageReference Include="FluentAssertions" />
   </ItemGroup>
 </Project>

--- a/test/Polly.Specs/RateLimit/AsyncRateLimitPolicySpecs.cs
+++ b/test/Polly.Specs/RateLimit/AsyncRateLimitPolicySpecs.cs
@@ -52,9 +52,9 @@ public class AsyncRateLimitPolicySpecs : RateLimitPolicySpecsBase, IDisposable
 
         var func = () => generic.Invoke(instance, [action, new Context(), CancellationToken, false]);
 
-        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("action");
+        var exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>()
+            .ParamName.ShouldBe("action");
     }
 }

--- a/test/Polly.Specs/RateLimit/AsyncRateLimitPolicyTResultSpecs.cs
+++ b/test/Polly.Specs/RateLimit/AsyncRateLimitPolicyTResultSpecs.cs
@@ -68,9 +68,9 @@ public class AsyncRateLimitPolicyTResultSpecs : RateLimitPolicyTResultSpecsBase,
 
         var func = () => methodInfo.Invoke(instance, [action, new Context(), CancellationToken, false]);
 
-        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("action");
+        var exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>()
+            .ParamName.ShouldBe("action");
     }
 }

--- a/test/Polly.Specs/RateLimit/RateLimitPolicySpecs.cs
+++ b/test/Polly.Specs/RateLimit/RateLimitPolicySpecs.cs
@@ -52,9 +52,9 @@ public class RateLimitPolicySpecs : RateLimitPolicySpecsBase, IDisposable
 
         var func = () => generic.Invoke(instance, [action, new Context(), CancellationToken]);
 
-        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("action");
+        var exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>()
+            .ParamName.ShouldBe("action");
     }
 }

--- a/test/Polly.Specs/RateLimit/RateLimitPolicySpecsBase.cs
+++ b/test/Polly.Specs/RateLimit/RateLimitPolicySpecsBase.cs
@@ -19,8 +19,8 @@ public abstract class RateLimitPolicySpecsBase : RateLimitSpecsBase
     {
         (bool permitExecution, TimeSpan retryAfter) = TryExecuteThroughPolicy(policy);
 
-        permitExecution.Should().BeTrue();
-        retryAfter.Should().Be(TimeSpan.Zero);
+        permitExecution.ShouldBeTrue();
+        retryAfter.ShouldBe(TimeSpan.Zero);
     }
 
     protected void ShouldPermitNExecutions(IRateLimitPolicy policy, long numberOfExecutions)
@@ -35,14 +35,14 @@ public abstract class RateLimitPolicySpecsBase : RateLimitSpecsBase
     {
         (bool PermitExecution, TimeSpan RetryAfter) canExecute = TryExecuteThroughPolicy(policy);
 
-        canExecute.PermitExecution.Should().BeFalse();
+        canExecute.PermitExecution.ShouldBeFalse();
         if (retryAfter == null)
         {
-            canExecute.RetryAfter.Should().BeGreaterThan(TimeSpan.Zero);
+            canExecute.RetryAfter.ShouldBeGreaterThan(TimeSpan.Zero);
         }
         else
         {
-            canExecute.RetryAfter.Should().Be(retryAfter.Value);
+            canExecute.RetryAfter.ShouldBe(retryAfter.Value);
         }
     }
 
@@ -51,7 +51,7 @@ public abstract class RateLimitPolicySpecsBase : RateLimitSpecsBase
     {
         Action invalidSyntax = () => GetPolicyViaSyntax(1, TimeSpan.Zero);
 
-        invalidSyntax.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("perTimeSpan");
+        Should.Throw<ArgumentOutOfRangeException>(invalidSyntax).ParamName.ShouldBe("perTimeSpan");
     }
 
     [Fact]
@@ -59,7 +59,7 @@ public abstract class RateLimitPolicySpecsBase : RateLimitSpecsBase
     {
         Action invalidSyntax = () => GetPolicyViaSyntax(1, System.Threading.Timeout.InfiniteTimeSpan);
 
-        invalidSyntax.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("perTimeSpan");
+        Should.Throw<ArgumentOutOfRangeException>(invalidSyntax).ParamName.ShouldBe("perTimeSpan");
     }
 
     [Fact]
@@ -67,8 +67,8 @@ public abstract class RateLimitPolicySpecsBase : RateLimitSpecsBase
     {
         Action invalidSyntax = () => GetPolicyViaSyntax(int.MaxValue, TimeSpan.FromSeconds(1));
 
-        invalidSyntax.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("perTimeSpan");
-        invalidSyntax.Should().Throw<ArgumentOutOfRangeException>().And.Message.Should().StartWith("The number of executions per timespan must be positive.");
+        Should.Throw<ArgumentOutOfRangeException>(invalidSyntax).ParamName.ShouldBe("perTimeSpan");
+        Should.Throw<ArgumentOutOfRangeException>(invalidSyntax).Message.ShouldStartWith("The number of executions per timespan must be positive.");
     }
 
     [Fact]
@@ -76,7 +76,7 @@ public abstract class RateLimitPolicySpecsBase : RateLimitSpecsBase
     {
         Action invalidSyntax = () => GetPolicyViaSyntax(-1, TimeSpan.FromSeconds(1));
 
-        invalidSyntax.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("numberOfExecutions");
+        Should.Throw<ArgumentOutOfRangeException>(invalidSyntax).ParamName.ShouldBe("numberOfExecutions");
     }
 
     [Fact]
@@ -84,7 +84,7 @@ public abstract class RateLimitPolicySpecsBase : RateLimitSpecsBase
     {
         Action invalidSyntax = () => GetPolicyViaSyntax(0, TimeSpan.FromSeconds(1));
 
-        invalidSyntax.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("numberOfExecutions");
+        Should.Throw<ArgumentOutOfRangeException>(invalidSyntax).ParamName.ShouldBe("numberOfExecutions");
     }
 
     [Fact]
@@ -92,7 +92,7 @@ public abstract class RateLimitPolicySpecsBase : RateLimitSpecsBase
     {
         Action invalidSyntax = () => GetPolicyViaSyntax(1, TimeSpan.FromTicks(-1));
 
-        invalidSyntax.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("perTimeSpan");
+        Should.Throw<ArgumentOutOfRangeException>(invalidSyntax).ParamName.ShouldBe("perTimeSpan");
     }
 
     [Fact]
@@ -100,7 +100,7 @@ public abstract class RateLimitPolicySpecsBase : RateLimitSpecsBase
     {
         Action invalidSyntax = () => GetPolicyViaSyntax(1, TimeSpan.FromSeconds(1), -1);
 
-        invalidSyntax.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("maxBurst");
+        Should.Throw<ArgumentOutOfRangeException>(invalidSyntax).ParamName.ShouldBe("maxBurst");
     }
 
     [Fact]
@@ -108,7 +108,7 @@ public abstract class RateLimitPolicySpecsBase : RateLimitSpecsBase
     {
         Action invalidSyntax = () => GetPolicyViaSyntax(1, TimeSpan.FromSeconds(1), 0);
 
-        invalidSyntax.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("maxBurst");
+        Should.Throw<ArgumentOutOfRangeException>(invalidSyntax).ParamName.ShouldBe("maxBurst");
     }
 
     [Theory]
@@ -223,7 +223,7 @@ public abstract class RateLimitPolicySpecsBase : RateLimitSpecsBase
     [InlineData(100)]
     public void Given_any_bucket_capacity_rate_limiter_permits_half_full_bucket_burst_after_half_required_refill_time_elapsed(int bucketCapacity)
     {
-        (bucketCapacity % 2).Should().Be(0);
+        (bucketCapacity % 2).ShouldBe(0);
 
         FixClock();
 
@@ -249,7 +249,7 @@ public abstract class RateLimitPolicySpecsBase : RateLimitSpecsBase
     [InlineData(100, 5)]
     public void Given_any_bucket_capacity_rate_limiter_permits_only_full_bucket_burst_even_if_multiple_required_refill_time_elapsed(int bucketCapacity, int multipleRefillTimePassed)
     {
-        multipleRefillTimePassed.Should().BeGreaterThan(1);
+        multipleRefillTimePassed.ShouldBeGreaterThan(1);
 
         FixClock();
 
@@ -302,7 +302,7 @@ public abstract class RateLimitPolicySpecsBase : RateLimitSpecsBase
 
         // Assert - one should have permitted execution, n-1 not.
         var results = tasks.Select(t => t.Result).ToList();
-        results.Count(r => r.PermitExecution).Should().Be(1);
-        results.Count(r => !r.PermitExecution).Should().Be(parallelContention - 1);
+        results.Count(r => r.PermitExecution).ShouldBe(1);
+        results.Count(r => !r.PermitExecution).ShouldBe(parallelContention - 1);
     }
 }

--- a/test/Polly.Specs/RateLimit/RateLimitPolicyTResultSpecs.cs
+++ b/test/Polly.Specs/RateLimit/RateLimitPolicyTResultSpecs.cs
@@ -68,9 +68,9 @@ public class RateLimitPolicyTResultSpecs : RateLimitPolicyTResultSpecsBase, IDis
 
         var func = () => methodInfo.Invoke(instance, [action, new Context(), CancellationToken.None]);
 
-        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("action");
+        var exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>()
+            .ParamName.ShouldBe("action");
     }
 }

--- a/test/Polly.Specs/RateLimit/RateLimitPolicyTResultSpecsBase.cs
+++ b/test/Polly.Specs/RateLimit/RateLimitPolicyTResultSpecsBase.cs
@@ -39,13 +39,13 @@ public abstract class RateLimitPolicyTResultSpecsBase : RateLimitPolicySpecsBase
         var resultExpectedBlocked = TryExecuteThroughPolicy(rateLimiter, contextToPassIn, new ResultClassWithRetryAfter(ResultPrimitive.Good));
 
         // Assert - should be blocked - time not advanced.
-        resultExpectedBlocked.ResultCode.Should().NotBe(ResultPrimitive.Good);
+        resultExpectedBlocked.ResultCode.ShouldNotBe(ResultPrimitive.Good);
 
         // Result should be expressed per the retryAfterFactory.
-        resultExpectedBlocked.RetryAfter.Should().Be(onePer);
+        resultExpectedBlocked.RetryAfter.ShouldBe(onePer);
 
         // Context should have been passed to the retryAfterFactory.
-        contextPassedToRetryAfter.Should().NotBeNull();
-        contextPassedToRetryAfter.Should().BeSameAs(contextToPassIn);
+        contextPassedToRetryAfter.ShouldNotBeNull();
+        contextPassedToRetryAfter.ShouldBeSameAs(contextToPassIn);
     }
 }

--- a/test/Polly.Specs/RateLimit/RateLimitRejectedExceptionTests.cs
+++ b/test/Polly.Specs/RateLimit/RateLimitRejectedExceptionTests.cs
@@ -9,27 +9,27 @@ public class RateLimitRejectedExceptionTests
         var exception = new InvalidOperationException();
         var retryAfter = TimeSpan.FromSeconds(4);
 
-        new RateLimitRejectedException().Message.Should().Be("The operation could not be executed because it was rejected by the rate limit.");
-        new RateLimitRejectedException(Dummy).Message.Should().Be(Dummy);
+        new RateLimitRejectedException().Message.ShouldBe("The operation could not be executed because it was rejected by the rate limit.");
+        new RateLimitRejectedException(Dummy).Message.ShouldBe(Dummy);
 
         var rate = new RateLimitRejectedException(Dummy, exception);
-        rate.Message.Should().Be(Dummy);
-        rate.InnerException.Should().Be(exception);
+        rate.Message.ShouldBe(Dummy);
+        rate.InnerException.ShouldBe(exception);
 
-        new RateLimitRejectedException(retryAfter).RetryAfter.Should().Be(retryAfter);
-        new RateLimitRejectedException(retryAfter).Message.Should().Be($"The operation has been rate-limited and should be retried after {retryAfter}");
+        new RateLimitRejectedException(retryAfter).RetryAfter.ShouldBe(retryAfter);
+        new RateLimitRejectedException(retryAfter).Message.ShouldBe($"The operation has been rate-limited and should be retried after {retryAfter}");
 
         rate = new RateLimitRejectedException(retryAfter, exception);
-        rate.RetryAfter.Should().Be(retryAfter);
-        rate.InnerException.Should().Be(exception);
+        rate.RetryAfter.ShouldBe(retryAfter);
+        rate.InnerException.ShouldBe(exception);
 
         rate = new RateLimitRejectedException(retryAfter, Dummy);
-        rate.RetryAfter.Should().Be(retryAfter);
-        rate.Message.Should().Be(Dummy);
+        rate.RetryAfter.ShouldBe(retryAfter);
+        rate.Message.ShouldBe(Dummy);
 
         rate = new RateLimitRejectedException(retryAfter, Dummy, exception);
-        rate.RetryAfter.Should().Be(retryAfter);
-        rate.Message.Should().Be(Dummy);
-        rate.InnerException.Should().Be(exception);
+        rate.RetryAfter.ShouldBe(retryAfter);
+        rate.Message.ShouldBe(Dummy);
+        rate.InnerException.ShouldBe(exception);
     }
 }

--- a/test/Polly.Specs/RateLimit/RateLimitSpecsBase.cs
+++ b/test/Polly.Specs/RateLimit/RateLimitSpecsBase.cs
@@ -23,7 +23,7 @@ public abstract class RateLimitSpecsBase
             }
             catch (Exception e)
             {
-                if (e is not AssertionFailedException and not IAssertionException)
+                if (e is not IAssertionException)
                 {
                     throw;
                 }

--- a/test/Polly.Specs/RateLimit/TokenBucketRateLimiterTestsBase.cs
+++ b/test/Polly.Specs/RateLimit/TokenBucketRateLimiterTestsBase.cs
@@ -120,7 +120,7 @@ public abstract class TokenBucketRateLimiterTestsBase : RateLimitSpecsBase, IDis
     [InlineData(100)]
     public void Given_any_bucket_capacity_rate_limiter_permits_half_full_bucket_burst_after_half_required_refill_time_elapsed(int bucketCapacity)
     {
-        (bucketCapacity % 2).Should().Be(0);
+        (bucketCapacity % 2).ShouldBe(0);
 
         FixClock();
 
@@ -146,7 +146,7 @@ public abstract class TokenBucketRateLimiterTestsBase : RateLimitSpecsBase, IDis
     [InlineData(100, 5)]
     public void Given_any_bucket_capacity_rate_limiter_permits_only_full_bucket_burst_even_if_multiple_required_refill_time_elapsed(int bucketCapacity, int multipleRefillTimePassed)
     {
-        multipleRefillTimePassed.Should().BeGreaterThan(1);
+        multipleRefillTimePassed.ShouldBeGreaterThan(1);
 
         FixClock();
 
@@ -200,7 +200,7 @@ public abstract class TokenBucketRateLimiterTestsBase : RateLimitSpecsBase, IDis
 
         // Assert - one should have permitted execution, n-1 not.
         var results = tasks.Select(t => t.Result).ToList();
-        results.Count(r => r.PermitExecution).Should().Be(1);
-        results.Count(r => !r.PermitExecution).Should().Be(parallelContention - 1);
+        results.Count(r => r.PermitExecution).ShouldBe(1);
+        results.Count(r => !r.PermitExecution).ShouldBe(parallelContention - 1);
     }
 }

--- a/test/Polly.Specs/Registry/ConcurrentPolicyRegistrySpecs.cs
+++ b/test/Polly.Specs/Registry/ConcurrentPolicyRegistrySpecs.cs
@@ -14,15 +14,15 @@ public class ConcurrentPolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         var insert = _registry.TryAdd(key, policy);
-        _registry.Count.Should().Be(1);
-        insert.Should().Be(true);
+        _registry.Count.ShouldBe(1);
+        insert.ShouldBe(true);
 
         Policy policy2 = Policy.NoOp();
         string key2 = Guid.NewGuid().ToString();
 
         var insert2 = _registry.TryAdd(key2, policy2);
-        _registry.Count.Should().Be(2);
-        insert2.Should().Be(true);
+        _registry.Count.ShouldBe(2);
+        insert2.ShouldBe(true);
     }
 
     [Fact]
@@ -32,15 +32,15 @@ public class ConcurrentPolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         var insert = _registry.TryAdd(key, policy);
-        _registry.Count.Should().Be(1);
-        insert.Should().Be(true);
+        _registry.Count.ShouldBe(1);
+        insert.ShouldBe(true);
 
         Policy<ResultPrimitive> policy2 = Policy<ResultPrimitive>.HandleResult(ResultPrimitive.Fault).Retry();
         string key2 = Guid.NewGuid().ToString();
 
         var insert2 = _registry.TryAdd(key2, policy2);
-        _registry.Count.Should().Be(2);
-        insert2.Should().Be(true);
+        _registry.Count.ShouldBe(2);
+        insert2.ShouldBe(true);
     }
 
     [Fact]
@@ -50,15 +50,15 @@ public class ConcurrentPolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         var insert = _registry.TryAdd(key, policy);
-        _registry.Count.Should().Be(1);
-        insert.Should().Be(true);
+        _registry.Count.ShouldBe(1);
+        insert.ShouldBe(true);
 
         ISyncPolicy<ResultPrimitive> policy2 = Policy<ResultPrimitive>.HandleResult(ResultPrimitive.Fault).Retry();
         string key2 = Guid.NewGuid().ToString();
 
         var insert2 = _registry.TryAdd(key2, policy2);
-        _registry.Count.Should().Be(2);
-        insert2.Should().Be(true);
+        _registry.Count.ShouldBe(2);
+        insert2.ShouldBe(true);
     }
 
     [Fact]
@@ -68,12 +68,12 @@ public class ConcurrentPolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         _registry.Add(key, policy);
-        _registry.Count.Should().Be(1);
+        _registry.Count.ShouldBe(1);
 
         bool removed = _registry.TryRemove(key, out IsPolicy removedPolicy);
-        _registry.Count.Should().Be(0);
-        removedPolicy.Should().BeSameAs(policy);
-        removed.Should().BeTrue();
+        _registry.Count.ShouldBe(0);
+        removedPolicy.ShouldBeSameAs(policy);
+        removed.ShouldBeTrue();
     }
 
     [Fact]
@@ -82,7 +82,7 @@ public class ConcurrentPolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         bool removed = _registry.TryRemove(key, out IsPolicy removedPolicy);
-        removed.Should().BeFalse();
+        removed.ShouldBeFalse();
     }
 
     [Fact]
@@ -96,8 +96,8 @@ public class ConcurrentPolicyRegistrySpecs
 
         bool updated = _registry.TryUpdate<IsPolicy>(key, newPolicy, existingPolicy);
 
-        updated.Should().BeTrue();
-        _registry[key].Should().BeSameAs(newPolicy);
+        updated.ShouldBeTrue();
+        _registry[key].ShouldBeSameAs(newPolicy);
     }
 
     [Fact]
@@ -112,8 +112,8 @@ public class ConcurrentPolicyRegistrySpecs
 
         bool updated = _registry.TryUpdate<IsPolicy>(key, newPolicy, someOtherPolicy);
 
-        updated.Should().BeFalse();
-        _registry[key].Should().BeSameAs(existingPolicy);
+        updated.ShouldBeFalse();
+        _registry[key].ShouldBeSameAs(existingPolicy);
     }
 
     [Fact]
@@ -126,8 +126,8 @@ public class ConcurrentPolicyRegistrySpecs
 
         bool updated = _registry.TryUpdate<IsPolicy>(key, newPolicy, someOtherPolicy);
 
-        updated.Should().BeFalse();
-        _registry.ContainsKey(key).Should().BeFalse();
+        updated.ShouldBeFalse();
+        _registry.ContainsKey(key).ShouldBeFalse();
     }
 
     [Fact]
@@ -138,7 +138,7 @@ public class ConcurrentPolicyRegistrySpecs
 
         var returnedPolicy = _registry.GetOrAdd(key, newPolicy);
 
-        returnedPolicy.Should().BeSameAs(newPolicy);
+        returnedPolicy.ShouldBeSameAs(newPolicy);
     }
 
     [Fact]
@@ -149,7 +149,7 @@ public class ConcurrentPolicyRegistrySpecs
 
         var returnedPolicy = _registry.GetOrAdd(key, _ => newPolicy);
 
-        returnedPolicy.Should().BeSameAs(newPolicy);
+        returnedPolicy.ShouldBeSameAs(newPolicy);
     }
 
     [Fact]
@@ -163,7 +163,7 @@ public class ConcurrentPolicyRegistrySpecs
 
         var returnedPolicy = _registry.GetOrAdd(key, newPolicy);
 
-        returnedPolicy.Should().BeSameAs(existingPolicy);
+        returnedPolicy.ShouldBeSameAs(existingPolicy);
     }
 
     [Fact]
@@ -177,7 +177,7 @@ public class ConcurrentPolicyRegistrySpecs
 
         var returnedPolicy = _registry.GetOrAdd(key, _ => newPolicy);
 
-        returnedPolicy.Should().BeSameAs(existingPolicy);
+        returnedPolicy.ShouldBeSameAs(existingPolicy);
     }
 
     [Fact]
@@ -191,7 +191,7 @@ public class ConcurrentPolicyRegistrySpecs
             newPolicy,
             (_, _) => throw new InvalidOperationException("Update factory should not be called in this test."));
 
-        returnedPolicy.Should().BeSameAs(newPolicy);
+        returnedPolicy.ShouldBeSameAs(newPolicy);
     }
 
     [Fact]
@@ -205,7 +205,7 @@ public class ConcurrentPolicyRegistrySpecs
             _ => newPolicy,
             (_, _) => throw new InvalidOperationException("Update factory should not be called in this test."));
 
-        returnedPolicy.Should().BeSameAs(newPolicy);
+        returnedPolicy.ShouldBeSameAs(newPolicy);
     }
 
     [Fact]
@@ -224,9 +224,9 @@ public class ConcurrentPolicyRegistrySpecs
             otherPolicyNotExpectingToAdd,
             (_, _) => existingPolicy.WithPolicyKey(PolicyKeyToDecorate));
 
-        returnedPolicy.Should().NotBeSameAs(otherPolicyNotExpectingToAdd);
-        returnedPolicy.Should().BeSameAs(existingPolicy);
-        returnedPolicy.PolicyKey.Should().Be(PolicyKeyToDecorate);
+        returnedPolicy.ShouldNotBeSameAs(otherPolicyNotExpectingToAdd);
+        returnedPolicy.ShouldBeSameAs(existingPolicy);
+        returnedPolicy.PolicyKey.ShouldBe(PolicyKeyToDecorate);
     }
 
     [Fact]
@@ -245,8 +245,8 @@ public class ConcurrentPolicyRegistrySpecs
             _ => otherPolicyNotExpectingToAdd,
             (_, _) => existingPolicy.WithPolicyKey(PolicyKeyToDecorate));
 
-        returnedPolicy.Should().NotBeSameAs(otherPolicyNotExpectingToAdd);
-        returnedPolicy.Should().BeSameAs(existingPolicy);
-        returnedPolicy.PolicyKey.Should().Be(PolicyKeyToDecorate);
+        returnedPolicy.ShouldNotBeSameAs(otherPolicyNotExpectingToAdd);
+        returnedPolicy.ShouldBeSameAs(existingPolicy);
+        returnedPolicy.PolicyKey.ShouldBe(PolicyKeyToDecorate);
     }
 }

--- a/test/Polly.Specs/Registry/PolicyRegistrySpecs.cs
+++ b/test/Polly.Specs/Registry/PolicyRegistrySpecs.cs
@@ -2,10 +2,7 @@
 
 public class PolicyRegistrySpecs
 {
-    private readonly IPolicyRegistry<string> _registry;
-
-    public PolicyRegistrySpecs() =>
-        _registry = new PolicyRegistry();
+    private readonly PolicyRegistry _registry = [];
 
     #region Tests for adding Policy
 
@@ -16,13 +13,13 @@ public class PolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         _registry.Add(key, policy);
-        _registry.Count.Should().Be(1);
+        _registry.Count.ShouldBe(1);
 
         Policy policy2 = Policy.NoOp();
         string key2 = Guid.NewGuid().ToString();
 
         _registry.Add(key2, policy2);
-        _registry.Count.Should().Be(2);
+        _registry.Count.ShouldBe(2);
     }
 
     [Fact]
@@ -32,13 +29,13 @@ public class PolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         _registry.Add(key, policy);
-        _registry.Count.Should().Be(1);
+        _registry.Count.ShouldBe(1);
 
         Policy<ResultPrimitive> policy2 = Policy<ResultPrimitive>.HandleResult(ResultPrimitive.Fault).Retry();
         string key2 = Guid.NewGuid().ToString();
 
         _registry.Add(key2, policy2);
-        _registry.Count.Should().Be(2);
+        _registry.Count.ShouldBe(2);
     }
 
     [Fact]
@@ -48,13 +45,13 @@ public class PolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         _registry.Add(key, policy);
-        _registry.Count.Should().Be(1);
+        _registry.Count.ShouldBe(1);
 
         ISyncPolicy<ResultPrimitive> policy2 = Policy<ResultPrimitive>.HandleResult(ResultPrimitive.Fault).Retry();
         string key2 = Guid.NewGuid().ToString();
 
         _registry.Add<ISyncPolicy<ResultPrimitive>>(key2, policy2);
-        _registry.Count.Should().Be(2);
+        _registry.Count.ShouldBe(2);
     }
 
     [Fact]
@@ -64,13 +61,13 @@ public class PolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         _registry[key] = policy;
-        _registry.Count.Should().Be(1);
+        _registry.Count.ShouldBe(1);
 
         Policy policy2 = Policy.NoOp();
         string key2 = Guid.NewGuid().ToString();
 
         _registry[key2] = policy2;
-        _registry.Count.Should().Be(2);
+        _registry.Count.ShouldBe(2);
     }
 
     [Fact]
@@ -80,13 +77,13 @@ public class PolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         _registry[key] = policy;
-        _registry.Count.Should().Be(1);
+        _registry.Count.ShouldBe(1);
 
         Policy<ResultPrimitive> policy2 = Policy<ResultPrimitive>.HandleResult(ResultPrimitive.Fault).Retry();
         string key2 = Guid.NewGuid().ToString();
 
         _registry[key2] = policy2;
-        _registry.Count.Should().Be(2);
+        _registry.Count.ShouldBe(2);
     }
 
     [Fact]
@@ -95,13 +92,11 @@ public class PolicyRegistrySpecs
         Policy policy = Policy.NoOp();
         string key = Guid.NewGuid().ToString();
 
-        _registry.Invoking(r => r.Add(key, policy))
-            .Should().NotThrow();
+        Should.NotThrow(() => _registry.Add(key, policy));
 
-        _registry.Invoking(r => r.Add(key, policy))
-            .Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => _registry.Add(key, policy));
 
-        _registry.Count.Should().Be(1);
+        _registry.Count.ShouldBe(1);
     }
 
     [Fact]
@@ -114,9 +109,9 @@ public class PolicyRegistrySpecs
         Policy policy_new = Policy.NoOp();
         _registry[key] = policy_new;
 
-        _registry.Count.Should().Be(1);
+        _registry.Count.ShouldBe(1);
 
-        _registry.Get<Policy>(key).Should().BeSameAs(policy_new);
+        _registry.Get<Policy>(key).ShouldBeSameAs(policy_new);
     }
 
     [Fact]
@@ -129,9 +124,9 @@ public class PolicyRegistrySpecs
         Policy<ResultPrimitive> policy_new = Policy<ResultPrimitive>.HandleResult(ResultPrimitive.Fault).Retry();
         _registry[key] = policy_new;
 
-        _registry.Count.Should().Be(1);
+        _registry.Count.ShouldBe(1);
 
-        _registry.Get<Policy<ResultPrimitive>>(key).Should().BeSameAs(policy_new);
+        _registry.Get<Policy<ResultPrimitive>>(key).ShouldBeSameAs(policy_new);
     }
 
     [Fact]
@@ -139,8 +134,7 @@ public class PolicyRegistrySpecs
     {
         string key = null!;
         Policy policy = Policy.NoOp();
-        _registry.Invoking(r => r.Add(key, policy))
-            .Should().Throw<ArgumentNullException>();
+        Should.Throw<ArgumentNullException>(() => _registry.Add(key, policy));
     }
 
     [Fact]
@@ -148,8 +142,7 @@ public class PolicyRegistrySpecs
     {
         string key = null!;
         Policy policy = Policy.NoOp();
-        _registry.Invoking(r => r[key] = policy)
-            .Should().Throw<ArgumentNullException>();
+        Should.Throw<ArgumentNullException>(() => _registry[key] = policy);
     }
 
     #endregion
@@ -163,8 +156,8 @@ public class PolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         _registry.Add(key, policy);
-        _registry.TryGet(key, out Policy? outPolicy).Should().BeTrue();
-        outPolicy.Should().BeSameAs(policy);
+        _registry.TryGet(key, out Policy? outPolicy).ShouldBeTrue();
+        outPolicy.ShouldBeSameAs(policy);
     }
 
     [Fact]
@@ -174,8 +167,8 @@ public class PolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         _registry.Add(key, policy);
-        _registry.TryGet(key, out Policy<ResultPrimitive> outPolicy).Should().BeTrue();
-        outPolicy.Should().BeSameAs(policy);
+        _registry.TryGet(key, out Policy<ResultPrimitive> outPolicy).ShouldBeTrue();
+        outPolicy.ShouldBeSameAs(policy);
     }
 
     [Fact]
@@ -185,8 +178,8 @@ public class PolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         _registry.Add(key, policy);
-        _registry.TryGet(key, out ISyncPolicy<ResultPrimitive> outPolicy).Should().BeTrue();
-        outPolicy.Should().BeSameAs(policy);
+        _registry.TryGet(key, out ISyncPolicy<ResultPrimitive> outPolicy).ShouldBeTrue();
+        outPolicy.ShouldBeSameAs(policy);
     }
 
     [Fact]
@@ -196,7 +189,7 @@ public class PolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         _registry.Add(key, policy);
-        _registry.Get<Policy>(key).Should().BeSameAs(policy);
+        _registry.Get<Policy>(key).ShouldBeSameAs(policy);
     }
 
     [Fact]
@@ -206,7 +199,7 @@ public class PolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         _registry.Add(key, policy);
-        _registry.Get<Policy<ResultPrimitive>>(key).Should().BeSameAs(policy);
+        _registry.Get<Policy<ResultPrimitive>>(key).ShouldBeSameAs(policy);
     }
 
     [Fact]
@@ -216,7 +209,7 @@ public class PolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         _registry.Add(key, policy);
-        _registry.Get<ISyncPolicy<ResultPrimitive>>(key).Should().BeSameAs(policy);
+        _registry.Get<ISyncPolicy<ResultPrimitive>>(key).ShouldBeSameAs(policy);
     }
 
     [Fact]
@@ -226,7 +219,7 @@ public class PolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         _registry.Add(key, policy);
-        _registry[key].Should().BeSameAs(policy);
+        _registry[key].ShouldBeSameAs(policy);
     }
 
     [Fact]
@@ -236,7 +229,7 @@ public class PolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         _registry.Add(key, policy);
-        _registry[key].Should().BeSameAs(policy);
+        _registry[key].ShouldBeSameAs(policy);
     }
 
     [Fact]
@@ -246,7 +239,7 @@ public class PolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         _registry.Add(key, policy);
-        _registry[key].Should().BeSameAs(policy);
+        _registry[key].ShouldBeSameAs(policy);
     }
 
     [Fact]
@@ -256,11 +249,10 @@ public class PolicyRegistrySpecs
         Policy? policy = null;
         bool result = false;
 
-        _registry.Invoking(r => result = r.TryGet(key, out policy))
-            .Should().NotThrow();
+        Should.NotThrow(() => result = _registry.TryGet(key, out policy));
 
-        result.Should().BeFalse();
-        policy.Should().BeNull();
+        result.ShouldBeFalse();
+        policy.ShouldBeNull();
     }
 
     [Fact]
@@ -270,11 +262,10 @@ public class PolicyRegistrySpecs
         Policy<ResultPrimitive>? policy = null;
         bool result = false;
 
-        _registry.Invoking(r => result = r.TryGet(key, out policy))
-            .Should().NotThrow();
+        Should.NotThrow(() => result = _registry.TryGet(key, out policy));
 
-        result.Should().BeFalse();
-        policy.Should().BeNull();
+        result.ShouldBeFalse();
+        policy.ShouldBeNull();
     }
 
     [Fact]
@@ -284,11 +275,10 @@ public class PolicyRegistrySpecs
         ISyncPolicy<ResultPrimitive>? policy = null;
         bool result = false;
 
-        _registry.Invoking(r => result = r.TryGet<ISyncPolicy<ResultPrimitive>>(key, out policy))
-            .Should().NotThrow();
+        Should.NotThrow(() => result = _registry.TryGet<ISyncPolicy<ResultPrimitive>>(key, out policy));
 
-        result.Should().BeFalse();
-        policy.Should().BeNull();
+        result.ShouldBeFalse();
+        policy.ShouldBeNull();
     }
 
     [Fact]
@@ -296,9 +286,8 @@ public class PolicyRegistrySpecs
     {
         string key = Guid.NewGuid().ToString();
         Policy? policy = null;
-        _registry.Invoking(r => policy = r.Get<Policy>(key))
-            .Should().Throw<KeyNotFoundException>();
-        policy.Should().BeNull();
+        Should.Throw<KeyNotFoundException>(() => policy = _registry.Get<Policy>(key));
+        policy.ShouldBeNull();
     }
 
     [Fact]
@@ -306,9 +295,8 @@ public class PolicyRegistrySpecs
     {
         string key = Guid.NewGuid().ToString();
         Policy<ResultPrimitive>? policy = null;
-        _registry.Invoking(r => policy = r.Get<Policy<ResultPrimitive>>(key))
-            .Should().Throw<KeyNotFoundException>();
-        policy.Should().BeNull();
+        Should.Throw<KeyNotFoundException>(() => policy = _registry.Get<Policy<ResultPrimitive>>(key));
+        policy.ShouldBeNull();
     }
 
     [Fact]
@@ -316,9 +304,8 @@ public class PolicyRegistrySpecs
     {
         string key = Guid.NewGuid().ToString();
         ISyncPolicy<ResultPrimitive>? policy = null;
-        _registry.Invoking(r => policy = r.Get<ISyncPolicy<ResultPrimitive>>(key))
-            .Should().Throw<KeyNotFoundException>();
-        policy.Should().BeNull();
+        Should.Throw<KeyNotFoundException>(() => policy = _registry.Get<ISyncPolicy<ResultPrimitive>>(key));
+        policy.ShouldBeNull();
     }
 
     [Fact]
@@ -326,9 +313,8 @@ public class PolicyRegistrySpecs
     {
         string key = Guid.NewGuid().ToString();
         IsPolicy? policy = null;
-        _registry.Invoking(r => policy = r[key])
-            .Should().Throw<KeyNotFoundException>();
-        policy.Should().BeNull();
+        Should.Throw<KeyNotFoundException>(() => policy = _registry[key]);
+        policy.ShouldBeNull();
     }
 
     [Fact]
@@ -336,9 +322,8 @@ public class PolicyRegistrySpecs
     {
         string key = null!;
         Policy? policy = null;
-        _registry.Invoking(r => policy = r.Get<Policy>(key))
-            .Should().Throw<ArgumentNullException>();
-        policy.Should().BeNull();
+        Should.Throw<ArgumentNullException>(() => policy = _registry.Get<Policy>(key));
+        policy.ShouldBeNull();
     }
 
     [Fact]
@@ -346,9 +331,8 @@ public class PolicyRegistrySpecs
     {
         string key = null!;
         Policy<ResultPrimitive>? policy = null;
-        _registry.Invoking(r => policy = r.Get<Policy<ResultPrimitive>>(key))
-            .Should().Throw<ArgumentNullException>();
-        policy.Should().BeNull();
+        Should.Throw<ArgumentNullException>(() => policy = _registry.Get<Policy<ResultPrimitive>>(key));
+        policy.ShouldBeNull();
     }
 
     [Fact]
@@ -356,9 +340,8 @@ public class PolicyRegistrySpecs
     {
         string key = null!;
         ISyncPolicy<ResultPrimitive>? policy = null;
-        _registry.Invoking(r => policy = r.Get<ISyncPolicy<ResultPrimitive>>(key))
-            .Should().Throw<ArgumentNullException>();
-        policy.Should().BeNull();
+        Should.Throw<ArgumentNullException>(() => policy = _registry.Get<ISyncPolicy<ResultPrimitive>>(key));
+        policy.ShouldBeNull();
     }
 
     [Fact]
@@ -366,9 +349,8 @@ public class PolicyRegistrySpecs
     {
         string key = null!;
         IsPolicy? policy = null;
-        _registry.Invoking(r => policy = r[key])
-            .Should().Throw<ArgumentNullException>();
-        policy.Should().BeNull();
+        Should.Throw<ArgumentNullException>(() => policy = _registry[key]);
+        policy.ShouldBeNull();
     }
     #endregion
 
@@ -380,16 +362,16 @@ public class PolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         _registry.Add(key, policy);
-        _registry.Count.Should().Be(1);
+        _registry.Count.ShouldBe(1);
 
         Policy policy2 = Policy.NoOp();
         string key2 = Guid.NewGuid().ToString();
 
         _registry.Add(key2, policy2);
-        _registry.Count.Should().Be(2);
+        _registry.Count.ShouldBe(2);
 
         _registry.Clear();
-        _registry.Count.Should().Be(0);
+        _registry.Count.ShouldBe(0);
     }
 
     [Fact]
@@ -399,18 +381,17 @@ public class PolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         _registry.Add(key, policy);
-        _registry.Count.Should().Be(1);
+        _registry.Count.ShouldBe(1);
 
         _registry.Remove(key);
-        _registry.Count.Should().Be(0);
+        _registry.Count.ShouldBe(0);
     }
 
     [Fact]
     public void Should_throw_when_removing_Policy_when_key_is_null()
     {
         string key = null!;
-        _registry.Invoking(r => r.Remove(key))
-            .Should().Throw<ArgumentNullException>();
+        Should.Throw<ArgumentNullException>(() => _registry.Remove(key));
     }
     #endregion
 
@@ -423,18 +404,17 @@ public class PolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         _registry.Add(key, policy);
-        _registry.ContainsKey(key).Should().BeTrue();
+        _registry.ContainsKey(key).ShouldBeTrue();
 
         string key2 = Guid.NewGuid().ToString();
-        _registry.ContainsKey(key2).Should().BeFalse();
+        _registry.ContainsKey(key2).ShouldBeFalse();
     }
 
     [Fact]
     public void Should_throw_when_checking_if_key_exists_when_key_is_null()
     {
         string key = null!;
-        _registry.Invoking(r => r.ContainsKey(key))
-            .Should().Throw<ArgumentNullException>();
+        Should.Throw<ArgumentNullException>(() => _registry.ContainsKey(key));
     }
     #endregion
 
@@ -448,7 +428,7 @@ public class PolicyRegistrySpecs
         // Generally, using reflection is a bad practice, but we are accepting it given we own the implementation.
         var registryField = typeof(PolicyRegistry).GetField("_registry", BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance)!;
         var registryFieldValue = registryField.GetValue(testRegistry);
-        registryFieldValue.Should().Be(testDictionary);
+        registryFieldValue.ShouldBe(testDictionary);
     }
 
     [Fact]
@@ -460,7 +440,7 @@ public class PolicyRegistrySpecs
         // Generally, using reflection is a bad practice, but we are accepting it given we own the implementation.
         var registryField = typeof(PolicyRegistry).GetField("_registry", BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance)!;
         var registryFieldValue = registryField.GetValue(testRegistry);
-        registryFieldValue.Should().BeOfType(expectedDictionaryType);
+        registryFieldValue.ShouldBeOfType(expectedDictionaryType);
     }
 
     #endregion

--- a/test/Polly.Specs/Registry/ReadOnlyPolicyRegistrySpecs.cs
+++ b/test/Polly.Specs/Registry/ReadOnlyPolicyRegistrySpecs.cs
@@ -18,8 +18,8 @@ public class ReadOnlyPolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         _registry.Add(key, policy);
-        ReadOnlyRegistry.TryGet(key, out Policy? outPolicy).Should().BeTrue();
-        outPolicy.Should().BeSameAs(policy);
+        ReadOnlyRegistry.TryGet(key, out Policy? outPolicy).ShouldBeTrue();
+        outPolicy.ShouldBeSameAs(policy);
     }
 
     [Fact]
@@ -29,8 +29,8 @@ public class ReadOnlyPolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         _registry.Add(key, policy);
-        ReadOnlyRegistry.TryGet(key, out Policy<ResultPrimitive>? outPolicy).Should().BeTrue();
-        outPolicy.Should().BeSameAs(policy);
+        ReadOnlyRegistry.TryGet(key, out Policy<ResultPrimitive>? outPolicy).ShouldBeTrue();
+        outPolicy.ShouldBeSameAs(policy);
     }
 
     [Fact]
@@ -40,8 +40,8 @@ public class ReadOnlyPolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         _registry.Add(key, policy);
-        ReadOnlyRegistry.TryGet(key, out ISyncPolicy<ResultPrimitive>? outPolicy).Should().BeTrue();
-        outPolicy.Should().BeSameAs(policy);
+        ReadOnlyRegistry.TryGet(key, out ISyncPolicy<ResultPrimitive>? outPolicy).ShouldBeTrue();
+        outPolicy.ShouldBeSameAs(policy);
     }
 
     [Fact]
@@ -51,7 +51,7 @@ public class ReadOnlyPolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         _registry.Add(key, policy);
-        ReadOnlyRegistry.Get<Policy>(key).Should().BeSameAs(policy);
+        ReadOnlyRegistry.Get<Policy>(key).ShouldBeSameAs(policy);
     }
 
     [Fact]
@@ -61,7 +61,7 @@ public class ReadOnlyPolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         _registry.Add(key, policy);
-        ReadOnlyRegistry.Get<Policy<ResultPrimitive>>(key).Should().BeSameAs(policy);
+        ReadOnlyRegistry.Get<Policy<ResultPrimitive>>(key).ShouldBeSameAs(policy);
     }
 
     [Fact]
@@ -71,7 +71,7 @@ public class ReadOnlyPolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         _registry.Add(key, policy);
-        ReadOnlyRegistry.Get<ISyncPolicy<ResultPrimitive>>(key).Should().BeSameAs(policy);
+        ReadOnlyRegistry.Get<ISyncPolicy<ResultPrimitive>>(key).ShouldBeSameAs(policy);
     }
 
     [Fact]
@@ -81,7 +81,7 @@ public class ReadOnlyPolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         _registry.Add(key, policy);
-        ReadOnlyRegistry[key].Should().BeSameAs(policy);
+        ReadOnlyRegistry[key].ShouldBeSameAs(policy);
     }
 
     [Fact]
@@ -91,7 +91,7 @@ public class ReadOnlyPolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         _registry.Add(key, policy);
-        ReadOnlyRegistry[key].Should().BeSameAs(policy);
+        ReadOnlyRegistry[key].ShouldBeSameAs(policy);
     }
 
     [Fact]
@@ -101,7 +101,7 @@ public class ReadOnlyPolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         _registry.Add(key, policy);
-        ReadOnlyRegistry[key].Should().BeSameAs(policy);
+        ReadOnlyRegistry[key].ShouldBeSameAs(policy);
     }
 
     [Fact]
@@ -111,11 +111,10 @@ public class ReadOnlyPolicyRegistrySpecs
         Policy? policy = null;
         bool result = false;
 
-        ReadOnlyRegistry.Invoking(r => result = r.TryGet(key, out policy))
-            .Should().NotThrow();
+        Should.NotThrow(() => result = ReadOnlyRegistry.TryGet(key, out policy));
 
-        result.Should().BeFalse();
-        policy.Should().BeNull();
+        result.ShouldBeFalse();
+        policy.ShouldBeNull();
     }
 
     [Fact]
@@ -125,11 +124,10 @@ public class ReadOnlyPolicyRegistrySpecs
         Policy<ResultPrimitive>? policy = null;
         bool result = false;
 
-        ReadOnlyRegistry.Invoking(r => result = r.TryGet(key, out policy))
-            .Should().NotThrow();
+        Should.NotThrow(() => result = ReadOnlyRegistry.TryGet(key, out policy));
 
-        result.Should().BeFalse();
-        policy.Should().BeNull();
+        result.ShouldBeFalse();
+        policy.ShouldBeNull();
     }
 
     [Fact]
@@ -139,11 +137,10 @@ public class ReadOnlyPolicyRegistrySpecs
         ISyncPolicy<ResultPrimitive>? policy = null;
         bool result = false;
 
-        ReadOnlyRegistry.Invoking(r => result = r.TryGet<ISyncPolicy<ResultPrimitive>>(key, out policy))
-            .Should().NotThrow();
+        Should.NotThrow(() => result = ReadOnlyRegistry.TryGet<ISyncPolicy<ResultPrimitive>>(key, out policy));
 
-        result.Should().BeFalse();
-        policy.Should().BeNull();
+        result.ShouldBeFalse();
+        policy.ShouldBeNull();
     }
 
     [Fact]
@@ -151,9 +148,8 @@ public class ReadOnlyPolicyRegistrySpecs
     {
         string key = Guid.NewGuid().ToString();
         Policy? policy = null;
-        ReadOnlyRegistry.Invoking(r => policy = r.Get<Policy>(key))
-            .Should().Throw<KeyNotFoundException>();
-        policy.Should().BeNull();
+        Should.Throw<KeyNotFoundException>(() => policy = ReadOnlyRegistry.Get<Policy>(key));
+        policy.ShouldBeNull();
     }
 
     [Fact]
@@ -161,9 +157,8 @@ public class ReadOnlyPolicyRegistrySpecs
     {
         string key = Guid.NewGuid().ToString();
         Policy<ResultPrimitive>? policy = null;
-        ReadOnlyRegistry.Invoking(r => policy = r.Get<Policy<ResultPrimitive>>(key))
-            .Should().Throw<KeyNotFoundException>();
-        policy.Should().BeNull();
+        Should.Throw<KeyNotFoundException>(() => policy = ReadOnlyRegistry.Get<Policy<ResultPrimitive>>(key));
+        policy.ShouldBeNull();
     }
 
     [Fact]
@@ -171,9 +166,8 @@ public class ReadOnlyPolicyRegistrySpecs
     {
         string key = Guid.NewGuid().ToString();
         ISyncPolicy<ResultPrimitive>? policy = null;
-        ReadOnlyRegistry.Invoking(r => policy = r.Get<ISyncPolicy<ResultPrimitive>>(key))
-            .Should().Throw<KeyNotFoundException>();
-        policy.Should().BeNull();
+        Should.Throw<KeyNotFoundException>(() => policy = ReadOnlyRegistry.Get<ISyncPolicy<ResultPrimitive>>(key));
+        policy.ShouldBeNull();
     }
 
     [Fact]
@@ -181,9 +175,8 @@ public class ReadOnlyPolicyRegistrySpecs
     {
         string key = Guid.NewGuid().ToString();
         IsPolicy? outPolicy = null;
-        ReadOnlyRegistry.Invoking(r => outPolicy = r[key])
-            .Should().Throw<KeyNotFoundException>();
-        outPolicy.Should().BeNull();
+        Should.Throw<KeyNotFoundException>(() => outPolicy = ReadOnlyRegistry[key]);
+        outPolicy.ShouldBeNull();
     }
 
     [Fact]
@@ -191,9 +184,8 @@ public class ReadOnlyPolicyRegistrySpecs
     {
         string key = null!;
         Policy? policy = null;
-        ReadOnlyRegistry.Invoking(r => policy = r.Get<Policy>(key))
-            .Should().Throw<ArgumentNullException>();
-        policy.Should().BeNull();
+        Should.Throw<ArgumentNullException>(() => policy = ReadOnlyRegistry.Get<Policy>(key));
+        policy.ShouldBeNull();
     }
 
     [Fact]
@@ -201,9 +193,8 @@ public class ReadOnlyPolicyRegistrySpecs
     {
         string key = null!;
         Policy<ResultPrimitive>? policy = null;
-        ReadOnlyRegistry.Invoking(r => policy = r.Get<Policy<ResultPrimitive>>(key))
-            .Should().Throw<ArgumentNullException>();
-        policy.Should().BeNull();
+        Should.Throw<ArgumentNullException>(() => policy = ReadOnlyRegistry.Get<Policy<ResultPrimitive>>(key));
+        policy.ShouldBeNull();
     }
 
     [Fact]
@@ -211,9 +202,8 @@ public class ReadOnlyPolicyRegistrySpecs
     {
         string key = null!;
         ISyncPolicy<ResultPrimitive>? policy = null;
-        ReadOnlyRegistry.Invoking(r => policy = r.Get<ISyncPolicy<ResultPrimitive>>(key))
-            .Should().Throw<ArgumentNullException>();
-        policy.Should().BeNull();
+        Should.Throw<ArgumentNullException>(() => policy = ReadOnlyRegistry.Get<ISyncPolicy<ResultPrimitive>>(key));
+        policy.ShouldBeNull();
     }
 
     [Fact]
@@ -221,9 +211,8 @@ public class ReadOnlyPolicyRegistrySpecs
     {
         string key = null!;
         IsPolicy? policy = null;
-        ReadOnlyRegistry.Invoking(r => policy = r[key])
-            .Should().Throw<ArgumentNullException>();
-        policy.Should().BeNull();
+        Should.Throw<ArgumentNullException>(() => policy = ReadOnlyRegistry[key]);
+        policy.ShouldBeNull();
     }
     #endregion
 
@@ -236,18 +225,17 @@ public class ReadOnlyPolicyRegistrySpecs
         string key = Guid.NewGuid().ToString();
 
         _registry.Add(key, policy);
-        ReadOnlyRegistry.ContainsKey(key).Should().BeTrue();
+        ReadOnlyRegistry.ContainsKey(key).ShouldBeTrue();
 
         string key2 = Guid.NewGuid().ToString();
-        ReadOnlyRegistry.ContainsKey(key2).Should().BeFalse();
+        ReadOnlyRegistry.ContainsKey(key2).ShouldBeFalse();
     }
 
     [Fact]
     public void Should_throw_when_checking_if_key_exists_when_key_is_null()
     {
         string key = null!;
-        ReadOnlyRegistry.Invoking(r => r.ContainsKey(key))
-            .Should().Throw<ArgumentNullException>();
+        Should.Throw<ArgumentNullException>(() => ReadOnlyRegistry.ContainsKey(key));
     }
     #endregion
 
@@ -276,12 +264,12 @@ public class ReadOnlyPolicyRegistrySpecs
 
         var testRegistry = new PolicyRegistry
         {
-            {key, policy}
+            [key] = policy
         };
 
-        testRegistry.Should().Equal(new Dictionary<string, IsPolicy>
+        testRegistry.ShouldBe(new Dictionary<string, IsPolicy>
         {
-            {key, policy}
+            [key] = policy
         });
     }
     #endregion

--- a/test/Polly.Specs/ResiliencePipelineConversionExtensionsTests.cs
+++ b/test/Polly.Specs/ResiliencePipelineConversionExtensionsTests.cs
@@ -22,11 +22,11 @@ public class ResiliencePipelineConversionExtensionsTests
         {
             Before = (context, _) =>
             {
-                context.GetType().GetProperty("IsVoid", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(context).Should().Be(_isVoid);
-                context.GetType().GetProperty("IsSynchronous", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(context).Should().Be(_isSynchronous);
+                context.GetType().GetProperty("IsVoid", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(context).ShouldBe(_isVoid);
+                context.GetType().GetProperty("IsSynchronous", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(context).ShouldBe(_isSynchronous);
                 context.Properties.Set(Outgoing, "outgoing-value");
-                context.Properties.GetValue(Incoming, string.Empty).Should().Be("incoming-value");
-                context.OperationKey.Should().Be("op-key");
+                context.Properties.GetValue(Incoming, string.Empty).ShouldBe("incoming-value");
+                context.OperationKey.ShouldBe("op-key");
             }
         };
 
@@ -66,7 +66,7 @@ public class ResiliencePipelineConversionExtensionsTests
 
         var result = _genericStrategy.AsSyncPolicy().Execute(_ => { context[Executing.Key] = "executing-value"; return "dummy"; }, context);
         AssertContext(context);
-        result.Should().Be("dummy");
+        result.ShouldBe("dummy");
     }
 
     [Fact]
@@ -82,7 +82,7 @@ public class ResiliencePipelineConversionExtensionsTests
         var result = _strategy.AsPipeline().AsSyncPolicy().Execute(_ => { context[Executing.Key] = "executing-value"; return "dummy"; }, context);
 
         AssertContext(context);
-        result.Should().Be("dummy");
+        result.ShouldBe("dummy");
     }
 
     [Fact]
@@ -122,7 +122,7 @@ public class ResiliencePipelineConversionExtensionsTests
         },
         context);
         AssertContext(context);
-        result.Should().Be("dummy");
+        result.ShouldBe("dummy");
     }
 
     [Fact]
@@ -143,7 +143,7 @@ public class ResiliencePipelineConversionExtensionsTests
         context);
 
         AssertContext(context);
-        result.Should().Be("dummy");
+        result.ShouldBe("dummy");
     }
 
     [Fact]
@@ -172,15 +172,14 @@ public class ResiliencePipelineConversionExtensionsTests
                 return "dummy";
             },
             context)
-            .Should()
-            .Be("dummy");
+            .ShouldBe("dummy");
 
-        context["retry"].Should().Be(6);
+        context["retry"].ShouldBe(6);
     }
 
     private static void AssertContext(Context context)
     {
-        context[Outgoing.Key].Should().Be("outgoing-value");
-        context[Executing.Key].Should().Be("executing-value");
+        context[Outgoing.Key].ShouldBe("outgoing-value");
+        context[Executing.Key].ShouldBe("executing-value");
     }
 }

--- a/test/Polly.Specs/Retry/RetryAsyncSpecs.cs
+++ b/test/Polly.Specs/Retry/RetryAsyncSpecs.cs
@@ -28,10 +28,10 @@ public class RetryAsyncSpecs
 
         var func = () => generic.Invoke(instance, [action, new Context(), CancellationToken.None, false]);
 
-        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("action");
+        var exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>()
+            .ParamName.ShouldBe("action");
     }
 
     [Fact]
@@ -43,8 +43,8 @@ public class RetryAsyncSpecs
                                   .Handle<DivideByZeroException>()
                                   .RetryAsync(-1, onRetry);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-              .ParamName.Should().Be("retryCount");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+              .ParamName.ShouldBe("retryCount");
     }
 
     [Fact]
@@ -54,8 +54,7 @@ public class RetryAsyncSpecs
             .Handle<DivideByZeroException>()
             .RetryAsync(3);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>(3))
-              .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<DivideByZeroException>(3));
     }
 
     [Fact]
@@ -66,8 +65,7 @@ public class RetryAsyncSpecs
             .Or<ArgumentException>()
             .RetryAsync(3);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<ArgumentException>(3))
-              .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<ArgumentException>(3));
     }
 
     [Fact]
@@ -77,8 +75,7 @@ public class RetryAsyncSpecs
             .Handle<DivideByZeroException>()
             .RetryAsync(3);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<DivideByZeroException>());
     }
 
     [Fact]
@@ -89,8 +86,7 @@ public class RetryAsyncSpecs
             .Or<ArgumentException>()
             .RetryAsync(3);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<ArgumentException>())
-              .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<ArgumentException>());
     }
 
     [Fact]
@@ -100,8 +96,7 @@ public class RetryAsyncSpecs
             .Handle<DivideByZeroException>()
             .RetryAsync(3);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>(3 + 1))
-              .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => policy.RaiseExceptionAsync<DivideByZeroException>(3 + 1));
     }
 
     [Fact]
@@ -112,8 +107,7 @@ public class RetryAsyncSpecs
             .Or<ArgumentException>()
             .RetryAsync(3);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<ArgumentException>(3 + 1))
-              .Should().ThrowAsync<ArgumentException>();
+        await Should.ThrowAsync<ArgumentException>(() => policy.RaiseExceptionAsync<ArgumentException>(3 + 1));
     }
 
     [Fact]
@@ -123,8 +117,7 @@ public class RetryAsyncSpecs
             .Handle<DivideByZeroException>()
             .RetryAsync();
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<NullReferenceException>())
-              .Should().ThrowAsync<NullReferenceException>();
+        await Should.ThrowAsync<NullReferenceException>(() => policy.RaiseExceptionAsync<NullReferenceException>());
     }
 
     [Fact]
@@ -135,8 +128,7 @@ public class RetryAsyncSpecs
             .Or<ArgumentException>()
             .RetryAsync();
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<NullReferenceException>())
-              .Should().ThrowAsync<NullReferenceException>();
+        await Should.ThrowAsync<NullReferenceException>(() => policy.RaiseExceptionAsync<NullReferenceException>());
     }
 
     [Fact]
@@ -146,8 +138,7 @@ public class RetryAsyncSpecs
             .Handle<DivideByZeroException>(_ => false)
             .RetryAsync();
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => policy.RaiseExceptionAsync<DivideByZeroException>());
     }
 
     [Fact]
@@ -158,8 +149,7 @@ public class RetryAsyncSpecs
             .Or<ArgumentException>(_ => false)
             .RetryAsync();
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<ArgumentException>())
-              .Should().ThrowAsync<ArgumentException>();
+        await Should.ThrowAsync<ArgumentException>(() => policy.RaiseExceptionAsync<ArgumentException>());
     }
 
     [Fact]
@@ -169,8 +159,7 @@ public class RetryAsyncSpecs
             .Handle<DivideByZeroException>(_ => true)
             .RetryAsync();
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<DivideByZeroException>());
     }
 
     [Fact]
@@ -181,8 +170,7 @@ public class RetryAsyncSpecs
             .Or<ArgumentException>(_ => true)
             .RetryAsync();
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<ArgumentException>())
-              .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<ArgumentException>());
     }
 
     [Fact]
@@ -192,7 +180,7 @@ public class RetryAsyncSpecs
             .Handle<DivideByZeroException>()
             .RetryAsync(3, (Action<Exception, int>)null!);
 
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("onRetry");
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe("onRetry");
     }
 
     [Fact]
@@ -202,7 +190,7 @@ public class RetryAsyncSpecs
             .Handle<DivideByZeroException>()
             .RetryAsync(3, (Func<Exception, int, Task>)null!);
 
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("onRetryAsync");
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe("onRetryAsync");
     }
 
     [Fact]
@@ -217,8 +205,7 @@ public class RetryAsyncSpecs
 
         await policy.RaiseExceptionAsync<DivideByZeroException>(3);
 
-        retryCounts.Should()
-                   .ContainInOrder(expectedRetryCounts);
+        retryCounts.ShouldBe(expectedRetryCounts);
     }
 
     [Fact]
@@ -235,8 +222,7 @@ public class RetryAsyncSpecs
 
         retryExceptions
             .Select(x => x.HelpLink)
-            .Should()
-            .ContainInOrder(expectedExceptions);
+            .ShouldBe(expectedExceptions);
     }
 
     [Fact]
@@ -253,7 +239,7 @@ public class RetryAsyncSpecs
 
         await policy.RaiseExceptionAsync(withInner);
 
-        passedToOnRetry.Should().BeSameAs(toRaiseAsInner);
+        passedToOnRetry.ShouldBeSameAs(toRaiseAsInner);
     }
 
     [Fact]
@@ -265,11 +251,9 @@ public class RetryAsyncSpecs
             .Handle<DivideByZeroException>()
             .RetryAsync((_, retryCount) => retryCounts.Add(retryCount));
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<ArgumentException>())
-              .Should().ThrowAsync<ArgumentException>();
+        await Should.ThrowAsync<ArgumentException>(() => policy.RaiseExceptionAsync<ArgumentException>());
 
-        retryCounts.Should()
-                   .BeEmpty();
+        retryCounts.ShouldBeEmpty();
     }
 
     [Fact]
@@ -279,11 +263,8 @@ public class RetryAsyncSpecs
             .Handle<DivideByZeroException>()
             .RetryAsync();
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().NotThrowAsync();
-
-        await policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<DivideByZeroException>());
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<DivideByZeroException>());
     }
 
     [Fact]
@@ -298,9 +279,9 @@ public class RetryAsyncSpecs
         policy.RaiseExceptionAsync<DivideByZeroException>(
             CreateDictionary("key1", "value1", "key2", "value2"));
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -312,13 +293,15 @@ public class RetryAsyncSpecs
             .Handle<DivideByZeroException>()
             .RetryAsync((_, _, context) => contextData = context);
 
-        await policy.Awaiting(p => p.ExecuteAndCaptureAsync(_ => { throw new DivideByZeroException(); },
-            CreateDictionary("key1", "value1", "key2", "value2")))
-            .Should().NotThrowAsync();
+        await Should.NotThrowAsync(
+            () =>
+                policy.ExecuteAndCaptureAsync(
+                    _ => { throw new DivideByZeroException(); },
+                    CreateDictionary("key1", "value1", "key2", "value2")));
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -330,10 +313,10 @@ public class RetryAsyncSpecs
             .Handle<DivideByZeroException>()
             .RetryAsync((_, _, context) => capturedContext = context);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>()).Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<DivideByZeroException>());
 
-        capturedContext.Should()
-                       .BeEmpty();
+        capturedContext.ShouldNotBeNull();
+        capturedContext.ShouldBeEmpty();
     }
 
     [Fact]
@@ -348,12 +331,12 @@ public class RetryAsyncSpecs
         policy.RaiseExceptionAsync<DivideByZeroException>(
             CreateDictionary("key", "original_value"));
 
-        contextValue.Should().Be("original_value");
+        contextValue.ShouldBe("original_value");
 
         policy.RaiseExceptionAsync<DivideByZeroException>(
             CreateDictionary("key", "new_value"));
 
-        contextValue.Should().Be("new_value");
+        contextValue.ShouldBe("new_value");
     }
 
     [Fact]
@@ -365,17 +348,21 @@ public class RetryAsyncSpecs
             .Handle<DivideByZeroException>()
             .RetryAsync((_, _, context) => contextValue = context["key"].ToString());
 
-        await policy.Awaiting(p => p.ExecuteAndCaptureAsync(_ => throw new DivideByZeroException(),
-            CreateDictionary("key", "original_value")))
-            .Should().NotThrowAsync();
+        await Should.NotThrowAsync(
+            () =>
+                policy.ExecuteAndCaptureAsync(
+                    _ => throw new DivideByZeroException(),
+                    CreateDictionary("key", "original_value")));
 
-        contextValue.Should().Be("original_value");
+        contextValue.ShouldBe("original_value");
 
-        await policy.Awaiting(p => p.ExecuteAndCaptureAsync(_ => throw new DivideByZeroException(),
-            CreateDictionary("key", "new_value")))
-            .Should().NotThrowAsync();
+        await Should.NotThrowAsync(
+            () =>
+                policy.ExecuteAndCaptureAsync(
+                    _ => throw new DivideByZeroException(),
+                    CreateDictionary("key", "new_value")));
 
-        contextValue.Should().Be("new_value");
+        contextValue.ShouldBe("new_value");
     }
 
     [Fact]
@@ -389,10 +376,9 @@ public class RetryAsyncSpecs
             .Handle<DivideByZeroException>()
             .RetryAsync(0, onRetry);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => policy.RaiseExceptionAsync<DivideByZeroException>());
 
-        retryInvoked.Should().BeFalse();
+        retryInvoked.ShouldBeFalse();
     }
 
     #region Async and cancellation tests
@@ -406,7 +392,7 @@ public class RetryAsyncSpecs
         // If Polly were to declare only an Action<...> delegate for onRetry - but users declared async () => { } onRetry delegates - the compiler would happily assign them to the Action<...>, but the next 'try' of the retry policy would/could occur before onRetry execution had completed.
         // This test ensures the relevant retry policy does have a Func<..., Task> form for onRetry, and that it is awaited before the next try commences.
 
-        TimeSpan shimTimeSpan = TimeSpan.FromSeconds(0.2); // Consider increasing shimTimeSpan if test fails transiently in different environments.
+        TimeSpan shimTimeSpan = TimeSpan.FromSeconds(0.2);
 
         int executeDelegateInvocations = 0;
         int executeDelegateInvocationsWhenOnRetryExits = 0;
@@ -419,20 +405,20 @@ public class RetryAsyncSpecs
                 executeDelegateInvocationsWhenOnRetryExits = executeDelegateInvocations;
             });
 
-        await policy.Awaiting(p => p.ExecuteAsync(async () =>
+        await Should.ThrowAsync<DivideByZeroException>(() => policy.ExecuteAsync(async () =>
         {
             executeDelegateInvocations++;
             await TaskHelper.EmptyTask;
             throw new DivideByZeroException();
-        })).Should().ThrowAsync<DivideByZeroException>();
+        }));
 
         while (executeDelegateInvocationsWhenOnRetryExits == 0)
         {
             // Wait for the onRetry delegate to complete.
         }
 
-        executeDelegateInvocationsWhenOnRetryExits.Should().Be(1); // If the async onRetry delegate is genuinely awaited, only one execution of the .Execute delegate should have occurred by the time onRetry completes.  If the async onRetry delegate were instead assigned to an Action<...>, then onRetry will return, and the second action execution will commence, before await Task.Delay() completes, leaving executeDelegateInvocationsWhenOnRetryExits == 2.
-        executeDelegateInvocations.Should().Be(2);
+        executeDelegateInvocationsWhenOnRetryExits.ShouldBe(1); // If the async onRetry delegate is genuinely awaited, only one execution of the .Execute delegate should have occurred by the time onRetry completes.  If the async onRetry delegate were instead assigned to an Action<...>, then onRetry will return, and the second action execution will commence, before await Task.Delay() completes, leaving executeDelegateInvocationsWhenOnRetryExits == 2.
+        executeDelegateInvocations.ShouldBe(2);
     }
 
     [Fact]
@@ -455,11 +441,10 @@ public class RetryAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().NotThrowAsync();
+            await Should.NotThrowAsync(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -482,11 +467,10 @@ public class RetryAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().ThrowAsync<DivideByZeroException>();
+            await Should.ThrowAsync<DivideByZeroException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1 + 3);
+        attemptsInvoked.ShouldBe(1 + 3);
     }
 
     [Fact]
@@ -510,12 +494,11 @@ public class RetryAsyncSpecs
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             cancellationTokenSource.Cancel();
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(0);
+        attemptsInvoked.ShouldBe(0);
     }
 
     [Fact]
@@ -539,12 +522,11 @@ public class RetryAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -568,12 +550,11 @@ public class RetryAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -596,12 +577,11 @@ public class RetryAsyncSpecs
         using (var cancellationTokenSource = new CancellationTokenSource())
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -625,12 +605,11 @@ public class RetryAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(2);
+        attemptsInvoked.ShouldBe(2);
     }
 
     [Fact]
@@ -654,12 +633,11 @@ public class RetryAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(2);
+        attemptsInvoked.ShouldBe(2);
     }
 
     [Fact]
@@ -683,12 +661,11 @@ public class RetryAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1 + 3);
+        attemptsInvoked.ShouldBe(1 + 3);
     }
 
     [Fact]
@@ -712,11 +689,10 @@ public class RetryAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().ThrowAsync<DivideByZeroException>();
+            await Should.ThrowAsync<DivideByZeroException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1 + 3);
+        attemptsInvoked.ShouldBe(1 + 3);
     }
 
     [Fact]
@@ -743,12 +719,11 @@ public class RetryAsyncSpecs
                     cancellationTokenSource.Cancel();
                 });
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -773,14 +748,14 @@ public class RetryAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            Func<AsyncRetryPolicy, Task> action = async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true);
-            await policy.Awaiting(action)
-                .Should().NotThrowAsync();
+            Func<Task> action = async () => result = await policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true);
+            await Should.NotThrowAsync(action);
         }
 
-        result.Should().BeTrue();
+        result.ShouldNotBeNull();
+        result.Value.ShouldBeTrue();
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -806,14 +781,14 @@ public class RetryAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            Func<AsyncRetryPolicy, Task> action = async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true);
-            var ex = await policy.Awaiting(action).Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            Func<Task> action = async () => result = await policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(action);
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        result.Should().Be(null);
+        result.ShouldBeNull();
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     #endregion

--- a/test/Polly.Specs/Retry/RetryForeverAsyncSpecs.cs
+++ b/test/Polly.Specs/Retry/RetryForeverAsyncSpecs.cs
@@ -11,8 +11,7 @@ public class RetryForeverAsyncSpecs
             .Handle<DivideByZeroException>()
             .RetryForeverAsync();
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>(3))
-              .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<DivideByZeroException>(3));
     }
 
     [Fact]
@@ -23,8 +22,7 @@ public class RetryForeverAsyncSpecs
             .Or<ArgumentException>()
             .RetryForeverAsync();
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<ArgumentException>(3))
-              .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<ArgumentException>(3));
     }
 
     [Fact]
@@ -34,8 +32,7 @@ public class RetryForeverAsyncSpecs
             .Handle<DivideByZeroException>()
             .RetryForeverAsync();
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<NullReferenceException>())
-              .Should().ThrowAsync<NullReferenceException>();
+        await Should.ThrowAsync<NullReferenceException>(() => policy.RaiseExceptionAsync<NullReferenceException>());
     }
 
     [Fact]
@@ -46,8 +43,7 @@ public class RetryForeverAsyncSpecs
             .Or<ArgumentException>()
             .RetryForeverAsync();
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<NullReferenceException>())
-              .Should().ThrowAsync<NullReferenceException>();
+        await Should.ThrowAsync<NullReferenceException>(() => policy.RaiseExceptionAsync<NullReferenceException>());
     }
 
     [Fact]
@@ -57,8 +53,7 @@ public class RetryForeverAsyncSpecs
             .Handle<DivideByZeroException>(_ => false)
             .RetryForeverAsync();
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => policy.RaiseExceptionAsync<DivideByZeroException>());
     }
 
     [Fact]
@@ -69,8 +64,7 @@ public class RetryForeverAsyncSpecs
             .Or<ArgumentException>(_ => false)
             .RetryForeverAsync();
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<ArgumentException>())
-              .Should().ThrowAsync<ArgumentException>();
+        await Should.ThrowAsync<ArgumentException>(() => policy.RaiseExceptionAsync<ArgumentException>());
     }
 
     [Fact]
@@ -80,8 +74,7 @@ public class RetryForeverAsyncSpecs
             .Handle<DivideByZeroException>(_ => true)
             .RetryForeverAsync();
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<DivideByZeroException>());
     }
 
     [Fact]
@@ -92,8 +85,7 @@ public class RetryForeverAsyncSpecs
             .Or<ArgumentException>(_ => true)
             .RetryForeverAsync();
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<ArgumentException>())
-              .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<ArgumentException>());
     }
 
     [Fact]
@@ -148,8 +140,7 @@ public class RetryForeverAsyncSpecs
 
         retryExceptions
             .Select(x => x.HelpLink)
-            .Should()
-            .ContainInOrder(expectedExceptions);
+            .ShouldBe(expectedExceptions);
     }
 
     [Fact]
@@ -164,9 +155,9 @@ public class RetryForeverAsyncSpecs
         policy.RaiseExceptionAsync<DivideByZeroException>(
             CreateDictionary("key1", "value1", "key2", "value2"));
 
-        contextData.Should()
-                   .ContainKeys("key1", "key2").And
-                   .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -181,8 +172,7 @@ public class RetryForeverAsyncSpecs
 
         policy.RaiseExceptionAsync<DivideByZeroException>(3);
 
-        retryCounts.Should()
-            .ContainInOrder(expectedRetryCounts);
+        retryCounts.ShouldBe(expectedRetryCounts);
     }
 
     [Fact]
@@ -194,10 +184,9 @@ public class RetryForeverAsyncSpecs
             .Handle<DivideByZeroException>()
             .RetryForeverAsync((_, context) => capturedContext = context);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>()).Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<DivideByZeroException>());
 
-        capturedContext.Should()
-                       .BeEmpty();
+        capturedContext.ShouldBeEmpty();
     }
 
     [Fact]
@@ -212,12 +201,12 @@ public class RetryForeverAsyncSpecs
         policy.RaiseExceptionAsync<DivideByZeroException>(
             CreateDictionary("key", "original_value"));
 
-        contextValue.Should().Be("original_value");
+        contextValue.ShouldBe("original_value");
 
         policy.RaiseExceptionAsync<DivideByZeroException>(
             CreateDictionary("key", "new_value"));
 
-        contextValue.Should().Be("new_value");
+        contextValue.ShouldBe("new_value");
     }
 
     [Fact]
@@ -227,13 +216,11 @@ public class RetryForeverAsyncSpecs
 
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .RetryForeverAsync(exception => retryExceptions.Add(exception));
+            .RetryForeverAsync(retryExceptions.Add);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<ArgumentException>())
-              .Should().ThrowAsync<ArgumentException>();
+        await Should.ThrowAsync<ArgumentException>(() => policy.RaiseExceptionAsync<ArgumentException>());
 
-        retryExceptions.Should()
-                       .BeEmpty();
+        retryExceptions.ShouldBeEmpty();
     }
 
     [Fact]
@@ -245,7 +232,7 @@ public class RetryForeverAsyncSpecs
         // If Polly were to declare only an Action<...> delegate for onRetry - but users declared async () => { } onRetry delegates - the compiler would happily assign them to the Action<...>, but the next 'try' would/could occur before onRetry execution had completed.
         // This test ensures the relevant retry policy does have a Func<..., Task> form for onRetry, and that it is awaited before the next try commences.
 
-        TimeSpan shimTimeSpan = TimeSpan.FromSeconds(0.2); // Consider increasing shimTimeSpan if test fails transiently in different environments.
+        TimeSpan shimTimeSpan = TimeSpan.FromSeconds(0.2);
 
         int executeDelegateInvocations = 0;
         int executeDelegateInvocationsWhenOnRetryExits = 0;
@@ -258,7 +245,7 @@ public class RetryForeverAsyncSpecs
                 executeDelegateInvocationsWhenOnRetryExits = executeDelegateInvocations;
             });
 
-        await policy.Awaiting(p => p.ExecuteAsync(async () =>
+        await Should.NotThrowAsync(() => policy.ExecuteAsync(async () =>
         {
             executeDelegateInvocations++;
             await TaskHelper.EmptyTask;
@@ -266,15 +253,15 @@ public class RetryForeverAsyncSpecs
             {
                 throw new DivideByZeroException();
             }
-        })).Should().NotThrowAsync();
+        }));
 
         while (executeDelegateInvocationsWhenOnRetryExits == 0)
         {
             // Wait for the onRetry delegate to complete.
         }
 
-        executeDelegateInvocationsWhenOnRetryExits.Should().Be(1); // If the async onRetry delegate is genuinely awaited, only one execution of the .Execute delegate should have occurred by the time onRetry completes.  If the async onRetry delegate were instead assigned to an Action<...>, then onRetry will return, and the second action execution will commence, before await Task.Delay() completes, leaving executeDelegateInvocationsWhenOnRetryExits == 2.
-        executeDelegateInvocations.Should().Be(2);
+        executeDelegateInvocationsWhenOnRetryExits.ShouldBe(1); // If the async onRetry delegate is genuinely awaited, only one execution of the .Execute delegate should have occurred by the time onRetry completes.  If the async onRetry delegate were instead assigned to an Action<...>, then onRetry will return, and the second action execution will commence, before await Task.Delay() completes, leaving executeDelegateInvocationsWhenOnRetryExits == 2.
+        executeDelegateInvocations.ShouldBe(2);
     }
 
     [Fact]
@@ -297,11 +284,10 @@ public class RetryForeverAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().NotThrowAsync();
+            await Should.NotThrowAsync(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -325,12 +311,11 @@ public class RetryForeverAsyncSpecs
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             cancellationTokenSource.Cancel();
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(0);
+        attemptsInvoked.ShouldBe(0);
     }
 
     [Fact]
@@ -354,12 +339,11 @@ public class RetryForeverAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -383,12 +367,11 @@ public class RetryForeverAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -412,12 +395,11 @@ public class RetryForeverAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -441,12 +423,11 @@ public class RetryForeverAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(2);
+        attemptsInvoked.ShouldBe(2);
     }
 
     [Fact]
@@ -470,12 +451,11 @@ public class RetryForeverAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(2);
+        attemptsInvoked.ShouldBe(2);
     }
 
     [Fact]
@@ -503,12 +483,11 @@ public class RetryForeverAsyncSpecs
                     cancellationTokenSource.Cancel();
                 });
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -533,14 +512,14 @@ public class RetryForeverAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            Func<AsyncRetryPolicy, Task> action = async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true);
-            await policy.Awaiting(action)
-                .Should().NotThrowAsync();
+            Func<Task> action = async () => result = await policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true);
+            await Should.NotThrowAsync(action);
         }
 
-        result.Should().BeTrue();
+        result.ShouldNotBeNull();
+        result.Value.ShouldBeTrue();
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -566,13 +545,13 @@ public class RetryForeverAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            Func<AsyncRetryPolicy, Task> action = async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true);
-            var ex = await policy.Awaiting(action).Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            Func<Task> action = async () => result = await policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(action);
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        result.Should().Be(null);
+        result.ShouldBe(null);
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 }

--- a/test/Polly.Specs/Retry/RetryForeverSpecs.cs
+++ b/test/Polly.Specs/Retry/RetryForeverSpecs.cs
@@ -11,8 +11,8 @@ public class RetryForeverSpecs
                                   .Handle<DivideByZeroException>()
                                   .RetryForever(nullOnRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("onRetry");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]
@@ -24,8 +24,8 @@ public class RetryForeverSpecs
                                   .Handle<DivideByZeroException>()
                                   .RetryForever(nullOnRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("onRetry");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]
@@ -35,8 +35,7 @@ public class RetryForeverSpecs
             .Handle<DivideByZeroException>()
             .RetryForever();
 
-        policy.Invoking(x => x.RaiseException<DivideByZeroException>(3))
-              .Should().NotThrow();
+        Should.NotThrow(() => policy.RaiseException<DivideByZeroException>(3));
     }
 
     [Fact]
@@ -47,8 +46,7 @@ public class RetryForeverSpecs
             .Or<ArgumentException>()
             .RetryForever();
 
-        policy.Invoking(x => x.RaiseException<ArgumentException>(3))
-              .Should().NotThrow();
+        Should.NotThrow(() => policy.RaiseException<ArgumentException>(3));
     }
 
     [Fact]
@@ -58,8 +56,7 @@ public class RetryForeverSpecs
             .Handle<DivideByZeroException>()
             .RetryForever();
 
-        policy.Invoking(x => x.RaiseException<NullReferenceException>())
-              .Should().Throw<NullReferenceException>();
+        Should.Throw<NullReferenceException>(() => policy.RaiseException<NullReferenceException>());
     }
 
     [Fact]
@@ -69,8 +66,7 @@ public class RetryForeverSpecs
             .Handle<DivideByZeroException>()
             .RetryForeverAsync();
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<NullReferenceException>())
-              .Should().ThrowAsync<NullReferenceException>();
+        await Should.ThrowAsync<NullReferenceException>(() => policy.RaiseExceptionAsync<NullReferenceException>());
     }
 
     [Fact]
@@ -81,8 +77,7 @@ public class RetryForeverSpecs
             .Or<ArgumentException>()
             .RetryForever();
 
-        policy.Invoking(x => x.RaiseException<NullReferenceException>())
-              .Should().Throw<NullReferenceException>();
+        Should.Throw<NullReferenceException>(() => policy.RaiseException<NullReferenceException>());
     }
 
     [Fact]
@@ -92,8 +87,7 @@ public class RetryForeverSpecs
             .Handle<DivideByZeroException>(_ => false)
             .RetryForever();
 
-        policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => policy.RaiseException<DivideByZeroException>());
     }
 
     [Fact]
@@ -104,8 +98,7 @@ public class RetryForeverSpecs
             .Or<ArgumentException>(_ => false)
             .RetryForever();
 
-        policy.Invoking(x => x.RaiseException<ArgumentException>())
-              .Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => policy.RaiseException<ArgumentException>());
     }
 
     [Fact]
@@ -115,8 +108,7 @@ public class RetryForeverSpecs
             .Handle<DivideByZeroException>(_ => true)
             .RetryForever();
 
-        policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().NotThrow();
+        Should.NotThrow(() => policy.RaiseException<DivideByZeroException>());
     }
 
     [Fact]
@@ -126,8 +118,7 @@ public class RetryForeverSpecs
             .Handle<DivideByZeroException>(_ => true)
             .RetryForeverAsync();
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<DivideByZeroException>());
     }
 
     [Fact]
@@ -138,8 +129,7 @@ public class RetryForeverSpecs
             .Or<ArgumentException>(_ => true)
             .RetryForever();
 
-        policy.Invoking(x => x.RaiseException<ArgumentException>())
-              .Should().NotThrow();
+        Should.NotThrow(() => policy.RaiseException<ArgumentException>());
     }
 
     [Fact]
@@ -150,8 +140,7 @@ public class RetryForeverSpecs
             .Or<ArgumentException>(_ => true)
             .RetryForeverAsync();
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<ArgumentException>())
-              .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<ArgumentException>());
     }
 
     [Fact]
@@ -162,14 +151,13 @@ public class RetryForeverSpecs
 
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .RetryForever(exception => retryExceptions.Add(exception));
+            .RetryForever(retryExceptions.Add);
 
         policy.RaiseException<DivideByZeroException>(3, (e, i) => e.HelpLink = "Exception #" + i);
 
         retryExceptions
             .Select(x => x.HelpLink)
-            .Should()
-            .ContainInOrder(expectedExceptions);
+            .ShouldBe(expectedExceptions);
     }
 
     [Fact]
@@ -184,9 +172,9 @@ public class RetryForeverSpecs
         policy.RaiseException<DivideByZeroException>(
             CreateDictionary("key1", "value1", "key2", "value2"));
 
-        contextData.Should()
-                   .ContainKeys("key1", "key2").And
-                   .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -201,8 +189,7 @@ public class RetryForeverSpecs
 
         policy.RaiseException<DivideByZeroException>(3);
 
-        retryCounts.Should()
-            .ContainInOrder(expectedRetryCounts);
+        retryCounts.ShouldBe(expectedRetryCounts);
     }
 
     [Fact]
@@ -212,13 +199,11 @@ public class RetryForeverSpecs
 
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .RetryForever(exception => retryExceptions.Add(exception));
+            .RetryForever(retryExceptions.Add);
 
-        policy.Invoking(x => x.RaiseException<ArgumentException>())
-              .Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => policy.RaiseException<ArgumentException>());
 
-        retryExceptions.Should()
-                       .BeEmpty();
+        retryExceptions.ShouldBeEmpty();
     }
 
     [Fact]
@@ -233,11 +218,11 @@ public class RetryForeverSpecs
         policy.RaiseException<DivideByZeroException>(
             CreateDictionary("key", "original_value"));
 
-        contextValue.Should().Be("original_value");
+        contextValue.ShouldBe("original_value");
 
         policy.RaiseException<DivideByZeroException>(
             CreateDictionary("key", "new_value"));
 
-        contextValue.Should().Be("new_value");
+        contextValue.ShouldBe("new_value");
     }
 }

--- a/test/Polly.Specs/Retry/RetrySpecs.cs
+++ b/test/Polly.Specs/Retry/RetrySpecs.cs
@@ -26,10 +26,10 @@ public class RetrySpecs
 
         var func = () => generic.Invoke(instance, [action, new Context(), CancellationToken.None]);
 
-        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("action");
+        var exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>()
+            .ParamName.ShouldBe("action");
     }
 
     [Fact]
@@ -41,8 +41,8 @@ public class RetrySpecs
                                   .Handle<DivideByZeroException>()
                                   .Retry(-1, onRetry);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-              .ParamName.Should().Be("retryCount");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+              .ParamName.ShouldBe("retryCount");
     }
 
     [Fact]
@@ -54,8 +54,8 @@ public class RetrySpecs
                                   .Handle<DivideByZeroException>()
                                   .Retry(1, nullOnRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("onRetry");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]
@@ -67,8 +67,8 @@ public class RetrySpecs
                                   .Handle<DivideByZeroException>()
                                   .Retry(-1, onRetry);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-              .ParamName.Should().Be("retryCount");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+              .ParamName.ShouldBe("retryCount");
     }
 
     [Fact]
@@ -80,8 +80,8 @@ public class RetrySpecs
                                   .Handle<DivideByZeroException>()
                                   .Retry(1, nullOnRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("onRetry");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]
@@ -91,8 +91,7 @@ public class RetrySpecs
             .Handle<DivideByZeroException>()
             .Retry(3);
 
-        policy.Invoking(x => x.RaiseException<DivideByZeroException>(3))
-              .Should().NotThrow();
+        Should.NotThrow(() => policy.RaiseException<DivideByZeroException>(3));
     }
 
     [Fact]
@@ -103,8 +102,7 @@ public class RetrySpecs
             .Or<ArgumentException>()
             .Retry(3);
 
-        policy.Invoking(x => x.RaiseException<ArgumentException>(3))
-              .Should().NotThrow();
+        Should.NotThrow(() => policy.RaiseException<ArgumentException>(3));
     }
 
     [Fact]
@@ -114,8 +112,7 @@ public class RetrySpecs
             .Handle<DivideByZeroException>()
             .Retry(3);
 
-        policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().NotThrow();
+        Should.NotThrow(() => policy.RaiseException<DivideByZeroException>());
     }
 
     [Fact]
@@ -126,8 +123,7 @@ public class RetrySpecs
             .Or<ArgumentException>()
             .Retry(3);
 
-        policy.Invoking(x => x.RaiseException<ArgumentException>())
-              .Should().NotThrow();
+        Should.NotThrow(() => policy.RaiseException<ArgumentException>());
     }
 
     [Fact]
@@ -137,8 +133,7 @@ public class RetrySpecs
             .Handle<DivideByZeroException>()
             .Retry(3);
 
-        policy.Invoking(x => x.RaiseException<DivideByZeroException>(3 + 1))
-              .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => policy.RaiseException<DivideByZeroException>(3 + 1));
     }
 
     [Fact]
@@ -149,8 +144,7 @@ public class RetrySpecs
             .Or<ArgumentException>()
             .Retry(3);
 
-        policy.Invoking(x => x.RaiseException<ArgumentException>(3 + 1))
-              .Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => policy.RaiseException<ArgumentException>(3 + 1));
     }
 
     [Fact]
@@ -160,8 +154,7 @@ public class RetrySpecs
             .Handle<DivideByZeroException>()
             .Retry();
 
-        policy.Invoking(x => x.RaiseException<NullReferenceException>())
-              .Should().Throw<NullReferenceException>();
+        Should.Throw<NullReferenceException>(() => policy.RaiseException<NullReferenceException>());
     }
 
     [Fact]
@@ -172,8 +165,7 @@ public class RetrySpecs
             .Or<ArgumentException>()
             .Retry();
 
-        policy.Invoking(x => x.RaiseException<NullReferenceException>())
-              .Should().Throw<NullReferenceException>();
+        Should.Throw<NullReferenceException>(() => policy.RaiseException<NullReferenceException>());
     }
 
     [Fact]
@@ -183,8 +175,7 @@ public class RetrySpecs
             .Handle<DivideByZeroException>(_ => false)
             .Retry();
 
-        policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => policy.RaiseException<DivideByZeroException>());
     }
 
     [Fact]
@@ -195,8 +186,7 @@ public class RetrySpecs
             .Or<ArgumentException>(_ => false)
             .Retry();
 
-        policy.Invoking(x => x.RaiseException<ArgumentException>())
-              .Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => policy.RaiseException<ArgumentException>());
     }
 
     [Fact]
@@ -206,8 +196,7 @@ public class RetrySpecs
             .Handle<DivideByZeroException>(_ => true)
             .Retry();
 
-        policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().NotThrow();
+        Should.NotThrow(() => policy.RaiseException<DivideByZeroException>());
     }
 
     [Fact]
@@ -218,8 +207,7 @@ public class RetrySpecs
             .Or<ArgumentException>(_ => true)
             .Retry();
 
-        policy.Invoking(x => x.RaiseException<ArgumentException>())
-              .Should().NotThrow();
+        Should.NotThrow(() => policy.RaiseException<ArgumentException>());
     }
 
     [Fact]
@@ -234,8 +222,7 @@ public class RetrySpecs
 
         policy.RaiseException<DivideByZeroException>(3);
 
-        retryCounts.Should()
-                   .ContainInOrder(expectedRetryCounts);
+        retryCounts.ShouldBe(expectedRetryCounts);
     }
 
     [Fact]
@@ -252,8 +239,7 @@ public class RetrySpecs
 
         retryExceptions
             .Select(x => x.HelpLink)
-            .Should()
-            .ContainInOrder(expectedExceptions);
+            .ShouldBe(expectedExceptions);
     }
 
     [Fact]
@@ -270,7 +256,7 @@ public class RetrySpecs
 
         policy.RaiseException(withInner);
 
-        passedToOnRetry.Should().BeSameAs(toRaiseAsInner);
+        passedToOnRetry.ShouldBeSameAs(toRaiseAsInner);
     }
 
     [Fact]
@@ -291,7 +277,7 @@ public class RetrySpecs
 
         policy.RaiseException(aggregateException);
 
-        passedToOnRetry.Should().BeSameAs(toRaiseAsInner);
+        passedToOnRetry.ShouldBeSameAs(toRaiseAsInner);
     }
 
     [Fact]
@@ -312,7 +298,7 @@ public class RetrySpecs
 
         policy.RaiseException(aggregateException);
 
-        passedToOnRetry.Should().BeSameAs(toRaiseAsInner);
+        passedToOnRetry.ShouldBeSameAs(toRaiseAsInner);
     }
 
     [Fact]
@@ -335,7 +321,7 @@ public class RetrySpecs
 
         policy.RaiseException(aggregateException);
 
-        passedToOnRetry.Should().BeSameAs(toRaiseAsInner);
+        passedToOnRetry.ShouldBeSameAs(toRaiseAsInner);
     }
 
     [Fact]
@@ -358,7 +344,7 @@ public class RetrySpecs
 
         policy.RaiseException(aggregateException);
 
-        passedToOnRetry.Should().BeSameAs(toRaiseAsInner);
+        passedToOnRetry.ShouldBeSameAs(toRaiseAsInner);
     }
 
     [Fact]
@@ -370,11 +356,9 @@ public class RetrySpecs
             .Handle<DivideByZeroException>()
             .Retry((_, retryCount) => retryCounts.Add(retryCount));
 
-        policy.Invoking(x => x.RaiseException<ArgumentException>())
-            .Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => policy.RaiseException<ArgumentException>());
 
-        retryCounts.Should()
-            .BeEmpty();
+        retryCounts.ShouldBeEmpty();
     }
 
     [Fact]
@@ -389,9 +373,9 @@ public class RetrySpecs
         policy.RaiseException<DivideByZeroException>(
             CreateDictionary("key1", "value1", "key2", "value2"));
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -403,13 +387,12 @@ public class RetrySpecs
             .Handle<DivideByZeroException>()
             .Retry((_, _, context) => contextData = context);
 
-        policy.Invoking(p => p.ExecuteAndCapture(_ => { throw new DivideByZeroException(); },
-            CreateDictionary("key1", "value1", "key2", "value2")))
-            .Should().NotThrow();
+        Should.NotThrow(() => policy.ExecuteAndCapture(_ => throw new DivideByZeroException(),
+            CreateDictionary("key1", "value1", "key2", "value2")));
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -423,8 +406,7 @@ public class RetrySpecs
 
         policy.RaiseException<DivideByZeroException>();
 
-        capturedContext.Should()
-                       .BeEmpty();
+        capturedContext.ShouldBeEmpty();
     }
 
     [Fact]
@@ -439,12 +421,12 @@ public class RetrySpecs
         policy.RaiseException<DivideByZeroException>(
             CreateDictionary("key", "original_value"));
 
-        contextValue.Should().Be("original_value");
+        contextValue.ShouldBe("original_value");
 
         policy.RaiseException<DivideByZeroException>(
             CreateDictionary("key", "new_value"));
 
-        contextValue.Should().Be("new_value");
+        contextValue.ShouldBe("new_value");
     }
 
     [Fact]
@@ -456,17 +438,13 @@ public class RetrySpecs
             .Handle<DivideByZeroException>()
             .Retry((_, _, context) => contextValue = context["key"].ToString());
 
-        policy.Invoking(p => p.ExecuteAndCapture(_ => throw new DivideByZeroException(),
-            CreateDictionary("key", "original_value")))
-            .Should().NotThrow();
+        Should.NotThrow(() => policy.ExecuteAndCapture(_ => throw new DivideByZeroException(), CreateDictionary("key", "original_value")));
 
-        contextValue.Should().Be("original_value");
+        contextValue.ShouldBe("original_value");
 
-        policy.Invoking(p => p.ExecuteAndCapture(_ => throw new DivideByZeroException(),
-            CreateDictionary("key", "new_value")))
-            .Should().NotThrow();
+        Should.NotThrow(() => policy.ExecuteAndCapture(_ => throw new DivideByZeroException(), CreateDictionary("key", "new_value")));
 
-        contextValue.Should().Be("new_value");
+        contextValue.ShouldBe("new_value");
     }
 
     [Fact]
@@ -476,11 +454,8 @@ public class RetrySpecs
             .Handle<DivideByZeroException>()
             .Retry();
 
-        policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().NotThrow();
-
-        policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-            .Should().NotThrow();
+        Should.NotThrow(() => policy.RaiseException<DivideByZeroException>());
+        Should.NotThrow(() => policy.RaiseException<DivideByZeroException>());
     }
 
     [Fact]
@@ -488,16 +463,15 @@ public class RetrySpecs
     {
         bool retryInvoked = false;
 
-        Action<Exception, int> onRetry = (_, _) => { retryInvoked = true; };
+        Action<Exception, int> onRetry = (_, _) => retryInvoked = true;
 
         var policy = Policy
             .Handle<DivideByZeroException>()
             .Retry(0, onRetry);
 
-        policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => policy.RaiseException<DivideByZeroException>());
 
-        retryInvoked.Should().BeFalse();
+        retryInvoked.ShouldBeFalse();
     }
 
     [Fact]
@@ -505,16 +479,15 @@ public class RetrySpecs
     {
         bool retryInvoked = false;
 
-        Action<Exception, int, Context> onRetry = (_, _, _) => { retryInvoked = true; };
+        Action<Exception, int, Context> onRetry = (_, _, _) => retryInvoked = true;
 
         var policy = Policy
             .Handle<DivideByZeroException>()
             .Retry(0, onRetry);
 
-        policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => policy.RaiseException<DivideByZeroException>());
 
-        retryInvoked.Should().BeFalse();
+        retryInvoked.ShouldBeFalse();
     }
 
     #region Sync cancellation tests
@@ -539,11 +512,10 @@ public class RetrySpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().NotThrow();
+            Should.NotThrow(() => policy.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -566,11 +538,10 @@ public class RetrySpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().Throw<DivideByZeroException>();
+            Should.Throw<DivideByZeroException>(() => policy.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1 + 3);
+        attemptsInvoked.ShouldBe(1 + 3);
     }
 
     [Fact]
@@ -594,12 +565,11 @@ public class RetrySpecs
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             cancellationTokenSource.Cancel();
 
-            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<OperationCanceledException>()
-                .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(0);
+        attemptsInvoked.ShouldBe(0);
     }
 
     [Fact]
@@ -623,12 +593,11 @@ public class RetrySpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().Throw<OperationCanceledException>()
-            .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -652,12 +621,11 @@ public class RetrySpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().Throw<OperationCanceledException>()
-            .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -681,12 +649,11 @@ public class RetrySpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().Throw<OperationCanceledException>()
-            .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -710,12 +677,11 @@ public class RetrySpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().Throw<OperationCanceledException>()
-            .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(2);
+        attemptsInvoked.ShouldBe(2);
     }
 
     [Fact]
@@ -739,12 +705,11 @@ public class RetrySpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().Throw<OperationCanceledException>()
-            .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(2);
+        attemptsInvoked.ShouldBe(2);
     }
 
     [Fact]
@@ -768,12 +733,11 @@ public class RetrySpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().Throw<OperationCanceledException>()
-            .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1 + 3);
+        attemptsInvoked.ShouldBe(1 + 3);
     }
 
     [Fact]
@@ -797,11 +761,10 @@ public class RetrySpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().Throw<DivideByZeroException>();
+            Should.Throw<DivideByZeroException>(() => policy.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1 + 3);
+        attemptsInvoked.ShouldBe(1 + 3);
     }
 
     [Fact]
@@ -828,12 +791,11 @@ public class RetrySpecs
                     cancellationTokenSource.Cancel();
                 });
 
-            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<OperationCanceledException>()
-                .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -858,13 +820,13 @@ public class RetrySpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            policy.Invoking(x => result = x.RaiseExceptionAndOrCancellation<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true))
-            .Should().NotThrow();
+            Should.NotThrow(() => result = policy.RaiseExceptionAndOrCancellation<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true));
         }
 
-        result.Should().BeTrue();
+        result.ShouldNotBeNull();
+        result.Value.ShouldBeTrue();
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -890,13 +852,13 @@ public class RetrySpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            policy.Invoking(x => result = x.RaiseExceptionAndOrCancellation<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true))
-            .Should().Throw<OperationCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => result = policy.RaiseExceptionAndOrCancellation<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        result.Should().Be(null);
+        result.ShouldBeNull();
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     #endregion

--- a/test/Polly.Specs/Retry/RetryTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/Retry/RetryTResultAsyncSpecs.cs
@@ -27,10 +27,10 @@ public class RetryTResultAsyncSpecs
 
         var func = () => methodInfo.Invoke(instance, [action, new Context(), CancellationToken.None, false]);
 
-        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("action");
+        var exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>()
+            .ParamName.ShouldBe("action");
     }
 
     [Fact]
@@ -42,8 +42,8 @@ public class RetryTResultAsyncSpecs
                                   .HandleResult(ResultPrimitive.Fault)
                                   .RetryAsync(-1, onRetry);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-              .ParamName.Should().Be("retryCount");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+              .ParamName.ShouldBe("retryCount");
     }
 
     [Fact]
@@ -55,8 +55,8 @@ public class RetryTResultAsyncSpecs
                                   .HandleResult(ResultPrimitive.Fault)
                                   .RetryAsync(1, nullOnRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("onRetry");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]
@@ -68,8 +68,8 @@ public class RetryTResultAsyncSpecs
                                   .HandleResult(ResultPrimitive.Fault)
                                   .RetryAsync(-1, onRetry);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-              .ParamName.Should().Be("retryCount");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+              .ParamName.ShouldBe("retryCount");
     }
 
     [Fact]
@@ -81,8 +81,8 @@ public class RetryTResultAsyncSpecs
                                   .HandleResult(ResultPrimitive.Fault)
                                   .RetryAsync(1, nullOnRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("onRetry");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]
@@ -93,7 +93,7 @@ public class RetryTResultAsyncSpecs
             .RetryAsync(3);
 
         ResultPrimitive result = await policy.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Fault, ResultPrimitive.Fault, ResultPrimitive.Good);
-        result.Should().Be(ResultPrimitive.Good);
+        result.ShouldBe(ResultPrimitive.Good);
     }
 
     [Fact]
@@ -105,7 +105,7 @@ public class RetryTResultAsyncSpecs
             .RetryAsync(3);
 
         ResultPrimitive result = await policy.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.FaultAgain, ResultPrimitive.Fault, ResultPrimitive.Good);
-        result.Should().Be(ResultPrimitive.Good);
+        result.ShouldBe(ResultPrimitive.Good);
     }
 
     [Fact]
@@ -116,7 +116,7 @@ public class RetryTResultAsyncSpecs
             .RetryAsync(3);
 
         ResultPrimitive result = await policy.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Good);
-        result.Should().Be(ResultPrimitive.Good);
+        result.ShouldBe(ResultPrimitive.Good);
     }
 
     [Fact]
@@ -128,7 +128,7 @@ public class RetryTResultAsyncSpecs
             .RetryAsync(3);
 
         ResultPrimitive result = await policy.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.FaultAgain, ResultPrimitive.Good);
-        result.Should().Be(ResultPrimitive.Good);
+        result.ShouldBe(ResultPrimitive.Good);
     }
 
     [Fact]
@@ -139,7 +139,7 @@ public class RetryTResultAsyncSpecs
             .RetryAsync(3);
 
         ResultPrimitive result = await policy.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Fault, ResultPrimitive.Fault, ResultPrimitive.Fault, ResultPrimitive.Good);
-        result.Should().Be(ResultPrimitive.Fault); // It should give up retrying after 3 retries and return the last failure, so should return Fault, not Good.
+        result.ShouldBe(ResultPrimitive.Fault); // It should give up retrying after 3 retries and return the last failure, so should return Fault, not Good.
     }
 
     [Fact]
@@ -151,7 +151,7 @@ public class RetryTResultAsyncSpecs
             .RetryAsync(3);
 
         ResultPrimitive result = await policy.RaiseResultSequenceAsync(ResultPrimitive.FaultAgain, ResultPrimitive.FaultAgain, ResultPrimitive.FaultAgain, ResultPrimitive.FaultAgain, ResultPrimitive.Good);
-        result.Should().Be(ResultPrimitive.FaultAgain);
+        result.ShouldBe(ResultPrimitive.FaultAgain);
     }
 
     [Fact]
@@ -162,7 +162,7 @@ public class RetryTResultAsyncSpecs
             .RetryAsync();
 
         ResultPrimitive result = await policy.RaiseResultSequenceAsync(ResultPrimitive.FaultAgain, ResultPrimitive.Good);
-        result.Should().Be(ResultPrimitive.FaultAgain);
+        result.ShouldBe(ResultPrimitive.FaultAgain);
     }
 
     [Fact]
@@ -174,7 +174,7 @@ public class RetryTResultAsyncSpecs
             .RetryAsync();
 
         ResultPrimitive result = await policy.RaiseResultSequenceAsync(ResultPrimitive.FaultYetAgain, ResultPrimitive.Good);
-        result.Should().Be(ResultPrimitive.FaultYetAgain);
+        result.ShouldBe(ResultPrimitive.FaultYetAgain);
     }
 
     [Fact]
@@ -185,7 +185,7 @@ public class RetryTResultAsyncSpecs
             .RetryAsync();
 
         ResultClass result = await policy.RaiseResultSequenceAsync(new ResultClass(ResultPrimitive.FaultAgain), new ResultClass(ResultPrimitive.Good));
-        result.ResultCode.Should().Be(ResultPrimitive.FaultAgain);
+        result.ResultCode.ShouldBe(ResultPrimitive.FaultAgain);
     }
 
     [Fact]
@@ -197,7 +197,7 @@ public class RetryTResultAsyncSpecs
             .RetryAsync();
 
         ResultClass result = await policy.RaiseResultSequenceAsync(new ResultClass(ResultPrimitive.FaultYetAgain), new ResultClass(ResultPrimitive.Good));
-        result.ResultCode.Should().Be(ResultPrimitive.FaultYetAgain);
+        result.ResultCode.ShouldBe(ResultPrimitive.FaultYetAgain);
     }
 
     [Fact]
@@ -208,7 +208,7 @@ public class RetryTResultAsyncSpecs
             .RetryAsync();
 
         ResultClass result = await policy.RaiseResultSequenceAsync(new ResultClass(ResultPrimitive.Fault), new ResultClass(ResultPrimitive.Good));
-        result.ResultCode.Should().Be(ResultPrimitive.Good);
+        result.ResultCode.ShouldBe(ResultPrimitive.Good);
     }
 
     [Fact]
@@ -220,7 +220,7 @@ public class RetryTResultAsyncSpecs
             .RetryAsync();
 
         ResultClass result = await policy.RaiseResultSequenceAsync(new ResultClass(ResultPrimitive.FaultAgain), new ResultClass(ResultPrimitive.Good));
-        result.ResultCode.Should().Be(ResultPrimitive.Good);
+        result.ResultCode.ShouldBe(ResultPrimitive.Good);
     }
 
     [Fact]
@@ -234,10 +234,9 @@ public class RetryTResultAsyncSpecs
             .RetryAsync(3, (_, retryCount) => retryCounts.Add(retryCount));
 
         (await policy.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Fault, ResultPrimitive.Fault, ResultPrimitive.Good))
-            .Should().Be(ResultPrimitive.Good);
+            .ShouldBe(ResultPrimitive.Good);
 
-        retryCounts.Should()
-                   .ContainInOrder(expectedRetryCounts);
+        retryCounts.ShouldBe(expectedRetryCounts);
     }
 
     [Fact]
@@ -250,15 +249,13 @@ public class RetryTResultAsyncSpecs
             .HandleResult<ResultClass>(r => r.ResultCode == ResultPrimitive.Fault)
             .RetryAsync(3, (outcome, _) => retryFaults.Add(outcome.Result.SomeString));
 
-        IList<ResultClass> resultsToRaise = expectedFaults.Select(s => new ResultClass(ResultPrimitive.Fault, s)).ToList();
+        var resultsToRaise = expectedFaults.Select(s => new ResultClass(ResultPrimitive.Fault, s)).ToList();
         resultsToRaise.Add(new ResultClass(ResultPrimitive.Fault));
 
         (await policy.RaiseResultSequenceAsync(resultsToRaise))
-            .ResultCode.Should().Be(ResultPrimitive.Fault);
+            .ResultCode.ShouldBe(ResultPrimitive.Fault);
 
-        retryFaults
-            .Should()
-            .ContainInOrder(expectedFaults);
+        retryFaults.ShouldBe(expectedFaults);
     }
 
     [Fact]
@@ -271,10 +268,9 @@ public class RetryTResultAsyncSpecs
             .RetryAsync((_, retryCount) => retryCounts.Add(retryCount));
 
         (await policy.RaiseResultSequenceAsync(ResultPrimitive.Good))
-            .Should().Be(ResultPrimitive.Good);
+            .ShouldBe(ResultPrimitive.Good);
 
-        retryCounts.Should()
-            .BeEmpty();
+        retryCounts.ShouldBeEmpty();
     }
 
     [Fact]
@@ -289,11 +285,11 @@ public class RetryTResultAsyncSpecs
         (await policy.RaiseResultSequenceAsync(
             CreateDictionary("key1", "value1", "key2", "value2"),
             ResultPrimitive.Fault, ResultPrimitive.Good))
-            .Should().Be(ResultPrimitive.Good);
+            .ShouldBe(ResultPrimitive.Good);
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -309,19 +305,17 @@ public class RetryTResultAsyncSpecs
             CreateDictionary("key1", "value1", "key2", "value2"),
             ResultPrimitive.Fault, ResultPrimitive.Good);
 
-        result.Should().BeEquivalentTo(new
-        {
-            Outcome = OutcomeType.Successful,
-            FinalException = (Exception?)null,
-            ExceptionType = (ExceptionType?)null,
-            FaultType = (FaultType?)null,
-            FinalHandledResult = default(ResultPrimitive),
-            Result = ResultPrimitive.Good
-        });
+        result.ShouldNotBeNull();
+        result.Outcome.ShouldBe(OutcomeType.Successful);
+        result.FinalException.ShouldBeNull();
+        result.ExceptionType.ShouldBeNull();
+        result.FaultType.ShouldBeNull();
+        result.FinalHandledResult.ShouldBe(default);
+        result.Result.ShouldBe(ResultPrimitive.Good);
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -335,8 +329,8 @@ public class RetryTResultAsyncSpecs
 
         await policy.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Good);
 
-        capturedContext.Should()
-                       .BeEmpty();
+        capturedContext.ShouldNotBeNull();
+        capturedContext.ShouldBeEmpty();
     }
 
     [Fact]
@@ -352,13 +346,13 @@ public class RetryTResultAsyncSpecs
             CreateDictionary("key", "original_value"),
             ResultPrimitive.Fault, ResultPrimitive.Good);
 
-        contextValue.Should().Be("original_value");
+        contextValue.ShouldBe("original_value");
 
         await policy.RaiseResultSequenceAsync(
             CreateDictionary("key", "new_value"),
             ResultPrimitive.Fault, ResultPrimitive.Good);
 
-        contextValue.Should().Be("new_value");
+        contextValue.ShouldBe("new_value");
     }
 
     [Fact]
@@ -374,13 +368,13 @@ public class RetryTResultAsyncSpecs
             CreateDictionary("key", "original_value"),
             ResultPrimitive.Fault, ResultPrimitive.Good);
 
-        contextValue.Should().Be("original_value");
+        contextValue.ShouldBe("original_value");
 
         await policy.RaiseResultSequenceOnExecuteAndCaptureAsync(
             CreateDictionary("key", "new_value"),
             ResultPrimitive.Fault, ResultPrimitive.Good);
 
-        contextValue.Should().Be("new_value");
+        contextValue.ShouldBe("new_value");
     }
 
     [Fact]
@@ -390,9 +384,9 @@ public class RetryTResultAsyncSpecs
             .HandleResult(ResultPrimitive.Fault)
             .RetryAsync(1);
 
-        (await policy.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Good)).Should().Be(ResultPrimitive.Good);
+        (await policy.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Good)).ShouldBe(ResultPrimitive.Good);
 
-        (await policy.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Good)).Should().Be(ResultPrimitive.Good);
+        (await policy.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Good)).ShouldBe(ResultPrimitive.Good);
 
     }
 
@@ -407,9 +401,9 @@ public class RetryTResultAsyncSpecs
             .HandleResult(ResultPrimitive.Fault)
             .RetryAsync(0, onRetry);
 
-        (await policy.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Good)).Should().Be(ResultPrimitive.Fault);
+        (await policy.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Good)).ShouldBe(ResultPrimitive.Fault);
 
-        retryInvoked.Should().BeFalse();
+        retryInvoked.ShouldBeFalse();
     }
 
     [Fact]
@@ -425,9 +419,9 @@ public class RetryTResultAsyncSpecs
 
         (await policy.RaiseResultSequenceAsync(
             CreateDictionary("key", "value"),
-            ResultPrimitive.Fault, ResultPrimitive.Good)).Should().Be(ResultPrimitive.Fault);
+            ResultPrimitive.Fault, ResultPrimitive.Good)).ShouldBe(ResultPrimitive.Fault);
 
-        retryInvoked.Should().BeFalse();
+        retryInvoked.ShouldBeFalse();
     }
 
     #region Async and cancellation tests
@@ -441,7 +435,7 @@ public class RetryTResultAsyncSpecs
         // If Polly were to declare only an Action<...> delegate for onRetry - but users declared async () => { } onRetry delegates - the compiler would happily assign them to the Action<...>, but the next 'try' would/could occur before onRetry execution had completed.
         // This test ensures the relevant retry policy does have a Func<..., Task> form for onRetry, and that it is awaited before the next try commences.
 
-        TimeSpan shimTimeSpan = TimeSpan.FromSeconds(0.2); // Consider increasing shimTimeSpan if test fails transiently in different environments.
+        TimeSpan shimTimeSpan = TimeSpan.FromSeconds(0.2);
 
         int executeDelegateInvocations = 0;
         int executeDelegateInvocationsWhenOnRetryExits = 0;
@@ -459,15 +453,15 @@ public class RetryTResultAsyncSpecs
             executeDelegateInvocations++;
             await TaskHelper.EmptyTask;
             return ResultPrimitive.Fault;
-        })).Should().Be(ResultPrimitive.Fault);
+        })).ShouldBe(ResultPrimitive.Fault);
 
         while (executeDelegateInvocationsWhenOnRetryExits == 0)
         {
             // Wait for the onRetry delegate to complete.
         }
 
-        executeDelegateInvocationsWhenOnRetryExits.Should().Be(1); // If the async onRetry delegate is genuinely awaited, only one execution of the .Execute delegate should have occurred by the time onRetry completes.  If the async onRetry delegate were instead assigned to an Action<...>, then onRetry will return, and the second action execution will commence, before await Task.Delay() completes, leaving executeDelegateInvocationsWhenOnRetryExits == 2.
-        executeDelegateInvocations.Should().Be(2);
+        executeDelegateInvocationsWhenOnRetryExits.ShouldBe(1); // If the async onRetry delegate is genuinely awaited, only one execution of the .Execute delegate should have occurred by the time onRetry completes.  If the async onRetry delegate were instead assigned to an Action<...>, then onRetry will return, and the second action execution will commence, before await Task.Delay() completes, leaving executeDelegateInvocationsWhenOnRetryExits == 2.
+        executeDelegateInvocations.ShouldBe(2);
     }
 
     [Fact]
@@ -494,10 +488,10 @@ public class RetryTResultAsyncSpecs
                 ResultPrimitive.Fault,
                 ResultPrimitive.Fault,
                 ResultPrimitive.Good))
-                .Should().Be(ResultPrimitive.Good);
+                .ShouldBe(ResultPrimitive.Good);
         }
 
-        attemptsInvoked.Should().Be(1 + 3);
+        attemptsInvoked.ShouldBe(1 + 3);
     }
 
     [Fact]
@@ -520,16 +514,19 @@ public class RetryTResultAsyncSpecs
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             cancellationTokenSource.Cancel();
 
-            var ex = await policy.Awaiting(x => x.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute,
-                   ResultPrimitive.Fault,
-                   ResultPrimitive.Fault,
-                   ResultPrimitive.Fault,
-                   ResultPrimitive.Good))
-                .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(
+                () => policy.RaiseResultSequenceAndOrCancellationAsync(
+                    scenario,
+                    cancellationTokenSource,
+                    onExecute,
+                    ResultPrimitive.Fault,
+                    ResultPrimitive.Fault,
+                    ResultPrimitive.Fault,
+                    ResultPrimitive.Good));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(0);
+        attemptsInvoked.ShouldBe(0);
     }
 
     [Fact]
@@ -552,16 +549,19 @@ public class RetryTResultAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await policy.Awaiting(x => x.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute,
-               ResultPrimitive.Good,
-               ResultPrimitive.Good,
-               ResultPrimitive.Good,
-               ResultPrimitive.Good))
-            .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(
+                () => policy.RaiseResultSequenceAndOrCancellationAsync(
+                    scenario,
+                    cancellationTokenSource,
+                    onExecute,
+                    ResultPrimitive.Good,
+                    ResultPrimitive.Good,
+                    ResultPrimitive.Good,
+                    ResultPrimitive.Good));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -584,16 +584,19 @@ public class RetryTResultAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await policy.Awaiting(x => x.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Good))
-            .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(
+                () => policy.RaiseResultSequenceAndOrCancellationAsync(
+                    scenario,
+                    cancellationTokenSource,
+                    onExecute,
+                    ResultPrimitive.Fault,
+                    ResultPrimitive.Fault,
+                    ResultPrimitive.Fault,
+                    ResultPrimitive.Good));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -616,16 +619,19 @@ public class RetryTResultAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await policy.Awaiting(x => x.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Good))
-            .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(
+                () => policy.RaiseResultSequenceAndOrCancellationAsync(
+                    scenario,
+                    cancellationTokenSource,
+                    onExecute,
+                    ResultPrimitive.Fault,
+                    ResultPrimitive.Fault,
+                    ResultPrimitive.Fault,
+                    ResultPrimitive.Good));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -648,16 +654,19 @@ public class RetryTResultAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await policy.Awaiting(x => x.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Good))
-            .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(
+                () => policy.RaiseResultSequenceAndOrCancellationAsync(
+                    scenario,
+                    cancellationTokenSource,
+                    onExecute,
+                    ResultPrimitive.Fault,
+                    ResultPrimitive.Fault,
+                    ResultPrimitive.Fault,
+                    ResultPrimitive.Good));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(2);
+        attemptsInvoked.ShouldBe(2);
     }
 
     [Fact]
@@ -680,16 +689,19 @@ public class RetryTResultAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await policy.Awaiting(x => x.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Good))
-            .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(
+                () => policy.RaiseResultSequenceAndOrCancellationAsync(
+                    scenario,
+                    cancellationTokenSource,
+                    onExecute,
+                    ResultPrimitive.Fault,
+                    ResultPrimitive.Fault,
+                    ResultPrimitive.Fault,
+                    ResultPrimitive.Good));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(2);
+        attemptsInvoked.ShouldBe(2);
     }
 
     [Fact]
@@ -712,17 +724,20 @@ public class RetryTResultAsyncSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await policy.Awaiting(x => x.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Good))
-            .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(
+                () => policy.RaiseResultSequenceAndOrCancellationAsync(
+                    scenario,
+                    cancellationTokenSource,
+                    onExecute,
+                    ResultPrimitive.Fault,
+                    ResultPrimitive.Fault,
+                    ResultPrimitive.Fault,
+                    ResultPrimitive.Fault,
+                    ResultPrimitive.Good));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1 + 3);
+        attemptsInvoked.ShouldBe(1 + 3);
     }
 
     [Fact]
@@ -751,10 +766,10 @@ public class RetryTResultAsyncSpecs
                ResultPrimitive.Fault,
                ResultPrimitive.Fault,
                ResultPrimitive.Good))
-           .Should().Be(ResultPrimitive.Fault);
+           .ShouldBe(ResultPrimitive.Fault);
         }
 
-        attemptsInvoked.Should().Be(1 + 3);
+        attemptsInvoked.ShouldBe(1 + 3);
     }
 
     [Fact]
@@ -780,16 +795,19 @@ public class RetryTResultAsyncSpecs
                     cancellationTokenSource.Cancel();
                 });
 
-            var ex = await policy.Awaiting(x => x.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute,
-                   ResultPrimitive.Fault,
-                   ResultPrimitive.Fault,
-                   ResultPrimitive.Fault,
-                   ResultPrimitive.Good))
-                .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(
+                () => policy.RaiseResultSequenceAndOrCancellationAsync(
+                    scenario,
+                    cancellationTokenSource,
+                    onExecute,
+                    ResultPrimitive.Fault,
+                    ResultPrimitive.Fault,
+                    ResultPrimitive.Fault,
+                    ResultPrimitive.Good));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     #endregion

--- a/test/Polly.Specs/Retry/RetryTResultMixedResultExceptionSpecs.cs
+++ b/test/Polly.Specs/Retry/RetryTResultMixedResultExceptionSpecs.cs
@@ -9,7 +9,7 @@ public class RetryTResultMixedResultExceptionSpecs
             .Handle<DivideByZeroException>().Retry(1);
 
         ResultPrimitive result = policy.RaiseResultAndOrExceptionSequence(new DivideByZeroException(), ResultPrimitive.Good);
-        result.Should().Be(ResultPrimitive.Good);
+        result.ShouldBe(ResultPrimitive.Good);
     }
 
     [Fact]
@@ -18,8 +18,7 @@ public class RetryTResultMixedResultExceptionSpecs
         Policy<ResultPrimitive> policy = Policy<ResultPrimitive>
             .Handle<DivideByZeroException>().Retry(1);
 
-        policy.Invoking(p => p.RaiseResultAndOrExceptionSequence(new ArgumentException(), ResultPrimitive.Good))
-            .Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => policy.RaiseResultAndOrExceptionSequence(new ArgumentException(), ResultPrimitive.Good));
     }
 
     [Fact]
@@ -31,7 +30,7 @@ public class RetryTResultMixedResultExceptionSpecs
             .Retry(2);
 
         ResultPrimitive result = policy.RaiseResultAndOrExceptionSequence(ResultPrimitive.Fault, new DivideByZeroException(), ResultPrimitive.Good);
-        result.Should().Be(ResultPrimitive.Good);
+        result.ShouldBe(ResultPrimitive.Good);
     }
 
     [Fact]
@@ -43,7 +42,7 @@ public class RetryTResultMixedResultExceptionSpecs
             .Retry(2);
 
         ResultPrimitive result = policy.RaiseResultAndOrExceptionSequence(ResultPrimitive.Fault, new DivideByZeroException(), ResultPrimitive.Good);
-        result.Should().Be(ResultPrimitive.Good);
+        result.ShouldBe(ResultPrimitive.Good);
     }
 
     [Fact]
@@ -57,7 +56,7 @@ public class RetryTResultMixedResultExceptionSpecs
             .Retry(4);
 
         ResultPrimitive result = policy.RaiseResultAndOrExceptionSequence(ResultPrimitive.Fault, new DivideByZeroException(), new ArgumentException(), ResultPrimitive.FaultAgain, ResultPrimitive.Good);
-        result.Should().Be(ResultPrimitive.Good);
+        result.ShouldBe(ResultPrimitive.Good);
     }
 
     [Fact]
@@ -71,7 +70,7 @@ public class RetryTResultMixedResultExceptionSpecs
             .Retry(4);
 
         ResultPrimitive result = policy.RaiseResultAndOrExceptionSequence(ResultPrimitive.Fault, new DivideByZeroException(), new ArgumentException(), ResultPrimitive.FaultAgain, ResultPrimitive.Good);
-        result.Should().Be(ResultPrimitive.Good);
+        result.ShouldBe(ResultPrimitive.Good);
     }
 
     [Fact]
@@ -85,7 +84,7 @@ public class RetryTResultMixedResultExceptionSpecs
             .Retry(3);
 
         ResultPrimitive result = policy.RaiseResultAndOrExceptionSequence(ResultPrimitive.Fault, new DivideByZeroException(), new ArgumentException(), ResultPrimitive.FaultAgain, ResultPrimitive.Good);
-        result.Should().Be(ResultPrimitive.FaultAgain);
+        result.ShouldBe(ResultPrimitive.FaultAgain);
     }
 
     [Fact]
@@ -98,8 +97,7 @@ public class RetryTResultMixedResultExceptionSpecs
             .Or<ArgumentException>()
             .Retry(3);
 
-        policy.Invoking(p => p.RaiseResultAndOrExceptionSequence(ResultPrimitive.Fault, new DivideByZeroException(), ResultPrimitive.FaultAgain, new ArgumentException(), ResultPrimitive.Good))
-            .Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => policy.RaiseResultAndOrExceptionSequence(ResultPrimitive.Fault, new DivideByZeroException(), ResultPrimitive.FaultAgain, new ArgumentException(), ResultPrimitive.Good));
     }
 
     [Fact]
@@ -113,7 +111,7 @@ public class RetryTResultMixedResultExceptionSpecs
             .Retry(3);
 
         ResultPrimitive result = policy.RaiseResultAndOrExceptionSequence(ResultPrimitive.Fault, new DivideByZeroException(), new ArgumentException(), ResultPrimitive.FaultAgain, ResultPrimitive.Good);
-        result.Should().Be(ResultPrimitive.FaultAgain);
+        result.ShouldBe(ResultPrimitive.FaultAgain);
     }
 
     [Fact]
@@ -126,8 +124,7 @@ public class RetryTResultMixedResultExceptionSpecs
             .OrResult(ResultPrimitive.FaultAgain)
             .Retry(3);
 
-        policy.Invoking(p => p.RaiseResultAndOrExceptionSequence(ResultPrimitive.Fault, new DivideByZeroException(), ResultPrimitive.FaultAgain, new ArgumentException(), ResultPrimitive.Good))
-            .Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => policy.RaiseResultAndOrExceptionSequence(ResultPrimitive.Fault, new DivideByZeroException(), ResultPrimitive.FaultAgain, new ArgumentException(), ResultPrimitive.Good));
     }
 
     [Fact]
@@ -139,7 +136,7 @@ public class RetryTResultMixedResultExceptionSpecs
             .Retry(2);
 
         ResultPrimitive result = policy.RaiseResultSequence(ResultPrimitive.FaultAgain);
-        result.Should().Be(ResultPrimitive.FaultAgain);
+        result.ShouldBe(ResultPrimitive.FaultAgain);
     }
 
     [Fact]
@@ -150,8 +147,7 @@ public class RetryTResultMixedResultExceptionSpecs
             .OrResult(ResultPrimitive.Fault)
             .Retry(2);
 
-        policy.Invoking(p => p.RaiseResultAndOrExceptionSequence(new ArgumentException(), ResultPrimitive.Good))
-            .Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => policy.RaiseResultAndOrExceptionSequence(new ArgumentException(), ResultPrimitive.Good));
     }
 
     [Fact]
@@ -163,7 +159,7 @@ public class RetryTResultMixedResultExceptionSpecs
             .Retry(2);
 
         ResultClass result = policy.RaiseResultAndOrExceptionSequence(new ResultClass(ResultPrimitive.Fault), new ArgumentException("message", "key"), new ResultClass(ResultPrimitive.Good));
-        result.ResultCode.Should().Be(ResultPrimitive.Good);
+        result.ResultCode.ShouldBe(ResultPrimitive.Good);
     }
 
     [Fact]
@@ -174,8 +170,7 @@ public class RetryTResultMixedResultExceptionSpecs
             .OrResult<ResultClass>(r => r.ResultCode == ResultPrimitive.Fault)
             .Retry(2);
 
-        policy.Invoking(p => p.RaiseResultAndOrExceptionSequence(new ResultClass(ResultPrimitive.Fault), new ArgumentException("message", "value"), new ResultClass(ResultPrimitive.Good)))
-            .Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => policy.RaiseResultAndOrExceptionSequence(new ResultClass(ResultPrimitive.Fault), new ArgumentException("message", "value"), new ResultClass(ResultPrimitive.Good)));
     }
 
     [Fact]
@@ -187,6 +182,6 @@ public class RetryTResultMixedResultExceptionSpecs
             .Retry(2);
 
         ResultClass result = policy.RaiseResultAndOrExceptionSequence(new ArgumentException("message", "key"), new ResultClass(ResultPrimitive.FaultAgain), new ResultClass(ResultPrimitive.Good));
-        result.ResultCode.Should().Be(ResultPrimitive.FaultAgain);
+        result.ResultCode.ShouldBe(ResultPrimitive.FaultAgain);
     }
 }

--- a/test/Polly.Specs/Retry/RetryTResultSpecs.cs
+++ b/test/Polly.Specs/Retry/RetryTResultSpecs.cs
@@ -27,10 +27,10 @@ public class RetryTResultSpecs
 
         var func = () => methodInfo.Invoke(instance, [action, new Context(), CancellationToken.None]);
 
-        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("action");
+        var exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>()
+            .ParamName.ShouldBe("action");
     }
 
     [Fact]
@@ -42,8 +42,8 @@ public class RetryTResultSpecs
                                   .HandleResult(ResultPrimitive.Fault)
                                   .Retry(-1, onRetry);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-              .ParamName.Should().Be("retryCount");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+              .ParamName.ShouldBe("retryCount");
     }
 
     [Fact]
@@ -55,8 +55,8 @@ public class RetryTResultSpecs
                                   .HandleResult(ResultPrimitive.Fault)
                                   .Retry(1, nullOnRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("onRetry");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]
@@ -68,8 +68,8 @@ public class RetryTResultSpecs
                                   .HandleResult(ResultPrimitive.Fault)
                                   .Retry(-1, onRetry);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-              .ParamName.Should().Be("retryCount");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+              .ParamName.ShouldBe("retryCount");
     }
 
     [Fact]
@@ -81,8 +81,8 @@ public class RetryTResultSpecs
                                   .HandleResult(ResultPrimitive.Fault)
                                   .Retry(1, nullOnRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("onRetry");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]
@@ -93,7 +93,7 @@ public class RetryTResultSpecs
             .Retry(3);
 
         ResultPrimitive result = policy.RaiseResultSequence(ResultPrimitive.Fault, ResultPrimitive.Fault, ResultPrimitive.Fault, ResultPrimitive.Good);
-        result.Should().Be(ResultPrimitive.Good);
+        result.ShouldBe(ResultPrimitive.Good);
     }
 
     [Fact]
@@ -105,7 +105,7 @@ public class RetryTResultSpecs
             .Retry(3);
 
         ResultPrimitive result = policy.RaiseResultSequence(ResultPrimitive.Fault, ResultPrimitive.FaultAgain, ResultPrimitive.Fault, ResultPrimitive.Good);
-        result.Should().Be(ResultPrimitive.Good);
+        result.ShouldBe(ResultPrimitive.Good);
     }
 
     [Fact]
@@ -116,7 +116,7 @@ public class RetryTResultSpecs
             .Retry(3);
 
         ResultPrimitive result = policy.RaiseResultSequence(ResultPrimitive.Fault, ResultPrimitive.Good);
-        result.Should().Be(ResultPrimitive.Good);
+        result.ShouldBe(ResultPrimitive.Good);
     }
 
     [Fact]
@@ -128,7 +128,7 @@ public class RetryTResultSpecs
             .Retry(3);
 
         ResultPrimitive result = policy.RaiseResultSequence(ResultPrimitive.Fault, ResultPrimitive.FaultAgain, ResultPrimitive.Good);
-        result.Should().Be(ResultPrimitive.Good);
+        result.ShouldBe(ResultPrimitive.Good);
     }
 
     [Fact]
@@ -139,7 +139,7 @@ public class RetryTResultSpecs
             .Retry(3);
 
         ResultPrimitive result = policy.RaiseResultSequence(ResultPrimitive.Fault, ResultPrimitive.Fault, ResultPrimitive.Fault, ResultPrimitive.Fault, ResultPrimitive.Good);
-        result.Should().Be(ResultPrimitive.Fault); // It should give up retrying after 3 retries and return the last failure, so should return Fault, not Good.
+        result.ShouldBe(ResultPrimitive.Fault); // It should give up retrying after 3 retries and return the last failure, so should return Fault, not Good.
     }
 
     [Fact]
@@ -151,7 +151,7 @@ public class RetryTResultSpecs
             .Retry(3);
 
         ResultPrimitive result = policy.RaiseResultSequence(ResultPrimitive.FaultAgain, ResultPrimitive.FaultAgain, ResultPrimitive.FaultAgain, ResultPrimitive.FaultAgain, ResultPrimitive.Good);
-        result.Should().Be(ResultPrimitive.FaultAgain);
+        result.ShouldBe(ResultPrimitive.FaultAgain);
     }
 
     [Fact]
@@ -162,7 +162,7 @@ public class RetryTResultSpecs
             .Retry();
 
         ResultPrimitive result = policy.RaiseResultSequence(ResultPrimitive.FaultAgain, ResultPrimitive.Good);
-        result.Should().Be(ResultPrimitive.FaultAgain);
+        result.ShouldBe(ResultPrimitive.FaultAgain);
     }
 
     [Fact]
@@ -174,7 +174,7 @@ public class RetryTResultSpecs
             .Retry();
 
         ResultPrimitive result = policy.RaiseResultSequence(ResultPrimitive.FaultYetAgain, ResultPrimitive.Good);
-        result.Should().Be(ResultPrimitive.FaultYetAgain);
+        result.ShouldBe(ResultPrimitive.FaultYetAgain);
     }
 
     [Fact]
@@ -185,7 +185,7 @@ public class RetryTResultSpecs
             .Retry();
 
         ResultClass result = policy.RaiseResultSequence(new ResultClass(ResultPrimitive.FaultAgain), new ResultClass(ResultPrimitive.Good));
-        result.ResultCode.Should().Be(ResultPrimitive.FaultAgain);
+        result.ResultCode.ShouldBe(ResultPrimitive.FaultAgain);
     }
 
     [Fact]
@@ -197,7 +197,7 @@ public class RetryTResultSpecs
             .Retry();
 
         ResultClass result = policy.RaiseResultSequence(new ResultClass(ResultPrimitive.FaultYetAgain), new ResultClass(ResultPrimitive.Good));
-        result.ResultCode.Should().Be(ResultPrimitive.FaultYetAgain);
+        result.ResultCode.ShouldBe(ResultPrimitive.FaultYetAgain);
     }
 
     [Fact]
@@ -208,7 +208,7 @@ public class RetryTResultSpecs
             .Retry();
 
         ResultClass result = policy.RaiseResultSequence(new ResultClass(ResultPrimitive.Fault), new ResultClass(ResultPrimitive.Good));
-        result.ResultCode.Should().Be(ResultPrimitive.Good);
+        result.ResultCode.ShouldBe(ResultPrimitive.Good);
     }
 
     [Fact]
@@ -220,7 +220,7 @@ public class RetryTResultSpecs
             .Retry();
 
         ResultClass result = policy.RaiseResultSequence(new ResultClass(ResultPrimitive.FaultAgain), new ResultClass(ResultPrimitive.Good));
-        result.ResultCode.Should().Be(ResultPrimitive.Good);
+        result.ResultCode.ShouldBe(ResultPrimitive.Good);
     }
 
     [Fact]
@@ -235,8 +235,7 @@ public class RetryTResultSpecs
 
         policy.RaiseResultSequence(ResultPrimitive.Fault, ResultPrimitive.Fault, ResultPrimitive.Fault, ResultPrimitive.Good);
 
-        retryCounts.Should()
-                   .ContainInOrder(expectedRetryCounts);
+        retryCounts.ShouldBe(expectedRetryCounts);
     }
 
     [Fact]
@@ -249,14 +248,12 @@ public class RetryTResultSpecs
             .HandleResult<ResultClass>(r => r.ResultCode == ResultPrimitive.Fault)
             .Retry(3, (outcome, _) => retryFaults.Add(outcome.Result.SomeString));
 
-        IList<ResultClass> resultsToRaise = expectedFaults.Select(s => new ResultClass(ResultPrimitive.Fault, s)).ToList();
+        var resultsToRaise = expectedFaults.Select(s => new ResultClass(ResultPrimitive.Fault, s)).ToList();
         resultsToRaise.Add(new ResultClass(ResultPrimitive.Fault));
 
         policy.RaiseResultSequence(resultsToRaise);
 
-        retryFaults
-            .Should()
-            .ContainInOrder(expectedFaults);
+        retryFaults.ShouldBe(expectedFaults);
     }
 
     [Fact]
@@ -270,8 +267,7 @@ public class RetryTResultSpecs
 
         policy.RaiseResultSequence(ResultPrimitive.Good);
 
-        retryCounts.Should()
-            .BeEmpty();
+        retryCounts.ShouldBeEmpty();
     }
 
     [Fact]
@@ -286,11 +282,11 @@ public class RetryTResultSpecs
         policy.RaiseResultSequence(
             CreateDictionary("key1", "value1", "key2", "value2"),
             ResultPrimitive.Fault, ResultPrimitive.Good)
-            .Should().Be(ResultPrimitive.Good);
+            .ShouldBe(ResultPrimitive.Good);
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -306,19 +302,17 @@ public class RetryTResultSpecs
             CreateDictionary("key1", "value1", "key2", "value2"),
             ResultPrimitive.Fault, ResultPrimitive.Good);
 
-        result.Should().BeEquivalentTo(new
-        {
-            Outcome = OutcomeType.Successful,
-            FinalException = (Exception?)null,
-            ExceptionType = (ExceptionType?)null,
-            FaultType = (FaultType?)null,
-            FinalHandledResult = default(ResultPrimitive),
-            Result = ResultPrimitive.Good
-        });
+        result.ShouldNotBeNull();
+        result.Outcome.ShouldBe(OutcomeType.Successful);
+        result.FinalException.ShouldBeNull();
+        result.ExceptionType.ShouldBeNull();
+        result.FaultType.ShouldBeNull();
+        result.FinalHandledResult.ShouldBe(default);
+        result.Result.ShouldBe(ResultPrimitive.Good);
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -332,8 +326,7 @@ public class RetryTResultSpecs
 
         policy.RaiseResultSequence(ResultPrimitive.Fault, ResultPrimitive.Good);
 
-        capturedContext.Should()
-                       .BeEmpty();
+        capturedContext.ShouldBeEmpty();
     }
 
     [Fact]
@@ -349,13 +342,13 @@ public class RetryTResultSpecs
             CreateDictionary("key", "original_value"),
             ResultPrimitive.Fault, ResultPrimitive.Good);
 
-        contextValue.Should().Be("original_value");
+        contextValue.ShouldBe("original_value");
 
         policy.RaiseResultSequence(
             CreateDictionary("key", "new_value"),
             ResultPrimitive.Fault, ResultPrimitive.Good);
 
-        contextValue.Should().Be("new_value");
+        contextValue.ShouldBe("new_value");
     }
 
     [Fact]
@@ -371,13 +364,13 @@ public class RetryTResultSpecs
             CreateDictionary("key", "original_value"),
             ResultPrimitive.Fault, ResultPrimitive.Good);
 
-        contextValue.Should().Be("original_value");
+        contextValue.ShouldBe("original_value");
 
         policy.RaiseResultSequenceOnExecuteAndCapture(
             CreateDictionary("key", "new_value"),
             ResultPrimitive.Fault, ResultPrimitive.Good);
 
-        contextValue.Should().Be("new_value");
+        contextValue.ShouldBe("new_value");
     }
 
     [Fact]
@@ -387,9 +380,9 @@ public class RetryTResultSpecs
             .HandleResult(ResultPrimitive.Fault)
             .Retry(1);
 
-        policy.RaiseResultSequence(ResultPrimitive.Fault, ResultPrimitive.Good).Should().Be(ResultPrimitive.Good);
+        policy.RaiseResultSequence(ResultPrimitive.Fault, ResultPrimitive.Good).ShouldBe(ResultPrimitive.Good);
 
-        policy.RaiseResultSequence(ResultPrimitive.Fault, ResultPrimitive.Good).Should().Be(ResultPrimitive.Good);
+        policy.RaiseResultSequence(ResultPrimitive.Fault, ResultPrimitive.Good).ShouldBe(ResultPrimitive.Good);
 
     }
 
@@ -404,9 +397,9 @@ public class RetryTResultSpecs
             .HandleResult(ResultPrimitive.Fault)
             .Retry(0, onRetry);
 
-        policy.RaiseResultSequence(ResultPrimitive.Fault, ResultPrimitive.Good).Should().Be(ResultPrimitive.Fault);
+        policy.RaiseResultSequence(ResultPrimitive.Fault, ResultPrimitive.Good).ShouldBe(ResultPrimitive.Fault);
 
-        retryInvoked.Should().BeFalse();
+        retryInvoked.ShouldBeFalse();
     }
 
     [Fact]
@@ -422,9 +415,9 @@ public class RetryTResultSpecs
 
         policy.RaiseResultSequence(
             CreateDictionary("key", "value"),
-            ResultPrimitive.Fault, ResultPrimitive.Good).Should().Be(ResultPrimitive.Fault);
+            ResultPrimitive.Fault, ResultPrimitive.Good).ShouldBe(ResultPrimitive.Fault);
 
-        retryInvoked.Should().BeFalse();
+        retryInvoked.ShouldBeFalse();
     }
 
     #region Sync cancellation tests
@@ -449,10 +442,10 @@ public class RetryTResultSpecs
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
             policy.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute, ResultPrimitive.Good)
-            .Should().Be(ResultPrimitive.Good);
+            .ShouldBe(ResultPrimitive.Good);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -479,10 +472,10 @@ public class RetryTResultSpecs
                 ResultPrimitive.Fault,
                 ResultPrimitive.Fault,
                 ResultPrimitive.Good)
-                .Should().Be(ResultPrimitive.Good);
+                .ShouldBe(ResultPrimitive.Good);
         }
 
-        attemptsInvoked.Should().Be(1 + 3);
+        attemptsInvoked.ShouldBe(1 + 3);
     }
 
     [Fact]
@@ -505,16 +498,20 @@ public class RetryTResultSpecs
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             cancellationTokenSource.Cancel();
 
-            policy.Invoking(x => x.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute,
-                   ResultPrimitive.Fault,
-                   ResultPrimitive.Fault,
-                   ResultPrimitive.Fault,
-                   ResultPrimitive.Good))
-                .Should().Throw<OperationCanceledException>()
-                .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(
+                () =>
+                    policy.RaiseResultSequenceAndOrCancellation(
+                        scenario,
+                        cancellationTokenSource,
+                        onExecute,
+                       ResultPrimitive.Fault,
+                       ResultPrimitive.Fault,
+                       ResultPrimitive.Fault,
+                       ResultPrimitive.Good))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(0);
+        attemptsInvoked.ShouldBe(0);
     }
 
     [Fact]
@@ -537,16 +534,20 @@ public class RetryTResultSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            policy.Invoking(x => x.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute,
-               ResultPrimitive.Good,
-               ResultPrimitive.Good,
-               ResultPrimitive.Good,
-               ResultPrimitive.Good))
-            .Should().Throw<OperationCanceledException>()
-            .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(
+                () =>
+                    policy.RaiseResultSequenceAndOrCancellation(
+                        scenario,
+                        cancellationTokenSource,
+                        onExecute,
+                        ResultPrimitive.Good,
+                        ResultPrimitive.Good,
+                        ResultPrimitive.Good,
+                        ResultPrimitive.Good))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -569,16 +570,20 @@ public class RetryTResultSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            policy.Invoking(x => x.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Good))
-            .Should().Throw<OperationCanceledException>()
-            .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(
+                () =>
+                    policy.RaiseResultSequenceAndOrCancellation(
+                        scenario,
+                        cancellationTokenSource,
+                        onExecute,
+                        ResultPrimitive.Fault,
+                        ResultPrimitive.Fault,
+                        ResultPrimitive.Fault,
+                        ResultPrimitive.Good))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -601,16 +606,20 @@ public class RetryTResultSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            policy.Invoking(x => x.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Good))
-            .Should().Throw<OperationCanceledException>()
-            .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(
+                () =>
+                    policy.RaiseResultSequenceAndOrCancellation(
+                        scenario,
+                        cancellationTokenSource,
+                        onExecute,
+                        ResultPrimitive.Fault,
+                        ResultPrimitive.Fault,
+                        ResultPrimitive.Fault,
+                        ResultPrimitive.Good))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -633,16 +642,20 @@ public class RetryTResultSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            policy.Invoking(x => x.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Good))
-            .Should().Throw<OperationCanceledException>()
-            .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(
+                () =>
+                    policy.RaiseResultSequenceAndOrCancellation(
+                        scenario,
+                        cancellationTokenSource,
+                        onExecute,
+                        ResultPrimitive.Fault,
+                        ResultPrimitive.Fault,
+                        ResultPrimitive.Fault,
+                        ResultPrimitive.Good))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(2);
+        attemptsInvoked.ShouldBe(2);
     }
 
     [Fact]
@@ -665,16 +678,20 @@ public class RetryTResultSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            policy.Invoking(x => x.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Good))
-            .Should().Throw<OperationCanceledException>()
-            .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(
+                () =>
+                    policy.RaiseResultSequenceAndOrCancellation(
+                        scenario,
+                        cancellationTokenSource,
+                        onExecute,
+                        ResultPrimitive.Fault,
+                        ResultPrimitive.Fault,
+                        ResultPrimitive.Fault,
+                        ResultPrimitive.Good))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(2);
+        attemptsInvoked.ShouldBe(2);
     }
 
     [Fact]
@@ -697,17 +714,21 @@ public class RetryTResultSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            policy.Invoking(x => x.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Good))
-            .Should().Throw<OperationCanceledException>()
-            .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(
+                () =>
+                    policy.RaiseResultSequenceAndOrCancellation(
+                        scenario,
+                        cancellationTokenSource,
+                        onExecute,
+                        ResultPrimitive.Fault,
+                        ResultPrimitive.Fault,
+                        ResultPrimitive.Fault,
+                        ResultPrimitive.Fault,
+                        ResultPrimitive.Good))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1 + 3);
+        attemptsInvoked.ShouldBe(1 + 3);
     }
 
     [Fact]
@@ -730,16 +751,19 @@ public class RetryTResultSpecs
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            policy.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Fault,
-               ResultPrimitive.Good)
-           .Should().Be(ResultPrimitive.Fault);
+            policy.RaiseResultSequenceAndOrCancellation(
+                scenario,
+                cancellationTokenSource,
+                onExecute,
+                ResultPrimitive.Fault,
+                ResultPrimitive.Fault,
+                ResultPrimitive.Fault,
+                ResultPrimitive.Fault,
+                ResultPrimitive.Good)
+            .ShouldBe(ResultPrimitive.Fault);
         }
 
-        attemptsInvoked.Should().Be(1 + 3);
+        attemptsInvoked.ShouldBe(1 + 3);
     }
 
     [Fact]
@@ -765,16 +789,20 @@ public class RetryTResultSpecs
                cancellationTokenSource.Cancel();
            });
 
-            policy.Invoking(x => x.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute,
-                   ResultPrimitive.Fault,
-                   ResultPrimitive.Fault,
-                   ResultPrimitive.Fault,
-                   ResultPrimitive.Good))
-                .Should().Throw<OperationCanceledException>()
-                .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(
+                () =>
+                    policy.RaiseResultSequenceAndOrCancellation(
+                        scenario,
+                        cancellationTokenSource,
+                        onExecute,
+                        ResultPrimitive.Fault,
+                        ResultPrimitive.Fault,
+                        ResultPrimitive.Fault,
+                        ResultPrimitive.Good))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     #endregion

--- a/test/Polly.Specs/Retry/WaitAndRetryAsyncSpecs.cs
+++ b/test/Polly.Specs/Retry/WaitAndRetryAsyncSpecs.cs
@@ -16,8 +16,8 @@ public class WaitAndRetryAsyncSpecs : IDisposable
                                   .Handle<DivideByZeroException>()
                                   .WaitAndRetryAsync(null, onRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("sleepDurations");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("sleepDurations");
     }
 
     [Fact]
@@ -27,10 +27,10 @@ public class WaitAndRetryAsyncSpecs : IDisposable
 
         Action policy = () => Policy
                                   .Handle<DivideByZeroException>()
-                                  .WaitAndRetryAsync(Enumerable.Empty<TimeSpan>(), nullOnRetry);
+                                  .WaitAndRetryAsync([], nullOnRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("onRetry");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]
@@ -38,10 +38,10 @@ public class WaitAndRetryAsyncSpecs : IDisposable
     {
         Action policy = () => Policy
                                   .Handle<DivideByZeroException>()
-                                  .WaitAndRetryAsync(Enumerable.Empty<TimeSpan>(), default(Action<Exception, TimeSpan, Context>));
+                                  .WaitAndRetryAsync([], default(Action<Exception, TimeSpan, Context>));
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("onRetry");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]
@@ -53,8 +53,8 @@ public class WaitAndRetryAsyncSpecs : IDisposable
                                   .Handle<DivideByZeroException>()
                                   .WaitAndRetryAsync(3, provider, default(Action<Exception, TimeSpan, int, Context>));
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("onRetry");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]
@@ -62,36 +62,36 @@ public class WaitAndRetryAsyncSpecs : IDisposable
     {
         Action policy = () => Policy
                                   .Handle<DivideByZeroException>()
-                                  .WaitAndRetryAsync(Enumerable.Empty<TimeSpan>(), default(Action<Exception, TimeSpan, int, Context>));
+                                  .WaitAndRetryAsync([], default(Action<Exception, TimeSpan, int, Context>));
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("onRetry");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]
     public void Should_throw_when_onretry_exception_timespan_context_is_null_with_sleep_duration_provider()
     {
-        Func<int, Context, TimeSpan> provider = (_, _) => 1.Seconds();
+        Func<int, Context, TimeSpan> provider = (_, _) => TimeSpan.FromSeconds(1);
 
         Action policy = () => Policy
                                   .Handle<DivideByZeroException>()
                                   .WaitAndRetryAsync(3, provider, default(Action<Exception, TimeSpan, Context>));
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("onRetry");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]
     public void Should_throw_when_onretry_exception_timespan_int_context_is_null_with_sleep_duration_provider()
     {
-        Func<int, Context, TimeSpan> provider = (_, _) => 1.Seconds();
+        Func<int, Context, TimeSpan> provider = (_, _) => TimeSpan.FromSeconds(1);
 
         Action policy = () => Policy
                                   .Handle<DivideByZeroException>()
                                   .WaitAndRetryAsync(3, provider, default(Action<Exception, TimeSpan, int, Context>));
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("onRetry");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]
@@ -99,15 +99,14 @@ public class WaitAndRetryAsyncSpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync(new[]
-            {
-               1.Seconds(),
-               2.Seconds(),
-               3.Seconds()
-            });
+            .WaitAndRetryAsync(
+            [
+               TimeSpan.FromSeconds(1),
+               TimeSpan.FromSeconds(2),
+               TimeSpan.FromSeconds(3)
+            ]);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>(3))
-              .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<DivideByZeroException>(3));
     }
 
     [Fact]
@@ -116,15 +115,14 @@ public class WaitAndRetryAsyncSpecs : IDisposable
         var policy = Policy
             .Handle<DivideByZeroException>()
             .Or<ArgumentException>()
-            .WaitAndRetryAsync(new[]
-            {
-               1.Seconds(),
-               2.Seconds(),
-               3.Seconds()
-            });
+            .WaitAndRetryAsync(
+            [
+               TimeSpan.FromSeconds(1),
+               TimeSpan.FromSeconds(2),
+               TimeSpan.FromSeconds(3)
+            ]);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<ArgumentException>(3))
-              .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<ArgumentException>(3));
     }
 
     [Fact]
@@ -132,15 +130,14 @@ public class WaitAndRetryAsyncSpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync(new[]
-            {
-               1.Seconds(),
-               2.Seconds(),
-               3.Seconds()
-            });
+            .WaitAndRetryAsync(
+            [
+               TimeSpan.FromSeconds(1),
+               TimeSpan.FromSeconds(2),
+               TimeSpan.FromSeconds(3)
+            ]);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>(2))
-              .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<DivideByZeroException>(2));
     }
 
     [Fact]
@@ -149,15 +146,14 @@ public class WaitAndRetryAsyncSpecs : IDisposable
         var policy = Policy
             .Handle<DivideByZeroException>()
             .Or<ArgumentException>()
-            .WaitAndRetryAsync(new[]
-            {
-               1.Seconds(),
-               2.Seconds(),
-               3.Seconds()
-            });
+            .WaitAndRetryAsync(
+            [
+               TimeSpan.FromSeconds(1),
+               TimeSpan.FromSeconds(2),
+               TimeSpan.FromSeconds(3)
+            ]);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<ArgumentException>(2))
-              .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<ArgumentException>(2));
     }
 
     [Fact]
@@ -165,15 +161,14 @@ public class WaitAndRetryAsyncSpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync(new[]
-            {
-               1.Seconds(),
-               2.Seconds(),
-               3.Seconds()
-            });
+            .WaitAndRetryAsync(
+            [
+               TimeSpan.FromSeconds(1),
+               TimeSpan.FromSeconds(2),
+               TimeSpan.FromSeconds(3)
+            ]);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>(3 + 1))
-              .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => policy.RaiseExceptionAsync<DivideByZeroException>(3 + 1));
     }
 
     [Fact]
@@ -182,15 +177,14 @@ public class WaitAndRetryAsyncSpecs : IDisposable
         var policy = Policy
             .Handle<DivideByZeroException>()
             .Or<ArgumentException>()
-            .WaitAndRetryAsync(new[]
-            {
-               1.Seconds(),
-               2.Seconds(),
-               3.Seconds()
-            });
+            .WaitAndRetryAsync(
+            [
+               TimeSpan.FromSeconds(1),
+               TimeSpan.FromSeconds(2),
+               TimeSpan.FromSeconds(3)
+            ]);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<ArgumentException>(3 + 1))
-              .Should().ThrowAsync<ArgumentException>();
+        await Should.ThrowAsync<ArgumentException>(() => policy.RaiseExceptionAsync<ArgumentException>(3 + 1));
     }
 
     [Fact]
@@ -198,10 +192,9 @@ public class WaitAndRetryAsyncSpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync(Enumerable.Empty<TimeSpan>());
+            .WaitAndRetryAsync([]);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<NullReferenceException>())
-              .Should().ThrowAsync<NullReferenceException>();
+        await Should.ThrowAsync<NullReferenceException>(() => policy.RaiseExceptionAsync<NullReferenceException>());
     }
 
     [Fact]
@@ -210,10 +203,9 @@ public class WaitAndRetryAsyncSpecs : IDisposable
         var policy = Policy
             .Handle<DivideByZeroException>()
             .Or<ArgumentException>()
-            .WaitAndRetryAsync(Enumerable.Empty<TimeSpan>());
+            .WaitAndRetryAsync([]);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<NullReferenceException>())
-              .Should().ThrowAsync<NullReferenceException>();
+        await Should.ThrowAsync<NullReferenceException>(() => policy.RaiseExceptionAsync<NullReferenceException>());
     }
 
     [Fact]
@@ -221,10 +213,9 @@ public class WaitAndRetryAsyncSpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>(_ => false)
-            .WaitAndRetryAsync(Enumerable.Empty<TimeSpan>());
+            .WaitAndRetryAsync([]);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => policy.RaiseExceptionAsync<DivideByZeroException>());
     }
 
     [Fact]
@@ -233,10 +224,9 @@ public class WaitAndRetryAsyncSpecs : IDisposable
         var policy = Policy
             .Handle<DivideByZeroException>(_ => false)
             .Or<ArgumentException>(_ => false)
-            .WaitAndRetryAsync(Enumerable.Empty<TimeSpan>());
+            .WaitAndRetryAsync([]);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<ArgumentException>())
-              .Should().ThrowAsync<ArgumentException>();
+        await Should.ThrowAsync<ArgumentException>(() => policy.RaiseExceptionAsync<ArgumentException>());
     }
 
     [Fact]
@@ -244,13 +234,12 @@ public class WaitAndRetryAsyncSpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>(_ => true)
-            .WaitAndRetryAsync(new[]
-            {
-               1.Seconds()
-            });
+            .WaitAndRetryAsync(
+            [
+               TimeSpan.FromSeconds(1)
+            ]);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<DivideByZeroException>());
     }
 
     [Fact]
@@ -259,13 +248,12 @@ public class WaitAndRetryAsyncSpecs : IDisposable
         var policy = Policy
             .Handle<DivideByZeroException>(_ => true)
             .Or<ArgumentException>(_ => true)
-           .WaitAndRetryAsync(new[]
-            {
-               1.Seconds()
-            });
+           .WaitAndRetryAsync(
+            [
+               TimeSpan.FromSeconds(1)
+            ]);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<ArgumentException>())
-              .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<ArgumentException>());
     }
 
     [Fact]
@@ -275,12 +263,12 @@ public class WaitAndRetryAsyncSpecs : IDisposable
 
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync(new[]
-            {
-               1.Seconds(),
-               2.Seconds(),
-               3.Seconds()
-            });
+            .WaitAndRetryAsync(
+            [
+               TimeSpan.FromSeconds(1),
+               TimeSpan.FromSeconds(2),
+               TimeSpan.FromSeconds(3)
+            ]);
 
         SystemClock.SleepAsync = (span, _) =>
         {
@@ -290,8 +278,7 @@ public class WaitAndRetryAsyncSpecs : IDisposable
 
         await policy.RaiseExceptionAsync<DivideByZeroException>(3);
 
-        totalTimeSlept.Should()
-                      .Be(1 + 2 + 3);
+        totalTimeSlept.ShouldBe(1 + 2 + 3);
     }
 
     [Fact]
@@ -301,12 +288,12 @@ public class WaitAndRetryAsyncSpecs : IDisposable
 
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync(new[]
-            {
-               1.Seconds(),
-               2.Seconds(),
-               3.Seconds()
-            });
+            .WaitAndRetryAsync(
+            [
+               TimeSpan.FromSeconds(1),
+               TimeSpan.FromSeconds(2),
+               TimeSpan.FromSeconds(3)
+            ]);
 
         SystemClock.SleepAsync = (span, _) =>
         {
@@ -314,11 +301,9 @@ public class WaitAndRetryAsyncSpecs : IDisposable
             return TaskHelper.EmptyTask;
         };
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>(3 + 1))
-              .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => policy.RaiseExceptionAsync<DivideByZeroException>(3 + 1));
 
-        totalTimeSlept.Should()
-                      .Be(1 + 2 + 3);
+        totalTimeSlept.ShouldBe(1 + 2 + 3);
     }
 
     [Fact]
@@ -328,12 +313,12 @@ public class WaitAndRetryAsyncSpecs : IDisposable
 
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync(new[]
-            {
-               1.Seconds(),
-               2.Seconds(),
-               3.Seconds()
-            });
+            .WaitAndRetryAsync(
+            [
+               TimeSpan.FromSeconds(1),
+               TimeSpan.FromSeconds(2),
+               TimeSpan.FromSeconds(3)
+            ]);
 
         SystemClock.SleepAsync = (span, _) =>
         {
@@ -343,8 +328,7 @@ public class WaitAndRetryAsyncSpecs : IDisposable
 
         await policy.RaiseExceptionAsync<DivideByZeroException>(2);
 
-        totalTimeSlept.Should()
-                      .Be(1 + 2);
+        totalTimeSlept.ShouldBe(1 + 2);
     }
 
     [Fact]
@@ -354,7 +338,7 @@ public class WaitAndRetryAsyncSpecs : IDisposable
 
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync(Enumerable.Empty<TimeSpan>());
+            .WaitAndRetryAsync([]);
 
         SystemClock.SleepAsync = (span, _) =>
         {
@@ -362,38 +346,35 @@ public class WaitAndRetryAsyncSpecs : IDisposable
             return TaskHelper.EmptyTask;
         };
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<NullReferenceException>())
-              .Should().ThrowAsync<NullReferenceException>();
+        await Should.ThrowAsync<NullReferenceException>(() => policy.RaiseExceptionAsync<NullReferenceException>());
 
-        totalTimeSlept.Should()
-                      .Be(0);
+        totalTimeSlept.ShouldBe(0);
     }
 
     [Fact]
     public async Task Should_call_onretry_on_each_retry_with_the_current_timespan()
     {
         var expectedRetryWaits = new[]
-            {
-                1.Seconds(),
-                2.Seconds(),
-                3.Seconds()
-            };
+        {
+            TimeSpan.FromSeconds(1),
+            TimeSpan.FromSeconds(2),
+            TimeSpan.FromSeconds(3)
+        };
 
         var actualRetryWaits = new List<TimeSpan>();
 
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync(new[]
-            {
-               1.Seconds(),
-               2.Seconds(),
-               3.Seconds()
-            }, (_, timeSpan) => actualRetryWaits.Add(timeSpan));
+            .WaitAndRetryAsync(
+            [
+               TimeSpan.FromSeconds(1),
+               TimeSpan.FromSeconds(2),
+               TimeSpan.FromSeconds(3)
+            ], (_, timeSpan) => actualRetryWaits.Add(timeSpan));
 
         await policy.RaiseExceptionAsync<DivideByZeroException>(3);
 
-        actualRetryWaits.Should()
-                   .ContainInOrder(expectedRetryWaits);
+        actualRetryWaits.ShouldBe(expectedRetryWaits);
     }
 
     [Fact]
@@ -404,19 +385,18 @@ public class WaitAndRetryAsyncSpecs : IDisposable
 
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync(new[]
-            {
-               1.Seconds(),
-               2.Seconds(),
-               3.Seconds()
-            }, (exception, _) => retryExceptions.Add(exception));
+            .WaitAndRetryAsync(
+            [
+               TimeSpan.FromSeconds(1),
+               TimeSpan.FromSeconds(2),
+               TimeSpan.FromSeconds(3)
+            ], (exception, _) => retryExceptions.Add(exception));
 
         await policy.RaiseExceptionAsync<DivideByZeroException>(3, (e, i) => e.HelpLink = "Exception #" + i);
 
         retryExceptions
             .Select(x => x.HelpLink)
-            .Should()
-            .ContainInOrder(expectedExceptions);
+            .ShouldBe(expectedExceptions);
     }
 
     [Fact]
@@ -427,17 +407,16 @@ public class WaitAndRetryAsyncSpecs : IDisposable
 
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync(new[]
-            {
-               1.Seconds(),
-               2.Seconds(),
-               3.Seconds()
-            }, (_, _, retryCount, _) => retryCounts.Add(retryCount));
+            .WaitAndRetryAsync(
+            [
+               TimeSpan.FromSeconds(1),
+               TimeSpan.FromSeconds(2),
+               TimeSpan.FromSeconds(3)
+            ], (_, _, retryCount, _) => retryCounts.Add(retryCount));
 
         await policy.RaiseExceptionAsync<DivideByZeroException>(3);
 
-        retryCounts.Should()
-                   .ContainInOrder(expectedRetryCounts);
+        retryCounts.ShouldBe(expectedRetryCounts);
     }
 
     [Fact]
@@ -447,12 +426,11 @@ public class WaitAndRetryAsyncSpecs : IDisposable
 
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync(Enumerable.Empty<TimeSpan>(), (exception, _) => retryExceptions.Add(exception));
+            .WaitAndRetryAsync([], (exception, _) => retryExceptions.Add(exception));
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<ArgumentException>())
-              .Should().ThrowAsync<ArgumentException>();
+        await Should.ThrowAsync<ArgumentException>(() => policy.RaiseExceptionAsync<ArgumentException>());
 
-        retryExceptions.Should().BeEmpty();
+        retryExceptions.ShouldBeEmpty();
     }
 
     [Fact]
@@ -460,16 +438,13 @@ public class WaitAndRetryAsyncSpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync(new[]
-            {
-                1.Seconds()
-            });
+            .WaitAndRetryAsync(
+            [
+                TimeSpan.FromSeconds(1)
+            ]);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().NotThrowAsync();
-
-        await policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<DivideByZeroException>());
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<DivideByZeroException>());
     }
 
     [Fact]
@@ -479,19 +454,19 @@ public class WaitAndRetryAsyncSpecs : IDisposable
 
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync(new[]
-            {
-                1.Seconds(),
-                2.Seconds(),
-                3.Seconds()
-            }, (_, _, context) => contextData = context);
+            .WaitAndRetryAsync(
+            [
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(2),
+                TimeSpan.FromSeconds(3)
+            ], (_, _, context) => contextData = context);
 
         await policy.RaiseExceptionAsync<DivideByZeroException>(
             CreateDictionary("key1", "value1", "key2", "value2"));
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -501,16 +476,15 @@ public class WaitAndRetryAsyncSpecs : IDisposable
 
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync(new[]
-            {
-                1.Seconds(),
-                2.Seconds(),
-                3.Seconds()
-            }, (_, _, context) => capturedContext = context);
-        await policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>()).Should().NotThrowAsync();
+            .WaitAndRetryAsync(
+            [
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(2),
+                TimeSpan.FromSeconds(3)
+            ], (_, _, context) => capturedContext = context);
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<DivideByZeroException>());
 
-        capturedContext.Should()
-                       .BeEmpty();
+        capturedContext.ShouldBeEmpty();
     }
 
     [Fact]
@@ -520,21 +494,18 @@ public class WaitAndRetryAsyncSpecs : IDisposable
 
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync(new[]
-            {
-                1.Seconds()
-            },
+            .WaitAndRetryAsync([TimeSpan.FromSeconds(1)],
             (_, _, context) => contextValue = context["key"].ToString());
 
         await policy.RaiseExceptionAsync<DivideByZeroException>(
             CreateDictionary("key", "original_value"));
 
-        contextValue.Should().Be("original_value");
+        contextValue.ShouldBe("original_value");
 
         await policy.RaiseExceptionAsync<DivideByZeroException>(
             CreateDictionary("key", "new_value"));
 
-        contextValue.Should().Be("new_value");
+        contextValue.ShouldBe("new_value");
     }
 
     [Fact]
@@ -543,11 +514,11 @@ public class WaitAndRetryAsyncSpecs : IDisposable
         Action<Exception, TimeSpan> onRetry = (_, _) => { };
 
         Action policy = () => Policy
-                                  .Handle<DivideByZeroException>()
-                                  .WaitAndRetryAsync(-1, _ => TimeSpan.Zero, onRetry);
+            .Handle<DivideByZeroException>()
+            .WaitAndRetryAsync(-1, _ => TimeSpan.Zero, onRetry);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-              .ParamName.Should().Be("retryCount");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+              .ParamName.ShouldBe("retryCount");
     }
 
     [Fact]
@@ -556,11 +527,11 @@ public class WaitAndRetryAsyncSpecs : IDisposable
         Action<Exception, TimeSpan> onRetry = (_, _) => { };
 
         Action policy = () => Policy
-                                  .Handle<DivideByZeroException>()
-                                  .WaitAndRetryAsync(1, null, onRetry);
+            .Handle<DivideByZeroException>()
+            .WaitAndRetryAsync(1, null, onRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("sleepDurationProvider");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("sleepDurationProvider");
     }
 
     [Fact]
@@ -569,24 +540,24 @@ public class WaitAndRetryAsyncSpecs : IDisposable
         Action<Exception, TimeSpan> nullOnRetry = null!;
 
         Action policy = () => Policy
-                                  .Handle<DivideByZeroException>()
-                                  .WaitAndRetryAsync(1, _ => TimeSpan.Zero, nullOnRetry);
+            .Handle<DivideByZeroException>()
+            .WaitAndRetryAsync(1, _ => TimeSpan.Zero, nullOnRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("onRetry");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]
     public async Task Should_calculate_retry_timespans_from_current_retry_attempt_and_timespan_provider()
     {
         var expectedRetryWaits = new[]
-            {
-                2.Seconds(),
-                4.Seconds(),
-                8.Seconds(),
-                16.Seconds(),
-                32.Seconds()
-            };
+        {
+            TimeSpan.FromSeconds(2),
+            TimeSpan.FromSeconds(4),
+            TimeSpan.FromSeconds(8),
+            TimeSpan.FromSeconds(16),
+            TimeSpan.FromSeconds(32)
+        };
 
         var actualRetryWaits = new List<TimeSpan>();
 
@@ -598,8 +569,7 @@ public class WaitAndRetryAsyncSpecs : IDisposable
 
         await policy.RaiseExceptionAsync<DivideByZeroException>(5);
 
-        actualRetryWaits.Should()
-                   .ContainInOrder(expectedRetryWaits);
+        actualRetryWaits.ShouldBe(expectedRetryWaits);
     }
 
     [Fact]
@@ -621,7 +591,7 @@ public class WaitAndRetryAsyncSpecs : IDisposable
 
         await policy.RaiseExceptionAsync(exceptionInstance);
 
-        capturedExceptionInstance.Should().Be(exceptionInstance);
+        capturedExceptionInstance.ShouldBe(exceptionInstance);
     }
 
     [Fact]
@@ -629,8 +599,8 @@ public class WaitAndRetryAsyncSpecs : IDisposable
     {
         Dictionary<Exception, TimeSpan> expectedRetryWaits = new Dictionary<Exception, TimeSpan>
         {
-            {new DivideByZeroException(), 2.Seconds()},
-            {new ArgumentNullException(), 4.Seconds()},
+            [new DivideByZeroException()] = TimeSpan.FromSeconds(2),
+            [new ArgumentNullException()] = TimeSpan.FromSeconds(4),
         };
 
         var actualRetryWaits = new List<TimeSpan>();
@@ -652,16 +622,16 @@ public class WaitAndRetryAsyncSpecs : IDisposable
                 : TaskHelper.EmptyTask);
         }
 
-        actualRetryWaits.Should().ContainInOrder(expectedRetryWaits.Values);
+        actualRetryWaits.ShouldBe(expectedRetryWaits.Values);
     }
 
     [Fact]
     public async Task Should_be_able_to_pass_retry_duration_from_execution_to_sleepDurationProvider_via_context()
     {
-        var expectedRetryDuration = 1.Seconds();
+        var expectedRetryDuration = TimeSpan.FromSeconds(1);
         TimeSpan? actualRetryDuration = null;
 
-        TimeSpan defaultRetryAfter = 30.Seconds();
+        TimeSpan defaultRetryAfter = TimeSpan.FromSeconds(30);
 
         var policy = Policy
             .Handle<DivideByZeroException>()
@@ -684,7 +654,7 @@ public class WaitAndRetryAsyncSpecs : IDisposable
             CreateDictionary("RetryAfter", defaultRetryAfter), // Can also set an initial value for RetryAfter, in the Context passed into the call.
             CancellationToken.None);
 
-        actualRetryDuration.Should().Be(expectedRetryDuration);
+        actualRetryDuration.ShouldBe(expectedRetryDuration);
     }
 
     [Fact]
@@ -692,16 +662,15 @@ public class WaitAndRetryAsyncSpecs : IDisposable
     {
         bool retryInvoked = false;
 
-        Action<Exception, TimeSpan> onRetry = (_, _) => { retryInvoked = true; };
+        Action<Exception, TimeSpan> onRetry = (_, _) => retryInvoked = true;
 
         var policy = Policy
             .Handle<DivideByZeroException>()
             .WaitAndRetryAsync(0, _ => TimeSpan.FromSeconds(1), onRetry);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => policy.RaiseExceptionAsync<DivideByZeroException>());
 
-        retryInvoked.Should().BeFalse();
+        retryInvoked.ShouldBeFalse();
     }
 
     [Fact]
@@ -712,8 +681,7 @@ public class WaitAndRetryAsyncSpecs : IDisposable
         // However, if it compiles to async void (assigning tp Action<...>), then the delegate, when run, will return at the first await, and execution continues without waiting for the Action to complete, as described by Stephen Toub: https://devblogs.microsoft.com/pfxteam/potential-pitfalls-to-avoid-when-passing-around-async-lambdas/
         // If Polly were to declare only an Action<...> delegate for onRetry - but users declared async () => { } onRetry delegates - the compiler would happily assign them to the Action<...>, but the next 'try' would/could occur before onRetry execution had completed.
         // This test ensures the relevant retry policy does have a Func<..., Task> form for onRetry, and that it is awaited before the next try commences.
-
-        TimeSpan shimTimeSpan = TimeSpan.FromSeconds(0.2); // Consider increasing shimTimeSpan if test fails transiently in different environments.
+        TimeSpan shimTimeSpan = TimeSpan.FromSeconds(0.2);
 
         int executeDelegateInvocations = 0;
         int executeDelegateInvocationsWhenOnRetryExits = 0;
@@ -728,20 +696,20 @@ public class WaitAndRetryAsyncSpecs : IDisposable
                 executeDelegateInvocationsWhenOnRetryExits = executeDelegateInvocations;
             });
 
-        await policy.Awaiting(p => p.ExecuteAsync(async () =>
+        await Should.ThrowAsync<DivideByZeroException>(() => policy.ExecuteAsync(async () =>
         {
             executeDelegateInvocations++;
             await TaskHelper.EmptyTask;
             throw new DivideByZeroException();
-        })).Should().ThrowAsync<DivideByZeroException>();
+        }));
 
         while (executeDelegateInvocationsWhenOnRetryExits == 0)
         {
             // Wait for the onRetry delegate to complete.
         }
 
-        executeDelegateInvocationsWhenOnRetryExits.Should().Be(1); // If the async onRetry delegate is genuinely awaited, only one execution of the .Execute delegate should have occurred by the time onRetry completes.  If the async onRetry delegate were instead assigned to an Action<...>, then onRetry will return, and the second action execution will commence, before await Task.Delay() completes, leaving executeDelegateInvocationsWhenOnRetryExits == 2.
-        executeDelegateInvocations.Should().Be(2);
+        executeDelegateInvocationsWhenOnRetryExits.ShouldBe(1); // If the async onRetry delegate is genuinely awaited, only one execution of the .Execute delegate should have occurred by the time onRetry completes.  If the async onRetry delegate were instead assigned to an Action<...>, then onRetry will return, and the second action execution will commence, before await Task.Delay() completes, leaving executeDelegateInvocationsWhenOnRetryExits == 2.
+        executeDelegateInvocations.ShouldBe(2);
     }
 
     [Fact]
@@ -749,7 +717,7 @@ public class WaitAndRetryAsyncSpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync(new[] { 1.Seconds(), 2.Seconds(), 3.Seconds() });
+            .WaitAndRetryAsync([TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3)]);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -764,11 +732,10 @@ public class WaitAndRetryAsyncSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().NotThrowAsync();
+            await Should.NotThrowAsync(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -776,7 +743,7 @@ public class WaitAndRetryAsyncSpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync(new[] { 1.Seconds(), 2.Seconds(), 3.Seconds() });
+            .WaitAndRetryAsync([TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3)]);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -791,11 +758,10 @@ public class WaitAndRetryAsyncSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().ThrowAsync<DivideByZeroException>();
+            await Should.ThrowAsync<DivideByZeroException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1 + 3);
+        attemptsInvoked.ShouldBe(1 + 3);
     }
 
     [Fact]
@@ -803,7 +769,7 @@ public class WaitAndRetryAsyncSpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync(new[] { 1.Seconds(), 2.Seconds(), 3.Seconds() });
+            .WaitAndRetryAsync([TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3)]);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -819,12 +785,11 @@ public class WaitAndRetryAsyncSpecs : IDisposable
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             cancellationTokenSource.Cancel();
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(0);
+        attemptsInvoked.ShouldBe(0);
     }
 
     [Fact]
@@ -832,7 +797,7 @@ public class WaitAndRetryAsyncSpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync(new[] { 1.Seconds(), 2.Seconds(), 3.Seconds() });
+            .WaitAndRetryAsync([TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3)]);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -848,12 +813,11 @@ public class WaitAndRetryAsyncSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -861,7 +825,7 @@ public class WaitAndRetryAsyncSpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync(new[] { 1.Seconds(), 2.Seconds(), 3.Seconds() });
+            .WaitAndRetryAsync([TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3)]);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -877,12 +841,11 @@ public class WaitAndRetryAsyncSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -890,7 +853,7 @@ public class WaitAndRetryAsyncSpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync(new[] { 1.Seconds(), 2.Seconds(), 3.Seconds() });
+            .WaitAndRetryAsync([TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3)]);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -906,12 +869,11 @@ public class WaitAndRetryAsyncSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -919,7 +881,7 @@ public class WaitAndRetryAsyncSpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync(new[] { 1.Seconds(), 2.Seconds(), 3.Seconds() });
+            .WaitAndRetryAsync([TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3)]);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -935,12 +897,11 @@ public class WaitAndRetryAsyncSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(2);
+        attemptsInvoked.ShouldBe(2);
     }
 
     [Fact]
@@ -948,7 +909,7 @@ public class WaitAndRetryAsyncSpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync(new[] { 1.Seconds(), 2.Seconds(), 3.Seconds() });
+            .WaitAndRetryAsync([TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3)]);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -964,12 +925,11 @@ public class WaitAndRetryAsyncSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(2);
+        attemptsInvoked.ShouldBe(2);
     }
 
     [Fact]
@@ -977,7 +937,7 @@ public class WaitAndRetryAsyncSpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync(new[] { 1.Seconds(), 2.Seconds(), 3.Seconds() });
+            .WaitAndRetryAsync([TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3)]);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -993,12 +953,11 @@ public class WaitAndRetryAsyncSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1 + 3);
+        attemptsInvoked.ShouldBe(1 + 3);
     }
 
     [Fact]
@@ -1006,7 +965,7 @@ public class WaitAndRetryAsyncSpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync(new[] { 1.Seconds(), 2.Seconds(), 3.Seconds() });
+            .WaitAndRetryAsync([TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3)]);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -1022,11 +981,10 @@ public class WaitAndRetryAsyncSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().ThrowAsync<DivideByZeroException>();
+            await Should.ThrowAsync<DivideByZeroException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1 + 3);
+        attemptsInvoked.ShouldBe(1 + 3);
     }
 
     [Fact]
@@ -1034,18 +992,17 @@ public class WaitAndRetryAsyncSpecs : IDisposable
     {
         SystemClock.SleepAsync = Task.Delay;
 
-        TimeSpan shimTimeSpan = TimeSpan.FromSeconds(1); // Consider increasing shimTimeSpan if test fails transiently in different environments.
+        TimeSpan shimTimeSpan = TimeSpan.FromSeconds(1);
         TimeSpan retryDelay = shimTimeSpan + shimTimeSpan + shimTimeSpan;
 
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync(new[] { retryDelay });
+            .WaitAndRetryAsync([retryDelay]);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
 
-        Stopwatch watch = new Stopwatch();
-        watch.Start();
+        Stopwatch watch = Stopwatch.StartNew();
 
         Scenario scenario = new Scenario
         {
@@ -1060,17 +1017,16 @@ public class WaitAndRetryAsyncSpecs : IDisposable
 
             cancellationTokenSource.CancelAfter(shimTimeSpan);
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                    .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
         watch.Stop();
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
 
-        watch.Elapsed.Should().BeLessThan(retryDelay);
-        watch.Elapsed.Should().BeCloseTo(shimTimeSpan, precision: TimeSpan.FromMilliseconds(shimTimeSpan.TotalMilliseconds / 2));  // Consider increasing shimTimeSpan, or loosening precision, if test fails transiently in different environments.
+        watch.Elapsed.ShouldBeLessThan(retryDelay);
+        watch.Elapsed.ShouldBe(shimTimeSpan, TimeSpan.FromMilliseconds(shimTimeSpan.TotalMilliseconds / 2));
     }
 
     [Fact]
@@ -1092,18 +1048,17 @@ public class WaitAndRetryAsyncSpecs : IDisposable
 
             var policy = Policy
                 .Handle<DivideByZeroException>()
-                .WaitAndRetryAsync(new[] { 1.Seconds(), 2.Seconds(), 3.Seconds() },
+                .WaitAndRetryAsync([TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3)],
                 (_, _) =>
                 {
                     cancellationTokenSource.Cancel();
                 });
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -1111,7 +1066,7 @@ public class WaitAndRetryAsyncSpecs : IDisposable
     {
         var policy = Policy
            .Handle<DivideByZeroException>()
-           .WaitAndRetryAsync(new[] { 1.Seconds(), 2.Seconds(), 3.Seconds() });
+           .WaitAndRetryAsync([TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3)]);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -1128,14 +1083,14 @@ public class WaitAndRetryAsyncSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            Func<AsyncRetryPolicy, Task> action = async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true);
-            await policy.Awaiting(action)
-                .Should().NotThrowAsync();
+            Func<Task> action = async () => result = await policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true);
+            await Should.NotThrowAsync(action);
         }
 
-        result.Should().BeTrue();
+        result.ShouldNotBeNull();
+        result.Value.ShouldBeTrue();
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -1143,7 +1098,7 @@ public class WaitAndRetryAsyncSpecs : IDisposable
     {
         var policy = Policy
            .Handle<DivideByZeroException>()
-           .WaitAndRetryAsync(new[] { 1.Seconds(), 2.Seconds(), 3.Seconds() });
+           .WaitAndRetryAsync([TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3)]);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -1161,14 +1116,14 @@ public class WaitAndRetryAsyncSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            Func<AsyncRetryPolicy, Task> action = async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true);
-            var ex = await policy.Awaiting(action).Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            Func<Task> action = async () => result = await policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(action);
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        result.Should().Be(null);
+        result.ShouldBeNull();
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     public void Dispose() =>

--- a/test/Polly.Specs/Retry/WaitAndRetryForeverAsyncSpecs.cs
+++ b/test/Polly.Specs/Retry/WaitAndRetryForeverAsyncSpecs.cs
@@ -16,8 +16,8 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
                                   .Handle<DivideByZeroException>()
                                   .WaitAndRetryForeverAsync(null, onRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("sleepDurationProvider");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("sleepDurationProvider");
     }
 
     [Fact]
@@ -29,8 +29,8 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
                                   .Handle<DivideByZeroException>()
                                   .WaitAndRetryForeverAsync(null, onRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("sleepDurationProvider");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("sleepDurationProvider");
     }
 
     [Fact]
@@ -40,8 +40,8 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
                                 .Handle<Exception>()
                                 .WaitAndRetryForeverAsync(default(Func<int, TimeSpan>));
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("sleepDurationProvider");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("sleepDurationProvider");
     }
 
     [Fact]
@@ -53,8 +53,8 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
                                 .Handle<Exception>()
                                 .WaitAndRetryForeverAsync(default, onRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("sleepDurationProvider");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("sleepDurationProvider");
     }
 
     [Fact]
@@ -64,8 +64,8 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
                                .Handle<Exception>()
                                .WaitAndRetryForeverAsync(default(Func<int, Context, TimeSpan>));
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("sleepDurationProvider");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("sleepDurationProvider");
     }
 
     [Fact]
@@ -77,8 +77,8 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
                                 .Handle<Exception>()
                                 .WaitAndRetryForeverAsync(provider, default(Action<Exception, int, TimeSpan>));
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("onRetry");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]
@@ -88,21 +88,21 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
                                .Handle<Exception>()
                                .WaitAndRetryForeverAsync(default, default(Action<Exception, int, TimeSpan, Context>));
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("sleepDurationProvider");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("sleepDurationProvider");
     }
 
     [Fact]
     public void Should_throw_when_onretry_exception_int_timespan_context_is_null_with_sleep_duration_provider()
     {
-        Func<int, Context, TimeSpan> provider = (_, _) => 1.Seconds();
+        Func<int, Context, TimeSpan> provider = (_, _) => TimeSpan.FromSeconds(1);
 
         Action policy = () => Policy
                                 .Handle<Exception>()
                                 .WaitAndRetryForeverAsync(provider, default(Action<Exception, int, TimeSpan, Context>));
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("onRetry");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]
@@ -115,8 +115,8 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
                                   .Handle<DivideByZeroException>()
                                   .WaitAndRetryForeverAsync(provider, nullOnRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("onRetry");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]
@@ -129,8 +129,8 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
                                   .Handle<DivideByZeroException>()
                                   .WaitAndRetryForeverAsync(provider, nullOnRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("onRetry");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]
@@ -140,8 +140,7 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .WaitAndRetryForeverAsync(_ => TimeSpan.Zero);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>(3))
-              .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<DivideByZeroException>(3));
     }
 
     [Fact]
@@ -152,8 +151,7 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
             .Or<ArgumentException>()
             .WaitAndRetryForeverAsync(_ => TimeSpan.Zero);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<ArgumentException>(3))
-              .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<ArgumentException>(3));
     }
 
     [Fact]
@@ -165,8 +163,7 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .WaitAndRetryForeverAsync(provider);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<NullReferenceException>())
-              .Should().ThrowAsync<NullReferenceException>();
+        await Should.ThrowAsync<NullReferenceException>(() => policy.RaiseExceptionAsync<NullReferenceException>());
     }
 
     [Fact]
@@ -179,8 +176,7 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
             .Or<ArgumentException>()
             .WaitAndRetryForeverAsync(provider);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<NullReferenceException>())
-              .Should().ThrowAsync<NullReferenceException>();
+        await Should.ThrowAsync<NullReferenceException>(() => policy.RaiseExceptionAsync<NullReferenceException>());
     }
 
     [Fact]
@@ -192,8 +188,7 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
             .Handle<DivideByZeroException>(_ => false)
             .WaitAndRetryForeverAsync(provider);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().ThrowAsync<DivideByZeroException>();
+        await Should.ThrowAsync<DivideByZeroException>(() => policy.RaiseExceptionAsync<DivideByZeroException>());
     }
 
     [Fact]
@@ -206,41 +201,38 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
             .Or<ArgumentException>(_ => false)
             .WaitAndRetryForeverAsync(provider);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<ArgumentException>())
-              .Should().ThrowAsync<ArgumentException>();
+        await Should.ThrowAsync<ArgumentException>(() => policy.RaiseExceptionAsync<ArgumentException>());
     }
 
     [Fact]
     public async Task Should_not_throw_when_specified_exception_predicate_is_satisfied()
     {
-        Func<int, TimeSpan> provider = _ => 1.Seconds();
+        Func<int, TimeSpan> provider = _ => TimeSpan.FromSeconds(1);
 
         var policy = Policy
             .Handle<DivideByZeroException>(_ => true)
             .WaitAndRetryForeverAsync(provider);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<DivideByZeroException>());
     }
 
     [Fact]
     public async Task Should_not_throw_when_one_of_the_specified_exception_predicates_are_satisfied()
     {
-        Func<int, TimeSpan> provider = _ => 1.Seconds();
+        Func<int, TimeSpan> provider = _ => TimeSpan.FromSeconds(1);
 
         var policy = Policy
             .Handle<DivideByZeroException>(_ => true)
             .Or<ArgumentException>(_ => true)
            .WaitAndRetryForeverAsync(provider);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<ArgumentException>())
-              .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<ArgumentException>());
     }
 
     [Fact]
     public async Task Should_not_sleep_if_no_retries()
     {
-        Func<int, TimeSpan> provider = _ => 1.Seconds();
+        Func<int, TimeSpan> provider = _ => TimeSpan.FromSeconds(1);
 
         var totalTimeSlept = 0;
 
@@ -250,11 +242,9 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
 
         SystemClock.Sleep = (span, _) => totalTimeSlept += span.Seconds;
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<NullReferenceException>())
-              .Should().ThrowAsync<NullReferenceException>();
+        await Should.ThrowAsync<NullReferenceException>(() => policy.RaiseExceptionAsync<NullReferenceException>());
 
-        totalTimeSlept.Should()
-                      .Be(0);
+        totalTimeSlept.ShouldBe(0);
     }
 
     [Fact]
@@ -272,8 +262,7 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
 
         retryExceptions
             .Select(x => x.HelpLink)
-            .Should()
-            .ContainInOrder(expectedExceptions);
+            .ShouldBe(expectedExceptions);
     }
 
     [Fact]
@@ -289,30 +278,28 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
 
         policy.RaiseExceptionAsync<DivideByZeroException>(3);
 
-        retryCounts.Should()
-            .ContainInOrder(expectedRetryCounts);
+        retryCounts.ShouldBe(expectedRetryCounts);
     }
 
     [Fact]
     public async Task Should_not_call_onretry_when_no_retries_are_performed()
     {
-        Func<int, TimeSpan> provider = _ => 1.Seconds();
+        Func<int, TimeSpan> provider = _ => TimeSpan.FromSeconds(1);
         var retryExceptions = new List<Exception>();
 
         var policy = Policy
             .Handle<DivideByZeroException>()
             .WaitAndRetryForeverAsync(provider, (exception, _) => retryExceptions.Add(exception));
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<ArgumentException>())
-              .Should().ThrowAsync<ArgumentException>();
+        await Should.ThrowAsync<ArgumentException>(() => policy.RaiseExceptionAsync<ArgumentException>());
 
-        retryExceptions.Should().BeEmpty();
+        retryExceptions.ShouldBeEmpty();
     }
 
     [Fact]
     public void Should_create_new_context_for_each_call_to_policy()
     {
-        Func<int, Context, TimeSpan> provider = (_, _) => 1.Seconds();
+        Func<int, Context, TimeSpan> provider = (_, _) => TimeSpan.FromSeconds(1);
 
         string? contextValue = null;
 
@@ -325,25 +312,25 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
         policy.RaiseExceptionAsync<DivideByZeroException>(
             CreateDictionary("key", "original_value"));
 
-        contextValue.Should().Be("original_value");
+        contextValue.ShouldBe("original_value");
 
         policy.RaiseExceptionAsync<DivideByZeroException>(
             CreateDictionary("key", "new_value"));
 
-        contextValue.Should().Be("new_value");
+        contextValue.ShouldBe("new_value");
     }
 
     [Fact]
     public async Task Should_calculate_retry_timespans_from_current_retry_attempt_and_timespan_provider()
     {
         var expectedRetryWaits = new[]
-            {
-                2.Seconds(),
-                4.Seconds(),
-                8.Seconds(),
-                16.Seconds(),
-                32.Seconds()
-            };
+        {
+            TimeSpan.FromSeconds(2),
+            TimeSpan.FromSeconds(4),
+            TimeSpan.FromSeconds(8),
+            TimeSpan.FromSeconds(16),
+            TimeSpan.FromSeconds(32)
+        };
 
         var actualRetryWaits = new List<TimeSpan>();
 
@@ -355,8 +342,7 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
 
         await policy.RaiseExceptionAsync<DivideByZeroException>(5);
 
-        actualRetryWaits.Should()
-                   .ContainInOrder(expectedRetryWaits);
+        actualRetryWaits.ShouldBe(expectedRetryWaits);
     }
 
     [Fact]
@@ -364,8 +350,8 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
     {
         Dictionary<Exception, TimeSpan> expectedRetryWaits = new Dictionary<Exception, TimeSpan>
         {
-            {new DivideByZeroException(), 2.Seconds()},
-            {new ArgumentNullException(), 4.Seconds()},
+            [new DivideByZeroException()] = TimeSpan.FromSeconds(2),
+            [new ArgumentNullException()] = TimeSpan.FromSeconds(4),
         };
 
         var actualRetryWaits = new List<TimeSpan>();
@@ -393,16 +379,16 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
             });
         }
 
-        actualRetryWaits.Should().ContainInOrder(expectedRetryWaits.Values);
+        actualRetryWaits.ShouldBe(expectedRetryWaits.Values);
     }
 
     [Fact]
     public async Task Should_be_able_to_pass_retry_duration_from_execution_to_sleepDurationProvider_via_context()
     {
-        var expectedRetryDuration = 1.Seconds();
+        var expectedRetryDuration = TimeSpan.FromSeconds(1);
         TimeSpan? actualRetryDuration = null;
 
-        TimeSpan defaultRetryAfter = 30.Seconds();
+        TimeSpan defaultRetryAfter = TimeSpan.FromSeconds(30);
 
         var policy = Policy
             .Handle<DivideByZeroException>()
@@ -425,7 +411,7 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
             CreateDictionary("RetryAfter", defaultRetryAfter), // Can also set an initial value for RetryAfter, in the Context passed into the call.
             CancellationToken.None);
 
-        actualRetryDuration.Should().Be(expectedRetryDuration);
+        actualRetryDuration.ShouldBe(expectedRetryDuration);
     }
 
     [Fact]
@@ -437,7 +423,7 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
         // If Polly were to declare only an Action<...> delegate for onRetry - but users declared async () => { } onRetry delegates - the compiler would happily assign them to the Action<...>, but the next 'try' would/could occur before onRetry execution had completed.
         // This test ensures the relevant retry policy does have a Func<..., Task> form for onRetry, and that it is awaited before the next try commences.
 
-        TimeSpan shimTimeSpan = TimeSpan.FromSeconds(0.2); // Consider increasing shimTimeSpan if test fails transiently in different environments.
+        TimeSpan shimTimeSpan = TimeSpan.FromSeconds(0.2);
 
         int executeDelegateInvocations = 0;
         int executeDelegateInvocationsWhenOnRetryExits = 0;
@@ -452,7 +438,7 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
                 executeDelegateInvocationsWhenOnRetryExits = executeDelegateInvocations;
             });
 
-        await policy.Awaiting(p => p.ExecuteAsync(async () =>
+        await Should.NotThrowAsync(() => policy.ExecuteAsync(async () =>
         {
             executeDelegateInvocations++;
             await TaskHelper.EmptyTask;
@@ -460,15 +446,15 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
             {
                 throw new DivideByZeroException();
             }
-        })).Should().NotThrowAsync();
+        }));
 
         while (executeDelegateInvocationsWhenOnRetryExits == 0)
         {
             // Wait for the onRetry delegate to complete.
         }
 
-        executeDelegateInvocationsWhenOnRetryExits.Should().Be(1); // If the async onRetry delegate is genuinely awaited, only one execution of the .Execute delegate should have occurred by the time onRetry completes.  If the async onRetry delegate were instead assigned to an Action<...>, then onRetry will return, and the second action execution will commence, before await Task.Delay() completes, leaving executeDelegateInvocationsWhenOnRetryExits == 2.
-        executeDelegateInvocations.Should().Be(2);
+        executeDelegateInvocationsWhenOnRetryExits.ShouldBe(1); // If the async onRetry delegate is genuinely awaited, only one execution of the .Execute delegate should have occurred by the time onRetry completes.  If the async onRetry delegate were instead assigned to an Action<...>, then onRetry will return, and the second action execution will commence, before await Task.Delay() completes, leaving executeDelegateInvocationsWhenOnRetryExits == 2.
+        executeDelegateInvocations.ShouldBe(2);
     }
 
     [Fact]
@@ -491,11 +477,10 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
 
         using (var cancellationTokenSource = new CancellationTokenSource())
         {
-            await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().NotThrowAsync();
+            await Should.NotThrowAsync(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -521,12 +506,11 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             cancellationTokenSource.Cancel();
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(0);
+        attemptsInvoked.ShouldBe(0);
     }
 
     [Fact]
@@ -552,12 +536,11 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -583,12 +566,11 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -614,12 +596,11 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -645,12 +626,11 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(2);
+        attemptsInvoked.ShouldBe(2);
     }
 
     [Fact]
@@ -676,12 +656,11 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(2);
+        attemptsInvoked.ShouldBe(2);
     }
 
     [Fact]
@@ -711,12 +690,11 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
                     cancellationTokenSource.Cancel();
                 });
 
-            var ex = await policy.Awaiting(x => x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -741,13 +719,14 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
 
         using (var cancellationTokenSource = new CancellationTokenSource())
         {
-            Func<AsyncRetryPolicy, Task> action = async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true);
-            await policy.Awaiting(action).Should().NotThrowAsync();
+            Func<Task> action = async () => result = await policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true);
+            await Should.NotThrowAsync(action);
         }
 
-        result.Should().BeTrue();
+        result.ShouldNotBeNull();
+        result.Value.ShouldBeTrue();
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -775,14 +754,14 @@ public class WaitAndRetryForeverAsyncSpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            Func<AsyncRetryPolicy, Task> action = async x => result = await x.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true);
-            var ex = await policy.Awaiting(action).Should().ThrowAsync<OperationCanceledException>();
-            ex.And.CancellationToken.Should().Be(cancellationToken);
+            Func<Task> action = async () => result = await policy.RaiseExceptionAndOrCancellationAsync<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true);
+            var ex = await Should.ThrowAsync<OperationCanceledException>(action);
+            ex.CancellationToken.ShouldBe(cancellationToken);
         }
 
-        result.Should().Be(null);
+        result.ShouldBeNull();
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     public void Dispose() =>

--- a/test/Polly.Specs/Retry/WaitAndRetryForeverSpecs.cs
+++ b/test/Polly.Specs/Retry/WaitAndRetryForeverSpecs.cs
@@ -14,8 +14,8 @@ public class WaitAndRetryForeverSpecs : IDisposable
                                   .Handle<DivideByZeroException>()
                                   .WaitAndRetryForever(null, onRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("sleepDurationProvider");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("sleepDurationProvider");
     }
 
     [Fact]
@@ -29,8 +29,8 @@ public class WaitAndRetryForeverSpecs : IDisposable
                                   .Handle<DivideByZeroException>()
                                   .WaitAndRetryForever(sleepDurationProvider, onRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("sleepDurationProvider");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("sleepDurationProvider");
     }
 
     [Fact]
@@ -43,8 +43,8 @@ public class WaitAndRetryForeverSpecs : IDisposable
                                   .Handle<DivideByZeroException>()
                                   .WaitAndRetryForever(provider, nullOnRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("onRetry");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]
@@ -57,8 +57,8 @@ public class WaitAndRetryForeverSpecs : IDisposable
                                   .Handle<DivideByZeroException>()
                                   .WaitAndRetryForever(provider, nullOnRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("onRetry");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]
@@ -68,8 +68,7 @@ public class WaitAndRetryForeverSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .WaitAndRetryForever(_ => default);
 
-        policy.Invoking(x => x.RaiseException<DivideByZeroException>(3))
-              .Should().NotThrow();
+        Should.NotThrow(() => policy.RaiseException<DivideByZeroException>(3));
     }
 
     [Fact]
@@ -80,8 +79,7 @@ public class WaitAndRetryForeverSpecs : IDisposable
             .Or<ArgumentException>()
             .WaitAndRetryForever(_ => default);
 
-        policy.Invoking(x => x.RaiseException<ArgumentException>(3))
-              .Should().NotThrow();
+        Should.NotThrow(() => policy.RaiseException<ArgumentException>(3));
     }
 
     [Fact]
@@ -93,8 +91,7 @@ public class WaitAndRetryForeverSpecs : IDisposable
             .Handle<DivideByZeroException>()
             .WaitAndRetryForever(provider);
 
-        policy.Invoking(x => x.RaiseException<NullReferenceException>())
-              .Should().Throw<NullReferenceException>();
+        Should.Throw<NullReferenceException>(() => policy.RaiseException<NullReferenceException>());
     }
 
     [Fact]
@@ -107,8 +104,7 @@ public class WaitAndRetryForeverSpecs : IDisposable
             .Or<ArgumentException>()
             .WaitAndRetryForever(provider);
 
-        policy.Invoking(x => x.RaiseException<NullReferenceException>())
-              .Should().Throw<NullReferenceException>();
+        Should.Throw<NullReferenceException>(() => policy.RaiseException<NullReferenceException>());
     }
 
     [Fact]
@@ -120,8 +116,7 @@ public class WaitAndRetryForeverSpecs : IDisposable
             .Handle<DivideByZeroException>(_ => false)
             .WaitAndRetryForever(provider);
 
-        policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => policy.RaiseException<DivideByZeroException>());
     }
 
     [Fact]
@@ -134,41 +129,38 @@ public class WaitAndRetryForeverSpecs : IDisposable
             .Or<ArgumentException>(_ => false)
             .WaitAndRetryForever(provider);
 
-        policy.Invoking(x => x.RaiseException<ArgumentException>())
-              .Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => policy.RaiseException<ArgumentException>());
     }
 
     [Fact]
     public void Should_not_throw_when_specified_exception_predicate_is_satisfied()
     {
-        Func<int, TimeSpan> provider = _ => 1.Seconds();
+        Func<int, TimeSpan> provider = _ => TimeSpan.FromSeconds(1);
 
         var policy = Policy
             .Handle<DivideByZeroException>(_ => true)
             .WaitAndRetryForever(provider);
 
-        policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().NotThrow();
+        Should.NotThrow(() => policy.RaiseException<DivideByZeroException>());
     }
 
     [Fact]
     public void Should_not_throw_when_one_of_the_specified_exception_predicates_are_satisfied()
     {
-        Func<int, TimeSpan> provider = _ => 1.Seconds();
+        Func<int, TimeSpan> provider = _ => TimeSpan.FromSeconds(1);
 
         var policy = Policy
             .Handle<DivideByZeroException>(_ => true)
             .Or<ArgumentException>(_ => true)
            .WaitAndRetryForever(provider);
 
-        policy.Invoking(x => x.RaiseException<ArgumentException>())
-              .Should().NotThrow();
+        Should.NotThrow(() => policy.RaiseException<ArgumentException>());
     }
 
     [Fact]
     public void Should_not_sleep_if_no_retries()
     {
-        Func<int, TimeSpan> provider = _ => 1.Seconds();
+        Func<int, TimeSpan> provider = _ => TimeSpan.FromSeconds(1);
 
         var totalTimeSlept = 0;
 
@@ -178,11 +170,9 @@ public class WaitAndRetryForeverSpecs : IDisposable
 
         SystemClock.Sleep = (span, _) => totalTimeSlept += span.Seconds;
 
-        policy.Invoking(x => x.RaiseException<NullReferenceException>())
-              .Should().Throw<NullReferenceException>();
+        Should.Throw<NullReferenceException>(() => policy.RaiseException<NullReferenceException>());
 
-        totalTimeSlept.Should()
-                      .Be(0);
+        totalTimeSlept.ShouldBe(0);
     }
 
     [Fact]
@@ -200,8 +190,7 @@ public class WaitAndRetryForeverSpecs : IDisposable
 
         retryExceptions
             .Select(x => x.HelpLink)
-            .Should()
-            .ContainInOrder(expectedExceptions);
+            .ShouldBe(expectedExceptions);
     }
 
     [Fact]
@@ -217,30 +206,28 @@ public class WaitAndRetryForeverSpecs : IDisposable
 
         policy.RaiseException<DivideByZeroException>(3);
 
-        retryCounts.Should()
-            .ContainInOrder(expectedRetryCounts);
+        retryCounts.ShouldBe(expectedRetryCounts);
     }
 
     [Fact]
     public void Should_not_call_onretry_when_no_retries_are_performed()
     {
-        Func<int, TimeSpan> provider = _ => 1.Seconds();
+        Func<int, TimeSpan> provider = _ => TimeSpan.FromSeconds(1);
         var retryExceptions = new List<Exception>();
 
         var policy = Policy
             .Handle<DivideByZeroException>()
             .WaitAndRetryForever(provider, (exception, _) => retryExceptions.Add(exception));
 
-        policy.Invoking(x => x.RaiseException<ArgumentException>())
-              .Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => policy.RaiseException<ArgumentException>());
 
-        retryExceptions.Should().BeEmpty();
+        retryExceptions.ShouldBeEmpty();
     }
 
     [Fact]
     public void Should_create_new_context_for_each_call_to_policy()
     {
-        Func<int, Context, TimeSpan> provider = (_, _) => 1.Seconds();
+        Func<int, Context, TimeSpan> provider = (_, _) => TimeSpan.FromSeconds(1);
 
         string? contextValue = null;
 
@@ -253,25 +240,25 @@ public class WaitAndRetryForeverSpecs : IDisposable
         policy.RaiseException<DivideByZeroException>(
             CreateDictionary("key", "original_value"));
 
-        contextValue.Should().Be("original_value");
+        contextValue.ShouldBe("original_value");
 
         policy.RaiseException<DivideByZeroException>(
             CreateDictionary("key", "new_value"));
 
-        contextValue.Should().Be("new_value");
+        contextValue.ShouldBe("new_value");
     }
 
     [Fact]
     public void Should_calculate_retry_timespans_from_current_retry_attempt_and_timespan_provider()
     {
         var expectedRetryWaits = new[]
-            {
-                2.Seconds(),
-                4.Seconds(),
-                8.Seconds(),
-                16.Seconds(),
-                32.Seconds()
-            };
+        {
+            TimeSpan.FromSeconds(2),
+            TimeSpan.FromSeconds(4),
+            TimeSpan.FromSeconds(8),
+            TimeSpan.FromSeconds(16),
+            TimeSpan.FromSeconds(32)
+        };
 
         var actualRetryWaits = new List<TimeSpan>();
 
@@ -283,8 +270,7 @@ public class WaitAndRetryForeverSpecs : IDisposable
 
         policy.RaiseException<DivideByZeroException>(5);
 
-        actualRetryWaits.Should()
-                   .ContainInOrder(expectedRetryWaits);
+        actualRetryWaits.ShouldBe(expectedRetryWaits);
     }
 
     [Fact]
@@ -292,8 +278,8 @@ public class WaitAndRetryForeverSpecs : IDisposable
     {
         Dictionary<Exception, TimeSpan> expectedRetryWaits = new Dictionary<Exception, TimeSpan>
         {
-            {new DivideByZeroException(), 2.Seconds()},
-            {new ArgumentNullException(), 4.Seconds()},
+            [new DivideByZeroException()] = TimeSpan.FromSeconds(2),
+            [new ArgumentNullException()] = TimeSpan.FromSeconds(4),
         };
 
         var actualRetryWaits = new List<TimeSpan>();
@@ -315,16 +301,16 @@ public class WaitAndRetryForeverSpecs : IDisposable
             });
         }
 
-        actualRetryWaits.Should().ContainInOrder(expectedRetryWaits.Values);
+        actualRetryWaits.ShouldBe(expectedRetryWaits.Values);
     }
 
     [Fact]
     public void Should_be_able_to_pass_retry_duration_from_execution_to_sleepDurationProvider_via_context()
     {
-        var expectedRetryDuration = 1.Seconds();
+        var expectedRetryDuration = TimeSpan.FromSeconds(1);
         TimeSpan? actualRetryDuration = null;
 
-        TimeSpan defaultRetryAfter = 30.Seconds();
+        TimeSpan defaultRetryAfter = TimeSpan.FromSeconds(30);
 
         var policy = Policy
             .Handle<DivideByZeroException>()
@@ -346,7 +332,7 @@ public class WaitAndRetryForeverSpecs : IDisposable
             },
             CreateDictionary("RetryAfter", defaultRetryAfter)); // Can also set an initial value for RetryAfter, in the Context passed into the call.
 
-        actualRetryDuration.Should().Be(expectedRetryDuration);
+        actualRetryDuration.ShouldBe(expectedRetryDuration);
     }
 
     public void Dispose() =>

--- a/test/Polly.Specs/Retry/WaitAndRetryForeverTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/Retry/WaitAndRetryForeverTResultAsyncSpecs.cs
@@ -10,8 +10,8 @@ public class WaitAndRetryForeverTResultAsyncSpecs : IDisposable
     {
         Dictionary<ResultPrimitive, TimeSpan> expectedRetryWaits = new Dictionary<ResultPrimitive, TimeSpan>
         {
-            {ResultPrimitive.Fault, 2.Seconds()},
-            {ResultPrimitive.FaultAgain, 4.Seconds()},
+            [ResultPrimitive.Fault] = TimeSpan.FromSeconds(2),
+            [ResultPrimitive.FaultAgain] = TimeSpan.FromSeconds(4)
         };
 
         var actualRetryWaits = new List<TimeSpan>();
@@ -38,7 +38,7 @@ public class WaitAndRetryForeverTResultAsyncSpecs : IDisposable
             });
         }
 
-        actualRetryWaits.Should().ContainInOrder(expectedRetryWaits.Values);
+        actualRetryWaits.ShouldBe(expectedRetryWaits.Values);
     }
 
     public void Dispose() =>

--- a/test/Polly.Specs/Retry/WaitAndRetryForeverTResultSpecs.cs
+++ b/test/Polly.Specs/Retry/WaitAndRetryForeverTResultSpecs.cs
@@ -10,8 +10,8 @@ public class WaitAndRetryForeverTResultSpecs : IDisposable
     {
         Dictionary<ResultPrimitive, TimeSpan> expectedRetryWaits = new Dictionary<ResultPrimitive, TimeSpan>
         {
-            {ResultPrimitive.Fault, 2.Seconds()},
-            {ResultPrimitive.FaultAgain, 4.Seconds()},
+            [ResultPrimitive.Fault] = TimeSpan.FromSeconds(2),
+            [ResultPrimitive.FaultAgain] = TimeSpan.FromSeconds(4),
         };
 
         var actualRetryWaits = new List<TimeSpan>();
@@ -30,7 +30,8 @@ public class WaitAndRetryForeverTResultSpecs : IDisposable
                 : ResultPrimitive.Undefined);
         }
 
-        actualRetryWaits.Should().ContainInOrder(expectedRetryWaits.Values);
+        actualRetryWaits.ShouldBeSubsetOf(expectedRetryWaits.Values);
+        actualRetryWaits.ShouldBeInOrder();
     }
 
     public void Dispose() =>

--- a/test/Polly.Specs/Retry/WaitAndRetrySpecs.cs
+++ b/test/Polly.Specs/Retry/WaitAndRetrySpecs.cs
@@ -10,12 +10,12 @@ public class WaitAndRetrySpecs : IDisposable
     {
         Action<Exception, TimeSpan> onRetry = (_, _) => { };
 
-        Action policy = () => Policy
-                                  .Handle<DivideByZeroException>()
-                                  .WaitAndRetry(null, onRetry);
+        Action policy = () =>
+            Policy.Handle<DivideByZeroException>()
+                  .WaitAndRetry(null, onRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("sleepDurations");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("sleepDurations");
     }
 
     [Fact]
@@ -23,12 +23,12 @@ public class WaitAndRetrySpecs : IDisposable
     {
         Action<Exception, TimeSpan, Context> onRetry = (_, _, _) => { };
 
-        Action policy = () => Policy
-                                  .Handle<DivideByZeroException>()
-                                  .WaitAndRetry(null, onRetry);
+        Action policy = () =>
+            Policy.Handle<DivideByZeroException>()
+                  .WaitAndRetry(null, onRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("sleepDurations");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("sleepDurations");
     }
 
     [Fact]
@@ -36,12 +36,12 @@ public class WaitAndRetrySpecs : IDisposable
     {
         Action<Exception, TimeSpan, int, Context> onRetry = (_, _, _, _) => { };
 
-        Action policy = () => Policy
-                                  .Handle<DivideByZeroException>()
-                                  .WaitAndRetry(null, onRetry);
+        Action policy = () =>
+            Policy.Handle<DivideByZeroException>()
+                  .WaitAndRetry(null, onRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("sleepDurations");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("sleepDurations");
     }
 
     [Fact]
@@ -49,12 +49,12 @@ public class WaitAndRetrySpecs : IDisposable
     {
         Action<Exception, TimeSpan> nullOnRetry = null!;
 
-        Action policy = () => Policy
-                                  .Handle<DivideByZeroException>()
-                                  .WaitAndRetry(Enumerable.Empty<TimeSpan>(), nullOnRetry);
+        Action policy = () =>
+            Policy.Handle<DivideByZeroException>()
+                  .WaitAndRetry([], nullOnRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("onRetry");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]
@@ -62,12 +62,12 @@ public class WaitAndRetrySpecs : IDisposable
     {
         Action<Exception, TimeSpan, Context> nullOnRetry = null!;
 
-        Action policy = () => Policy
-                                  .Handle<DivideByZeroException>()
-                                  .WaitAndRetry(Enumerable.Empty<TimeSpan>(), nullOnRetry);
+        Action policy = () =>
+            Policy.Handle<DivideByZeroException>()
+                  .WaitAndRetry([], nullOnRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("onRetry");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]
@@ -75,12 +75,12 @@ public class WaitAndRetrySpecs : IDisposable
     {
         Action<Exception, TimeSpan, int, Context> nullOnRetry = null!;
 
-        Action policy = () => Policy
-                                  .Handle<DivideByZeroException>()
-                                  .WaitAndRetry(Enumerable.Empty<TimeSpan>(), nullOnRetry);
+        Action policy = () =>
+            Policy.Handle<DivideByZeroException>()
+                  .WaitAndRetry([], nullOnRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("onRetry");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]
@@ -88,15 +88,14 @@ public class WaitAndRetrySpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetry(new[]
-            {
-               1.Seconds(),
-               2.Seconds(),
-               3.Seconds()
-            });
+            .WaitAndRetry(
+            [
+               TimeSpan.FromSeconds(1),
+               TimeSpan.FromSeconds(2),
+               TimeSpan.FromSeconds(3)
+            ]);
 
-        policy.Invoking(x => x.RaiseException<DivideByZeroException>(3))
-              .Should().NotThrow();
+        Should.NotThrow(() => policy.RaiseException<DivideByZeroException>(3));
     }
 
     [Fact]
@@ -105,15 +104,14 @@ public class WaitAndRetrySpecs : IDisposable
         var policy = Policy
             .Handle<DivideByZeroException>()
             .Or<ArgumentException>()
-            .WaitAndRetry(new[]
-            {
-               1.Seconds(),
-               2.Seconds(),
-               3.Seconds()
-            });
+            .WaitAndRetry(
+            [
+               TimeSpan.FromSeconds(1),
+               TimeSpan.FromSeconds(2),
+               TimeSpan.FromSeconds(3)
+            ]);
 
-        policy.Invoking(x => x.RaiseException<ArgumentException>(3))
-              .Should().NotThrow();
+        Should.NotThrow(() => policy.RaiseException<ArgumentException>(3));
     }
 
     [Fact]
@@ -121,15 +119,14 @@ public class WaitAndRetrySpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetry(new[]
-            {
-               1.Seconds(),
-               2.Seconds(),
-               3.Seconds()
-            });
+            .WaitAndRetry(
+            [
+               TimeSpan.FromSeconds(1),
+               TimeSpan.FromSeconds(2),
+               TimeSpan.FromSeconds(3)
+            ]);
 
-        policy.Invoking(x => x.RaiseException<DivideByZeroException>(2))
-              .Should().NotThrow();
+        Should.NotThrow(() => policy.RaiseException<DivideByZeroException>(2));
     }
 
     [Fact]
@@ -138,15 +135,14 @@ public class WaitAndRetrySpecs : IDisposable
         var policy = Policy
             .Handle<DivideByZeroException>()
             .Or<ArgumentException>()
-            .WaitAndRetry(new[]
-            {
-               1.Seconds(),
-               2.Seconds(),
-               3.Seconds()
-            });
+            .WaitAndRetry(
+            [
+               TimeSpan.FromSeconds(1),
+               TimeSpan.FromSeconds(2),
+               TimeSpan.FromSeconds(3)
+            ]);
 
-        policy.Invoking(x => x.RaiseException<ArgumentException>(2))
-              .Should().NotThrow();
+        Should.NotThrow(() => policy.RaiseException<ArgumentException>(2));
     }
 
     [Fact]
@@ -154,15 +150,14 @@ public class WaitAndRetrySpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetry(new[]
-            {
-               1.Seconds(),
-               2.Seconds(),
-               3.Seconds()
-            });
+            .WaitAndRetry(
+            [
+               TimeSpan.FromSeconds(1),
+               TimeSpan.FromSeconds(2),
+               TimeSpan.FromSeconds(3)
+            ]);
 
-        policy.Invoking(x => x.RaiseException<DivideByZeroException>(3 + 1))
-              .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => policy.RaiseException<DivideByZeroException>(3 + 1));
     }
 
     [Fact]
@@ -171,15 +166,14 @@ public class WaitAndRetrySpecs : IDisposable
         var policy = Policy
             .Handle<DivideByZeroException>()
             .Or<ArgumentException>()
-            .WaitAndRetry(new[]
-            {
-               1.Seconds(),
-               2.Seconds(),
-               3.Seconds()
-            });
+            .WaitAndRetry(
+            [
+               TimeSpan.FromSeconds(1),
+               TimeSpan.FromSeconds(2),
+               TimeSpan.FromSeconds(3)
+            ]);
 
-        policy.Invoking(x => x.RaiseException<ArgumentException>(3 + 1))
-              .Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => policy.RaiseException<ArgumentException>(3 + 1));
     }
 
     [Fact]
@@ -187,10 +181,9 @@ public class WaitAndRetrySpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetry(Enumerable.Empty<TimeSpan>());
+            .WaitAndRetry([]);
 
-        policy.Invoking(x => x.RaiseException<NullReferenceException>())
-              .Should().Throw<NullReferenceException>();
+        Should.Throw<NullReferenceException>(() => policy.RaiseException<NullReferenceException>());
     }
 
     [Fact]
@@ -198,10 +191,9 @@ public class WaitAndRetrySpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync(Enumerable.Empty<TimeSpan>());
+            .WaitAndRetryAsync([]);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<NullReferenceException>())
-              .Should().ThrowAsync<NullReferenceException>();
+        await Should.ThrowAsync<NullReferenceException>(() => policy.RaiseExceptionAsync<NullReferenceException>());
     }
 
     [Fact]
@@ -210,10 +202,9 @@ public class WaitAndRetrySpecs : IDisposable
         var policy = Policy
             .Handle<DivideByZeroException>()
             .Or<ArgumentException>()
-            .WaitAndRetry(Enumerable.Empty<TimeSpan>());
+            .WaitAndRetry([]);
 
-        policy.Invoking(x => x.RaiseException<NullReferenceException>())
-              .Should().Throw<NullReferenceException>();
+        Should.Throw<NullReferenceException>(() => policy.RaiseException<NullReferenceException>());
     }
 
     [Fact]
@@ -222,10 +213,9 @@ public class WaitAndRetrySpecs : IDisposable
         var policy = Policy
             .Handle<DivideByZeroException>()
             .Or<ArgumentException>()
-            .WaitAndRetryAsync(Enumerable.Empty<TimeSpan>());
+            .WaitAndRetryAsync([]);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<NullReferenceException>())
-              .Should().ThrowAsync<NullReferenceException>();
+        await Should.ThrowAsync<NullReferenceException>(() => policy.RaiseExceptionAsync<NullReferenceException>());
     }
 
     [Fact]
@@ -233,10 +223,9 @@ public class WaitAndRetrySpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>(_ => false)
-            .WaitAndRetry(Enumerable.Empty<TimeSpan>());
+            .WaitAndRetry([]);
 
-        policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => policy.RaiseException<DivideByZeroException>());
     }
 
     [Fact]
@@ -245,10 +234,9 @@ public class WaitAndRetrySpecs : IDisposable
         var policy = Policy
             .Handle<DivideByZeroException>(_ => false)
             .Or<ArgumentException>(_ => false)
-            .WaitAndRetry(Enumerable.Empty<TimeSpan>());
+            .WaitAndRetry([]);
 
-        policy.Invoking(x => x.RaiseException<ArgumentException>())
-              .Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => policy.RaiseException<ArgumentException>());
     }
 
     [Fact]
@@ -256,13 +244,9 @@ public class WaitAndRetrySpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>(_ => true)
-            .WaitAndRetry(new[]
-            {
-               1.Seconds()
-            });
+            .WaitAndRetry([TimeSpan.FromSeconds(1)]);
 
-        policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().NotThrow();
+        Should.NotThrow(() => policy.RaiseException<DivideByZeroException>());
     }
 
     [Fact]
@@ -270,13 +254,9 @@ public class WaitAndRetrySpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>(_ => true)
-            .WaitAndRetryAsync(new[]
-            {
-               1.Seconds()
-            });
+            .WaitAndRetryAsync([TimeSpan.FromSeconds(1)]);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>())
-              .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<DivideByZeroException>());
     }
 
     [Fact]
@@ -285,13 +265,9 @@ public class WaitAndRetrySpecs : IDisposable
         var policy = Policy
             .Handle<DivideByZeroException>(_ => true)
             .Or<ArgumentException>(_ => true)
-            .WaitAndRetry(new[]
-            {
-               1.Seconds()
-            });
+            .WaitAndRetry([TimeSpan.FromSeconds(1)]);
 
-        policy.Invoking(x => x.RaiseException<ArgumentException>())
-              .Should().NotThrow();
+        Should.NotThrow(() => policy.RaiseException<ArgumentException>());
     }
 
     [Fact]
@@ -300,13 +276,9 @@ public class WaitAndRetrySpecs : IDisposable
         var policy = Policy
             .Handle<DivideByZeroException>(_ => true)
             .Or<ArgumentException>(_ => true)
-            .WaitAndRetryAsync(new[]
-            {
-               1.Seconds()
-            });
+            .WaitAndRetryAsync([TimeSpan.FromSeconds(1)]);
 
-        await policy.Awaiting(x => x.RaiseExceptionAsync<ArgumentException>())
-              .Should().NotThrowAsync();
+        await Should.NotThrowAsync(() => policy.RaiseExceptionAsync<ArgumentException>());
     }
 
     [Fact]
@@ -316,19 +288,18 @@ public class WaitAndRetrySpecs : IDisposable
 
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetry(new[]
-            {
-               1.Seconds(),
-               2.Seconds(),
-               3.Seconds()
-            });
+            .WaitAndRetry(
+            [
+               TimeSpan.FromSeconds(1),
+               TimeSpan.FromSeconds(2),
+               TimeSpan.FromSeconds(3)
+            ]);
 
         SystemClock.Sleep = (span, _) => totalTimeSlept += span.Seconds;
 
         policy.RaiseException<DivideByZeroException>(3);
 
-        totalTimeSlept.Should()
-                      .Be(1 + 2 + 3);
+        totalTimeSlept.ShouldBe(1 + 2 + 3);
     }
 
     [Fact]
@@ -338,20 +309,18 @@ public class WaitAndRetrySpecs : IDisposable
 
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetry(new[]
-            {
-               1.Seconds(),
-               2.Seconds(),
-               3.Seconds()
-            });
+            .WaitAndRetry(
+            [
+               TimeSpan.FromSeconds(1),
+               TimeSpan.FromSeconds(2),
+               TimeSpan.FromSeconds(3)
+            ]);
 
         SystemClock.Sleep = (span, _) => totalTimeSlept += span.Seconds;
 
-        policy.Invoking(x => x.RaiseException<DivideByZeroException>(3 + 1))
-              .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => policy.RaiseException<DivideByZeroException>(3 + 1));
 
-        totalTimeSlept.Should()
-                      .Be(1 + 2 + 3);
+        totalTimeSlept.ShouldBe(1 + 2 + 3);
     }
 
     [Fact]
@@ -361,19 +330,18 @@ public class WaitAndRetrySpecs : IDisposable
 
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetry(new[]
-            {
-               1.Seconds(),
-               2.Seconds(),
-               3.Seconds()
-            });
+            .WaitAndRetry(
+            [
+               TimeSpan.FromSeconds(1),
+               TimeSpan.FromSeconds(2),
+               TimeSpan.FromSeconds(3)
+            ]);
 
         SystemClock.Sleep = (span, _) => totalTimeSlept += span.Seconds;
 
         policy.RaiseException<DivideByZeroException>(2);
 
-        totalTimeSlept.Should()
-                      .Be(1 + 2);
+        totalTimeSlept.ShouldBe(1 + 2);
     }
 
     [Fact]
@@ -383,42 +351,39 @@ public class WaitAndRetrySpecs : IDisposable
 
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetry(Enumerable.Empty<TimeSpan>());
+            .WaitAndRetry([]);
 
         SystemClock.Sleep = (span, _) => totalTimeSlept += span.Seconds;
 
-        policy.Invoking(x => x.RaiseException<NullReferenceException>())
-              .Should().Throw<NullReferenceException>();
+        Should.Throw<NullReferenceException>(() => policy.RaiseException<NullReferenceException>());
 
-        totalTimeSlept.Should()
-                      .Be(0);
+        totalTimeSlept.ShouldBe(0);
     }
 
     [Fact]
     public void Should_call_onretry_on_each_retry_with_the_current_timespan()
     {
         var expectedRetryWaits = new[]
-            {
-                1.Seconds(),
-                2.Seconds(),
-                3.Seconds()
-            };
+        {
+            TimeSpan.FromSeconds(1),
+            TimeSpan.FromSeconds(2),
+            TimeSpan.FromSeconds(3)
+        };
 
         var actualRetryWaits = new List<TimeSpan>();
 
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetry(new[]
-            {
-               1.Seconds(),
-               2.Seconds(),
-               3.Seconds()
-            }, (_, timeSpan) => actualRetryWaits.Add(timeSpan));
+            .WaitAndRetry(
+            [
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(2),
+                TimeSpan.FromSeconds(3)
+            ], (_, timeSpan) => actualRetryWaits.Add(timeSpan));
 
         policy.RaiseException<DivideByZeroException>(3);
 
-        actualRetryWaits.Should()
-                   .ContainInOrder(expectedRetryWaits);
+        actualRetryWaits.ShouldBeSubsetOf(expectedRetryWaits);
     }
 
     [Fact]
@@ -429,19 +394,16 @@ public class WaitAndRetrySpecs : IDisposable
 
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetry(new[]
-            {
-               1.Seconds(),
-               2.Seconds(),
-               3.Seconds()
-            }, (exception, _) => retryExceptions.Add(exception));
+            .WaitAndRetry(
+            [
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(2),
+                TimeSpan.FromSeconds(3)
+            ], (exception, _) => retryExceptions.Add(exception));
 
         policy.RaiseException<DivideByZeroException>(3, (e, i) => e.HelpLink = "Exception #" + i);
 
-        retryExceptions
-            .Select(x => x.HelpLink)
-            .Should()
-            .ContainInOrder(expectedExceptions);
+        retryExceptions.Select((p) => p.HelpLink).ShouldBe(expectedExceptions);
     }
 
     [Fact]
@@ -452,17 +414,16 @@ public class WaitAndRetrySpecs : IDisposable
 
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetry(new[]
-            {
-               1.Seconds(),
-               2.Seconds(),
-               3.Seconds()
-            }, (_, _, retryCount, _) => retryCounts.Add(retryCount));
+            .WaitAndRetry(
+            [
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(2),
+                TimeSpan.FromSeconds(3)
+            ], (_, _, retryCount, _) => retryCounts.Add(retryCount));
 
         policy.RaiseException<DivideByZeroException>(3);
 
-        retryCounts.Should()
-                   .ContainInOrder(expectedRetryCounts);
+        retryCounts.ShouldBe(expectedRetryCounts);
     }
 
     [Fact]
@@ -472,13 +433,11 @@ public class WaitAndRetrySpecs : IDisposable
 
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetry(Enumerable.Empty<TimeSpan>(), (exception, _) => retryExceptions.Add(exception));
+            .WaitAndRetry([], (exception, _) => retryExceptions.Add(exception));
 
-        policy.Invoking(x => x.RaiseException<ArgumentException>())
-              .Should().Throw<ArgumentException>();
+        Should.Throw<ArgumentException>(() => policy.RaiseException<ArgumentException>());
 
-        retryExceptions.Should()
-                   .BeEmpty();
+        retryExceptions.ShouldBeEmpty();
     }
 
     [Fact]
@@ -486,16 +445,10 @@ public class WaitAndRetrySpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetry(new[]
-            {
-                1.Seconds()
-            });
+            .WaitAndRetry([TimeSpan.FromSeconds(1)]);
 
-        policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().NotThrow();
-
-        policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().NotThrow();
+        Should.NotThrow(() => policy.RaiseException<DivideByZeroException>());
+        Should.NotThrow(() => policy.RaiseException<DivideByZeroException>());
     }
 
     [Fact]
@@ -505,19 +458,19 @@ public class WaitAndRetrySpecs : IDisposable
 
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetry(new[]
-            {
-                1.Seconds(),
-                2.Seconds(),
-                3.Seconds()
-            }, (_, _, context) => contextData = context);
+            .WaitAndRetry(
+            [
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(2),
+                TimeSpan.FromSeconds(3)
+            ], (_, _, context) => contextData = context);
 
         policy.RaiseException<DivideByZeroException>(
             CreateDictionary("key1", "value1", "key2", "value2"));
 
-        contextData.Should()
-            .ContainKeys("key1", "key2").And
-            .ContainValues("value1", "value2");
+        contextData.ShouldNotBeNull();
+        contextData.ShouldContainKeyAndValue("key1", "value1");
+        contextData.ShouldContainKeyAndValue("key2", "value2");
     }
 
     [Fact]
@@ -527,21 +480,18 @@ public class WaitAndRetrySpecs : IDisposable
 
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetry(new[]
-            {
-                1.Seconds()
-            },
+            .WaitAndRetry([TimeSpan.FromSeconds(1)],
             (_, _, context) => contextValue = context["key"].ToString());
 
         policy.RaiseException<DivideByZeroException>(
             CreateDictionary("key", "original_value"));
 
-        contextValue.Should().Be("original_value");
+        contextValue.ShouldBe("original_value");
 
         policy.RaiseException<DivideByZeroException>(
             CreateDictionary("key", "new_value"));
 
-        contextValue.Should().Be("new_value");
+        contextValue.ShouldBe("new_value");
     }
 
     [Fact]
@@ -549,12 +499,12 @@ public class WaitAndRetrySpecs : IDisposable
     {
         Action<Exception, TimeSpan> onRetry = (_, _) => { };
 
-        Action policy = () => Policy
-                                  .Handle<DivideByZeroException>()
-                                  .WaitAndRetry(-1, _ => default, onRetry);
+        Action policy = () =>
+            Policy.Handle<DivideByZeroException>()
+                  .WaitAndRetry(-1, _ => default, onRetry);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-              .ParamName.Should().Be("retryCount");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+              .ParamName.ShouldBe("retryCount");
     }
 
     [Fact]
@@ -562,12 +512,12 @@ public class WaitAndRetrySpecs : IDisposable
     {
         Action<Exception, TimeSpan, Context> onRetry = (_, _, _) => { };
 
-        Action policy = () => Policy
-                                  .Handle<DivideByZeroException>()
-                                  .WaitAndRetry(-1, _ => default, onRetry);
+        Action policy = () =>
+            Policy.Handle<DivideByZeroException>()
+                  .WaitAndRetry(-1, _ => default, onRetry);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-              .ParamName.Should().Be("retryCount");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+              .ParamName.ShouldBe("retryCount");
     }
 
     [Fact]
@@ -575,12 +525,12 @@ public class WaitAndRetrySpecs : IDisposable
     {
         Action<Exception, TimeSpan, int, Context> onRetry = (_, _, _, _) => { };
 
-        Action policy = () => Policy
-                                  .Handle<DivideByZeroException>()
-                                  .WaitAndRetry(-1, _ => default, onRetry);
+        Action policy = () =>
+            Policy.Handle<DivideByZeroException>()
+                  .WaitAndRetry(-1, _ => default, onRetry);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-              .ParamName.Should().Be("retryCount");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+              .ParamName.ShouldBe("retryCount");
     }
 
     [Fact]
@@ -588,12 +538,12 @@ public class WaitAndRetrySpecs : IDisposable
     {
         Action<Exception, TimeSpan> onRetry = (_, _) => { };
 
-        Action policy = () => Policy
-                                  .Handle<DivideByZeroException>()
-                                  .WaitAndRetry(1, null, onRetry);
+        Action policy = () =>
+            Policy.Handle<DivideByZeroException>()
+                  .WaitAndRetry(1, null, onRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("sleepDurationProvider");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("sleepDurationProvider");
     }
 
     [Fact]
@@ -601,12 +551,12 @@ public class WaitAndRetrySpecs : IDisposable
     {
         Action<Exception, TimeSpan, Context> onRetry = (_, _, _) => { };
 
-        Action policy = () => Policy
-                                  .Handle<DivideByZeroException>()
-                                  .WaitAndRetry(1, (Func<int, TimeSpan>)null!, onRetry);
+        Action policy = () =>
+            Policy.Handle<DivideByZeroException>()
+                  .WaitAndRetry(1, (Func<int, TimeSpan>)null!, onRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("sleepDurationProvider");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("sleepDurationProvider");
     }
 
     [Fact]
@@ -614,12 +564,12 @@ public class WaitAndRetrySpecs : IDisposable
     {
         Action<Exception, TimeSpan, int, Context> onRetry = (_, _, _, _) => { };
 
-        Action policy = () => Policy
-                                  .Handle<DivideByZeroException>()
-                                  .WaitAndRetry(1, (Func<int, TimeSpan>)null!, onRetry);
+        Action policy = () =>
+            Policy.Handle<DivideByZeroException>()
+                  .WaitAndRetry(1, (Func<int, TimeSpan>)null!, onRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("sleepDurationProvider");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("sleepDurationProvider");
     }
 
     [Fact]
@@ -627,12 +577,12 @@ public class WaitAndRetrySpecs : IDisposable
     {
         Action<Exception, TimeSpan> nullOnRetry = null!;
 
-        Action policy = () => Policy
-                                  .Handle<DivideByZeroException>()
-                                  .WaitAndRetry(1, _ => default, nullOnRetry);
+        Action policy = () =>
+            Policy.Handle<DivideByZeroException>()
+                  .WaitAndRetry(1, _ => default, nullOnRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("onRetry");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]
@@ -640,12 +590,12 @@ public class WaitAndRetrySpecs : IDisposable
     {
         Action<Exception, TimeSpan, Context> nullOnRetry = null!;
 
-        Action policy = () => Policy
-                                  .Handle<DivideByZeroException>()
-                                  .WaitAndRetry(1, _ => default, nullOnRetry);
+        Action policy = () =>
+            Policy.Handle<DivideByZeroException>()
+                  .WaitAndRetry(1, _ => default, nullOnRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("onRetry");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]
@@ -653,25 +603,25 @@ public class WaitAndRetrySpecs : IDisposable
     {
         Action<Exception, TimeSpan, int, Context> nullOnRetry = null!;
 
-        Action policy = () => Policy
-                                  .Handle<DivideByZeroException>()
-                                  .WaitAndRetry(1, _ => default, nullOnRetry);
+        Action policy = () =>
+            Policy.Handle<DivideByZeroException>()
+                  .WaitAndRetry(1, _ => default, nullOnRetry);
 
-        policy.Should().Throw<ArgumentNullException>().And
-              .ParamName.Should().Be("onRetry");
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]
     public void Should_calculate_retry_timespans_from_current_retry_attempt_and_timespan_provider()
     {
         var expectedRetryWaits = new[]
-            {
-                2.Seconds(),
-                4.Seconds(),
-                8.Seconds(),
-                16.Seconds(),
-                32.Seconds()
-            };
+        {
+            TimeSpan.FromSeconds(2),
+            TimeSpan.FromSeconds(4),
+            TimeSpan.FromSeconds(8),
+            TimeSpan.FromSeconds(16),
+            TimeSpan.FromSeconds(32)
+        };
 
         var actualRetryWaits = new List<TimeSpan>();
 
@@ -683,8 +633,7 @@ public class WaitAndRetrySpecs : IDisposable
 
         policy.RaiseException<DivideByZeroException>(5);
 
-        actualRetryWaits.Should()
-                   .ContainInOrder(expectedRetryWaits);
+        actualRetryWaits.ShouldBe(expectedRetryWaits);
     }
 
     [Fact]
@@ -702,13 +651,11 @@ public class WaitAndRetrySpecs : IDisposable
                     capturedExceptionInstance = ex;
                     return TimeSpan.FromMilliseconds(0);
                 },
-                onRetry: (_, _, _, _) =>
-                {
-                });
+                onRetry: (_, _, _, _) => { });
 
         policy.RaiseException(exceptionInstance);
 
-        capturedExceptionInstance.Should().Be(exceptionInstance);
+        capturedExceptionInstance.ShouldBe(exceptionInstance);
     }
 
     [Fact]
@@ -716,8 +663,8 @@ public class WaitAndRetrySpecs : IDisposable
     {
         Dictionary<Exception, TimeSpan> expectedRetryWaits = new Dictionary<Exception, TimeSpan>
         {
-            {new DivideByZeroException(), 2.Seconds()},
-            {new ArgumentNullException(), 4.Seconds()},
+            [new DivideByZeroException()] = TimeSpan.FromSeconds(2),
+            [new ArgumentNullException()] = TimeSpan.FromSeconds(4),
         };
 
         var actualRetryWaits = new List<TimeSpan>();
@@ -739,16 +686,16 @@ public class WaitAndRetrySpecs : IDisposable
             });
         }
 
-        actualRetryWaits.Should().ContainInOrder(expectedRetryWaits.Values);
+        actualRetryWaits.ShouldBe(expectedRetryWaits.Values);
     }
 
     [Fact]
     public void Should_be_able_to_pass_retry_duration_from_execution_to_sleepDurationProvider_via_context()
     {
-        var expectedRetryDuration = 1.Seconds();
+        var expectedRetryDuration = TimeSpan.FromSeconds(1);
         TimeSpan? actualRetryDuration = null;
 
-        TimeSpan defaultRetryAfter = 30.Seconds();
+        var defaultRetryAfter = TimeSpan.FromSeconds(30);
 
         var policy = Policy
             .Handle<DivideByZeroException>()
@@ -770,7 +717,7 @@ public class WaitAndRetrySpecs : IDisposable
         },
             CreateDictionary("RetryAfter", defaultRetryAfter)); // Can also set an initial value for RetryAfter, in the Context passed into the call.
 
-        actualRetryDuration.Should().Be(expectedRetryDuration);
+        actualRetryDuration.ShouldBe(expectedRetryDuration);
     }
 
     [Fact]
@@ -778,16 +725,15 @@ public class WaitAndRetrySpecs : IDisposable
     {
         bool retryInvoked = false;
 
-        Action<Exception, TimeSpan> onRetry = (_, _) => { retryInvoked = true; };
+        Action<Exception, TimeSpan> onRetry = (_, _) => retryInvoked = true;
 
         var policy = Policy
             .Handle<DivideByZeroException>()
             .WaitAndRetry(0, _ => TimeSpan.FromSeconds(1), onRetry);
 
-        policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => policy.RaiseException<DivideByZeroException>());
 
-        retryInvoked.Should().BeFalse();
+        retryInvoked.ShouldBeFalse();
     }
 
     [Fact]
@@ -795,16 +741,15 @@ public class WaitAndRetrySpecs : IDisposable
     {
         bool retryInvoked = false;
 
-        Action<Exception, TimeSpan, Context> onRetry = (_, _, _) => { retryInvoked = true; };
+        Action<Exception, TimeSpan, Context> onRetry = (_, _, _) => retryInvoked = true;
 
         Policy policy = Policy
             .Handle<DivideByZeroException>()
             .WaitAndRetry(0, _ => TimeSpan.FromSeconds(1), onRetry);
 
-        policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => policy.RaiseException<DivideByZeroException>());
 
-        retryInvoked.Should().BeFalse();
+        retryInvoked.ShouldBeFalse();
     }
 
     [Fact]
@@ -812,16 +757,15 @@ public class WaitAndRetrySpecs : IDisposable
     {
         bool retryInvoked = false;
 
-        Action<Exception, TimeSpan, int, Context> onRetry = (_, _, _, _) => { retryInvoked = true; };
+        Action<Exception, TimeSpan, int, Context> onRetry = (_, _, _, _) => retryInvoked = true;
 
         Policy policy = Policy
             .Handle<DivideByZeroException>()
             .WaitAndRetry(0, _ => TimeSpan.FromSeconds(1), onRetry);
 
-        policy.Invoking(x => x.RaiseException<DivideByZeroException>())
-              .Should().Throw<DivideByZeroException>();
+        Should.Throw<DivideByZeroException>(() => policy.RaiseException<DivideByZeroException>());
 
-        retryInvoked.Should().BeFalse();
+        retryInvoked.ShouldBeFalse();
     }
 
     #region Sync cancellation tests
@@ -831,7 +775,12 @@ public class WaitAndRetrySpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetry(new[] { 1.Seconds(), 2.Seconds(), 3.Seconds() });
+            .WaitAndRetry(
+            [
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(2),
+                TimeSpan.FromSeconds(3)
+            ]);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -847,12 +796,11 @@ public class WaitAndRetrySpecs : IDisposable
             CancellationToken cancellationToken = cancellationTokenSource.Token;
             cancellationTokenSource.Cancel();
 
-            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<OperationCanceledException>()
-                .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(0);
+        attemptsInvoked.ShouldBe(0);
     }
 
     [Fact]
@@ -860,7 +808,12 @@ public class WaitAndRetrySpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetry(new[] { 1.Seconds(), 2.Seconds(), 3.Seconds() });
+            .WaitAndRetry(
+            [
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(2),
+                TimeSpan.FromSeconds(3)
+            ]);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -876,12 +829,11 @@ public class WaitAndRetrySpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().Throw<OperationCanceledException>()
-            .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -889,7 +841,12 @@ public class WaitAndRetrySpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetry(new[] { 1.Seconds(), 2.Seconds(), 3.Seconds() });
+            .WaitAndRetry(
+            [
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(2),
+                TimeSpan.FromSeconds(3)
+            ]);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -905,12 +862,11 @@ public class WaitAndRetrySpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().Throw<OperationCanceledException>()
-            .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -918,7 +874,12 @@ public class WaitAndRetrySpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetry(new[] { 1.Seconds(), 2.Seconds(), 3.Seconds() });
+            .WaitAndRetry(
+            [
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(2),
+                TimeSpan.FromSeconds(3)
+            ]);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -934,12 +895,11 @@ public class WaitAndRetrySpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().Throw<OperationCanceledException>()
-            .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -947,7 +907,12 @@ public class WaitAndRetrySpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetry(new[] { 1.Seconds(), 2.Seconds(), 3.Seconds() });
+            .WaitAndRetry(
+            [
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(2),
+                TimeSpan.FromSeconds(3)
+            ]);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -963,12 +928,11 @@ public class WaitAndRetrySpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().Throw<OperationCanceledException>()
-            .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(2);
+        attemptsInvoked.ShouldBe(2);
     }
 
     [Fact]
@@ -976,7 +940,12 @@ public class WaitAndRetrySpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetry(new[] { 1.Seconds(), 2.Seconds(), 3.Seconds() });
+            .WaitAndRetry(
+            [
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(2),
+                TimeSpan.FromSeconds(3)
+            ]);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -992,12 +961,11 @@ public class WaitAndRetrySpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().Throw<OperationCanceledException>()
-            .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(2);
+        attemptsInvoked.ShouldBe(2);
     }
 
     [Fact]
@@ -1005,7 +973,12 @@ public class WaitAndRetrySpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetry(new[] { 1.Seconds(), 2.Seconds(), 3.Seconds() });
+            .WaitAndRetry(
+            [
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(2),
+                TimeSpan.FromSeconds(3)
+            ]);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -1021,12 +994,11 @@ public class WaitAndRetrySpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().Throw<OperationCanceledException>()
-            .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1 + 3);
+        attemptsInvoked.ShouldBe(1 + 3);
     }
 
     [Fact]
@@ -1034,7 +1006,12 @@ public class WaitAndRetrySpecs : IDisposable
     {
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetry(new[] { 1.Seconds(), 2.Seconds(), 3.Seconds() });
+            .WaitAndRetry(
+            [
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(2),
+                TimeSpan.FromSeconds(3)
+            ]);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -1050,11 +1027,10 @@ public class WaitAndRetrySpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-            .Should().Throw<DivideByZeroException>();
+            Should.Throw<DivideByZeroException>(() => policy.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute));
         }
 
-        attemptsInvoked.Should().Be(1 + 3);
+        attemptsInvoked.ShouldBe(1 + 3);
     }
 
     [Fact]
@@ -1062,12 +1038,12 @@ public class WaitAndRetrySpecs : IDisposable
     {
         SystemClock.Sleep = (timeSpan, ct) => Task.Delay(timeSpan, ct).Wait(ct);
 
-        TimeSpan shimTimeSpan = TimeSpan.FromSeconds(1); // Consider increasing shimTimeSpan if test fails transiently in different environments.
+        TimeSpan shimTimeSpan = TimeSpan.FromSeconds(1);
         TimeSpan retryDelay = shimTimeSpan + shimTimeSpan + shimTimeSpan;
 
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetry(new[] { retryDelay });
+            .WaitAndRetry([retryDelay]);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -1088,17 +1064,16 @@ public class WaitAndRetrySpecs : IDisposable
 
             cancellationTokenSource.CancelAfter(shimTimeSpan);
 
-            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                    .Should().Throw<OperationCanceledException>()
-                    .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
         watch.Stop();
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
 
-        watch.Elapsed.Should().BeLessThan(retryDelay);
-        watch.Elapsed.Should().BeCloseTo(shimTimeSpan, precision: TimeSpan.FromMilliseconds(shimTimeSpan.TotalMilliseconds / 2));  // Consider increasing shimTimeSpan, or loosening precision, if test fails transiently in different environments.
+        watch.Elapsed.ShouldBeLessThan(retryDelay);
+        watch.Elapsed.ShouldBe(shimTimeSpan, TimeSpan.FromMilliseconds(shimTimeSpan.TotalMilliseconds / 2));  // Consider increasing shimTimeSpan, or loosening precision, if test fails transiently in different environments.
     }
 
     [Fact]
@@ -1120,18 +1095,19 @@ public class WaitAndRetrySpecs : IDisposable
 
             var policy = Policy
                 .Handle<DivideByZeroException>()
-                .WaitAndRetry(new[] { 1.Seconds(), 2.Seconds(), 3.Seconds() },
-                (_, _) =>
-                {
-                    cancellationTokenSource.Cancel();
-                });
+                .WaitAndRetry(
+                [
+                    TimeSpan.FromSeconds(1),
+                    TimeSpan.FromSeconds(2),
+                    TimeSpan.FromSeconds(3)
+                ],
+                (_, _) => cancellationTokenSource.Cancel());
 
-            policy.Invoking(x => x.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
-                .Should().Throw<OperationCanceledException>()
-                .And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => policy.RaiseExceptionAndOrCancellation<DivideByZeroException>(scenario, cancellationTokenSource, onExecute))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -1139,7 +1115,12 @@ public class WaitAndRetrySpecs : IDisposable
     {
         var policy = Policy
            .Handle<DivideByZeroException>()
-           .WaitAndRetry(new[] { 1.Seconds(), 2.Seconds(), 3.Seconds() });
+           .WaitAndRetry(
+            [
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(2),
+                TimeSpan.FromSeconds(3)
+            ]);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -1154,13 +1135,13 @@ public class WaitAndRetrySpecs : IDisposable
 
         using (var cancellationTokenSource = new CancellationTokenSource())
         {
-            policy.Invoking(x => result = x.RaiseExceptionAndOrCancellation<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true))
-            .Should().NotThrow();
+            Should.NotThrow(() => result = policy.RaiseExceptionAndOrCancellation<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true));
         }
 
-        result.Should().BeTrue();
+        result.ShouldNotBeNull();
+        result.Value.ShouldBeTrue();
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     [Fact]
@@ -1168,7 +1149,12 @@ public class WaitAndRetrySpecs : IDisposable
     {
         var policy = Policy
            .Handle<DivideByZeroException>()
-           .WaitAndRetry(new[] { 1.Seconds(), 2.Seconds(), 3.Seconds() });
+           .WaitAndRetry(
+            [
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(2),
+                TimeSpan.FromSeconds(3)
+            ]);
 
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
@@ -1186,13 +1172,13 @@ public class WaitAndRetrySpecs : IDisposable
         {
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            policy.Invoking(x => result = x.RaiseExceptionAndOrCancellation<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true))
-            .Should().Throw<OperationCanceledException>().And.CancellationToken.Should().Be(cancellationToken);
+            Should.Throw<OperationCanceledException>(() => result = policy.RaiseExceptionAndOrCancellation<DivideByZeroException, bool>(scenario, cancellationTokenSource, onExecute, true))
+                .CancellationToken.ShouldBe(cancellationToken);
         }
 
-        result.Should().Be(null);
+        result.ShouldBe(null);
 
-        attemptsInvoked.Should().Be(1);
+        attemptsInvoked.ShouldBe(1);
     }
 
     #endregion

--- a/test/Polly.Specs/Retry/WaitAndRetrySpecs.cs
+++ b/test/Polly.Specs/Retry/WaitAndRetrySpecs.cs
@@ -1048,8 +1048,7 @@ public class WaitAndRetrySpecs : IDisposable
         int attemptsInvoked = 0;
         Action onExecute = () => attemptsInvoked++;
 
-        Stopwatch watch = new Stopwatch();
-        watch.Start();
+        var watch = Stopwatch.StartNew();
 
         PolicyExtensions.ExceptionAndOrCancellationScenario scenario = new PolicyExtensions.ExceptionAndOrCancellationScenario
         {

--- a/test/Polly.Specs/Retry/WaitAndRetryTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/Retry/WaitAndRetryTResultAsyncSpecs.cs
@@ -10,8 +10,8 @@ public class WaitAndRetryTResultAsyncSpecs : IDisposable
     {
         Dictionary<ResultPrimitive, TimeSpan> expectedRetryWaits = new Dictionary<ResultPrimitive, TimeSpan>
         {
-            {ResultPrimitive.Fault, 2.Seconds()},
-            {ResultPrimitive.FaultAgain, 4.Seconds()},
+            [ResultPrimitive.Fault] = TimeSpan.FromSeconds(2),
+            [ResultPrimitive.FaultAgain] = TimeSpan.FromSeconds(4),
         };
 
         var actualRetryWaits = new List<TimeSpan>();
@@ -38,7 +38,7 @@ public class WaitAndRetryTResultAsyncSpecs : IDisposable
             });
         }
 
-        actualRetryWaits.Should().ContainInOrder(expectedRetryWaits.Values);
+        actualRetryWaits.ShouldBeSubsetOf(expectedRetryWaits.Values);
     }
 
     [Fact]
@@ -46,8 +46,8 @@ public class WaitAndRetryTResultAsyncSpecs : IDisposable
     {
         var expectedRetryWaits = new Dictionary<ResultPrimitive, TimeSpan>
         {
-            {ResultPrimitive.Fault, 2.Seconds()},
-            {ResultPrimitive.FaultAgain, 4.Seconds()},
+            [ResultPrimitive.Fault] = TimeSpan.FromSeconds(2),
+            [ResultPrimitive.FaultAgain] = TimeSpan.FromSeconds(4),
         };
 
         var actualRetryWaits = new List<TimeSpan>();
@@ -62,7 +62,7 @@ public class WaitAndRetryTResultAsyncSpecs : IDisposable
                     return TaskHelper.EmptyTask;
                 });
 
-        configure.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("retryCount");
+        Should.Throw<ArgumentOutOfRangeException>(configure).ParamName.ShouldBe("retryCount");
     }
 
     [Fact]
@@ -70,8 +70,8 @@ public class WaitAndRetryTResultAsyncSpecs : IDisposable
     {
         var expectedRetryWaits = new Dictionary<ResultPrimitive, TimeSpan>
         {
-            {ResultPrimitive.Fault, 2.Seconds()},
-            {ResultPrimitive.FaultAgain, 4.Seconds()},
+            [ResultPrimitive.Fault] = TimeSpan.FromSeconds(2),
+            [ResultPrimitive.FaultAgain] = TimeSpan.FromSeconds(4),
         };
 
         Action configure = () => Policy
@@ -80,7 +80,7 @@ public class WaitAndRetryTResultAsyncSpecs : IDisposable
                 (_, outcome, _) => expectedRetryWaits[outcome.Result],
                 null);
 
-        configure.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("onRetryAsync");
+        Should.Throw<ArgumentNullException>(configure).ParamName.ShouldBe("onRetryAsync");
     }
 
     public void Dispose() =>

--- a/test/Polly.Specs/Retry/WaitAndRetryTResultSpecs.cs
+++ b/test/Polly.Specs/Retry/WaitAndRetryTResultSpecs.cs
@@ -10,8 +10,8 @@ public class WaitAndRetryTResultSpecs : IDisposable
     {
         Dictionary<ResultPrimitive, TimeSpan> expectedRetryWaits = new Dictionary<ResultPrimitive, TimeSpan>
         {
-            {ResultPrimitive.Fault, 2.Seconds()},
-            {ResultPrimitive.FaultAgain, 4.Seconds()},
+            {ResultPrimitive.Fault, TimeSpan.FromSeconds(2)},
+            {ResultPrimitive.FaultAgain, TimeSpan.FromSeconds(4)},
         };
 
         var actualRetryWaits = new List<TimeSpan>();
@@ -30,7 +30,7 @@ public class WaitAndRetryTResultSpecs : IDisposable
                 : ResultPrimitive.Undefined);
         }
 
-        actualRetryWaits.Should().ContainInOrder(expectedRetryWaits.Values);
+        actualRetryWaits.ShouldBeSubsetOf(expectedRetryWaits.Values);
     }
 
     public void Dispose() =>

--- a/test/Polly.Specs/Timeout/TimeoutAsyncSpecs.cs
+++ b/test/Polly.Specs/Timeout/TimeoutAsyncSpecs.cs
@@ -29,10 +29,10 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
 
         var func = () => generic.Invoke(instance, [action, new Context(), CancellationToken, false]);
 
-        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("action");
+        var exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>()
+            .ParamName.ShouldBe("action");
     }
 
     [Fact]
@@ -40,8 +40,8 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.TimeoutAsync(TimeSpan.Zero);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-            .ParamName.Should().Be("timeout");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+            .ParamName.ShouldBe("timeout");
     }
 
     [Fact]
@@ -49,8 +49,8 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.TimeoutAsync(0);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-            .ParamName.Should().Be("seconds");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+            .ParamName.ShouldBe("seconds");
     }
 
     [Fact]
@@ -58,8 +58,8 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.TimeoutAsync(-TimeSpan.FromHours(1));
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-            .ParamName.Should().Be("timeout");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+            .ParamName.ShouldBe("timeout");
     }
 
     [Fact]
@@ -67,8 +67,8 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.TimeoutAsync(-10);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-            .ParamName.Should().Be("seconds");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+            .ParamName.ShouldBe("seconds");
     }
 
     [Fact]
@@ -76,7 +76,7 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.TimeoutAsync(TimeSpan.FromMilliseconds(1));
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -84,7 +84,7 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.TimeoutAsync(3);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -92,7 +92,7 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.TimeoutAsync(TimeSpan.MaxValue);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -100,7 +100,7 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.TimeoutAsync(int.MaxValue);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -108,7 +108,7 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.TimeoutAsync(System.Threading.Timeout.InfiniteTimeSpan);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -116,7 +116,7 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.TimeoutAsync(System.Threading.Timeout.InfiniteTimeSpan, TimeoutStrategy.Optimistic);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -125,7 +125,7 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
         Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, _, _) => TaskHelper.EmptyTask;
         Action policy = () => Policy.TimeoutAsync(System.Threading.Timeout.InfiniteTimeSpan, doNothingAsync);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -134,7 +134,7 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
         Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, _, _) => TaskHelper.EmptyTask;
         Action policy = () => Policy.TimeoutAsync(System.Threading.Timeout.InfiniteTimeSpan, TimeoutStrategy.Optimistic, doNothingAsync);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -143,8 +143,8 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
         Func<Context, TimeSpan, Task, Task> onTimeout = null!;
         Action policy = () => Policy.TimeoutAsync(TimeSpan.FromMinutes(0.5), onTimeout);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onTimeoutAsync");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onTimeoutAsync");
     }
 
     [Fact]
@@ -153,8 +153,8 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
         Func<Context, TimeSpan, Task, Exception, Task> onTimeout = null!;
         Action policy = () => Policy.TimeoutAsync(TimeSpan.FromMinutes(0.5), onTimeout);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onTimeoutAsync");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onTimeoutAsync");
     }
 
     [Fact]
@@ -163,8 +163,8 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
         Func<Context, TimeSpan, Task, Task> onTimeout = null!;
         Action policy = () => Policy.TimeoutAsync(30, onTimeout);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onTimeoutAsync");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onTimeoutAsync");
     }
 
     [Fact]
@@ -173,8 +173,8 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
         Func<Context, TimeSpan, Task, Exception, Task> onTimeout = null!;
         Action policy = () => Policy.TimeoutAsync(30, onTimeout);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onTimeoutAsync");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onTimeoutAsync");
     }
 
     [Fact]
@@ -182,8 +182,8 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.TimeoutAsync((Func<TimeSpan>)null!);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("timeoutProvider");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("timeoutProvider");
     }
 
     [Fact]
@@ -192,8 +192,8 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
         Func<Context, TimeSpan, Task, Task> onTimeout = null!;
         Action policy = () => Policy.TimeoutAsync(() => TimeSpan.FromSeconds(30), onTimeout);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onTimeoutAsync");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onTimeoutAsync");
     }
 
     [Fact]
@@ -202,8 +202,8 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
         Func<Context, TimeSpan, Task, Exception, Task> onTimeout = null!;
         Action policy = () => Policy.TimeoutAsync(() => TimeSpan.FromSeconds(30), onTimeout);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onTimeoutAsync");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onTimeoutAsync");
     }
 
     [Fact]
@@ -211,7 +211,7 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.TimeoutAsync(() => TimeSpan.FromSeconds(1));
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     #endregion
@@ -225,11 +225,11 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
 
         var policy = Policy.TimeoutAsync(timeout, TimeoutStrategy.Pessimistic);
 
-        await policy.Awaiting(p => p.ExecuteAsync(async () =>
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async () =>
         {
             await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken);
 
-        })).Should().ThrowAsync<TimeoutRejectedException>();
+        }));
     }
 
     [Fact]
@@ -244,30 +244,29 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
             result = await policy.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good));
         };
 
-        act.Should().NotThrowAsync();
-        result.Should().Be(ResultPrimitive.Good);
+        Should.NotThrowAsync(act);
+        result.ShouldBe(ResultPrimitive.Good);
     }
 
     [Fact]
     public async Task Should_throw_timeout_after_correct_duration__pessimistic()
     {
-        Stopwatch watch = new Stopwatch();
-
         TimeSpan timeout = TimeSpan.FromSeconds(1);
         var policy = Policy.TimeoutAsync(timeout, TimeoutStrategy.Pessimistic);
 
-        TimeSpan tolerance = TimeSpan.FromSeconds(3); // Consider increasing tolerance, if test fails transiently in different test/build environments.
+        TimeSpan tolerance = TimeSpan.FromSeconds(3);
 
-        watch.Start();
-        await policy.Awaiting(p => p.ExecuteAsync(async () =>
+        var watch = Stopwatch.StartNew();
+
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async () =>
         {
             await SystemClock.SleepAsync(TimeSpan.FromSeconds(10), CancellationToken);
 
-        }))
-            .Should().ThrowAsync<TimeoutRejectedException>();
+        }));
+
         watch.Stop();
 
-        watch.Elapsed.Should().BeCloseTo(timeout, TimeSpan.FromMilliseconds(tolerance.TotalMilliseconds));
+        watch.Elapsed.ShouldBe(timeout, tolerance);
     }
 
     [Fact]
@@ -275,7 +274,7 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
     {
         var policy = Policy.TimeoutAsync(TimeSpan.FromSeconds(10), TimeoutStrategy.Pessimistic);
 
-        await policy.Awaiting(p => p.ExecuteAsync(() => throw new NotSupportedException())).Should().ThrowAsync<NotSupportedException>();
+        await Should.ThrowAsync<NotSupportedException>(() => policy.ExecuteAsync(() => throw new NotSupportedException()));
     }
 
     [Fact]
@@ -296,9 +295,9 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
             await SystemClock.SleepAsync(TimeSpan.FromMilliseconds(1000), combinedToken);
         }, CancellationToken);
 
-        await act.Should().ThrowAsync<TimeoutRejectedException>();
+        await Should.ThrowAsync<TimeoutRejectedException>(act);
 
-        isCancelled.Should().BeTrue();
+        isCancelled.ShouldBeTrue();
     }
 
     #endregion
@@ -313,12 +312,11 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
         var policy = Policy.TimeoutAsync(timeout, TimeoutStrategy.Optimistic);
         var userCancellationToken = CancellationToken;
 
-        await policy.Awaiting(p => p.ExecuteAsync(async ct =>
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async ct =>
         {
             await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct);
 
-        }, userCancellationToken))
-        .Should().ThrowAsync<TimeoutRejectedException>();
+        }, userCancellationToken));
     }
 
     [Fact]
@@ -337,30 +335,29 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
                 }, userCancellationToken);
         };
 
-        act.Should().NotThrowAsync<TimeoutRejectedException>();
-        result.Should().Be(ResultPrimitive.Good);
+        Should.NotThrowAsync(act);
+        result.ShouldBe(ResultPrimitive.Good);
     }
 
     [Fact]
     public async Task Should_throw_timeout_after_correct_duration__optimistic()
     {
-        Stopwatch watch = new Stopwatch();
-
         TimeSpan timeout = TimeSpan.FromSeconds(1);
         var policy = Policy.TimeoutAsync(timeout, TimeoutStrategy.Optimistic);
         var userCancellationToken = CancellationToken;
 
-        TimeSpan tolerance = TimeSpan.FromSeconds(3); // Consider increasing tolerance, if test fails transiently in different test/build environments.
+        TimeSpan tolerance = TimeSpan.FromSeconds(3);
 
-        watch.Start();
-        await policy.Awaiting(p => p.ExecuteAsync(async ct =>
+        var watch = Stopwatch.StartNew();
+
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async ct =>
         {
             await SystemClock.SleepAsync(TimeSpan.FromSeconds(10), ct);
-        }, userCancellationToken))
-            .Should().ThrowAsync<TimeoutRejectedException>();
+        }, userCancellationToken));
+
         watch.Stop();
 
-        watch.Elapsed.Should().BeCloseTo(timeout, TimeSpan.FromMilliseconds(tolerance.TotalMilliseconds));
+        watch.Elapsed.ShouldBe(timeout, tolerance);
     }
 
     [Fact]
@@ -368,7 +365,7 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
     {
         var policy = Policy.TimeoutAsync(TimeSpan.FromSeconds(10), TimeoutStrategy.Optimistic);
 
-        await policy.Awaiting(p => p.ExecuteAsync(() => throw new NotSupportedException())).Should().ThrowAsync<NotSupportedException>();
+        await Should.ThrowAsync<NotSupportedException>(() => policy.ExecuteAsync(() => throw new NotSupportedException()));
     }
 
     #endregion
@@ -382,13 +379,12 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
         var policy = Policy.TimeoutAsync(timeout, TimeoutStrategy.Pessimistic);
 
         using CancellationTokenSource userTokenSource = new CancellationTokenSource();
-        await policy.Awaiting(p => p.ExecuteAsync(async
-            _ =>
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async _ =>
         {
             userTokenSource.Cancel(); // User token cancels in the middle of execution ...
             await SystemClock.SleepAsync(TimeSpan.FromSeconds(timeout * 2),
                 CancellationToken); // ... but if the executed delegate does not observe it
-        }, userTokenSource.Token)).Should().ThrowAsync<TimeoutRejectedException>(); // ... it's still the timeout we expect.
+        }, userTokenSource.Token));
     }
 
     [Fact]
@@ -402,15 +398,14 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
         {
             cts.Cancel();
 
-            await policy.Awaiting(p => p.ExecuteAsync(_ =>
+            await Should.ThrowAsync<OperationCanceledException>(() => policy.ExecuteAsync(_ =>
             {
                 executed = true;
                 return TaskHelper.EmptyTask;
-            }, cts.Token))
-            .Should().ThrowAsync<OperationCanceledException>();
+            }, cts.Token));
         }
 
-        executed.Should().BeFalse();
+        executed.ShouldBeFalse();
     }
 
     #endregion
@@ -424,14 +419,13 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
         var policy = Policy.TimeoutAsync(timeout, TimeoutStrategy.Optimistic);
 
         using CancellationTokenSource userTokenSource = new CancellationTokenSource();
-        await policy.Awaiting(p => p.ExecuteAsync(
+        await Should.ThrowAsync<OperationCanceledException>(() => policy.ExecuteAsync(
             ct =>
             {
                 userTokenSource.Cancel();
                 ct.ThrowIfCancellationRequested();   // Simulate cancel in the middle of execution
                 return TaskHelper.EmptyTask;
-            }, userTokenSource.Token)) // ... with user token.
-           .Should().ThrowAsync<OperationCanceledException>();
+            }, userTokenSource.Token)); // ... with user token.
     }
 
     [Fact]
@@ -445,15 +439,14 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
         {
             cts.Cancel();
 
-            await policy.Awaiting(p => p.ExecuteAsync(_ =>
+            await Should.ThrowAsync<OperationCanceledException>(() => policy.ExecuteAsync(_ =>
             {
                 executed = true;
                 return TaskHelper.EmptyTask;
-            }, cts.Token))
-            .Should().ThrowAsync<OperationCanceledException>();
+            }, cts.Token));
         }
 
-        executed.Should().BeFalse();
+        executed.ShouldBeFalse();
     }
 
     [Fact]
@@ -463,31 +456,30 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
         var shimTimeSpan = TimeSpan.FromSeconds(0.2);
         var policy = Policy.TimeoutAsync(shimTimeSpan, TimeoutStrategy.Optimistic);
 
-        var thrown = await policy.Awaiting(p => p.ExecuteAsync(async _ =>
+        var thrown = await Should.ThrowAsync<Exception>(() => policy.ExecuteAsync(async _ =>
+        {
+            try
             {
-                try
-                {
-                    await SystemClock.SleepAsync(shimTimeSpan + shimTimeSpan, CancellationToken);
-                }
-                catch
-                {
-                    // Throw a different exception - this exception should not be masked.
-                    // The issue of more interest for issue 620 is an edge-case race condition where a user exception is thrown
-                    // quasi-simultaneously to timeout (rather than in a manual catch of a timeout as here), but this is a good way to simulate it.
-                    // A real-world case can be if timeout occurs while code is marshalling a user-exception into or through the catch block in TimeoutEngine.
-                    throw userException;
-                }
+                await SystemClock.SleepAsync(shimTimeSpan + shimTimeSpan, CancellationToken);
+            }
+            catch
+            {
+                // Throw a different exception - this exception should not be masked.
+                // The issue of more interest for issue 620 is an edge-case race condition where a user exception is thrown
+                // quasi-simultaneously to timeout (rather than in a manual catch of a timeout as here), but this is a good way to simulate it.
+                // A real-world case can be if timeout occurs while code is marshalling a user-exception into or through the catch block in TimeoutEngine.
+                throw userException;
+            }
 
-                throw new InvalidOperationException("This exception should not be thrown. Test should throw for timeout earlier.");
+            throw new InvalidOperationException("This exception should not be thrown. Test should throw for timeout earlier.");
 
-            }, CancellationToken))
-            .Should()
-            .ThrowAsync<Exception>();
+        }, CancellationToken));
 
-        thrown.NotBeOfType<OperationCanceledException>();
-        thrown.NotBeOfType<TimeoutRejectedException>();
-        thrown.NotBeOfType<InvalidOperationException>();
-        thrown.Which.Should().BeSameAs(userException);
+        thrown.ShouldNotBeNull();
+        thrown.ShouldNotBeOfType<OperationCanceledException>();
+        thrown.ShouldNotBeOfType<TimeoutRejectedException>();
+        thrown.ShouldNotBeOfType<InvalidOperationException>();
+        thrown.ShouldBeSameAs(userException);
     }
 
     #endregion
@@ -508,13 +500,12 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
 
         var policy = Policy.TimeoutAsync(timeoutPassedToConfiguration, TimeoutStrategy.Pessimistic, onTimeoutAsync);
 
-        await policy.Awaiting(p => p.ExecuteAsync(async () =>
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async () =>
         {
             await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken);
-        }))
-        .Should().ThrowAsync<TimeoutRejectedException>();
+        }));
 
-        timeoutPassedToOnTimeout.Should().Be(timeoutPassedToConfiguration);
+        timeoutPassedToOnTimeout.ShouldBe(timeoutPassedToConfiguration);
     }
 
     [Fact]
@@ -533,15 +524,14 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
         TimeSpan timeout = TimeSpan.FromMilliseconds(250);
         var policy = Policy.TimeoutAsync(timeout, TimeoutStrategy.Pessimistic, onTimeoutAsync);
 
-        await policy.Awaiting(p => p.ExecuteAsync(async _ =>
-            {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken);
-            }, contextPassedToExecute))
-            .Should().ThrowAsync<TimeoutRejectedException>();
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async _ =>
+        {
+            await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken);
+        }, contextPassedToExecute));
 
-        contextPassedToOnTimeout!.Should().NotBeNull();
-        contextPassedToOnTimeout!.OperationKey.Should().Be(operationKey);
-        contextPassedToOnTimeout!.Should().BeSameAs(contextPassedToExecute);
+        contextPassedToOnTimeout!.ShouldNotBeNull();
+        contextPassedToOnTimeout!.OperationKey.ShouldBe(operationKey);
+        contextPassedToOnTimeout!.ShouldBeSameAs(contextPassedToExecute);
     }
 
     [Theory]
@@ -561,13 +551,12 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
 
         var policy = Policy.TimeoutAsync(timeoutFunc, TimeoutStrategy.Pessimistic, onTimeoutAsync);
 
-        await policy.Awaiting(p => p.ExecuteAsync(async () =>
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async () =>
         {
             await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken);
-        }))
-        .Should().ThrowAsync<TimeoutRejectedException>();
+        }));
 
-        timeoutPassedToOnTimeout.Should().Be(timeoutFunc());
+        timeoutPassedToOnTimeout.ShouldBe(timeoutFunc());
     }
 
     [Theory]
@@ -590,13 +579,12 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
         // Supply a programatically-controlled timeout, via the execution context.
         Context context = new Context("SomeOperationKey") { ["timeout"] = TimeSpan.FromMilliseconds(25 * programaticallyControlledDelay) };
 
-        await policy.Awaiting(p => p.ExecuteAsync(async _ =>
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async _ =>
         {
             await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken);
-        }, context))
-        .Should().ThrowAsync<TimeoutRejectedException>();
+        }, context));
 
-        timeoutPassedToOnTimeout.Should().Be(timeoutProvider(context));
+        timeoutPassedToOnTimeout.ShouldBe(timeoutProvider(context));
     }
 
     [Fact]
@@ -612,13 +600,12 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
         TimeSpan timeout = TimeSpan.FromMilliseconds(250);
         var policy = Policy.TimeoutAsync(timeout, TimeoutStrategy.Pessimistic, onTimeoutAsync);
 
-        await policy.Awaiting(p => p.ExecuteAsync(async () =>
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async () =>
         {
             await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken);
-        }))
-        .Should().ThrowAsync<TimeoutRejectedException>();
+        }));
 
-        taskPassedToOnTimeout.Should().NotBeNull();
+        Assert.NotNull(taskPassedToOnTimeout);
     }
 
     [Fact]
@@ -642,16 +629,15 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
         TimeSpan thriceShimTimeSpan = shimTimespan + shimTimespan + shimTimespan;
         var policy = Policy.TimeoutAsync(shimTimespan, TimeoutStrategy.Pessimistic, onTimeoutAsync);
 
-        await policy.Awaiting(p => p.ExecuteAsync(async () =>
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async () =>
         {
             await SystemClock.SleepAsync(thriceShimTimeSpan, CancellationToken);
             throw exceptionToThrow;
-        }))
-        .Should().ThrowAsync<TimeoutRejectedException>();
+        }));
 
         await SystemClock.SleepAsync(thriceShimTimeSpan, CancellationToken);
-        exceptionObservedFromTaskPassedToOnTimeout.Should().NotBeNull();
-        exceptionObservedFromTaskPassedToOnTimeout.Should().Be(exceptionToThrow);
+        exceptionObservedFromTaskPassedToOnTimeout.ShouldNotBeNull();
+        exceptionObservedFromTaskPassedToOnTimeout.ShouldBe(exceptionToThrow);
 
     }
 
@@ -669,14 +655,13 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
 
         var policy = Policy.TimeoutAsync(timeoutPassedToConfiguration, TimeoutStrategy.Pessimistic, onTimeoutAsync);
 
-        await policy.Awaiting(p => p.ExecuteAsync(async () =>
-            {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken);
-            }))
-            .Should().ThrowAsync<TimeoutRejectedException>();
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async () =>
+        {
+            await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken);
+        }));
 
-        exceptionPassedToOnTimeout.Should().NotBeNull();
-        exceptionPassedToOnTimeout.Should().BeOfType<OperationCanceledException>();
+        exceptionPassedToOnTimeout.ShouldNotBeNull();
+        exceptionPassedToOnTimeout.ShouldBeOfType<OperationCanceledException>();
     }
 
     #endregion
@@ -698,13 +683,12 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
         var policy = Policy.TimeoutAsync(timeoutPassedToConfiguration, TimeoutStrategy.Optimistic, onTimeoutAsync);
         var userCancellationToken = CancellationToken;
 
-        await policy.Awaiting(p => p.ExecuteAsync(async ct =>
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async ct =>
         {
             await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct);
-        }, userCancellationToken))
-        .Should().ThrowAsync<TimeoutRejectedException>();
+        }, userCancellationToken));
 
-        timeoutPassedToOnTimeout.Should().Be(timeoutPassedToConfiguration);
+        timeoutPassedToOnTimeout.ShouldBe(timeoutPassedToConfiguration);
     }
 
     [Fact]
@@ -724,15 +708,14 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
         var policy = Policy.TimeoutAsync(timeout, TimeoutStrategy.Optimistic, onTimeoutAsync);
         var userCancellationToken = CancellationToken;
 
-        await policy.Awaiting(p => p.ExecuteAsync(async (_, ct) =>
-            {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct);
-            }, contextPassedToExecute, userCancellationToken))
-            .Should().ThrowAsync<TimeoutRejectedException>();
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async (_, ct) =>
+        {
+            await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct);
+        }, contextPassedToExecute, userCancellationToken));
 
-        contextPassedToOnTimeout!.Should().NotBeNull();
-        contextPassedToOnTimeout!.OperationKey.Should().Be(operationKey);
-        contextPassedToOnTimeout!.Should().BeSameAs(contextPassedToExecute);
+        contextPassedToOnTimeout!.ShouldNotBeNull();
+        contextPassedToOnTimeout!.OperationKey.ShouldBe(operationKey);
+        contextPassedToOnTimeout!.ShouldBeSameAs(contextPassedToExecute);
     }
 
     [Theory]
@@ -753,13 +736,12 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
         var policy = Policy.TimeoutAsync(timeoutFunc, TimeoutStrategy.Optimistic, onTimeoutAsync);
         var userCancellationToken = CancellationToken;
 
-        await policy.Awaiting(p => p.ExecuteAsync(async ct =>
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async ct =>
             {
                 await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct);
-            }, userCancellationToken))
-            .Should().ThrowAsync<TimeoutRejectedException>();
+            }, userCancellationToken));
 
-        timeoutPassedToOnTimeout.Should().Be(timeoutFunc());
+        timeoutPassedToOnTimeout.ShouldBe(timeoutFunc());
     }
 
     [Theory]
@@ -786,14 +768,13 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
             ["timeout"] = TimeSpan.FromMilliseconds(25 * programaticallyControlledDelay)
         };
 
-        await policy.Awaiting(p => p.ExecuteAsync(async (_, ct) =>
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async (_, ct) =>
         {
             await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct);
 
-        }, context, userCancellationToken))
-            .Should().ThrowAsync<TimeoutRejectedException>();
+        }, context, userCancellationToken));
 
-        timeoutPassedToOnTimeout.Should().Be(timeoutProvider(context));
+        timeoutPassedToOnTimeout.ShouldBe(timeoutProvider(context));
     }
 
     [Fact]
@@ -810,13 +791,12 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
         var policy = Policy.TimeoutAsync(timeout, TimeoutStrategy.Optimistic, onTimeoutAsync);
         var userCancellationToken = CancellationToken;
 
-        await policy.Awaiting(p => p.ExecuteAsync(async ct =>
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async ct =>
         {
             await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct);
-        }, userCancellationToken))
-        .Should().ThrowAsync<TimeoutRejectedException>();
+        }, userCancellationToken));
 
-        taskPassedToOnTimeout.Should().BeNull();
+        taskPassedToOnTimeout.ShouldBeNull();
     }
 
     [Fact]
@@ -834,14 +814,13 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
         var policy = Policy.TimeoutAsync(timeoutPassedToConfiguration, TimeoutStrategy.Optimistic, onTimeoutAsync);
         var userCancellationToken = CancellationToken;
 
-        await policy.Awaiting(p => p.ExecuteAsync(async ct =>
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async ct =>
         {
             await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct);
-        }, userCancellationToken))
-        .Should().ThrowAsync<TimeoutRejectedException>();
+        }, userCancellationToken));
 
-        exceptionPassedToOnTimeout.Should().NotBeNull();
-        exceptionPassedToOnTimeout.Should().BeOfType<OperationCanceledException>();
+        exceptionPassedToOnTimeout.ShouldNotBeNull();
+        exceptionPassedToOnTimeout.ShouldBeOfType<OperationCanceledException>();
     }
 
     #endregion

--- a/test/Polly.Specs/Timeout/TimeoutSpecs.cs
+++ b/test/Polly.Specs/Timeout/TimeoutSpecs.cs
@@ -266,14 +266,12 @@ public class TimeoutSpecs : TimeoutSpecsBase
     [Fact]
     public void Should_throw_timeout_after_correct_duration__pessimistic()
     {
-        Stopwatch watch = new Stopwatch();
-
         TimeSpan timeout = TimeSpan.FromSeconds(1);
         var policy = Policy.Timeout(timeout, TimeoutStrategy.Pessimistic);
 
         TimeSpan tolerance = TimeSpan.FromSeconds(3); // Consider increasing tolerance, if test fails transiently in different test/build environments.
 
-        watch.Start();
+        var watch = Stopwatch.StartNew();
         Should.Throw<TimeoutRejectedException>(() => policy.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(10), CancellationToken)));
         watch.Stop();
 
@@ -410,15 +408,13 @@ public class TimeoutSpecs : TimeoutSpecsBase
     [Fact]
     public void Should_throw_timeout_after_correct_duration__optimistic()
     {
-        Stopwatch watch = new Stopwatch();
-
         TimeSpan timeout = TimeSpan.FromSeconds(1);
         var policy = Policy.Timeout(timeout);
         var userCancellationToken = CancellationToken;
 
         TimeSpan tolerance = TimeSpan.FromSeconds(3); // Consider increasing tolerance, if test fails transiently in different test/build environments.
 
-        watch.Start();
+        var watch = Stopwatch.StartNew();
 
         // Delegate observes cancellation token, so permitting optimistic cancellation.
         Should.Throw<TimeoutRejectedException>(() => policy.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(10), ct), userCancellationToken));

--- a/test/Polly.Specs/Timeout/TimeoutSpecs.cs
+++ b/test/Polly.Specs/Timeout/TimeoutSpecs.cs
@@ -27,10 +27,10 @@ public class TimeoutSpecs : TimeoutSpecsBase
 
         var func = () => generic.Invoke(instance, [action, new Context(), CancellationToken]);
 
-        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("action");
+        var exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>()
+            .ParamName.ShouldBe("action");
     }
 
     [Fact]
@@ -38,8 +38,8 @@ public class TimeoutSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.Timeout(TimeSpan.Zero);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-            .ParamName.Should().Be("timeout");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+            .ParamName.ShouldBe("timeout");
     }
 
     [Fact]
@@ -47,8 +47,8 @@ public class TimeoutSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.Timeout(0);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-            .ParamName.Should().Be("seconds");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+            .ParamName.ShouldBe("seconds");
     }
 
     [Fact]
@@ -56,8 +56,8 @@ public class TimeoutSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.Timeout(-TimeSpan.FromHours(1));
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-            .ParamName.Should().Be("timeout");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+            .ParamName.ShouldBe("timeout");
     }
 
     [Fact]
@@ -65,8 +65,8 @@ public class TimeoutSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.Timeout(-10);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-            .ParamName.Should().Be("seconds");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+            .ParamName.ShouldBe("seconds");
     }
 
     [Fact]
@@ -74,7 +74,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.Timeout(TimeSpan.FromMilliseconds(1));
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -82,7 +82,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.Timeout(3);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -90,7 +90,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.Timeout(TimeSpan.MaxValue);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -98,7 +98,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.Timeout(int.MaxValue);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -106,7 +106,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.Timeout(System.Threading.Timeout.InfiniteTimeSpan);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -114,7 +114,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.Timeout(System.Threading.Timeout.InfiniteTimeSpan, TimeoutStrategy.Optimistic);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -123,7 +123,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
         Action<Context, TimeSpan, Task> doNothing = (_, _, _) => { };
         Action policy = () => Policy.Timeout(System.Threading.Timeout.InfiniteTimeSpan, doNothing);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -132,7 +132,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
         Action<Context, TimeSpan, Task, Exception> doNothing = (_, _, _, _) => { };
         Action policy = () => Policy.Timeout(System.Threading.Timeout.InfiniteTimeSpan, doNothing);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -141,7 +141,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
         Action<Context, TimeSpan, Task> doNothing = (_, _, _) => { };
         Action policy = () => Policy.Timeout(System.Threading.Timeout.InfiniteTimeSpan, TimeoutStrategy.Optimistic, doNothing);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -150,7 +150,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
         Action<Context, TimeSpan, Task, Exception> doNothing = (_, _, _, _) => { };
         Action policy = () => Policy.Timeout(System.Threading.Timeout.InfiniteTimeSpan, TimeoutStrategy.Optimistic, doNothing);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -159,8 +159,8 @@ public class TimeoutSpecs : TimeoutSpecsBase
         Action<Context, TimeSpan, Task> onTimeout = null!;
         Action policy = () => Policy.Timeout(TimeSpan.FromMinutes(0.5), onTimeout);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onTimeout");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onTimeout");
     }
 
     [Fact]
@@ -169,8 +169,8 @@ public class TimeoutSpecs : TimeoutSpecsBase
         Action<Context, TimeSpan, Task, Exception> onTimeout = null!;
         Action policy = () => Policy.Timeout(TimeSpan.FromMinutes(0.5), onTimeout);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onTimeout");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onTimeout");
     }
 
     [Fact]
@@ -179,8 +179,8 @@ public class TimeoutSpecs : TimeoutSpecsBase
         Action<Context, TimeSpan, Task> onTimeout = null!;
         Action policy = () => Policy.Timeout(30, onTimeout);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onTimeout");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onTimeout");
     }
 
     [Fact]
@@ -189,8 +189,8 @@ public class TimeoutSpecs : TimeoutSpecsBase
         Action<Context, TimeSpan, Task, Exception> onTimeout = null!;
         Action policy = () => Policy.Timeout(30, onTimeout);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onTimeout");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onTimeout");
     }
 
     [Fact]
@@ -198,8 +198,8 @@ public class TimeoutSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.Timeout((Func<TimeSpan>)null!);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("timeoutProvider");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("timeoutProvider");
     }
 
     [Fact]
@@ -208,8 +208,8 @@ public class TimeoutSpecs : TimeoutSpecsBase
         Action<Context, TimeSpan, Task> onTimeout = null!;
         Action policy = () => Policy.Timeout(() => TimeSpan.FromSeconds(30), onTimeout);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onTimeout");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onTimeout");
     }
 
     [Fact]
@@ -218,8 +218,8 @@ public class TimeoutSpecs : TimeoutSpecsBase
         Action<Context, TimeSpan, Task, Exception> onTimeout = null!;
         Action policy = () => Policy.Timeout(() => TimeSpan.FromSeconds(30), onTimeout);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onTimeout");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onTimeout");
     }
 
     [Fact]
@@ -227,7 +227,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.Timeout(() => TimeSpan.FromSeconds(1));
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     #endregion
@@ -239,8 +239,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
     {
         var policy = Policy.Timeout(TimeSpan.FromMilliseconds(50), TimeoutStrategy.Pessimistic);
 
-        policy.Invoking(p => p.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken)))
-            .Should().Throw<TimeoutRejectedException>();
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken)));
     }
 
     [Fact]
@@ -260,8 +259,8 @@ public class TimeoutSpecs : TimeoutSpecsBase
             }, userCancellationToken);
         };
 
-        act.Should().NotThrow<TimeoutRejectedException>();
-        result.Should().Be(ResultPrimitive.Good);
+        Should.NotThrow(act);
+        result.ShouldBe(ResultPrimitive.Good);
     }
 
     [Fact]
@@ -275,11 +274,10 @@ public class TimeoutSpecs : TimeoutSpecsBase
         TimeSpan tolerance = TimeSpan.FromSeconds(3); // Consider increasing tolerance, if test fails transiently in different test/build environments.
 
         watch.Start();
-        policy.Invoking(p => p.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(10), CancellationToken)))
-            .Should().Throw<TimeoutRejectedException>();
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(10), CancellationToken)));
         watch.Stop();
 
-        watch.Elapsed.Should().BeCloseTo(timeout, TimeSpan.FromMilliseconds(tolerance.TotalMilliseconds));
+        watch.Elapsed.ShouldBe(timeout, TimeSpan.FromMilliseconds(tolerance.TotalMilliseconds));
     }
 
     [Fact]
@@ -287,7 +285,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
     {
         var policy = Policy.Timeout(TimeSpan.FromSeconds(10), TimeoutStrategy.Pessimistic);
 
-        policy.Invoking(p => p.Execute(() => throw new NotSupportedException())).Should().Throw<NotSupportedException>();
+        Should.Throw<NotSupportedException>(() => policy.Execute(() => throw new NotSupportedException()));
     }
 
     [Fact]
@@ -299,11 +297,11 @@ public class TimeoutSpecs : TimeoutSpecsBase
         // Check to see if nested aggregate exceptions are unwrapped correctly
         AggregateException exception = new AggregateException(msg, new NotImplementedException());
 
-        policy.Invoking(p => p.Execute(() => { Helper_ThrowException(exception); }))
-            .Should().Throw<AggregateException>()
-            .WithMessage(exception.Message)
-            .Where(e => e.InnerException is NotImplementedException)
-            .And.StackTrace.Should().Contain(nameof(Helper_ThrowException));
+        var actual = Should.Throw<AggregateException>(() => policy.Execute(() => Helper_ThrowException(exception)));
+        actual.Message.ShouldBe(exception.Message);
+        actual.InnerException.ShouldBeOfType<NotImplementedException>();
+        actual.StackTrace.ShouldNotBeNull();
+        actual.StackTrace.ShouldContain(nameof(Helper_ThrowException));
     }
 
     [Fact]
@@ -318,13 +316,13 @@ public class TimeoutSpecs : TimeoutSpecsBase
         Action action = () => throw aggregateException;
 
         // Whether executing the delegate directly, or through the policy, exception behavior should be the same.
-        action.Should().Throw<AggregateException>()
-            .WithMessage(aggregateException.Message)
-            .And.InnerExceptions.Should().BeEquivalentTo<Exception>(new[] { innerException1, innerException2 });
+        var exception = Should.Throw<AggregateException>(action);
+        exception.Message.ShouldBe(aggregateException.Message);
+        exception.InnerExceptions.ShouldBe([innerException1, innerException2]);
 
-        policy.Invoking(p => p.Execute(action)).Should().Throw<AggregateException>()
-            .WithMessage(aggregateException.Message)
-            .And.InnerExceptions.Should().BeEquivalentTo<Exception>(new[] { innerException1, innerException2 });
+        exception = Should.Throw<AggregateException>(() => policy.Execute(action));
+        exception.Message.ShouldBe(aggregateException.Message);
+        exception.InnerExceptions.ShouldBe([innerException1, innerException2]);
     }
 
     [Fact]
@@ -342,11 +340,13 @@ public class TimeoutSpecs : TimeoutSpecsBase
         };
 
         // Whether executing the delegate directly, or through the policy, exception behavior should be the same.
-        action.Should().Throw<AggregateException>()
-            .And.InnerExceptions.Should().BeEquivalentTo<Exception>(new[] { innerException1, innerException2 });
+        var exception = Should.Throw<AggregateException>(action);
+        exception.InnerExceptions.ShouldContain(innerException1);
+        exception.InnerExceptions.ShouldContain(innerException2);
 
-        policy.Invoking(p => p.Execute(action)).Should().Throw<AggregateException>()
-            .And.InnerExceptions.Should().BeEquivalentTo<Exception>(new[] { innerException1, innerException2 });
+        exception = Should.Throw<AggregateException>(() => policy.Execute(action));
+        exception.InnerExceptions.ShouldContain(innerException1);
+        exception.InnerExceptions.ShouldContain(innerException2);
     }
 
     [Fact]
@@ -364,11 +364,13 @@ public class TimeoutSpecs : TimeoutSpecsBase
         };
 
         // Whether executing the delegate directly, or through the policy, exception behavior should be the same.
-        action.Should().Throw<AggregateException>()
-            .And.InnerExceptions.Should().BeEquivalentTo<Exception>(new[] { innerException1, innerException2 });
+        var ex = Should.Throw<AggregateException>(action);
+        ex.InnerExceptions.ShouldContain(innerException1);
+        ex.InnerExceptions.ShouldContain(innerException2);
 
-        policy.Invoking(p => p.Execute(action)).Should().Throw<AggregateException>()
-            .And.InnerExceptions.Should().BeEquivalentTo<Exception>(new[] { innerException1, innerException2 });
+        ex = Should.Throw<AggregateException>(() => policy.Execute(action));
+        ex.InnerExceptions.ShouldContain(innerException1);
+        ex.InnerExceptions.ShouldContain(innerException2);
     }
 
     #endregion
@@ -381,8 +383,8 @@ public class TimeoutSpecs : TimeoutSpecsBase
         var policy = Policy.Timeout(TimeSpan.FromMilliseconds(50), TimeoutStrategy.Optimistic);
         var userCancellationToken = CancellationToken;
 
-        policy.Invoking(p => p.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(3), ct), userCancellationToken)) // Delegate observes cancellation token, so permitting optimistic cancellation.
-            .Should().Throw<TimeoutRejectedException>();
+        // Delegate observes cancellation token, so permitting optimistic cancellation.
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(3), ct), userCancellationToken));
     }
 
     [Fact]
@@ -401,8 +403,8 @@ public class TimeoutSpecs : TimeoutSpecsBase
                 }, userCancellationToken);
         };
 
-        act.Should().NotThrow<TimeoutRejectedException>();
-        result.Should().Be(ResultPrimitive.Good);
+        Should.NotThrow(act);
+        result.ShouldBe(ResultPrimitive.Good);
     }
 
     [Fact]
@@ -417,11 +419,12 @@ public class TimeoutSpecs : TimeoutSpecsBase
         TimeSpan tolerance = TimeSpan.FromSeconds(3); // Consider increasing tolerance, if test fails transiently in different test/build environments.
 
         watch.Start();
-        policy.Invoking(p => p.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(10), ct), userCancellationToken)) // Delegate observes cancellation token, so permitting optimistic cancellation.
-            .Should().Throw<TimeoutRejectedException>();
+
+        // Delegate observes cancellation token, so permitting optimistic cancellation.
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(10), ct), userCancellationToken));
         watch.Stop();
 
-        watch.Elapsed.Should().BeCloseTo(timeout, TimeSpan.FromMilliseconds(tolerance.TotalMilliseconds));
+        watch.Elapsed.ShouldBe(timeout, TimeSpan.FromMilliseconds(tolerance.TotalMilliseconds));
     }
 
     [Fact]
@@ -429,8 +432,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
     {
         var policy = Policy.Timeout(TimeSpan.FromSeconds(10), TimeoutStrategy.Optimistic);
 
-        policy.Invoking(p => p.Execute(() => throw new NotSupportedException())).Should().Throw<NotSupportedException>();
-
+        Should.Throw<NotSupportedException>(() => policy.Execute(() => throw new NotSupportedException()));
     }
 
     #endregion
@@ -444,14 +446,14 @@ public class TimeoutSpecs : TimeoutSpecsBase
         var policy = Policy.Timeout(timeout, TimeoutStrategy.Pessimistic);
 
         using CancellationTokenSource userTokenSource = new CancellationTokenSource();
-        policy.Invoking(p => p.Execute(
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(
             _ =>
             {
                 userTokenSource.Cancel(); // User token cancels in the middle of execution ...
                 SystemClock.Sleep(TimeSpan.FromSeconds(timeout * 2),
                     CancellationToken); // ... but if the executed delegate does not observe it
             },
-            userTokenSource.Token)).Should().Throw<TimeoutRejectedException>(); // ... it's still the timeout we expect.
+            userTokenSource.Token)); // ... it's still the timeout we expect.
     }
 
     [Fact]
@@ -465,11 +467,10 @@ public class TimeoutSpecs : TimeoutSpecsBase
         {
             cts.Cancel();
 
-            policy.Invoking(p => p.Execute(_ => { executed = true; }, cts.Token))
-                .Should().Throw<OperationCanceledException>();
+            Should.Throw<OperationCanceledException>(() => policy.Execute(_ => executed = true, cts.Token));
         }
 
-        executed.Should().BeFalse();
+        executed.ShouldBeFalse();
     }
 
     #endregion
@@ -483,10 +484,17 @@ public class TimeoutSpecs : TimeoutSpecsBase
         var policy = Policy.Timeout(timeout, TimeoutStrategy.Optimistic);
 
         using CancellationTokenSource userTokenSource = new CancellationTokenSource();
-        policy.Invoking(p => p.Execute(
-            ct => { userTokenSource.Cancel(); ct.ThrowIfCancellationRequested(); }, // Simulate cancel in the middle of execution
-            userTokenSource.Token)) // ... with user token.
-           .Should().Throw<OperationCanceledException>(); // Not a TimeoutRejectedException; i.e. policy can distinguish user cancellation from timeout cancellation.
+
+        // Not a TimeoutRejectedException; i.e. policy can distinguish user cancellation from timeout cancellation.
+        Should.Throw<OperationCanceledException>(() => policy.Execute(
+            ct =>
+            {
+                userTokenSource.Cancel();
+
+                // Simulate cancel in the middle of execution
+                ct.ThrowIfCancellationRequested();
+            },
+            userTokenSource.Token)); // ... with user token.
     }
 
     [Fact]
@@ -500,11 +508,10 @@ public class TimeoutSpecs : TimeoutSpecsBase
         {
             cts.Cancel();
 
-            policy.Invoking(p => p.Execute(_ => { executed = true; }, cts.Token))
-                .Should().Throw<OperationCanceledException>();
+            Should.Throw<OperationCanceledException>(() => policy.Execute(_ => executed = true, cts.Token));
         }
 
-        executed.Should().BeFalse();
+        executed.ShouldBeFalse();
     }
 
     [Fact]
@@ -514,7 +521,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
         var shimTimeSpan = TimeSpan.FromSeconds(0.2);
         var policy = Policy.Timeout(shimTimeSpan, TimeoutStrategy.Optimistic);
 
-        var thrown = policy.Invoking(p => p.Execute(_ =>
+        var thrown = Should.Throw<Exception>(() => policy.Execute(_ =>
             {
                 try
                 {
@@ -531,15 +538,12 @@ public class TimeoutSpecs : TimeoutSpecsBase
 
                 throw new InvalidOperationException("This exception should not be thrown. Test should throw for timeout earlier.");
 
-            }, CancellationToken))
-            .Should()
-            .Throw<Exception>()
-            .Which;
+            }, CancellationToken));
 
-        thrown.Should().NotBeOfType<OperationCanceledException>();
-        thrown.Should().NotBeOfType<TimeoutRejectedException>();
-        thrown.Should().NotBeOfType<InvalidOperationException>();
-        thrown.Should().BeSameAs(userException);
+        thrown.ShouldNotBeOfType<OperationCanceledException>();
+        thrown.ShouldNotBeOfType<TimeoutRejectedException>();
+        thrown.ShouldNotBeOfType<InvalidOperationException>();
+        thrown.ShouldBeSameAs(userException);
     }
 
     #endregion
@@ -556,10 +560,9 @@ public class TimeoutSpecs : TimeoutSpecsBase
 
         var policy = Policy.Timeout(timeoutPassedToConfiguration, TimeoutStrategy.Pessimistic, onTimeout);
 
-        policy.Invoking(p => p.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken)))
-            .Should().Throw<TimeoutRejectedException>();
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken)));
 
-        timeoutPassedToOnTimeout.Should().Be(timeoutPassedToConfiguration);
+        timeoutPassedToOnTimeout.ShouldBe(timeoutPassedToConfiguration);
     }
 
     [Fact]
@@ -574,12 +577,11 @@ public class TimeoutSpecs : TimeoutSpecsBase
         TimeSpan timeout = TimeSpan.FromMilliseconds(250);
         var policy = Policy.Timeout(timeout, TimeoutStrategy.Pessimistic, onTimeout);
 
-        policy.Invoking(p => p.Execute(_ => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken), contextPassedToExecute))
-            .Should().Throw<TimeoutRejectedException>();
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(_ => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken), contextPassedToExecute));
 
-        contextPassedToOnTimeout!.Should().NotBeNull();
-        contextPassedToOnTimeout!.OperationKey.Should().Be(operationKey);
-        contextPassedToOnTimeout!.Should().BeSameAs(contextPassedToExecute);
+        contextPassedToOnTimeout!.ShouldNotBeNull();
+        contextPassedToOnTimeout!.OperationKey.ShouldBe(operationKey);
+        contextPassedToOnTimeout!.ShouldBeSameAs(contextPassedToExecute);
     }
 
     [Theory]
@@ -595,10 +597,9 @@ public class TimeoutSpecs : TimeoutSpecsBase
 
         var policy = Policy.Timeout(timeoutFunc, TimeoutStrategy.Pessimistic, onTimeout);
 
-        policy.Invoking(p => p.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken)))
-            .Should().Throw<TimeoutRejectedException>();
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken)));
 
-        timeoutPassedToOnTimeout.Should().Be(timeoutFunc());
+        timeoutPassedToOnTimeout.ShouldBe(timeoutFunc());
     }
 
     [Theory]
@@ -616,10 +617,9 @@ public class TimeoutSpecs : TimeoutSpecsBase
         // Supply a programatically-controlled timeout, via the execution context.
         Context context = new Context("SomeOperationKey") { ["timeout"] = TimeSpan.FromMilliseconds(25 * programaticallyControlledDelay) };
 
-        policy.Invoking(p => p.Execute(_ => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken), context))
-            .Should().Throw<TimeoutRejectedException>();
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(_ => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken), context));
 
-        timeoutPassedToOnTimeout.Should().Be(timeoutProvider(context));
+        timeoutPassedToOnTimeout.ShouldBe(timeoutProvider(context));
     }
 
     [Fact]
@@ -631,10 +631,9 @@ public class TimeoutSpecs : TimeoutSpecsBase
         TimeSpan timeout = TimeSpan.FromMilliseconds(250);
         var policy = Policy.Timeout(timeout, TimeoutStrategy.Pessimistic, onTimeout);
 
-        policy.Invoking(p => p.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken)))
-            .Should().Throw<TimeoutRejectedException>();
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken)));
 
-        taskPassedToOnTimeout.Should().NotBeNull();
+        taskPassedToOnTimeout.ShouldNotBeNull();
     }
 
     [Fact]
@@ -657,16 +656,15 @@ public class TimeoutSpecs : TimeoutSpecsBase
         TimeSpan thriceShimTimeSpan = shimTimespan + shimTimespan + shimTimespan;
         var policy = Policy.Timeout(shimTimespan, TimeoutStrategy.Pessimistic, onTimeout);
 
-        policy.Invoking(p => p.Execute(() =>
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(() =>
         {
             SystemClock.Sleep(thriceShimTimeSpan, CancellationToken);
             throw exceptionToThrow;
-        }))
-            .Should().Throw<TimeoutRejectedException>();
+        }));
 
         SystemClock.Sleep(thriceShimTimeSpan, CancellationToken);
-        exceptionObservedFromTaskPassedToOnTimeout.Should().NotBeNull();
-        exceptionObservedFromTaskPassedToOnTimeout.Should().Be(exceptionToThrow);
+        exceptionObservedFromTaskPassedToOnTimeout.ShouldNotBeNull();
+        exceptionObservedFromTaskPassedToOnTimeout.ShouldBe(exceptionToThrow);
 
     }
 
@@ -680,11 +678,10 @@ public class TimeoutSpecs : TimeoutSpecsBase
 
         var policy = Policy.Timeout(timeoutPassedToConfiguration, TimeoutStrategy.Pessimistic, onTimeout);
 
-        policy.Invoking(p => p.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken)))
-            .Should().Throw<TimeoutRejectedException>();
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken)));
 
-        exceptionPassedToOnTimeout.Should().NotBeNull();
-        exceptionPassedToOnTimeout.Should().BeOfType<OperationCanceledException>();
+        exceptionPassedToOnTimeout.ShouldNotBeNull();
+        exceptionPassedToOnTimeout.ShouldBeOfType<OperationCanceledException>();
     }
 
     #endregion
@@ -702,10 +699,9 @@ public class TimeoutSpecs : TimeoutSpecsBase
         var policy = Policy.Timeout(timeoutPassedToConfiguration, TimeoutStrategy.Optimistic, onTimeout);
         var userCancellationToken = CancellationToken;
 
-        policy.Invoking(p => p.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(1), ct), userCancellationToken))
-            .Should().Throw<TimeoutRejectedException>();
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(1), ct), userCancellationToken));
 
-        timeoutPassedToOnTimeout.Should().Be(timeoutPassedToConfiguration);
+        timeoutPassedToOnTimeout.ShouldBe(timeoutPassedToConfiguration);
     }
 
     [Fact]
@@ -721,12 +717,11 @@ public class TimeoutSpecs : TimeoutSpecsBase
         var policy = Policy.Timeout(timeout, TimeoutStrategy.Optimistic, onTimeout);
         var userCancellationToken = CancellationToken;
 
-        policy.Invoking(p => p.Execute((_, ct) => SystemClock.Sleep(TimeSpan.FromSeconds(3), ct), contextPassedToExecute, userCancellationToken))
-            .Should().Throw<TimeoutRejectedException>();
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute((_, ct) => SystemClock.Sleep(TimeSpan.FromSeconds(3), ct), contextPassedToExecute, userCancellationToken));
 
-        contextPassedToOnTimeout!.Should().NotBeNull();
-        contextPassedToOnTimeout!.OperationKey.Should().Be(operationKey);
-        contextPassedToOnTimeout!.Should().BeSameAs(contextPassedToExecute);
+        contextPassedToOnTimeout!.ShouldNotBeNull();
+        contextPassedToOnTimeout!.OperationKey.ShouldBe(operationKey);
+        contextPassedToOnTimeout!.ShouldBeSameAs(contextPassedToExecute);
     }
 
     [Theory]
@@ -743,10 +738,9 @@ public class TimeoutSpecs : TimeoutSpecsBase
         var policy = Policy.Timeout(timeoutFunc, TimeoutStrategy.Optimistic, onTimeout);
         var userCancellationToken = CancellationToken;
 
-        policy.Invoking(p => p.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(3), ct), userCancellationToken))
-            .Should().Throw<TimeoutRejectedException>();
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(3), ct), userCancellationToken));
 
-        timeoutPassedToOnTimeout.Should().Be(timeoutFunc());
+        timeoutPassedToOnTimeout.ShouldBe(timeoutFunc());
     }
 
     [Theory]
@@ -769,10 +763,9 @@ public class TimeoutSpecs : TimeoutSpecsBase
             ["timeout"] = TimeSpan.FromMilliseconds(25 * programaticallyControlledDelay)
         };
 
-        policy.Invoking(p => p.Execute((_, ct) => SystemClock.Sleep(TimeSpan.FromSeconds(3), ct), context, userCancellationToken))
-            .Should().Throw<TimeoutRejectedException>();
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute((_, ct) => SystemClock.Sleep(TimeSpan.FromSeconds(3), ct), context, userCancellationToken));
 
-        timeoutPassedToOnTimeout.Should().Be(timeoutProvider(context));
+        timeoutPassedToOnTimeout.ShouldBe(timeoutProvider(context));
     }
 
     [Fact]
@@ -785,10 +778,9 @@ public class TimeoutSpecs : TimeoutSpecsBase
         var policy = Policy.Timeout(timeout, TimeoutStrategy.Optimistic, onTimeout);
         var userCancellationToken = CancellationToken;
 
-        policy.Invoking(p => p.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(3), ct), userCancellationToken))
-            .Should().Throw<TimeoutRejectedException>();
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(3), ct), userCancellationToken));
 
-        taskPassedToOnTimeout.Should().BeNull();
+        taskPassedToOnTimeout.ShouldBeNull();
     }
 
     [Fact]
@@ -802,11 +794,10 @@ public class TimeoutSpecs : TimeoutSpecsBase
         var policy = Policy.Timeout(timeoutPassedToConfiguration, TimeoutStrategy.Optimistic, onTimeout);
         var userCancellationToken = CancellationToken;
 
-        policy.Invoking(p => p.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(1), ct), userCancellationToken))
-            .Should().Throw<TimeoutRejectedException>();
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(ct => SystemClock.Sleep(TimeSpan.FromSeconds(1), ct), userCancellationToken));
 
-        exceptionPassedToOnTimeout.Should().NotBeNull();
-        exceptionPassedToOnTimeout.Should().BeOfType<OperationCanceledException>();
+        exceptionPassedToOnTimeout.ShouldNotBeNull();
+        exceptionPassedToOnTimeout.ShouldBeOfType<OperationCanceledException>();
     }
 
     #endregion

--- a/test/Polly.Specs/Timeout/TimeoutTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/Timeout/TimeoutTResultAsyncSpecs.cs
@@ -26,10 +26,10 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
 
         var func = () => methodInfo.Invoke(instance, [action, new Context(), CancellationToken, false]);
 
-        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("action");
+        var exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>()
+            .ParamName.ShouldBe("action");
     }
 
     [Fact]
@@ -37,8 +37,8 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(TimeSpan.Zero);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-            .ParamName.Should().Be("timeout");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+            .ParamName.ShouldBe("timeout");
     }
 
     [Fact]
@@ -46,8 +46,8 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(0);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-            .ParamName.Should().Be("seconds");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+            .ParamName.ShouldBe("seconds");
     }
 
     [Fact]
@@ -55,8 +55,8 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(-TimeSpan.FromHours(1));
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-            .ParamName.Should().Be("timeout");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+            .ParamName.ShouldBe("timeout");
     }
 
     [Fact]
@@ -64,8 +64,8 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(-10);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-            .ParamName.Should().Be("seconds");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+            .ParamName.ShouldBe("seconds");
     }
 
     [Fact]
@@ -73,7 +73,7 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(TimeSpan.FromMilliseconds(1));
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -81,7 +81,7 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(3);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -89,7 +89,7 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(TimeSpan.MaxValue);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -97,7 +97,7 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(int.MaxValue);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -105,7 +105,7 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(System.Threading.Timeout.InfiniteTimeSpan);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -113,7 +113,7 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(System.Threading.Timeout.InfiniteTimeSpan, TimeoutStrategy.Optimistic);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -122,7 +122,7 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
         Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, _, _) => TaskHelper.EmptyTask;
         Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(System.Threading.Timeout.InfiniteTimeSpan, doNothingAsync);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -131,7 +131,7 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
         Func<Context, TimeSpan, Task, Task> doNothingAsync = (_, _, _) => TaskHelper.EmptyTask;
         Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(System.Threading.Timeout.InfiniteTimeSpan, TimeoutStrategy.Optimistic, doNothingAsync);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -140,8 +140,8 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
         Func<Context, TimeSpan, Task, Task> onTimeout = null!;
         Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(TimeSpan.FromMinutes(0.5), onTimeout);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onTimeoutAsync");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onTimeoutAsync");
     }
 
     [Fact]
@@ -150,8 +150,8 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
         Func<Context, TimeSpan, Task, Exception, Task> onTimeout = null!;
         Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(TimeSpan.FromMinutes(0.5), onTimeout);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onTimeoutAsync");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onTimeoutAsync");
     }
 
     [Fact]
@@ -160,8 +160,8 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
         Func<Context, TimeSpan, Task, Task> onTimeout = null!;
         Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(30, onTimeout);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onTimeoutAsync");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onTimeoutAsync");
     }
 
     [Fact]
@@ -170,8 +170,8 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
         Func<Context, TimeSpan, Task, Exception, Task> onTimeout = null!;
         Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(30, onTimeout);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onTimeoutAsync");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onTimeoutAsync");
     }
 
     [Fact]
@@ -179,8 +179,8 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.TimeoutAsync<ResultPrimitive>((Func<TimeSpan>)null!);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("timeoutProvider");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("timeoutProvider");
     }
 
     [Fact]
@@ -189,8 +189,8 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
         Func<Context, TimeSpan, Task, Task> onTimeoutAsync = null!;
         Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(() => TimeSpan.FromSeconds(30), onTimeoutAsync);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onTimeoutAsync");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onTimeoutAsync");
     }
 
     [Fact]
@@ -199,8 +199,8 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
         Func<Context, TimeSpan, Task, Exception, Task> onTimeoutAsync = null!;
         Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(() => TimeSpan.FromSeconds(30), onTimeoutAsync);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onTimeoutAsync");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onTimeoutAsync");
     }
 
     [Fact]
@@ -208,7 +208,7 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.TimeoutAsync<ResultPrimitive>(() => TimeSpan.FromSeconds(1));
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     #endregion
@@ -222,11 +222,11 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
 
         var policy = Policy.TimeoutAsync<ResultPrimitive>(timeout, TimeoutStrategy.Pessimistic);
 
-        await policy.Awaiting(p => p.ExecuteAsync(async () =>
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async () =>
         {
             await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken);
             return ResultPrimitive.WhateverButTooLate;
-        })).Should().ThrowAsync<TimeoutRejectedException>();
+        }));
     }
 
     [Fact]
@@ -238,30 +238,28 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
 
         Func<Task> act = async () => result = await policy.ExecuteAsync(() => Task.FromResult(ResultPrimitive.Good));
 
-        act.Should().NotThrowAsync();
-        result.Should().Be(ResultPrimitive.Good);
+        Should.NotThrowAsync(act);
+        result.ShouldBe(ResultPrimitive.Good);
     }
 
     [Fact]
     public async Task Should_throw_timeout_after_correct_duration__pessimistic()
     {
-        Stopwatch watch = new Stopwatch();
-
         TimeSpan timeout = TimeSpan.FromSeconds(1);
         var policy = Policy.TimeoutAsync<ResultPrimitive>(timeout, TimeoutStrategy.Pessimistic);
 
         TimeSpan tolerance = TimeSpan.FromSeconds(3); // Consider increasing tolerance, if test fails transiently in different test/build environments.
 
-        watch.Start();
-        await policy.Awaiting(p => p.ExecuteAsync(async () =>
+        Stopwatch watch = Stopwatch.StartNew();
+
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async () =>
         {
             await SystemClock.SleepAsync(TimeSpan.FromSeconds(10), CancellationToken);
             return ResultPrimitive.WhateverButTooLate;
-        }))
-            .Should().ThrowAsync<TimeoutRejectedException>();
-        watch.Stop();
+        }));
 
-        watch.Elapsed.Should().BeCloseTo(timeout, TimeSpan.FromMilliseconds(tolerance.TotalMilliseconds));
+        watch.Stop();
+        watch.Elapsed.ShouldBe(timeout, tolerance);
     }
 
     [Fact]
@@ -269,7 +267,7 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
     {
         var policy = Policy.TimeoutAsync<ResultPrimitive>(TimeSpan.FromSeconds(10), TimeoutStrategy.Pessimistic);
 
-        await policy.Awaiting(p => p.ExecuteAsync(() => throw new NotSupportedException())).Should().ThrowAsync<NotSupportedException>();
+        await Should.ThrowAsync<NotSupportedException>(() => policy.ExecuteAsync(() => throw new NotSupportedException()));
     }
 
     #endregion
@@ -282,11 +280,11 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
         var policy = Policy.TimeoutAsync<ResultPrimitive>(TimeSpan.FromMilliseconds(50), TimeoutStrategy.Optimistic);
         var userCancellationToken = CancellationToken;
 
-        await policy.Awaiting(p => p.ExecuteAsync(async ct =>
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async ct =>
         {
             await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct);
             return ResultPrimitive.WhateverButTooLate;
-        }, userCancellationToken)).Should().ThrowAsync<TimeoutRejectedException>();
+        }, userCancellationToken));
     }
 
     [Fact]
@@ -299,31 +297,28 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
 
         Func<Task> act = async () => result = await policy.ExecuteAsync(_ => Task.FromResult(ResultPrimitive.Good), userCancellationToken);
 
-        act.Should().NotThrowAsync();
-        result.Should().Be(ResultPrimitive.Good);
+        Should.NotThrowAsync(act);
+        result.ShouldBe(ResultPrimitive.Good);
     }
 
     [Fact]
     public async Task Should_throw_timeout_after_correct_duration__optimistic()
     {
-        Stopwatch watch = new Stopwatch();
-
         TimeSpan timeout = TimeSpan.FromSeconds(1);
         var policy = Policy.TimeoutAsync<ResultPrimitive>(timeout, TimeoutStrategy.Optimistic);
         var userCancellationToken = CancellationToken;
 
         TimeSpan tolerance = TimeSpan.FromSeconds(3); // Consider increasing tolerance, if test fails transiently in different test/build environments.
 
-        watch.Start();
-        await policy.Awaiting(p => p.ExecuteAsync(async ct =>
+        Stopwatch watch = Stopwatch.StartNew();
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async ct =>
         {
             await SystemClock.SleepAsync(TimeSpan.FromSeconds(10), ct);
             return ResultPrimitive.WhateverButTooLate;
-        }, userCancellationToken))
-            .Should().ThrowAsync<TimeoutRejectedException>();
-        watch.Stop();
+        }, userCancellationToken));
 
-        watch.Elapsed.Should().BeCloseTo(timeout, TimeSpan.FromMilliseconds(tolerance.TotalMilliseconds));
+        watch.Stop();
+        watch.Elapsed.ShouldBe(timeout, tolerance);
     }
 
     [Fact]
@@ -331,7 +326,7 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
     {
         var policy = Policy.TimeoutAsync<ResultPrimitive>(TimeSpan.FromSeconds(10), TimeoutStrategy.Optimistic);
 
-        await policy.Awaiting(p => p.ExecuteAsync(() => throw new NotSupportedException())).Should().ThrowAsync<NotSupportedException>();
+        await Should.ThrowAsync<NotSupportedException>(() => policy.ExecuteAsync(() => throw new NotSupportedException()));
     }
 
     #endregion
@@ -345,14 +340,14 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
         var policy = Policy.TimeoutAsync<ResultPrimitive>(timeout, TimeoutStrategy.Pessimistic);
 
         using CancellationTokenSource userTokenSource = new CancellationTokenSource();
-        await policy.Awaiting(p => p.ExecuteAsync(async
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async
             _ =>
         {
             userTokenSource.Cancel(); // User token cancels in the middle of execution ...
             await SystemClock.SleepAsync(TimeSpan.FromSeconds(timeout * 2),
                 CancellationToken); // ... but if the executed delegate does not observe it
             return ResultPrimitive.WhateverButTooLate;
-        }, userTokenSource.Token)).Should().ThrowAsync<TimeoutRejectedException>(); // ... it's still the timeout we expect.
+        }, userTokenSource.Token));
     }
 
     [Fact]
@@ -366,16 +361,15 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
         {
             cts.Cancel();
 
-            await policy.Awaiting(p => p.ExecuteAsync(async _ =>
+            await Should.ThrowAsync<OperationCanceledException>(() => policy.ExecuteAsync(async _ =>
             {
                 executed = true;
                 await TaskHelper.EmptyTask;
                 return ResultPrimitive.WhateverButTooLate;
-            }, cts.Token))
-            .Should().ThrowAsync<OperationCanceledException>();
+            }, cts.Token));
         }
 
-        executed.Should().BeFalse();
+        executed.ShouldBeFalse();
     }
 
     #endregion
@@ -388,14 +382,13 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
         int timeout = 10;
         var policy = Policy.TimeoutAsync<ResultPrimitive>(timeout, TimeoutStrategy.Optimistic);
         using CancellationTokenSource userTokenSource = new CancellationTokenSource();
-        await policy.Awaiting(p => p.ExecuteAsync(
+        await Should.ThrowAsync<OperationCanceledException>(() => policy.ExecuteAsync(
             ct =>
             {
                 userTokenSource.Cancel();
                 ct.ThrowIfCancellationRequested();   // Simulate cancel in the middle of execution
                 return Task.FromResult(ResultPrimitive.WhateverButTooLate);
-            }, userTokenSource.Token)) // ... with user token.
-           .Should().ThrowAsync<OperationCanceledException>();
+            }, userTokenSource.Token)); // ... with user token.
     }
 
     [Fact]
@@ -409,16 +402,15 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
         {
             cts.Cancel();
 
-            await policy.Awaiting(p => p.ExecuteAsync(async _ =>
+            await Should.ThrowAsync<OperationCanceledException>(() => policy.ExecuteAsync(async _ =>
             {
                 executed = true;
                 await TaskHelper.EmptyTask;
                 return ResultPrimitive.WhateverButTooLate;
-            }, cts.Token))
-            .Should().ThrowAsync<OperationCanceledException>();
+            }, cts.Token));
         }
 
-        executed.Should().BeFalse();
+        executed.ShouldBeFalse();
     }
 
     #endregion
@@ -439,14 +431,13 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
 
         var policy = Policy.TimeoutAsync<ResultPrimitive>(timeoutPassedToConfiguration, TimeoutStrategy.Pessimistic, onTimeoutAsync);
 
-        await policy.Awaiting(p => p.ExecuteAsync(async () =>
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async () =>
         {
             await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken);
             return ResultPrimitive.WhateverButTooLate;
-        }))
-        .Should().ThrowAsync<TimeoutRejectedException>();
+        }));
 
-        timeoutPassedToOnTimeout.Should().Be(timeoutPassedToConfiguration);
+        timeoutPassedToOnTimeout.ShouldBe(timeoutPassedToConfiguration);
     }
 
     [Fact]
@@ -465,16 +456,15 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
         TimeSpan timeout = TimeSpan.FromMilliseconds(250);
         var policy = Policy.TimeoutAsync<ResultPrimitive>(timeout, TimeoutStrategy.Pessimistic, onTimeoutAsync);
 
-        await policy.Awaiting(p => p.ExecuteAsync(async _ =>
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async _ =>
             {
                 await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken);
                 return ResultPrimitive.WhateverButTooLate;
-            }, contextPassedToExecute))
-            .Should().ThrowAsync<TimeoutRejectedException>();
+            }, contextPassedToExecute));
 
-        contextPassedToOnTimeout!.Should().NotBeNull();
-        contextPassedToOnTimeout!.OperationKey.Should().Be(operationKey);
-        contextPassedToOnTimeout!.Should().BeSameAs(contextPassedToExecute);
+        contextPassedToOnTimeout!.ShouldNotBeNull();
+        contextPassedToOnTimeout!.OperationKey.ShouldBe(operationKey);
+        contextPassedToOnTimeout!.ShouldBeSameAs(contextPassedToExecute);
     }
 
     [Theory]
@@ -494,14 +484,13 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
 
         var policy = Policy.TimeoutAsync<ResultPrimitive>(timeoutFunc, TimeoutStrategy.Pessimistic, onTimeoutAsync);
 
-        await policy.Awaiting(p => p.ExecuteAsync(async () =>
-            {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken);
-                return ResultPrimitive.WhateverButTooLate;
-            }))
-            .Should().ThrowAsync<TimeoutRejectedException>();
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async () =>
+        {
+            await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken);
+            return ResultPrimitive.WhateverButTooLate;
+        }));
 
-        timeoutPassedToOnTimeout.Should().Be(timeoutFunc());
+        timeoutPassedToOnTimeout.ShouldBe(timeoutFunc());
     }
 
     [Theory]
@@ -524,14 +513,13 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
         // Supply a programatically-controlled timeout, via the execution context.
         Context context = new Context("SomeOperationKey") { ["timeout"] = TimeSpan.FromMilliseconds(25 * programaticallyControlledDelay) };
 
-        await policy.Awaiting(p => p.ExecuteAsync(async _ =>
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async _ =>
         {
             await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken);
             return ResultPrimitive.WhateverButTooLate;
-        }, context))
-        .Should().ThrowAsync<TimeoutRejectedException>();
+        }, context));
 
-        timeoutPassedToOnTimeout.Should().Be(timeoutProvider(context));
+        timeoutPassedToOnTimeout.ShouldBe(timeoutProvider(context));
     }
 
     [Fact]
@@ -547,14 +535,13 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
         TimeSpan timeout = TimeSpan.FromMilliseconds(250);
         var policy = Policy.TimeoutAsync<ResultPrimitive>(timeout, TimeoutStrategy.Pessimistic, onTimeoutAsync);
 
-        await policy.Awaiting(p => p.ExecuteAsync(async () =>
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async () =>
         {
             await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken);
             return ResultPrimitive.WhateverButTooLate;
-        }))
-        .Should().ThrowAsync<TimeoutRejectedException>();
+        }));
 
-        taskPassedToOnTimeout.Should().NotBeNull();
+        Assert.NotNull(taskPassedToOnTimeout);
     }
 
     [Fact]
@@ -578,16 +565,15 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
         TimeSpan thriceShimTimeSpan = shimTimespan + shimTimespan + shimTimespan;
         var policy = Policy.TimeoutAsync<ResultPrimitive>(shimTimespan, TimeoutStrategy.Pessimistic, onTimeoutAsync);
 
-        await policy.Awaiting(p => p.ExecuteAsync(async () =>
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async () =>
         {
             await SystemClock.SleepAsync(thriceShimTimeSpan, CancellationToken);
             throw exceptionToThrow;
-        }))
-        .Should().ThrowAsync<TimeoutRejectedException>();
+        }));
 
         await SystemClock.SleepAsync(thriceShimTimeSpan, CancellationToken);
-        exceptionObservedFromTaskPassedToOnTimeout.Should().NotBeNull();
-        exceptionObservedFromTaskPassedToOnTimeout.Should().Be(exceptionToThrow);
+        exceptionObservedFromTaskPassedToOnTimeout.ShouldNotBeNull();
+        exceptionObservedFromTaskPassedToOnTimeout.ShouldBe(exceptionToThrow);
 
     }
 
@@ -605,15 +591,14 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
 
         var policy = Policy.TimeoutAsync<ResultPrimitive>(timeoutPassedToConfiguration, TimeoutStrategy.Pessimistic, onTimeoutAsync);
 
-        await policy.Awaiting(p => p.ExecuteAsync(async () =>
-            {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken);
-                return ResultPrimitive.WhateverButTooLate;
-            }))
-            .Should().ThrowAsync<TimeoutRejectedException>();
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async () =>
+        {
+            await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken);
+            return ResultPrimitive.WhateverButTooLate;
+        }));
 
-        exceptionPassedToOnTimeout.Should().NotBeNull();
-        exceptionPassedToOnTimeout.Should().BeOfType<OperationCanceledException>();
+        exceptionPassedToOnTimeout.ShouldNotBeNull();
+        exceptionPassedToOnTimeout.ShouldBeOfType<OperationCanceledException>();
     }
 
     #endregion
@@ -635,14 +620,13 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
         var policy = Policy.TimeoutAsync<ResultPrimitive>(timeoutPassedToConfiguration, TimeoutStrategy.Optimistic, onTimeoutAsync);
         var userCancellationToken = CancellationToken;
 
-        await policy.Awaiting(p => p.ExecuteAsync(async ct =>
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async ct =>
         {
             await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct);
             return ResultPrimitive.WhateverButTooLate;
-        }, userCancellationToken))
-        .Should().ThrowAsync<TimeoutRejectedException>();
+        }, userCancellationToken));
 
-        timeoutPassedToOnTimeout.Should().Be(timeoutPassedToConfiguration);
+        timeoutPassedToOnTimeout.ShouldBe(timeoutPassedToConfiguration);
     }
 
     [Fact]
@@ -662,16 +646,15 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
         var policy = Policy.TimeoutAsync<ResultPrimitive>(timeout, TimeoutStrategy.Optimistic, onTimeoutAsync);
         var userCancellationToken = CancellationToken;
 
-        await policy.Awaiting(p => p.ExecuteAsync(async (_, ct) =>
-            {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct);
-                return ResultPrimitive.WhateverButTooLate;
-            }, contextPassedToExecute, userCancellationToken))
-            .Should().ThrowAsync<TimeoutRejectedException>();
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async (_, ct) =>
+        {
+            await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct);
+            return ResultPrimitive.WhateverButTooLate;
+        }, contextPassedToExecute, userCancellationToken));
 
-        contextPassedToOnTimeout!.Should().NotBeNull();
-        contextPassedToOnTimeout!.OperationKey.Should().Be(operationKey);
-        contextPassedToOnTimeout!.Should().BeSameAs(contextPassedToExecute);
+        contextPassedToOnTimeout.ShouldNotBeNull();
+        contextPassedToOnTimeout.OperationKey.ShouldBe(operationKey);
+        contextPassedToOnTimeout.ShouldBeSameAs(contextPassedToExecute);
     }
 
     [Theory]
@@ -692,14 +675,13 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
         var policy = Policy.TimeoutAsync<ResultPrimitive>(timeoutFunc, TimeoutStrategy.Optimistic, onTimeoutAsync);
         var userCancellationToken = CancellationToken;
 
-        await policy.Awaiting(p => p.ExecuteAsync(async ct =>
-            {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct);
-                return ResultPrimitive.WhateverButTooLate;
-            }, userCancellationToken))
-            .Should().ThrowAsync<TimeoutRejectedException>();
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async ct =>
+        {
+            await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct);
+            return ResultPrimitive.WhateverButTooLate;
+        }, userCancellationToken));
 
-        timeoutPassedToOnTimeout.Should().Be(timeoutFunc());
+        timeoutPassedToOnTimeout.ShouldBe(timeoutFunc());
     }
 
     [Theory]
@@ -726,14 +708,13 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
             ["timeout"] = TimeSpan.FromMilliseconds(25 * programaticallyControlledDelay)
         };
 
-        await policy.Awaiting(p => p.ExecuteAsync(async (_, ct) =>
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async (_, ct) =>
         {
             await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct);
             return ResultPrimitive.WhateverButTooLate;
-        }, context, userCancellationToken))
-            .Should().ThrowAsync<TimeoutRejectedException>();
+        }, context, userCancellationToken));
 
-        timeoutPassedToOnTimeout.Should().Be(timeoutProvider(context));
+        timeoutPassedToOnTimeout.ShouldBe(timeoutProvider(context));
     }
 
     [Fact]
@@ -750,14 +731,13 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
         var policy = Policy.TimeoutAsync<ResultPrimitive>(timeout, TimeoutStrategy.Optimistic, onTimeoutAsync);
         var userCancellationToken = CancellationToken;
 
-        await policy.Awaiting(p => p.ExecuteAsync(async ct =>
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async ct =>
         {
             await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct);
             return ResultPrimitive.WhateverButTooLate;
-        }, userCancellationToken))
-        .Should().ThrowAsync<TimeoutRejectedException>();
+        }, userCancellationToken));
 
-        taskPassedToOnTimeout.Should().BeNull();
+        taskPassedToOnTimeout.ShouldBeNull();
     }
 
     [Fact]
@@ -775,15 +755,14 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
         var policy = Policy.TimeoutAsync<ResultPrimitive>(timeoutPassedToConfiguration, TimeoutStrategy.Optimistic, onTimeoutAsync);
         var userCancellationToken = CancellationToken;
 
-        await policy.Awaiting(p => p.ExecuteAsync(async ct =>
-            {
-                await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct);
-                return ResultPrimitive.WhateverButTooLate;
-            }, userCancellationToken))
-            .Should().ThrowAsync<TimeoutRejectedException>();
+        await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async ct =>
+        {
+            await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct);
+            return ResultPrimitive.WhateverButTooLate;
+        }, userCancellationToken));
 
-        exceptionPassedToOnTimeout.Should().NotBeNull();
-        exceptionPassedToOnTimeout.Should().BeOfType<OperationCanceledException>();
+        exceptionPassedToOnTimeout.ShouldNotBeNull();
+        exceptionPassedToOnTimeout.ShouldBeOfType<OperationCanceledException>();
     }
 
     #endregion

--- a/test/Polly.Specs/Timeout/TimeoutTResultSpecs.cs
+++ b/test/Polly.Specs/Timeout/TimeoutTResultSpecs.cs
@@ -26,10 +26,10 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
 
         var func = () => methodInfo.Invoke(instance, [action, new Context(), CancellationToken]);
 
-        var exceptionAssertions = func.Should().Throw<TargetInvocationException>();
-        exceptionAssertions.And.Message.Should().Be("Exception has been thrown by the target of an invocation.");
-        exceptionAssertions.And.InnerException.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("action");
+        var exceptionAssertions = Should.Throw<TargetInvocationException>(func);
+        exceptionAssertions.Message.ShouldBe("Exception has been thrown by the target of an invocation.");
+        exceptionAssertions.InnerException.ShouldBeOfType<ArgumentNullException>()
+            .ParamName.ShouldBe("action");
     }
 
     [Fact]
@@ -37,8 +37,8 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.Timeout<ResultPrimitive>(TimeSpan.Zero);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-            .ParamName.Should().Be("timeout");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+            .ParamName.ShouldBe("timeout");
     }
 
     [Fact]
@@ -46,8 +46,8 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.Timeout<ResultPrimitive>(0);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-            .ParamName.Should().Be("seconds");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+            .ParamName.ShouldBe("seconds");
     }
 
     [Fact]
@@ -55,8 +55,8 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.Timeout<ResultPrimitive>(-TimeSpan.FromHours(1));
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-            .ParamName.Should().Be("timeout");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+            .ParamName.ShouldBe("timeout");
     }
 
     [Fact]
@@ -64,8 +64,8 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.Timeout<ResultPrimitive>(-10);
 
-        policy.Should().Throw<ArgumentOutOfRangeException>().And
-            .ParamName.Should().Be("seconds");
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+            .ParamName.ShouldBe("seconds");
     }
 
     [Fact]
@@ -73,7 +73,7 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.Timeout<ResultPrimitive>(TimeSpan.FromMilliseconds(1));
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -81,7 +81,7 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.Timeout<ResultPrimitive>(3);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -89,7 +89,7 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.Timeout<ResultPrimitive>(TimeSpan.MaxValue);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -97,7 +97,7 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.Timeout<ResultPrimitive>(int.MaxValue);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -105,7 +105,7 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.Timeout<ResultPrimitive>(System.Threading.Timeout.InfiniteTimeSpan);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -113,7 +113,7 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.Timeout<ResultPrimitive>(System.Threading.Timeout.InfiniteTimeSpan, TimeoutStrategy.Optimistic);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -122,7 +122,7 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         Action<Context, TimeSpan, Task> doNothing = (_, _, _) => { };
         Action policy = () => Policy.Timeout<ResultPrimitive>(System.Threading.Timeout.InfiniteTimeSpan, doNothing);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -131,7 +131,7 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         Action<Context, TimeSpan, Task> doNothing = (_, _, _) => { };
         Action policy = () => Policy.Timeout<ResultPrimitive>(System.Threading.Timeout.InfiniteTimeSpan, TimeoutStrategy.Optimistic, doNothing);
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     [Fact]
@@ -140,8 +140,8 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         Action<Context, TimeSpan, Task> onTimeout = null!;
         Action policy = () => Policy.Timeout<ResultPrimitive>(TimeSpan.FromMinutes(0.5), onTimeout);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onTimeout");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onTimeout");
     }
 
     [Fact]
@@ -150,8 +150,8 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         Action<Context, TimeSpan, Task, Exception> onTimeout = null!;
         Action policy = () => Policy.Timeout<ResultPrimitive>(TimeSpan.FromMinutes(0.5), onTimeout);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onTimeout");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onTimeout");
     }
 
     [Fact]
@@ -160,8 +160,8 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         Action<Context, TimeSpan, Task> onTimeout = null!;
         Action policy = () => Policy.Timeout<ResultPrimitive>(30, onTimeout);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onTimeout");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onTimeout");
     }
 
     [Fact]
@@ -170,8 +170,8 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         Action<Context, TimeSpan, Task, Exception> onTimeout = null!;
         Action policy = () => Policy.Timeout<ResultPrimitive>(30, onTimeout);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onTimeout");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onTimeout");
     }
 
     [Fact]
@@ -179,8 +179,8 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.Timeout<ResultPrimitive>((Func<TimeSpan>)null!);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("timeoutProvider");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("timeoutProvider");
     }
 
     [Fact]
@@ -189,8 +189,8 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         Action<Context, TimeSpan, Task> onTimeout = null!;
         Action policy = () => Policy.Timeout<ResultPrimitive>(() => TimeSpan.FromSeconds(30), onTimeout);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onTimeout");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onTimeout");
     }
 
     [Fact]
@@ -199,8 +199,8 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         Action<Context, TimeSpan, Task, Exception> onTimeout = null!;
         Action policy = () => Policy.Timeout<ResultPrimitive>(() => TimeSpan.FromSeconds(30), onTimeout);
 
-        policy.Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("onTimeout");
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onTimeout");
     }
 
     [Fact]
@@ -208,7 +208,7 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
     {
         Action policy = () => Policy.Timeout<ResultPrimitive>(() => TimeSpan.FromSeconds(1));
 
-        policy.Should().NotThrow();
+        Should.NotThrow(policy);
     }
 
     #endregion
@@ -222,11 +222,11 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
 
         var policy = Policy.Timeout<ResultPrimitive>(timeout, TimeoutStrategy.Pessimistic);
 
-        policy.Invoking(p => p.Execute(() =>
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(() =>
         {
             SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken);
             return ResultPrimitive.WhateverButTooLate;
-        })).Should().Throw<TimeoutRejectedException>();
+        }));
     }
 
     [Fact]
@@ -246,30 +246,28 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
             }, userCancellationToken);
         };
 
-        act.Should().NotThrow<TimeoutRejectedException>();
-        result.Should().Be(ResultPrimitive.Good);
+        Should.NotThrow(act);
+        result.ShouldBe(ResultPrimitive.Good);
     }
 
     [Fact]
     public void Should_throw_timeout_after_correct_duration__pessimistic()
     {
-        Stopwatch watch = new Stopwatch();
-
         TimeSpan timeout = TimeSpan.FromSeconds(1);
         var policy = Policy.Timeout<ResultPrimitive>(timeout, TimeoutStrategy.Pessimistic);
 
         TimeSpan tolerance = TimeSpan.FromSeconds(3); // Consider increasing tolerance, if test fails transiently in different test/build environments.
 
-        watch.Start();
-        policy.Invoking(p => p.Execute(() =>
+        Stopwatch watch = Stopwatch.StartNew();
+
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(() =>
         {
             SystemClock.Sleep(TimeSpan.FromSeconds(10), CancellationToken);
             return ResultPrimitive.WhateverButTooLate;
-        }))
-            .Should().Throw<TimeoutRejectedException>();
-        watch.Stop();
+        }));
 
-        watch.Elapsed.Should().BeCloseTo(timeout, TimeSpan.FromMilliseconds(tolerance.TotalMilliseconds));
+        watch.Stop();
+        watch.Elapsed.ShouldBe(timeout, TimeSpan.FromMilliseconds(tolerance.TotalMilliseconds));
     }
 
     [Fact]
@@ -277,7 +275,7 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
     {
         var policy = Policy.Timeout<ResultPrimitive>(TimeSpan.FromSeconds(10), TimeoutStrategy.Pessimistic);
 
-        policy.Invoking(p => p.Execute(() => throw new NotSupportedException())).Should().Throw<NotSupportedException>();
+        Should.Throw<NotSupportedException>(() => policy.Execute(() => throw new NotSupportedException()));
     }
 
     [Fact]
@@ -289,11 +287,12 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         // Check to see if nested aggregate exceptions are unwrapped correctly
         AggregateException exception = new AggregateException(msg, new NotImplementedException());
 
-        policy.Invoking(p => p.Execute(() => { Helper_ThrowException(exception); return ResultPrimitive.WhateverButTooLate; }))
-            .Should().Throw<AggregateException>()
-            .WithMessage(exception.Message)
-            .Where(e => e.InnerException is NotImplementedException)
-            .And.StackTrace.Should().Contain(nameof(Helper_ThrowException));
+        var actual = Should.Throw<AggregateException>(() => policy.Execute(() => { Helper_ThrowException(exception); return ResultPrimitive.WhateverButTooLate; }));
+        actual.Message.ShouldBe(exception.Message);
+
+        actual.InnerExceptions
+            .Where(p => p.InnerException is NotImplementedException)
+            .ShouldAllBe(p => p.StackTrace != null && p.StackTrace.Contains(nameof(Helper_ThrowException)));
     }
 
     [Fact]
@@ -305,16 +304,17 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         Exception innerException1 = new NotImplementedException();
         Exception innerException2 = new DivideByZeroException();
         AggregateException aggregateException = new AggregateException(msg, innerException1, innerException2);
+
         Func<ResultPrimitive> func = () => { Helper_ThrowException(aggregateException); return ResultPrimitive.WhateverButTooLate; };
 
         // Whether executing the delegate directly, or through the policy, exception behavior should be the same.
-        func.Should().Throw<AggregateException>()
-            .WithMessage(aggregateException.Message)
-            .And.InnerExceptions.Should().BeEquivalentTo<Exception>(new[] { innerException1, innerException2 });
+        var exception = Should.Throw<AggregateException>(() => func());
+        exception.Message.ShouldBe(aggregateException.Message);
+        exception.InnerExceptions.ShouldBe([innerException1, innerException2]);
 
-        policy.Invoking(p => p.Execute(func)).Should().Throw<AggregateException>()
-            .WithMessage(aggregateException.Message)
-            .And.InnerExceptions.Should().BeEquivalentTo<Exception>(new[] { innerException1, innerException2 });
+        exception = Should.Throw<AggregateException>(() => policy.Execute(func));
+        exception.Message.ShouldBe(aggregateException.Message);
+        exception.InnerExceptions.ShouldBe([innerException1, innerException2]);
     }
 
     [Fact]
@@ -333,11 +333,13 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         };
 
         // Whether executing the delegate directly, or through the policy, exception behavior should be the same.
-        func.Should().Throw<AggregateException>()
-            .And.InnerExceptions.Should().BeEquivalentTo<Exception>(new[] { innerException1, innerException2 });
+        var exception = Should.Throw<AggregateException>(() => func());
+        exception.InnerExceptions.ShouldContain(innerException1);
+        exception.InnerExceptions.ShouldContain(innerException2);
 
-        policy.Invoking(p => p.Execute(func)).Should().Throw<AggregateException>()
-            .And.InnerExceptions.Should().BeEquivalentTo<Exception>(new[] { innerException1, innerException2 });
+        exception = Should.Throw<AggregateException>(() => policy.Execute(func));
+        exception.InnerExceptions.ShouldContain(innerException1);
+        exception.InnerExceptions.ShouldContain(innerException2);
     }
 
     [Fact]
@@ -356,11 +358,13 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         };
 
         // Whether executing the delegate directly, or through the policy, exception behavior should be the same.
-        func.Should().Throw<AggregateException>()
-            .And.InnerExceptions.Should().BeEquivalentTo<Exception>(new[] { innerException1, innerException2 });
+        var exception = Should.Throw<AggregateException>(() => func());
+        exception.InnerExceptions.ShouldContain(innerException1);
+        exception.InnerExceptions.ShouldContain(innerException2);
 
-        policy.Invoking(p => p.Execute(func)).Should().Throw<AggregateException>()
-            .And.InnerExceptions.Should().BeEquivalentTo<Exception>(new[] { innerException1, innerException2 });
+        exception = Should.Throw<AggregateException>(() => policy.Execute(func));
+        exception.InnerExceptions.ShouldContain(innerException1);
+        exception.InnerExceptions.ShouldContain(innerException2);
     }
 
     #endregion
@@ -373,12 +377,11 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         var policy = Policy.Timeout<ResultPrimitive>(TimeSpan.FromMilliseconds(50), TimeoutStrategy.Optimistic);
         var userCancellationToken = CancellationToken;
 
-        policy.Invoking(p => p.Execute(ct =>
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(ct =>
         {
             SystemClock.Sleep(TimeSpan.FromSeconds(3), ct);
             return ResultPrimitive.WhateverButTooLate;
-        }, userCancellationToken))
-        .Should().Throw<TimeoutRejectedException>();
+        }, userCancellationToken));
     }
 
     [Fact]
@@ -397,31 +400,30 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
             }, userCancellationToken);
         };
 
-        act.Should().NotThrow<TimeoutRejectedException>();
-        result.Should().Be(ResultPrimitive.Good);
+        Should.NotThrow(act);
+        result.ShouldBe(ResultPrimitive.Good);
     }
 
     [Fact]
     public void Should_throw_timeout_after_correct_duration__optimistic()
     {
-        Stopwatch watch = new Stopwatch();
-
         TimeSpan timeout = TimeSpan.FromSeconds(1);
         var policy = Policy.Timeout<ResultPrimitive>(timeout, TimeoutStrategy.Optimistic);
         var userCancellationToken = CancellationToken;
 
-        TimeSpan tolerance = TimeSpan.FromSeconds(3); // Consider increasing tolerance, if test fails transiently in different test/build environments.
+        TimeSpan tolerance = TimeSpan.FromSeconds(3);
 
-        watch.Start();
-        policy.Invoking(p => p.Execute(ct =>
+        var watch = Stopwatch.StartNew();
+
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(ct =>
         {
             SystemClock.Sleep(TimeSpan.FromSeconds(10), ct);
             return ResultPrimitive.WhateverButTooLate;
-        }, userCancellationToken))
-            .Should().Throw<TimeoutRejectedException>();
+        }, userCancellationToken));
+
         watch.Stop();
 
-        watch.Elapsed.Should().BeCloseTo(timeout, TimeSpan.FromMilliseconds(tolerance.TotalMilliseconds));
+        watch.Elapsed.ShouldBe(timeout, TimeSpan.FromMilliseconds(tolerance.TotalMilliseconds));
     }
 
     [Fact]
@@ -429,7 +431,7 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
     {
         var policy = Policy.Timeout<ResultPrimitive>(TimeSpan.FromSeconds(10), TimeoutStrategy.Optimistic);
 
-        policy.Invoking(p => p.Execute(() => throw new NotSupportedException())).Should().Throw<NotSupportedException>();
+        Should.Throw<NotSupportedException>(() => policy.Execute(() => throw new NotSupportedException()));
     }
 
     #endregion
@@ -443,14 +445,12 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         var policy = Policy.Timeout<ResultPrimitive>(timeout, TimeoutStrategy.Pessimistic);
 
         using CancellationTokenSource userTokenSource = new CancellationTokenSource();
-        policy.Invoking(p => p.Execute(
-            _ =>
-            {
-                userTokenSource.Cancel(); // User token cancels in the middle of execution ...
-                SystemClock.Sleep(TimeSpan.FromSeconds(timeout * 2),
-                    CancellationToken); // ... but if the executed delegate does not observe it
-                return ResultPrimitive.WhateverButTooLate;
-            }, userTokenSource.Token)).Should().Throw<TimeoutRejectedException>(); // ... it's still the timeout we expect.
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(_ =>
+        {
+            userTokenSource.Cancel(); // User token cancels in the middle of execution ...
+            SystemClock.Sleep(TimeSpan.FromSeconds(timeout * 2), CancellationToken); // ... but if the executed delegate does not observe it
+            return ResultPrimitive.WhateverButTooLate;
+        }, userTokenSource.Token));
     }
 
     [Fact]
@@ -464,15 +464,14 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         {
             cts.Cancel();
 
-            policy.Invoking(p => p.Execute(_ =>
+            Should.Throw<OperationCanceledException>(() => policy.Execute(_ =>
             {
                 executed = true;
                 return ResultPrimitive.WhateverButTooLate;
-            }, cts.Token))
-            .Should().Throw<OperationCanceledException>();
+            }, cts.Token));
         }
 
-        executed.Should().BeFalse();
+        executed.ShouldBeFalse();
     }
 
     #endregion
@@ -484,15 +483,13 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
     {
         int timeout = 10;
         var policy = Policy.Timeout<ResultPrimitive>(timeout, TimeoutStrategy.Optimistic);
-        using CancellationTokenSource userTokenSource = new CancellationTokenSource();
-        policy.Invoking(p => p.Execute(
-            ct =>
-            {
-                userTokenSource.Cancel();
-                ct.ThrowIfCancellationRequested(); // Simulate cancel in the middle of execution
-                return ResultPrimitive.WhateverButTooLate;
-            }, userTokenSource.Token)) // ... with user token.
-           .Should().Throw<OperationCanceledException>(); // Not a TimeoutRejectedException; i.e. policy can distinguish user cancellation from timeout cancellation.
+        using var userTokenSource = new CancellationTokenSource();
+        Should.Throw<OperationCanceledException>(() => policy.Execute(ct =>
+        {
+            userTokenSource.Cancel();
+            ct.ThrowIfCancellationRequested(); // Simulate cancel in the middle of execution
+            return ResultPrimitive.WhateverButTooLate;
+        }, userTokenSource.Token)); // ... with user token.
     }
 
     [Fact]
@@ -506,15 +503,14 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         {
             cts.Cancel();
 
-            policy.Invoking(p => p.Execute(_ =>
+            Should.Throw<OperationCanceledException>(() => policy.Execute(_ =>
             {
                 executed = true;
                 return ResultPrimitive.WhateverButTooLate;
-            }, cts.Token))
-            .Should().Throw<OperationCanceledException>();
+            }, cts.Token));
         }
 
-        executed.Should().BeFalse();
+        executed.ShouldBeFalse();
     }
 
     #endregion
@@ -531,14 +527,13 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
 
         var policy = Policy.Timeout<ResultPrimitive>(timeoutPassedToConfiguration, TimeoutStrategy.Pessimistic, onTimeout);
 
-        policy.Invoking(p => p.Execute(() =>
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(() =>
         {
             SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken);
             return ResultPrimitive.WhateverButTooLate;
-        }))
-        .Should().Throw<TimeoutRejectedException>();
+        }));
 
-        timeoutPassedToOnTimeout.Should().Be(timeoutPassedToConfiguration);
+        timeoutPassedToOnTimeout.ShouldBe(timeoutPassedToConfiguration);
     }
 
     [Fact]
@@ -548,21 +543,20 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         Context contextPassedToExecute = new Context(operationKey);
 
         Context? contextPassedToOnTimeout = null;
-        Action<Context, TimeSpan, Task> onTimeout = (ctx, _, _) => { contextPassedToOnTimeout = ctx; };
+        Action<Context, TimeSpan, Task> onTimeout = (ctx, _, _) => contextPassedToOnTimeout = ctx;
 
         TimeSpan timeout = TimeSpan.FromMilliseconds(250);
         var policy = Policy.Timeout<ResultPrimitive>(timeout, TimeoutStrategy.Pessimistic, onTimeout);
 
-        policy.Invoking(p => p.Execute(_ =>
-            {
-                SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken);
-                return ResultPrimitive.WhateverButTooLate;
-            }, contextPassedToExecute))
-            .Should().Throw<TimeoutRejectedException>();
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(_ =>
+        {
+            SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken);
+            return ResultPrimitive.WhateverButTooLate;
+        }, contextPassedToExecute));
 
-        contextPassedToOnTimeout!.Should().NotBeNull();
-        contextPassedToOnTimeout!.OperationKey.Should().Be(operationKey);
-        contextPassedToOnTimeout!.Should().BeSameAs(contextPassedToExecute);
+        contextPassedToOnTimeout!.ShouldNotBeNull();
+        contextPassedToOnTimeout!.OperationKey.ShouldBe(operationKey);
+        contextPassedToOnTimeout!.ShouldBeSameAs(contextPassedToExecute);
     }
 
     [Theory]
@@ -574,18 +568,17 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         Func<TimeSpan> timeoutFunc = () => TimeSpan.FromMilliseconds(25 * programaticallyControlledDelay);
 
         TimeSpan? timeoutPassedToOnTimeout = null;
-        Action<Context, TimeSpan, Task> onTimeout = (_, span, _) => { timeoutPassedToOnTimeout = span; };
+        Action<Context, TimeSpan, Task> onTimeout = (_, span, _) => timeoutPassedToOnTimeout = span;
 
         var policy = Policy.Timeout<ResultPrimitive>(timeoutFunc, TimeoutStrategy.Pessimistic, onTimeout);
 
-        policy.Invoking(p => p.Execute(() =>
-            {
-                SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken);
-                return ResultPrimitive.WhateverButTooLate;
-            }))
-            .Should().Throw<TimeoutRejectedException>();
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(() =>
+        {
+            SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken);
+            return ResultPrimitive.WhateverButTooLate;
+        }));
 
-        timeoutPassedToOnTimeout.Should().Be(timeoutFunc());
+        timeoutPassedToOnTimeout.ShouldBe(timeoutFunc());
 
     }
 
@@ -604,33 +597,31 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         // Supply a programatically-controlled timeout, via the execution context.
         Context context = new Context("SomeOperationKey") { ["timeout"] = TimeSpan.FromMilliseconds(25 * programaticallyControlledDelay) };
 
-        policy.Invoking(p => p.Execute(_ =>
-            {
-                SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken);
-                return ResultPrimitive.WhateverButTooLate;
-            }, context))
-            .Should().Throw<TimeoutRejectedException>();
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(_ =>
+        {
+            SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken);
+            return ResultPrimitive.WhateverButTooLate;
+        }, context));
 
-        timeoutPassedToOnTimeout.Should().Be(timeoutProvider(context));
+        timeoutPassedToOnTimeout.ShouldBe(timeoutProvider(context));
     }
 
     [Fact]
     public void Should_call_ontimeout_with_task_wrapping_abandoned_action__pessimistic()
     {
         Task? taskPassedToOnTimeout = null;
-        Action<Context, TimeSpan, Task> onTimeout = (_, _, task) => { taskPassedToOnTimeout = task; };
+        Action<Context, TimeSpan, Task> onTimeout = (_, _, task) => taskPassedToOnTimeout = task;
 
         TimeSpan timeout = TimeSpan.FromMilliseconds(250);
         var policy = Policy.Timeout<ResultPrimitive>(timeout, TimeoutStrategy.Pessimistic, onTimeout);
 
-        policy.Invoking(p => p.Execute(() =>
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(() =>
         {
             SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken);
             return ResultPrimitive.WhateverButTooLate;
-        }))
-        .Should().Throw<TimeoutRejectedException>();
+        }));
 
-        taskPassedToOnTimeout.Should().NotBeNull();
+        taskPassedToOnTimeout.ShouldNotBeNull();
     }
 
     [Fact]
@@ -649,21 +640,19 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
             task.ContinueWith(t => exceptionObservedFromTaskPassedToOnTimeout = t.Exception!.InnerException!);
         };
 
-        TimeSpan shimTimespan = TimeSpan.FromSeconds(1); // Consider increasing shimTimeSpan if test fails transiently in different environments.
+        TimeSpan shimTimespan = TimeSpan.FromSeconds(1);
         TimeSpan thriceShimTimeSpan = shimTimespan + shimTimespan + shimTimespan;
         var policy = Policy.Timeout<ResultPrimitive>(shimTimespan, TimeoutStrategy.Pessimistic, onTimeout);
 
-        policy.Invoking(p => p.Execute(() =>
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(() =>
         {
             SystemClock.Sleep(thriceShimTimeSpan, CancellationToken);
             throw exceptionToThrow;
-        }))
-        .Should().Throw<TimeoutRejectedException>();
+        }));
 
         SystemClock.Sleep(thriceShimTimeSpan, CancellationToken);
-        exceptionObservedFromTaskPassedToOnTimeout.Should().NotBeNull();
-        exceptionObservedFromTaskPassedToOnTimeout.Should().Be(exceptionToThrow);
-
+        exceptionObservedFromTaskPassedToOnTimeout.ShouldNotBeNull();
+        exceptionObservedFromTaskPassedToOnTimeout.ShouldBe(exceptionToThrow);
     }
 
     [Fact]
@@ -672,19 +661,18 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         TimeSpan timeoutPassedToConfiguration = TimeSpan.FromMilliseconds(250);
 
         Exception? exceptionPassedToOnTimeout = null;
-        Action<Context, TimeSpan, Task, Exception> onTimeout = (_, _, _, exception) => { exceptionPassedToOnTimeout = exception; };
+        Action<Context, TimeSpan, Task, Exception> onTimeout = (_, _, _, exception) => exceptionPassedToOnTimeout = exception;
 
         var policy = Policy.Timeout<ResultPrimitive>(timeoutPassedToConfiguration, TimeoutStrategy.Pessimistic, onTimeout);
 
-        policy.Invoking(p => p.Execute(() =>
-            {
-                SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken);
-                return ResultPrimitive.WhateverButTooLate;
-            }))
-            .Should().Throw<TimeoutRejectedException>();
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(() =>
+        {
+            SystemClock.Sleep(TimeSpan.FromSeconds(3), CancellationToken);
+            return ResultPrimitive.WhateverButTooLate;
+        }));
 
-        exceptionPassedToOnTimeout.Should().NotBeNull();
-        exceptionPassedToOnTimeout.Should().BeOfType<OperationCanceledException>();
+        exceptionPassedToOnTimeout.ShouldNotBeNull();
+        exceptionPassedToOnTimeout.ShouldBeOfType<OperationCanceledException>();
     }
 
     #endregion
@@ -697,19 +685,18 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         TimeSpan timeoutPassedToConfiguration = TimeSpan.FromMilliseconds(250);
 
         TimeSpan? timeoutPassedToOnTimeout = null;
-        Action<Context, TimeSpan, Task> onTimeout = (_, span, _) => { timeoutPassedToOnTimeout = span; };
+        Action<Context, TimeSpan, Task> onTimeout = (_, span, _) => timeoutPassedToOnTimeout = span;
 
         var policy = Policy.Timeout<ResultPrimitive>(timeoutPassedToConfiguration, TimeoutStrategy.Optimistic, onTimeout);
         var userCancellationToken = CancellationToken;
 
-        policy.Invoking(p => p.Execute(ct =>
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(ct =>
         {
             SystemClock.Sleep(TimeSpan.FromSeconds(1), ct);
             return ResultPrimitive.WhateverButTooLate;
-        }, userCancellationToken))
-        .Should().Throw<TimeoutRejectedException>();
+        }, userCancellationToken));
 
-        timeoutPassedToOnTimeout.Should().Be(timeoutPassedToConfiguration);
+        timeoutPassedToOnTimeout.ShouldBe(timeoutPassedToConfiguration);
     }
 
     [Fact]
@@ -719,22 +706,21 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         Context contextPassedToExecute = new Context(operationKey);
 
         Context? contextPassedToOnTimeout = null;
-        Action<Context, TimeSpan, Task> onTimeout = (ctx, _, _) => { contextPassedToOnTimeout = ctx; };
+        Action<Context, TimeSpan, Task> onTimeout = (ctx, _, _) => contextPassedToOnTimeout = ctx;
 
         TimeSpan timeout = TimeSpan.FromMilliseconds(250);
         var policy = Policy.Timeout<ResultPrimitive>(timeout, TimeoutStrategy.Optimistic, onTimeout);
         var userCancellationToken = CancellationToken;
 
-        policy.Invoking(p => p.Execute((_, ct) =>
-            {
-                SystemClock.Sleep(TimeSpan.FromSeconds(3), ct);
-                return ResultPrimitive.WhateverButTooLate;
-            }, contextPassedToExecute, userCancellationToken))
-            .Should().Throw<TimeoutRejectedException>();
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute((_, ct) =>
+        {
+            SystemClock.Sleep(TimeSpan.FromSeconds(3), ct);
+            return ResultPrimitive.WhateverButTooLate;
+        }, contextPassedToExecute, userCancellationToken));
 
-        contextPassedToOnTimeout!.Should().NotBeNull();
-        contextPassedToOnTimeout!.OperationKey.Should().Be(operationKey);
-        contextPassedToOnTimeout!.Should().BeSameAs(contextPassedToExecute);
+        contextPassedToOnTimeout.ShouldNotBeNull();
+        contextPassedToOnTimeout.OperationKey.ShouldBe(operationKey);
+        contextPassedToOnTimeout.ShouldBeSameAs(contextPassedToExecute);
     }
 
     [Theory]
@@ -751,14 +737,13 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         var policy = Policy.Timeout<ResultPrimitive>(timeoutFunc, TimeoutStrategy.Optimistic, onTimeout);
         var userCancellationToken = CancellationToken;
 
-        policy.Invoking(p => p.Execute(ct =>
-            {
-                SystemClock.Sleep(TimeSpan.FromSeconds(3), ct);
-                return ResultPrimitive.WhateverButTooLate;
-            }, userCancellationToken))
-            .Should().Throw<TimeoutRejectedException>();
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(ct =>
+        {
+            SystemClock.Sleep(TimeSpan.FromSeconds(3), ct);
+            return ResultPrimitive.WhateverButTooLate;
+        }, userCancellationToken));
 
-        timeoutPassedToOnTimeout.Should().Be(timeoutFunc());
+        timeoutPassedToOnTimeout.ShouldBe(timeoutFunc());
     }
 
     [Theory]
@@ -780,14 +765,13 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
             ["timeout"] = TimeSpan.FromMilliseconds(25 * programaticallyControlledDelay)
         };
 
-        policy.Invoking(p => p.Execute((_, ct) =>
-            {
-                SystemClock.Sleep(TimeSpan.FromSeconds(3), ct);
-                return ResultPrimitive.WhateverButTooLate;
-            }, context, userCancellationToken))
-            .Should().Throw<TimeoutRejectedException>();
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute((_, ct) =>
+        {
+            SystemClock.Sleep(TimeSpan.FromSeconds(3), ct);
+            return ResultPrimitive.WhateverButTooLate;
+        }, context, userCancellationToken));
 
-        timeoutPassedToOnTimeout.Should().Be(timeoutProvider(context));
+        timeoutPassedToOnTimeout.ShouldBe(timeoutProvider(context));
     }
 
     [Fact]
@@ -800,14 +784,13 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         var policy = Policy.Timeout<ResultPrimitive>(timeout, TimeoutStrategy.Optimistic, onTimeout);
         var userCancellationToken = CancellationToken;
 
-        policy.Invoking(p => p.Execute(ct =>
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(ct =>
         {
             SystemClock.Sleep(TimeSpan.FromSeconds(3), ct);
             return ResultPrimitive.WhateverButTooLate;
-        }, userCancellationToken))
-        .Should().Throw<TimeoutRejectedException>();
+        }, userCancellationToken));
 
-        taskPassedToOnTimeout.Should().BeNull();
+        taskPassedToOnTimeout.ShouldBeNull();
     }
 
     [Fact]
@@ -821,15 +804,14 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         var policy = Policy.Timeout<ResultPrimitive>(timeoutPassedToConfiguration, TimeoutStrategy.Optimistic, onTimeout);
         var userCancellationToken = CancellationToken;
 
-        policy.Invoking(p => p.Execute(ct =>
-            {
-                SystemClock.Sleep(TimeSpan.FromSeconds(1), ct);
-                return ResultPrimitive.WhateverButTooLate;
-            }, userCancellationToken))
-            .Should().Throw<TimeoutRejectedException>();
+        Should.Throw<TimeoutRejectedException>(() => policy.Execute(ct =>
+        {
+            SystemClock.Sleep(TimeSpan.FromSeconds(1), ct);
+            return ResultPrimitive.WhateverButTooLate;
+        }, userCancellationToken));
 
-        exceptionPassedToOnTimeout.Should().NotBeNull();
-        exceptionPassedToOnTimeout.Should().BeOfType<OperationCanceledException>();
+        exceptionPassedToOnTimeout.ShouldNotBeNull();
+        exceptionPassedToOnTimeout.ShouldBeOfType<OperationCanceledException>();
     }
 
     #endregion

--- a/test/Polly.Specs/Utilities/LockTimeoutExceptionTests.cs
+++ b/test/Polly.Specs/Utilities/LockTimeoutExceptionTests.cs
@@ -8,11 +8,11 @@ public class LockTimeoutExceptionTests
         const string Dummy = "dummy";
         var exception = new InvalidOperationException();
 
-        new LockTimeoutException().Message.Should().Be("Timeout waiting for lock");
-        new LockTimeoutException(Dummy).Message.Should().Be(Dummy);
+        new LockTimeoutException().Message.ShouldBe("Timeout waiting for lock");
+        new LockTimeoutException(Dummy).Message.ShouldBe(Dummy);
 
         var rate = new LockTimeoutException(Dummy, exception);
-        rate.Message.Should().Be(Dummy);
-        rate.InnerException.Should().Be(exception);
+        rate.Message.ShouldBe(Dummy);
+        rate.InnerException.ShouldBe(exception);
     }
 }

--- a/test/Polly.Specs/Utilities/SystemClockSpecs.cs
+++ b/test/Polly.Specs/Utilities/SystemClockSpecs.cs
@@ -14,36 +14,36 @@ public class SystemClockSpecs
     }
 
     [Fact]
-    public void Sleep_ShouldNotThrow_WhenCancellationNotRequested() =>
-        _sleep.Invoking(s =>
+    public void Sleep_Should_NotThrow_WhenCancellationNotRequested() =>
+        Should.NotThrow(() =>
         {
             using var cts = new CancellationTokenSource();
-            s(TimeSpan.FromMilliseconds(1), cts.Token);
-        }).Should().NotThrow();
+            _sleep(TimeSpan.FromMilliseconds(1), cts.Token);
+        });
 
     [Fact]
-    public void Sleep_ShouldThrow_WhenCancellationRequested() =>
-        _sleep.Invoking(s =>
+    public void Sleep_Should_Throw_WhenCancellationRequested() =>
+        Should.Throw<OperationCanceledException>(() =>
         {
             using var cts = new CancellationTokenSource();
             cts.Cancel();
-            s(TimeSpan.FromMilliseconds(1), cts.Token);
-        }).Should().Throw<OperationCanceledException>();
+            _sleep(TimeSpan.FromMilliseconds(1), cts.Token);
+        });
 
     [Fact]
-    public async Task SleepAsync_ShouldNotThrow_WhenCancellationNotRequested() =>
-        await _sleepAsync.Invoking(async s =>
+    public async Task SleepAsync_Should_NotThrow_WhenCancellationNotRequested() =>
+        await Should.NotThrowAsync(async () =>
         {
             using var cts = new CancellationTokenSource();
-            await s(TimeSpan.FromMilliseconds(1), cts.Token);
-        }).Should().NotThrowAsync();
+            await _sleepAsync(TimeSpan.FromMilliseconds(1), cts.Token);
+        });
 
     [Fact]
-    public async Task SleepAsync_ShouldThrow_WhenCancellationRequested() =>
-        await _sleepAsync.Invoking(async s =>
+    public async Task SleepAsync_Should_Throw_WhenCancellationRequested() =>
+        await Should.ThrowAsync<OperationCanceledException>(async () =>
         {
             using var cts = new CancellationTokenSource();
             cts.Cancel();
-            await s(TimeSpan.FromMilliseconds(1), cts.Token);
-        }).Should().ThrowAsync<OperationCanceledException>();
+            await _sleepAsync(TimeSpan.FromMilliseconds(1), cts.Token);
+        });
 }

--- a/test/Polly.Specs/Wrap/IPolicyWrapExtensionSpecs.cs
+++ b/test/Polly.Specs/Wrap/IPolicyWrapExtensionSpecs.cs
@@ -7,8 +7,8 @@ public class IPolicyWrapExtensionSpecs
     {
         IPolicyWrap policyWrap = null!;
 
-        var action = () => policyWrap.GetPolicies();
-        action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("policyWrap");
+        var action = policyWrap.GetPolicies;
+        Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe("policyWrap");
     }
 
     [Fact]
@@ -21,10 +21,10 @@ public class IPolicyWrapExtensionSpecs
         PolicyWrap policyWrap = Policy.Wrap(policy0, policy1, policy2);
 
         List<IsPolicy> policies = policyWrap.GetPolicies().ToList();
-        policies.Count.Should().Be(3);
-        policies[0].Should().Be(policy0);
-        policies[1].Should().Be(policy1);
-        policies[2].Should().Be(policy2);
+        policies.Count.ShouldBe(3);
+        policies[0].ShouldBe(policy0);
+        policies[1].ShouldBe(policy1);
+        policies[2].ShouldBe(policy2);
     }
 
     [Fact]
@@ -34,11 +34,7 @@ public class IPolicyWrapExtensionSpecs
         Policy policyB = Policy.NoOp();
         PolicyWrap wrap = Policy.Wrap(policyA, policyB);
 
-        wrap.GetPolicies().Should().BeEquivalentTo(new[] { policyA, policyB },
-            options => options
-                .WithStrictOrdering()
-                .Using<IsPolicy>(ctx => ctx.Subject.Should().BeSameAs(ctx.Expectation))
-                .WhenTypeIs<IsPolicy>());
+        wrap.GetPolicies().ShouldBe([policyA, policyB]);
     }
 
     [Fact]
@@ -49,11 +45,7 @@ public class IPolicyWrapExtensionSpecs
         Policy policyC = Policy.NoOp();
         PolicyWrap wrap = Policy.Wrap(policyA, policyB, policyC);
 
-        wrap.GetPolicies().Should().BeEquivalentTo(new[] { policyA, policyB, policyC },
-            options => options
-                .WithStrictOrdering()
-                .Using<IsPolicy>(ctx => ctx.Subject.Should().BeSameAs(ctx.Expectation))
-                .WhenTypeIs<IsPolicy>());
+        wrap.GetPolicies().ShouldBe([policyA, policyB, policyC]);
     }
 
     [Fact]
@@ -64,11 +56,7 @@ public class IPolicyWrapExtensionSpecs
         Policy policyC = Policy.NoOp();
         PolicyWrap wrap = policyA.Wrap(policyB).Wrap(policyC);
 
-        wrap.GetPolicies().Should().BeEquivalentTo(new[] { policyA, policyB, policyC },
-            options => options
-                .WithStrictOrdering()
-                .Using<IsPolicy>(ctx => ctx.Subject.Should().BeSameAs(ctx.Expectation))
-                .WhenTypeIs<IsPolicy>());
+        wrap.GetPolicies().ShouldBe([policyA, policyB, policyC]);
     }
 
     [Fact]
@@ -79,11 +67,7 @@ public class IPolicyWrapExtensionSpecs
         Policy policyC = Policy.NoOp();
         PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
 
-        wrap.GetPolicies().Should().BeEquivalentTo(new[] { policyA, policyB, policyC },
-            options => options
-                .WithStrictOrdering()
-                .Using<IsPolicy>(ctx => ctx.Subject.Should().BeSameAs(ctx.Expectation))
-                .WhenTypeIs<IsPolicy>());
+        wrap.GetPolicies().ShouldBe([policyA, policyB, policyC]);
     }
 
     [Fact]
@@ -94,11 +78,9 @@ public class IPolicyWrapExtensionSpecs
         Policy policyC = Policy.NoOp();
         PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
 
-        wrap.GetPolicies<RetryPolicy>().Should().BeEquivalentTo(new[] { policyB },
-            options => options
-                .WithStrictOrdering()
-                .Using<IsPolicy>(ctx => ctx.Subject.Should().BeSameAs(ctx.Expectation))
-                .WhenTypeIs<IsPolicy>());
+        wrap.GetPolicies<RetryPolicy>()
+            .OfType<IsPolicy>()
+            .ShouldBe([policyB]);
     }
 
     [Fact]
@@ -109,7 +91,7 @@ public class IPolicyWrapExtensionSpecs
         Policy policyC = Policy.NoOp();
         PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
 
-        wrap.GetPolicies<CircuitBreakerPolicy>().Should().BeEmpty();
+        wrap.GetPolicies<CircuitBreakerPolicy>().ShouldBeEmpty();
     }
 
     [Fact]
@@ -120,11 +102,9 @@ public class IPolicyWrapExtensionSpecs
         Policy policyC = Policy.NoOp();
         PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
 
-        wrap.GetPolicies<NoOpPolicy>().Should().BeEquivalentTo(new[] { policyA, policyC },
-            options => options
-                .WithStrictOrdering()
-                .Using<IsPolicy>(ctx => ctx.Subject.Should().BeSameAs(ctx.Expectation))
-                .WhenTypeIs<IsPolicy>());
+        wrap.GetPolicies<NoOpPolicy>()
+            .OfType<IsPolicy>()
+            .ShouldBe([policyA, policyC]);
     }
 
     [Fact]
@@ -138,11 +118,7 @@ public class IPolicyWrapExtensionSpecs
 
         PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
 
-        wrap.GetPolicies<CircuitBreakerPolicy>(p => p.CircuitState == CircuitState.Closed).Should().BeEquivalentTo(new[] { policyC },
-            options => options
-                .WithStrictOrdering()
-                .Using<IsPolicy>(ctx => ctx.Subject.Should().BeSameAs(ctx.Expectation))
-                .WhenTypeIs<IsPolicy>());
+        wrap.GetPolicies<CircuitBreakerPolicy>(p => p.CircuitState == CircuitState.Closed).ShouldBe([policyC]);
     }
 
     [Fact]
@@ -154,7 +130,7 @@ public class IPolicyWrapExtensionSpecs
 
         PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
 
-        wrap.GetPolicies<CircuitBreakerPolicy>(p => p.CircuitState == CircuitState.Open).Should().BeEmpty();
+        wrap.GetPolicies<CircuitBreakerPolicy>(p => p.CircuitState == CircuitState.Open).ShouldBeEmpty();
     }
 
     [Fact]
@@ -165,11 +141,7 @@ public class IPolicyWrapExtensionSpecs
         Policy policyC = Policy.NoOp();
         PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
 
-        wrap.GetPolicies<NoOpPolicy>(_ => true).Should().BeEquivalentTo(new[] { policyA, policyC },
-            options => options
-                .WithStrictOrdering()
-                .Using<IsPolicy>(ctx => ctx.Subject.Should().BeSameAs(ctx.Expectation))
-                .WhenTypeIs<IsPolicy>());
+        wrap.GetPolicies<NoOpPolicy>(_ => true).ShouldBe([policyA, policyC]);
     }
 
     [Fact]
@@ -181,7 +153,7 @@ public class IPolicyWrapExtensionSpecs
 
         Action configure = () => wrap.GetPolicies<NoOpPolicy>(null);
 
-        configure.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("filter");
+        Should.Throw<ArgumentNullException>(configure).ParamName.ShouldBe("filter");
     }
 
     [Fact]
@@ -192,7 +164,7 @@ public class IPolicyWrapExtensionSpecs
         Policy policyC = Policy.NoOp();
         PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
 
-        wrap.GetPolicy<RetryPolicy>().Should().BeSameAs(policyB);
+        wrap.GetPolicy<RetryPolicy>().ShouldBeSameAs(policyB);
     }
 
     [Fact]
@@ -203,7 +175,7 @@ public class IPolicyWrapExtensionSpecs
         Policy policyC = Policy.NoOp();
         PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
 
-        wrap.GetPolicy<CircuitBreakerPolicy>().Should().BeNull();
+        wrap.GetPolicy<CircuitBreakerPolicy>().ShouldBeNull();
     }
 
     [Fact]
@@ -214,7 +186,7 @@ public class IPolicyWrapExtensionSpecs
         Policy policyC = Policy.NoOp();
         PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
 
-        wrap.Invoking(p => p.GetPolicy<NoOpPolicy>()).Should().Throw<InvalidOperationException>();
+        Should.Throw<InvalidOperationException>(() => wrap.GetPolicy<NoOpPolicy>());
     }
 
     [Fact]
@@ -228,7 +200,7 @@ public class IPolicyWrapExtensionSpecs
 
         PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
 
-        wrap.GetPolicy<CircuitBreakerPolicy>(p => p.CircuitState == CircuitState.Closed).Should().BeSameAs(policyC);
+        wrap.GetPolicy<CircuitBreakerPolicy>(p => p.CircuitState == CircuitState.Closed).ShouldBeSameAs(policyC);
     }
 
     [Fact]
@@ -240,7 +212,7 @@ public class IPolicyWrapExtensionSpecs
 
         PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
 
-        wrap.GetPolicy<CircuitBreakerPolicy>(p => p.CircuitState == CircuitState.Open).Should().BeNull();
+        wrap.GetPolicy<CircuitBreakerPolicy>(p => p.CircuitState == CircuitState.Open).ShouldBeNull();
     }
 
     [Fact]
@@ -251,7 +223,7 @@ public class IPolicyWrapExtensionSpecs
         Policy policyC = Policy.NoOp();
         PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
 
-        wrap.Invoking(p => p.GetPolicy<NoOpPolicy>(_ => true)).Should().Throw<InvalidOperationException>();
+        Should.Throw<InvalidOperationException>(() => wrap.GetPolicy<NoOpPolicy>(_ => true));
     }
 
     [Fact]
@@ -263,6 +235,6 @@ public class IPolicyWrapExtensionSpecs
 
         Action configure = () => wrap.GetPolicy<NoOpPolicy>(null);
 
-        configure.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("filter");
+        Should.Throw<ArgumentNullException>(configure).ParamName.ShouldBe("filter");
     }
 }

--- a/test/Polly.Specs/Wrap/PolicyWrapAsyncSpecs.cs
+++ b/test/Polly.Specs/Wrap/PolicyWrapAsyncSpecs.cs
@@ -12,7 +12,7 @@ public class PolicyWrapAsyncSpecs
 
         Action config = () => retry.WrapAsync(null!);
 
-        config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+        Should.Throw<ArgumentNullException>(config).ParamName.ShouldBe("innerPolicy");
     }
 
     [Fact]
@@ -22,7 +22,7 @@ public class PolicyWrapAsyncSpecs
 
         Action config = () => retry.WrapAsync<int>(null!);
 
-        config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+        Should.Throw<ArgumentNullException>(config).ParamName.ShouldBe("innerPolicy");
     }
 
     [Fact]
@@ -33,8 +33,8 @@ public class PolicyWrapAsyncSpecs
 
         AsyncPolicyWrap wrap = policyA.WrapAsync(policyB);
 
-        wrap.Outer.Should().BeSameAs(policyA);
-        wrap.Inner.Should().BeSameAs(policyB);
+        wrap.Outer.ShouldBeSameAs(policyA);
+        wrap.Inner.ShouldBeSameAs(policyB);
     }
 
     [Fact]
@@ -45,8 +45,8 @@ public class PolicyWrapAsyncSpecs
 
         AsyncPolicyWrap<int> wrap = policyA.WrapAsync(policyB);
 
-        wrap.Outer.Should().BeSameAs(policyA);
-        wrap.Inner.Should().BeSameAs(policyB);
+        wrap.Outer.ShouldBeSameAs(policyA);
+        wrap.Inner.ShouldBeSameAs(policyB);
     }
 
     #endregion
@@ -56,21 +56,21 @@ public class PolicyWrapAsyncSpecs
     [Fact]
     public void Generic_wraps_nongeneric_instance_syntax_wrapping_null_should_throw()
     {
-        var retry = Policy.HandleResult<int>(0).RetryAsync(1);
+        var retry = Policy.HandleResult(0).RetryAsync(1);
 
         Action config = () => retry.WrapAsync((AsyncPolicy)null!);
 
-        config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+        Should.Throw<ArgumentNullException>(config).ParamName.ShouldBe("innerPolicy");
     }
 
     [Fact]
     public void Generic_wraps_generic_instance_syntax_wrapping_null_should_throw()
     {
-        var retry = Policy.HandleResult<int>(0).RetryAsync(1);
+        var retry = Policy.HandleResult(0).RetryAsync(1);
 
         Action config = () => retry.WrapAsync((AsyncPolicy<int>)null!);
 
-        config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+        Should.Throw<ArgumentNullException>(config).ParamName.ShouldBe("innerPolicy");
     }
 
     [Fact]
@@ -81,8 +81,8 @@ public class PolicyWrapAsyncSpecs
 
         AsyncPolicyWrap<int> wrap = policyA.WrapAsync(policyB);
 
-        wrap.Outer.Should().BeSameAs(policyA);
-        wrap.Inner.Should().BeSameAs(policyB);
+        wrap.Outer.ShouldBeSameAs(policyA);
+        wrap.Inner.ShouldBeSameAs(policyB);
     }
 
     [Fact]
@@ -93,8 +93,8 @@ public class PolicyWrapAsyncSpecs
 
         AsyncPolicyWrap<int> wrap = policyA.WrapAsync(policyB);
 
-        wrap.Outer.Should().BeSameAs(policyA);
-        wrap.Inner.Should().BeSameAs(policyB);
+        wrap.Outer.ShouldBeSameAs(policyA);
+        wrap.Inner.ShouldBeSameAs(policyB);
     }
 
     #endregion
@@ -109,18 +109,18 @@ public class PolicyWrapAsyncSpecs
 
         Action config = () => outerNull.WrapAsync(retry);
 
-        config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
+        Should.Throw<ArgumentNullException>(config).ParamName.ShouldBe("outerPolicy");
     }
 
     [Fact]
     public void Nongeneric_interface_wraps_generic_instance_syntax_null_wrapping_should_throw()
     {
         IAsyncPolicy outerNull = null!;
-        IAsyncPolicy<int> retry = Policy.HandleResult<int>(0).RetryAsync(1);
+        IAsyncPolicy<int> retry = Policy.HandleResult(0).RetryAsync(1);
 
-        Action config = () => outerNull.WrapAsync<int>(retry);
+        Action config = () => outerNull.WrapAsync(retry);
 
-        config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
+        Should.Throw<ArgumentNullException>(config).ParamName.ShouldBe("outerPolicy");
     }
 
     [Fact]
@@ -130,7 +130,7 @@ public class PolicyWrapAsyncSpecs
 
         Action config = () => retry.WrapAsync(null!);
 
-        config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+        Should.Throw<ArgumentNullException>(config).ParamName.ShouldBe("innerPolicy");
     }
 
     [Fact]
@@ -140,7 +140,7 @@ public class PolicyWrapAsyncSpecs
 
         Action config = () => retry.WrapAsync<int>(null!);
 
-        config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+        Should.Throw<ArgumentNullException>(config).ParamName.ShouldBe("innerPolicy");
     }
 
     [Fact]
@@ -149,10 +149,10 @@ public class PolicyWrapAsyncSpecs
         IAsyncPolicy policyA = Policy.NoOpAsync();
         IAsyncPolicy policyB = Policy.NoOpAsync();
 
-        IPolicyWrap wrap = policyA.WrapAsync(policyB);
+        var wrap = policyA.WrapAsync(policyB);
 
-        wrap.Outer.Should().BeSameAs(policyA);
-        wrap.Inner.Should().BeSameAs(policyB);
+        wrap.Outer.ShouldBeSameAs(policyA);
+        wrap.Inner.ShouldBeSameAs(policyB);
     }
 
     [Fact]
@@ -161,10 +161,10 @@ public class PolicyWrapAsyncSpecs
         IAsyncPolicy policyA = Policy.NoOpAsync();
         IAsyncPolicy<int> policyB = Policy.NoOpAsync<int>();
 
-        IPolicyWrap<int> wrap = policyA.WrapAsync(policyB);
+        var wrap = policyA.WrapAsync(policyB);
 
-        wrap.Outer.Should().BeSameAs(policyA);
-        wrap.Inner.Should().BeSameAs(policyB);
+        wrap.Outer.ShouldBeSameAs(policyA);
+        wrap.Inner.ShouldBeSameAs(policyB);
     }
 
     #endregion
@@ -179,38 +179,38 @@ public class PolicyWrapAsyncSpecs
 
         Action config = () => outerNull.WrapAsync(retry);
 
-        config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
+        Should.Throw<ArgumentNullException>(config).ParamName.ShouldBe("outerPolicy");
     }
 
     [Fact]
     public void Generic_interface_wraps_generic_instance_syntax_null_wrapping_should_throw()
     {
         IAsyncPolicy<int> outerNull = null!;
-        IAsyncPolicy<int> retry = Policy.HandleResult<int>(0).RetryAsync(1);
+        IAsyncPolicy<int> retry = Policy.HandleResult(0).RetryAsync(1);
 
-        Action config = () => outerNull.WrapAsync<int>(retry);
+        Action config = () => outerNull.WrapAsync(retry);
 
-        config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
+        Should.Throw<ArgumentNullException>(config).ParamName.ShouldBe("outerPolicy");
     }
 
     [Fact]
     public void Generic_interface_wraps_nongeneric_instance_syntax_wrapping_null_should_throw()
     {
-        IAsyncPolicy<int> retry = Policy.HandleResult<int>(0).RetryAsync(1);
+        IAsyncPolicy<int> retry = Policy.HandleResult(0).RetryAsync(1);
 
         Action config = () => retry.WrapAsync((AsyncPolicy)null!);
 
-        config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+        Should.Throw<ArgumentNullException>(config).ParamName.ShouldBe("innerPolicy");
     }
 
     [Fact]
     public void Generic_interface_wraps_generic_instance_syntax_wrapping_null_should_throw()
     {
-        IAsyncPolicy<int> retry = Policy.HandleResult<int>(0).RetryAsync(1);
+        IAsyncPolicy<int> retry = Policy.HandleResult(0).RetryAsync(1);
 
         Action config = () => retry.WrapAsync((AsyncPolicy<int>)null!);
 
-        config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+        Should.Throw<ArgumentNullException>(config).ParamName.ShouldBe("innerPolicy");
     }
 
     [Fact]
@@ -219,10 +219,10 @@ public class PolicyWrapAsyncSpecs
         IAsyncPolicy<int> policyA = Policy.NoOpAsync<int>();
         IAsyncPolicy policyB = Policy.NoOpAsync();
 
-        IPolicyWrap<int> wrap = policyA.WrapAsync(policyB);
+        var wrap = policyA.WrapAsync(policyB);
 
-        wrap.Outer.Should().BeSameAs(policyA);
-        wrap.Inner.Should().BeSameAs(policyB);
+        wrap.Outer.ShouldBeSameAs(policyA);
+        wrap.Inner.ShouldBeSameAs(policyB);
     }
 
     [Fact]
@@ -231,10 +231,10 @@ public class PolicyWrapAsyncSpecs
         IAsyncPolicy<int> policyA = Policy.NoOpAsync<int>();
         IAsyncPolicy<int> policyB = Policy.NoOpAsync<int>();
 
-        IPolicyWrap<int> wrap = policyA.WrapAsync(policyB);
+        var wrap = policyA.WrapAsync(policyB);
 
-        wrap.Outer.Should().BeSameAs(policyA);
-        wrap.Inner.Should().BeSameAs(policyB);
+        wrap.Outer.ShouldBeSameAs(policyA);
+        wrap.Inner.ShouldBeSameAs(policyB);
     }
 
     #endregion
@@ -246,7 +246,7 @@ public class PolicyWrapAsyncSpecs
     {
         Action config = () => Policy.WrapAsync();
 
-        config.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policies");
+        Should.Throw<ArgumentException>(config).ParamName.ShouldBe("policies");
     }
 
     [Fact]
@@ -255,7 +255,7 @@ public class PolicyWrapAsyncSpecs
         AsyncPolicy singlePolicy = Policy.Handle<Exception>().RetryAsync();
         Action config = () => Policy.WrapAsync(singlePolicy);
 
-        config.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policies");
+        Should.Throw<ArgumentException>(config).ParamName.ShouldBe("policies");
     }
 
     [Fact]
@@ -265,7 +265,7 @@ public class PolicyWrapAsyncSpecs
         AsyncPolicy breaker = Policy.Handle<Exception>().CircuitBreakerAsync(1, TimeSpan.FromSeconds(10));
         Action config = () => Policy.WrapAsync(retry, breaker);
 
-        config.Should().NotThrow();
+        Should.NotThrow(config);
     }
 
     [Fact]
@@ -277,7 +277,7 @@ public class PolicyWrapAsyncSpecs
 
         Action config = () => Policy.WrapAsync(divideByZeroRetry, retry, breaker);
 
-        config.Should().NotThrow();
+        Should.NotThrow(config);
     }
 
     [Fact]
@@ -288,8 +288,8 @@ public class PolicyWrapAsyncSpecs
 
         AsyncPolicyWrap wrap = Policy.WrapAsync(policyA, policyB);
 
-        wrap.Outer.Should().BeSameAs(policyA);
-        wrap.Inner.Should().BeSameAs(policyB);
+        wrap.Outer.ShouldBeSameAs(policyA);
+        wrap.Inner.ShouldBeSameAs(policyB);
     }
 
     #endregion
@@ -301,16 +301,16 @@ public class PolicyWrapAsyncSpecs
     {
         Action config = () => Policy.WrapAsync<int>();
 
-        config.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policies");
+        Should.Throw<ArgumentException>(config).ParamName.ShouldBe("policies");
     }
 
     [Fact]
     public void Wrapping_only_one_policy_using_static_wrap_strongly_typed_syntax_should_throw()
     {
         AsyncPolicy<int> singlePolicy = Policy<int>.Handle<Exception>().RetryAsync();
-        Action config = () => Policy.WrapAsync<int>(singlePolicy);
+        Action config = () => Policy.WrapAsync(singlePolicy);
 
-        config.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policies");
+        Should.Throw<ArgumentException>(config).ParamName.ShouldBe("policies");
     }
 
     [Fact]
@@ -318,9 +318,9 @@ public class PolicyWrapAsyncSpecs
     {
         AsyncPolicy<int> retry = Policy<int>.Handle<Exception>().RetryAsync();
         AsyncPolicy<int> breaker = Policy<int>.Handle<Exception>().CircuitBreakerAsync(1, TimeSpan.FromSeconds(10));
-        Action config = () => Policy.WrapAsync<int>(retry, breaker);
+        Action config = () => Policy.WrapAsync(retry, breaker);
 
-        config.Should().NotThrow();
+        Should.NotThrow(config);
     }
 
     [Fact]
@@ -330,9 +330,9 @@ public class PolicyWrapAsyncSpecs
         AsyncPolicy<int> divideByZeroRetry = Policy<int>.Handle<DivideByZeroException>().RetryAsync(2);
         AsyncPolicy<int> breaker = Policy<int>.Handle<Exception>().CircuitBreakerAsync(1, TimeSpan.FromSeconds(10));
 
-        Action config = () => Policy.WrapAsync<int>(divideByZeroRetry, retry, breaker);
+        Action config = () => Policy.WrapAsync(divideByZeroRetry, retry, breaker);
 
-        config.Should().NotThrow();
+        Should.NotThrow(config);
     }
 
     [Fact]
@@ -343,8 +343,8 @@ public class PolicyWrapAsyncSpecs
 
         AsyncPolicyWrap<int> wrap = Policy.WrapAsync(policyA, policyB);
 
-        wrap.Outer.Should().BeSameAs(policyA);
-        wrap.Inner.Should().BeSameAs(policyB);
+        wrap.Outer.ShouldBeSameAs(policyA);
+        wrap.Inner.ShouldBeSameAs(policyB);
     }
 
     #endregion
@@ -362,15 +362,13 @@ public class PolicyWrapAsyncSpecs
 
         // When the retry wraps the breaker, the retry (being outer) should cause the call to be put through the breaker twice - causing the breaker to break.
         breaker.Reset();
-        await retryWrappingBreaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>(2))
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => retryWrappingBreaker.RaiseExceptionAsync<DivideByZeroException>(2));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // When the breaker wraps the retry, the retry (being inner) should retry twice before throwing the exception back on the breaker - the exception only hits the breaker once - so the breaker should not break.
         breaker.Reset();
-        await breakerWrappingRetry.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>(2))
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breakerWrappingRetry.RaiseExceptionAsync<DivideByZeroException>(2));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
@@ -385,14 +383,14 @@ public class PolicyWrapAsyncSpecs
         // When the retry wraps the breaker, the retry (being outer) should cause the call to be put through the breaker twice - causing the breaker to break.
         breaker.Reset();
         (await retryWrappingBreaker.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Fault))
-            .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+            .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // When the breaker wraps the retry, the retry (being inner) should retry twice before throwing the exception back on the breaker - the exception only hits the breaker once - so the breaker should not break.
         breaker.Reset();
         (await breakerWrappingRetry.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Fault))
-            .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+            .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     #endregion
@@ -410,15 +408,13 @@ public class PolicyWrapAsyncSpecs
 
         // When the retry wraps the breaker, the retry (being outer) should cause the call to be put through the breaker twice - causing the breaker to break.
         breaker.Reset();
-        await retryWrappingBreaker.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>(2))
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        await Should.ThrowAsync<DivideByZeroException>(() => retryWrappingBreaker.RaiseExceptionAsync<DivideByZeroException>(2));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // When the breaker wraps the retry, the retry (being inner) should retry twice before throwing the exception back on the breaker - the exception only hits the breaker once - so the breaker should not break.
         breaker.Reset();
-        await breakerWrappingRetry.Awaiting(x => x.RaiseExceptionAsync<DivideByZeroException>(2))
-            .Should().ThrowAsync<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        await Should.ThrowAsync<DivideByZeroException>(() => breakerWrappingRetry.RaiseExceptionAsync<DivideByZeroException>(2));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
@@ -433,14 +429,14 @@ public class PolicyWrapAsyncSpecs
         // When the retry wraps the breaker, the retry (being outer) should cause the call to be put through the breaker twice - causing the breaker to break.
         breaker.Reset();
         (await retryWrappingBreaker.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // When the breaker wraps the retry, the retry (being inner) should retry twice before throwing the exception back on the breaker - the exception only hits the breaker once - so the breaker should not break.
         breaker.Reset();
         (await breakerWrappingRetry.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Fault))
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     #endregion
@@ -461,9 +457,9 @@ public class PolicyWrapAsyncSpecs
         PolicyResult executeAndCaptureResultOnPolicyWrap =
             await wrap.ExecuteAndCaptureAsync(() => { throw new ArgumentNullException(); });
 
-        executeAndCaptureResultOnPolicyWrap.Outcome.Should().Be(OutcomeType.Failure);
-        executeAndCaptureResultOnPolicyWrap.FinalException.Should().BeOfType<ArgumentNullException>();
-        executeAndCaptureResultOnPolicyWrap.ExceptionType.Should().Be(ExceptionType.HandledByThisPolicy);
+        executeAndCaptureResultOnPolicyWrap.Outcome.ShouldBe(OutcomeType.Failure);
+        executeAndCaptureResultOnPolicyWrap.FinalException.ShouldBeOfType<ArgumentNullException>();
+        executeAndCaptureResultOnPolicyWrap.ExceptionType.ShouldBe(ExceptionType.HandledByThisPolicy);
     }
 
     [Fact]
@@ -480,9 +476,9 @@ public class PolicyWrapAsyncSpecs
         PolicyResult executeAndCaptureResultOnPolicyWrap =
             await wrap.ExecuteAndCaptureAsync(() => { throw new DivideByZeroException(); });
 
-        executeAndCaptureResultOnPolicyWrap.Outcome.Should().Be(OutcomeType.Failure);
-        executeAndCaptureResultOnPolicyWrap.FinalException.Should().BeOfType<DivideByZeroException>();
-        executeAndCaptureResultOnPolicyWrap.ExceptionType.Should().Be(ExceptionType.Unhandled);
+        executeAndCaptureResultOnPolicyWrap.Outcome.ShouldBe(OutcomeType.Failure);
+        executeAndCaptureResultOnPolicyWrap.FinalException.ShouldBeOfType<DivideByZeroException>();
+        executeAndCaptureResultOnPolicyWrap.ExceptionType.ShouldBe(ExceptionType.Unhandled);
     }
 
     [Fact]
@@ -498,10 +494,10 @@ public class PolicyWrapAsyncSpecs
 
         PolicyResult<ResultPrimitive> executeAndCaptureResultOnPolicyWrap = await wrap.ExecuteAndCaptureAsync(() => { throw new ArgumentNullException(); });
 
-        executeAndCaptureResultOnPolicyWrap.Outcome.Should().Be(OutcomeType.Failure);
-        executeAndCaptureResultOnPolicyWrap.FinalException.Should().BeOfType<ArgumentNullException>();
-        executeAndCaptureResultOnPolicyWrap.ExceptionType.Should().Be(ExceptionType.HandledByThisPolicy);
-        executeAndCaptureResultOnPolicyWrap.FaultType.Should().Be(FaultType.ExceptionHandledByThisPolicy);
+        executeAndCaptureResultOnPolicyWrap.Outcome.ShouldBe(OutcomeType.Failure);
+        executeAndCaptureResultOnPolicyWrap.FinalException.ShouldBeOfType<ArgumentNullException>();
+        executeAndCaptureResultOnPolicyWrap.ExceptionType.ShouldBe(ExceptionType.HandledByThisPolicy);
+        executeAndCaptureResultOnPolicyWrap.FaultType.ShouldBe(FaultType.ExceptionHandledByThisPolicy);
     }
 
     [Fact]
@@ -517,10 +513,10 @@ public class PolicyWrapAsyncSpecs
 
         PolicyResult<ResultPrimitive> executeAndCaptureResultOnPolicyWrap = await wrap.ExecuteAndCaptureAsync(() => { throw new DivideByZeroException(); });
 
-        executeAndCaptureResultOnPolicyWrap.Outcome.Should().Be(OutcomeType.Failure);
-        executeAndCaptureResultOnPolicyWrap.FinalException.Should().BeOfType<DivideByZeroException>();
-        executeAndCaptureResultOnPolicyWrap.ExceptionType.Should().Be(ExceptionType.Unhandled);
-        executeAndCaptureResultOnPolicyWrap.FaultType.Should().Be(FaultType.UnhandledException);
+        executeAndCaptureResultOnPolicyWrap.Outcome.ShouldBe(OutcomeType.Failure);
+        executeAndCaptureResultOnPolicyWrap.FinalException.ShouldBeOfType<DivideByZeroException>();
+        executeAndCaptureResultOnPolicyWrap.ExceptionType.ShouldBe(ExceptionType.Unhandled);
+        executeAndCaptureResultOnPolicyWrap.FaultType.ShouldBe(FaultType.UnhandledException);
     }
 
     [Fact]
@@ -536,11 +532,11 @@ public class PolicyWrapAsyncSpecs
 
         PolicyResult<ResultPrimitive> executeAndCaptureResultOnPolicyWrap = await wrap.ExecuteAndCaptureAsync(() => Task.FromResult(ResultPrimitive.Fault));
 
-        executeAndCaptureResultOnPolicyWrap.Outcome.Should().Be(OutcomeType.Failure);
-        executeAndCaptureResultOnPolicyWrap.FaultType.Should().Be(FaultType.ResultHandledByThisPolicy);
-        executeAndCaptureResultOnPolicyWrap.FinalHandledResult.Should().Be(ResultPrimitive.Fault);
-        executeAndCaptureResultOnPolicyWrap.FinalException.Should().BeNull();
-        executeAndCaptureResultOnPolicyWrap.ExceptionType.Should().BeNull();
+        executeAndCaptureResultOnPolicyWrap.Outcome.ShouldBe(OutcomeType.Failure);
+        executeAndCaptureResultOnPolicyWrap.FaultType.ShouldBe(FaultType.ResultHandledByThisPolicy);
+        executeAndCaptureResultOnPolicyWrap.FinalHandledResult.ShouldBe(ResultPrimitive.Fault);
+        executeAndCaptureResultOnPolicyWrap.FinalException.ShouldBeNull();
+        executeAndCaptureResultOnPolicyWrap.ExceptionType.ShouldBeNull();
     }
 
     [Fact]
@@ -556,11 +552,11 @@ public class PolicyWrapAsyncSpecs
 
         PolicyResult<ResultPrimitive> executeAndCaptureResultOnPolicyWrap = await wrap.ExecuteAndCaptureAsync(() => Task.FromResult(ResultPrimitive.FaultAgain));
 
-        executeAndCaptureResultOnPolicyWrap.Outcome.Should().Be(OutcomeType.Successful);
-        executeAndCaptureResultOnPolicyWrap.FinalHandledResult.Should().Be(default);
-        executeAndCaptureResultOnPolicyWrap.FaultType.Should().BeNull();
-        executeAndCaptureResultOnPolicyWrap.FinalException.Should().BeNull();
-        executeAndCaptureResultOnPolicyWrap.ExceptionType.Should().BeNull();
+        executeAndCaptureResultOnPolicyWrap.Outcome.ShouldBe(OutcomeType.Successful);
+        executeAndCaptureResultOnPolicyWrap.FinalHandledResult.ShouldBe(default);
+        executeAndCaptureResultOnPolicyWrap.FaultType.ShouldBeNull();
+        executeAndCaptureResultOnPolicyWrap.FinalException.ShouldBeNull();
+        executeAndCaptureResultOnPolicyWrap.ExceptionType.ShouldBeNull();
     }
 
     #endregion

--- a/test/Polly.Specs/Wrap/PolicyWrapContextAndKeyAsyncSpecs.cs
+++ b/test/Polly.Specs/Wrap/PolicyWrapContextAndKeyAsyncSpecs.cs
@@ -24,9 +24,10 @@ public class PolicyWrapContextAndKeyAsyncSpecs
 
         await wrap.RaiseExceptionAsync<Exception>(1);
 
-        policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
-        policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
-        policyWrapKeySetOnExecutionContext.Should().Be(wrapKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBeNull();
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(retryKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(breakerKey);
+        policyWrapKeySetOnExecutionContext.ShouldBe(wrapKey);
     }
 
     [Fact]
@@ -49,9 +50,10 @@ public class PolicyWrapContextAndKeyAsyncSpecs
 
         await wrap.RaiseExceptionAsync<Exception>(1);
 
-        policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
-        policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
-        policyWrapKeySetOnExecutionContext.Should().Be(wrapKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBeNull();
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(retryKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(breakerKey);
+        policyWrapKeySetOnExecutionContext.ShouldBe(wrapKey);
     }
 
     [Fact]
@@ -61,8 +63,8 @@ public class PolicyWrapContextAndKeyAsyncSpecs
             .Handle<Exception>()
             .FallbackAsync((_, _) => TaskHelper.EmptyTask, (_, context) =>
             {
-                context.PolicyWrapKey.Should().Be("PolicyWrap");
-                context.PolicyKey.Should().Be("FallbackPolicy");
+                context.PolicyWrapKey.ShouldBe("PolicyWrap");
+                context.PolicyKey.ShouldBe("FallbackPolicy");
                 return TaskHelper.EmptyTask;
             })
             .WithPolicyKey("FallbackPolicy");
@@ -71,12 +73,12 @@ public class PolicyWrapContextAndKeyAsyncSpecs
             .Handle<Exception>()
             .RetryAsync(1, onRetry: (_, _, context) =>
             {
-                context.PolicyWrapKey.Should().Be("PolicyWrap");
-                context.PolicyKey.Should().Be("RetryPolicy");
+                context.PolicyWrapKey.ShouldBe("PolicyWrap");
+                context.PolicyKey.ShouldBe("RetryPolicy");
             })
             .WithPolicyKey("RetryPolicy");
 
-        IAsyncPolicy policyWrap = Policy.WrapAsync(fallback, retry)
+        var policyWrap = Policy.WrapAsync(fallback, retry)
             .WithPolicyKey("PolicyWrap");
 
         await policyWrap.ExecuteAsync(() => throw new Exception());
@@ -89,8 +91,8 @@ public class PolicyWrapContextAndKeyAsyncSpecs
             .Handle<Exception>()
             .FallbackAsync((_, _) => TaskHelper.EmptyTask, (_, context) =>
             {
-                context.PolicyWrapKey.Should().Be("PolicyWrap");
-                context.PolicyKey.Should().Be("FallbackPolicy");
+                context.PolicyWrapKey.ShouldBe("PolicyWrap");
+                context.PolicyKey.ShouldBe("FallbackPolicy");
                 return TaskHelper.EmptyTask;
             })
             .WithPolicyKey("FallbackPolicy");
@@ -99,12 +101,12 @@ public class PolicyWrapContextAndKeyAsyncSpecs
             .Handle<Exception>()
             .RetryAsync(1, onRetry: (_, _, context) =>
             {
-                context.PolicyWrapKey.Should().Be("PolicyWrap");
-                context.PolicyKey.Should().Be("RetryPolicy");
+                context.PolicyWrapKey.ShouldBe("PolicyWrap");
+                context.PolicyKey.ShouldBe("RetryPolicy");
             })
             .WithPolicyKey("RetryPolicy");
 
-        IAsyncPolicy policyWrap = Policy.WrapAsync(fallback, retry)
+        var policyWrap = Policy.WrapAsync(fallback, retry)
             .WithPolicyKey("PolicyWrap");
 
         await policyWrap.ExecuteAsync(async () => await Task.Run(() => throw new Exception())); // Regression test for issue 510
@@ -135,11 +137,11 @@ public class PolicyWrapContextAndKeyAsyncSpecs
 
         await outerWrap.RaiseExceptionAsync<Exception>(1);
 
-        policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
-        policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
-        policyWrapKeySetOnExecutionContext.Should().NotBe(fallbackKey);
-        policyWrapKeySetOnExecutionContext.Should().NotBe(innerWrapKey);
-        policyWrapKeySetOnExecutionContext.Should().Be(outerWrapKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(retryKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(breakerKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(fallbackKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(innerWrapKey);
+        policyWrapKeySetOnExecutionContext.ShouldBe(outerWrapKey);
     }
 
     [Fact]
@@ -177,11 +179,11 @@ public class PolicyWrapContextAndKeyAsyncSpecs
             return TaskHelper.EmptyTask;
         });
 
-        policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
-        policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
-        policyWrapKeySetOnExecutionContext.Should().NotBe(fallbackKey);
-        policyWrapKeySetOnExecutionContext.Should().NotBe(innerWrapKey);
-        policyWrapKeySetOnExecutionContext.Should().Be(outerWrapKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(retryKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(breakerKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(fallbackKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(innerWrapKey);
+        policyWrapKeySetOnExecutionContext.ShouldBe(outerWrapKey);
     }
 
     #endregion
@@ -213,9 +215,9 @@ public class PolicyWrapTResultContextAndKeyAsyncSpecs
 
         await wrap.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Good);
 
-        policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
-        policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
-        policyWrapKeySetOnExecutionContext.Should().Be(wrapKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(retryKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(breakerKey);
+        policyWrapKeySetOnExecutionContext.ShouldBe(wrapKey);
     }
 
     [Fact]
@@ -238,9 +240,9 @@ public class PolicyWrapTResultContextAndKeyAsyncSpecs
 
         await wrap.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Good);
 
-        policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
-        policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
-        policyWrapKeySetOnExecutionContext.Should().Be(wrapKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(retryKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(breakerKey);
+        policyWrapKeySetOnExecutionContext.ShouldBe(wrapKey);
     }
 
     [Fact]
@@ -250,8 +252,8 @@ public class PolicyWrapTResultContextAndKeyAsyncSpecs
             .Handle<Exception>()
             .FallbackAsync((_, _) => Task.FromResult(ResultPrimitive.Undefined), (_, context) =>
             {
-                context.PolicyWrapKey.Should().Be("PolicyWrap");
-                context.PolicyKey.Should().Be("FallbackPolicy");
+                context.PolicyWrapKey.ShouldBe("PolicyWrap");
+                context.PolicyKey.ShouldBe("FallbackPolicy");
                 return TaskHelper.EmptyTask;
             })
             .WithPolicyKey("FallbackPolicy");
@@ -260,12 +262,12 @@ public class PolicyWrapTResultContextAndKeyAsyncSpecs
             .Handle<Exception>()
             .RetryAsync(1, onRetry: (_, _, context) =>
             {
-                context.PolicyWrapKey.Should().Be("PolicyWrap");
-                context.PolicyKey.Should().Be("RetryPolicy");
+                context.PolicyWrapKey.ShouldBe("PolicyWrap");
+                context.PolicyKey.ShouldBe("RetryPolicy");
             })
             .WithPolicyKey("RetryPolicy");
 
-        IAsyncPolicy<ResultPrimitive> policyWrap = Policy.WrapAsync(fallback, retry)
+        var policyWrap = Policy.WrapAsync(fallback, retry)
             .WithPolicyKey("PolicyWrap");
 
         await policyWrap.ExecuteAsync(() => throw new Exception());
@@ -278,8 +280,8 @@ public class PolicyWrapTResultContextAndKeyAsyncSpecs
             .Handle<Exception>()
             .FallbackAsync((_, _) => Task.FromResult(ResultPrimitive.Undefined), (_, context) =>
             {
-                context.PolicyWrapKey.Should().Be("PolicyWrap");
-                context.PolicyKey.Should().Be("FallbackPolicy");
+                context.PolicyWrapKey.ShouldBe("PolicyWrap");
+                context.PolicyKey.ShouldBe("FallbackPolicy");
                 return TaskHelper.EmptyTask;
             })
             .WithPolicyKey("FallbackPolicy");
@@ -288,12 +290,12 @@ public class PolicyWrapTResultContextAndKeyAsyncSpecs
             .Handle<Exception>()
             .RetryAsync(1, onRetry: (_, _, context) =>
             {
-                context.PolicyWrapKey.Should().Be("PolicyWrap");
-                context.PolicyKey.Should().Be("RetryPolicy");
+                context.PolicyWrapKey.ShouldBe("PolicyWrap");
+                context.PolicyKey.ShouldBe("RetryPolicy");
             })
             .WithPolicyKey("RetryPolicy");
 
-        IAsyncPolicy<ResultPrimitive> policyWrap = Policy.WrapAsync(fallback, retry)
+        var policyWrap = Policy.WrapAsync(fallback, retry)
             .WithPolicyKey("PolicyWrap");
 
         await policyWrap.ExecuteAsync(async () => await Task.Run(() => // Regression test for issue 510
@@ -328,11 +330,11 @@ public class PolicyWrapTResultContextAndKeyAsyncSpecs
 
         await outerWrap.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Good);
 
-        policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
-        policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
-        policyWrapKeySetOnExecutionContext.Should().NotBe(fallbackKey);
-        policyWrapKeySetOnExecutionContext.Should().NotBe(innerWrapKey);
-        policyWrapKeySetOnExecutionContext.Should().Be(outerWrapKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(retryKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(breakerKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(fallbackKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(innerWrapKey);
+        policyWrapKeySetOnExecutionContext.ShouldBe(outerWrapKey);
     }
 
     #endregion

--- a/test/Polly.Specs/Wrap/PolicyWrapContextAndKeySpecs.cs
+++ b/test/Polly.Specs/Wrap/PolicyWrapContextAndKeySpecs.cs
@@ -1,7 +1,4 @@
 ﻿namespace Polly.Specs.Wrap;
-﻿using Shouldly;
-
-namespace Polly.Specs.Wrap;
 
 [Collection(Constants.SystemClockDependentTestCollection)]
 public class PolicyWrapContextAndKeySpecs

--- a/test/Polly.Specs/Wrap/PolicyWrapContextAndKeySpecs.cs
+++ b/test/Polly.Specs/Wrap/PolicyWrapContextAndKeySpecs.cs
@@ -1,4 +1,7 @@
 ﻿namespace Polly.Specs.Wrap;
+﻿using Shouldly;
+
+namespace Polly.Specs.Wrap;
 
 [Collection(Constants.SystemClockDependentTestCollection)]
 public class PolicyWrapContextAndKeySpecs
@@ -24,9 +27,10 @@ public class PolicyWrapContextAndKeySpecs
 
         wrap.RaiseException<Exception>(1);
 
-        policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
-        policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
-        policyWrapKeySetOnExecutionContext.Should().Be(wrapKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBeNull();
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(retryKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(breakerKey);
+        policyWrapKeySetOnExecutionContext.ShouldBe(wrapKey);
     }
 
     [Fact]
@@ -49,33 +53,34 @@ public class PolicyWrapContextAndKeySpecs
 
         wrap.RaiseException<Exception>(1);
 
-        policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
-        policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
-        policyWrapKeySetOnExecutionContext.Should().Be(wrapKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBeNull();
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(retryKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(breakerKey);
+        policyWrapKeySetOnExecutionContext.ShouldBe(wrapKey);
     }
 
     [Fact]
     public void Should_restore_PolicyKey_of_outer_policy_to_execution_context_as_move_outwards_through_PolicyWrap()
     {
-        ISyncPolicy fallback = Policy
+        var fallback = Policy
             .Handle<Exception>()
             .Fallback(_ => { }, onFallback: (_, context) =>
             {
-                context.PolicyWrapKey.Should().Be("PolicyWrap");
-                context.PolicyKey.Should().Be("FallbackPolicy");
+                context.PolicyWrapKey.ShouldBe("PolicyWrap");
+                context.PolicyKey.ShouldBe("FallbackPolicy");
             })
             .WithPolicyKey("FallbackPolicy");
 
-        ISyncPolicy retry = Policy
+        var retry = Policy
             .Handle<Exception>()
             .Retry(1, onRetry: (_, _, context) =>
             {
-                context.PolicyWrapKey.Should().Be("PolicyWrap");
-                context.PolicyKey.Should().Be("RetryPolicy");
+                context.PolicyWrapKey.ShouldBe("PolicyWrap");
+                context.PolicyKey.ShouldBe("RetryPolicy");
             })
             .WithPolicyKey("RetryPolicy");
 
-        ISyncPolicy policyWrap = Policy.Wrap(fallback, retry)
+        var policyWrap = Policy.Wrap(fallback, retry)
             .WithPolicyKey("PolicyWrap");
 
         policyWrap.Execute(() => throw new Exception());
@@ -106,11 +111,11 @@ public class PolicyWrapContextAndKeySpecs
 
         outerWrap.RaiseException<Exception>(1);
 
-        policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
-        policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
-        policyWrapKeySetOnExecutionContext.Should().NotBe(fallbackKey);
-        policyWrapKeySetOnExecutionContext.Should().NotBe(innerWrapKey);
-        policyWrapKeySetOnExecutionContext.Should().Be(outerWrapKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(retryKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(breakerKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(fallbackKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(innerWrapKey);
+        policyWrapKeySetOnExecutionContext.ShouldBe(outerWrapKey);
     }
 
     [Fact]
@@ -146,11 +151,11 @@ public class PolicyWrapContextAndKeySpecs
             }
         });
 
-        policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
-        policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
-        policyWrapKeySetOnExecutionContext.Should().NotBe(fallbackKey);
-        policyWrapKeySetOnExecutionContext.Should().NotBe(innerWrapKey);
-        policyWrapKeySetOnExecutionContext.Should().Be(outerWrapKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(retryKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(breakerKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(fallbackKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(innerWrapKey);
+        policyWrapKeySetOnExecutionContext.ShouldBe(outerWrapKey);
     }
 
     #endregion
@@ -180,9 +185,9 @@ public class PolicyWrapTResultContextAndKeySpecs
 
         wrap.RaiseResultSequence(ResultPrimitive.Fault, ResultPrimitive.Good);
 
-        policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
-        policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
-        policyWrapKeySetOnExecutionContext.Should().Be(wrapKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(retryKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(breakerKey);
+        policyWrapKeySetOnExecutionContext.ShouldBe(wrapKey);
     }
 
     [Fact]
@@ -205,9 +210,9 @@ public class PolicyWrapTResultContextAndKeySpecs
 
         wrap.RaiseResultSequence(ResultPrimitive.Fault, ResultPrimitive.Good);
 
-        policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
-        policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
-        policyWrapKeySetOnExecutionContext.Should().Be(wrapKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(retryKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(breakerKey);
+        policyWrapKeySetOnExecutionContext.ShouldBe(wrapKey);
     }
 
     [Fact]
@@ -217,8 +222,8 @@ public class PolicyWrapTResultContextAndKeySpecs
             .Handle<Exception>()
             .Fallback<ResultPrimitive>(ResultPrimitive.Undefined, onFallback: (_, context) =>
             {
-                context.PolicyWrapKey.Should().Be("PolicyWrap");
-                context.PolicyKey.Should().Be("FallbackPolicy");
+                context.PolicyWrapKey.ShouldBe("PolicyWrap");
+                context.PolicyKey.ShouldBe("FallbackPolicy");
             })
             .WithPolicyKey("FallbackPolicy");
 
@@ -226,8 +231,8 @@ public class PolicyWrapTResultContextAndKeySpecs
             .Handle<Exception>()
             .Retry(1, onRetry: (_, _, context) =>
             {
-                context.PolicyWrapKey.Should().Be("PolicyWrap");
-                context.PolicyKey.Should().Be("RetryPolicy");
+                context.PolicyWrapKey.ShouldBe("PolicyWrap");
+                context.PolicyKey.ShouldBe("RetryPolicy");
             })
             .WithPolicyKey("RetryPolicy");
 
@@ -262,11 +267,11 @@ public class PolicyWrapTResultContextAndKeySpecs
 
         outerWrap.RaiseResultSequence(ResultPrimitive.Fault, ResultPrimitive.Good);
 
-        policyWrapKeySetOnExecutionContext.Should().NotBe(retryKey);
-        policyWrapKeySetOnExecutionContext.Should().NotBe(breakerKey);
-        policyWrapKeySetOnExecutionContext.Should().NotBe(fallbackKey);
-        policyWrapKeySetOnExecutionContext.Should().NotBe(innerWrapKey);
-        policyWrapKeySetOnExecutionContext.Should().Be(outerWrapKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(retryKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(breakerKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(fallbackKey);
+        policyWrapKeySetOnExecutionContext.ShouldNotBe(innerWrapKey);
+        policyWrapKeySetOnExecutionContext.ShouldBe(outerWrapKey);
     }
 
     #endregion

--- a/test/Polly.Specs/Wrap/PolicyWrapSpecs.cs
+++ b/test/Polly.Specs/Wrap/PolicyWrapSpecs.cs
@@ -12,7 +12,7 @@ public class PolicyWrapSpecs
 
         Action config = () => retry.Wrap(null!);
 
-        config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+        Should.Throw<ArgumentNullException>(config).ParamName.ShouldBe("innerPolicy");
     }
 
     [Fact]
@@ -22,7 +22,7 @@ public class PolicyWrapSpecs
 
         Action config = () => retry.Wrap<int>(null!);
 
-        config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+        Should.Throw<ArgumentNullException>(config).ParamName.ShouldBe("innerPolicy");
     }
 
     [Fact]
@@ -33,8 +33,8 @@ public class PolicyWrapSpecs
 
         PolicyWrap wrap = policyA.Wrap(policyB);
 
-        wrap.Outer.Should().BeSameAs(policyA);
-        wrap.Inner.Should().BeSameAs(policyB);
+        wrap.Outer.ShouldBeSameAs(policyA);
+        wrap.Inner.ShouldBeSameAs(policyB);
     }
 
     [Fact]
@@ -45,8 +45,8 @@ public class PolicyWrapSpecs
 
         PolicyWrap<int> wrap = policyA.Wrap(policyB);
 
-        wrap.Outer.Should().BeSameAs(policyA);
-        wrap.Inner.Should().BeSameAs(policyB);
+        wrap.Outer.ShouldBeSameAs(policyA);
+        wrap.Inner.ShouldBeSameAs(policyB);
     }
 
     #endregion
@@ -56,21 +56,21 @@ public class PolicyWrapSpecs
     [Fact]
     public void Generic_wraps_nongeneric_instance_syntax_wrapping_null_should_throw()
     {
-        RetryPolicy<int> retry = Policy.HandleResult<int>(0).Retry(1);
+        RetryPolicy<int> retry = Policy.HandleResult(0).Retry(1);
 
         Action config = () => retry.Wrap((Policy)null!);
 
-        config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+        Should.Throw<ArgumentNullException>(config).ParamName.ShouldBe("innerPolicy");
     }
 
     [Fact]
     public void Generic_wraps_generic_instance_syntax_wrapping_null_should_throw()
     {
-        RetryPolicy<int> retry = Policy.HandleResult<int>(0).Retry(1);
+        RetryPolicy<int> retry = Policy.HandleResult(0).Retry(1);
 
         Action config = () => retry.Wrap((Policy<int>)null!);
 
-        config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+        Should.Throw<ArgumentNullException>(config).ParamName.ShouldBe("innerPolicy");
     }
 
     [Fact]
@@ -81,8 +81,8 @@ public class PolicyWrapSpecs
 
         PolicyWrap<int> wrap = policyA.Wrap(policyB);
 
-        wrap.Outer.Should().BeSameAs(policyA);
-        wrap.Inner.Should().BeSameAs(policyB);
+        wrap.Outer.ShouldBeSameAs(policyA);
+        wrap.Inner.ShouldBeSameAs(policyB);
     }
 
     [Fact]
@@ -93,8 +93,8 @@ public class PolicyWrapSpecs
 
         PolicyWrap<int> wrap = policyA.Wrap(policyB);
 
-        wrap.Outer.Should().BeSameAs(policyA);
-        wrap.Inner.Should().BeSameAs(policyB);
+        wrap.Outer.ShouldBeSameAs(policyA);
+        wrap.Inner.ShouldBeSameAs(policyB);
     }
 
     #endregion
@@ -109,18 +109,18 @@ public class PolicyWrapSpecs
 
         Action config = () => outerNull.Wrap(retry);
 
-        config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
+        Should.Throw<ArgumentNullException>(config).ParamName.ShouldBe("outerPolicy");
     }
 
     [Fact]
     public void Nongeneric_interface_wraps_generic_instance_syntax_null_wrapping_should_throw()
     {
         ISyncPolicy outerNull = null!;
-        ISyncPolicy<int> retry = Policy.HandleResult<int>(0).Retry(1);
+        ISyncPolicy<int> retry = Policy.HandleResult(0).Retry(1);
 
-        Action config = () => outerNull.Wrap<int>(retry);
+        Action config = () => outerNull.Wrap(retry);
 
-        config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
+        Should.Throw<ArgumentNullException>(config).ParamName.ShouldBe("outerPolicy");
     }
 
     [Fact]
@@ -130,7 +130,7 @@ public class PolicyWrapSpecs
 
         Action config = () => retry.Wrap(null!);
 
-        config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+        Should.Throw<ArgumentNullException>(config).ParamName.ShouldBe("innerPolicy");
     }
 
     [Fact]
@@ -140,7 +140,7 @@ public class PolicyWrapSpecs
 
         Action config = () => retry.Wrap<int>(null!);
 
-        config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+        Should.Throw<ArgumentNullException>(config).ParamName.ShouldBe("innerPolicy");
     }
 
     [Fact]
@@ -149,10 +149,10 @@ public class PolicyWrapSpecs
         ISyncPolicy policyA = Policy.NoOp();
         ISyncPolicy policyB = Policy.NoOp();
 
-        IPolicyWrap wrap = policyA.Wrap(policyB);
+        var wrap = policyA.Wrap(policyB);
 
-        wrap.Outer.Should().BeSameAs(policyA);
-        wrap.Inner.Should().BeSameAs(policyB);
+        wrap.Outer.ShouldBeSameAs(policyA);
+        wrap.Inner.ShouldBeSameAs(policyB);
     }
 
     [Fact]
@@ -161,10 +161,10 @@ public class PolicyWrapSpecs
         ISyncPolicy policyA = Policy.NoOp();
         ISyncPolicy<int> policyB = Policy.NoOp<int>();
 
-        IPolicyWrap<int> wrap = policyA.Wrap(policyB);
+        var wrap = policyA.Wrap(policyB);
 
-        wrap.Outer.Should().BeSameAs(policyA);
-        wrap.Inner.Should().BeSameAs(policyB);
+        wrap.Outer.ShouldBeSameAs(policyA);
+        wrap.Inner.ShouldBeSameAs(policyB);
     }
 
     #endregion
@@ -179,38 +179,38 @@ public class PolicyWrapSpecs
 
         Action config = () => outerNull.Wrap(retry);
 
-        config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
+        Should.Throw<ArgumentNullException>(config).ParamName.ShouldBe("outerPolicy");
     }
 
     [Fact]
     public void Generic_interface_wraps_generic_instance_syntax_null_wrapping_should_throw()
     {
         ISyncPolicy<int> outerNull = null!;
-        ISyncPolicy<int> retry = Policy.HandleResult<int>(0).Retry(1);
+        ISyncPolicy<int> retry = Policy.HandleResult(0).Retry(1);
 
-        Action config = () => outerNull.Wrap<int>(retry);
+        Action config = () => outerNull.Wrap(retry);
 
-        config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("outerPolicy");
+        Should.Throw<ArgumentNullException>(config).ParamName.ShouldBe("outerPolicy");
     }
 
     [Fact]
     public void Generic_interface_wraps_nongeneric_instance_syntax_wrapping_null_should_throw()
     {
-        ISyncPolicy<int> retry = Policy.HandleResult<int>(0).Retry(1);
+        ISyncPolicy<int> retry = Policy.HandleResult(0).Retry(1);
 
         Action config = () => retry.Wrap((Policy)null!);
 
-        config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+        Should.Throw<ArgumentNullException>(config).ParamName.ShouldBe("innerPolicy");
     }
 
     [Fact]
     public void Generic_interface_wraps_generic_instance_syntax_wrapping_null_should_throw()
     {
-        ISyncPolicy<int> retry = Policy.HandleResult<int>(0).Retry(1);
+        ISyncPolicy<int> retry = Policy.HandleResult(0).Retry(1);
 
         Action config = () => retry.Wrap((Policy<int>)null!);
 
-        config.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("innerPolicy");
+        Should.Throw<ArgumentNullException>(config).ParamName.ShouldBe("innerPolicy");
     }
 
     [Fact]
@@ -219,10 +219,10 @@ public class PolicyWrapSpecs
         ISyncPolicy<int> policyA = Policy.NoOp<int>();
         ISyncPolicy policyB = Policy.NoOp();
 
-        IPolicyWrap<int> wrap = policyA.Wrap(policyB);
+        var wrap = policyA.Wrap(policyB);
 
-        wrap.Outer.Should().BeSameAs(policyA);
-        wrap.Inner.Should().BeSameAs(policyB);
+        wrap.Outer.ShouldBeSameAs(policyA);
+        wrap.Inner.ShouldBeSameAs(policyB);
     }
 
     [Fact]
@@ -231,10 +231,10 @@ public class PolicyWrapSpecs
         ISyncPolicy<int> policyA = Policy.NoOp<int>();
         ISyncPolicy<int> policyB = Policy.NoOp<int>();
 
-        IPolicyWrap<int> wrap = policyA.Wrap(policyB);
+        var wrap = policyA.Wrap(policyB);
 
-        wrap.Outer.Should().BeSameAs(policyA);
-        wrap.Inner.Should().BeSameAs(policyB);
+        wrap.Outer.ShouldBeSameAs(policyA);
+        wrap.Inner.ShouldBeSameAs(policyB);
     }
 
     #endregion
@@ -246,7 +246,7 @@ public class PolicyWrapSpecs
     {
         Action config = () => Policy.Wrap();
 
-        config.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policies");
+        Should.Throw<ArgumentException>(config).ParamName.ShouldBe("policies");
     }
 
     [Fact]
@@ -257,7 +257,7 @@ public class PolicyWrapSpecs
 
         Action config = () => Policy.Wrap(policies);
 
-        config.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policies");
+        Should.Throw<ArgumentException>(config).ParamName.ShouldBe("policies");
     }
 
     [Fact]
@@ -267,7 +267,7 @@ public class PolicyWrapSpecs
         Policy breaker = Policy.Handle<Exception>().CircuitBreaker(1, TimeSpan.FromSeconds(10));
         Action config = () => Policy.Wrap(retry, breaker);
 
-        config.Should().NotThrow();
+        Should.NotThrow(config);
     }
 
     [Fact]
@@ -279,7 +279,7 @@ public class PolicyWrapSpecs
 
         Action config = () => Policy.Wrap(divideByZeroRetry, retry, breaker);
 
-        config.Should().NotThrow();
+        Should.NotThrow(config);
     }
 
     [Fact]
@@ -290,8 +290,8 @@ public class PolicyWrapSpecs
 
         PolicyWrap wrap = Policy.Wrap(policyA, policyB);
 
-        wrap.Outer.Should().BeSameAs(policyA);
-        wrap.Inner.Should().BeSameAs(policyB);
+        wrap.Outer.ShouldBeSameAs(policyA);
+        wrap.Inner.ShouldBeSameAs(policyB);
     }
 
     #endregion
@@ -303,16 +303,16 @@ public class PolicyWrapSpecs
     {
         Action config = () => Policy.Wrap<int>();
 
-        config.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policies");
+        Should.Throw<ArgumentException>(config).ParamName.ShouldBe("policies");
     }
 
     [Fact]
     public void Wrapping_only_one_policy_using_static_wrap_strongly_typed_syntax_should_throw()
     {
         Policy<int> singlePolicy = Policy<int>.Handle<Exception>().Retry();
-        Action config = () => Policy.Wrap<int>(singlePolicy);
+        Action config = () => Policy.Wrap(singlePolicy);
 
-        config.Should().Throw<ArgumentException>().And.ParamName.Should().Be("policies");
+        Should.Throw<ArgumentException>(config).ParamName.ShouldBe("policies");
     }
 
     [Fact]
@@ -322,7 +322,7 @@ public class PolicyWrapSpecs
         Policy<int> breaker = Policy<int>.Handle<Exception>().CircuitBreaker(1, TimeSpan.FromSeconds(10));
         Action config = () => Policy.Wrap<int>(retry, breaker);
 
-        config.Should().NotThrow();
+        Should.NotThrow(config);
     }
 
     [Fact]
@@ -332,9 +332,9 @@ public class PolicyWrapSpecs
         Policy<int> divideByZeroRetry = Policy<int>.Handle<DivideByZeroException>().Retry(2);
         Policy<int> breaker = Policy<int>.Handle<Exception>().CircuitBreaker(1, TimeSpan.FromSeconds(10));
 
-        Action config = () => Policy.Wrap<int>(divideByZeroRetry, retry, breaker);
+        Action config = () => Policy.Wrap(divideByZeroRetry, retry, breaker);
 
-        config.Should().NotThrow();
+        Should.NotThrow(config);
     }
 
     [Fact]
@@ -345,8 +345,8 @@ public class PolicyWrapSpecs
 
         PolicyWrap<int> wrap = Policy.Wrap(policyA, policyB);
 
-        wrap.Outer.Should().BeSameAs(policyA);
-        wrap.Inner.Should().BeSameAs(policyB);
+        wrap.Outer.ShouldBeSameAs(policyA);
+        wrap.Inner.ShouldBeSameAs(policyB);
     }
 
     #endregion
@@ -364,15 +364,13 @@ public class PolicyWrapSpecs
 
         // When the retry wraps the breaker, the retry (being outer) should cause the call to be put through the breaker twice - causing the breaker to break.
         breaker.Reset();
-        retryWrappingBreaker.Invoking(x => x.RaiseException<DivideByZeroException>(2))
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => retryWrappingBreaker.RaiseException<DivideByZeroException>(2));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // When the breaker wraps the retry, the retry (being inner) should retry twice before throwing the exception back on the breaker - the exception only hits the breaker once - so the breaker should not break.
         breaker.Reset();
-        breakerWrappingRetry.Invoking(x => x.RaiseException<DivideByZeroException>(2))
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breakerWrappingRetry.RaiseException<DivideByZeroException>(2));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
@@ -387,14 +385,14 @@ public class PolicyWrapSpecs
         // When the retry wraps the breaker, the retry (being outer) should cause the call to be put through the breaker twice - causing the breaker to break.
         breaker.Reset();
         retryWrappingBreaker.RaiseResultSequence(ResultPrimitive.Fault, ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+            .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // When the breaker wraps the retry, the retry (being inner) should retry twice before throwing the exception back on the breaker - the exception only hits the breaker once - so the breaker should not break.
         breaker.Reset();
         breakerWrappingRetry.RaiseResultSequence(ResultPrimitive.Fault, ResultPrimitive.Fault)
-            .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+            .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     #endregion
@@ -412,15 +410,13 @@ public class PolicyWrapSpecs
 
         // When the retry wraps the breaker, the retry (being outer) should cause the call to be put through the breaker twice - causing the breaker to break.
         breaker.Reset();
-        retryWrappingBreaker.Invoking(x => x.RaiseException<DivideByZeroException>(2))
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+        Should.Throw<DivideByZeroException>(() => retryWrappingBreaker.RaiseException<DivideByZeroException>(2));
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // When the breaker wraps the retry, the retry (being inner) should retry twice before throwing the exception back on the breaker - the exception only hits the breaker once - so the breaker should not break.
         breaker.Reset();
-        breakerWrappingRetry.Invoking(x => x.RaiseException<DivideByZeroException>(2))
-            .Should().Throw<DivideByZeroException>();
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+        Should.Throw<DivideByZeroException>(() => breakerWrappingRetry.RaiseException<DivideByZeroException>(2));
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     [Fact]
@@ -435,14 +431,14 @@ public class PolicyWrapSpecs
         // When the retry wraps the breaker, the retry (being outer) should cause the call to be put through the breaker twice - causing the breaker to break.
         breaker.Reset();
         retryWrappingBreaker.RaiseResultSequence(ResultPrimitive.Fault, ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Open);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Open);
 
         // When the breaker wraps the retry, the retry (being inner) should retry twice before throwing the exception back on the breaker - the exception only hits the breaker once - so the breaker should not break.
         breaker.Reset();
         breakerWrappingRetry.RaiseResultSequence(ResultPrimitive.Fault, ResultPrimitive.Fault)
-              .Should().Be(ResultPrimitive.Fault);
-        breaker.CircuitState.Should().Be(CircuitState.Closed);
+              .ShouldBe(ResultPrimitive.Fault);
+        breaker.CircuitState.ShouldBe(CircuitState.Closed);
     }
 
     #endregion
@@ -462,9 +458,9 @@ public class PolicyWrapSpecs
 
         PolicyResult executeAndCaptureResultOnPolicyWrap = wrap.ExecuteAndCapture(() => { throw new ArgumentNullException(); });
 
-        executeAndCaptureResultOnPolicyWrap.Outcome.Should().Be(OutcomeType.Failure);
-        executeAndCaptureResultOnPolicyWrap.FinalException.Should().BeOfType<ArgumentNullException>();
-        executeAndCaptureResultOnPolicyWrap.ExceptionType.Should().Be(ExceptionType.HandledByThisPolicy);
+        executeAndCaptureResultOnPolicyWrap.Outcome.ShouldBe(OutcomeType.Failure);
+        executeAndCaptureResultOnPolicyWrap.FinalException.ShouldBeOfType<ArgumentNullException>();
+        executeAndCaptureResultOnPolicyWrap.ExceptionType.ShouldBe(ExceptionType.HandledByThisPolicy);
     }
 
     [Fact]
@@ -480,9 +476,9 @@ public class PolicyWrapSpecs
 
         PolicyResult executeAndCaptureResultOnPolicyWrap = wrap.ExecuteAndCapture(() => { throw new DivideByZeroException(); });
 
-        executeAndCaptureResultOnPolicyWrap.Outcome.Should().Be(OutcomeType.Failure);
-        executeAndCaptureResultOnPolicyWrap.FinalException.Should().BeOfType<DivideByZeroException>();
-        executeAndCaptureResultOnPolicyWrap.ExceptionType.Should().Be(ExceptionType.Unhandled);
+        executeAndCaptureResultOnPolicyWrap.Outcome.ShouldBe(OutcomeType.Failure);
+        executeAndCaptureResultOnPolicyWrap.FinalException.ShouldBeOfType<DivideByZeroException>();
+        executeAndCaptureResultOnPolicyWrap.ExceptionType.ShouldBe(ExceptionType.Unhandled);
     }
 
     [Fact]
@@ -498,10 +494,10 @@ public class PolicyWrapSpecs
 
         PolicyResult<ResultPrimitive> executeAndCaptureResultOnPolicyWrap = wrap.ExecuteAndCapture(() => { throw new ArgumentNullException(); });
 
-        executeAndCaptureResultOnPolicyWrap.Outcome.Should().Be(OutcomeType.Failure);
-        executeAndCaptureResultOnPolicyWrap.FinalException.Should().BeOfType<ArgumentNullException>();
-        executeAndCaptureResultOnPolicyWrap.ExceptionType.Should().Be(ExceptionType.HandledByThisPolicy);
-        executeAndCaptureResultOnPolicyWrap.FaultType.Should().Be(FaultType.ExceptionHandledByThisPolicy);
+        executeAndCaptureResultOnPolicyWrap.Outcome.ShouldBe(OutcomeType.Failure);
+        executeAndCaptureResultOnPolicyWrap.FinalException.ShouldBeOfType<ArgumentNullException>();
+        executeAndCaptureResultOnPolicyWrap.ExceptionType.ShouldBe(ExceptionType.HandledByThisPolicy);
+        executeAndCaptureResultOnPolicyWrap.FaultType.ShouldBe(FaultType.ExceptionHandledByThisPolicy);
     }
 
     [Fact]
@@ -517,10 +513,10 @@ public class PolicyWrapSpecs
 
         PolicyResult<ResultPrimitive> executeAndCaptureResultOnPolicyWrap = wrap.ExecuteAndCapture(() => { throw new DivideByZeroException(); });
 
-        executeAndCaptureResultOnPolicyWrap.Outcome.Should().Be(OutcomeType.Failure);
-        executeAndCaptureResultOnPolicyWrap.FinalException.Should().BeOfType<DivideByZeroException>();
-        executeAndCaptureResultOnPolicyWrap.ExceptionType.Should().Be(ExceptionType.Unhandled);
-        executeAndCaptureResultOnPolicyWrap.FaultType.Should().Be(FaultType.UnhandledException);
+        executeAndCaptureResultOnPolicyWrap.Outcome.ShouldBe(OutcomeType.Failure);
+        executeAndCaptureResultOnPolicyWrap.FinalException.ShouldBeOfType<DivideByZeroException>();
+        executeAndCaptureResultOnPolicyWrap.ExceptionType.ShouldBe(ExceptionType.Unhandled);
+        executeAndCaptureResultOnPolicyWrap.FaultType.ShouldBe(FaultType.UnhandledException);
     }
 
     [Fact]
@@ -536,11 +532,11 @@ public class PolicyWrapSpecs
 
         PolicyResult<ResultPrimitive> executeAndCaptureResultOnPolicyWrap = wrap.ExecuteAndCapture(() => ResultPrimitive.Fault);
 
-        executeAndCaptureResultOnPolicyWrap.Outcome.Should().Be(OutcomeType.Failure);
-        executeAndCaptureResultOnPolicyWrap.FaultType.Should().Be(FaultType.ResultHandledByThisPolicy);
-        executeAndCaptureResultOnPolicyWrap.FinalHandledResult.Should().Be(ResultPrimitive.Fault);
-        executeAndCaptureResultOnPolicyWrap.FinalException.Should().BeNull();
-        executeAndCaptureResultOnPolicyWrap.ExceptionType.Should().BeNull();
+        executeAndCaptureResultOnPolicyWrap.Outcome.ShouldBe(OutcomeType.Failure);
+        executeAndCaptureResultOnPolicyWrap.FaultType.ShouldBe(FaultType.ResultHandledByThisPolicy);
+        executeAndCaptureResultOnPolicyWrap.FinalHandledResult.ShouldBe(ResultPrimitive.Fault);
+        executeAndCaptureResultOnPolicyWrap.FinalException.ShouldBeNull();
+        executeAndCaptureResultOnPolicyWrap.ExceptionType.ShouldBeNull();
     }
 
     [Fact]
@@ -556,11 +552,11 @@ public class PolicyWrapSpecs
 
         PolicyResult<ResultPrimitive> executeAndCaptureResultOnPolicyWrap = wrap.ExecuteAndCapture(() => ResultPrimitive.FaultAgain);
 
-        executeAndCaptureResultOnPolicyWrap.Outcome.Should().Be(OutcomeType.Successful);
-        executeAndCaptureResultOnPolicyWrap.FinalHandledResult.Should().Be(default);
-        executeAndCaptureResultOnPolicyWrap.FaultType.Should().BeNull();
-        executeAndCaptureResultOnPolicyWrap.FinalException.Should().BeNull();
-        executeAndCaptureResultOnPolicyWrap.ExceptionType.Should().BeNull();
+        executeAndCaptureResultOnPolicyWrap.Outcome.ShouldBe(OutcomeType.Successful);
+        executeAndCaptureResultOnPolicyWrap.FinalHandledResult.ShouldBe(default);
+        executeAndCaptureResultOnPolicyWrap.FaultType.ShouldBeNull();
+        executeAndCaptureResultOnPolicyWrap.FinalException.ShouldBeNull();
+        executeAndCaptureResultOnPolicyWrap.ExceptionType.ShouldBeNull();
     }
 
     #endregion

--- a/test/Polly.Testing.Tests/Polly.Testing.Tests.csproj
+++ b/test/Polly.Testing.Tests/Polly.Testing.Tests.csproj
@@ -13,9 +13,5 @@
     <ProjectReference Include="..\..\src\Polly.Extensions\Polly.Extensions.csproj" />
     <ProjectReference Include="..\..\src\Polly.RateLimiting\Polly.RateLimiting.csproj" />
     <ProjectReference Include="..\..\src\Polly.Testing\Polly.Testing.csproj" />
-    <PackageReference Include="Shouldly" />
-  </ItemGroup>
-  <ItemGroup>
-    <Using Include="Shouldly" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Complete migration from FluentAssertions to Shouldly.

Resolves #2450.
