### PR TITLE
Update maxQueuingCompounded in BulkheadSemaphoreFactory

### DIFF
--- a/src/Polly/Bulkhead/BulkheadSemaphoreFactory.cs
+++ b/src/Polly/Bulkhead/BulkheadSemaphoreFactory.cs
@@ -7,7 +7,7 @@ internal static class BulkheadSemaphoreFactory
     {
         var maxParallelizationSemaphore = new SemaphoreSlim(maxParallelization, maxParallelization);
 
-        var maxQueuingCompounded = Math.Min(maxQueueingActions + maxParallelization, int.MaxValue);
+        var maxQueuingCompounded = (int) Math.Min((long) maxQueueingActions + maxParallelization, int.MaxValue);
         var maxQueuedActionsSemaphore = new SemaphoreSlim(maxQueuingCompounded, maxQueuingCompounded);
 
         return (maxParallelizationSemaphore, maxQueuedActionsSemaphore);

--- a/src/Polly/Bulkhead/BulkheadSemaphoreFactory.cs
+++ b/src/Polly/Bulkhead/BulkheadSemaphoreFactory.cs
@@ -7,7 +7,7 @@ internal static class BulkheadSemaphoreFactory
     {
         var maxParallelizationSemaphore = new SemaphoreSlim(maxParallelization, maxParallelization);
 
-        var maxQueuingCompounded = (int) Math.Min((long) maxQueueingActions + maxParallelization, int.MaxValue);
+        var maxQueuingCompounded = (int)Math.Min((long)maxQueueingActions + maxParallelization, int.MaxValue);
         var maxQueuedActionsSemaphore = new SemaphoreSlim(maxQueuingCompounded, maxQueuingCompounded);
 
         return (maxParallelizationSemaphore, maxQueuedActionsSemaphore);

--- a/test/Polly.Specs/Bulkhead/BulkheadAsyncSpecs.cs
+++ b/test/Polly.Specs/Bulkhead/BulkheadAsyncSpecs.cs
@@ -64,6 +64,15 @@ public class BulkheadAsyncSpecs(ITestOutputHelper testOutputHelper) : BulkheadSp
     }
 
     [Fact]
+    public void Should_not_throw_when_maxQueuingActions_is_int_MaxValue()
+    {
+        Action policy = () => Policy
+            .BulkheadAsync(1, int.MaxValue);
+
+        policy.ShouldNotThrow();
+    }
+
+    [Fact]
     public void Should_throw_when_onBulkheadRejected_is_null()
     {
         Action policy = () => Policy

--- a/test/Polly.Specs/Bulkhead/BulkheadSpecs.cs
+++ b/test/Polly.Specs/Bulkhead/BulkheadSpecs.cs
@@ -54,6 +54,15 @@ public class BulkheadSpecs(ITestOutputHelper testOutputHelper) : BulkheadSpecsBa
     }
 
     [Fact]
+    public void Should_not_throw_when_maxQueuingActions_is_int_MaxValue()
+    {
+        Action policy = () => Policy
+            .Bulkhead(1, int.MaxValue);
+
+        policy.ShouldNotThrow();
+    }
+
+    [Fact]
     public void Should_throw_when_maxQueuedActions_less_than_zero()
     {
         Action policy = () => Policy

--- a/test/Polly.Specs/Bulkhead/BulkheadTResultSpecs.cs
+++ b/test/Polly.Specs/Bulkhead/BulkheadTResultSpecs.cs
@@ -53,6 +53,15 @@ public class BulkheadTResultSpecs(ITestOutputHelper testOutputHelper) : Bulkhead
     }
 
     [Fact]
+    public void Should_not_throw_when_maxQueuingActions_is_int_MaxValue()
+    {
+        Action policy = () => Policy
+            .Bulkhead<int>(1, int.MaxValue);
+
+        policy.ShouldNotThrow();
+    }
+
+    [Fact]
     public void Should_throw_when_maxQueuingActions_less_than_zero()
     {
         Action policy = () => Policy


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed

Fixes #2637, caused by overflow in `BulkheadSemaphoreFactory`.

## Details on the issue fix or feature implementation

Set compound math to long before evaluating Min with int.MaxValue.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [ ]  I have included unit tests for the issue/feature
- [ ]  I have successfully run a local build
