### PR TITLE
Fix baseline script if no nullable header

### DIFF
--- a/eng/update-baselines.ps1
+++ b/eng/update-baselines.ps1
@@ -37,8 +37,9 @@ foreach ($file in $files) {
 
     $edited = $false
 
-    # Skip the "#nullable enable" header
-    $index = (($additions.Count -gt 0) -And ($additions[0] -eq "#nullable enable")) ? 1 : 0
+    # Skip any "#nullable enable" header
+    $nullableHeader = "#nullable enable"
+    $index = (($additions.Count -gt 0) -And ($additions[0] -eq $nullableHeader)) ? 1 : 0
     while ($additions.Count -gt $index) {
         $addition = $additions[$index]
         $additions.RemoveAt($index)
@@ -50,7 +51,12 @@ foreach ($file in $files) {
         $additions.Sort($comparer)
         $baseline.Sort($comparer)
 
-        $additions | Set-Content $changesPath -Encoding $encoding
+        if (($additions.Count -eq 1) -and ($additions[0] -eq $nullableHeader)) {
+            $additions | Set-Content $changesPath -Encoding $encoding
+        } else {
+            $null | Set-Content $changesPath -Encoding $encoding
+        }
+
         $baseline | Set-Content $baselinePath -Encoding $encoding
     }
 }


### PR DESCRIPTION
Fix baseline files not being cleared if the `#nullable` header is not present in the `Unshipped` file.

Found in https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/3317 when I copied the script to use there.

This use case doesn't affect us, but it's good to make it Technically Correct™️.
