### PR TITLE
Try ARM64 runners for mutation tests

### DIFF
--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   mutations:
     name: 'mutations-${{ matrix.name }}'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
 
     strategy:


### PR DESCRIPTION
Try out running the mutation tests on the new Ubuntu ARM64 runner as an immediate follow-on to #2520 to see if it gets faster still.
