### PR TITLE
Investigate macOS issue with dotnet-validate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,6 @@ jobs:
       uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # v4.3.0
       with:
         dotnet-version: |
-          6.0.x
           8.0.x
 
     - name: Setup .NET SDK

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,7 @@ jobs:
         restore-keys: ${{ runner.os }}-nuget-
 
     - run: |
+        echo "DOTNET_NUGET_SIGNATURE_VERIFICATION=${DOTNET_NUGET_SIGNATURE_VERIFICATION}"
         dotnet --version
         dotnet --info
         dotnet restore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,8 @@ jobs:
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props') }}
         restore-keys: ${{ runner.os }}-nuget-
 
+    - run: dotnet restore
+
     - name: Build, Test and Package
       id: build
       shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
         dotnet --version
         dotnet --info
         dotnet restore
-        dotnet tool restore
+        dotnet tool restore --no-http-cache
       env:
         DOTNET_NUGET_SIGNATURE_VERIFICATION: false
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,9 @@ jobs:
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props') }}
         restore-keys: ${{ runner.os }}-nuget-
 
-    - run: dotnet restore
+    - run: |
+        dotnet restore
+        dotnet tool restore
 
     - name: Build, Test and Package
       id: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,14 +67,15 @@ jobs:
       uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # v4.3.0
       id: setup-dotnet
 
-    - run: |
+    - name: Restore packages and tools
+      env:
+        DOTNET_NUGET_SIGNATURE_VERIFICATION: false
+      run: |
         echo "DOTNET_NUGET_SIGNATURE_VERIFICATION=${DOTNET_NUGET_SIGNATURE_VERIFICATION}"
         dotnet --version
         dotnet --info
         dotnet restore
-        dotnet tool restore --no-http-cache
-      env:
-        DOTNET_NUGET_SIGNATURE_VERIFICATION: false
+        dotnet tool restore --no-http-cache --verbosity diagnostic
 
     - name: Build, Test and Package
       id: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,8 @@ jobs:
         dotnet --info
         dotnet restore
         dotnet tool restore
+      env:
+        DOTNET_NUGET_SIGNATURE_VERIFICATION: false
 
     - name: Build, Test and Package
       id: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,13 +67,6 @@ jobs:
       uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # v4.3.0
       id: setup-dotnet
 
-    - name: Setup NuGet cache
-      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
-      with:
-        path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props') }}
-        restore-keys: ${{ runner.os }}-nuget-
-
     - run: |
         echo "DOTNET_NUGET_SIGNATURE_VERIFICATION=${DOTNET_NUGET_SIGNATURE_VERIFICATION}"
         dotnet --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,8 @@ jobs:
         restore-keys: ${{ runner.os }}-nuget-
 
     - run: |
+        dotnet --version
+        dotnet --info
         dotnet restore
         dotnet tool restore
 


### PR DESCRIPTION
Investigate issue with restoring dotnet-validate on macOS. Working in some of my own projects, but why isn't it working here? Something to do with cake?

https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/issues/1698

No issue here for instance, despite using the same tool: https://github.com/martincostello/openapi-extensions/pull/252