### PR TITLE
Cleanup the Polly and Polly.Specs codebase

### DIFF
--- a/src/Polly/AsyncPolicy.ExecuteOverloads.cs
+++ b/src/Polly/AsyncPolicy.ExecuteOverloads.cs
@@ -511,7 +511,9 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
             await ExecuteAsync(action, context, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
             return PolicyResult.Successful(context);
         }
+#pragma warning disable CA1031
         catch (Exception exception)
+#pragma warning restore CA1031
         {
             return PolicyResult.Failure(exception, GetExceptionType(ExceptionPredicates, exception), context);
         }
@@ -529,7 +531,9 @@ public abstract partial class AsyncPolicy : PolicyBase, IAsyncPolicy
                 await ExecuteAsync(action, context, cancellationToken, continueOnCapturedContext)
                     .ConfigureAwait(continueOnCapturedContext), context);
         }
+#pragma warning disable CA1031
         catch (Exception exception)
+#pragma warning restore CA1031
         {
             return PolicyResult<TResult>.Failure(exception, GetExceptionType(ExceptionPredicates, exception), context);
         }

--- a/src/Polly/AsyncPolicy.TResult.ExecuteOverloads.cs
+++ b/src/Polly/AsyncPolicy.TResult.ExecuteOverloads.cs
@@ -259,7 +259,9 @@ public abstract partial class AsyncPolicy<TResult> : IAsyncPolicy<TResult>
 
             return PolicyResult<TResult>.Successful(result, context);
         }
+#pragma warning disable CA1031
         catch (Exception exception)
+#pragma warning restore CA1031
         {
             return PolicyResult<TResult>.Failure(exception, GetExceptionType(ExceptionPredicates, exception), context);
         }

--- a/src/Polly/Bulkhead/AsyncBulkheadPolicy.cs
+++ b/src/Polly/Bulkhead/AsyncBulkheadPolicy.cs
@@ -4,7 +4,9 @@ namespace Polly.Bulkhead;
 /// <summary>
 /// A bulkhead-isolation policy which can be applied to delegates.
 /// </summary>
+#pragma warning disable CA1063
 public class AsyncBulkheadPolicy : AsyncPolicy, IBulkheadPolicy
+#pragma warning restore CA1063
 {
     private readonly SemaphoreSlim _maxParallelizationSemaphore;
     private readonly SemaphoreSlim _maxQueuedActionsSemaphore;
@@ -68,7 +70,9 @@ public class AsyncBulkheadPolicy : AsyncPolicy, IBulkheadPolicy
 /// A bulkhead-isolation policy which can be applied to delegates.
 /// </summary>
 /// <typeparam name="TResult">The return type of delegates which may be executed through the policy.</typeparam>
+#pragma warning disable CA1063
 public class AsyncBulkheadPolicy<TResult> : AsyncPolicy<TResult>, IBulkheadPolicy<TResult>
+#pragma warning restore CA1063
 {
     private readonly SemaphoreSlim _maxParallelizationSemaphore;
     private readonly SemaphoreSlim _maxQueuedActionsSemaphore;

--- a/src/Polly/Bulkhead/AsyncBulkheadPolicy.cs
+++ b/src/Polly/Bulkhead/AsyncBulkheadPolicy.cs
@@ -57,8 +57,10 @@ public class AsyncBulkheadPolicy : AsyncPolicy, IBulkheadPolicy
             cancellationToken);
     }
 
+#pragma warning disable CA1063
     /// <inheritdoc/>
     public void Dispose()
