### PR TITLE
MaxRetryAttempts should support ZERO.

### DIFF
--- a/src/Polly.Core/Retry/RetryStrategyOptions.TResult.cs
+++ b/src/Polly.Core/Retry/RetryStrategyOptions.TResult.cs
@@ -25,7 +25,7 @@ public class RetryStrategyOptions<TResult> : ResilienceStrategyOptions
     /// <remarks>
     /// To retry indefinitely use <see cref="int.MaxValue"/>. Note that the reported attempt number is capped at <see cref="int.MaxValue"/>.
     /// </remarks>
-    [Range(1, RetryConstants.MaxRetryCount)]
+    [Range(0, RetryConstants.MaxRetryCount)]
     public int MaxRetryAttempts { get; set; } = RetryConstants.DefaultRetryCount;
 
     /// <summary>

--- a/test/Polly.Core.Tests/ResiliencePipelineBuilderTests.cs
+++ b/test/Polly.Core.Tests/ResiliencePipelineBuilderTests.cs
@@ -159,7 +159,7 @@ public class ResiliencePipelineBuilderTests
         exception.Message.Trim().ShouldBe("""
             The primary message.
             Validation Errors:
-            The field MaxRetryAttempts must be between 1 and 2147483647.
+            The field MaxRetryAttempts must be between 0 and 2147483647.
             """);
     }
 

--- a/test/Polly.Core.Tests/Retry/RetryStrategyOptionsTests.cs
+++ b/test/Polly.Core.Tests/Retry/RetryStrategyOptionsTests.cs
@@ -52,7 +52,7 @@ public class RetryStrategyOptionsTests
         exception.Message.Trim().ShouldBe("""
             Invalid Options
             Validation Errors:
-            The field MaxRetryAttempts must be between 1 and 2147483647.
+            The field MaxRetryAttempts must be between 0 and 2147483647.
             The field Delay must be between 00:00:00 and 1.00:00:00.
             The field MaxDelay must be between 00:00:00 and 1.00:00:00.
             The ShouldHandle field is required.


### PR DESCRIPTION
# Pull Request

MaxRetryAttempt should be allowed to be 0.
Here's the github issue: [2547](https://github.com/App-vNext/Polly/issues/2547)

## Details on the issue fix or feature implementation

Change the min value of constraint on MaxRetryAttempt as 0

## Confirm the following

- [ ]  I started this PR by branching from the head of the default branch
- [ ]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build
