### PR TITLE
Tidy up code in Polly.Specs

### DIFF
--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -1,2 +1,6 @@
 [*.cs]
+
+dotnet_diagnostic.CA1062.severity = none
+dotnet_diagnostic.SA1204.severity = none
+dotnet_diagnostic.SA1600.severity = none
 dotnet_diagnostic.xUnit1031.severity = suggestion

--- a/test/Polly.Core.Tests/Polly.Core.Tests.csproj
+++ b/test/Polly.Core.Tests/Polly.Core.Tests.csproj
@@ -6,7 +6,7 @@
     <ProjectType>Test</ProjectType>
     <Nullable>enable</Nullable>
     <Threshold>100</Threshold>
-    <NoWarn>$(NoWarn);S6966;SA1600;SA1204</NoWarn>
+    <NoWarn>$(NoWarn);S6966</NoWarn>
     <Include>[Polly.Core]*</Include>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>

--- a/test/Polly.Extensions.Tests/Polly.Extensions.Tests.csproj
+++ b/test/Polly.Extensions.Tests/Polly.Extensions.Tests.csproj
@@ -5,7 +5,6 @@
     <ProjectType>Test</ProjectType>
     <Nullable>enable</Nullable>
     <Threshold>100</Threshold>
-    <NoWarn>$(NoWarn);SA1600;SA1204</NoWarn>
     <Include>[Polly.Extensions]*</Include>
   </PropertyGroup>
 

--- a/test/Polly.RateLimiting.Tests/Polly.RateLimiting.Tests.csproj
+++ b/test/Polly.RateLimiting.Tests/Polly.RateLimiting.Tests.csproj
@@ -5,7 +5,6 @@
     <ProjectType>Test</ProjectType>
     <Nullable>enable</Nullable>
     <Threshold>100</Threshold>
-    <NoWarn>$(NoWarn);SA1600;SA1204</NoWarn>
     <Include>[Polly.RateLimiting]*</Include>
   </PropertyGroup>
   <ItemGroup>

--- a/test/Polly.Specs/.editorconfig
+++ b/test/Polly.Specs/.editorconfig
@@ -1,0 +1,4 @@
+[*.cs]
+
+dotnet_diagnostic.S104.severity = none
+dotnet_diagnostic.S6966.severity = none

--- a/test/Polly.Specs/.editorconfig
+++ b/test/Polly.Specs/.editorconfig
@@ -1,4 +1,6 @@
 [*.cs]
 
+dotnet_diagnostic.CA2008.severity = none
+dotnet_diagnostic.CA2201.severity = none
 dotnet_diagnostic.S104.severity = none
 dotnet_diagnostic.S6966.severity = none

--- a/test/Polly.Specs/.editorconfig
+++ b/test/Polly.Specs/.editorconfig
@@ -1,5 +1,6 @@
 [*.cs]
 
+dotnet_diagnostic.CA1030.severity = none
 dotnet_diagnostic.CA2008.severity = none
 dotnet_diagnostic.CA2201.severity = none
 dotnet_diagnostic.S104.severity = none

--- a/test/Polly.Specs/Bulkhead/BulkheadSpecs.cs
+++ b/test/Polly.Specs/Bulkhead/BulkheadSpecs.cs
@@ -1,13 +1,8 @@
 ﻿namespace Polly.Specs.Bulkhead;
 
 [Collection(Constants.ParallelThreadDependentTestCollection)]
-public class BulkheadSpecs : BulkheadSpecsBase
+public class BulkheadSpecs(ITestOutputHelper testOutputHelper) : BulkheadSpecsBase(testOutputHelper)
 {
-    public BulkheadSpecs(ITestOutputHelper testOutputHelper)
-        : base(testOutputHelper)
-    {
-    }
-
     #region Configuration
 
     [Fact]

--- a/test/Polly.Specs/Bulkhead/BulkheadSpecsBase.cs
+++ b/test/Polly.Specs/Bulkhead/BulkheadSpecsBase.cs
@@ -12,7 +12,7 @@ public abstract class BulkheadSpecsBase : IDisposable
     #region Time constraints
 
     protected readonly TimeSpan ShimTimeSpan = TimeSpan.FromMilliseconds(50); // How frequently to retry the assertions.
-    protected readonly TimeSpan CohesionTimeLimit = TimeSpan.FromMilliseconds(1000); // Consider increasing CohesionTimeLimit if bulkhead specs fail transiently in slower build environments.
+    protected readonly TimeSpan CohesionTimeLimit = TimeSpan.FromSeconds(1);
 
     #endregion
 
@@ -33,9 +33,9 @@ public abstract class BulkheadSpecsBase : IDisposable
 
     protected IBulkheadPolicy BulkheadForStats { get; set; } = null!;
 
-    internal TraceableAction[] Actions { get; set; } = { };
+    internal TraceableAction[] Actions { get; set; } = [];
 
-    protected Task[] Tasks { get; set; } = { };
+    protected Task[] Tasks { get; set; } = [];
 
     protected readonly AutoResetEvent StatusChangedEvent = new(false);
 
@@ -84,10 +84,7 @@ public abstract class BulkheadSpecsBase : IDisposable
     [ClassData(typeof(BulkheadScenarios))]
     public void Should_control_executions_per_specification(int maxParallelization, int maxQueuingActions, int totalActions, bool cancelQueuing, bool cancelExecuting, string scenario)
     {
-        if (totalActions < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(totalActions));
-        }
+        totalActions.ShouldBeGreaterThanOrEqualTo(0);
 
         MaxParallelization = maxParallelization;
         MaxQueuingActions = maxQueuingActions;
@@ -312,7 +309,7 @@ public abstract class BulkheadSpecsBase : IDisposable
             }
             catch (Exception e)
             {
-                throw new Exception("Task " + i + " raised the following unobserved task exception: ", e);
+                throw new Exception($"Task {i} raised the following unobserved task exception: ", e);
             }
         }
     }
@@ -373,6 +370,7 @@ public abstract class BulkheadSpecsBase : IDisposable
     private void ShowTestOutput() =>
         ((AnnotatedOutputHelper)TestOutputHelper).Flush();
 #endif
+
     #endregion
 
     public void Dispose()

--- a/test/Polly.Specs/Bulkhead/BulkheadTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/Bulkhead/BulkheadTResultAsyncSpecs.cs
@@ -124,7 +124,7 @@ public class BulkheadTResultAsyncSpecs(ITestOutputHelper testOutputHelper) : Bul
         Policy.BulkheadAsync<ResultPrimitive>(maxParallelization, maxQueuingActions);
 
     protected override Task ExecuteOnBulkhead(IBulkheadPolicy bulkhead, TraceableAction action) =>
-        action.ExecuteOnBulkheadAsync<ResultPrimitive>((AsyncBulkheadPolicy<ResultPrimitive>)bulkhead);
+        action.ExecuteOnBulkheadAsync((AsyncBulkheadPolicy<ResultPrimitive>)bulkhead);
 
     #endregion
 }

--- a/test/Polly.Specs/Bulkhead/BulkheadTResultSpecs.cs
+++ b/test/Polly.Specs/Bulkhead/BulkheadTResultSpecs.cs
@@ -124,7 +124,7 @@ public class BulkheadTResultSpecs(ITestOutputHelper testOutputHelper) : Bulkhead
         Policy.Bulkhead<ResultPrimitive>(maxParallelization, maxQueuingActions);
 
     protected override Task ExecuteOnBulkhead(IBulkheadPolicy bulkhead, TraceableAction action) =>
-        action.ExecuteOnBulkhead<ResultPrimitive>((BulkheadPolicy<ResultPrimitive>)bulkhead);
+        action.ExecuteOnBulkhead((BulkheadPolicy<ResultPrimitive>)bulkhead);
 
     #endregion
 }

--- a/test/Polly.Specs/Bulkhead/IBulkheadPolicySpecs.cs
+++ b/test/Polly.Specs/Bulkhead/IBulkheadPolicySpecs.cs
@@ -5,7 +5,7 @@ public class IBulkheadPolicySpecs
     [Fact]
     public void Should_be_able_to_use_BulkheadAvailableCount_via_interface()
     {
-        IBulkheadPolicy bulkhead = Policy.Bulkhead(20, 10);
+        var bulkhead = Policy.Bulkhead(20, 10);
 
         bulkhead.BulkheadAvailableCount.ShouldBe(20);
     }
@@ -13,7 +13,7 @@ public class IBulkheadPolicySpecs
     [Fact]
     public void Should_be_able_to_use_QueueAvailableCount_via_interface()
     {
-        IBulkheadPolicy bulkhead = Policy.Bulkhead(20, 10);
+        var bulkhead = Policy.Bulkhead(20, 10);
 
         bulkhead.QueueAvailableCount.ShouldBe(10);
     }

--- a/test/Polly.Specs/Caching/CacheAsyncSpecs.cs
+++ b/test/Polly.Specs/Caching/CacheAsyncSpecs.cs
@@ -313,7 +313,7 @@ public class CacheAsyncSpecs : IDisposable
         Action action = () => Policy.WrapAsync(policies);
         Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe("policies");
 
-        action = () => Policy.WrapAsync<int>(policiesGeneric);
+        action = () => Policy.WrapAsync(policiesGeneric);
         Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe("policies");
     }
     #endregion

--- a/test/Polly.Specs/Caching/CacheSpecs.cs
+++ b/test/Polly.Specs/Caching/CacheSpecs.cs
@@ -312,7 +312,7 @@ public class CacheSpecs : IDisposable
         Action action = () => Policy.Wrap(policies);
         Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe("policies");
 
-        action = () => Policy.Wrap<int>(policiesGeneric);
+        action = () => Policy.Wrap(policiesGeneric);
         Should.Throw<ArgumentNullException>(action).ParamName.ShouldBe("policies");
     }
 

--- a/test/Polly.Specs/Caching/CacheTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/Caching/CacheTResultAsyncSpecs.cs
@@ -321,7 +321,7 @@ public class CacheTResultAsyncSpecs : IDisposable
         var stubCacheProvider = new StubCacheProvider();
         var cacheKeyStrategy = new StubCacheKeyStrategy(context => context.OperationKey + context["id"]);
 
-        var cache = Policy.CacheAsync<ResultClass>(stubCacheProvider.AsyncFor<ResultClass>(), new RelativeTtl(TimeSpan.MaxValue), cacheKeyStrategy, emptyDelegate, emptyDelegate, emptyDelegate, noErrorHandling, noErrorHandling);
+        var cache = Policy.CacheAsync(stubCacheProvider.AsyncFor<ResultClass>(), new RelativeTtl(TimeSpan.MaxValue), cacheKeyStrategy, emptyDelegate, emptyDelegate, emptyDelegate, noErrorHandling, noErrorHandling);
 
         object person1 = new ResultClass(ResultPrimitive.Good, "person1");
         await stubCacheProvider.PutAsync("person1", person1, new Ttl(TimeSpan.MaxValue), CancellationToken, false);

