### PR TITLE
Remove .NET 6 SDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,6 @@ jobs:
       uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # v4.3.0
       with:
         dotnet-version: |
-          6.0.x
           8.0.x
 
     - name: Setup .NET SDK

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -51,7 +51,6 @@ jobs:
       uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # v4.3.0
       with:
         dotnet-version: |
-          6.0.x
           8.0.x
 
     - name: Setup .NET SDK


### PR DESCRIPTION
Remove usage of the .NET 6 SDK as we shouldn't need it anymore.
