### PR TITLE
Fix package signing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,7 @@ env:
   NUGET_XMLDOC_MODE: skip
   TERM: xterm
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   build:
@@ -38,6 +37,9 @@ jobs:
       dotnet-validate-version: ${{ steps.get-dotnet-tools-versions.outputs.dotnet-validate-version }}
       package-names: ${{ steps.build.outputs.package-names }}
       package-version: ${{ steps.build.outputs.package-version }}
+
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
@@ -187,6 +189,9 @@ jobs:
     #  github.event.repository.fork == false &&
     #  startsWith(github.ref, 'refs/tags/')
 
+    permissions:
+      id-token: write
+
     steps:
 
     - name: Download unsigned packages
@@ -251,6 +256,7 @@ jobs:
   validate-signed-packages:
     needs: [ build, sign ]
     runs-on: windows-latest
+
     steps:
 
     - name: Download packages
@@ -342,6 +348,7 @@ jobs:
     if: false # TODO Remove once signing is tested as working again
     needs: [ build, validate-signed-packages ]
     runs-on: ubuntu-latest
+
     steps:
 
     - name: Download signed packages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,12 +216,12 @@ jobs:
         DOTNET_SIGN_VERSION: ${{ needs.build.outputs.dotnet-sign-version }}
       run: dotnet tool install --tool-path . sign --version ${env:DOTNET_SIGN_VERSION}
 
-    #- name: Azure log in
-    #  uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
-    #  with:
-    #    client-id: ${{ secrets.SIGN_CLI_APPLICATION_ID }}
-    #    subscription-id: ${{ secrets.SIGN_CLI_SUBSCRIPTION_ID }}
-    #    tenant-id: ${{ secrets.SIGN_CLI_TENANT_ID }}
+    - name: Azure log in
+      uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+      with:
+        client-id: ${{ secrets.SIGN_CLI_APPLICATION_ID }}
+        subscription-id: ${{ secrets.SIGN_CLI_SUBSCRIPTION_ID }}
+        tenant-id: ${{ secrets.SIGN_CLI_TENANT_ID }}
 
     - name: Sign artifacts
       shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -219,6 +219,7 @@ jobs:
     - name: Azure log in
       uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
       with:
+        auth-type: IDENTITY
         client-id: ${{ secrets.SIGN_CLI_APPLICATION_ID }}
         subscription-id: ${{ secrets.SIGN_CLI_SUBSCRIPTION_ID }}
         tenant-id: ${{ secrets.SIGN_CLI_TENANT_ID }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -219,7 +219,6 @@ jobs:
     - name: Azure log in
       uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
       with:
-        auth-type: IDENTITY
         client-id: ${{ secrets.SIGN_CLI_APPLICATION_ID }}
         subscription-id: ${{ secrets.SIGN_CLI_SUBSCRIPTION_ID }}
         tenant-id: ${{ secrets.SIGN_CLI_TENANT_ID }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,12 +216,12 @@ jobs:
         DOTNET_SIGN_VERSION: ${{ needs.build.outputs.dotnet-sign-version }}
       run: dotnet tool install --tool-path . sign --version ${env:DOTNET_SIGN_VERSION}
 
-    - name: Azure log in
-      uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
-      with:
-        client-id: ${{ secrets.SIGN_CLI_APPLICATION_ID }}
-        subscription-id: ${{ secrets.SIGN_CLI_SUBSCRIPTION_ID }}
-        tenant-id: ${{ secrets.SIGN_CLI_TENANT_ID }}
+    #- name: Azure log in
+    #  uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+    #  with:
+    #    client-id: ${{ secrets.SIGN_CLI_APPLICATION_ID }}
+    #    subscription-id: ${{ secrets.SIGN_CLI_SUBSCRIPTION_ID }}
+    #    tenant-id: ${{ secrets.SIGN_CLI_TENANT_ID }}
 
     - name: Sign artifacts
       shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,9 +185,9 @@ jobs:
   sign:
     needs: [ build, validate-packages ]
     runs-on: windows-latest
-    #if: |
-    #  github.event.repository.fork == false &&
-    #  startsWith(github.ref, 'refs/tags/')
+    if: |
+      github.event.repository.fork == false &&
+      startsWith(github.ref, 'refs/tags/')
 
     permissions:
       id-token: write
@@ -345,7 +345,6 @@ jobs:
         }
 
   publish-nuget:
-    if: false # TODO Remove once signing is tested as working again
     needs: [ build, validate-signed-packages ]
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,9 +183,9 @@ jobs:
   sign:
     needs: [ build, validate-packages ]
     runs-on: windows-latest
-    if: |
-      github.event.repository.fork == false &&
-      startsWith(github.ref, 'refs/tags/')
+    #if: |
+    #  github.event.repository.fork == false &&
+    #  startsWith(github.ref, 'refs/tags/')
 
     steps:
 
@@ -211,14 +211,18 @@ jobs:
         DOTNET_SIGN_VERSION: ${{ needs.build.outputs.dotnet-sign-version }}
       run: dotnet tool install --tool-path . sign --version ${env:DOTNET_SIGN_VERSION}
 
+    - name: Azure log in
+      uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+      with:
+        client-id: ${{ secrets.SIGN_CLI_APPLICATION_ID }}
+        subscription-id: ${{ secrets.SIGN_CLI_SUBSCRIPTION_ID }}
+        tenant-id: ${{ secrets.SIGN_CLI_TENANT_ID }}
+
     - name: Sign artifacts
       shell: pwsh
       env:
-        AZURE_CLIENT_ID: ${{ secrets.SIGN_CLI_APPLICATION_ID }}
-        AZURE_CLIENT_SECRET: ${{ secrets.SIGN_CLI_SECRET }}
         AZURE_KEY_VAULT_CERTIFICATE: ${{ secrets.SIGN_CLI_CERT_NAME }}
         AZURE_KEY_VAULT_URL: ${{ secrets.SIGN_CLI_VAULT_URI }}
-        AZURE_TENANT_ID: ${{ secrets.SIGN_CLI_TENANT_ID }}
         VERBOSITY: ${{ runner.debug == '1' && 'Debug' || 'Warning' }}
       run: |
         ./sign code azure-key-vault `
@@ -335,6 +339,7 @@ jobs:
         }
 
   publish-nuget:
+    if: false # TODO Remove once signing is tested as working again
     needs: [ build, validate-signed-packages ]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Use a federated credential to access Azure Key Vault for the code-signing certificate instead of the now-expired secrets.