+#pragma warning restore CA1063
     {
         _maxParallelizationSemaphore.Dispose();
         _maxQueuedActionsSemaphore.Dispose();
@@ -123,8 +125,10 @@ public class AsyncBulkheadPolicy<TResult> : AsyncPolicy<TResult>, IBulkheadPolic
     /// </summary>
     public int QueueAvailableCount => Math.Min(_maxQueuedActionsSemaphore.CurrentCount, _maxQueueingActions);
 
+#pragma warning disable CA1063
     /// <inheritdoc/>
     public void Dispose()
+#pragma warning restore CA1063
     {
         _maxParallelizationSemaphore.Dispose();
         _maxQueuedActionsSemaphore.Dispose();

--- a/src/Polly/Bulkhead/AsyncBulkheadSyntax.cs
+++ b/src/Polly/Bulkhead/AsyncBulkheadSyntax.cs
@@ -1,7 +1,9 @@
 #nullable enable
 namespace Polly;
 
+#pragma warning disable CA1724
 public partial class Policy
+#pragma warning restore CA1724
 {
     /// <summary>
     /// <para>Builds a bulkhead isolation <see cref="Policy"/>, which limits the maximum concurrency of actions executed through the policy.  Imposing a maximum concurrency limits the potential of governed actions, when faulting, to bring down the system.</para>

--- a/src/Polly/Bulkhead/BulkheadPolicy.cs
+++ b/src/Polly/Bulkhead/BulkheadPolicy.cs
@@ -4,7 +4,9 @@ namespace Polly.Bulkhead;
 /// <summary>
 /// A bulkhead-isolation policy which can be applied to delegates.
 /// </summary>
+#pragma warning disable CA1063
 public class BulkheadPolicy : Policy, IBulkheadPolicy
+#pragma warning restore CA1063
 {
     private readonly SemaphoreSlim _maxParallelizationSemaphore;
     private readonly SemaphoreSlim _maxQueuedActionsSemaphore;
@@ -66,7 +68,9 @@ public class BulkheadPolicy : Policy, IBulkheadPolicy
 /// A bulkhead-isolation policy which can be applied to delegates returning a value of type <typeparamref name="TResult"/>.
 /// </summary>
 /// <typeparam name="TResult">The type of the result.</typeparam>
+#pragma warning disable CA1063
 public class BulkheadPolicy<TResult> : Policy<TResult>, IBulkheadPolicy<TResult>
+#pragma warning restore CA1063
 {
     private readonly SemaphoreSlim _maxParallelizationSemaphore;
     private readonly SemaphoreSlim _maxQueuedActionsSemaphore;

--- a/src/Polly/Bulkhead/BulkheadPolicy.cs
+++ b/src/Polly/Bulkhead/BulkheadPolicy.cs
@@ -52,11 +52,13 @@ public class BulkheadPolicy : Policy, IBulkheadPolicy
     /// </summary>
     public int QueueAvailableCount => Math.Min(_maxQueuedActionsSemaphore.CurrentCount, _maxQueueingActions);
 
+#pragma warning disable CA1063
     /// <summary>
     /// Disposes of the <see cref="BulkheadPolicy"/>, allowing it to dispose its internal resources.
     /// <remarks>Only call <see cref="Dispose()"/> on a <see cref="BulkheadPolicy"/> after all actions executed through the policy have completed.  If actions are still executing through the policy when <see cref="Dispose()"/> is called, an <see cref="ObjectDisposedException"/> may be thrown on the actions' threads when those actions complete.</remarks>
     /// </summary>
     public void Dispose()
+#pragma warning restore CA1063
     {
         _maxParallelizationSemaphore.Dispose();
         _maxQueuedActionsSemaphore.Dispose();
@@ -115,11 +117,13 @@ public class BulkheadPolicy<TResult> : Policy<TResult>, IBulkheadPolicy<TResult>
     /// </summary>
     public int QueueAvailableCount => Math.Min(_maxQueuedActionsSemaphore.CurrentCount, _maxQueueingActions);
 
+#pragma warning disable CA1063
     /// <summary>
     /// Disposes of the <see cref="BulkheadPolicy"/>, allowing it to dispose its internal resources.
     /// <remarks>Only call <see cref="Dispose()"/> on a <see cref="BulkheadPolicy"/> after all actions executed through the policy have completed.  If actions are still executing through the policy when <see cref="Dispose()"/> is called, an <see cref="ObjectDisposedException"/> may be thrown on the actions' threads when those actions complete.</remarks>
     /// </summary>
     public void Dispose()
+#pragma warning restore CA1063
     {
         _maxParallelizationSemaphore.Dispose();
         _maxQueuedActionsSemaphore.Dispose();

--- a/src/Polly/Caching/AsyncCacheEngine.cs
+++ b/src/Polly/Caching/AsyncCacheEngine.cs
@@ -32,7 +32,9 @@ internal static class AsyncCacheEngine
         {
             (cacheHit, valueFromCache) = await cacheProvider.TryGetAsync(cacheKey, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
         }
+#pragma warning disable CA1031
         catch (Exception ex)
+#pragma warning restore CA1031
         {
             cacheHit = false;
             valueFromCache = default;
@@ -59,7 +61,9 @@ internal static class AsyncCacheEngine
                 await cacheProvider.PutAsync(cacheKey, result, ttl, cancellationToken, continueOnCapturedContext).ConfigureAwait(continueOnCapturedContext);
                 onCachePut(context, cacheKey);
             }
+#pragma warning disable CA1031
             catch (Exception ex)
+#pragma warning restore CA1031
             {
                 onCachePutError?.Invoke(context, cacheKey, ex);
             }

--- a/src/Polly/Caching/CacheEngine.cs
+++ b/src/Polly/Caching/CacheEngine.cs
@@ -31,7 +31,9 @@ internal static class CacheEngine
         {
             (cacheHit, valueFromCache) = cacheProvider.TryGet(cacheKey);
         }
+#pragma warning disable CA1031
         catch (Exception ex)
+#pragma warning restore CA1031
         {
             cacheHit = false;
             valueFromCache = default;
@@ -58,7 +60,9 @@ internal static class CacheEngine
                 cacheProvider.Put(cacheKey, result, ttl);
                 onCachePut(context, cacheKey);
             }
+#pragma warning disable CA1031
             catch (Exception ex)
+#pragma warning restore CA1031
             {
                 onCachePutError?.Invoke(context, cacheKey, ex);
             }

--- a/src/Polly/Caching/NonSlidingTtl.cs
+++ b/src/Polly/Caching/NonSlidingTtl.cs
@@ -6,11 +6,13 @@ namespace Polly.Caching;
 /// </summary>
 public abstract class NonSlidingTtl : ITtlStrategy
 {
+#pragma warning disable CA1051 // Do not declare visible instance fields
 #pragma warning disable IDE1006
     /// <summary>
     /// The absolute expiration time for cache items, represented by this strategy.
     /// </summary>
     protected readonly DateTimeOffset absoluteExpirationTime;
+#pragma warning restore CA1051 // Do not declare visible instance fields
 #pragma warning restore IDE1006
 
     /// <summary>

--- a/src/Polly/Caching/Ttl.cs
+++ b/src/Polly/Caching/Ttl.cs
@@ -8,15 +8,19 @@ namespace Polly.Caching;
 public struct Ttl
 #pragma warning restore CA1815
 {
+#pragma warning disable CA1051 // Do not declare visible instance fields
     /// <summary>
     /// The timespan for which this cache-item remains valid.
     /// </summary>
     public TimeSpan Timespan;
+#pragma warning restore CA1051 // Do not declare visible instance fields
 
+#pragma warning disable CA1051 // Do not declare visible instance fields
     /// <summary>
     /// Whether this <see cref="Ttl"/> should be considered as sliding expiration: that is, the cache item should be considered valid for a further period of duration <see cref="Timespan"/> each time the cache item is retrieved.
     /// </summary>
     public bool SlidingExpiration;
+#pragma warning restore CA1051 // Do not declare visible instance fields
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Ttl"/> struct.

--- a/src/Polly/Policy.ContextAndKeys.cs
+++ b/src/Polly/Policy.ContextAndKeys.cs
@@ -37,7 +37,9 @@ public abstract partial class Policy
     }
 }
 
+#pragma warning disable CA1724
 public abstract partial class Policy<TResult>
+#pragma warning restore CA1724
 {
     /// <summary>
     /// Sets the PolicyKey for this <see cref="Policy{TResult}"/> instance.

--- a/src/Polly/Policy.ExecuteOverloads.cs
+++ b/src/Polly/Policy.ExecuteOverloads.cs
@@ -242,7 +242,9 @@ public abstract partial class Policy : ISyncPolicy
             Execute(action, context, cancellationToken);
             return PolicyResult.Successful(context);
         }
+#pragma warning disable CA1031
         catch (Exception exception)
+#pragma warning restore CA1031
         {
             return PolicyResult.Failure(exception, GetExceptionType(ExceptionPredicates, exception), context);
         }
@@ -327,7 +329,9 @@ public abstract partial class Policy : ISyncPolicy
         {
             return PolicyResult<TResult>.Successful(Execute(action, context, cancellationToken), context);
         }
+#pragma warning disable CA1031
         catch (Exception exception)
+#pragma warning restore CA1031
         {
             return PolicyResult<TResult>.Failure(exception, GetExceptionType(ExceptionPredicates, exception), context);
         }

--- a/src/Polly/Policy.TResult.ExecuteOverloads.cs
+++ b/src/Polly/Policy.TResult.ExecuteOverloads.cs
@@ -167,7 +167,9 @@ public abstract partial class Policy<TResult> : ISyncPolicy<TResult>
 
             return PolicyResult<TResult>.Successful(result, context);
         }
+#pragma warning disable CA1031
         catch (Exception exception)
+#pragma warning restore CA1031
         {
             return PolicyResult<TResult>.Failure(exception, GetExceptionType(ExceptionPredicates, exception), context);
         }

--- a/src/Polly/PolicyBase.ContextAndKeys.cs
+++ b/src/Polly/PolicyBase.ContextAndKeys.cs
@@ -2,17 +2,19 @@
 
 public abstract partial class PolicyBase
 {
+#pragma warning disable CA1051 // Do not declare visible instance fields
 #pragma warning disable IDE1006
     /// <summary>
     /// A key intended to be unique to each <see cref="IsPolicy"/> instance.
     /// </summary>
     protected string policyKeyInternal;
+#pragma warning restore CA1051 // Do not declare visible instance fields
 #pragma warning restore IDE1006
 
     /// <summary>
     /// Gets a key intended to be unique to each <see cref="IsPolicy"/> instance, which is passed with executions as the <see cref="Context.PolicyKey"/> property.
     /// </summary>
-    public string PolicyKey => policyKeyInternal ?? (policyKeyInternal = GetType().Name + "-" + KeyHelper.GuidPart());
+    public string PolicyKey => policyKeyInternal ??= GetType().Name + "-" + KeyHelper.GuidPart();
 
     internal static ArgumentException PolicyKeyMustBeImmutableException(string policyKeyParamName) => new("PolicyKey cannot be changed once set; or (when using the default value after the PolicyKey property has been accessed.", policyKeyParamName);
 

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -7,7 +7,7 @@
     <ProjectType>Library</ProjectType>
     <MutationScore>70</MutationScore>
     <IncludePollyUsings>true</IncludePollyUsings>
-    <NoWarn>$(NoWarn);CA1031;CA1051;CA1063;CA1064;CA1724</NoWarn>
+    <NoWarn>$(NoWarn);CA1031;CA1063;CA1064;CA1724</NoWarn>
     <!--Public API Analyzers: We do not need to fix these as it would break compatibility with released Polly versions-->
     <NoWarn>$(NoWarn);RS0037</NoWarn>
   </PropertyGroup>

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -7,10 +7,9 @@
     <ProjectType>Library</ProjectType>
     <MutationScore>70</MutationScore>
     <IncludePollyUsings>true</IncludePollyUsings>
-    <NoWarn>$(NoWarn);CA1031;CA1051;CA1063;CA1064;CA1724;</NoWarn>
-    <NoWarn>$(NoWarn);S2223</NoWarn>
+    <NoWarn>$(NoWarn);CA1031;CA1051;CA1063;CA1064;CA1724</NoWarn>
     <!--Public API Analyzers: We do not need to fix these as it would break compatibility with released Polly versions-->
-    <NoWarn>$(NoWarn);RS0037;</NoWarn>
+    <NoWarn>$(NoWarn);RS0037</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -7,8 +7,7 @@
     <ProjectType>Library</ProjectType>
     <MutationScore>70</MutationScore>
     <IncludePollyUsings>true</IncludePollyUsings>
-    <NoWarn>$(NoWarn);CA1063</NoWarn>
-    <!--Public API Analyzers: We do not need to fix these as it would break compatibility with released Polly versions-->
+    <!-- We do not plan on enabling nullable annotations for Polly -->
     <NoWarn>$(NoWarn);RS0037</NoWarn>
   </PropertyGroup>
 

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -7,7 +7,7 @@
     <ProjectType>Library</ProjectType>
     <MutationScore>70</MutationScore>
     <IncludePollyUsings>true</IncludePollyUsings>
-    <NoWarn>$(NoWarn);CA1031;CA1063;CA1064</NoWarn>
+    <NoWarn>$(NoWarn);CA1031;CA1063</NoWarn>
     <!--Public API Analyzers: We do not need to fix these as it would break compatibility with released Polly versions-->
     <NoWarn>$(NoWarn);RS0037</NoWarn>
   </PropertyGroup>

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -8,7 +8,7 @@
     <MutationScore>70</MutationScore>
     <IncludePollyUsings>true</IncludePollyUsings>
     <NoWarn>$(NoWarn);CA1031;CA1051;CA1063;CA1064;CA1724;</NoWarn>
-    <NoWarn>$(NoWarn);S2223;S3215;</NoWarn>
+    <NoWarn>$(NoWarn);S2223</NoWarn>
     <!--Public API Analyzers: We do not need to fix these as it would break compatibility with released Polly versions-->
     <NoWarn>$(NoWarn);RS0037;</NoWarn>
   </PropertyGroup>

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -7,7 +7,7 @@
     <ProjectType>Library</ProjectType>
     <MutationScore>70</MutationScore>
     <IncludePollyUsings>true</IncludePollyUsings>
-    <NoWarn>$(NoWarn);CA1031;CA1063;CA1064;CA1724</NoWarn>
+    <NoWarn>$(NoWarn);CA1031;CA1063;CA1064</NoWarn>
     <!--Public API Analyzers: We do not need to fix these as it would break compatibility with released Polly versions-->
     <NoWarn>$(NoWarn);RS0037</NoWarn>
   </PropertyGroup>

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -7,7 +7,7 @@
     <ProjectType>Library</ProjectType>
     <MutationScore>70</MutationScore>
     <IncludePollyUsings>true</IncludePollyUsings>
-    <NoWarn>$(NoWarn);CA1031;CA1063</NoWarn>
+    <NoWarn>$(NoWarn);CA1063</NoWarn>
     <!--Public API Analyzers: We do not need to fix these as it would break compatibility with released Polly versions-->
     <NoWarn>$(NoWarn);RS0037</NoWarn>
   </PropertyGroup>

--- a/src/Polly/Utilities/SystemClock.cs
+++ b/src/Polly/Utilities/SystemClock.cs
@@ -12,7 +12,9 @@ public static class SystemClock
     /// Allows the setting of a custom Thread.Sleep implementation for testing.
     /// By default this will use the <see cref="CancellationToken"/>'s <see cref="WaitHandle"/>.
     /// </summary>
+#pragma warning disable S2223 // Non-constant static fields should not be visible
     public static Action<TimeSpan, CancellationToken> Sleep = (timeSpan, cancellationToken) =>
+#pragma warning restore S2223 // Non-constant static fields should not be visible
     {
         if (cancellationToken.WaitHandle.WaitOne(timeSpan))
         {
@@ -24,25 +26,33 @@ public static class SystemClock
     /// Allows the setting of a custom async Sleep implementation for testing.
     /// By default this will be a call to <see cref="Task.Delay(TimeSpan)"/> taking a <see cref="CancellationToken"/>.
     /// </summary>
+#pragma warning disable S2223 // Non-constant static fields should not be visible
     public static Func<TimeSpan, CancellationToken, Task> SleepAsync = Task.Delay;
+#pragma warning restore S2223 // Non-constant static fields should not be visible
 
     /// <summary>
     /// Allows the setting of a custom DateTime.UtcNow implementation for testing.
     /// By default this will be a call to <see cref="DateTime.UtcNow"/>.
     /// </summary>
+#pragma warning disable S2223 // Non-constant static fields should not be visible
     public static Func<DateTime> UtcNow = () => DateTime.UtcNow;
+#pragma warning restore S2223 // Non-constant static fields should not be visible
 
     /// <summary>
     /// Allows the setting of a custom DateTimeOffset.UtcNow implementation for testing.
     /// By default this will be a call to <see cref="DateTime.UtcNow"/>.
     /// </summary>
+#pragma warning disable S2223 // Non-constant static fields should not be visible
     public static Func<DateTimeOffset> DateTimeOffsetUtcNow = () => DateTimeOffset.UtcNow;
+#pragma warning restore S2223 // Non-constant static fields should not be visible
 
     /// <summary>
     /// Allows the setting of a custom method for cancelling tokens after a timespan, for use in testing.
     /// By default this will be a call to CancellationTokenSource.CancelAfter(timespan).
     /// </summary>
+#pragma warning disable S2223 // Non-constant static fields should not be visible
     public static Action<CancellationTokenSource, TimeSpan> CancelTokenAfter = (tokenSource, timespan) => tokenSource.CancelAfter(timespan);
+#pragma warning restore S2223 // Non-constant static fields should not be visible
 
     /// <summary>
     /// Resets the custom implementations to their defaults.
@@ -65,6 +75,5 @@ public static class SystemClock
         DateTimeOffsetUtcNow = () => DateTimeOffset.UtcNow;
 
         CancelTokenAfter = (tokenSource, timespan) => tokenSource.CancelAfter(timespan);
-
     }
 }

--- a/src/Polly/Utilities/SystemClock.cs
+++ b/src/Polly/Utilities/SystemClock.cs
@@ -8,11 +8,11 @@ namespace Polly.Utilities;
 /// </summary>
 public static class SystemClock
 {
+#pragma warning disable S2223 // Non-constant static fields should not be visible
     /// <summary>
     /// Allows the setting of a custom Thread.Sleep implementation for testing.
     /// By default this will use the <see cref="CancellationToken"/>'s <see cref="WaitHandle"/>.
     /// </summary>
-#pragma warning disable S2223 // Non-constant static fields should not be visible
     public static Action<TimeSpan, CancellationToken> Sleep = (timeSpan, cancellationToken) =>
 #pragma warning restore S2223 // Non-constant static fields should not be visible
     {
@@ -22,35 +22,35 @@ public static class SystemClock
         }
     };
 
+#pragma warning disable S2223 // Non-constant static fields should not be visible
     /// <summary>
     /// Allows the setting of a custom async Sleep implementation for testing.
     /// By default this will be a call to <see cref="Task.Delay(TimeSpan)"/> taking a <see cref="CancellationToken"/>.
     /// </summary>
-#pragma warning disable S2223 // Non-constant static fields should not be visible
     public static Func<TimeSpan, CancellationToken, Task> SleepAsync = Task.Delay;
 #pragma warning restore S2223 // Non-constant static fields should not be visible
 
+#pragma warning disable S2223 // Non-constant static fields should not be visible
     /// <summary>
     /// Allows the setting of a custom DateTime.UtcNow implementation for testing.
     /// By default this will be a call to <see cref="DateTime.UtcNow"/>.
     /// </summary>
-#pragma warning disable S2223 // Non-constant static fields should not be visible
     public static Func<DateTime> UtcNow = () => DateTime.UtcNow;
 #pragma warning restore S2223 // Non-constant static fields should not be visible
 
+#pragma warning disable S2223 // Non-constant static fields should not be visible
     /// <summary>
     /// Allows the setting of a custom DateTimeOffset.UtcNow implementation for testing.
     /// By default this will be a call to <see cref="DateTime.UtcNow"/>.
     /// </summary>
-#pragma warning disable S2223 // Non-constant static fields should not be visible
     public static Func<DateTimeOffset> DateTimeOffsetUtcNow = () => DateTimeOffset.UtcNow;
 #pragma warning restore S2223 // Non-constant static fields should not be visible
 
+#pragma warning disable S2223 // Non-constant static fields should not be visible
     /// <summary>
     /// Allows the setting of a custom method for cancelling tokens after a timespan, for use in testing.
     /// By default this will be a call to CancellationTokenSource.CancelAfter(timespan).
     /// </summary>
-#pragma warning disable S2223 // Non-constant static fields should not be visible
     public static Action<CancellationTokenSource, TimeSpan> CancelTokenAfter = (tokenSource, timespan) => tokenSource.CancelAfter(timespan);
 #pragma warning restore S2223 // Non-constant static fields should not be visible
 

--- a/src/Polly/Utilities/TaskHelper.cs
+++ b/src/Polly/Utilities/TaskHelper.cs
@@ -7,6 +7,7 @@ namespace Polly.Utilities;
 public static class TaskHelper
 {
 #pragma warning disable CA2211 // Non-constant fields should not be visible
+#pragma warning disable S2223 // Non-constant static fields should not be visible
     /// <summary>
     /// Defines a completed Task for use as a completed, empty asynchronous delegate.
     /// </summary>

--- a/src/Polly/Utilities/TimedLock.cs
+++ b/src/Polly/Utilities/TimedLock.cs
@@ -93,7 +93,9 @@ internal readonly struct TimedLock : IDisposable
 #endif
 }
 
+#pragma warning disable CA1064 // Exceptions should be public
 internal sealed class LockTimeoutException : Exception
+#pragma warning restore CA1064 // Exceptions should be public
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="LockTimeoutException"/> class.

--- a/src/Polly/Wrap/IAsyncPolicyPolicyWrapExtensions.cs
+++ b/src/Polly/Wrap/IAsyncPolicyPolicyWrapExtensions.cs
@@ -18,7 +18,9 @@ public static class IAsyncPolicyPolicyWrapExtensions
             throw new ArgumentNullException(nameof(outerPolicy));
         }
 
+#pragma warning disable S3215 // "interface" instances should not be cast to concrete types
         return ((AsyncPolicy)outerPolicy).WrapAsync(innerPolicy);
+#pragma warning restore S3215 // "interface" instances should not be cast to concrete types
     }
 
     /// <summary>
@@ -35,7 +37,9 @@ public static class IAsyncPolicyPolicyWrapExtensions
             throw new ArgumentNullException(nameof(outerPolicy));
         }
 
+#pragma warning disable S3215 // "interface" instances should not be cast to concrete types
         return ((AsyncPolicy)outerPolicy).WrapAsync(innerPolicy);
+#pragma warning restore S3215 // "interface" instances should not be cast to concrete types
     }
 
     /// <summary>
@@ -52,7 +56,9 @@ public static class IAsyncPolicyPolicyWrapExtensions
             throw new ArgumentNullException(nameof(outerPolicy));
         }
 
+#pragma warning disable S3215 // "interface" instances should not be cast to concrete types
         return ((AsyncPolicy<TResult>)outerPolicy).WrapAsync(innerPolicy);
+#pragma warning restore S3215 // "interface" instances should not be cast to concrete types
     }
 
     /// <summary>
@@ -69,7 +75,9 @@ public static class IAsyncPolicyPolicyWrapExtensions
             throw new ArgumentNullException(nameof(outerPolicy));
         }
 
+#pragma warning disable S3215 // "interface" instances should not be cast to concrete types
         return ((AsyncPolicy<TResult>)outerPolicy).WrapAsync(innerPolicy);
+#pragma warning restore S3215 // "interface" instances should not be cast to concrete types
     }
 }
 
