### PR TITLE
Remove System.Text.Json reference

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,7 +46,6 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="System.Threading.RateLimiting" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />

--- a/samples/Chaos/Chaos.csproj
+++ b/samples/Chaos/Chaos.csproj
@@ -10,7 +10,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Polly.Core" />
-    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
 </Project>

--- a/samples/DependencyInjection/DependencyInjection.csproj
+++ b/samples/DependencyInjection/DependencyInjection.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Polly.Extensions" />
-    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Remove explicit reference to System.Text.Json as it should be redundant.

Identified by #2531, assuming this isn't something that _needs_ .NET 10.
