### PR TITLE
Add missing mutations

### DIFF
--- a/src/Polly/Bulkhead/BulkheadSyntax.cs
+++ b/src/Polly/Bulkhead/BulkheadSyntax.cs
@@ -11,10 +11,7 @@ public partial class Policy
     /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
     /// <returns>The policy instance.</returns>
     public static BulkheadPolicy Bulkhead(int maxParallelization)
-    {
-        Action<Context> doNothing = _ => { };
-        return Bulkhead(maxParallelization, 0, doNothing);
-    }
+        => Bulkhead(maxParallelization, 0, EmptyAction);
 
     /// <summary>
     /// <para>Builds a bulkhead isolation <see cref="Policy"/>, which limits the maximum concurrency of actions executed through the policy.  Imposing a maximum concurrency limits the potential of governed actions, when faulting, to bring down the system.</para>
@@ -38,10 +35,7 @@ public partial class Policy
     /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentOutOfRangeException">maxQueuingActions;Value must be greater than or equal to zero.</exception>
     public static BulkheadPolicy Bulkhead(int maxParallelization, int maxQueuingActions)
-    {
-        Action<Context> doNothing = _ => { };
-        return Bulkhead(maxParallelization, maxQueuingActions, doNothing);
-    }
+        => Bulkhead(maxParallelization, maxQueuingActions, EmptyAction);
 
     /// <summary>
     /// Builds a bulkhead isolation <see cref="Policy" />, which limits the maximum concurrency of actions executed through the policy.  Imposing a maximum concurrency limits the potential of governed actions, when faulting, to bring down the system.
@@ -75,5 +69,10 @@ public partial class Policy
             maxParallelization,
             maxQueuingActions,
             onBulkheadRejected);
+    }
+
+    private static void EmptyAction(Context context)
+    {
+        // No-op
     }
 }

--- a/src/Polly/Bulkhead/BulkheadTResultSyntax.cs
+++ b/src/Polly/Bulkhead/BulkheadTResultSyntax.cs
@@ -12,10 +12,7 @@ public partial class Policy
     /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
     /// <returns>The policy instance.</returns>
     public static BulkheadPolicy<TResult> Bulkhead<TResult>(int maxParallelization)
-    {
-        Action<Context> doNothing = _ => { };
-        return Bulkhead<TResult>(maxParallelization, 0, doNothing);
-    }
+        => Bulkhead<TResult>(maxParallelization, 0, EmptyAction);
 
     /// <summary>
     /// <para>Builds a bulkhead isolation <see cref="Policy{TResult}"/>, which limits the maximum concurrency of actions executed through the policy.  Imposing a maximum concurrency limits the potential of governed actions, when faulting, to bring down the system.</para>
@@ -41,10 +38,7 @@ public partial class Policy
     /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentOutOfRangeException">maxQueuingActions;Value must be greater than or equal to zero.</exception>
     public static BulkheadPolicy<TResult> Bulkhead<TResult>(int maxParallelization, int maxQueuingActions)
-    {
-        Action<Context> doNothing = _ => { };
-        return Bulkhead<TResult>(maxParallelization, maxQueuingActions, doNothing);
-    }
+        => Bulkhead<TResult>(maxParallelization, maxQueuingActions, EmptyAction);
 
     /// <summary>
     /// Builds a bulkhead isolation <see cref="Policy{TResult}" />, which limits the maximum concurrency of actions executed through the policy.  Imposing a maximum concurrency limits the potential of governed actions, when faulting, to bring down the system.

--- a/src/Polly/Fallback/AsyncFallbackSyntax.cs
+++ b/src/Polly/Fallback/AsyncFallbackSyntax.cs
@@ -14,17 +14,7 @@ public static class AsyncFallbackSyntax
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static AsyncFallbackPolicy FallbackAsync(this PolicyBuilder policyBuilder, Func<CancellationToken, Task> fallbackAction)
-    {
-        if (fallbackAction == null)
-        {
-            throw new ArgumentNullException(nameof(fallbackAction));
-        }
-
-        Func<Exception, Task> doNothing = _ => TaskHelper.EmptyTask;
-        return policyBuilder.FallbackAsync(
-            fallbackAction,
-            doNothing);
-    }
+        => policyBuilder.FallbackAsync(fallbackAction, static _ => TaskHelper.EmptyTask);
 
     /// <summary>
     /// Builds an <see cref="AsyncFallbackPolicy"/> which provides a fallback action if the main execution fails.  Executes the main delegate asynchronously, but if this throws a handled exception, first asynchronously calls <paramref name="onFallbackAsync"/> with details of the handled exception; then asynchronously calls <paramref name="fallbackAction"/>.
@@ -114,12 +104,7 @@ public static class AsyncFallbackTResultSyntax
     /// <param name="fallbackValue">The fallback <typeparamref name="TResult"/> value to provide.</param>
     /// <returns>The policy instance.</returns>
     public static AsyncFallbackPolicy<TResult> FallbackAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, TResult fallbackValue)
-    {
-        Func<DelegateResult<TResult>, Task> doNothing = _ => TaskHelper.EmptyTask;
-        return policyBuilder.FallbackAsync(
-            _ => Task.FromResult(fallbackValue),
-            doNothing);
-    }
+        => policyBuilder.FallbackAsync(_ => Task.FromResult(fallbackValue), static _ => TaskHelper.EmptyTask);
 
     /// <summary>
     /// Builds an <see cref="AsyncFallbackPolicy{TResult}"/> which provides a fallback value if the main execution fails.  Executes the main delegate asynchronously, but if this throws a handled exception or raises a handled result, asynchronously calls <paramref name="fallbackAction"/> and returns its result.
@@ -130,17 +115,7 @@ public static class AsyncFallbackTResultSyntax
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static AsyncFallbackPolicy<TResult> FallbackAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<CancellationToken, Task<TResult>> fallbackAction)
-    {
-        if (fallbackAction == null)
-        {
-            throw new ArgumentNullException(nameof(fallbackAction));
-        }
-
-        Func<DelegateResult<TResult>, Task> doNothing = _ => TaskHelper.EmptyTask;
-        return policyBuilder.FallbackAsync(
-            fallbackAction,
-            doNothing);
-    }
+        => policyBuilder.FallbackAsync(fallbackAction, static _ => TaskHelper.EmptyTask);
 
     /// <summary>
     /// Builds an <see cref="AsyncFallbackPolicy{TResult}"/> which provides a fallback value if the main execution fails.  Executes the main delegate asynchronously, but if this throws a handled exception or raises a handled result, first asynchronously calls <paramref name="onFallbackAsync"/> with details of the handled exception or result; then returns <paramref name="fallbackValue"/>.

--- a/src/Polly/Fallback/AsyncFallbackSyntax.cs
+++ b/src/Polly/Fallback/AsyncFallbackSyntax.cs
@@ -234,8 +234,8 @@ public static class AsyncFallbackTResultSyntax
         }
 
         return new AsyncFallbackPolicy<TResult>(
-                policyBuilder,
-                onFallbackAsync,
-                fallbackAction);
+            policyBuilder,
+            onFallbackAsync,
+            fallbackAction);
     }
 }

--- a/src/Polly/Fallback/FallbackSyntax.cs
+++ b/src/Polly/Fallback/FallbackSyntax.cs
@@ -14,15 +14,7 @@ public static class FallbackSyntax
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static FallbackPolicy Fallback(this PolicyBuilder policyBuilder, Action fallbackAction)
-    {
-        if (fallbackAction == null)
-        {
-            throw new ArgumentNullException(nameof(fallbackAction));
-        }
-
-        Action<Exception> doNothing = _ => { };
-        return policyBuilder.Fallback(fallbackAction, doNothing);
-    }
+        => policyBuilder.Fallback(fallbackAction, EmptyAction);
 
     /// <summary>
     /// Builds a <see cref="FallbackPolicy"/> which provides a fallback action if the main execution fails.  Executes the main delegate, but if this throws a handled exception, calls <paramref name="fallbackAction"/>.
@@ -32,15 +24,7 @@ public static class FallbackSyntax
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static FallbackPolicy Fallback(this PolicyBuilder policyBuilder, Action<CancellationToken> fallbackAction)
-    {
-        if (fallbackAction == null)
-        {
-            throw new ArgumentNullException(nameof(fallbackAction));
-        }
-
-        Action<Exception> doNothing = _ => { };
-        return policyBuilder.Fallback(fallbackAction, doNothing);
-    }
+        => policyBuilder.Fallback(fallbackAction, EmptyAction);
 
     /// <summary>
     /// Builds a <see cref="FallbackPolicy"/> which provides a fallback action if the main execution fails.  Executes the main delegate, but if this throws a handled exception, first calls <paramref name="onFallback"/> with details of the handled exception; then calls <paramref name="fallbackAction"/>.
@@ -164,6 +148,11 @@ public static class FallbackSyntax
                 onFallback,
                 fallbackAction);
     }
+
+    private static void EmptyAction(Exception exception)
+    {
+        // No-op
+    }
 }
 
 /// <summary>
@@ -179,10 +168,7 @@ public static class FallbackTResultSyntax
     /// <param name="fallbackValue">The fallback <typeparamref name="TResult"/> value to provide.</param>
     /// <returns>The policy instance.</returns>
     public static FallbackPolicy<TResult> Fallback<TResult>(this PolicyBuilder<TResult> policyBuilder, TResult fallbackValue)
-    {
-        Action<DelegateResult<TResult>> doNothing = _ => { };
-        return policyBuilder.Fallback(() => fallbackValue, doNothing);
-    }
+        => policyBuilder.Fallback(() => fallbackValue, EmptyAction);
 
     /// <summary>
     /// Builds a <see cref="FallbackPolicy"/> which provides a fallback value if the main execution fails.  Executes the main delegate, but if this throws a handled exception or raises a handled result, calls <paramref name="fallbackAction"/> and returns its result.
@@ -193,15 +179,7 @@ public static class FallbackTResultSyntax
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static FallbackPolicy<TResult> Fallback<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<TResult> fallbackAction)
-    {
-        if (fallbackAction == null)
-        {
-            throw new ArgumentNullException(nameof(fallbackAction));
-        }
-
-        Action<DelegateResult<TResult>> doNothing = _ => { };
-        return policyBuilder.Fallback(fallbackAction, doNothing);
-    }
+        => policyBuilder.Fallback(fallbackAction, EmptyAction);
 
     /// <summary>
     /// Builds a <see cref="FallbackPolicy"/> which provides a fallback value if the main execution fails.  Executes the main delegate, but if this throws a handled exception or raises a handled result, calls <paramref name="fallbackAction"/> and returns its result.
@@ -212,15 +190,7 @@ public static class FallbackTResultSyntax
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="fallbackAction"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static FallbackPolicy<TResult> Fallback<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<CancellationToken, TResult> fallbackAction)
-    {
-        if (fallbackAction == null)
-        {
-            throw new ArgumentNullException(nameof(fallbackAction));
-        }
-
-        Action<DelegateResult<TResult>> doNothing = _ => { };
-        return policyBuilder.Fallback(fallbackAction, doNothing);
-    }
+        => policyBuilder.Fallback(fallbackAction, EmptyAction);
 
     /// <summary>
     /// Builds a <see cref="FallbackPolicy"/> which provides a fallback value if the main execution fails.  Executes the main delegate, but if this throws a handled exception or raises a handled result, first calls <paramref name="onFallback"/> with details of the handled exception or result; then returns <paramref name="fallbackValue"/>.
@@ -386,5 +356,10 @@ public static class FallbackTResultSyntax
             policyBuilder,
             onFallback,
             fallbackAction);
+    }
+
+    private static void EmptyAction<T>(DelegateResult<T> result)
+    {
+        // No-op
     }
 }

--- a/src/Polly/Polly.csproj
+++ b/src/Polly/Polly.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>Polly</AssemblyTitle>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ProjectType>Library</ProjectType>
-    <MutationScore>97</MutationScore>
+    <MutationScore>100</MutationScore>
     <IncludePollyUsings>true</IncludePollyUsings>
     <!-- We do not plan on enabling nullable annotations for Polly -->
     <NoWarn>$(NoWarn);RS0037</NoWarn>

