### PR TITLE
.NET 10 preparation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,6 @@
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net9.0'))">
     <MicrosoftExtensionsVersion>9.0.0</MicrosoftExtensionsVersion>
-    <MicrosoftExtensionsTimeProviderVersion>9.0.0</MicrosoftExtensionsTimeProviderVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />

--- a/src/Polly.Core/Utils/DefaultPredicates.cs
+++ b/src/Polly.Core/Utils/DefaultPredicates.cs
@@ -1,4 +1,5 @@
 ﻿namespace Polly.Utils;
+
 internal static class DefaultPredicates<TArgs, TResult>
     where TArgs : IOutcomeArguments<TResult>
 {
@@ -6,6 +7,6 @@ internal static class DefaultPredicates<TArgs, TResult>
     {
         OperationCanceledException => PredicateResult.False(),
         Exception => PredicateResult.True(),
-        _ => PredicateResult.False()
+        _ => PredicateResult.False(),
     };
 }


### PR DESCRIPTION
Cherry-pick changes from #2531 to:

- Fix IDE0055 warning.
- Remove redundant MSBuild property.
