### PR TITLE
Add missing coverage

### DIFF
--- a/src/Polly.Extensions/DependencyInjection/PollyServiceCollectionExtensions.cs
+++ b/src/Polly.Extensions/DependencyInjection/PollyServiceCollectionExtensions.cs
@@ -234,7 +234,6 @@ public static class PollyServiceCollectionExtensions
             return services;
         }
 
-        services.AddOptions();
         services.Add(RegistryMarker<TKey>.ServiceDescriptor);
         services.AddResiliencePipelineBuilder();
 

--- a/src/Polly/Bulkhead/AsyncBulkheadTResultSyntax.cs
+++ b/src/Polly/Bulkhead/AsyncBulkheadTResultSyntax.cs
@@ -11,10 +11,7 @@ public partial class Policy
     /// <param name="maxParallelization">The maximum number of concurrent actions that may be executing through the policy.</param>
     /// <returns>The policy instance.</returns>
     public static AsyncBulkheadPolicy<TResult> BulkheadAsync<TResult>(int maxParallelization)
-    {
-        Func<Context, Task> doNothingAsync = _ => TaskHelper.EmptyTask;
-        return BulkheadAsync<TResult>(maxParallelization, 0, doNothingAsync);
-    }
+        => BulkheadAsync<TResult>(maxParallelization, 0, EmptyHandler);
 
     /// <summary>
     /// <para>Builds a bulkhead isolation <see cref="AsyncPolicy{TResult}"/>, which limits the maximum concurrency of actions executed through the policy.  Imposing a maximum concurrency limits the potential of governed actions, when faulting, to bring down the system.</para>
@@ -40,10 +37,7 @@ public partial class Policy
     /// <exception cref="ArgumentOutOfRangeException">maxParallelization;Value must be greater than zero.</exception>
     /// <exception cref="ArgumentOutOfRangeException">maxQueuingActions;Value must be greater than or equal to zero.</exception>
     public static AsyncBulkheadPolicy<TResult> BulkheadAsync<TResult>(int maxParallelization, int maxQueuingActions)
-    {
-        Func<Context, Task> doNothingAsync = _ => TaskHelper.EmptyTask;
-        return BulkheadAsync<TResult>(maxParallelization, maxQueuingActions, doNothingAsync);
-    }
+        => BulkheadAsync<TResult>(maxParallelization, maxQueuingActions, EmptyHandler);
 
     /// <summary>
     /// Builds a bulkhead isolation <see cref="AsyncPolicy{TResult}" />, which limits the maximum concurrency of actions executed through the policy.  Imposing a maximum concurrency limits the potential of governed actions, when faulting, to bring down the system.
@@ -79,4 +73,6 @@ public partial class Policy
             maxQueuingActions,
             onBulkheadRejectedAsync);
     }
+
+    private static Task EmptyHandler(Context context) => TaskHelper.EmptyTask;
 }

--- a/src/Polly/Caching/CacheSyntax.cs
+++ b/src/Polly/Caching/CacheSyntax.cs
@@ -90,9 +90,7 @@ public partial class Policy
             throw new ArgumentNullException(nameof(cacheKeyStrategy));
         }
 
-        Action<Context, string> emptyDelegate = (_, _) => { };
-
-        return Cache(cacheProvider, ttlStrategy, cacheKeyStrategy.GetCacheKey, emptyDelegate, emptyDelegate, emptyDelegate, onCacheError, onCacheError);
+        return Cache(cacheProvider, ttlStrategy, cacheKeyStrategy.GetCacheKey, EmptyCallback, EmptyCallback, EmptyCallback, onCacheError, onCacheError);
     }
 
     /// <summary>
@@ -142,9 +140,7 @@ public partial class Policy
             throw new ArgumentNullException(nameof(cacheKeyStrategy));
         }
 
-        Action<Context, string> emptyDelegate = (_, _) => { };
-
-        return Cache(cacheProvider, ttlStrategy, cacheKeyStrategy, emptyDelegate, emptyDelegate, emptyDelegate, onCacheError, onCacheError);
+        return Cache(cacheProvider, ttlStrategy, cacheKeyStrategy, EmptyCallback, EmptyCallback, EmptyCallback, onCacheError, onCacheError);
     }
 
     /// <summary>

--- a/src/Polly/Policy.ContextAndKeys.cs
+++ b/src/Polly/Policy.ContextAndKeys.cs
@@ -25,16 +25,7 @@ public abstract partial class Policy
     /// </summary>
     /// <param name="policyKey">The unique, used-definable key to assign to this <see cref="Policy"/> instance.</param>
     /// <returns>An instance of <see cref="ISyncPolicy"/>.</returns>