--- a/src/Polly/Retry/AsyncRetryTResultSyntax.cs
+++ b/src/Polly/Retry/AsyncRetryTResultSyntax.cs
@@ -376,8 +376,11 @@ public static class AsyncRetryTResultSyntax
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetry"/> is <see langword="null"/>.</exception>
-    public static AsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
-        Func<int, TimeSpan> sleepDurationProvider, Action<DelegateResult<TResult>, TimeSpan> onRetry)
+    public static AsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(
+        this PolicyBuilder<TResult> policyBuilder,
+        int retryCount,
+        Func<int, TimeSpan> sleepDurationProvider,
+        Action<DelegateResult<TResult>, TimeSpan> onRetry)
     {
         if (onRetry == null)
         {

--- a/src/Polly/Retry/AsyncRetryTResultSyntax.cs
+++ b/src/Polly/Retry/AsyncRetryTResultSyntax.cs
@@ -22,11 +22,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="retryCount">The retry count.</param>
     /// <returns>The policy instance.</returns>
     public static AsyncRetryPolicy<TResult> RetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount)
-    {
-        Action<DelegateResult<TResult>, int> doNothing = (_, _) => { };
-
-        return policyBuilder.RetryAsync(retryCount, doNothing);
-    }
+        => policyBuilder.RetryAsync(retryCount, static (_, _) => { });
 
     /// <summary>
     ///     Builds an <see cref="AsyncRetryPolicy{TResult}" /> that will retry once
@@ -183,11 +179,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <returns>The policy instance.</returns>
     public static AsyncRetryPolicy<TResult> RetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder)
-    {
-        Action<DelegateResult<TResult>> doNothing = _ => { };
-
-        return policyBuilder.RetryForeverAsync(doNothing);
-    }
+        => policyBuilder.RetryForeverAsync(static _ => { });
 
     /// <summary>
     ///     Builds an <see cref="AsyncRetryPolicy{TResult}" /> that will retry indefinitely
@@ -368,11 +360,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="sleepDurationProvider">The function that provides the duration to wait for a particular retry attempt.</param>
     /// <returns>The policy instance.</returns>
     public static AsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider)
-    {
-        Action<DelegateResult<TResult>, TimeSpan> doNothing = (_, _) => { };
-
-        return policyBuilder.WaitAndRetryAsync(retryCount, sleepDurationProvider, doNothing);
-    }
+        => policyBuilder.WaitAndRetryAsync(retryCount, sleepDurationProvider, EmptyAction);
 
     /// <summary>
     ///     Builds an <see cref="AsyncRetryPolicy{TResult}" /> that will wait and retry <paramref name="retryCount" /> times
@@ -667,8 +655,11 @@ public static class AsyncRetryTResultSyntax
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
-    public static AsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
-        Func<int, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync)
+    public static AsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(
+        this PolicyBuilder<TResult> policyBuilder,
+        int retryCount,
+        Func<int, Context, TimeSpan> sleepDurationProvider,
+        Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync)
     {
         if (sleepDurationProvider == null)
         {
@@ -695,8 +686,11 @@ public static class AsyncRetryTResultSyntax
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentOutOfRangeException">retryCount;Value must be greater than or equal to zero.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> or <paramref name="onRetryAsync"/> is <see langword="null"/>.</exception>
-    public static AsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, int retryCount,
-        Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider, Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync)
+    public static AsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(
+        this PolicyBuilder<TResult> policyBuilder,
+        int retryCount,
+        Func<int, DelegateResult<TResult>, Context, TimeSpan> sleepDurationProvider,
+        Func<DelegateResult<TResult>, TimeSpan, int, Context, Task> onRetryAsync)
     {
         if (retryCount < 0)
         {
@@ -730,11 +724,7 @@ public static class AsyncRetryTResultSyntax
     /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
     /// <returns>The policy instance.</returns>
     public static AsyncRetryPolicy<TResult> WaitAndRetryAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, IEnumerable<TimeSpan> sleepDurations)
-    {
-        Action<DelegateResult<TResult>, TimeSpan> doNothing = (_, _) => { };
-
-        return policyBuilder.WaitAndRetryAsync(sleepDurations, doNothing);
-    }
+        => policyBuilder.WaitAndRetryAsync(sleepDurations, EmptyAction);
 
     /// <summary>
     ///     Builds an <see cref="AsyncRetryPolicy{TResult}" /> that will wait and retry as many times as there are provided
@@ -903,16 +893,7 @@ public static class AsyncRetryTResultSyntax
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, TimeSpan> sleepDurationProvider)
-    {
-        if (sleepDurationProvider == null)
-        {
-            throw new ArgumentNullException(nameof(sleepDurationProvider));
-        }
-
-        Action<DelegateResult<TResult>, TimeSpan> doNothing = (_, _) => { };
-
-        return policyBuilder.WaitAndRetryForeverAsync(sleepDurationProvider, doNothing);
-    }
+        => policyBuilder.WaitAndRetryForeverAsync(sleepDurationProvider, EmptyAction);
 
     /// <summary>
     /// Builds an <see cref="AsyncRetryPolicy{TResult}"/> that will wait and retry indefinitely until the action succeeds.
@@ -925,16 +906,7 @@ public static class AsyncRetryTResultSyntax
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
     public static AsyncRetryPolicy<TResult> WaitAndRetryForeverAsync<TResult>(this PolicyBuilder<TResult> policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider)
-    {
-        if (sleepDurationProvider == null)
-        {
-            throw new ArgumentNullException(nameof(sleepDurationProvider));
-        }
-
-        Action<DelegateResult<TResult>, TimeSpan, Context> doNothing = (_, _, _) => { };
-
-        return policyBuilder.WaitAndRetryForeverAsync(sleepDurationProvider, doNothing);
-    }
+        => policyBuilder.WaitAndRetryForeverAsync(sleepDurationProvider, static (_, _, _) => { });
 
     /// <summary>
     /// Builds an <see cref="AsyncRetryPolicy{TResult}"/> that will wait and retry indefinitely until the action succeeds,
@@ -1220,6 +1192,11 @@ public static class AsyncRetryTResultSyntax
             policyBuilder,
             (exception, timespan, i, ctx) => onRetryAsync(exception, i, timespan, ctx),
             sleepDurationProvider: sleepDurationProvider);
+    }
+
+    private static void EmptyAction<T>(DelegateResult<T> result, TimeSpan retryAfter)
+    {
+        // No-op
     }
 }
 

--- a/src/Polly/Retry/RetrySyntax.cs
+++ b/src/Polly/Retry/RetrySyntax.cs
@@ -20,11 +20,7 @@ public static class RetrySyntax
     /// <param name="retryCount">The retry count.</param>
     /// <returns>The policy instance.</returns>
     public static RetryPolicy Retry(this PolicyBuilder policyBuilder, int retryCount)
-    {
-        Action<Exception, int> doNothing = (_, _) => { };
-
-        return policyBuilder.Retry(retryCount, doNothing);
-    }
+        => policyBuilder.Retry(retryCount, static (_, _) => { });
 
     /// <summary>
     /// Builds a <see cref="Policy"/> that will retry once
@@ -107,11 +103,7 @@ public static class RetrySyntax
     /// <param name="policyBuilder">The policy builder.</param>
     /// <returns>The policy instance.</returns>
     public static RetryPolicy RetryForever(this PolicyBuilder policyBuilder)
-    {
-        Action<Exception> doNothing = _ => { };
-
-        return policyBuilder.RetryForever(doNothing);
-    }
+        => policyBuilder.RetryForever(static _ => { });
 
     /// <summary>
     /// Builds a <see cref="Policy"/> that will retry indefinitely
@@ -199,11 +191,7 @@ public static class RetrySyntax
     /// <param name="sleepDurationProvider">The function that provides the duration to wait for a particular retry attempt.</param>
     /// <returns>The policy instance.</returns>
     public static RetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, TimeSpan> sleepDurationProvider)
-    {
-        Action<Exception, TimeSpan, int, Context> doNothing = (_, _, _, _) => { };
-
-        return policyBuilder.WaitAndRetry(retryCount, sleepDurationProvider, doNothing);
-    }
+        => policyBuilder.WaitAndRetry(retryCount, sleepDurationProvider, EmptyHandlerWithContext);
 
     /// <summary>
     /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
@@ -307,11 +295,7 @@ public static class RetrySyntax
     /// <param name="sleepDurationProvider">The function that provides the duration to wait for a particular retry attempt.</param>
     /// <returns>The policy instance.</returns>
     public static RetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, int retryCount, Func<int, Context, TimeSpan> sleepDurationProvider)
-    {
-        Action<Exception, TimeSpan, int, Context> doNothing = (_, _, _, _) => { };
-
-        return policyBuilder.WaitAndRetry(retryCount, sleepDurationProvider, doNothing);
-    }
+        => policyBuilder.WaitAndRetry(retryCount, sleepDurationProvider, EmptyHandlerWithContext);
 
     /// <summary>
     /// Builds a <see cref="Policy"/> that will wait and retry <paramref name="retryCount"/> times
@@ -410,11 +394,7 @@ public static class RetrySyntax
     /// <param name="sleepDurations">The sleep durations to wait for on each retry.</param>
     /// <returns>The policy instance.</returns>
     public static RetryPolicy WaitAndRetry(this PolicyBuilder policyBuilder, IEnumerable<TimeSpan> sleepDurations)
-    {
-        Action<Exception, TimeSpan> doNothing = (_, _) => { };
-
-        return policyBuilder.WaitAndRetry(sleepDurations, doNothing);
-    }
+        => policyBuilder.WaitAndRetry(sleepDurations, EmptyHandler);
 
     /// <summary>
     /// Builds a <see cref="Policy"/> that will wait and retry as many times as there are provided <paramref name="sleepDurations"/>
@@ -494,16 +474,7 @@ public static class RetrySyntax
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
     public static RetryPolicy WaitAndRetryForever(this PolicyBuilder policyBuilder, Func<int, TimeSpan> sleepDurationProvider)
-    {
-        if (sleepDurationProvider == null)
-        {
-            throw new ArgumentNullException(nameof(sleepDurationProvider));
-        }
-
-        Action<Exception, TimeSpan> doNothing = (_, _) => { };
-
-        return policyBuilder.WaitAndRetryForever(sleepDurationProvider, doNothing);
-    }
+        => policyBuilder.WaitAndRetryForever(sleepDurationProvider, EmptyHandler);
 
     /// <summary>
     /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds.
@@ -515,16 +486,7 @@ public static class RetrySyntax
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="sleepDurationProvider"/> is <see langword="null"/>.</exception>
     public static RetryPolicy WaitAndRetryForever(this PolicyBuilder policyBuilder, Func<int, Context, TimeSpan> sleepDurationProvider)
-    {
-        if (sleepDurationProvider == null)
-        {
-            throw new ArgumentNullException(nameof(sleepDurationProvider));
-        }
-
-        Action<Exception, TimeSpan, Context> doNothing = (_, _, _) => { };
-
-        return policyBuilder.WaitAndRetryForever(sleepDurationProvider, doNothing);
-    }
+        => policyBuilder.WaitAndRetryForever(sleepDurationProvider, static (_, _, _) => { });
 
     /// <summary>
     /// Builds a <see cref="Policy"/> that will wait and retry indefinitely until the action succeeds,
@@ -690,5 +652,15 @@ public static class RetrySyntax
             policyBuilder,
             (exception, timespan, i, ctx) => onRetry(exception, i, timespan, ctx),
             sleepDurationProvider: sleepDurationProvider);
+    }
+
+    private static void EmptyHandler(Exception exception, TimeSpan retryAfter)
+    {
+        // No-op
+    }
+
+    private static void EmptyHandlerWithContext(Exception exception, TimeSpan retryAfter, int attempts, Context context)
+    {
+        // No-op
     }
 }

--- a/src/Polly/Timeout/TimeoutTResultSyntax.cs
+++ b/src/Polly/Timeout/TimeoutTResultSyntax.cs
@@ -12,9 +12,7 @@ public partial class Policy
     public static TimeoutPolicy<TResult> Timeout<TResult>(int seconds)
     {
         TimeoutValidator.ValidateSecondsTimeout(seconds);
-        Action<Context, TimeSpan, Task, Exception> doNothing = (_, _, _, _) => { };
-
-        return Timeout<TResult>(_ => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, doNothing);
+        return Timeout<TResult>(_ => TimeSpan.FromSeconds(seconds), TimeoutStrategy.Optimistic, EmptyHandler);
     }
 
     /// <summary>
@@ -28,9 +26,7 @@ public partial class Policy
     public static TimeoutPolicy<TResult> Timeout<TResult>(int seconds, TimeoutStrategy timeoutStrategy)
     {
         TimeoutValidator.ValidateSecondsTimeout(seconds);
-        Action<Context, TimeSpan, Task, Exception> doNothing = (_, _, _, _) => { };
-
-        return Timeout<TResult>(_ => TimeSpan.FromSeconds(seconds), timeoutStrategy, doNothing);
+        return Timeout<TResult>(_ => TimeSpan.FromSeconds(seconds), timeoutStrategy, EmptyHandler);
     }
 
     /// <summary>
@@ -120,9 +116,7 @@ public partial class Policy
 #pragma warning restore S3872
     {
         TimeoutValidator.ValidateTimeSpanTimeout(timeout);
-        Action<Context, TimeSpan, Task, Exception> doNothing = (_, _, _, _) => { };
-
-        return Timeout<TResult>(_ => timeout, TimeoutStrategy.Optimistic, doNothing);
+        return Timeout<TResult>(_ => timeout, TimeoutStrategy.Optimistic, EmptyHandler);
     }
 
 #pragma warning disable S3872