@@ -165,12 +173,14 @@ public partial class Policy
             throw new ArgumentNullException(nameof(policies));
         }
 
+#pragma warning disable S3215 // "interface" instances should not be cast to concrete types
         return policies.Length switch
         {
             < MinimumPoliciesRequiredForWrap => throw new ArgumentException("The enumerable of policies to form the wrap must contain at least two policies.", nameof(policies)),
             MinimumPoliciesRequiredForWrap => new AsyncPolicyWrap((AsyncPolicy)policies[0], policies[1]),
             _ => WrapAsync(policies[0], WrapAsync(policies.Skip(1).ToArray())),
         };
+#pragma warning restore S3215 // "interface" instances should not be cast to concrete types
     }
 
     /// <summary>
@@ -187,11 +197,13 @@ public partial class Policy
             throw new ArgumentNullException(nameof(policies));
         }
 
+#pragma warning disable S3215 // "interface" instances should not be cast to concrete types
         return policies.Length switch
         {
             < MinimumPoliciesRequiredForWrap => throw new ArgumentException("The enumerable of policies to form the wrap must contain at least two policies.", nameof(policies)),
             MinimumPoliciesRequiredForWrap => new AsyncPolicyWrap<TResult>((AsyncPolicy<TResult>)policies[0], policies[1]),
             _ => WrapAsync(policies[0], WrapAsync(policies.Skip(1).ToArray())),
         };
