### PR TITLE
Fix Retry strategy ShouldHandle in example code

### DIFF
--- a/docs/strategies/retry.md
+++ b/docs/strategies/retry.md
@@ -494,7 +494,7 @@ ImmutableArray<Type> retryableExceptions = networkExceptions
 var retry = new ResiliencePipelineBuilder()
     .AddRetry(new()
     {
-        ShouldHandle = ex => new ValueTask<bool>(retryableExceptions.Contains(ex.GetType())),
+        ShouldHandle = args => ValueTask.FromResult(retryableExceptions.Contains(args.Outcome.Exception?.GetType())),
         MaxRetryAttempts = 3,
     })
     .Build();

--- a/docs/strategies/retry.md
+++ b/docs/strategies/retry.md
@@ -474,18 +474,18 @@ Use collections and simple predicate functions:
 
 <!-- snippet: retry-pattern-overusing-builder -->
 ```cs
-ImmutableArray<Type> networkExceptions = new[]
-{
+ImmutableArray<Type> networkExceptions =
+[
     typeof(SocketException),
     typeof(HttpRequestException),
-}.ToImmutableArray();
+];
 
-ImmutableArray<Type> strategyExceptions = new[]
-{
+ImmutableArray<Type> strategyExceptions =
+[
     typeof(TimeoutRejectedException),
     typeof(BrokenCircuitException),
     typeof(RateLimitRejectedException),
-}.ToImmutableArray();
+];
 
 ImmutableArray<Type> retryableExceptions = networkExceptions
     .Union(strategyExceptions)
@@ -494,7 +494,8 @@ ImmutableArray<Type> retryableExceptions = networkExceptions
 var retry = new ResiliencePipelineBuilder()
     .AddRetry(new()
     {
-        ShouldHandle = args => ValueTask.FromResult(retryableExceptions.Contains(args.Outcome.Exception?.GetType())),
+        ShouldHandle = args
+            => ValueTask.FromResult(args.Outcome.Exception != null && retryableExceptions.Contains(args.Outcome.Exception.GetType())),
         MaxRetryAttempts = 3,
     })
     .Build();

--- a/src/Snippets/Docs/Retry.cs
+++ b/src/Snippets/Docs/Retry.cs
@@ -194,7 +194,7 @@ internal static class Retry
         var retry = new ResiliencePipelineBuilder()
             .AddRetry(new()
             {
-                ShouldHandle = ex => new ValueTask<bool>(retryableExceptions.Contains(ex.GetType())),
+                ShouldHandle = args => ValueTask.FromResult(retryableExceptions.Contains(args.Outcome.Exception?.GetType())),
                 MaxRetryAttempts = 3,
             })
             .Build();

--- a/src/Snippets/Docs/Retry.cs
+++ b/src/Snippets/Docs/Retry.cs
@@ -174,18 +174,18 @@ internal static class Retry
     {
         #region retry-pattern-overusing-builder
 
-        ImmutableArray<Type> networkExceptions = new[]
-        {
+        ImmutableArray<Type> networkExceptions =
+        [
             typeof(SocketException),
             typeof(HttpRequestException),
-        }.ToImmutableArray();
+        ];
 
-        ImmutableArray<Type> strategyExceptions = new[]
-        {
+        ImmutableArray<Type> strategyExceptions =
+        [
             typeof(TimeoutRejectedException),
             typeof(BrokenCircuitException),
             typeof(RateLimitRejectedException),
-        }.ToImmutableArray();
+        ];
 
         ImmutableArray<Type> retryableExceptions = networkExceptions
             .Union(strategyExceptions)
@@ -194,7 +194,9 @@ internal static class Retry
         var retry = new ResiliencePipelineBuilder()
             .AddRetry(new()
             {
-                ShouldHandle = args => ValueTask.FromResult(retryableExceptions.Contains(args.Outcome.Exception?.GetType())),
+                ShouldHandle = args
+                    => ValueTask.FromResult(args.Outcome.Exception is not null
+                        && retryableExceptions.Contains(args.Outcome.Exception.GetType())),
                 MaxRetryAttempts = 3,
             })
             .Build();


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

The existing example compiles, but incorrectly shows the `ShouldHandle` delegate as operating on an Exception object. 

## Details on the issue fix or feature implementation

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- _N/A, doc only_  I have included unit tests for the issue/feature 
- _N/A, doc only_  I have successfully run a local build