@@ -138,9 +132,7 @@ public partial class Policy
 #pragma warning restore S3872
     {
         TimeoutValidator.ValidateTimeSpanTimeout(timeout);
-        Action<Context, TimeSpan, Task, Exception> doNothing = (_, _, _, _) => { };
-
-        return Timeout<TResult>(_ => timeout, timeoutStrategy, doNothing);
+        return Timeout<TResult>(_ => timeout, timeoutStrategy, EmptyHandler);
     }
 
 #pragma warning disable S3872
@@ -231,8 +223,7 @@ public partial class Policy
             throw new ArgumentNullException(nameof(timeoutProvider));
         }
 
-        Action<Context, TimeSpan, Task, Exception> doNothing = (_, _, _, _) => { };
-        return Timeout<TResult>(_ => timeoutProvider(), TimeoutStrategy.Optimistic, doNothing);
+        return Timeout<TResult>(_ => timeoutProvider(), TimeoutStrategy.Optimistic, EmptyHandler);
     }
 
     /// <summary>
@@ -250,8 +241,7 @@ public partial class Policy
             throw new ArgumentNullException(nameof(timeoutProvider));
         }
 
-        Action<Context, TimeSpan, Task, Exception> doNothing = (_, _, _, _) => { };
-        return Timeout<TResult>(_ => timeoutProvider(), timeoutStrategy, doNothing);
+        return Timeout<TResult>(_ => timeoutProvider(), timeoutStrategy, EmptyHandler);
     }
 
     /// <summary>
@@ -344,10 +334,7 @@ public partial class Policy
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
     /// <returns>The policy instance.</returns>
     public static TimeoutPolicy<TResult> Timeout<TResult>(Func<Context, TimeSpan> timeoutProvider)
-    {
-        Action<Context, TimeSpan, Task, Exception> doNothing = (_, _, _, _) => { };
-        return Timeout<TResult>(timeoutProvider, TimeoutStrategy.Optimistic, doNothing);
-    }
+        => Timeout<TResult>(timeoutProvider, TimeoutStrategy.Optimistic, EmptyHandler);
 
     /// <summary>
     /// Builds a <see cref="Policy{TResult}" /> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException" /> will be thrown if the delegate does not complete within the configured timeout.
@@ -358,10 +345,7 @@ public partial class Policy
     /// <returns>The policy instance.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeoutProvider"/> is <see langword="null"/>.</exception>
     public static TimeoutPolicy<TResult> Timeout<TResult>(Func<Context, TimeSpan> timeoutProvider, TimeoutStrategy timeoutStrategy)
-    {
-        Action<Context, TimeSpan, Task, Exception> doNothing = (_, _, _, _) => { };
-        return Timeout<TResult>(timeoutProvider, timeoutStrategy, doNothing);
-    }
+        => Timeout<TResult>(timeoutProvider, timeoutStrategy, EmptyHandler);
 
     /// <summary>
     /// Builds a <see cref="Policy{TResult}"/> that will wait for a delegate to complete for a specified period of time. A <see cref="TimeoutRejectedException"/> will be thrown if the delegate does not complete within the configured timeout.

--- a/test/Polly.Specs/Fallback/FallbackAsyncSpecs.cs
+++ b/test/Polly.Specs/Fallback/FallbackAsyncSpecs.cs
@@ -17,31 +17,28 @@ public class FallbackAsyncSpecs
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("fallbackAction");
-    }
 
-    [Fact]
-    public void Should_throw_when_fallback_func_is_null_with_onFallback()
-    {
-        Func<CancellationToken, Task> fallbackActionAsync = null!;
-        Func<Exception, Task> onFallbackAsync = _ => TaskHelper.EmptyTask;
-
-        Action policy = () => Policy
+        policy = () => Policy
             .Handle<DivideByZeroException>()
-            .FallbackAsync(fallbackActionAsync, onFallbackAsync);
+            .FallbackAsync(fallbackActionAsync, _ => TaskHelper.EmptyTask);
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("fallbackAction");
-    }
 