+#pragma warning restore S3215 // "interface" instances should not be cast to concrete types
     }
 }

--- a/src/Polly/Wrap/ISyncPolicyPolicyWrapExtensions.cs
+++ b/src/Polly/Wrap/ISyncPolicyPolicyWrapExtensions.cs
@@ -18,7 +18,9 @@ public static class ISyncPolicyPolicyWrapExtensions
             throw new ArgumentNullException(nameof(outerPolicy));
         }
 
+#pragma warning disable S3215 // "interface" instances should not be cast to concrete types
         return ((Policy)outerPolicy).Wrap(innerPolicy);
+#pragma warning restore S3215 // "interface" instances should not be cast to concrete types
     }
 
     /// <summary>
@@ -35,7 +37,9 @@ public static class ISyncPolicyPolicyWrapExtensions
             throw new ArgumentNullException(nameof(outerPolicy));
         }
 
+#pragma warning disable S3215 // "interface" instances should not be cast to concrete types
         return ((Policy)outerPolicy).Wrap(innerPolicy);
+#pragma warning restore S3215 // "interface" instances should not be cast to concrete types
     }
 
     /// <summary>
@@ -52,7 +56,9 @@ public static class ISyncPolicyPolicyWrapExtensions
             throw new ArgumentNullException(nameof(outerPolicy));
         }
 
+#pragma warning disable S3215 // "interface" instances should not be cast to concrete types
         return ((Policy<TResult>)outerPolicy).Wrap(innerPolicy);
+#pragma warning restore S3215 // "interface" instances should not be cast to concrete types
     }
 
     /// <summary>
@@ -69,7 +75,9 @@ public static class ISyncPolicyPolicyWrapExtensions
             throw new ArgumentNullException(nameof(outerPolicy));
         }
 
+#pragma warning disable S3215 // "interface" instances should not be cast to concrete types
         return ((Policy<TResult>)outerPolicy).Wrap(innerPolicy);
+#pragma warning restore S3215 // "interface" instances should not be cast to concrete types
     }
 }
 
@@ -163,6 +171,7 @@ public partial class Policy
             throw new ArgumentNullException(nameof(policies));
         }
 
+#pragma warning disable S3215 // "interface" instances should not be cast to concrete types
         return policies.Length switch
         {
             < MinimumPoliciesRequiredForWrap => throw new ArgumentException(
@@ -170,6 +179,7 @@ public partial class Policy
             MinimumPoliciesRequiredForWrap => new PolicyWrap((Policy)policies[0], policies[1]),
             _ => Wrap(policies[0], Wrap(policies.Skip(1).ToArray())),
         };
+#pragma warning restore S3215 // "interface" instances should not be cast to concrete types
     }
 
     /// <summary>
@@ -186,6 +196,7 @@ public partial class Policy
             throw new ArgumentNullException(nameof(policies));
         }
 
+#pragma warning disable S3215 // "interface" instances should not be cast to concrete types
         return policies.Length switch
         {
             < MinimumPoliciesRequiredForWrap => throw new ArgumentException(
@@ -193,5 +204,6 @@ public partial class Policy
             MinimumPoliciesRequiredForWrap => new PolicyWrap<TResult>((Policy<TResult>)policies[0], policies[1]),
             _ => Wrap(policies[0], Wrap(policies.Skip(1).ToArray())),
         };
+#pragma warning restore S3215 // "interface" instances should not be cast to concrete types
     }
 }

--- a/test/Polly.Specs/Bulkhead/BulkheadScenario.cs
+++ b/test/Polly.Specs/Bulkhead/BulkheadScenario.cs
@@ -1,32 +1,27 @@
 ﻿namespace Polly.Specs.Bulkhead;
 
-internal readonly struct BulkheadScenario
+internal readonly struct BulkheadScenario(
+    int maxParallelization,
+    int maxQueuingActions,
+    int totalTestLoad,
+    bool cancelQueuing,
+    bool cancelExecuting,
+    string scenario)
 {
-    private readonly int _maxParallelization;
-    private readonly int _maxQueuingActions;
-    private readonly int _totalTestLoad;
-    private readonly string _scenario;
-    private readonly bool _cancelQueuing;
-    private readonly bool _cancelExecuting;
-
-    public BulkheadScenario(int maxParallelization, int maxQueuingActions, int totalTestLoad, bool cancelQueuing, bool cancelExecuting, string scenario)
-    {
-        _maxParallelization = maxParallelization;
-        _maxQueuingActions = maxQueuingActions;
-        _totalTestLoad = totalTestLoad;
-        _scenario = scenario;
-        _cancelQueuing = cancelQueuing;
-        _cancelExecuting = cancelExecuting;
-    }
+    private readonly int _maxParallelization = maxParallelization;
+    private readonly int _maxQueuingActions = maxQueuingActions;
+    private readonly int _totalTestLoad = totalTestLoad;
+    private readonly string _scenario = scenario;
+    private readonly bool _cancelQueuing = cancelQueuing;
+    private readonly bool _cancelExecuting = cancelExecuting;
 
     public object[] ToTheoryData() =>
-        new object[]
-        {
-            _maxParallelization,
-            _maxQueuingActions,
-            _totalTestLoad,
-            _cancelQueuing,
-            _cancelExecuting,
-            _scenario
-        };
+    [
+        _maxParallelization,
+        _maxQueuingActions,
+        _totalTestLoad,
+        _cancelQueuing,
+        _cancelExecuting,
+        _scenario
+    ];
 }

--- a/test/Polly.Specs/Bulkhead/BulkheadTResultSpecs.cs
+++ b/test/Polly.Specs/Bulkhead/BulkheadTResultSpecs.cs
@@ -83,7 +83,7 @@ public class BulkheadTResultSpecs(ITestOutputHelper testOutputHelper) : Bulkhead
         Context contextPassedToExecute = new Context(operationKey);
 
         Context? contextPassedToOnRejected = null;
-        Action<Context> onRejected = ctx => { contextPassedToOnRejected = ctx; };
+        Action<Context> onRejected = ctx => contextPassedToOnRejected = ctx;
 
         using BulkheadPolicy<int> bulkhead = Policy.Bulkhead<int>(1, onRejected);
         TaskCompletionSource<object> tcs = new TaskCompletionSource<object>();

--- a/test/Polly.Specs/Caching/CacheAsyncSpecs.cs
+++ b/test/Polly.Specs/Caching/CacheAsyncSpecs.cs
@@ -801,7 +801,7 @@ public class CacheAsyncSpecs : IDisposable
         const string ValueToReturnFromExecution = "valueToReturnFromExecution";
         const string OperationKey = "SomeOperationKey";
 
-        Action<Context, string, Exception> onError = (_, _, exc) => { exceptionFromCacheProvider = exc; };
+        Action<Context, string, Exception> onError = (_, _, exc) => exceptionFromCacheProvider = exc;
 
         var cache = Policy.CacheAsync(stubCacheProvider, TimeSpan.MaxValue, onError);
 
