### PR TITLE
Improve mutation tests performance by ensuring solution file isn't discovered

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -345,9 +345,15 @@ void RunMutationTests(FilePath target, FilePath testProject)
 
     Information($"Running mutation tests for '{targetFileName}'. Test Project: '{testProject}'");
 
-    var args = $"stryker --project {targetFileName} --test-project {testProject.FullPath} --break-at {score} --config-file {strykerConfigPath} --output {strykerOutput}/{targetFileName}";
+    var args = $"stryker --project {targetFileName} --test-project {testProject.GetFilename()} --break-at {score} --config-file {strykerConfigPath} --output {strykerOutput}/{targetFileName}";
 
-    var result = StartProcess("dotnet", args);
+    var testProjectDir = testProject.GetDirectory();
+    var result = StartProcess("dotnet", new ProcessSettings
+    {
+        Arguments = args,
+        WorkingDirectory = testProjectDir.FullPath,
+    });
+
     if (result != 0)
     {
         throw new InvalidOperationException($"The mutation testing of '{targetFileName}' project failed.");


### PR DESCRIPTION
I was doing some testing locally and I've noticed that what is happening with the Cake build script is that when mutation tests are triggered, because they are launched from the root of the repo, the solution file is automatically detected which causes all tests to run.

This should limit each mutation test to only run the tests from the matching project.