-    [Fact]
-    public void Should_throw_when_fallback_func_is_null_with_onFallback_with_context()
-    {
-        Func<Context, CancellationToken, Task> fallbackActionAsync = null!;
-        Func<Exception, Context, Task> onFallbackAsync = (_, _) => TaskHelper.EmptyTask;
+        Func<Context, CancellationToken, Task> fallbackActionAsyncContext = null!;
 
-        Action policy = () => Policy
-                                .Handle<DivideByZeroException>()
-                                .FallbackAsync(fallbackActionAsync, onFallbackAsync);
+        policy = () => Policy
+            .Handle<DivideByZeroException>()
+            .FallbackAsync(fallbackActionAsyncContext, (_, _) => TaskHelper.EmptyTask);
+
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("fallbackAction");
+
+        Func<Exception, Context, CancellationToken, Task> fallbackActionAsyncExceptionContext = null!;
+
+        policy = () => Policy
+            .Handle<DivideByZeroException>()
+            .FallbackAsync(fallbackActionAsyncExceptionContext, (_, _) => TaskHelper.EmptyTask);
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("fallbackAction");
@@ -50,33 +47,20 @@ public class FallbackAsyncSpecs
     [Fact]
     public void Should_throw_when_onFallback_delegate_is_null()
     {
-        Func<CancellationToken, Task> fallbackActionAsync = _ => TaskHelper.EmptyTask;
         Func<Exception, Task> onFallbackAsync = null!;
 
         Action policy = () => Policy
-                                .Handle<DivideByZeroException>()
-                                .FallbackAsync(fallbackActionAsync, onFallbackAsync);
+            .Handle<DivideByZeroException>()
+            .FallbackAsync(_ => TaskHelper.EmptyTask, onFallbackAsync);
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("onFallbackAsync");
+
+        Func<Exception, Context, Task> onFallbackAsyncContext = null!;
 
         policy = () => Policy
             .Handle<DivideByZeroException>()
-            .FallbackAsync(fallbackActionAsync, onFallbackAsync);
-
-        Should.Throw<ArgumentNullException>(policy)
-            .ParamName.ShouldBe("onFallbackAsync");
-    }
-
-    [Fact]
-    public void Should_throw_when_onFallback_delegate_is_null_with_context()
-    {
-        Func<Context, CancellationToken, Task> fallbackActionAsync = (_, _) => TaskHelper.EmptyTask;
-        Func<Exception, Context, Task> onFallbackAsync = null!;
-
-        Action policy = () => Policy
-                                .Handle<DivideByZeroException>()
-                                .FallbackAsync(fallbackActionAsync, onFallbackAsync);
+            .FallbackAsync((_, _, _) => TaskHelper.EmptyTask, onFallbackAsyncContext);
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("onFallbackAsync");

--- a/test/Polly.Specs/Fallback/FallbackAsyncSpecs.cs
+++ b/test/Polly.Specs/Fallback/FallbackAsyncSpecs.cs
@@ -60,6 +60,13 @@ public class FallbackAsyncSpecs
 
         policy = () => Policy
             .Handle<DivideByZeroException>()
+            .FallbackAsync((_, _) => TaskHelper.EmptyTask, onFallbackAsyncContext);
+
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onFallbackAsync");
+
+        policy = () => Policy
+            .Handle<DivideByZeroException>()
             .FallbackAsync((_, _, _) => TaskHelper.EmptyTask, onFallbackAsyncContext);
 
         Should.Throw<ArgumentNullException>(policy)

--- a/test/Polly.Specs/Fallback/FallbackSpecs.cs
+++ b/test/Polly.Specs/Fallback/FallbackSpecs.cs
@@ -42,72 +42,44 @@ public class FallbackSpecs
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("fallbackAction");
-    }
 
-    [Fact]
-    public void Should_throw_when_fallback_action_with_cancellation_is_null()
-    {
-        Action<CancellationToken> fallbackAction = null!;
-
-        Action policy = () => Policy
+        policy = () => Policy
             .Handle<DivideByZeroException>()
-            .Fallback(fallbackAction);
+            .Fallback(fallbackAction, _ => { });
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("fallbackAction");
-    }
 
-    [Fact]
-    public void Should_throw_when_fallback_action_is_null_with_onFallback()
-    {
-        Action fallbackAction = null!;
-        Action<Exception> onFallback = _ => { };
-
-        Action policy = () => Policy
+        policy = () => Policy
             .Handle<DivideByZeroException>()
-            .Fallback(fallbackAction, onFallback);
+            .Fallback(fallbackActionToken, _ => { });
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("fallbackAction");
-    }
 
-    [Fact]
-    public void Should_throw_when_fallback_action_with_cancellation_is_null_with_onFallback()
-    {
-        Action<CancellationToken> fallbackAction = null!;
-        Action<Exception> onFallback = _ => { };
+        Action<Context> fallbackActionContext = null!;
 
-        Action policy = () => Policy
+        policy = () => Policy
             .Handle<DivideByZeroException>()
-            .Fallback(fallbackAction, onFallback);
+            .Fallback(fallbackActionContext, (_, _) => { });
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("fallbackAction");
-    }
 
-    [Fact]
-    public void Should_throw_when_fallback_action_is_null_with_onFallback_with_context()
-    {
-        Action<Context> fallbackAction = null!;
-        Action<Exception, Context> onFallback = (_, _) => { };
+        Action<Context, CancellationToken> fallbackActionContextToken = null!;
 
-        Action policy = () => Policy
+        policy = () => Policy
             .Handle<DivideByZeroException>()
-            .Fallback(fallbackAction, onFallback);
+            .Fallback(fallbackActionContextToken, (_, _) => { });
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("fallbackAction");
-    }
 
-    [Fact]
-    public void Should_throw_when_fallback_action_with_cancellation_is_null_with_onFallback_with_context()
-    {
-        Action<Context, CancellationToken> fallbackAction = null!;
-        Action<Exception, Context> onFallback = (_, _) => { };
+        Action<Exception, Context, CancellationToken> fallbackActionExceptionContextToken = null!;
 
-        Action policy = () => Policy
+        policy = () => Policy
             .Handle<DivideByZeroException>()
-            .Fallback(fallbackAction, onFallback);
+            .Fallback(fallbackActionExceptionContextToken, (_, _) => { });
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("fallbackAction");
@@ -116,54 +88,43 @@ public class FallbackSpecs
     [Fact]
     public void Should_throw_when_onFallback_delegate_is_null()
     {
-        Action fallbackAction = () => { };
         Action<Exception> onFallback = null!;
 
         Action policy = () => Policy
             .Handle<DivideByZeroException>()
-            .Fallback(fallbackAction, onFallback);
+            .Fallback(() => { }, onFallback);
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("onFallback");
-    }
 
-    [Fact]
-    public void Should_throw_when_onFallback_delegate_is_null_with_action_with_cancellation()
-    {
-        Action<CancellationToken> fallbackAction = _ => { };
-        Action<Exception> onFallback = null!;
+        Action<Exception> onFallbackException = null!;
 
-        Action policy = () => Policy
+        policy = () => Policy
             .Handle<DivideByZeroException>()
-            .Fallback(fallbackAction, onFallback);
+            .Fallback(_ => { }, onFallbackException);
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("onFallback");
-    }
 
-    [Fact]
-    public void Should_throw_when_onFallback_delegate_is_null_with_context()
-    {
-        Action<Context> fallbackAction = _ => { };
-        Action<Exception, Context> onFallback = null!;
+        Action<Exception, Context> onFallbackExceptionContext = null!;
 
-        Action policy = () => Policy
+        policy = () => Policy
             .Handle<DivideByZeroException>()
-            .Fallback(fallbackAction, onFallback);
+            .Fallback(_ => { }, onFallbackExceptionContext);
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("onFallback");
-    }
 
-    [Fact]
-    public void Should_throw_when_onFallback_delegate_is_null_with_context_with_action_with_cancellation()
-    {
-        Action<Context, CancellationToken> fallbackAction = (_, _) => { };
-        Action<Exception, Context> onFallback = null!;
-
-        Action policy = () => Policy
+        policy = () => Policy
             .Handle<DivideByZeroException>()
-            .Fallback(fallbackAction, onFallback);
+            .Fallback((_, _) => { }, onFallbackExceptionContext);
+
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onFallback");
+
+        policy = () => Policy
+            .Handle<DivideByZeroException>()
+            .Fallback((_, _, _) => { }, onFallbackExceptionContext);
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("onFallback");

--- a/test/Polly.Specs/Fallback/FallbackTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/Fallback/FallbackTResultAsyncSpecs.cs
@@ -44,31 +44,29 @@ public class FallbackTResultAsyncSpecs
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("fallbackAction");
-    }
-
-    [Fact]
-    public void Should_throw_when_fallback_action_is_null_with_onFallback()
-    {
-        Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = null!;
         Func<DelegateResult<ResultPrimitive>, Task> onFallbackAsync = _ => TaskHelper.EmptyTask;
 
-        Action policy = () => Policy
+        policy = () => Policy
             .HandleResult(ResultPrimitive.Fault)
-            .FallbackAsync(fallbackAction, onFallbackAsync);
+            .FallbackAsync(fallbackAction, _ => TaskHelper.EmptyTask);
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("fallbackAction");
-    }
 
-    [Fact]
-    public void Should_throw_when_fallback_action_is_null_with_onFallback_with_context()
-    {
-        Func<Context, CancellationToken, Task<ResultPrimitive>> fallbackAction = null!;
-        Func<DelegateResult<ResultPrimitive>, Context, Task> onFallbackAsync = (_, _) => TaskHelper.EmptyTask;
+        Func<Context, CancellationToken, Task<ResultPrimitive>> fallbackActionContext = null!;
 
-        Action policy = () => Policy
+        policy = () => Policy
             .HandleResult(ResultPrimitive.Fault)
-            .FallbackAsync(fallbackAction, onFallbackAsync);
+            .FallbackAsync(fallbackActionContext, (_, _) => TaskHelper.EmptyTask);
+
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("fallbackAction");
+
+        Func<DelegateResult<ResultPrimitive>, Context, CancellationToken, Task<ResultPrimitive>> fallbackActionResult = null!;
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .FallbackAsync(fallbackActionResult, (_, _) => TaskHelper.EmptyTask);
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("fallbackAction");
@@ -77,12 +75,11 @@ public class FallbackTResultAsyncSpecs
     [Fact]
     public void Should_throw_when_onFallback_delegate_is_null()
     {
-        Func<CancellationToken, Task<ResultPrimitive>> fallbackAction = _ => Task.FromResult(ResultPrimitive.Substitute);
         Func<DelegateResult<ResultPrimitive>, Task> onFallbackAsync = null!;
 
         Action policy = () => Policy
             .HandleResult(ResultPrimitive.Fault)
-            .FallbackAsync(fallbackAction, onFallbackAsync);
+            .FallbackAsync(_ => Task.FromResult(ResultPrimitive.Substitute), onFallbackAsync);
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("onFallbackAsync");
@@ -93,17 +90,12 @@ public class FallbackTResultAsyncSpecs
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("onFallbackAsync");
-    }
 
-    [Fact]
-    public void Should_throw_when_onFallback_delegate_is_null_with_context()
-    {
-        Func<Context, CancellationToken, Task<ResultPrimitive>> fallbackAction = (_, _) => Task.FromResult(ResultPrimitive.Substitute);
-        Func<DelegateResult<ResultPrimitive>, Context, Task> onFallbackAsync = null!;
+        Func<DelegateResult<ResultPrimitive>, Context, Task> onFallbackAsyncContext = null!;
 
-        Action policy = () => Policy
+        policy = () => Policy
             .HandleResult(ResultPrimitive.Fault)
-            .FallbackAsync(fallbackAction, onFallbackAsync);
+            .FallbackAsync((_, _) => Task.FromResult(ResultPrimitive.Substitute), onFallbackAsyncContext);
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("onFallbackAsync");
@@ -111,6 +103,13 @@ public class FallbackTResultAsyncSpecs
         policy = () => Policy
             .HandleResult(ResultPrimitive.Fault)
             .FallbackAsync(ResultPrimitive.Substitute, onFallbackAsync);
+
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onFallbackAsync");
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .FallbackAsync((_, _, _) => Task.FromResult(ResultPrimitive.Substitute), onFallbackAsyncContext);
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("onFallbackAsync");
@@ -122,6 +121,12 @@ public class FallbackTResultAsyncSpecs
         Action policy = () => Policy
             .HandleResult(ResultPrimitive.Fault)
             .FallbackAsync((_, _) => Task.FromResult(ResultPrimitive.Substitute), (_, _) => TaskHelper.EmptyTask);
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .FallbackAsync(ResultPrimitive.Substitute, (_) => TaskHelper.EmptyTask);
 
         Should.NotThrow(policy);
 

--- a/test/Polly.Specs/Fallback/FallbackTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/Fallback/FallbackTResultAsyncSpecs.cs
@@ -113,6 +113,13 @@ public class FallbackTResultAsyncSpecs
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("onFallbackAsync");
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .FallbackAsync(ResultPrimitive.Substitute, onFallbackAsyncContext);
+
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onFallbackAsync");
     }
 
     [Fact]

--- a/test/Polly.Specs/Fallback/FallbackTResultSpecs.cs
+++ b/test/Polly.Specs/Fallback/FallbackTResultSpecs.cs
@@ -34,28 +34,6 @@ public class FallbackTResultSpecs
     }
 
     [Fact]
-    public void Should_throw_when_fallback_action_is_null()
-    {
-        Func<ResultPrimitive> fallbackAction = null!;
-
-        Action policy = () => Policy
-                                .HandleResult(ResultPrimitive.Fault)
-                                .Fallback(fallbackAction);
-
-        Should.Throw<ArgumentNullException>(policy)
-            .ParamName.ShouldBe("fallbackAction");
-
-        Func<CancellationToken, ResultPrimitive> fallbackActionToken = null!;
-
-        policy = () => Policy
-            .HandleResult(ResultPrimitive.Fault)
-            .Fallback(fallbackActionToken);
-
-        Should.Throw<ArgumentNullException>(policy)
-            .ParamName.ShouldBe("fallbackAction");
-    }
-
-    [Fact]
     public void Should_not_throw_when_fallback_action_is_not_null()
     {
         Action policy = () => Policy
@@ -69,12 +47,18 @@ public class FallbackTResultSpecs
             .Fallback((_) => ResultPrimitive.Substitute);
 
         Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .Fallback(ResultPrimitive.Substitute, (_) => { });
+
+        Should.NotThrow(policy);
     }
 
     [Fact]
-    public void Should_throw_when_fallback_action_with_cancellation_is_null()
+    public void Should_throw_when_fallback_action_is_null()
     {
-        Func<CancellationToken, ResultPrimitive> fallbackAction = null!;
+        Func<ResultPrimitive> fallbackAction = null!;
 
         Action policy = () => Policy
             .HandleResult(ResultPrimitive.Fault)
@@ -82,59 +66,53 @@ public class FallbackTResultSpecs
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("fallbackAction");
-    }
 
-    [Fact]
-    public void Should_throw_when_fallback_action_is_null_with_onFallback()
-    {
-        Func<ResultPrimitive> fallbackAction = null!;
-        Action<DelegateResult<ResultPrimitive>> onFallback = _ => { };
+        Func<CancellationToken, ResultPrimitive> fallbackActionToken = null!;
 
-        Action policy = () => Policy
-                                .HandleResult(ResultPrimitive.Fault)
-                                .Fallback(fallbackAction, onFallback);
-
-        Should.Throw<ArgumentNullException>(policy)
-            .ParamName.ShouldBe("fallbackAction");
-    }
-
-    [Fact]
-    public void Should_throw_when_fallback_action_with_cancellation_is_null_with_onFallback()
-    {
-        Func<CancellationToken, ResultPrimitive> fallbackAction = null!;
-        Action<DelegateResult<ResultPrimitive>> onFallback = _ => { };
-
-        Action policy = () => Policy
+        policy = () => Policy
             .HandleResult(ResultPrimitive.Fault)
-            .Fallback(fallbackAction, onFallback);
+            .Fallback(fallbackActionToken);
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("fallbackAction");
-    }
 
-    [Fact]
-    public void Should_throw_when_fallback_action_is_null_with_onFallback_with_context()
-    {
-        Func<Context, ResultPrimitive> fallbackAction = null!;
-        Action<DelegateResult<ResultPrimitive>, Context> onFallback = (_, _) => { };
-
-        Action policy = () => Policy
-                                .HandleResult(ResultPrimitive.Fault)
-                                .Fallback(fallbackAction, onFallback);
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .Fallback(fallbackAction, _ => { });
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("fallbackAction");
-    }
 
-    [Fact]
-    public void Should_throw_when_fallback_action_with_cancellation_is_null_with_onFallback_with_context()
-    {
-        Func<Context, CancellationToken, ResultPrimitive> fallbackAction = null!;
-        Action<DelegateResult<ResultPrimitive>, Context> onFallback = (_, _) => { };
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .Fallback(fallbackActionToken, _ => { });
 
-        Action policy = () => Policy
-                                .HandleResult(ResultPrimitive.Fault)
-                                .Fallback(fallbackAction, onFallback);
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("fallbackAction");
+
+        Func<Context, ResultPrimitive> fallbackActionContext = null!;
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .Fallback(fallbackActionContext, (_, _) => { });
+
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("fallbackAction");
+
+        Func<Context, CancellationToken, ResultPrimitive> fallbackActionContextToken = null!;
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .Fallback(fallbackActionContextToken, (_, _) => { });
+
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("fallbackAction");
+
+        Func<DelegateResult<ResultPrimitive>, Context, CancellationToken, ResultPrimitive> fallbackActionResultContextToken = null!;
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .Fallback(fallbackActionResultContextToken, (_, _) => { });
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("fallbackAction");
@@ -143,12 +121,11 @@ public class FallbackTResultSpecs
     [Fact]
     public void Should_throw_when_onFallback_delegate_is_null()
     {
-        Func<ResultPrimitive> fallbackAction = () => ResultPrimitive.Substitute;
         Action<DelegateResult<ResultPrimitive>> onFallback = null!;
 
         Action policy = () => Policy
-                                .HandleResult(ResultPrimitive.Fault)
-                                .Fallback(fallbackAction, onFallback);
+            .HandleResult(ResultPrimitive.Fault)
+            .Fallback(() => ResultPrimitive.Substitute, onFallback);
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("onFallback");
@@ -159,45 +136,40 @@ public class FallbackTResultSpecs
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("onFallback");
-    }
 
-    [Fact]
-    public void Should_throw_when_onFallback_delegate_is_null_with_action_with_cancellation()
-    {
-        Func<CancellationToken, ResultPrimitive> fallbackAction = _ => ResultPrimitive.Substitute;
-        Action<DelegateResult<ResultPrimitive>> onFallback = null!;
-
-        Action policy = () => Policy
+        policy = () => Policy
             .HandleResult(ResultPrimitive.Fault)
-            .Fallback(fallbackAction, onFallback);
+            .Fallback(_ => ResultPrimitive.Substitute, onFallback);
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("onFallback");
-    }
 
-    [Fact]
-    public void Should_throw_when_onFallback_delegate_is_null_with_context()
-    {
-        Func<Context, ResultPrimitive> fallbackAction = _ => ResultPrimitive.Substitute;
-        Action<DelegateResult<ResultPrimitive>, Context> onFallback = null!;
+        Action<DelegateResult<ResultPrimitive>, Context> onFallbackContext = null!;
 
-        Action policy = () => Policy
-                                .HandleResult(ResultPrimitive.Fault)
-                                .Fallback(fallbackAction, onFallback);
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .Fallback(_ => ResultPrimitive.Substitute, onFallbackContext);
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("onFallback");
-    }
 
-    [Fact]
-    public void Should_throw_when_onFallback_delegate_is_null_with_context_with_action_with_cancellation()
-    {
-        Func<Context, CancellationToken, ResultPrimitive> fallbackAction = (_, _) => ResultPrimitive.Substitute;
-        Action<DelegateResult<ResultPrimitive>, Context> onFallback = null!;
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .Fallback((_, _) => ResultPrimitive.Substitute, onFallbackContext);
 
-        Action policy = () => Policy
-                                .HandleResult(ResultPrimitive.Fault)
-                                .Fallback(fallbackAction, onFallback);
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onFallback");
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .Fallback(ResultPrimitive.Substitute, onFallbackContext);
+
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onFallback");
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .Fallback((_, _, _) => ResultPrimitive.Substitute, onFallbackContext);
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("onFallback");

--- a/test/Polly.Specs/Polly.Specs.csproj
+++ b/test/Polly.Specs/Polly.Specs.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net481</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ProjectType>Test</ProjectType>
-    <Threshold>85,80,85</Threshold>
+    <Threshold>91,90,89</Threshold>
     <Include>[Polly]*</Include>
     <IncludePollyUsings>true</IncludePollyUsings>
   </PropertyGroup>

--- a/test/Polly.Specs/Retry/RetryForeverAsyncSpecs.cs
+++ b/test/Polly.Specs/Retry/RetryForeverAsyncSpecs.cs
@@ -5,6 +5,16 @@ namespace Polly.Specs.Retry;
 public class RetryForeverAsyncSpecs
 {
     [Fact]
+    public void Should_not_throw_if_arguments_are_valid()
+    {
+        Action policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .RetryForeverAsync((DelegateResult<ResultPrimitive> _, Context _) => { });
+
+        Should.NotThrow(policy);
+    }
+
+    [Fact]
     public async Task Should_not_throw_regardless_of_how_many_times_the_specified_exception_is_raised()
     {
         var policy = Policy
@@ -108,11 +118,20 @@ public class RetryForeverAsyncSpecs
         Action<DelegateResult<ResultPrimitive>> onRetry = null!;
 
         Action policy = () => Policy
-                                  .HandleResult(ResultPrimitive.Fault)
-                                  .RetryForeverAsync(onRetry);
+            .HandleResult(ResultPrimitive.Fault)
+            .RetryForeverAsync(onRetry);
 
         Should.Throw<ArgumentNullException>(policy)
-              .ParamName.ShouldBe("onRetry");
+            .ParamName.ShouldBe("onRetry");
+
+        Action<DelegateResult<ResultPrimitive>, int> onRetryAttempts = null!;
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .RetryForeverAsync(onRetryAttempts);
+
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]

--- a/test/Polly.Specs/Retry/RetryForeverSpecs.cs
+++ b/test/Polly.Specs/Retry/RetryForeverSpecs.cs
@@ -65,6 +65,15 @@ public class RetryForeverSpecs
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("onRetry");
+
+        Action<Exception, int, Context> onRetryAttemptsContext = null!;
+
+        policy = () => Policy
+            .Handle<DivideByZeroException>()
+            .RetryForever(onRetryAttemptsContext);
+
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]

--- a/test/Polly.Specs/Retry/RetryForeverSpecs.cs
+++ b/test/Polly.Specs/Retry/RetryForeverSpecs.cs
@@ -3,68 +3,68 @@
 public class RetryForeverSpecs
 {
     [Fact]
-    public void Should_throw_when_onretry_action_without_context_is_null()
-    {
-        Action<Exception> nullOnRetry = null!;
-
-        Action policy = () => Policy
-                                  .Handle<DivideByZeroException>()
-                                  .RetryForever(nullOnRetry);
-
-        Should.Throw<ArgumentNullException>(policy)
-              .ParamName.ShouldBe("onRetry");
-    }
-
-    [Fact]
-    public void Should_throw_when_onretry_action_with_context_is_null()
-    {
-        Action<Exception, Context> nullOnRetry = null!;
-
-        Action policy = () => Policy
-                                  .Handle<DivideByZeroException>()
-                                  .RetryForever(nullOnRetry);
-
-        Should.Throw<ArgumentNullException>(policy)
-              .ParamName.ShouldBe("onRetry");
-    }
-
-    [Fact]
     public void Should_throw_when_onretry_action_is_null()
     {
-        Action<DelegateResult<ResultPrimitive>> nullOnRetry = null!;
+        Action<Exception> onRetry = null!;
 
         Action policy = () => Policy
-                                  .HandleResult(ResultPrimitive.Fault)
-                                  .RetryForever(nullOnRetry);
+            .Handle<DivideByZeroException>()
+            .RetryForever(onRetry);
+
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onRetry");
+
+        Action<Exception, Context> onRetryContext = null!;
+
+        policy = () => Policy
+            .Handle<DivideByZeroException>()
+            .RetryForever(onRetryContext);
 
         Should.Throw<ArgumentNullException>(policy)
               .ParamName.ShouldBe("onRetry");
-    }
 
-    [Fact]
-    public void Should_throw_when_onretry_action_with_int_is_null()
-    {
-        Action<DelegateResult<ResultPrimitive>, int> nullOnRetry = null!;
+        Action<DelegateResult<ResultPrimitive>> onRetryResult = null!;
 
-        Action policy = () => Policy
-                                  .HandleResult(ResultPrimitive.Fault)
-                                  .RetryForever(nullOnRetry);
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .RetryForever(onRetryResult);
 
         Should.Throw<ArgumentNullException>(policy)
-              .ParamName.ShouldBe("onRetry");
-    }
+            .ParamName.ShouldBe("onRetry");
 
-    [Fact]
-    public void Should_throw_when_onretry_for_result_action_with_context_is_null()
-    {
-        Action<DelegateResult<ResultPrimitive>, Context> nullOnRetry = null!;
+        Action<DelegateResult<ResultPrimitive>, int> onRetryResultAttempts = null!;
 
-        Action policy = () => Policy
-                                  .HandleResult(ResultPrimitive.Fault)
-                                  .RetryForever(nullOnRetry);
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .RetryForever(onRetryResultAttempts);
 
         Should.Throw<ArgumentNullException>(policy)
-              .ParamName.ShouldBe("onRetry");
+            .ParamName.ShouldBe("onRetry");
+
+        Action<DelegateResult<ResultPrimitive>, Context> onRetryResultContext = null!;
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .RetryForever(onRetryResultContext);
+
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onRetry");
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .RetryForever(onRetryResultContext);
+
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onRetry");
+
+        Action<Exception, int> onRetryAttempts = null!;
+
+        policy = () => Policy
+            .Handle<DivideByZeroException>()
+            .RetryForever(onRetryAttempts);
+
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]

--- a/test/Polly.Specs/Retry/RetrySpecs.cs
+++ b/test/Polly.Specs/Retry/RetrySpecs.cs
@@ -46,29 +46,39 @@ public class RetrySpecs
     }
 
     [Fact]
-    public void Should_throw_when_onretry_action_without_context_is_null()
+    public void Should_throw_when_onretry_action_is_null()
     {
-        Action<Exception, int> nullOnRetry = null!;
+        Action<Exception, int> onRetry = null!;
 
         Action policy = () => Policy
-                                  .Handle<DivideByZeroException>()
-                                  .Retry(1, nullOnRetry);
+            .Handle<DivideByZeroException>()
+            .Retry(1, onRetry);
 
         Should.Throw<ArgumentNullException>(policy)
-              .ParamName.ShouldBe("onRetry");
-    }
+            .ParamName.ShouldBe("onRetry");
 
-    [Fact]
-    public void Should_throw_when_retry_count_is_less_than_zero_with_context()
-    {
-        Action<Exception, int, Context> onRetry = (_, _, _) => { };
+        policy = () => Policy
+            .Handle<DivideByZeroException>()
+            .Retry(onRetry);
 
-        Action policy = () => Policy
-                                  .Handle<DivideByZeroException>()
-                                  .Retry(-1, onRetry);
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("onRetry");
+
+        Action<Exception, int, Context> onRetryContext = (_, _, _) => { };
+
+        policy = () => Policy
+            .Handle<DivideByZeroException>()
+            .Retry(-1, onRetryContext);
 
         Should.Throw<ArgumentOutOfRangeException>(policy)
-              .ParamName.ShouldBe("retryCount");
+            .ParamName.ShouldBe("retryCount");
+
+        policy = () => Policy
+            .Handle<DivideByZeroException>()
+            .Retry(-1, onRetryContext);
+
+        Should.Throw<ArgumentOutOfRangeException>(policy)
+            .ParamName.ShouldBe("retryCount");
     }
 
     [Fact]

--- a/test/Polly.Specs/Retry/RetryTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/Retry/RetryTResultAsyncSpecs.cs
@@ -56,7 +56,7 @@ public class RetryTResultAsyncSpecs
 
         policy = () => Policy
             .HandleResult(ResultPrimitive.Fault)
-            .RetryForeverAsync((DelegateResult<ResultPrimitive> _) => { });
+            .RetryForeverAsync((_) => { });
 
         Should.NotThrow(policy);
 
@@ -72,15 +72,19 @@ public class RetryTResultAsyncSpecs
 
         Should.NotThrow(policy);
 
+        Func<DelegateResult<ResultPrimitive>, int, Task> onRetryAttempts = (_, _) => TaskHelper.EmptyTask;
+
         policy = () => Policy
             .HandleResult(ResultPrimitive.Fault)
-            .RetryForeverAsync((DelegateResult<ResultPrimitive> _, int _) => TaskHelper.EmptyTask);
+            .RetryForeverAsync(onRetryAttempts);
 
         Should.NotThrow(policy);
 
+        Func<DelegateResult<ResultPrimitive>, Context, Task> onRetryContext = (_, _) => TaskHelper.EmptyTask;
+
         policy = () => Policy
             .HandleResult(ResultPrimitive.Fault)
-            .RetryForeverAsync((DelegateResult<ResultPrimitive> _, Context _) => TaskHelper.EmptyTask);
+            .RetryForeverAsync(onRetryContext);
 
         Should.NotThrow(policy);
 

--- a/test/Polly.Specs/Retry/RetryTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/Retry/RetryTResultAsyncSpecs.cs
@@ -34,13 +34,93 @@ public class RetryTResultAsyncSpecs
     }
 
     [Fact]
+    public void Should_not_throw_when_arguments_are_valid()
+    {
+        Action policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .RetryAsync(1, (_, _) => TaskHelper.EmptyTask);
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .RetryAsync((_, _, _) => TaskHelper.EmptyTask);
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .RetryForeverAsync();
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .RetryForeverAsync((DelegateResult<ResultPrimitive> _) => { });
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .RetryForeverAsync((DelegateResult<ResultPrimitive> _, int _) => { });
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .RetryForeverAsync((_) => TaskHelper.EmptyTask);
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .RetryForeverAsync((DelegateResult<ResultPrimitive> _, int _) => TaskHelper.EmptyTask);
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .RetryForeverAsync((DelegateResult<ResultPrimitive> _, Context _) => TaskHelper.EmptyTask);
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .RetryForeverAsync((_, _, _) => { });
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .RetryForeverAsync((_, _, _) => TaskHelper.EmptyTask);
+
+        Should.NotThrow(policy);
+    }
+
+    [Fact]
     public void Should_throw_when_onretryasync_is_null()
     {
         Func<DelegateResult<ResultPrimitive>, int, Task> onRetryAsync = null!;
 
         Action policy = () => Policy
-                                  .HandleResult(ResultPrimitive.Fault)
-                                  .RetryAsync(1, onRetryAsync);
+            .HandleResult(ResultPrimitive.Fault)
+            .RetryAsync(1, onRetryAsync);
+
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetryAsync");
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .RetryAsync(1, onRetryAsync);
+
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetryAsync");
+
+        Func<DelegateResult<ResultPrimitive>, int, Context, Task> onRetryAsyncContext = null!;
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .RetryAsync(1, onRetryAsyncContext);
 
         Should.Throw<ArgumentNullException>(policy)
               .ParamName.ShouldBe("onRetryAsync");

--- a/test/Polly.Specs/Retry/WaitAndRetryAsyncSpecs.cs
+++ b/test/Polly.Specs/Retry/WaitAndRetryAsyncSpecs.cs
@@ -509,7 +509,7 @@ public class WaitAndRetryAsyncSpecs : IDisposable
     }
 
     [Fact]
-    public void Should_throw_when_retry_count_is_less_than_zero_without_context()
+    public void Should_throw_when_retry_count_is_less_than_zero()
     {
         Action<Exception, TimeSpan> onRetry = (_, _) => { };
 
@@ -529,7 +529,7 @@ public class WaitAndRetryAsyncSpecs : IDisposable
     }
 
     [Fact]
-    public void Should_not_throw_when_retry_count_is_zero_without_context()
+    public void Should_not_throw_when_arguments_are_valid()
     {
         Action policy = () => Policy
             .Handle<DivideByZeroException>()
@@ -540,6 +540,18 @@ public class WaitAndRetryAsyncSpecs : IDisposable
         policy = () => Policy
             .Handle<DivideByZeroException>()
             .WaitAndRetryAsync(0, (_, _, _) => TimeSpan.Zero, (_, _, _, _) => TaskHelper.EmptyTask);
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .Handle<DivideByZeroException>()
+            .WaitAndRetryAsync([], (_, _) => TaskHelper.EmptyTask);
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .Handle<DivideByZeroException>()
+            .WaitAndRetryAsync([], (_, _, _) => TaskHelper.EmptyTask);
 
         Should.NotThrow(policy);
     }
@@ -558,7 +570,7 @@ public class WaitAndRetryAsyncSpecs : IDisposable
     }
 
     [Fact]
-    public void Should_throw_when_onretry_action_is_null_without_context_when_using_provider_overload()
+    public void Should_throw_when_onretry_action_is_null()
     {
         Action<Exception, TimeSpan> nullOnRetry = null!;
 
@@ -571,7 +583,7 @@ public class WaitAndRetryAsyncSpecs : IDisposable
     }
 
     [Fact]
-    public void Should_throw_when_onretryasync_action_is_null_without_context()
+    public void Should_throw_when_onretryasync_action_is_null()
     {
         Func<Exception, TimeSpan, Context, Task> onRetryWithContextAsync = null!;
 
@@ -599,32 +611,10 @@ public class WaitAndRetryAsyncSpecs : IDisposable
 
         Should.Throw<ArgumentNullException>(policy)
               .ParamName.ShouldBe("onRetryAsync");
-    }
-
-    [Fact]
-    public void Should_not_throw_when_onretryasync_action_has_context()
-    {
-        Action policy = () => Policy
-            .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync([], (_, _) => TaskHelper.EmptyTask);
-
-        Should.NotThrow(policy);
 
         policy = () => Policy
             .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync([], (_, _, _) => TaskHelper.EmptyTask);
-
-        Should.NotThrow(policy);
-    }
-
-    [Fact]
-    public void Should_throw_when_onretryasync_action_is_null_with_context()
-    {
-        Func<Exception, TimeSpan, Context, Task> onRetryAsync = null!;
-
-        Action policy = () => Policy
-            .Handle<DivideByZeroException>()
-            .WaitAndRetryAsync(1, (_, _) => TimeSpan.Zero, onRetryAsync);
+            .WaitAndRetryAsync(1, (_, _) => TimeSpan.Zero, onRetryWithContextAsync);
 
         Should.Throw<ArgumentNullException>(policy)
               .ParamName.ShouldBe("onRetryAsync");

--- a/test/Polly.Specs/Retry/WaitAndRetryForeverSpecs.cs
+++ b/test/Polly.Specs/Retry/WaitAndRetryForeverSpecs.cs
@@ -6,99 +6,114 @@ public class WaitAndRetryForeverSpecs : IDisposable
     public WaitAndRetryForeverSpecs() => SystemClock.Sleep = (_, _) => { };
 
     [Fact]
-    public void Should_throw_when_sleep_duration_provider_is_null_without_context()
+    public void Should_throw_when_sleep_duration_provider_is_null()
     {
         Func<int, Context, TimeSpan> sleepDurationProvider = null!;
 
         Action policy = () => Policy
-                                  .Handle<DivideByZeroException>()
-                                  .WaitAndRetryForever(sleepDurationProvider);
+            .Handle<DivideByZeroException>()
+            .WaitAndRetryForever(sleepDurationProvider);
 
         Should.Throw<ArgumentNullException>(policy)
-              .ParamName.ShouldBe("sleepDurationProvider");
+            .ParamName.ShouldBe("sleepDurationProvider");
+
+        policy = () => Policy
+            .Handle<DivideByZeroException>()
+            .WaitAndRetryForever(null, (_, _) => { });
+
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("sleepDurationProvider");
+
+        policy = () => Policy
+            .Handle<DivideByZeroException>()
+            .WaitAndRetryForever(sleepDurationProvider, (_, _, _) => { });
+
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("sleepDurationProvider");
+
+        policy = () => Policy
+            .Handle<DivideByZeroException>()
+            .WaitAndRetryForever(sleepDurationProvider, (_, _, _, _) => { });
+
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("sleepDurationProvider");
+
+        policy = () => Policy
+            .Handle<DivideByZeroException>()
+            .WaitAndRetryForever((Func<int, TimeSpan>)null!, (_, _, _) => { });
+
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("sleepDurationProvider");
+
+        policy = () => Policy
+            .Handle<DivideByZeroException>()
+            .WaitAndRetryForever((Func<int, Exception, Context, TimeSpan>)null!, (_, _, _) => { });
+
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("sleepDurationProvider");
+
+        policy = () => Policy
+            .Handle<DivideByZeroException>()
+            .WaitAndRetryForever((Func<int, Exception, Context, TimeSpan>)null!, (_, _, _, _) => { });
+
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("sleepDurationProvider");
     }
 
     [Fact]
-    public void Should_throw_not_when_sleep_duration_provider_is_not_null_with_context()
+    public void Should_throw_not_when_argumets_are_valid()
     {
-        Func<int, Context, TimeSpan> sleepDurationProvider = (_, _) => TimeSpan.Zero;
-
         Action policy = () => Policy
-                                  .Handle<DivideByZeroException>()
-                                  .WaitAndRetryForever(sleepDurationProvider);
+            .Handle<DivideByZeroException>()
+            .WaitAndRetryForever((_, _) => TimeSpan.Zero);
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .Handle<DivideByZeroException>()
+            .WaitAndRetryForever((_, _) => TimeSpan.Zero, (_, _, _, _) => { });
 
         Should.NotThrow(policy);
     }
 
     [Fact]
-    public void Should_throw_when_sleep_duration_provider_is_null_without_context_with_onretry()
+    public void Should_throw_when_onretry_action_is_null()
     {
-        Action<Exception, TimeSpan> onRetry = (_, _) => { };
+        Action<Exception, TimeSpan> onRetry = null!;
 
         Action policy = () => Policy
-                                  .Handle<DivideByZeroException>()
-                                  .WaitAndRetryForever(null, onRetry);
+            .Handle<DivideByZeroException>()
+            .WaitAndRetryForever(_ => TimeSpan.Zero, onRetry);
 
         Should.Throw<ArgumentNullException>(policy)
-              .ParamName.ShouldBe("sleepDurationProvider");
-    }
+            .ParamName.ShouldBe("onRetry");
 
-    [Fact]
-    public void Should_throw_when_sleep_duration_provider_is_null_with_context()
-    {
-        Action<Exception, TimeSpan, Context> onRetry = (_, _, _) => { };
+        Action<Exception, TimeSpan, Context> onRetryContext = null!;
 
-        Func<int, Context, TimeSpan> sleepDurationProvider = null!;
-
-        Action policy = () => Policy
-                                  .Handle<DivideByZeroException>()
-                                  .WaitAndRetryForever(sleepDurationProvider, onRetry);
+        policy = () => Policy
+            .Handle<DivideByZeroException>()
+            .WaitAndRetryForever((_, _) => TimeSpan.Zero, onRetryContext);
 
         Should.Throw<ArgumentNullException>(policy)
-              .ParamName.ShouldBe("sleepDurationProvider");
-    }
+            .ParamName.ShouldBe("onRetry");
 
-    [Fact]
-    public void Should_throw_when_sleep_duration_provider_is_null_with_context_and_onretry_with_attempt()
-    {
-        Action<Exception, int, TimeSpan, Context> onRetry = (_, _, _, _) => { };
+        Action<Exception, int, TimeSpan> onRetryAttempts = null!;
 
-        Func<int, Context, TimeSpan> sleepDurationProvider = null!;
-
-        Action policy = () => Policy
-                                  .Handle<DivideByZeroException>()
-                                  .WaitAndRetryForever(sleepDurationProvider, onRetry);
+        policy = () => Policy
+            .Handle<DivideByZeroException>()
+            .WaitAndRetryForever((_) => TimeSpan.Zero, onRetryAttempts);
 
         Should.Throw<ArgumentNullException>(policy)
-              .ParamName.ShouldBe("sleepDurationProvider");
-    }
+            .ParamName.ShouldBe("onRetry");
 
-    [Fact]
-    public void Should_throw_when_onretry_action_is_null_without_context()
-    {
-        Action<Exception, TimeSpan> nullOnRetry = null!;
-        Func<int, TimeSpan> provider = _ => TimeSpan.Zero;
+        Action<Exception, int, TimeSpan, Context> onRetryAttemptsContext = null!;
 
-        Action policy = () => Policy
-                                  .Handle<DivideByZeroException>()
-                                  .WaitAndRetryForever(provider, nullOnRetry);
+        policy = () => Policy
+            .Handle<DivideByZeroException>()
+            .WaitAndRetryForever((_, _, _) => TimeSpan.Zero, onRetryAttemptsContext);
 
         Should.Throw<ArgumentNullException>(policy)
-              .ParamName.ShouldBe("onRetry");
-    }
-
-    [Fact]
-    public void Should_throw_when_onretry_action_is_null_with_context()
-    {
-        Action<Exception, TimeSpan, Context> nullOnRetry = null!;
-        Func<int, Context, TimeSpan> provider = (_, _) => TimeSpan.Zero;
-
-        Action policy = () => Policy
-                                  .Handle<DivideByZeroException>()
-                                  .WaitAndRetryForever(provider, nullOnRetry);
-
-        Should.Throw<ArgumentNullException>(policy)
-              .ParamName.ShouldBe("onRetry");
+            .ParamName.ShouldBe("onRetry");
     }
 
     [Fact]

--- a/test/Polly.Specs/Retry/WaitAndRetryForeverTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/Retry/WaitAndRetryForeverTResultAsyncSpecs.cs
@@ -96,7 +96,15 @@ public class WaitAndRetryForeverTResultAsyncSpecs : IDisposable
 
         Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetryAsync");
 
-        Func<DelegateResult<ResultPrimitive>, int, TimeSpan, Context, Task> onRetryResultAsync = null!;
+        Func<DelegateResult<ResultPrimitive>, TimeSpan, Context, Task> onRetryResultRetryAfterAsync = null!;
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync((_, _, _) => TimeSpan.Zero, onRetryResultRetryAfterAsync);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetryAsync");
+
+        Func<DelegateResult<ResultPrimitive>, TimeSpan, Context, Task> onRetryResultAsync = null!;
 
         policy = () => Policy
             .HandleResult(ResultPrimitive.Fault)
@@ -161,6 +169,12 @@ public class WaitAndRetryForeverTResultAsyncSpecs : IDisposable
         Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("sleepDurationProvider");
 
         Func<int, DelegateResult<ResultPrimitive>, Context, TimeSpan> sleepDurationProviderFunc = null!;
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync(sleepDurationProviderFunc, (_, _, _) => TaskHelper.EmptyTask);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("sleepDurationProvider");
 
         policy = () => Policy
             .HandleResult(ResultPrimitive.Fault)

--- a/test/Polly.Specs/Retry/WaitAndRetryForeverTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/Retry/WaitAndRetryForeverTResultAsyncSpecs.cs
@@ -104,11 +104,20 @@ public class WaitAndRetryForeverTResultAsyncSpecs : IDisposable
 
         Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetryAsync");
 
-        Func<DelegateResult<ResultPrimitive>, TimeSpan, Context, Task> onRetryResultAsync = null!;
+        Func<DelegateResult<ResultPrimitive>, TimeSpan, Context, Task> onRetryResultTimeSpanAsync = null!;
 
         policy = () => Policy
             .HandleResult(ResultPrimitive.Fault)
-            .WaitAndRetryForeverAsync((_, _, _) => TimeSpan.Zero, onRetryResultAsync);
+            .WaitAndRetryForeverAsync((_, _, _) => TimeSpan.Zero, onRetryResultTimeSpanAsync);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetryAsync");
+
+        Func<DelegateResult<ResultPrimitive>, int, TimeSpan, Context, Task> onRetryResultSecondsAsync = null!;
+        Func<int, DelegateResult<ResultPrimitive>, Context, TimeSpan> sleepDurationProvider = (_, _, _) => TimeSpan.Zero;
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync(sleepDurationProvider, onRetryResultSecondsAsync);
 
         Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetryAsync");
     }

--- a/test/Polly.Specs/Retry/WaitAndRetryForeverTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/Retry/WaitAndRetryForeverTResultAsyncSpecs.cs
@@ -41,6 +41,202 @@ public class WaitAndRetryForeverTResultAsyncSpecs : IDisposable
         actualRetryWaits.ShouldBe(expectedRetryWaits.Values);
     }
 
+    [Fact]
+    public void Should_throw_if_onRetry_is_null()
+    {
+        Action<DelegateResult<ResultPrimitive>, TimeSpan> onRetry = null!;
+
+        Action policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync((_) => TimeSpan.Zero, onRetry);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetry");
+
+        Action<DelegateResult<ResultPrimitive>, int, TimeSpan> onRetryAttempts = null!;
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync((_) => TimeSpan.Zero, onRetryAttempts);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetry");
+
+        Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onRetryContext = null!;
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync((_, _) => TimeSpan.Zero, onRetryContext);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetry");
+
+        Action<DelegateResult<ResultPrimitive>, int, TimeSpan, Context> onRetryAttemptsContext = null!;
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync((_, _) => TimeSpan.Zero, onRetryAttemptsContext);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetry");
+    }
+
+    [Fact]
+    public void Should_throw_if_onRetryAsync_is_null()
+    {
+        Func<DelegateResult<ResultPrimitive>, TimeSpan, Task> onRetryAsync = null!;
+
+        Action policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync((_) => TimeSpan.Zero, onRetryAsync);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetryAsync");
+
+        Func<DelegateResult<ResultPrimitive>, int, TimeSpan, Task> onRetryAttemptsAsync = null!;
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync((_) => TimeSpan.Zero, onRetryAttemptsAsync);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetryAsync");
+
+        Func<DelegateResult<ResultPrimitive>, int, TimeSpan, Context, Task> onRetryResultAsync = null!;
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync((_, _, _) => TimeSpan.Zero, onRetryResultAsync);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetryAsync");
+    }
+
+    [Fact]
+    public void Should_throw_if_sleepDurationProvider_is_null()
+    {
+        Func<int, TimeSpan> sleepDurationProvider = null!;
+
+        Action policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync(sleepDurationProvider);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("sleepDurationProvider");
+
+        Func<int, Context, TimeSpan> sleepDurationProviderContext = null!;
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync(sleepDurationProviderContext);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("sleepDurationProvider");
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync(sleepDurationProvider, (_, _) => { });
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("sleepDurationProvider");
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync(sleepDurationProvider, (_, _, _) => { });
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("sleepDurationProvider");
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync(sleepDurationProvider, (_, _) => TaskHelper.EmptyTask);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("sleepDurationProvider");
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync(sleepDurationProvider, (_, _, _) => TaskHelper.EmptyTask);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("sleepDurationProvider");
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync(sleepDurationProviderContext, (_, _, _) => TaskHelper.EmptyTask);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("sleepDurationProvider");
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync(sleepDurationProviderContext, (_, _, _, _) => TaskHelper.EmptyTask);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("sleepDurationProvider");
+
+        Func<int, DelegateResult<ResultPrimitive>, Context, TimeSpan> sleepDurationProviderFunc = null!;
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync(sleepDurationProviderFunc, (_, _, _, _) => TaskHelper.EmptyTask);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("sleepDurationProvider");
+    }
+
+    [Fact]
+    public void Should_not_throw_if_arguments_are_valid()
+    {
+        Action policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync((_) => TimeSpan.Zero);
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync((_, _) => TimeSpan.Zero);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync((_) => TimeSpan.Zero, (_, _) => { });
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync((_) => TimeSpan.Zero, (_, _, _) => { });
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync((_) => TimeSpan.Zero, (_, _) => TaskHelper.EmptyTask);
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync((_) => TimeSpan.Zero, (_, _, _) => TaskHelper.EmptyTask);
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync((_, _) => TimeSpan.Zero, (_, _, _) => { });
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync((_, _) => TimeSpan.Zero, (_, _, _, _) => { });
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync((_, _) => TimeSpan.Zero, (_, _, _) => TaskHelper.EmptyTask);
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync((_, _) => TimeSpan.Zero, (_, _, _, _) => TaskHelper.EmptyTask);
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryForeverAsync((_, _, _) => TimeSpan.Zero, (_, _, _, _) => TaskHelper.EmptyTask);
+
+        Should.NotThrow(policy);
+    }
+
     public void Dispose() =>
         SystemClock.Reset();
 }