@@ -835,7 +835,7 @@ public class CacheAsyncSpecs : IDisposable
         const string ValueToReturn = "valueToReturn";
         const string OperationKey = "SomeOperationKey";
 
-        Action<Context, string, Exception> onError = (_, _, exc) => { exceptionFromCacheProvider = exc; };
+        Action<Context, string, Exception> onError = (_, _, exc) => exceptionFromCacheProvider = exc;
 
         var cache = Policy.CacheAsync(stubCacheProvider, TimeSpan.MaxValue, onError);
 
@@ -868,7 +868,11 @@ public class CacheAsyncSpecs : IDisposable
 
         Action<Context, string, Exception> noErrorHandling = (_, _, _) => { };
         Action<Context, string> emptyDelegate = (_, _) => { };
-        Action<Context, string> onCacheAction = (ctx, key) => { contextPassedToDelegate = ctx; keyPassedToDelegate = key; };
+        Action<Context, string> onCacheAction = (ctx, key) =>
+        {
+            contextPassedToDelegate = ctx;
+            keyPassedToDelegate = key;
+        };
 
         var stubCacheProvider = new StubCacheProvider();
         var cache = Policy.CacheAsync(stubCacheProvider, new RelativeTtl(TimeSpan.MaxValue), DefaultCacheKeyStrategy.Instance, onCacheAction, emptyDelegate, emptyDelegate, noErrorHandling, noErrorHandling);
@@ -967,7 +971,7 @@ public class CacheAsyncSpecs : IDisposable
         Action<Context, string> emptyDelegate = (_, _) => { };
 
         bool onCacheMissExecuted = false;
-        Action<Context, string> onCacheMiss = (_, _) => { onCacheMissExecuted = true; };
+        Action<Context, string> onCacheMiss = (_, _) => onCacheMissExecuted = true;
 
         var cache = Policy.CacheAsync(new StubCacheProvider(), new RelativeTtl(TimeSpan.MaxValue), DefaultCacheKeyStrategy.Instance, emptyDelegate, onCacheMiss, emptyDelegate, noErrorHandling, noErrorHandling);
 

--- a/test/Polly.Specs/Caching/CacheSpecs.cs
+++ b/test/Polly.Specs/Caching/CacheSpecs.cs
@@ -823,7 +823,7 @@ public class CacheSpecs : IDisposable
         const string ValueToReturn = "valueToReturn";
         const string OperationKey = "SomeOperationKey";
 
-        Action<Context, string, Exception> onError = (_, _, exc) => { exceptionFromCacheProvider = exc; };
+        Action<Context, string, Exception> onError = (_, _, exc) => exceptionFromCacheProvider = exc;
 
         CachePolicy cache = Policy.Cache(stubCacheProvider, TimeSpan.MaxValue, onError);
 
@@ -857,7 +857,11 @@ public class CacheSpecs : IDisposable
 
         Action<Context, string, Exception> noErrorHandling = (_, _, _) => { };
         Action<Context, string> emptyDelegate = (_, _) => { };
-        Action<Context, string> onCacheAction = (ctx, key) => { contextPassedToDelegate = ctx; keyPassedToDelegate = key; };
+        Action<Context, string> onCacheAction = (ctx, key) =>
+        {
+            contextPassedToDelegate = ctx;
+            keyPassedToDelegate = key;
+        };
 
         var stubCacheProvider = new StubCacheProvider();
         CachePolicy cache = Policy.Cache(stubCacheProvider, new RelativeTtl(TimeSpan.MaxValue), DefaultCacheKeyStrategy.Instance, onCacheAction, emptyDelegate, emptyDelegate, noErrorHandling, noErrorHandling);
@@ -957,7 +961,7 @@ public class CacheSpecs : IDisposable
         Action<Context, string> emptyDelegate = (_, _) => { };
 
         bool onCacheMissExecuted = false;
-        Action<Context, string> onCacheMiss = (_, _) => { onCacheMissExecuted = true; };
+        Action<Context, string> onCacheMiss = (_, _) => onCacheMissExecuted = true;
 
         CachePolicy cache = Policy.Cache(new StubCacheProvider(), new RelativeTtl(TimeSpan.MaxValue), DefaultCacheKeyStrategy.Instance, emptyDelegate, onCacheMiss, emptyDelegate, noErrorHandling, noErrorHandling);
 