--- a/test/Polly.Specs/Caching/GenericCacheProviderAsyncSpecs.cs
+++ b/test/Polly.Specs/Caching/GenericCacheProviderAsyncSpecs.cs
@@ -9,9 +9,9 @@ public class GenericCacheProviderAsyncSpecs : IDisposable
         const string OperationKey = "SomeOperationKey";
 
         bool onErrorCalled = false;
-        Action<Context, string, Exception> onError = (_, _, _) => { onErrorCalled = true; };
+        Action<Context, string, Exception> onError = (_, _, _) => onErrorCalled = true;
 
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         var cache = Policy.CacheAsync(stubCacheProvider, TimeSpan.MaxValue, onError);
 
         (bool cacheHit, object? fromCache) = await stubCacheProvider.TryGetAsync(OperationKey, CancellationToken.None, false);
@@ -34,7 +34,7 @@ public class GenericCacheProviderAsyncSpecs : IDisposable
         const string OperationKey = "SomeOperationKey";
 
         var cancellationToken = CancellationToken.None;
-        IAsyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         var cache = Policy.CacheAsync(stubCacheProvider, TimeSpan.MaxValue);
 
         (bool cacheHit1, object? fromCache1) = await stubCacheProvider.TryGetAsync(OperationKey, cancellationToken, false);

--- a/test/Polly.Specs/Caching/GenericCacheProviderSpecs.cs
+++ b/test/Polly.Specs/Caching/GenericCacheProviderSpecs.cs
@@ -29,7 +29,7 @@ public class GenericCacheProviderSpecs : IDisposable
         const ResultPrimitive ValueToReturn = ResultPrimitive.Substitute;
         const string OperationKey = "SomeOperationKey";
 
-        ISyncCacheProvider stubCacheProvider = new StubCacheProvider();
+        var stubCacheProvider = new StubCacheProvider();
         CachePolicy cache = Policy.Cache(stubCacheProvider, TimeSpan.MaxValue);
 
         (bool cacheHit1, object? fromCache1) = stubCacheProvider.TryGet(OperationKey);