--- a/test/Polly.Specs/Retry/WaitAndRetrySpecs.cs
+++ b/test/Polly.Specs/Retry/WaitAndRetrySpecs.cs
@@ -642,6 +642,13 @@ public class WaitAndRetrySpecs : IDisposable
 
         Should.Throw<ArgumentNullException>(policy)
               .ParamName.ShouldBe("sleepDurationProvider");
+
+        policy = () =>
+            Policy.Handle<DivideByZeroException>()
+                  .WaitAndRetry(1, (Func<int, Context, TimeSpan>)null!, (_, _, _, _) => { });
+
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("sleepDurationProvider");
     }
 
     [Fact]

--- a/test/Polly.Specs/Retry/WaitAndRetrySpecs.cs
+++ b/test/Polly.Specs/Retry/WaitAndRetrySpecs.cs
@@ -45,39 +45,66 @@ public class WaitAndRetrySpecs : IDisposable
     }
 
     [Fact]
-    public void Should_throw_when_onretry_action_is_null_without_context()
+    public void Should_throw_when_onretry_action_is_null()
     {
-        Action<Exception, TimeSpan> nullOnRetry = null!;
+        Action<Exception, TimeSpan> onRetry = null!;
 
         Action policy = () =>
             Policy.Handle<DivideByZeroException>()
-                  .WaitAndRetry([], nullOnRetry);
+                  .WaitAndRetry([], onRetry);
 
         Should.Throw<ArgumentNullException>(policy)
               .ParamName.ShouldBe("onRetry");
-    }
 
