### PR TITLE
Remove ignored mutations

### DIFF
--- a/eng/stryker-config.json
+++ b/eng/stryker-config.json
@@ -16,8 +16,6 @@
       "LogInformation"
     ],
     "ignore-mutations": [
-      "block",
-      "statement"
     ],
     "configuration": "Debug",
     "target-framework": "net8.0",


### PR DESCRIPTION
Just curious as to the impact on the mutation tests if we remove this, as Polly.Testing has to manually remove it to get any results at all anyway:

https://github.com/App-vNext/Polly/blob/4469d8392076e4025157f437dc5a9f7d8634bc7c/build.cake#L315-L318