-    ISyncPolicy ISyncPolicy.WithPolicyKey(string policyKey)
-    {
-        if (policyKeyInternal != null)
-        {
-            throw PolicyKeyMustBeImmutableException(nameof(policyKey));
-        }
-
-        policyKeyInternal = policyKey;
-        return this;
-    }
+    ISyncPolicy ISyncPolicy.WithPolicyKey(string policyKey) => WithPolicyKey(policyKey);
 }
 
 #pragma warning disable CA1724
@@ -64,14 +55,5 @@ public abstract partial class Policy<TResult>
     /// </summary>
     /// <param name="policyKey">The unique, used-definable key to assign to this <see cref="Policy{TResult}"/> instance.</param>
     /// <returns>An instance of <see cref="ISyncPolicy{TResult}"/>.</returns>
-    ISyncPolicy<TResult> ISyncPolicy<TResult>.WithPolicyKey(string policyKey)
-    {
-        if (policyKeyInternal != null)
-        {
-            throw PolicyKeyMustBeImmutableException(nameof(policyKey));
-        }
-
-        policyKeyInternal = policyKey;
-        return this;
-    }
+    ISyncPolicy<TResult> ISyncPolicy<TResult>.WithPolicyKey(string policyKey) => WithPolicyKey(policyKey);
 }