-    [Fact]
-    public void Should_throw_when_onretry_action_is_null_with_context()
-    {
-        Action<Exception, TimeSpan, Context> nullOnRetry = null!;
+        Action<Exception, TimeSpan, Context> onRetryContext = null!;
 
-        Action policy = () =>
+        policy = () =>
             Policy.Handle<DivideByZeroException>()
-                  .WaitAndRetry([], nullOnRetry);
+                  .WaitAndRetry([], onRetryContext);
 
         Should.Throw<ArgumentNullException>(policy)
               .ParamName.ShouldBe("onRetry");
-    }
 
-    [Fact]
-    public void Should_throw_when_onretry_action_is_null_with_attempts_with_context()
-    {
-        Action<Exception, TimeSpan, int, Context> nullOnRetry = null!;
+        Action<Exception, TimeSpan, int, Context> onRetryAttemptsContext = null!;
 
-        Action policy = () =>
+        policy = () =>
             Policy.Handle<DivideByZeroException>()
-                  .WaitAndRetry([], nullOnRetry);
+                  .WaitAndRetry([], onRetryAttemptsContext);
+
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
+
+        policy = () =>
+            Policy.Handle<DivideByZeroException>()
+                  .WaitAndRetry(1, _ => default, onRetry);
+
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
+
+        policy = () =>
+            Policy.Handle<DivideByZeroException>()
+                  .WaitAndRetry(1, _ => default, onRetryContext);
+
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
+
+        policy = () =>
+            Policy.Handle<DivideByZeroException>()
+                  .WaitAndRetry(1, _ => default, onRetryAttemptsContext);
+
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
+
+        policy = () =>
+            Policy.Handle<DivideByZeroException>()
+                  .WaitAndRetry(1, (_, _) => default, onRetryContext);
+
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("onRetry");
+
+        policy = () =>
+            Policy.Handle<DivideByZeroException>()
+                  .WaitAndRetry(1, (_, _) => default, onRetryAttemptsContext);
 
         Should.Throw<ArgumentNullException>(policy)
               .ParamName.ShouldBe("onRetry");
@@ -517,6 +544,22 @@ public class WaitAndRetrySpecs : IDisposable
     }
 
     [Fact]