--- a/test/Polly.Specs/CircuitBreaker/ICircuitBreakerTResultPolicySpecs.cs
+++ b/test/Polly.Specs/CircuitBreaker/ICircuitBreakerTResultPolicySpecs.cs
@@ -5,7 +5,7 @@ public class ICircuitBreakerTResultPolicySpecs
     [Fact]
     public void Should_be_able_to_use_LastHandledResult_via_interface()
     {
-        ICircuitBreakerPolicy<ResultPrimitive> breaker = Policy
+        var breaker = Policy
             .HandleResult(ResultPrimitive.Fault)
             .CircuitBreaker(2, TimeSpan.FromMinutes(1));
 

--- a/test/Polly.Specs/Custom/CustomTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/Custom/CustomTResultAsyncSpecs.cs
@@ -36,7 +36,7 @@ public class CustomTResultAsyncSpecs
     {
         Action construct = () =>
         {
-            AsyncAddBehaviourIfHandlePolicy<ResultPrimitive> policy = Policy.HandleResult<ResultPrimitive>(ResultPrimitive.Fault).WithBehaviourAsync(async outcome =>
+            AsyncAddBehaviourIfHandlePolicy<ResultPrimitive> policy = Policy.HandleResult(ResultPrimitive.Fault).WithBehaviourAsync(async outcome =>
             {
                 // Placeholder for more substantive async work.
                 Console.WriteLine("Handling " + outcome.Result);
@@ -52,7 +52,7 @@ public class CustomTResultAsyncSpecs
     {
         ResultPrimitive handled = ResultPrimitive.Undefined;
         AsyncAddBehaviourIfHandlePolicy<ResultPrimitive> policy = Policy
-            .HandleResult<ResultPrimitive>(ResultPrimitive.Fault)
+            .HandleResult(ResultPrimitive.Fault)
             .WithBehaviourAsync(async outcome => { handled = outcome.Result; await Task.CompletedTask; });
 
         ResultPrimitive toReturn = ResultPrimitive.Fault;
@@ -75,7 +75,7 @@ public class CustomTResultAsyncSpecs
     {
         ResultPrimitive? handled = null;
         AsyncAddBehaviourIfHandlePolicy<ResultPrimitive> policy = Policy
-            .HandleResult<ResultPrimitive>(ResultPrimitive.Fault)
+            .HandleResult(ResultPrimitive.Fault)
             .WithBehaviourAsync(async outcome => { handled = outcome.Result; await Task.CompletedTask; });
 
         ResultPrimitive toReturn = ResultPrimitive.FaultYetAgain;

--- a/test/Polly.Specs/Custom/CustomTResultSpecs.cs
+++ b/test/Polly.Specs/Custom/CustomTResultSpecs.cs
@@ -36,7 +36,7 @@ public class CustomTResultSpecs
     {
         Action construct = () =>
         {
-            AddBehaviourIfHandlePolicy<ResultPrimitive> policy = Policy.HandleResult<ResultPrimitive>(ResultPrimitive.Fault).WithBehaviour(outcome => Console.WriteLine("Handling " + outcome.Result));
+            AddBehaviourIfHandlePolicy<ResultPrimitive> policy = Policy.HandleResult(ResultPrimitive.Fault).WithBehaviour(outcome => Console.WriteLine("Handling " + outcome.Result));
         };
 
         Should.NotThrow(construct);
@@ -46,7 +46,7 @@ public class CustomTResultSpecs
     public void Reactive_policy_should_handle_result()
     {
         ResultPrimitive handled = ResultPrimitive.Undefined;
-        AddBehaviourIfHandlePolicy<ResultPrimitive> policy = Policy.HandleResult<ResultPrimitive>(ResultPrimitive.Fault).WithBehaviour(outcome => handled = outcome.Result);
+        AddBehaviourIfHandlePolicy<ResultPrimitive> policy = Policy.HandleResult(ResultPrimitive.Fault).WithBehaviour(outcome => handled = outcome.Result);
 
         ResultPrimitive toReturn = ResultPrimitive.Fault;
         bool executed = false;
@@ -66,7 +66,7 @@ public class CustomTResultSpecs
     public void Reactive_policy_should_be_able_to_ignore_unhandled_result()
     {
         ResultPrimitive? handled = null;
-        AddBehaviourIfHandlePolicy<ResultPrimitive> policy = Policy.HandleResult<ResultPrimitive>(ResultPrimitive.Fault).WithBehaviour(outcome => handled = outcome.Result);
+        AddBehaviourIfHandlePolicy<ResultPrimitive> policy = Policy.HandleResult(ResultPrimitive.Fault).WithBehaviour(outcome => handled = outcome.Result);
 
         ResultPrimitive toReturn = ResultPrimitive.FaultYetAgain;
         bool executed = false;

--- a/test/Polly.Specs/Fallback/FallbackAsyncSpecs.cs
+++ b/test/Polly.Specs/Fallback/FallbackAsyncSpecs.cs
@@ -245,7 +245,7 @@ public class FallbackAsyncSpecs
             .Handle<DivideByZeroException>()
             .FallbackAsync(_ => TaskHelper.EmptyTask);
 
-        await Should.ThrowAsync<InvalidOperationException>(() => fallbackPolicy.ExecuteAsync<int>(() => Task.FromResult(0)));
+        await Should.ThrowAsync<InvalidOperationException>(() => fallbackPolicy.ExecuteAsync(() => Task.FromResult(0)));
     }
 
     #endregion

--- a/test/Polly.Specs/Helpers/Bulkhead/TraceableAction.cs
+++ b/test/Polly.Specs/Helpers/Bulkhead/TraceableAction.cs
@@ -4,14 +4,14 @@
 /// A traceable action that can be executed on a <see cref="BulkheadPolicy"/>, to support specs.
 /// <remarks>We can execute multiple instances of <see cref="TraceableAction"/> in parallel on a bulkhead, and manually control the cancellation and completion of each, to provide determinate tests on the bulkhead operation.  The status of this <see cref="TraceableAction"/> as it executes is fully traceable through the <see cref="TraceableActionStatus"/> property.</remarks>
 /// </summary>
-public class TraceableAction : IDisposable
+public class TraceableAction(int id, AutoResetEvent statusChanged, ITestOutputHelper testOutputHelper) : IDisposable
 {
-    private readonly string _id;
-    private readonly ITestOutputHelper _testOutputHelper;
+    private readonly string _id = $"{id:00}: ";
+    private readonly ITestOutputHelper _testOutputHelper = testOutputHelper;
 
     private readonly TaskCompletionSource<object?> _tcsProxyForRealWork = new();
     private readonly CancellationTokenSource _cancellationSource = new();
-    private readonly AutoResetEvent _statusChanged;
+    private readonly AutoResetEvent _statusChanged = statusChanged;
 
     private TraceableActionStatus _status;
 
@@ -24,13 +24,6 @@ public class TraceableAction : IDisposable
             _testOutputHelper.WriteLine(_id + "Updated status to {0}, signalling AutoResetEvent.", _status);
             SignalStateChange();
         }
-    }
-
-    public TraceableAction(int id, AutoResetEvent statusChanged, ITestOutputHelper testOutputHelper)
-    {
-        _id = $"{id:00}: ";
-        _statusChanged = statusChanged;
-        _testOutputHelper = testOutputHelper;
     }
 
     public void SignalStateChange()
@@ -237,6 +230,9 @@ public class TraceableAction : IDisposable
         _tcsProxyForRealWork.SetCanceled();
     }
 
-    public void Dispose() =>
+    public void Dispose()
+    {
+        _statusChanged?.Dispose();
         _cancellationSource.Dispose();
+    }
 }

--- a/test/Polly.Specs/Helpers/Bulkhead/TraceableAction.cs
+++ b/test/Polly.Specs/Helpers/Bulkhead/TraceableAction.cs
@@ -99,7 +99,9 @@ public class TraceableAction : IDisposable
                     throw;
                 }
             }
+#pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception e)
+#pragma warning restore CA1031 // Do not catch general exception types
             {
                 _testOutputHelper.WriteLine(_id + "Caught unexpected exception during execution: " + e);
 
@@ -165,7 +167,9 @@ public class TraceableAction : IDisposable
                         Status = TraceableActionStatus.Canceled;
                     } // else: was execution cancellation rethrown: ignore
                 }
+#pragma warning disable CA1031 // Do not catch general exception types
                 catch (Exception e)
+#pragma warning restore CA1031 // Do not catch general exception types
                 {
                     _testOutputHelper.WriteLine(_id + "Caught unexpected exception during execution: " + e);
 

--- a/test/Polly.Specs/Helpers/Constants.cs
+++ b/test/Polly.Specs/Helpers/Constants.cs
@@ -6,12 +6,14 @@
 public static class Constants
 {
     /// <summary>
-    /// Denotes a test collection dependent on manipulating the abstracted <see cref="Polly.Utilities.SystemClock"/>.  <remarks>These tests are not parallelized.</remarks>
+    /// Denotes a test collection dependent on manipulating the abstracted <see cref="SystemClock"/>.
     /// </summary>
+    /// <remarks>These tests are not parallelized.</remarks>
     public const string SystemClockDependentTestCollection = "SystemClockDependentTestCollection";
 
     /// <summary>
-    /// Denotes a test collection making heavy use of parallel threads.  <remarks>These tests are not run in parallel with each other, to reduce heavy use of threads in the build/CI environment.</remarks>
+    /// Denotes a test collection making heavy use of parallel threads.
     /// </summary>
+    /// <remarks>These tests are not run in parallel with each other, to reduce heavy use of threads in the build/CI environment.</remarks>
     public const string ParallelThreadDependentTestCollection = "ParallelThreadDependentTestCollection";
 }

--- a/test/Polly.Specs/Helpers/ContextualPolicyTResultExtensionsAsync.cs
+++ b/test/Polly.Specs/Helpers/ContextualPolicyTResultExtensionsAsync.cs
@@ -2,10 +2,11 @@
 
 public static class ContextualPolicyTResultExtensionsAsync
 {
-    public static Task<TResult> RaiseResultSequenceAsync<TResult>(this AsyncPolicy<TResult> policy,
-IDictionary<string, object> contextData,
-params TResult[] resultsToRaise) =>
-        policy.RaiseResultSequenceAsync(contextData, CancellationToken.None, resultsToRaise.ToList());
+    public static Task<TResult> RaiseResultSequenceAsync<TResult>(
+        this AsyncPolicy<TResult> policy,
+        IDictionary<string, object> contextData,
+        params TResult[] resultsToRaise) =>
+        policy.RaiseResultSequenceAsync(contextData, CancellationToken.None, [.. resultsToRaise]);
 
     public static Task<TResult> RaiseResultSequenceAsync<TResult>(this AsyncPolicy<TResult> policy, IDictionary<string, object> contextData, CancellationToken cancellationToken, IEnumerable<TResult> resultsToRaise)
     {

--- a/test/Polly.Specs/Helpers/Custom/AddBehaviourIfHandle/AddBehaviourIfHandleSyntax.cs
+++ b/test/Polly.Specs/Helpers/Custom/AddBehaviourIfHandle/AddBehaviourIfHandleSyntax.cs
@@ -4,21 +4,13 @@ internal static class AddBehaviourIfHandleSyntax
 {
     internal static AddBehaviourIfHandlePolicy WithBehaviour(this PolicyBuilder policyBuilder, Action<Exception> behaviourIfHandle)
     {
-        if (behaviourIfHandle == null)
-        {
-            throw new ArgumentNullException(nameof(behaviourIfHandle));
-        }
-
+        behaviourIfHandle.ShouldNotBeNull();
         return new AddBehaviourIfHandlePolicy(behaviourIfHandle, policyBuilder);
     }
 
     internal static AddBehaviourIfHandlePolicy<TResult> WithBehaviour<TResult>(this PolicyBuilder<TResult> policyBuilder, Action<DelegateResult<TResult>> behaviourIfHandle)
     {
-        if (behaviourIfHandle == null)
-        {
-            throw new ArgumentNullException(nameof(behaviourIfHandle));
-        }
-
+        behaviourIfHandle.ShouldNotBeNull();
         return new AddBehaviourIfHandlePolicy<TResult>(behaviourIfHandle, policyBuilder);
     }
 }

--- a/test/Polly.Specs/Helpers/Custom/AddBehaviourIfHandle/AsyncAddBehaviourIfHandlePolicy.cs
+++ b/test/Polly.Specs/Helpers/Custom/AddBehaviourIfHandle/AsyncAddBehaviourIfHandlePolicy.cs
@@ -10,7 +10,7 @@ internal class AsyncAddBehaviourIfHandlePolicy : AsyncPolicy
         : base(policyBuilder) =>
         _behaviourIfHandle = behaviourIfHandle ?? throw new ArgumentNullException(nameof(behaviourIfHandle));
 
-    protected override Task<TResult> ImplementationAsync<TResult>(Func<Context, System.Threading.CancellationToken, Task<TResult>> action, Context context, System.Threading.CancellationToken cancellationToken,
+    protected override Task<TResult> ImplementationAsync<TResult>(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken,
         bool continueOnCapturedContext) =>
         AsyncAddBehaviourIfHandleEngine.ImplementationAsync(
             ExceptionPredicates,
@@ -32,7 +32,7 @@ internal class AsyncAddBehaviourIfHandlePolicy<TResult> : AsyncPolicy<TResult>
         : base(policyBuilder) =>
         _behaviourIfHandle = behaviourIfHandle ?? throw new ArgumentNullException(nameof(behaviourIfHandle));
 
-    protected override Task<TResult> ImplementationAsync(Func<Context, System.Threading.CancellationToken, Task<TResult>> action, Context context, System.Threading.CancellationToken cancellationToken,
+    protected override Task<TResult> ImplementationAsync(Func<Context, CancellationToken, Task<TResult>> action, Context context, CancellationToken cancellationToken,
         bool continueOnCapturedContext) =>
         AsyncAddBehaviourIfHandleEngine.ImplementationAsync(
             ExceptionPredicates,

--- a/test/Polly.Specs/Helpers/PolicyExtensions.cs
+++ b/test/Polly.Specs/Helpers/PolicyExtensions.cs
@@ -52,7 +52,7 @@ public static class PolicyExtensions
     public static void RaiseExceptionAndOrCancellation<TException>(this Policy policy, ExceptionAndOrCancellationScenario scenario, CancellationTokenSource cancellationTokenSource, Action onExecute)
         where TException : Exception, new()
         =>
-        policy.RaiseExceptionAndOrCancellation<TException>(scenario, cancellationTokenSource, onExecute, _ => new TException());
+        policy.RaiseExceptionAndOrCancellation(scenario, cancellationTokenSource, onExecute, _ => new TException());
 
     public static TResult RaiseExceptionAndOrCancellation<TException, TResult>(this Policy policy, ExceptionAndOrCancellationScenario scenario, CancellationTokenSource cancellationTokenSource, Action onExecute, TResult successResult)
         where TException : Exception, new()

--- a/test/Polly.Specs/Helpers/PolicyExtensionsAsync.cs
+++ b/test/Polly.Specs/Helpers/PolicyExtensionsAsync.cs
@@ -54,7 +54,7 @@ public static class PolicyExtensionsAsync
     public static Task RaiseExceptionAndOrCancellationAsync<TException>(this AsyncPolicy policy, ExceptionAndOrCancellationScenario scenario, CancellationTokenSource cancellationTokenSource, Action onExecute)
         where TException : Exception, new()
         =>
-        policy.RaiseExceptionAndOrCancellationAsync<TException>(scenario, cancellationTokenSource, onExecute, _ => new TException());
+        policy.RaiseExceptionAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute, _ => new TException());
 
     public static Task<TResult> RaiseExceptionAndOrCancellationAsync<TException, TResult>(this AsyncPolicy policy, ExceptionAndOrCancellationScenario scenario, CancellationTokenSource cancellationTokenSource, Action onExecute, TResult successResult)
         where TException : Exception, new()

--- a/test/Polly.Specs/Helpers/PolicyTResultExtensionsAsync.cs
+++ b/test/Polly.Specs/Helpers/PolicyTResultExtensionsAsync.cs
@@ -18,7 +18,7 @@ public static class PolicyTResultExtensionsAsync
         {
             if (!enumerator.MoveNext())
             {
-                throw new ArgumentOutOfRangeException(nameof(resultsToRaise), $"Not enough {typeof(TResult).Name}  values in {nameof(resultsToRaise)}.");
+                throw new ArgumentOutOfRangeException(nameof(resultsToRaise), $"Not enough {typeof(TResult).Name} values in {nameof(resultsToRaise)}.");
             }
 
             return Task.FromResult(enumerator.Current);

--- a/test/Polly.Specs/Helpers/ResultClass.cs
+++ b/test/Polly.Specs/Helpers/ResultClass.cs
@@ -3,16 +3,14 @@
 /// <summary>
 /// A helper class supporting tests on how Policy&lt;TResult&gt; policies handle return results which are class types (as opposed to primitive types).
 /// </summary>
-internal class ResultClass
+internal class ResultClass(ResultPrimitive resultCode, string? someString)
 {
-    public ResultClass(ResultPrimitive resultCode) =>
-        ResultCode = resultCode;
+    public ResultClass(ResultPrimitive resultCode)
+        : this(resultCode, null)
+    {
+    }
 
-    public ResultClass(ResultPrimitive resultCode, string someString)
-        : this(resultCode) =>
-        SomeString = someString;
+    public ResultPrimitive ResultCode { get; set; } = resultCode;
 
-    public ResultPrimitive ResultCode { get; set; }
-
-    public string? SomeString { get; set; }
+    public string? SomeString { get; set; } = someString;
 }

--- a/test/Polly.Specs/PolicyKeyAsyncSpecs.cs
+++ b/test/Polly.Specs/PolicyKeyAsyncSpecs.cs
@@ -120,7 +120,7 @@ public class PolicyKeyAsyncSpecs
         string policyKey = Guid.NewGuid().ToString();
 
         string? policyKeySetOnExecutionContext = null;
-        Action<Exception, int, Context> onRetry = (_, _, context) => { policyKeySetOnExecutionContext = context.PolicyKey; };
+        Action<Exception, int, Context> onRetry = (_, _, context) => policyKeySetOnExecutionContext = context.PolicyKey;
         var retry = Policy.Handle<Exception>().RetryAsync(1, onRetry).WithPolicyKey(policyKey);
 
         await retry.RaiseExceptionAsync<Exception>(1);
@@ -134,7 +134,7 @@ public class PolicyKeyAsyncSpecs
         string operationKey = "SomeKey";
 
         string? operationKeySetOnContext = null;
-        Action<Exception, int, Context> onRetry = (_, _, context) => { operationKeySetOnContext = context.OperationKey; };
+        Action<Exception, int, Context> onRetry = (_, _, context) => operationKeySetOnContext = context.OperationKey;
         var retry = Policy.Handle<Exception>().RetryAsync(1, onRetry);
 
         bool firstExecution = true;
@@ -157,11 +157,11 @@ public class PolicyKeyAsyncSpecs
         string policyKey = Guid.NewGuid().ToString();
 
         string? policyKeySetOnExecutionContext = null;
-        Action<Exception, int, Context> onRetry = (_, _, context) => { policyKeySetOnExecutionContext = context.PolicyKey; };
+        Action<Exception, int, Context> onRetry = (_, _, context) => policyKeySetOnExecutionContext = context.PolicyKey;
         var retry = Policy.Handle<Exception>().RetryAsync(1, onRetry).WithPolicyKey(policyKey);
 
         bool firstExecution = true;
-        await retry.ExecuteAsync<int>(async () =>
+        await retry.ExecuteAsync(async () =>
         {
             await TaskHelper.EmptyTask;
             if (firstExecution)
@@ -182,7 +182,7 @@ public class PolicyKeyAsyncSpecs
         string operationKey = "SomeKey";
 
         string? operationKeySetOnContext = null;
-        Action<Exception, int, Context> onRetry = (_, _, context) => { operationKeySetOnContext = context.OperationKey; };
+        Action<Exception, int, Context> onRetry = (_, _, context) => operationKeySetOnContext = context.OperationKey;
         var retry = Policy.Handle<Exception>().RetryAsync(1, onRetry);
 
         bool firstExecution = true;

--- a/test/Polly.Specs/PolicyKeySpecs.cs
+++ b/test/Polly.Specs/PolicyKeySpecs.cs
@@ -101,7 +101,7 @@ public class PolicyKeySpecs
         string policyKey = Guid.NewGuid().ToString();
 
         string? policyKeySetOnExecutionContext = null;
-        Action<Exception, int, Context> onRetry = (_, _, context) => { policyKeySetOnExecutionContext = context.PolicyKey; };
+        Action<Exception, int, Context> onRetry = (_, _, context) => policyKeySetOnExecutionContext = context.PolicyKey;
         var retry = Policy.Handle<Exception>().Retry(1, onRetry).WithPolicyKey(policyKey);
 
         retry.RaiseException<Exception>(1);
@@ -115,7 +115,7 @@ public class PolicyKeySpecs
         string operationKey = "SomeKey";
 
         string? operationKeySetOnContext = null;
-        Action<Exception, int, Context> onRetry = (_, _, context) => { operationKeySetOnContext = context.OperationKey; };
+        Action<Exception, int, Context> onRetry = (_, _, context) => operationKeySetOnContext = context.OperationKey;
         var retry = Policy.Handle<Exception>().Retry(1, onRetry);
 
         bool firstExecution = true;
@@ -137,11 +137,11 @@ public class PolicyKeySpecs
         string policyKey = Guid.NewGuid().ToString();
 
         string? policyKeySetOnExecutionContext = null;
-        Action<Exception, int, Context> onRetry = (_, _, context) => { policyKeySetOnExecutionContext = context.PolicyKey; };
+        Action<Exception, int, Context> onRetry = (_, _, context) => policyKeySetOnExecutionContext = context.PolicyKey;
         var retry = Policy.Handle<Exception>().Retry(1, onRetry).WithPolicyKey(policyKey);
 
         bool firstExecution = true;
-        retry.Execute<int>(() =>
+        retry.Execute(() =>
         {
             if (firstExecution)
             {
@@ -161,11 +161,11 @@ public class PolicyKeySpecs
         string operationKey = "SomeKey";
 
         string? operationKeySetOnContext = null;
-        Action<Exception, int, Context> onRetry = (_, _, context) => { operationKeySetOnContext = context.OperationKey; };
+        Action<Exception, int, Context> onRetry = (_, _, context) => operationKeySetOnContext = context.OperationKey;
         var retry = Policy.Handle<Exception>().Retry(1, onRetry);
 
         bool firstExecution = true;
-        retry.Execute<int>(_ =>
+        retry.Execute(_ =>
         {
             if (firstExecution)
             {

--- a/test/Polly.Specs/PolicyTResultKeyAsyncSpecs.cs
+++ b/test/Polly.Specs/PolicyTResultKeyAsyncSpecs.cs
@@ -7,7 +7,7 @@ public class PolicyTResultKeyAsyncSpecs
     [Fact]
     public void Should_be_able_fluently_to_configure_the_policy_key()
     {
-        var policy = Policy.HandleResult<int>(0).RetryAsync().WithPolicyKey(Guid.NewGuid().ToString());
+        var policy = Policy.HandleResult(0).RetryAsync().WithPolicyKey(Guid.NewGuid().ToString());
 
         policy.ShouldBeAssignableTo<AsyncPolicy<int>>();
     }
@@ -15,7 +15,7 @@ public class PolicyTResultKeyAsyncSpecs
     [Fact]
     public void Should_be_able_fluently_to_configure_the_policy_key_via_interface()
     {
-        IAsyncPolicy<int> policyAsInterface = Policy.HandleResult<int>(0).RetryAsync();
+        IAsyncPolicy<int> policyAsInterface = Policy.HandleResult(0).RetryAsync();
         var policyAsInterfaceAfterWithPolicyKey = policyAsInterface.WithPolicyKey(Guid.NewGuid().ToString());
 
         policyAsInterfaceAfterWithPolicyKey.ShouldBeAssignableTo<IAsyncPolicy<int>>();
@@ -112,7 +112,7 @@ public class PolicyTResultKeyAsyncSpecs
         string policyKey = Guid.NewGuid().ToString();
 
         string? policyKeySetOnExecutionContext = null;
-        Action<DelegateResult<ResultPrimitive>, int, Context> onRetry = (_, _, context) => { policyKeySetOnExecutionContext = context.PolicyKey; };
+        Action<DelegateResult<ResultPrimitive>, int, Context> onRetry = (_, _, context) => policyKeySetOnExecutionContext = context.PolicyKey;
         var retry = Policy.HandleResult(ResultPrimitive.Fault).RetryAsync(1, onRetry).WithPolicyKey(policyKey);
 
         await retry.RaiseResultSequenceAsync(ResultPrimitive.Fault, ResultPrimitive.Good);
@@ -126,7 +126,7 @@ public class PolicyTResultKeyAsyncSpecs
         string operationKey = "SomeKey";
 
         string? operationKeySetOnContext = null;
-        Action<DelegateResult<ResultPrimitive>, int, Context> onRetry = (_, _, context) => { operationKeySetOnContext = context.OperationKey; };
+        Action<DelegateResult<ResultPrimitive>, int, Context> onRetry = (_, _, context) => operationKeySetOnContext = context.OperationKey;
         var retry = Policy.HandleResult(ResultPrimitive.Fault).RetryAsync(1, onRetry);
 
         bool firstExecution = true;

--- a/test/Polly.Specs/PolicyTResultKeySpecs.cs
+++ b/test/Polly.Specs/PolicyTResultKeySpecs.cs
@@ -7,7 +7,7 @@ public class PolicyTResultKeySpecs
     [Fact]
     public void Should_be_able_fluently_to_configure_the_policy_key()
     {
-        var policy = Policy.HandleResult<int>(0).Retry().WithPolicyKey(Guid.NewGuid().ToString());
+        var policy = Policy.HandleResult(0).Retry().WithPolicyKey(Guid.NewGuid().ToString());
 
         policy.ShouldBeAssignableTo<Policy<int>>();
     }
@@ -15,7 +15,7 @@ public class PolicyTResultKeySpecs
     [Fact]
     public void Should_be_able_fluently_to_configure_the_policy_key_via_interface()
     {
-        ISyncPolicy<int> policyAsInterface = Policy.HandleResult<int>(0).Retry();
+        ISyncPolicy<int> policyAsInterface = Policy.HandleResult(0).Retry();
         var policyAsInterfaceAfterWithPolicyKey = policyAsInterface.WithPolicyKey(Guid.NewGuid().ToString());
 
         policyAsInterfaceAfterWithPolicyKey.ShouldBeAssignableTo<ISyncPolicy<int>>();
@@ -101,7 +101,7 @@ public class PolicyTResultKeySpecs
         string policyKey = Guid.NewGuid().ToString();
 
         string? policyKeySetOnExecutionContext = null;
-        Action<DelegateResult<ResultPrimitive>, int, Context> onRetry = (_, _, context) => { policyKeySetOnExecutionContext = context.PolicyKey; };
+        Action<DelegateResult<ResultPrimitive>, int, Context> onRetry = (_, _, context) => policyKeySetOnExecutionContext = context.PolicyKey;
         var retry = Policy.HandleResult(ResultPrimitive.Fault).Retry(1, onRetry).WithPolicyKey(policyKey);
 
         retry.RaiseResultSequence(ResultPrimitive.Fault, ResultPrimitive.Good);
@@ -115,7 +115,7 @@ public class PolicyTResultKeySpecs
         string operationKey = "SomeKey";
 
         string? operationKeySetOnContext = null;
-        Action<DelegateResult<ResultPrimitive>, int, Context> onRetry = (_, _, context) => { operationKeySetOnContext = context.OperationKey; };
+        Action<DelegateResult<ResultPrimitive>, int, Context> onRetry = (_, _, context) => operationKeySetOnContext = context.OperationKey;
         var retry = Policy.HandleResult(ResultPrimitive.Fault).Retry(1, onRetry);
 
         bool firstExecution = true;

--- a/test/Polly.Specs/Polly.Specs.csproj
+++ b/test/Polly.Specs/Polly.Specs.csproj
@@ -10,7 +10,6 @@
     <IncludePollyUsings>true</IncludePollyUsings>
     <NoWarn>$(NoWarn);CA1030;CA1031;CA2008;CA2201</NoWarn>
     <NoWarn>$(NoWarn);S104;S6966</NoWarn>
-    <NoWarn>$(NoWarn);SA1402;SA1600</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Polly.Specs/Polly.Specs.csproj
+++ b/test/Polly.Specs/Polly.Specs.csproj
@@ -8,7 +8,7 @@
     <Threshold>75,60,70</Threshold>
     <Include>[Polly]*</Include>
     <IncludePollyUsings>true</IncludePollyUsings>
-    <NoWarn>$(NoWarn);CA1030;CA1031</NoWarn>
+    <NoWarn>$(NoWarn);CA1030</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Polly.Specs/Polly.Specs.csproj
+++ b/test/Polly.Specs/Polly.Specs.csproj
@@ -8,7 +8,6 @@
     <Threshold>75,60,70</Threshold>
     <Include>[Polly]*</Include>
     <IncludePollyUsings>true</IncludePollyUsings>
-    <NoWarn>$(NoWarn);CA1030</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Polly.Specs/Polly.Specs.csproj
+++ b/test/Polly.Specs/Polly.Specs.csproj
@@ -8,7 +8,7 @@
     <Threshold>75,60,70</Threshold>
     <Include>[Polly]*</Include>
     <IncludePollyUsings>true</IncludePollyUsings>
-    <NoWarn>$(NoWarn);CA1030;CA1031;CA2008;CA2201</NoWarn>
+    <NoWarn>$(NoWarn);CA1030;CA1031</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Polly.Specs/Polly.Specs.csproj
+++ b/test/Polly.Specs/Polly.Specs.csproj
@@ -9,7 +9,6 @@
     <Include>[Polly]*</Include>
     <IncludePollyUsings>true</IncludePollyUsings>
     <NoWarn>$(NoWarn);CA1030;CA1031;CA2008;CA2201</NoWarn>
-    <NoWarn>$(NoWarn);S104;S6966</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Polly.Specs/RateLimit/AsyncRateLimitPolicyTResultSpecs.cs
+++ b/test/Polly.Specs/RateLimit/AsyncRateLimitPolicyTResultSpecs.cs
@@ -14,7 +14,7 @@ public class AsyncRateLimitPolicyTResultSpecs : RateLimitPolicyTResultSpecsBase,
 
     protected override IRateLimitPolicy<TResult> GetPolicyViaSyntax<TResult>(int numberOfExecutions, TimeSpan perTimeSpan, int maxBurst,
         Func<TimeSpan, Context, TResult> retryAfterFactory) =>
-        Policy.RateLimitAsync<TResult>(numberOfExecutions, perTimeSpan, maxBurst, retryAfterFactory);
+        Policy.RateLimitAsync(numberOfExecutions, perTimeSpan, maxBurst, retryAfterFactory);
 
     protected override (bool, TimeSpan) TryExecuteThroughPolicy(IRateLimitPolicy policy)
     {

--- a/test/Polly.Specs/RateLimit/RateLimitPolicyTResultSpecs.cs
+++ b/test/Polly.Specs/RateLimit/RateLimitPolicyTResultSpecs.cs
@@ -14,7 +14,7 @@ public class RateLimitPolicyTResultSpecs : RateLimitPolicyTResultSpecsBase, IDis
 
     protected override IRateLimitPolicy<TResult> GetPolicyViaSyntax<TResult>(int numberOfExecutions, TimeSpan perTimeSpan, int maxBurst,
         Func<TimeSpan, Context, TResult> retryAfterFactory) =>
-        Policy.RateLimit<TResult>(numberOfExecutions, perTimeSpan, maxBurst, retryAfterFactory);
+        Policy.RateLimit(numberOfExecutions, perTimeSpan, maxBurst, retryAfterFactory);
 
     protected override (bool, TimeSpan) TryExecuteThroughPolicy(IRateLimitPolicy policy)
     {

--- a/test/Polly.Specs/RateLimit/RateLimitPolicyTResultSpecsBase.cs
+++ b/test/Polly.Specs/RateLimit/RateLimitPolicyTResultSpecsBase.cs
@@ -26,7 +26,7 @@ public abstract class RateLimitPolicyTResultSpecsBase : RateLimitPolicySpecsBase
             contextPassedToRetryAfter = ctx;
             return new ResultClassWithRetryAfter(t);
         };
-        var rateLimiter = GetPolicyViaSyntax<ResultClassWithRetryAfter>(1, onePer, 1, retryAfterFactory);
+        var rateLimiter = GetPolicyViaSyntax(1, onePer, 1, retryAfterFactory);
 
         // Arrange - drain first permitted execution after initialising.
         ShouldPermitAnExecution(rateLimiter);

--- a/test/Polly.Specs/Registry/ConcurrentPolicyRegistrySpecs.cs
+++ b/test/Polly.Specs/Registry/ConcurrentPolicyRegistrySpecs.cs
@@ -2,10 +2,7 @@
 
 public class ConcurrentPolicyRegistrySpecs
 {
-    private readonly IConcurrentPolicyRegistry<string> _registry;
-
-    public ConcurrentPolicyRegistrySpecs() =>
-        _registry = new PolicyRegistry();
+    private readonly PolicyRegistry _registry = [];
 
     [Fact]
     public void Should_be_able_to_add_Policy_using_TryAdd()

--- a/test/Polly.Specs/Registry/PolicyRegistrySpecs.cs
+++ b/test/Polly.Specs/Registry/PolicyRegistrySpecs.cs
@@ -50,7 +50,7 @@ public class PolicyRegistrySpecs
         ISyncPolicy<ResultPrimitive> policy2 = Policy<ResultPrimitive>.HandleResult(ResultPrimitive.Fault).Retry();
         string key2 = Guid.NewGuid().ToString();
 
-        _registry.Add<ISyncPolicy<ResultPrimitive>>(key2, policy2);
+        _registry.Add(key2, policy2);
         _registry.Count.ShouldBe(2);
     }
 

--- a/test/Polly.Specs/Registry/ReadOnlyPolicyRegistrySpecs.cs
+++ b/test/Polly.Specs/Registry/ReadOnlyPolicyRegistrySpecs.cs
@@ -2,12 +2,9 @@
 
 public class ReadOnlyPolicyRegistrySpecs
 {
-    private readonly IPolicyRegistry<string> _registry;
+    private readonly PolicyRegistry _registry = [];
 
     private IReadOnlyPolicyRegistry<string> ReadOnlyRegistry => _registry;
-
-    public ReadOnlyPolicyRegistrySpecs() =>
-        _registry = new PolicyRegistry();
 
     #region Tests for retrieving policy
 

--- a/test/Polly.Specs/Retry/RetryTResultSpecs.cs
+++ b/test/Polly.Specs/Retry/RetryTResultSpecs.cs
@@ -391,7 +391,7 @@ public class RetryTResultSpecs
     {
         bool retryInvoked = false;
 
-        Action<DelegateResult<ResultPrimitive>, int> onRetry = (_, _) => { retryInvoked = true; };
+        Action<DelegateResult<ResultPrimitive>, int> onRetry = (_, _) => retryInvoked = true;
 
         RetryPolicy<ResultPrimitive> policy = Policy
             .HandleResult(ResultPrimitive.Fault)
@@ -407,7 +407,7 @@ public class RetryTResultSpecs
     {
         bool retryInvoked = false;
 
-        Action<DelegateResult<ResultPrimitive>, int, Context> onRetry = (_, _, _) => { retryInvoked = true; };
+        Action<DelegateResult<ResultPrimitive>, int, Context> onRetry = (_, _, _) => retryInvoked = true;
 
         RetryPolicy<ResultPrimitive> policy = Policy
             .HandleResult(ResultPrimitive.Fault)

--- a/test/Polly.Specs/Retry/WaitAndRetrySpecs.cs
+++ b/test/Polly.Specs/Retry/WaitAndRetrySpecs.cs
@@ -1072,7 +1072,7 @@ public class WaitAndRetrySpecs : IDisposable
         attemptsInvoked.ShouldBe(1);
 
         watch.Elapsed.ShouldBeLessThan(retryDelay);
-        watch.Elapsed.ShouldBe(shimTimeSpan, TimeSpan.FromMilliseconds(shimTimeSpan.TotalMilliseconds / 2));  // Consider increasing shimTimeSpan, or loosening precision, if test fails transiently in different environments.
+        watch.Elapsed.ShouldBe(shimTimeSpan, TimeSpan.FromMilliseconds(shimTimeSpan.TotalMilliseconds / 2));
     }
 
     [Fact]

--- a/test/Polly.Specs/Retry/WaitAndRetryTResultSpecs.cs
+++ b/test/Polly.Specs/Retry/WaitAndRetryTResultSpecs.cs
@@ -10,8 +10,8 @@ public class WaitAndRetryTResultSpecs : IDisposable
     {
         Dictionary<ResultPrimitive, TimeSpan> expectedRetryWaits = new Dictionary<ResultPrimitive, TimeSpan>
         {
-            {ResultPrimitive.Fault, TimeSpan.FromSeconds(2)},
-            {ResultPrimitive.FaultAgain, TimeSpan.FromSeconds(4)},
+            [ResultPrimitive.Fault] = TimeSpan.FromSeconds(2),
+            [ResultPrimitive.FaultAgain] = TimeSpan.FromSeconds(4),
         };
 
         var actualRetryWaits = new List<TimeSpan>();

--- a/test/Polly.Specs/Timeout/TimeoutAsyncSpecs.cs
+++ b/test/Polly.Specs/Timeout/TimeoutAsyncSpecs.cs
@@ -228,7 +228,6 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
         await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async () =>
         {
             await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), CancellationToken);
-
         }));
     }
 
@@ -261,7 +260,6 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
         await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async () =>
         {
             await SystemClock.SleepAsync(TimeSpan.FromSeconds(10), CancellationToken);
-
         }));
 
         watch.Stop();
@@ -315,7 +313,6 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
         await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async ct =>
         {
             await SystemClock.SleepAsync(TimeSpan.FromSeconds(3), ct);
-
         }, userCancellationToken));
     }
 
@@ -625,7 +622,7 @@ public class TimeoutAsyncSpecs : TimeoutSpecsBase
             return TaskHelper.EmptyTask;
         };
 
-        TimeSpan shimTimespan = TimeSpan.FromSeconds(1); // Consider increasing shimTimeSpan if test fails transiently in different environments.
+        TimeSpan shimTimespan = TimeSpan.FromSeconds(1);
         TimeSpan thriceShimTimeSpan = shimTimespan + shimTimespan + shimTimespan;
         var policy = Policy.TimeoutAsync(shimTimespan, TimeoutStrategy.Pessimistic, onTimeoutAsync);
 

--- a/test/Polly.Specs/Timeout/TimeoutSpecs.cs
+++ b/test/Polly.Specs/Timeout/TimeoutSpecs.cs
@@ -269,7 +269,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
         TimeSpan timeout = TimeSpan.FromSeconds(1);
         var policy = Policy.Timeout(timeout, TimeoutStrategy.Pessimistic);
 
-        TimeSpan tolerance = TimeSpan.FromSeconds(3); // Consider increasing tolerance, if test fails transiently in different test/build environments.
+        TimeSpan tolerance = TimeSpan.FromSeconds(3);
 
         var watch = Stopwatch.StartNew();
         Should.Throw<TimeoutRejectedException>(() => policy.Execute(() => SystemClock.Sleep(TimeSpan.FromSeconds(10), CancellationToken)));
@@ -412,7 +412,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
         var policy = Policy.Timeout(timeout);
         var userCancellationToken = CancellationToken;
 
-        TimeSpan tolerance = TimeSpan.FromSeconds(3); // Consider increasing tolerance, if test fails transiently in different test/build environments.
+        TimeSpan tolerance = TimeSpan.FromSeconds(3);
 
         var watch = Stopwatch.StartNew();
 
@@ -552,7 +552,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
         TimeSpan timeoutPassedToConfiguration = TimeSpan.FromMilliseconds(250);
 
         TimeSpan? timeoutPassedToOnTimeout = null;
-        Action<Context, TimeSpan, Task> onTimeout = (_, span, _) => { timeoutPassedToOnTimeout = span; };
+        Action<Context, TimeSpan, Task> onTimeout = (_, span, _) => timeoutPassedToOnTimeout = span;
 
         var policy = Policy.Timeout(timeoutPassedToConfiguration, TimeoutStrategy.Pessimistic, onTimeout);
 
@@ -568,7 +568,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
         Context contextPassedToExecute = new Context(operationKey);
 
         Context? contextPassedToOnTimeout = null;
-        Action<Context, TimeSpan, Task> onTimeout = (ctx, _, _) => { contextPassedToOnTimeout = ctx; };
+        Action<Context, TimeSpan, Task> onTimeout = (ctx, _, _) => contextPassedToOnTimeout = ctx;
 
         TimeSpan timeout = TimeSpan.FromMilliseconds(250);
         var policy = Policy.Timeout(timeout, TimeoutStrategy.Pessimistic, onTimeout);
@@ -589,7 +589,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
         Func<TimeSpan> timeoutFunc = () => TimeSpan.FromMilliseconds(25 * programaticallyControlledDelay);
 
         TimeSpan? timeoutPassedToOnTimeout = null;
-        Action<Context, TimeSpan, Task> onTimeout = (_, span, _) => { timeoutPassedToOnTimeout = span; };
+        Action<Context, TimeSpan, Task> onTimeout = (_, span, _) => timeoutPassedToOnTimeout = span;
 
         var policy = Policy.Timeout(timeoutFunc, TimeoutStrategy.Pessimistic, onTimeout);
 
@@ -607,7 +607,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
         Func<Context, TimeSpan> timeoutProvider = ctx => (TimeSpan)ctx["timeout"];
 
         TimeSpan? timeoutPassedToOnTimeout = null;
-        Action<Context, TimeSpan, Task> onTimeout = (_, span, _) => { timeoutPassedToOnTimeout = span; };
+        Action<Context, TimeSpan, Task> onTimeout = (_, span, _) => timeoutPassedToOnTimeout = span;
         var policy = Policy.Timeout(timeoutProvider, TimeoutStrategy.Pessimistic, onTimeout);
 
         // Supply a programatically-controlled timeout, via the execution context.
@@ -622,7 +622,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
     public void Should_call_ontimeout_with_task_wrapping_abandoned_action__pessimistic()
     {
         Task? taskPassedToOnTimeout = null;
-        Action<Context, TimeSpan, Task> onTimeout = (_, _, task) => { taskPassedToOnTimeout = task; };
+        Action<Context, TimeSpan, Task> onTimeout = (_, _, task) => taskPassedToOnTimeout = task;
 
         TimeSpan timeout = TimeSpan.FromMilliseconds(250);
         var policy = Policy.Timeout(timeout, TimeoutStrategy.Pessimistic, onTimeout);
@@ -648,7 +648,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
             task.ContinueWith(t => exceptionObservedFromTaskPassedToOnTimeout = t.Exception!.InnerException);
         };
 
-        TimeSpan shimTimespan = TimeSpan.FromSeconds(1); // Consider increasing shimTimeSpan if test fails transiently in different environments.
+        TimeSpan shimTimespan = TimeSpan.FromSeconds(1);
         TimeSpan thriceShimTimeSpan = shimTimespan + shimTimespan + shimTimespan;
         var policy = Policy.Timeout(shimTimespan, TimeoutStrategy.Pessimistic, onTimeout);
 
@@ -670,7 +670,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
         TimeSpan timeoutPassedToConfiguration = TimeSpan.FromMilliseconds(250);
 
         Exception? exceptionPassedToOnTimeout = null;
-        Action<Context, TimeSpan, Task, Exception> onTimeout = (_, _, _, exception) => { exceptionPassedToOnTimeout = exception; };
+        Action<Context, TimeSpan, Task, Exception> onTimeout = (_, _, _, exception) => exceptionPassedToOnTimeout = exception;
 
         var policy = Policy.Timeout(timeoutPassedToConfiguration, TimeoutStrategy.Pessimistic, onTimeout);
 
@@ -690,7 +690,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
         TimeSpan timeoutPassedToConfiguration = TimeSpan.FromMilliseconds(250);
 
         TimeSpan? timeoutPassedToOnTimeout = null;
-        Action<Context, TimeSpan, Task> onTimeout = (_, span, _) => { timeoutPassedToOnTimeout = span; };
+        Action<Context, TimeSpan, Task> onTimeout = (_, span, _) => timeoutPassedToOnTimeout = span;
 
         var policy = Policy.Timeout(timeoutPassedToConfiguration, TimeoutStrategy.Optimistic, onTimeout);
         var userCancellationToken = CancellationToken;
@@ -707,7 +707,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
         Context contextPassedToExecute = new Context(operationKey);
 
         Context? contextPassedToOnTimeout = null;
-        Action<Context, TimeSpan, Task> onTimeout = (ctx, _, _) => { contextPassedToOnTimeout = ctx; };
+        Action<Context, TimeSpan, Task> onTimeout = (ctx, _, _) => contextPassedToOnTimeout = ctx;
 
         TimeSpan timeout = TimeSpan.FromMilliseconds(250);
         var policy = Policy.Timeout(timeout, TimeoutStrategy.Optimistic, onTimeout);
@@ -729,7 +729,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
         Func<TimeSpan> timeoutFunc = () => TimeSpan.FromMilliseconds(25 * programaticallyControlledDelay);
 
         TimeSpan? timeoutPassedToOnTimeout = null;
-        Action<Context, TimeSpan, Task> onTimeout = (_, span, _) => { timeoutPassedToOnTimeout = span; };
+        Action<Context, TimeSpan, Task> onTimeout = (_, span, _) => timeoutPassedToOnTimeout = span;
 
         var policy = Policy.Timeout(timeoutFunc, TimeoutStrategy.Optimistic, onTimeout);
         var userCancellationToken = CancellationToken;
@@ -748,7 +748,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
         Func<Context, TimeSpan> timeoutProvider = ctx => (TimeSpan)ctx["timeout"];
 
         TimeSpan? timeoutPassedToOnTimeout = null;
-        Action<Context, TimeSpan, Task> onTimeout = (_, span, _) => { timeoutPassedToOnTimeout = span; };
+        Action<Context, TimeSpan, Task> onTimeout = (_, span, _) => timeoutPassedToOnTimeout = span;
         var policy = Policy.Timeout(timeoutProvider, TimeoutStrategy.Optimistic, onTimeout);
 
         var userCancellationToken = CancellationToken;
@@ -768,7 +768,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
     public void Should_call_ontimeout_but_not_with_task_wrapping_abandoned_action__optimistic()
     {
         Task? taskPassedToOnTimeout = null;
-        Action<Context, TimeSpan, Task> onTimeout = (_, _, task) => { taskPassedToOnTimeout = task; };
+        Action<Context, TimeSpan, Task> onTimeout = (_, _, task) => taskPassedToOnTimeout = task;
 
         TimeSpan timeout = TimeSpan.FromMilliseconds(250);
         var policy = Policy.Timeout(timeout, TimeoutStrategy.Optimistic, onTimeout);
@@ -785,7 +785,7 @@ public class TimeoutSpecs : TimeoutSpecsBase
         TimeSpan timeoutPassedToConfiguration = TimeSpan.FromMilliseconds(250);
 
         Exception? exceptionPassedToOnTimeout = null;
-        Action<Context, TimeSpan, Task, Exception> onTimeout = (_, _, _, exception) => { exceptionPassedToOnTimeout = exception; };
+        Action<Context, TimeSpan, Task, Exception> onTimeout = (_, _, _, exception) => exceptionPassedToOnTimeout = exception;
 
         var policy = Policy.Timeout(timeoutPassedToConfiguration, TimeoutStrategy.Optimistic, onTimeout);
         var userCancellationToken = CancellationToken;

--- a/test/Polly.Specs/Timeout/TimeoutTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/Timeout/TimeoutTResultAsyncSpecs.cs
@@ -248,7 +248,7 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
         TimeSpan timeout = TimeSpan.FromSeconds(1);
         var policy = Policy.TimeoutAsync<ResultPrimitive>(timeout, TimeoutStrategy.Pessimistic);
 
-        TimeSpan tolerance = TimeSpan.FromSeconds(3); // Consider increasing tolerance, if test fails transiently in different test/build environments.
+        TimeSpan tolerance = TimeSpan.FromSeconds(3);
 
         Stopwatch watch = Stopwatch.StartNew();
 
@@ -308,7 +308,7 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
         var policy = Policy.TimeoutAsync<ResultPrimitive>(timeout, TimeoutStrategy.Optimistic);
         var userCancellationToken = CancellationToken;
 
-        TimeSpan tolerance = TimeSpan.FromSeconds(3); // Consider increasing tolerance, if test fails transiently in different test/build environments.
+        TimeSpan tolerance = TimeSpan.FromSeconds(3);
 
         Stopwatch watch = Stopwatch.StartNew();
         await Should.ThrowAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(async ct =>
@@ -561,7 +561,7 @@ public class TimeoutTResultAsyncSpecs : TimeoutSpecsBase
             return TaskHelper.EmptyTask;
         };
 
-        TimeSpan shimTimespan = TimeSpan.FromSeconds(1); // Consider increasing shimTimeSpan if test fails transiently in different environments.
+        TimeSpan shimTimespan = TimeSpan.FromSeconds(1);
         TimeSpan thriceShimTimeSpan = shimTimespan + shimTimespan + shimTimespan;
         var policy = Policy.TimeoutAsync<ResultPrimitive>(shimTimespan, TimeoutStrategy.Pessimistic, onTimeoutAsync);
 

--- a/test/Polly.Specs/Timeout/TimeoutTResultSpecs.cs
+++ b/test/Polly.Specs/Timeout/TimeoutTResultSpecs.cs
@@ -256,7 +256,7 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         TimeSpan timeout = TimeSpan.FromSeconds(1);
         var policy = Policy.Timeout<ResultPrimitive>(timeout, TimeoutStrategy.Pessimistic);
 
-        TimeSpan tolerance = TimeSpan.FromSeconds(3); // Consider increasing tolerance, if test fails transiently in different test/build environments.
+        TimeSpan tolerance = TimeSpan.FromSeconds(3);
 
         Stopwatch watch = Stopwatch.StartNew();
 
@@ -591,7 +591,7 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         Func<Context, TimeSpan> timeoutProvider = ctx => (TimeSpan)ctx["timeout"];
 
         TimeSpan? timeoutPassedToOnTimeout = null;
-        Action<Context, TimeSpan, Task> onTimeout = (_, span, _) => { timeoutPassedToOnTimeout = span; };
+        Action<Context, TimeSpan, Task> onTimeout = (_, span, _) => timeoutPassedToOnTimeout = span;
         var policy = Policy.Timeout<ResultPrimitive>(timeoutProvider, TimeoutStrategy.Pessimistic, onTimeout);
 
         // Supply a programatically-controlled timeout, via the execution context.
@@ -732,7 +732,7 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         Func<TimeSpan> timeoutFunc = () => TimeSpan.FromMilliseconds(25 * programaticallyControlledDelay);
 
         TimeSpan? timeoutPassedToOnTimeout = null;
-        Action<Context, TimeSpan, Task> onTimeout = (_, span, _) => { timeoutPassedToOnTimeout = span; };
+        Action<Context, TimeSpan, Task> onTimeout = (_, span, _) => timeoutPassedToOnTimeout = span;
 
         var policy = Policy.Timeout<ResultPrimitive>(timeoutFunc, TimeoutStrategy.Optimistic, onTimeout);
         var userCancellationToken = CancellationToken;
@@ -755,7 +755,7 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         Func<Context, TimeSpan> timeoutProvider = ctx => (TimeSpan)ctx["timeout"];
 
         TimeSpan? timeoutPassedToOnTimeout = null;
-        Action<Context, TimeSpan, Task> onTimeout = (_, span, _) => { timeoutPassedToOnTimeout = span; };
+        Action<Context, TimeSpan, Task> onTimeout = (_, span, _) => timeoutPassedToOnTimeout = span;
         var policy = Policy.Timeout<ResultPrimitive>(timeoutProvider, TimeoutStrategy.Optimistic, onTimeout);
         var userCancellationToken = CancellationToken;
 
@@ -778,7 +778,7 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
     public void Should_call_ontimeout_but_not_with_task_wrapping_abandoned_action__optimistic()
     {
         Task? taskPassedToOnTimeout = null;
-        Action<Context, TimeSpan, Task> onTimeout = (_, _, task) => { taskPassedToOnTimeout = task; };
+        Action<Context, TimeSpan, Task> onTimeout = (_, _, task) => taskPassedToOnTimeout = task;
 
         TimeSpan timeout = TimeSpan.FromMilliseconds(250);
         var policy = Policy.Timeout<ResultPrimitive>(timeout, TimeoutStrategy.Optimistic, onTimeout);
@@ -799,7 +799,7 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         TimeSpan timeoutPassedToConfiguration = TimeSpan.FromMilliseconds(250);
 
         Exception? exceptionPassedToOnTimeout = null;
-        Action<Context, TimeSpan, Task, Exception> onTimeout = (_, _, _, exception) => { exceptionPassedToOnTimeout = exception; };
+        Action<Context, TimeSpan, Task, Exception> onTimeout = (_, _, _, exception) => exceptionPassedToOnTimeout = exception;
 
         var policy = Policy.Timeout<ResultPrimitive>(timeoutPassedToConfiguration, TimeoutStrategy.Optimistic, onTimeout);
         var userCancellationToken = CancellationToken;

--- a/test/Polly.Specs/Wrap/PolicyWrapAsyncSpecs.cs
+++ b/test/Polly.Specs/Wrap/PolicyWrapAsyncSpecs.cs
@@ -455,7 +455,7 @@ public class PolicyWrapAsyncSpecs
         AsyncPolicyWrap wrap = outerHandlingANE.WrapAsync(innerHandlingDBZE);
 
         PolicyResult executeAndCaptureResultOnPolicyWrap =
-            await wrap.ExecuteAndCaptureAsync(() => { throw new ArgumentNullException(); });
+            await wrap.ExecuteAndCaptureAsync(() => throw new ArgumentNullException());
 
         executeAndCaptureResultOnPolicyWrap.Outcome.ShouldBe(OutcomeType.Failure);
         executeAndCaptureResultOnPolicyWrap.FinalException.ShouldBeOfType<ArgumentNullException>();
@@ -474,7 +474,7 @@ public class PolicyWrapAsyncSpecs
         AsyncPolicyWrap wrap = outerHandlingANE.WrapAsync(innerHandlingDBZE);
 
         PolicyResult executeAndCaptureResultOnPolicyWrap =
-            await wrap.ExecuteAndCaptureAsync(() => { throw new DivideByZeroException(); });
+            await wrap.ExecuteAndCaptureAsync(() => throw new DivideByZeroException());
 
         executeAndCaptureResultOnPolicyWrap.Outcome.ShouldBe(OutcomeType.Failure);
         executeAndCaptureResultOnPolicyWrap.FinalException.ShouldBeOfType<DivideByZeroException>();
@@ -492,7 +492,7 @@ public class PolicyWrapAsyncSpecs
             .CircuitBreakerAsync(1, TimeSpan.Zero);
         AsyncPolicyWrap<ResultPrimitive> wrap = outerHandlingANE.WrapAsync(innerHandlingDBZE);
 
-        PolicyResult<ResultPrimitive> executeAndCaptureResultOnPolicyWrap = await wrap.ExecuteAndCaptureAsync(() => { throw new ArgumentNullException(); });
+        PolicyResult<ResultPrimitive> executeAndCaptureResultOnPolicyWrap = await wrap.ExecuteAndCaptureAsync(() => throw new ArgumentNullException());
 
         executeAndCaptureResultOnPolicyWrap.Outcome.ShouldBe(OutcomeType.Failure);
         executeAndCaptureResultOnPolicyWrap.FinalException.ShouldBeOfType<ArgumentNullException>();
@@ -511,7 +511,7 @@ public class PolicyWrapAsyncSpecs
             .CircuitBreakerAsync(1, TimeSpan.Zero);
         AsyncPolicyWrap<ResultPrimitive> wrap = outerHandlingANE.WrapAsync(innerHandlingDBZE);
 
-        PolicyResult<ResultPrimitive> executeAndCaptureResultOnPolicyWrap = await wrap.ExecuteAndCaptureAsync(() => { throw new DivideByZeroException(); });
+        PolicyResult<ResultPrimitive> executeAndCaptureResultOnPolicyWrap = await wrap.ExecuteAndCaptureAsync(() => throw new DivideByZeroException());
 
         executeAndCaptureResultOnPolicyWrap.Outcome.ShouldBe(OutcomeType.Failure);
         executeAndCaptureResultOnPolicyWrap.FinalException.ShouldBeOfType<DivideByZeroException>();

--- a/test/Polly.Specs/Wrap/PolicyWrapContextAndKeyAsyncSpecs.cs
+++ b/test/Polly.Specs/Wrap/PolicyWrapContextAndKeyAsyncSpecs.cs
@@ -13,10 +13,7 @@ public class PolicyWrapContextAndKeyAsyncSpecs
         string wrapKey = Guid.NewGuid().ToString();
 
         string? policyWrapKeySetOnExecutionContext = null;
-        Action<Exception, int, Context> onRetry = (_, _, context) =>
-        {
-            policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
-        };
+        Action<Exception, int, Context> onRetry = (_, _, context) => policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
 
         var retry = Policy.Handle<Exception>().RetryAsync(1, onRetry).WithPolicyKey(retryKey);
         var breaker = Policy.Handle<Exception>().CircuitBreakerAsync(1, TimeSpan.Zero).WithPolicyKey(breakerKey);
@@ -38,10 +35,7 @@ public class PolicyWrapContextAndKeyAsyncSpecs
         string wrapKey = Guid.NewGuid().ToString();
 
         string? policyWrapKeySetOnExecutionContext = null;
-        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) =>
-        {
-            policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
-        };
+        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) => policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
         Action<Context> onReset = _ => { };
 
         var retry = Policy.Handle<Exception>().RetryAsync(1).WithPolicyKey(retryKey);
@@ -122,10 +116,7 @@ public class PolicyWrapContextAndKeyAsyncSpecs
         string outerWrapKey = Guid.NewGuid().ToString();
 
         string? policyWrapKeySetOnExecutionContext = null;
-        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) =>
-        {
-            policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
-        };
+        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) => policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
         Action<Context> doNothingOnReset = _ => { };
 
         var retry = Policy.Handle<Exception>().RetryAsync(1).WithPolicyKey(retryKey);
@@ -154,10 +145,7 @@ public class PolicyWrapContextAndKeyAsyncSpecs
         string outerWrapKey = Guid.NewGuid().ToString();
 
         string? policyWrapKeySetOnExecutionContext = null;
-        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) =>
-        {
-            policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
-        };
+        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) => policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
         Action<Context> doNothingOnReset = _ => { };
 
         var retry = Policy.Handle<Exception>().RetryAsync(1).WithPolicyKey(retryKey);
@@ -204,10 +192,7 @@ public class PolicyWrapTResultContextAndKeyAsyncSpecs
         string wrapKey = Guid.NewGuid().ToString();
 
         string? policyWrapKeySetOnExecutionContext = null;
-        Action<DelegateResult<ResultPrimitive>, int, Context> onRetry = (_, _, context) =>
-        {
-            policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
-        };
+        Action<DelegateResult<ResultPrimitive>, int, Context> onRetry = (_, _, context) => policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
 
         var retry = Policy.HandleResult(ResultPrimitive.Fault).RetryAsync(1, onRetry).WithPolicyKey(retryKey);
         var breaker = Policy.HandleResult(ResultPrimitive.Fault).CircuitBreakerAsync(1, TimeSpan.Zero).WithPolicyKey(breakerKey);
@@ -228,10 +213,7 @@ public class PolicyWrapTResultContextAndKeyAsyncSpecs
         string wrapKey = Guid.NewGuid().ToString();
 
         string? policyWrapKeySetOnExecutionContext = null;
-        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (_, _, context) =>
-        {
-            policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
-        };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (_, _, context) => policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
         Action<Context> onReset = _ => { };
 
         var retry = Policy.HandleResult(ResultPrimitive.Fault).RetryAsync(1).WithPolicyKey(retryKey);
@@ -315,10 +297,7 @@ public class PolicyWrapTResultContextAndKeyAsyncSpecs
         string outerWrapKey = Guid.NewGuid().ToString();
 
         string? policyWrapKeySetOnExecutionContext = null;
-        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (_, _, context) =>
-        {
-            policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
-        };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (_, _, context) => policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
         Action<Context> doNothingOnReset = _ => { };
 
         var retry = Policy.HandleResult(ResultPrimitive.Fault).RetryAsync(1).WithPolicyKey(retryKey);

--- a/test/Polly.Specs/Wrap/PolicyWrapContextAndKeySpecs.cs
+++ b/test/Polly.Specs/Wrap/PolicyWrapContextAndKeySpecs.cs
@@ -13,10 +13,7 @@ public class PolicyWrapContextAndKeySpecs
         string wrapKey = Guid.NewGuid().ToString();
 
         string? policyWrapKeySetOnExecutionContext = null;
-        Action<Exception, int, Context> onRetry = (_, _, context) =>
-        {
-            policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
-        };
+        Action<Exception, int, Context> onRetry = (_, _, context) => policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
 
         var retry = Policy.Handle<Exception>().Retry(1, onRetry).WithPolicyKey(retryKey);
         var breaker = Policy.Handle<Exception>().CircuitBreaker(1, TimeSpan.Zero).WithPolicyKey(breakerKey);
@@ -38,10 +35,7 @@ public class PolicyWrapContextAndKeySpecs
         string wrapKey = Guid.NewGuid().ToString();
 
         string? policyWrapKeySetOnExecutionContext = null;
-        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) =>
-        {
-            policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
-        };
+        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) => policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
         Action<Context> onReset = _ => { };
 
         var retry = Policy.Handle<Exception>().Retry(1).WithPolicyKey(retryKey);
@@ -93,10 +87,7 @@ public class PolicyWrapContextAndKeySpecs
         string outerWrapKey = Guid.NewGuid().ToString();
 
         string? policyWrapKeySetOnExecutionContext = null;
-        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) =>
-        {
-            policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
-        };
+        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) => policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
         Action<Context> doNothingOnReset = _ => { };
 
         var retry = Policy.Handle<Exception>().Retry(1).WithPolicyKey(retryKey);
@@ -125,10 +116,7 @@ public class PolicyWrapContextAndKeySpecs
         string outerWrapKey = Guid.NewGuid().ToString();
 
         string? policyWrapKeySetOnExecutionContext = null;
-        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) =>
-        {
-            policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
-        };
+        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) => policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
         Action<Context> doNothingOnReset = _ => { };
 
         var retry = Policy.Handle<Exception>().Retry(1).WithPolicyKey(retryKey);
@@ -171,10 +159,7 @@ public class PolicyWrapTResultContextAndKeySpecs
         string wrapKey = Guid.NewGuid().ToString();
 
         string? policyWrapKeySetOnExecutionContext = null;
-        Action<DelegateResult<ResultPrimitive>, int, Context> onRetry = (_, _, context) =>
-        {
-            policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
-        };
+        Action<DelegateResult<ResultPrimitive>, int, Context> onRetry = (_, _, context) => policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
 
         var retry = Policy.HandleResult(ResultPrimitive.Fault).Retry(1, onRetry).WithPolicyKey(retryKey);
         var breaker = Policy.HandleResult(ResultPrimitive.Fault).CircuitBreaker(1, TimeSpan.Zero).WithPolicyKey(breakerKey);
@@ -195,10 +180,7 @@ public class PolicyWrapTResultContextAndKeySpecs
         string wrapKey = Guid.NewGuid().ToString();
 
         string? policyWrapKeySetOnExecutionContext = null;
-        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (_, _, context) =>
-        {
-            policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
-        };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (_, _, context) => policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
         Action<Context> onReset = _ => { };
 
         var retry = Policy.HandleResult(ResultPrimitive.Fault).Retry(1).WithPolicyKey(retryKey);
@@ -217,7 +199,7 @@ public class PolicyWrapTResultContextAndKeySpecs
     {
         ISyncPolicy<ResultPrimitive> fallback = Policy<ResultPrimitive>
             .Handle<Exception>()
-            .Fallback<ResultPrimitive>(ResultPrimitive.Undefined, onFallback: (_, context) =>
+            .Fallback(ResultPrimitive.Undefined, onFallback: (_, context) =>
             {
                 context.PolicyWrapKey.ShouldBe("PolicyWrap");
                 context.PolicyKey.ShouldBe("FallbackPolicy");
@@ -249,10 +231,7 @@ public class PolicyWrapTResultContextAndKeySpecs
         string outerWrapKey = Guid.NewGuid().ToString();
 
         string? policyWrapKeySetOnExecutionContext = null;
-        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (_, _, context) =>
-        {
-            policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
-        };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (_, _, context) => policyWrapKeySetOnExecutionContext = context.PolicyWrapKey;
         Action<Context> doNothingOnReset = _ => { };
 
         var retry = Policy.HandleResult(ResultPrimitive.Fault).Retry(1).WithPolicyKey(retryKey);

--- a/test/Polly.Specs/Wrap/PolicyWrapSpecs.cs
+++ b/test/Polly.Specs/Wrap/PolicyWrapSpecs.cs
@@ -320,7 +320,7 @@ public class PolicyWrapSpecs
     {
         Policy<int> retry = Policy<int>.Handle<Exception>().Retry();
         Policy<int> breaker = Policy<int>.Handle<Exception>().CircuitBreaker(1, TimeSpan.FromSeconds(10));
-        Action config = () => Policy.Wrap<int>(retry, breaker);
+        Action config = () => Policy.Wrap(retry, breaker);
 
         Should.NotThrow(config);
     }
@@ -456,7 +456,7 @@ public class PolicyWrapSpecs
             .CircuitBreaker(1, TimeSpan.Zero);
         PolicyWrap wrap = outerHandlingANE.Wrap(innerHandlingDBZE);
 
-        PolicyResult executeAndCaptureResultOnPolicyWrap = wrap.ExecuteAndCapture(() => { throw new ArgumentNullException(); });
+        PolicyResult executeAndCaptureResultOnPolicyWrap = wrap.ExecuteAndCapture(() => throw new ArgumentNullException());
 
         executeAndCaptureResultOnPolicyWrap.Outcome.ShouldBe(OutcomeType.Failure);
         executeAndCaptureResultOnPolicyWrap.FinalException.ShouldBeOfType<ArgumentNullException>();
@@ -474,7 +474,7 @@ public class PolicyWrapSpecs
             .CircuitBreaker(1, TimeSpan.Zero);
         PolicyWrap wrap = outerHandlingANE.Wrap(innerHandlingDBZE);
 
-        PolicyResult executeAndCaptureResultOnPolicyWrap = wrap.ExecuteAndCapture(() => { throw new DivideByZeroException(); });
+        PolicyResult executeAndCaptureResultOnPolicyWrap = wrap.ExecuteAndCapture(() => throw new DivideByZeroException());
 
         executeAndCaptureResultOnPolicyWrap.Outcome.ShouldBe(OutcomeType.Failure);
         executeAndCaptureResultOnPolicyWrap.FinalException.ShouldBeOfType<DivideByZeroException>();
@@ -492,7 +492,7 @@ public class PolicyWrapSpecs
             .CircuitBreaker(1, TimeSpan.Zero);
         PolicyWrap<ResultPrimitive> wrap = outerHandlingANE.Wrap(innerHandlingDBZE);
 
-        PolicyResult<ResultPrimitive> executeAndCaptureResultOnPolicyWrap = wrap.ExecuteAndCapture(() => { throw new ArgumentNullException(); });
+        PolicyResult<ResultPrimitive> executeAndCaptureResultOnPolicyWrap = wrap.ExecuteAndCapture(() => throw new ArgumentNullException());
 
         executeAndCaptureResultOnPolicyWrap.Outcome.ShouldBe(OutcomeType.Failure);
         executeAndCaptureResultOnPolicyWrap.FinalException.ShouldBeOfType<ArgumentNullException>();
@@ -511,7 +511,7 @@ public class PolicyWrapSpecs
             .CircuitBreaker(1, TimeSpan.Zero);
         PolicyWrap<ResultPrimitive> wrap = outerHandlingANE.Wrap(innerHandlingDBZE);
 
-        PolicyResult<ResultPrimitive> executeAndCaptureResultOnPolicyWrap = wrap.ExecuteAndCapture(() => { throw new DivideByZeroException(); });
+        PolicyResult<ResultPrimitive> executeAndCaptureResultOnPolicyWrap = wrap.ExecuteAndCapture(() => throw new DivideByZeroException());
 
         executeAndCaptureResultOnPolicyWrap.Outcome.ShouldBe(OutcomeType.Failure);
         executeAndCaptureResultOnPolicyWrap.FinalException.ShouldBeOfType<DivideByZeroException>();

--- a/test/Polly.TestUtils/Polly.TestUtils.csproj
+++ b/test/Polly.TestUtils/Polly.TestUtils.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net481</TargetFrameworks>
     <ProjectType>Library</ProjectType>
     <Nullable>enable</Nullable>
-    <NoWarn>$(NoWarn);SA1600;SA1204;CA1062</NoWarn>
     <IsPackable>false</IsPackable>
     <EnablePackageValidation>false</EnablePackageValidation>
     <UsePublicApiAnalyzers>false</UsePublicApiAnalyzers>

--- a/test/Polly.Testing.Tests/Polly.Testing.Tests.csproj
+++ b/test/Polly.Testing.Tests/Polly.Testing.Tests.csproj
@@ -5,7 +5,6 @@
     <ProjectType>Test</ProjectType>
     <Nullable>enable</Nullable>
     <Threshold>100</Threshold>
-    <NoWarn>$(NoWarn);SA1600;SA1204</NoWarn>
     <Include>[Polly.Testing]*</Include>
   </PropertyGroup>
 


### PR DESCRIPTION
Tidies up various bits of code in Polly.Specs.

- Suppress CA1062, SA1204 and SA1600 warnings centrally for test projects.
- Suppress S104 and S6966 in editorconfig.
- Suppress the CA1030, CA2008 and CA2201 warnings in Polly.Specs.
- Suppress CA1031 at the two usages and re-enable.
- Apply various IDE suggestions to simplify/modernise code.

Contributes to #1290.