--- a/test/Polly.Extensions.Tests/DependencyInjection/PollyServiceCollectionExtensionTests.cs
+++ b/test/Polly.Extensions.Tests/DependencyInjection/PollyServiceCollectionExtensionTests.cs
@@ -22,24 +22,34 @@ public class PollyServiceCollectionExtensionTests
     public void AddResiliencePipeline_ArgValidation()
     {
         _services = null!;
-        Assert.Throws<ArgumentNullException>(() => AddResiliencePipeline(Key));
-        Assert.Throws<ArgumentNullException>(() => AddResiliencePipeline<string>(Key));
+        Assert.Throws<ArgumentNullException>("services", () => AddResiliencePipeline(Key));
+        Assert.Throws<ArgumentNullException>("services", () => AddResiliencePipeline<string>(Key));
+        Assert.Throws<ArgumentNullException>("services", () => _services.AddResiliencePipeline(Key, (_) => { }));
+        Assert.Throws<ArgumentNullException>("services", () => _services.AddResiliencePipeline(Key, (_, _) => { }));
+        Assert.Throws<ArgumentNullException>("services", () => _services.AddResiliencePipeline<string, string>(Key, (_) => { }));
+        Assert.Throws<ArgumentNullException>("services", () => _services.AddResiliencePipeline<string, string>(Key, (_, _) => { }));
 
         _services = [];
-        Assert.Throws<ArgumentNullException>(() => _services.AddResiliencePipeline(
+        Assert.Throws<ArgumentNullException>("configure", () => _services.AddResiliencePipeline(
             Key,
             (Action<ResiliencePipelineBuilder, AddResiliencePipelineContext<string>>)null!));
-        Assert.Throws<ArgumentNullException>(() => _services.AddResiliencePipeline(
+        Assert.Throws<ArgumentNullException>("configure", () => _services.AddResiliencePipeline(
             Key,
             (Action<ResiliencePipelineBuilder<string>, AddResiliencePipelineContext<string>>)null!));
 
-        Assert.Throws<ArgumentNullException>(() => _services.AddResiliencePipeline(
+        Assert.Throws<ArgumentNullException>("configure", () => _services.AddResiliencePipeline(
             Key,
             (Action<ResiliencePipelineBuilder>)null!));
 
-        Assert.Throws<ArgumentNullException>(() => _services.AddResiliencePipeline(
+        Assert.Throws<ArgumentNullException>("configure", () => _services.AddResiliencePipeline(
             Key,
             (Action<ResiliencePipelineBuilder<string>>)null!));
+
+        _services.AddResiliencePipelines<string>(ctx =>
+        {
+            Assert.Throws<ArgumentNullException>("configure", () => ctx.AddResiliencePipeline(Key, null!));
+            Assert.Throws<ArgumentNullException>("configure", () => ctx.AddResiliencePipeline<string>(Key, null!));
+        });
     }
 
     [InlineData(true)]
@@ -62,6 +72,7 @@ public class PollyServiceCollectionExtensionTests
         serviceProvider.GetServices<ResiliencePipelineRegistry<string>>().ShouldNotBeNull();
         serviceProvider.GetServices<ResiliencePipelineProvider<string>>().ShouldNotBeNull();
         serviceProvider.GetServices<ResiliencePipelineBuilder>().ShouldNotBeSameAs(serviceProvider.GetServices<ResiliencePipelineBuilder>());
+        serviceProvider.GetRequiredService<IOptions<ResiliencePipelineRegistryOptions<string>>>().ShouldNotBeNull();
     }
 
     [Fact]

--- a/test/Polly.Extensions.Tests/DisposablePipelineTests.cs
+++ b/test/Polly.Extensions.Tests/DisposablePipelineTests.cs
@@ -68,6 +68,23 @@ public class DisposablePipelineTests
         Should.Throw<ObjectDisposedException>(() => pipeline2.Execute(() => string.Empty));
     }
 
+    [Fact]
+    public void DisposePipeline_OnPipelineDisposed_Throws_NullArg()
+    {
+        var asserted = false;
+
+        var provider = new ServiceCollection()
+            .AddResiliencePipeline("my-pipeline", (_, context) =>
+            {
+                Assert.Throws<ArgumentNullException>("callback", () => context.OnPipelineDisposed(null!));
+                asserted = true;
+            })
+            .BuildServiceProvider();
+
+        provider.GetRequiredService<ResiliencePipelineProvider<string>>().GetPipeline("my-pipeline");
+        asserted.ShouldBeTrue();
+    }
+
     private static bool IsDisposed(RateLimiter limiter)
     {
         try

--- a/test/Polly.Extensions.Tests/Registry/ConfigureBuilderContextExtensionsTests.cs
+++ b/test/Polly.Extensions.Tests/Registry/ConfigureBuilderContextExtensionsTests.cs
@@ -8,6 +8,22 @@ namespace Polly.Extensions.Tests.Registry;
 public class ConfigureBuilderContextExtensionsTests
 {
     [Fact]
+    public async Task ConfigureReloads_NullArguments_Throws()
+    {
+        await using var registry = new ResiliencePipelineRegistry<string>();
+        registry.GetOrAddPipeline("pipeline", (_, builderContext) =>
+        {
+            ConfigureBuilderContext<string> nullContext = null!;
+            IOptionsMonitor<Options> nullMonitor = null!;
+
+            var monitor = Substitute.For<IOptionsMonitor<Options>>();
+
+            Assert.Throws<ArgumentNullException>("context", () => nullContext.EnableReloads(monitor));
+            Assert.Throws<ArgumentNullException>("optionsMonitor", () => builderContext.EnableReloads(nullMonitor));
+        });
+    }
+
+    [Fact]
     public async Task ConfigureReloads_MonitorRegistrationReturnsNull_DoesNotThrow()
     {
         var monitor = Substitute.For<IOptionsMonitor<Options>>();
@@ -27,5 +43,7 @@ public class ConfigureBuilderContextExtensionsTests
         listener.Events.ShouldBeEmpty();
     }
 
+#pragma warning disable S2094 // Classes should not be empty
     public class Options;
+#pragma warning restore S2094 // Classes should not be empty
 }

--- a/test/Polly.Extensions.Tests/Telemetry/TelemetryOptionsTests.cs
+++ b/test/Polly.Extensions.Tests/Telemetry/TelemetryOptionsTests.cs
@@ -25,6 +25,13 @@ public class TelemetryOptionsTests
     }
 
     [Fact]
+    public void CopyCtor_OtherNull_Throws()
+    {
+        var options = new TelemetryOptions();
+        Assert.Throws<ArgumentNullException>("other", () => new TelemetryOptions(null!));
+    }
+
+    [Fact]
     public void CopyCtor_Ok()
     {
         var options = new TelemetryOptions

--- a/test/Polly.Extensions.Tests/Telemetry/TelemetryResiliencePipelineBuilderExtensionsTests.cs
+++ b/test/Polly.Extensions.Tests/Telemetry/TelemetryResiliencePipelineBuilderExtensionsTests.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Polly.Telemetry;
 
@@ -26,6 +27,24 @@ public class TelemetryResiliencePipelineBuilderExtensionsTests
 
         fakeLogger.GetRecords().ShouldNotBeEmpty();
         fakeLogger.GetRecords().Count().ShouldBe(2);
+    }
+
+    [Fact]
+    public void ConfigureTelemetry_NullArguments_Throws()
+    {
+        ResiliencePipelineBuilder builder = null!;
+
+        using var loggerFactory = TestUtilities.CreateLoggerFactory(out var fakeLogger);
+        var options = new TelemetryOptions();
+
+        Assert.Throws<ArgumentNullException>("builder", () => builder.ConfigureTelemetry(loggerFactory));
+        Assert.Throws<ArgumentNullException>("builder", () => builder.ConfigureTelemetry(options));
+
+        ILoggerFactory nulLoggerFactory = null!;
+        TelemetryOptions nulOptions = null!;
+
+        Assert.Throws<ArgumentNullException>("loggerFactory", () => _builder.ConfigureTelemetry(nulLoggerFactory));
+        Assert.Throws<ArgumentNullException>("options", () => _builder.ConfigureTelemetry(nulOptions));
     }
 
     [Fact]

--- a/test/Polly.Specs/Bulkhead/BulkheadTResultAsyncSpecs.cs
+++ b/test/Polly.Specs/Bulkhead/BulkheadTResultAsyncSpecs.cs
@@ -72,6 +72,14 @@ public class BulkheadTResultAsyncSpecs(ITestOutputHelper testOutputHelper) : Bul
             .ParamName.ShouldBe("onBulkheadRejectedAsync");
     }
 
+    [Fact]
+    public void Should_not_throw_when_arguments_valid()
+    {
+        Action policy = () => Policy.BulkheadAsync<int>(1);
+
+        Should.NotThrow(policy);
+    }
+
     #endregion
 
     #region onBulkheadRejected delegate

--- a/test/Polly.Specs/Caching/CacheSpecs.cs
+++ b/test/Polly.Specs/Caching/CacheSpecs.cs
@@ -60,6 +60,54 @@ public class CacheSpecs : IDisposable
     }
 
     [Fact]
+    public void Should_not_throw_when_arguments_valid()
+    {
+        ISyncCacheProvider cacheProvider = new StubCacheProvider();
+        var ttl = TimeSpan.MaxValue;
+        ITtlStrategy ttlStrategy = new ContextualTtl();
+        ICacheKeyStrategy cacheKeyStrategy = new StubCacheKeyStrategy(context => context.OperationKey + context["id"]);
+        Func<Context, string> cacheKeyStrategyFunc = (_) => string.Empty;
+        Action<Context, string> onCache = (_, _) => { };
+        Action<Context, string, Exception>? onCacheError = (_, _, _) => { };
+
+        Action action = () => Policy.Cache(cacheProvider, ttl, onCacheError);
+        Should.NotThrow(action);
+
+        action = () => Policy.Cache(cacheProvider, ttlStrategy, onCacheError);
+        Should.NotThrow(action);
+
+        action = () => Policy.Cache(cacheProvider, ttl, cacheKeyStrategy, onCacheError);
+        Should.NotThrow(action);
+
+        action = () => Policy.Cache(cacheProvider, ttlStrategy, cacheKeyStrategy, onCacheError);
+        Should.NotThrow(action);
+
+        action = () => Policy.Cache(cacheProvider, ttl, cacheKeyStrategyFunc, onCacheError);
+        Should.NotThrow(action);
+
+        action = () => Policy.Cache(cacheProvider, ttlStrategy, cacheKeyStrategyFunc, onCacheError);
+        Should.NotThrow(action);
+
+        action = () => Policy.Cache(cacheProvider, ttl, onCache, onCache, onCache, onCacheError, onCacheError);
+        Should.NotThrow(action);
+
+        action = () => Policy.Cache(cacheProvider, ttlStrategy, onCache, onCache, onCache, onCacheError, onCacheError);
+        Should.NotThrow(action);
+
+        action = () => Policy.Cache(cacheProvider, ttl, cacheKeyStrategy, onCache, onCache, onCache, onCacheError, onCacheError);
+        Should.NotThrow(action);
+
+        action = () => Policy.Cache(cacheProvider, ttlStrategy, cacheKeyStrategy, onCache, onCache, onCache, onCacheError, onCacheError);
+        Should.NotThrow(action);
+
+        action = () => Policy.Cache(cacheProvider, ttl, cacheKeyStrategyFunc, onCache, onCache, onCache, onCacheError, onCacheError);
+        Should.NotThrow(action);
+
+        action = () => Policy.Cache(cacheProvider, ttlStrategy, cacheKeyStrategyFunc, onCache, onCache, onCache, onCacheError, onCacheError);
+        Should.NotThrow(action);
+    }
+
+    [Fact]
     public void Should_throw_when_cache_provider_is_null()
     {
         ISyncCacheProvider cacheProvider = null!;

--- a/test/Polly.Specs/PolicyAsyncSpecs.cs
+++ b/test/Polly.Specs/PolicyAsyncSpecs.cs
@@ -150,7 +150,7 @@ public class PolicyAsyncSpecs
             .Handle<DivideByZeroException>()
             .RetryAsync((_, _, _) => { });
 
-        await Should.ThrowAsync<ArgumentNullException>(() => policy.ExecuteAsync(_ => TaskHelper.EmptyTask, (IDictionary<string, object>)null!));
+        await Assert.ThrowsAsync<ArgumentNullException>("contextData", () => policy.ExecuteAsync(_ => TaskHelper.EmptyTask, (IDictionary<string, object>)null!));
     }
 
     [Fact]


### PR DESCRIPTION
Add missing coverage highlighted by #2512.

- Add missing coverage.
- Remove redundant code paths.
- Avoid allocating delegates.
- Fix file name casing.