+    public void Should_not_throw_if_arguments_are_valid()
+    {
+        var policy = () =>
+            Policy.Handle<DivideByZeroException>()
+                  .WaitAndRetry(1, _ => TimeSpan.Zero);
+
+        Should.NotThrow(policy);
+
+        policy = () =>
+            Policy.Handle<DivideByZeroException>()
+                  .WaitAndRetry(1, (_, _) => TimeSpan.Zero);
+
+        Should.NotThrow(policy);
+    }
+
+    [Fact]
     public void Should_not_throw_when_retry_count_is_zero()
     {
         Action<Exception, TimeSpan> onRetry = (_, _) => { };
@@ -570,78 +613,43 @@ public class WaitAndRetrySpecs : IDisposable
     }
 
     [Fact]
-    public void Should_throw_when_sleep_duration_provider_is_null_without_context()
+    public void Should_throw_when_sleep_duration_provider_is_null()
     {
-        Action<Exception, TimeSpan> onRetry = (_, _) => { };
-
         Action policy = () =>
             Policy.Handle<DivideByZeroException>()
-                  .WaitAndRetry(1, null, onRetry);
+                  .WaitAndRetry(1, null, (_, _) => { });
+
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("sleepDurationProvider");
+
+        policy = () =>
+            Policy.Handle<DivideByZeroException>()
+                  .WaitAndRetry(1, (Func<int, TimeSpan>)null!, (_, _, _) => { });
+
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("sleepDurationProvider");
+
+        policy = () =>
+            Policy.Handle<DivideByZeroException>()
+                  .WaitAndRetry(1, (Func<int, TimeSpan>)null!, (_, _, _, _) => { });
+
+        Should.Throw<ArgumentNullException>(policy)
+              .ParamName.ShouldBe("sleepDurationProvider");
+
+        policy = () =>
+            Policy.Handle<DivideByZeroException>()
+                  .WaitAndRetry(1, (Func<int, Exception, Context, TimeSpan>)null!, (_, _, _, _) => { });
 
         Should.Throw<ArgumentNullException>(policy)
               .ParamName.ShouldBe("sleepDurationProvider");
     }
 
     [Fact]
-    public void Should_throw_when_sleep_duration_provider_is_null_with_context()
+    public void Should_throw_when_onRetry_is_null()
     {
-        Action<Exception, TimeSpan, Context> onRetry = (_, _, _) => { };
-
         Action policy = () =>
             Policy.Handle<DivideByZeroException>()
-                  .WaitAndRetry(1, (Func<int, TimeSpan>)null!, onRetry);
-
-        Should.Throw<ArgumentNullException>(policy)
-              .ParamName.ShouldBe("sleepDurationProvider");
-    }
-
-    [Fact]
-    public void Should_throw_when_sleep_duration_provider_is_null_with_attempts_with_context()
-    {
-        Action<Exception, TimeSpan, int, Context> onRetry = (_, _, _, _) => { };
-
-        Action policy = () =>
-            Policy.Handle<DivideByZeroException>()
-                  .WaitAndRetry(1, (Func<int, TimeSpan>)null!, onRetry);
-
-        Should.Throw<ArgumentNullException>(policy)
-              .ParamName.ShouldBe("sleepDurationProvider");
-    }
-
-    [Fact]
-    public void Should_throw_when_onretry_action_is_null_without_context_when_using_provider_overload()
-    {
-        Action<Exception, TimeSpan> nullOnRetry = null!;
-
-        Action policy = () =>
-            Policy.Handle<DivideByZeroException>()
-                  .WaitAndRetry(1, _ => default, nullOnRetry);
-
-        Should.Throw<ArgumentNullException>(policy)
-              .ParamName.ShouldBe("onRetry");
-    }
-
-    [Fact]
-    public void Should_throw_when_onretry_action_is_null_with_context_when_using_provider_overload()
-    {
-        Action<Exception, TimeSpan, Context> nullOnRetry = null!;
-
-        Action policy = () =>
-            Policy.Handle<DivideByZeroException>()
-                  .WaitAndRetry(1, _ => default, nullOnRetry);
-
-        Should.Throw<ArgumentNullException>(policy)
-              .ParamName.ShouldBe("onRetry");
-    }
-
-    [Fact]
-    public void Should_throw_when_onretry_action_is_null_with_attempts_with_context_when_using_provider_overload()
-    {
-        Action<Exception, TimeSpan, int, Context> nullOnRetry = null!;
-
-        Action policy = () =>
-            Policy.Handle<DivideByZeroException>()
-                  .WaitAndRetry(1, _ => default, nullOnRetry);
+                  .WaitAndRetry(1, (_, _, _) => TimeSpan.Zero, null);
 
         Should.Throw<ArgumentNullException>(policy)
               .ParamName.ShouldBe("onRetry");

--- a/test/Polly.Specs/Retry/WaitAndRetryTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/Retry/WaitAndRetryTResultAsyncSpecs.cs
@@ -146,6 +146,12 @@ public class WaitAndRetryTResultAsyncSpecs : IDisposable
             .WaitAndRetryAsync([], onRetryWithAttemptsAsync);
 
         Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetryAsync");
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync(1, (_) => TimeSpan.Zero, onRetryWithAttemptsAsync);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetryAsync");
     }
 
     [Fact]
@@ -224,6 +230,14 @@ public class WaitAndRetryTResultAsyncSpecs : IDisposable
         policy = () => Policy
             .HandleResult(ResultPrimitive.Fault)
             .WaitAndRetryAsync(1, sleepDurationProviderContext, (_, _, _, _) => TaskHelper.EmptyTask);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("sleepDurationProvider");
+
+        Func<int, DelegateResult<ResultPrimitive>, Context, TimeSpan> sleepDurationProviderResultContext = null!;
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync(1, sleepDurationProviderResultContext, (_, _, _, _) => TaskHelper.EmptyTask);
 
         Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("sleepDurationProvider");
     }
@@ -312,6 +326,30 @@ public class WaitAndRetryTResultAsyncSpecs : IDisposable
         policy = () => Policy
             .HandleResult(ResultPrimitive.Fault)
             .WaitAndRetryAsync([], (_, _, _, _) => TaskHelper.EmptyTask);
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync(1, (_) => TimeSpan.Zero);
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync(1, (_) => TimeSpan.Zero, (_, _) => TaskHelper.EmptyTask);
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync(1, (_) => TimeSpan.Zero, (_, _, _) => TaskHelper.EmptyTask);
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync([]);
 
         Should.NotThrow(policy);
     }