--- a/test/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerAsyncSpecs.cs
+++ b/test/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerAsyncSpecs.cs
@@ -1272,11 +1272,11 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        Should.NotThrow(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution. (tho still in half-open condition).
-        Should.Throw<BrokenCircuitException>(() => breaker.BreakerController.OnActionPreExecute());
+        Should.Throw<BrokenCircuitException>(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
     }
 
@@ -1306,11 +1306,11 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        Should.NotThrow(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution. (tho still in half-open condition).
-        Should.Throw<BrokenCircuitException>(() => breaker.BreakerController.OnActionPreExecute());
+        Should.Throw<BrokenCircuitException>(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // Allow another time window to pass (breaker should still be HalfOpen).
@@ -1318,7 +1318,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should now permit another trial execution.
-        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        Should.NotThrow(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
     }
 
@@ -1916,7 +1916,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
     {
         Action<Exception, TimeSpan> onBreak = (_, _) => { };
         bool onResetCalled = false;
-        Action onReset = () => { onResetCalled = true; };
+        Action onReset = () => onResetCalled = true;
 
         var durationOfBreak = TimeSpan.FromSeconds(30);
         var breaker = Policy
@@ -2049,7 +2049,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         int onBreakCalled = 0;
         int onResetCalled = 0;
         Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled++;
-        Action onReset = () => { onResetCalled++; };
+        Action onReset = () => onResetCalled++;
 
         var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
@@ -2081,7 +2081,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
     {
         Exception? passedException = null;
 
-        Action<Exception, TimeSpan, Context> onBreak = (exception, _, _) => { passedException = exception; };
+        Action<Exception, TimeSpan, Context> onBreak = (exception, _, _) => passedException = exception;
         Action<Context> onReset = _ => { };
 
         var breaker = Policy
@@ -2152,7 +2152,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
     {
         List<CircuitState> transitionedStates = [];
 
-        Action<Exception, CircuitState, TimeSpan, Context> onBreak = (_, state, _, _) => { transitionedStates.Add(state); };
+        Action<Exception, CircuitState, TimeSpan, Context> onBreak = (_, state, _, _) => transitionedStates.Add(state);
         Action<Context> onReset = _ => { };
         Action onHalfOpen = () => { };
 
@@ -2290,7 +2290,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
     [Fact]
     public void Should_throw_when_failureThreshold_is_more_than_one()
     {
-        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => { _ = timespan; };
+        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => _ = timespan;
         Action<Context> onReset = _ => { };
 
         var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
@@ -2312,7 +2312,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
     [Fact]
     public void Should_throw_when_samplingDuration_is_less_than_resolutionOfCircuit()
     {
-        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => { _ = timespan; };
+        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => _ = timespan;
         Action<Context> onReset = _ => { };
 
         var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
@@ -2334,7 +2334,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
     [Fact]
     public void Should_throw_when_minimumThroughput_is_less_or_equals_than_one()
     {
-        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => { _ = timespan; };
+        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => _ = timespan;
         Action<Context> onReset = _ => { };
 
         var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
@@ -2356,7 +2356,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
     [Fact]
     public void Should_throw_when_durationOfBreak_is_negative_timespan()
     {
-        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => { _ = timespan; };
+        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => _ = timespan;
         Action<Context> onReset = _ => { };
 
         var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
@@ -2378,7 +2378,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
     [Fact]
     public void Should_throw_when_onReset_is_null()
     {
-        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => { _ = timespan; };
+        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => _ = timespan;
 
         var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
@@ -2399,7 +2399,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
     [Fact]
     public void Should_throw_when_onHalfOpen_is_null()
     {
-        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => { _ = timespan; };
+        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => _ = timespan;
         Action<Context> onReset = _ => { };
 
         var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
@@ -2428,7 +2428,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
     {
         IDictionary<string, object>? contextData = null;
 
-        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) => { contextData = context; };
+        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) => contextData = context;
         Action<Context> onReset = _ => { };
 
         var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
@@ -2471,7 +2471,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         IDictionary<string, object>? contextData = null;
 
         Action<Exception, TimeSpan, Context> onBreak = (_, _, _) => { };
-        Action<Context> onReset = context => { contextData = context; };
+        Action<Context> onReset = context => contextData = context;
 
         var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
@@ -2518,7 +2518,7 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
     {
         IDictionary<string, object> contextData = CreateDictionary("key1", "value1", "key2", "value2");
 
-        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) => { contextData = context; };
+        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) => contextData = context;
         Action<Context> onReset = _ => { };
 
         var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
@@ -2556,9 +2556,9 @@ public class AdvancedCircuitBreakerAsyncSpecs : IDisposable
         string? contextValue = null;
 
         Action<Exception, TimeSpan, Context> onBreak =
-            (_, _, context) => { contextValue = context.ContainsKey("key") ? context["key"].ToString() : null; };
+            (_, _, context) => contextValue = context.ContainsKey("key") ? context["key"].ToString() : null;
         Action<Context> onReset =
-            context => { contextValue = context.ContainsKey("key") ? context["key"].ToString() : null; };
+            context => contextValue = context.ContainsKey("key") ? context["key"].ToString() : null;
 
         var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;

--- a/test/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerSpecs.cs
+++ b/test/Polly.Specs/CircuitBreaker/AdvancedCircuitBreakerSpecs.cs
@@ -1276,11 +1276,11 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        Should.NotThrow(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution.
-        Should.Throw<BrokenCircuitException>(() => breaker.BreakerController.OnActionPreExecute());
+        Should.Throw<BrokenCircuitException>(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
     }
 
@@ -1311,11 +1311,11 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        Should.NotThrow(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution.
-        Should.Throw<BrokenCircuitException>(() => breaker.BreakerController.OnActionPreExecute());
+        Should.Throw<BrokenCircuitException>(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // Allow another time window to pass (breaker should still be HalfOpen).
@@ -1323,7 +1323,7 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should now permit another trial execution.
-        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        Should.NotThrow(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
     }
 
@@ -2152,7 +2152,7 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
     {
         List<CircuitState> transitionedStates = [];
 
-        Action<Exception, CircuitState, TimeSpan, Context> onBreak = (_, state, _, _) => { transitionedStates.Add(state); };
+        Action<Exception, CircuitState, TimeSpan, Context> onBreak = (_, state, _, _) => transitionedStates.Add(state);
         Action<Context> onReset = _ => { };
         Action onHalfOpen = () => { };
 
@@ -2398,9 +2398,9 @@ public class AdvancedCircuitBreakerSpecs : IDisposable
         string? contextValue = null;
 
         Action<Exception, TimeSpan, Context> onBreak =
-            (_, _, context) => { contextValue = context.ContainsKey("key") ? context["key"].ToString() : null; };
+            (_, _, context) => contextValue = context.ContainsKey("key") ? context["key"].ToString() : null;
         Action<Context> onReset =
-            context => { contextValue = context.ContainsKey("key") ? context["key"].ToString() : null; };
+            context => contextValue = context.ContainsKey("key") ? context["key"].ToString() : null;
 
         var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;

--- a/test/Polly.Specs/CircuitBreaker/CircuitBreakerAsyncSpecs.cs
+++ b/test/Polly.Specs/CircuitBreaker/CircuitBreakerAsyncSpecs.cs
@@ -289,11 +289,11 @@ public class CircuitBreakerAsyncSpecs : IDisposable
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        Should.NotThrow(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution.
-        Should.Throw<BrokenCircuitException>(() => breaker.BreakerController.OnActionPreExecute());
+        Should.Throw<BrokenCircuitException>(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
     }
 
@@ -318,11 +318,11 @@ public class CircuitBreakerAsyncSpecs : IDisposable
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        Should.NotThrow(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution.
-        Should.Throw<BrokenCircuitException>(() => breaker.BreakerController.OnActionPreExecute());
+        Should.Throw<BrokenCircuitException>(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // Allow another time window to pass (breaker should still be HalfOpen).
@@ -330,7 +330,7 @@ public class CircuitBreakerAsyncSpecs : IDisposable
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should now permit another trial execution.
-        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        Should.NotThrow(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
     }
 
@@ -685,7 +685,7 @@ public class CircuitBreakerAsyncSpecs : IDisposable
     public async Task Should_call_onbreak_when_breaking_circuit_automatically()
     {
         bool onBreakCalled = false;
-        Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled = true; };
+        Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled = true;
         Action onReset = () => { };
 
         var breaker = Policy
@@ -707,7 +707,7 @@ public class CircuitBreakerAsyncSpecs : IDisposable
     public void Should_call_onbreak_when_breaking_circuit_manually()
     {
         bool onBreakCalled = false;
-        Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled = true; };
+        Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled = true;
         Action onReset = () => { };
 
         var breaker = Policy
@@ -752,7 +752,7 @@ public class CircuitBreakerAsyncSpecs : IDisposable
     public async Task Should_call_onbreak_when_breaking_circuit_first_time_but_not_for_subsequent_call_failure_which_arrives_on_open_state_though_started_on_closed_state()
     {
         int onBreakCalled = 0;
-        Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
+        Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled++;
         Action onReset = () => { };
 
         var breaker = Policy
@@ -866,7 +866,7 @@ public class CircuitBreakerAsyncSpecs : IDisposable
     {
         Action<Exception, TimeSpan> onBreak = (_, _) => { };
         bool onResetCalled = false;
-        Action onReset = () => { onResetCalled = true; };
+        Action onReset = () => onResetCalled = true;
 
         var breaker = Policy
             .Handle<DivideByZeroException>()
@@ -891,7 +891,7 @@ public class CircuitBreakerAsyncSpecs : IDisposable
         int onHalfOpenCalled = 0;
         Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled++;
         Action onReset = () => onResetCalled++;
-        Action onHalfOpen = () => { onHalfOpenCalled++; };
+        Action onHalfOpen = () => onHalfOpenCalled++;
 
         var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
@@ -1119,7 +1119,7 @@ public class CircuitBreakerAsyncSpecs : IDisposable
     {
         TimeSpan? passedBreakTimespan = null;
 
-        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => { passedBreakTimespan = timespan; };
+        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => passedBreakTimespan = timespan;
         Action<Context> onReset = _ => { };
 
         TimeSpan durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1244,8 +1244,8 @@ public class CircuitBreakerAsyncSpecs : IDisposable
     {
         string? contextValue = null;
 
-        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) => { contextValue = context.ContainsKey("key") ? context["key"].ToString() : null; };
-        Action<Context> onReset = context => { contextValue = context.ContainsKey("key") ? context["key"].ToString() : null; };
+        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) => contextValue = context.ContainsKey("key") ? context["key"].ToString() : null;
+        Action<Context> onReset = context => contextValue = context.ContainsKey("key") ? context["key"].ToString() : null;
 
         var breaker = Policy
                         .Handle<DivideByZeroException>()

--- a/test/Polly.Specs/CircuitBreaker/CircuitBreakerSpecs.cs
+++ b/test/Polly.Specs/CircuitBreaker/CircuitBreakerSpecs.cs
@@ -287,11 +287,11 @@ public class CircuitBreakerSpecs : IDisposable
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        Should.NotThrow(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution.
-        Should.Throw<BrokenCircuitException>(() => breaker.BreakerController.OnActionPreExecute());
+        Should.Throw<BrokenCircuitException>(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
     }
 
@@ -316,11 +316,11 @@ public class CircuitBreakerSpecs : IDisposable
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        Should.NotThrow(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution in the same time window.
-        Should.Throw<BrokenCircuitException>(() => breaker.BreakerController.OnActionPreExecute());
+        Should.Throw<BrokenCircuitException>(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // Allow another time window to pass (breaker should still be HalfOpen).
@@ -328,7 +328,7 @@ public class CircuitBreakerSpecs : IDisposable
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should now permit another trial execution.
-        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        Should.NotThrow(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
     }
 
@@ -679,7 +679,7 @@ public class CircuitBreakerSpecs : IDisposable
     public void Should_call_onbreak_when_breaking_circuit_automatically()
     {
         bool onBreakCalled = false;
-        Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled = true; };
+        Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled = true;
         Action onReset = () => { };
 
         CircuitBreakerPolicy breaker = Policy
@@ -701,7 +701,7 @@ public class CircuitBreakerSpecs : IDisposable
     public void Should_call_onbreak_when_breaking_circuit_manually()
     {
         bool onBreakCalled = false;
-        Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled = true; };
+        Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled = true;
         Action onReset = () => { };
 
         CircuitBreakerPolicy breaker = Policy
@@ -718,7 +718,7 @@ public class CircuitBreakerSpecs : IDisposable
     public void Should_call_onbreak_when_breaking_circuit_first_time_but_not_for_subsequent_calls_placed_through_open_circuit()
     {
         int onBreakCalled = 0;
-        Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
+        Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled++;
         Action onReset = () => { };
 
         CircuitBreakerPolicy breaker = Policy
@@ -746,7 +746,7 @@ public class CircuitBreakerSpecs : IDisposable
     public void Should_call_onbreak_when_breaking_circuit_first_time_but_not_for_subsequent_call_failure_which_arrives_on_open_state_though_started_on_closed_state()
     {
         int onBreakCalled = 0;
-        Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
+        Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled++;
         Action onReset = () => { };
 
         CircuitBreakerPolicy breaker = Policy
@@ -815,7 +815,7 @@ public class CircuitBreakerSpecs : IDisposable
         int onBreakCalled = 0;
         int onResetCalled = 0;
         Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
-        Action onReset = () => { onResetCalled++; };
+        Action onReset = () => onResetCalled++;
 
         var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
@@ -858,7 +858,7 @@ public class CircuitBreakerSpecs : IDisposable
     {
         Action<Exception, TimeSpan> onBreak = (_, _) => { };
         bool onResetCalled = false;
-        Action onReset = () => { onResetCalled = true; };
+        Action onReset = () => onResetCalled = true;
 
         CircuitBreakerPolicy breaker = Policy
             .Handle<DivideByZeroException>()
@@ -881,9 +881,9 @@ public class CircuitBreakerSpecs : IDisposable
         int onBreakCalled = 0;
         int onResetCalled = 0;
         int onHalfOpenCalled = 0;
-        Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
-        Action onReset = () => { onResetCalled++; };
-        Action onHalfOpen = () => { onHalfOpenCalled++; };
+        Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled++;
+        Action onReset = () => onResetCalled++;
+        Action onHalfOpen = () => onHalfOpenCalled++;
 
         var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
@@ -925,9 +925,9 @@ public class CircuitBreakerSpecs : IDisposable
         int onBreakCalled = 0;
         int onResetCalled = 0;
         int onHalfOpenCalled = 0;
-        Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
-        Action onReset = () => { onResetCalled++; };
-        Action onHalfOpen = () => { onHalfOpenCalled++; };
+        Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled++;
+        Action onReset = () => onResetCalled++;
+        Action onHalfOpen = () => onHalfOpenCalled++;
 
         var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
@@ -964,8 +964,8 @@ public class CircuitBreakerSpecs : IDisposable
     {
         int onBreakCalled = 0;
         int onResetCalled = 0;
-        Action<Exception, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
-        Action onReset = () => { onResetCalled++; };
+        Action<Exception, TimeSpan> onBreak = (_, _) => onBreakCalled++;
+        Action onReset = () => onResetCalled++;
 
         var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
@@ -998,7 +998,7 @@ public class CircuitBreakerSpecs : IDisposable
     {
         Exception? passedException = null;
 
-        Action<Exception, TimeSpan, Context> onBreak = (exception, _, _) => { passedException = exception; };
+        Action<Exception, TimeSpan, Context> onBreak = (exception, _, _) => passedException = exception;
         Action<Context> onReset = _ => { };
 
         TimeSpan durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1020,7 +1020,7 @@ public class CircuitBreakerSpecs : IDisposable
     {
         CircuitState? transitionedState = null;
 
-        Action<Exception, CircuitState, TimeSpan, Context> onBreak = (_, state, _, _) => { transitionedState = state; };
+        Action<Exception, CircuitState, TimeSpan, Context> onBreak = (_, state, _, _) => transitionedState = state;
         Action<Context> onReset = _ => { };
         Action onHalfOpen = () => { };
 
@@ -1083,7 +1083,7 @@ public class CircuitBreakerSpecs : IDisposable
     {
         Exception? passedException = null;
 
-        Action<Exception, TimeSpan, Context> onBreak = (exception, _, _) => { passedException = exception; };
+        Action<Exception, TimeSpan, Context> onBreak = (exception, _, _) => passedException = exception;
         Action<Context> onReset = _ => { };
 
         TimeSpan durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1111,7 +1111,7 @@ public class CircuitBreakerSpecs : IDisposable
     {
         TimeSpan? passedBreakTimespan = null;
 
-        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => { passedBreakTimespan = timespan; };
+        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => passedBreakTimespan = timespan;
         Action<Context> onReset = _ => { };
 
         TimeSpan durationOfBreak = TimeSpan.FromMinutes(1);
@@ -1132,7 +1132,7 @@ public class CircuitBreakerSpecs : IDisposable
     public void Should_open_circuit_with_timespan_maxvalue_if_manual_override_open()
     {
         TimeSpan? passedBreakTimespan = null;
-        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => { passedBreakTimespan = timespan; };
+        Action<Exception, TimeSpan, Context> onBreak = (_, timespan, _) => passedBreakTimespan = timespan;
         Action<Context> onReset = _ => { };
 
         var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
@@ -1161,7 +1161,7 @@ public class CircuitBreakerSpecs : IDisposable
     {
         IDictionary<string, object>? contextData = null;
 
-        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) => { contextData = context; };
+        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) => contextData = context;
         Action<Context> onReset = _ => { };
 
         CircuitBreakerPolicy breaker = Policy
@@ -1185,7 +1185,7 @@ public class CircuitBreakerSpecs : IDisposable
         IDictionary<string, object>? contextData = null;
 
         Action<Exception, TimeSpan, Context> onBreak = (_, _, _) => { };
-        Action<Context> onReset = context => { contextData = context; };
+        Action<Context> onReset = context => contextData = context;
 
         var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
@@ -1216,7 +1216,7 @@ public class CircuitBreakerSpecs : IDisposable
     {
         IDictionary<string, object> contextData = CreateDictionary("key1", "value1", "key2", "value2");
 
-        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) => { contextData = context; };
+        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) => contextData = context;
         Action<Context> onReset = _ => { };
 
         CircuitBreakerPolicy breaker = Policy
@@ -1236,8 +1236,8 @@ public class CircuitBreakerSpecs : IDisposable
     {
         string? contextValue = null;
 
-        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) => { contextValue = context.ContainsKey("key") ? context["key"].ToString() : null; };
-        Action<Context> onReset = context => { contextValue = context.ContainsKey("key") ? context["key"].ToString() : null; };
+        Action<Exception, TimeSpan, Context> onBreak = (_, _, context) => contextValue = context.ContainsKey("key") ? context["key"].ToString() : null;
+        Action<Context> onReset = context => contextValue = context.ContainsKey("key") ? context["key"].ToString() : null;
 
         CircuitBreakerPolicy breaker = Policy
             .Handle<DivideByZeroException>()

--- a/test/Polly.Specs/CircuitBreaker/CircuitBreakerTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/CircuitBreaker/CircuitBreakerTResultAsyncSpecs.cs
@@ -412,11 +412,11 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        Should.NotThrow(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution.
-        Should.Throw<BrokenCircuitException>(() => breaker.BreakerController.OnActionPreExecute());
+        Should.Throw<BrokenCircuitException>(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
     }
 
@@ -442,11 +442,11 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        Should.NotThrow(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution.
-        Should.Throw<BrokenCircuitException>(() => breaker.BreakerController.OnActionPreExecute());
+        Should.Throw<BrokenCircuitException>(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // Allow another time window to pass (breaker should still be HalfOpen).
@@ -454,7 +454,7 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should now permit another trial execution.
-        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        Should.NotThrow(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
     }
 
@@ -1010,7 +1010,7 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
     {
         Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => { };
         bool onResetCalled = false;
-        Action onReset = () => { onResetCalled = true; };
+        Action onReset = () => onResetCalled = true;
 
         var breaker = Policy
             .HandleResult(ResultPrimitive.Fault)
@@ -1315,8 +1315,8 @@ public class CircuitBreakerTResultAsyncSpecs : IDisposable
     {
         string? contextValue = null;
 
-        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (_, _, context) => { contextValue = context.ContainsKey("key") ? context["key"].ToString() : null; };
-        Action<Context> onReset = context => { contextValue = context.ContainsKey("key") ? context["key"].ToString() : null; };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onBreak = (_, _, context) => contextValue = context.ContainsKey("key") ? context["key"].ToString() : null;
+        Action<Context> onReset = context => contextValue = context.ContainsKey("key") ? context["key"].ToString() : null;
 
         var breaker = Policy
             .HandleResult(ResultPrimitive.Fault)

--- a/test/Polly.Specs/CircuitBreaker/CircuitBreakerTResultSpecs.cs
+++ b/test/Polly.Specs/CircuitBreaker/CircuitBreakerTResultSpecs.cs
@@ -411,11 +411,11 @@ public class CircuitBreakerTResultSpecs : IDisposable
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        Should.NotThrow(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution.
-        Should.Throw<BrokenCircuitException>(() => breaker.BreakerController.OnActionPreExecute());
+        Should.Throw<BrokenCircuitException>(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
     }
 
@@ -441,11 +441,11 @@ public class CircuitBreakerTResultSpecs : IDisposable
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should permit first execution.
-        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        Should.NotThrow(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should reject a second execution.
-        Should.Throw<BrokenCircuitException>(() => breaker.BreakerController.OnActionPreExecute());
+        Should.Throw<BrokenCircuitException>(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // Allow another time window to pass (breaker should still be HalfOpen).
@@ -453,7 +453,7 @@ public class CircuitBreakerTResultSpecs : IDisposable
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
 
         // OnActionPreExecute() should now permit another trial execution.
-        Should.NotThrow(() => breaker.BreakerController.OnActionPreExecute());
+        Should.NotThrow(breaker.BreakerController.OnActionPreExecute);
         breaker.CircuitState.ShouldBe(CircuitState.HalfOpen);
     }
 
@@ -816,7 +816,7 @@ public class CircuitBreakerTResultSpecs : IDisposable
     public void Should_call_onbreak_when_breaking_circuit_automatically()
     {
         bool onBreakCalled = false;
-        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => { onBreakCalled = true; };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => onBreakCalled = true;
         Action onReset = () => { };
 
         CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
@@ -840,7 +840,7 @@ public class CircuitBreakerTResultSpecs : IDisposable
     public void Should_call_onbreak_when_breaking_circuit_manually()
     {
         bool onBreakCalled = false;
-        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => { onBreakCalled = true; };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => onBreakCalled = true;
         Action onReset = () => { };
 
         CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
@@ -857,7 +857,7 @@ public class CircuitBreakerTResultSpecs : IDisposable
     public void Should_call_onbreak_when_breaking_circuit_first_time_but_not_for_subsequent_calls_placed_through_open_circuit()
     {
         int onBreakCalled = 0;
-        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => onBreakCalled++;
         Action onReset = () => { };
 
         CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
@@ -887,7 +887,7 @@ public class CircuitBreakerTResultSpecs : IDisposable
     public void Should_call_onbreak_when_breaking_circuit_first_time_but_not_for_subsequent_call_failure_which_arrives_on_open_state_though_started_on_closed_state()
     {
         int onBreakCalled = 0;
-        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => onBreakCalled++;
         Action onReset = () => { };
 
         CircuitBreakerPolicy<ResultPrimitive> breaker = Policy
@@ -955,8 +955,8 @@ public class CircuitBreakerTResultSpecs : IDisposable
     {
         int onBreakCalled = 0;
         int onResetCalled = 0;
-        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
-        Action onReset = () => { onResetCalled++; };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => onBreakCalled++;
+        Action onReset = () => onResetCalled++;
 
         var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
@@ -1070,9 +1070,9 @@ public class CircuitBreakerTResultSpecs : IDisposable
         int onBreakCalled = 0;
         int onResetCalled = 0;
         int onHalfOpenCalled = 0;
-        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
-        Action onReset = () => { onResetCalled++; };
-        Action onHalfOpen = () => { onHalfOpenCalled++; };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => onBreakCalled++;
+        Action onReset = () => onResetCalled++;
+        Action onHalfOpen = () => onHalfOpenCalled++;
 
         var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;
@@ -1111,8 +1111,8 @@ public class CircuitBreakerTResultSpecs : IDisposable
     {
         int onBreakCalled = 0;
         int onResetCalled = 0;
-        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => { onBreakCalled++; };
-        Action onReset = () => { onResetCalled++; };
+        Action<DelegateResult<ResultPrimitive>, TimeSpan> onBreak = (_, _) => onBreakCalled++;
+        Action onReset = () => onResetCalled++;
 
         var time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         SystemClock.UtcNow = () => time;

--- a/test/Polly.Specs/Fallback/FallbackSpecs.cs
+++ b/test/Polly.Specs/Fallback/FallbackSpecs.cs
@@ -1001,10 +1001,7 @@ public class FallbackSpecs
     {
         Exception? fallbackException = null;
 
-        Action<Exception, Context, CancellationToken> fallbackAction = (ex, _, _) =>
-        {
-            fallbackException = ex;
-        };
+        Action<Exception, Context, CancellationToken> fallbackAction = (ex, _, _) => fallbackException = ex;
 
         Action<Exception, Context> onFallback = (_, _) => { };
 
@@ -1025,7 +1022,7 @@ public class FallbackSpecs
     public void Should_execute_action_when_non_faulting_and_cancellationToken_not_cancelled()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy policy = Policy
             .Handle<DivideByZeroException>()
@@ -1054,7 +1051,7 @@ public class FallbackSpecs
     public void Should_execute_fallback_when_faulting_and_cancellationToken_not_cancelled()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy policy = Policy
             .Handle<DivideByZeroException>()
@@ -1083,7 +1080,7 @@ public class FallbackSpecs
     public void Should_not_execute_action_when_cancellationToken_cancelled_before_execute()
     {
         bool fallbackActionExecuted = false;
-        Action fallbackAction = () => { fallbackActionExecuted = true; };
+        Action fallbackAction = () => fallbackActionExecuted = true;
 
         FallbackPolicy policy = Policy
             .Handle<DivideByZeroException>()

--- a/test/Polly.Specs/Fallback/FallbackTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/Fallback/FallbackTResultAsyncSpecs.cs
@@ -405,7 +405,12 @@ public class FallbackTResultAsyncSpecs
         bool onFallbackExecuted = false;
 
         Func<Context, CancellationToken, Task<ResultPrimitive>> fallbackAction = (_, _) => Task.FromResult(ResultPrimitive.Substitute);
-        Func<DelegateResult<ResultPrimitive>, Context, Task> onFallbackAsync = (_, ctx) => { onFallbackExecuted = true; capturedContext = ctx; return TaskHelper.EmptyTask; };
+        Func<DelegateResult<ResultPrimitive>, Context, Task> onFallbackAsync = (_, ctx) =>
+        {
+            onFallbackExecuted = true;
+            capturedContext = ctx;
+            return TaskHelper.EmptyTask;
+        };
 
         var fallbackPolicy = Policy
             .HandleResult(ResultPrimitive.Fault)

--- a/test/Polly.Specs/Fallback/FallbackTResultSpecs.cs
+++ b/test/Polly.Specs/Fallback/FallbackTResultSpecs.cs
@@ -399,7 +399,7 @@ public class FallbackTResultSpecs
 
         IDictionary<string, object>? contextData = null;
 
-        Action<DelegateResult<ResultPrimitive>, Context> onFallback = (_, ctx) => { contextData = ctx; };
+        Action<DelegateResult<ResultPrimitive>, Context> onFallback = (_, ctx) => contextData = ctx;
 
         FallbackPolicy<ResultPrimitive> fallbackPolicy = Policy
             .HandleResult(ResultPrimitive.Fault)
@@ -421,7 +421,7 @@ public class FallbackTResultSpecs
 
         IDictionary<string, object>? contextData = null;
 
-        Action<DelegateResult<ResultPrimitive>, Context> onFallback = (_, ctx) => { contextData = ctx; };
+        Action<DelegateResult<ResultPrimitive>, Context> onFallback = (_, ctx) => contextData = ctx;
 
         FallbackPolicy<ResultPrimitive> fallbackPolicy = Policy
             .HandleResult(ResultPrimitive.Fault)
@@ -443,7 +443,7 @@ public class FallbackTResultSpecs
 
         IDictionary<ResultPrimitive, object> contextData = new Dictionary<ResultPrimitive, object>();
 
-        Action<DelegateResult<ResultPrimitive>, Context> onFallback = (dr, ctx) => { contextData[dr.Result] = ctx["key"]; };
+        Action<DelegateResult<ResultPrimitive>, Context> onFallback = (dr, ctx) => contextData[dr.Result] = ctx["key"];
 
         FallbackPolicy<ResultPrimitive> fallbackPolicy = Policy
             .HandleResult(ResultPrimitive.Fault)
@@ -533,7 +533,12 @@ public class FallbackTResultSpecs
         Context? capturedContext = null;
         bool fallbackExecuted = false;
 
-        Func<Context, CancellationToken, ResultPrimitive> fallbackAction = (ctx, _) => { fallbackExecuted = true; capturedContext = ctx; return ResultPrimitive.Substitute; };
+        Func<Context, CancellationToken, ResultPrimitive> fallbackAction = (ctx, _) =>
+        {
+            fallbackExecuted = true;
+            capturedContext = ctx;
+            return ResultPrimitive.Substitute;
+        };
 
         Action<DelegateResult<ResultPrimitive>, Context> onFallback = (_, _) => { };
 

--- a/test/Polly.Specs/Retry/RetryForeverAsyncSpecs.cs
+++ b/test/Polly.Specs/Retry/RetryForeverAsyncSpecs.cs
@@ -134,7 +134,7 @@ public class RetryForeverAsyncSpecs
 
         var policy = Policy
             .Handle<DivideByZeroException>()
-            .RetryForeverAsync(exception => retryExceptions.Add(exception));
+            .RetryForeverAsync(retryExceptions.Add);
 
         await policy.RaiseExceptionAsync<DivideByZeroException>(3, (e, i) => e.HelpLink = "Exception #" + i);
 

--- a/test/Polly.Specs/Wrap/IPolicyWrapExtensionSpecs.cs
+++ b/test/Polly.Specs/Wrap/IPolicyWrapExtensionSpecs.cs
@@ -186,7 +186,7 @@ public class IPolicyWrapExtensionSpecs
         Policy policyC = Policy.NoOp();
         PolicyWrap wrap = policyA.Wrap(policyB.Wrap(policyC));
 
-        Should.Throw<InvalidOperationException>(() => wrap.GetPolicy<NoOpPolicy>());
+        Should.Throw<InvalidOperationException>(wrap.GetPolicy<NoOpPolicy>);
     }
 
     [Fact]


### PR DESCRIPTION
- Suppress extant occurences of code analysis warnings inline in the code and re-enable suppressed rules.
- Fix remaining IDE/formatting suggestions in Polly.Specs.

Resolves #1290.
