### PR TITLE
Fix Polly.Testing mutations

### DIFF
--- a/src/Polly.Testing/ResiliencePipelineExtensions.cs
+++ b/src/Polly.Testing/ResiliencePipelineExtensions.cs
@@ -40,7 +40,11 @@ public static class ResiliencePipelineExtensions
         var components = new List<PipelineComponent>();
         component.ExpandComponents(components);
 
-        var descriptors = components.OfType<BridgeComponentBase>().Select(s => new ResilienceStrategyDescriptor(s.Options, GetStrategyInstance<T>(s))).ToList().AsReadOnly();
+        var descriptors = components
+            .OfType<BridgeComponentBase>()
+            .Select(s => new ResilienceStrategyDescriptor(s.Options, GetStrategyInstance<T>(s)))
+            .ToList()
+            .AsReadOnly();
 
         return new ResiliencePipelineDescriptor(
             descriptors,
@@ -73,7 +77,6 @@ public static class ResiliencePipelineExtensions
         }
         else if (component is ExecutionTrackingComponent tracking)
         {
-            components.Add(tracking);
             ExpandComponents(tracking.Component, components);
         }
         else if (component is ComponentWithDisposeCallbacks callbacks)


### PR DESCRIPTION
While working on #2500 I noticed that no mutations were being tested for Polly.Testing.

This fixes that by removing the `ignore-mutations` setting for that project, otherwise Stryker finds no ways to mutate the code and does nothing.

Once that was fixed, some additional changes were needed to get back to 100% mutations score for that project.