--- a/test/Polly.Specs/Retry/WaitAndRetryTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/Retry/WaitAndRetryTResultAsyncSpecs.cs
@@ -88,14 +88,64 @@ public class WaitAndRetryTResultAsyncSpecs : IDisposable
     [Fact]
     public void Should_throw_when_onRetryAsync_is_null()
     {
-        Action configure = () => Policy
+        Action policy = () => Policy
             .HandleResult(ResultPrimitive.Fault)
             .WaitAndRetryAsync(
                 2,
                 (_, _, _) => default,
                 null);
 
-        Should.Throw<ArgumentNullException>(configure).ParamName.ShouldBe("onRetryAsync");
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetryAsync");
+
+        Func<DelegateResult<ResultPrimitive>, TimeSpan, Task> onRetryAsync = null!;
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync(1, (_) => TimeSpan.Zero, onRetryAsync);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetryAsync");
+
+        Func<DelegateResult<ResultPrimitive>, TimeSpan, Context, Task> onRetryAsyncContext = null!;
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync(1, (_) => TimeSpan.Zero, onRetryAsyncContext);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetryAsync");
+
+        Func<DelegateResult<ResultPrimitive>, TimeSpan, Context, Task> onRetryWithContextAsync = null!;
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync(1, (_, _) => TimeSpan.Zero, onRetryWithContextAsync);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetryAsync");
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync([], onRetryAsync);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetryAsync");
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync([], onRetryWithContextAsync);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetryAsync");
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync([], onRetryWithContextAsync);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetryAsync");
+
+        Func<DelegateResult<ResultPrimitive>, TimeSpan, int, Context, Task> onRetryWithAttemptsAsync = null!;
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync([], onRetryWithAttemptsAsync);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetryAsync");
     }
 
     [Fact]
@@ -109,14 +159,6 @@ public class WaitAndRetryTResultAsyncSpecs : IDisposable
 
         Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetry");
 
-        Func<DelegateResult<ResultPrimitive>, TimeSpan, Task> onRetryAsync = null!;
-
-        policy = () => Policy
-            .HandleResult(ResultPrimitive.Fault)
-            .WaitAndRetryAsync(1, (_) => TimeSpan.Zero, onRetryAsync);
-
-        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetryAsync");
-
         Action<DelegateResult<ResultPrimitive>, TimeSpan, Context> onRetryContext = null!;
 
         policy = () => Policy
@@ -124,14 +166,6 @@ public class WaitAndRetryTResultAsyncSpecs : IDisposable
             .WaitAndRetryAsync(1, (_) => TimeSpan.Zero, onRetryContext);
 
         Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetry");
-
-        Func<DelegateResult<ResultPrimitive>, TimeSpan, Context, Task> onRetryAsyncContext = null!;
-
-        policy = () => Policy
-            .HandleResult(ResultPrimitive.Fault)
-            .WaitAndRetryAsync(1, (_) => TimeSpan.Zero, onRetryAsyncContext);
-
-        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetryAsync");
 
         Action<DelegateResult<ResultPrimitive>, TimeSpan, int, Context> onRetryAttemptsResult = null!;
 
@@ -148,6 +182,62 @@ public class WaitAndRetryTResultAsyncSpecs : IDisposable
             .WaitAndRetryAsync(1, (_, _) => TimeSpan.Zero, onRetryResult);
 
         Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetry");
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync(1, (_, _) => TimeSpan.Zero, onRetryAttemptsResult);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetry");
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync([], onRetry);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetry");
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync([], onRetryContext);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetry");
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync([], onRetryAttemptsResult);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("onRetry");
+    }
+
+    [Fact]
+    public void Should_throw_sleepDurationProvider_is_null()
+    {
+        Func<int, TimeSpan> sleepDurationProvider = null!;
+
+        Action policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync(1, sleepDurationProvider, (_, _, _, _) => { });
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("sleepDurationProvider");
+
+        Func<int, Context, TimeSpan> sleepDurationProviderContext = null!;
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync(1, sleepDurationProviderContext, (_, _, _, _) => TaskHelper.EmptyTask);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("sleepDurationProvider");
+    }
+
+    [Fact]
+    public void Should_throw_sleepDurations_is_null()
+    {
+        IEnumerable<TimeSpan> sleepDurations = null!;
+
+        Action policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync(sleepDurations, (_, _, _, _) => TaskHelper.EmptyTask);
+
+        Should.Throw<ArgumentNullException>(policy).ParamName.ShouldBe("sleepDurations");
     }
 
     [Fact]
@@ -156,6 +246,72 @@ public class WaitAndRetryTResultAsyncSpecs : IDisposable
         Action policy = () => Policy
             .HandleResult(ResultPrimitive.Fault)
             .WaitAndRetryAsync(1, (_) => TimeSpan.Zero, (_, _, _, _) => { });
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync(1, (_) => TimeSpan.Zero, (_, _, _) => { });
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync(1, (_, _) => TimeSpan.Zero, (_, _, _) => { });
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync(1, (_, _) => TimeSpan.Zero, (_, _, _, _) => { });
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync(1, (_, _) => TimeSpan.Zero, (_, _, _) => TaskHelper.EmptyTask);
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync(1, (_, _) => TimeSpan.Zero, (_, _, _, _) => TaskHelper.EmptyTask);
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync([], (_, _) => { });
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync([], (_, _, _) => { });
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync([], (_, _) => TaskHelper.EmptyTask);
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync([], (_, _, _) => TaskHelper.EmptyTask);
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync([], (_, _, _, _) => { });
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy
+            .HandleResult(ResultPrimitive.Fault)
+            .WaitAndRetryAsync([], (_, _, _, _) => TaskHelper.EmptyTask);
 
         Should.NotThrow(policy);
     }

--- a/test/Polly.Specs/Timeout/TimeoutTResultSpecs.cs
+++ b/test/Polly.Specs/Timeout/TimeoutTResultSpecs.cs
@@ -69,67 +69,65 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
     }
 
     [Fact]
-    public void Should_not_throw_when_timeout_is_greater_than_zero_by_timespan()
+    public void Should_not_throw_when_arguments_are_valid()
     {
         Action policy = () => Policy.Timeout<ResultPrimitive>(TimeSpan.FromMilliseconds(1));
 
         Should.NotThrow(policy);
-    }
 
-    [Fact]
-    public void Should_not_throw_when_timeout_is_greater_than_zero_by_seconds()
-    {
-        Action policy = () => Policy.Timeout<ResultPrimitive>(3);
+        policy = () => Policy.Timeout<ResultPrimitive>(3);
 
         Should.NotThrow(policy);
-    }
 
-    [Fact]
-    public void Should_not_throw_when_timeout_is_maxvalue()
-    {
-        Action policy = () => Policy.Timeout<ResultPrimitive>(TimeSpan.MaxValue);
+        policy = () => Policy.Timeout<ResultPrimitive>(TimeSpan.MaxValue);
 
         Should.NotThrow(policy);
-    }
 
-    [Fact]
-    public void Should_not_throw_when_timeout_seconds_is_maxvalue()
-    {
-        Action policy = () => Policy.Timeout<ResultPrimitive>(int.MaxValue);
+        policy = () => Policy.Timeout<ResultPrimitive>(int.MaxValue);
 
         Should.NotThrow(policy);
-    }
 
-    [Fact]
-    public void Should_not_throw_when_timeout_is_infinitetimespan()
-    {
-        Action policy = () => Policy.Timeout<ResultPrimitive>(System.Threading.Timeout.InfiniteTimeSpan);
+        policy = () => Policy.Timeout<ResultPrimitive>(System.Threading.Timeout.InfiniteTimeSpan);
 
         Should.NotThrow(policy);
-    }
 
-    [Fact]
-    public void Should_not_throw_when_timeout_is_infinitetimespan_with_timeoutstrategy()
-    {
-        Action policy = () => Policy.Timeout<ResultPrimitive>(System.Threading.Timeout.InfiniteTimeSpan, TimeoutStrategy.Optimistic);
+        policy = () => Policy.Timeout<ResultPrimitive>(System.Threading.Timeout.InfiniteTimeSpan, TimeoutStrategy.Optimistic);
 
         Should.NotThrow(policy);
-    }
 
-    [Fact]
-    public void Should_not_throw_when_timeout_is_infinitetimespan_with_ontimeout()
-    {
-        Action<Context, TimeSpan, Task> doNothing = (_, _, _) => { };
-        Action policy = () => Policy.Timeout<ResultPrimitive>(System.Threading.Timeout.InfiniteTimeSpan, doNothing);
+        policy = () => Policy.Timeout<ResultPrimitive>(System.Threading.Timeout.InfiniteTimeSpan, (_, _, _) => { });
 
         Should.NotThrow(policy);
-    }
 
-    [Fact]
-    public void Should_not_throw_when_timeout_is_infinitetimespan_with_timeoutstrategy_and_ontimeout()
-    {
-        Action<Context, TimeSpan, Task> doNothing = (_, _, _) => { };
-        Action policy = () => Policy.Timeout<ResultPrimitive>(System.Threading.Timeout.InfiniteTimeSpan, TimeoutStrategy.Optimistic, doNothing);
+        policy = () => Policy.Timeout<ResultPrimitive>(System.Threading.Timeout.InfiniteTimeSpan, TimeoutStrategy.Optimistic, (_, _, _) => { });
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy.Timeout<ResultPrimitive>(1, TimeoutStrategy.Optimistic, (_, _, _) => { });
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy.Timeout<ResultPrimitive>(1, TimeoutStrategy.Optimistic, (_, _, _, _) => { });
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy.Timeout<ResultPrimitive>(() => TimeSpan.Zero, TimeoutStrategy.Optimistic);
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy.Timeout<ResultPrimitive>((_) => TimeSpan.Zero);
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy.Timeout<ResultPrimitive>((_) => TimeSpan.Zero, TimeoutStrategy.Optimistic);
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy.Timeout<ResultPrimitive>((_) => TimeSpan.Zero, TimeoutStrategy.Optimistic, (_, _, _) => { });
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy.Timeout<ResultPrimitive>((_) => TimeSpan.Zero, TimeoutStrategy.Optimistic, (_, _, _, _) => { });
 
         Should.NotThrow(policy);
     }
@@ -205,6 +203,31 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
     public void Should_throw_when_timeoutProvider_is_null()
     {
         Action policy = () => Policy.Timeout<ResultPrimitive>((Func<TimeSpan>)null!);
+
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("timeoutProvider");
+
+        policy = () => Policy.Timeout<ResultPrimitive>((Func<TimeSpan>)null!, (_, _, _) => { });
+
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("timeoutProvider");
+
+        policy = () => Policy.Timeout<ResultPrimitive>((Func<TimeSpan>)null!, (_, _, _, _) => { });
+
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("timeoutProvider");
+
+        policy = () => Policy.Timeout<ResultPrimitive>((Func<TimeSpan>)null!, TimeoutStrategy.Pessimistic, (_, _, _) => { });
+
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("timeoutProvider");
+
+        policy = () => Policy.Timeout<ResultPrimitive>((Func<TimeSpan>)null!, TimeoutStrategy.Pessimistic, (_, _, _, _) => { });
+
+        Should.Throw<ArgumentNullException>(policy)
+            .ParamName.ShouldBe("timeoutProvider");
+
+        policy = () => Policy.Timeout<ResultPrimitive>((Func<Context, TimeSpan>)null!, TimeoutStrategy.Pessimistic, (_, _, _, _) => { });
 
         Should.Throw<ArgumentNullException>(policy)
             .ParamName.ShouldBe("timeoutProvider");

--- a/test/Polly.Specs/Timeout/TimeoutTResultSpecs.cs
+++ b/test/Polly.Specs/Timeout/TimeoutTResultSpecs.cs
@@ -130,6 +130,18 @@ public class TimeoutTResultSpecs : TimeoutSpecsBase
         policy = () => Policy.Timeout<ResultPrimitive>((_) => TimeSpan.Zero, TimeoutStrategy.Optimistic, (_, _, _, _) => { });
 
         Should.NotThrow(policy);
+
+        policy = () => Policy.Timeout<ResultPrimitive>(() => TimeSpan.Zero, TimeoutStrategy.Optimistic, (_, _, _, _) => { });
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy.Timeout<ResultPrimitive>((_) => TimeSpan.Zero, (_, _, _) => { });
+
+        Should.NotThrow(policy);
+
+        policy = () => Policy.Timeout<ResultPrimitive>((_) => TimeSpan.Zero, (_, _, _, _) => { });
+
+        Should.NotThrow(policy);
     }
 
     [Fact]


### PR DESCRIPTION
- Add tests for the remaining undetected mutations.
- Remove remaining explicit `doNothing` delegate allocations.
- Increase mutation score for Polly to 100.
- Increase minimum code coverage for Polly.Specs to ~90%.
