### PR TITLE
Remove dotnet tool restore

### DIFF
--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -57,9 +57,6 @@ jobs:
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # v4.3.0
 
-    - name: Restore .NET tools
-      run: dotnet tool restore
-
     - name: Run mutation tests for ${{ matrix.target }}
       shell: pwsh
       env:


### PR DESCRIPTION
This was added by #2500 but I think it's actually redundant.
