### PR TITLE
Simplify test analytics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,6 @@ jobs:
       uses: codecov/test-results-action@f2dba722c67b86c6caa034178c6e4d35335f6706 # v1.1.0
       if: ${{ !cancelled() }}
       with:
-        files: ./test/Polly.Core.Tests/TestResults/TestResults.xml,./test/Polly.Extensions.Tests/TestResults/TestResults.xml,./test/Polly.RateLimiting.Tests/TestResults/TestResults.xml,./test/Polly.Specs/TestResults/TestResults.xml,./test/Polly.Testing.Tests/TestResults/TestResults.xml
         flags: ${{ matrix.os_name }}
         token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/build.cake
+++ b/build.cake
@@ -137,11 +137,15 @@ Task("__ValidateAot")
 Task("__RunTests")
     .Does(() =>
 {
-    string[] loggers = ["junit"];
+    var loggers = Array.Empty<string>();
 
     if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("GITHUB_SHA")))
     {
-        loggers = [.. loggers, "GitHubActions;report-warnings=false"];
+        loggers =
+        [
+            "junit;LogFilePath=junit.xml",
+            "GitHubActions;report-warnings=false",
+        ];
     }
 
     var projects = GetFiles("./test/**/*.csproj");


### PR DESCRIPTION
- Only enable JUnit output in CI.
- Change the default JUnit file name so codecov/test-results-action finds the files automatically.
