### PR TITLE
Use tip instead of important

### DIFF
--- a/docs/advanced/resilience-context.md
+++ b/docs/advanced/resilience-context.md
@@ -9,7 +9,7 @@ The resilience context exposes several properties:
 - `Properties`: An instance of `ResilienceProperties` for attaching custom data to the context.
 - `ContinueOnCapturedContext`: Specifies whether the asynchronous execution should continue on the captured context.
 
-> [!IMPORTANT]
+> [!TIP]
 > When using a custom `ResilienceContext`, ensure that your usage is correct to avoid the context being treated as custom
 > _state_ for the execution instead of as the _context_ for the execution. Otherwise, the delegate invoked by the resilience
 > pipeline will be a different instance obtained from the shared pool, rather than the value specified for your execution.


### PR DESCRIPTION
Important is rendered in red, which isn't the effect intended compared to GitHub's purple.
