### PR TITLE
Suppress CA2025

### DIFF
--- a/test/Polly.Extensions.Tests/Issues/IssuesTests.PartitionedRateLimiter_1365.cs
+++ b/test/Polly.Extensions.Tests/Issues/IssuesTests.PartitionedRateLimiter_1365.cs
@@ -48,12 +48,14 @@ public partial class IssuesTests
         await Assert.ThrowsAsync<RateLimiterRejectedException>(() => ExecuteBatch("guest-user", asserted));
         asserted.Set();
 
+#pragma warning disable CA2025
         // assert admin is not limited
         using var adminAsserted = new ManualResetEvent(false);
         var task = ExecuteBatch("admin", adminAsserted);
         task.Wait(100).ShouldBeFalse();
         adminAsserted.Set();
         await task;
+#pragma warning restore CA2025
 
         async Task ExecuteBatch(string user, ManualResetEvent waitAsserted)
         {

--- a/test/Polly.Specs/Bulkhead/BulkheadSpecsBase.cs
+++ b/test/Polly.Specs/Bulkhead/BulkheadSpecsBase.cs
@@ -107,7 +107,9 @@ public abstract class BulkheadSpecsBase : IDisposable
             Tasks = new Task[totalActions];
             for (int i = 0; i < totalActions; i++)
             {
+#pragma warning disable CA2025
                 Tasks[i] = ExecuteOnBulkhead(bulkhead, Actions[i]);
+#pragma warning restore CA2025
             }
 
             OutputStatus("Immediately after queueing...");

--- a/test/Polly.Specs/Helpers/PolicyExtensionsAsync.cs
+++ b/test/Polly.Specs/Helpers/PolicyExtensionsAsync.cs
@@ -21,8 +21,10 @@ public static class PolicyExtensionsAsync
             NumberOfTimesToRaiseException = 1
         };
 
-        using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+#pragma warning disable CA2025
+        using var cancellationTokenSource = new CancellationTokenSource();
         return policy.RaiseExceptionAndOrCancellationAsync(scenario, cancellationTokenSource, () => { }, _ => instance);
+#pragma warning restore CA2025
     }
 
     public static Task RaiseExceptionAsync<TException>(this AsyncPolicy policy, Action<TException, int>? configureException = null)
@@ -47,8 +49,10 @@ public static class PolicyExtensionsAsync
             return exception;
         };
 
-        using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+#pragma warning disable CA2025
+        using var cancellationTokenSource = new CancellationTokenSource();
         return policy.RaiseExceptionAndOrCancellationAsync(scenario, cancellationTokenSource, () => { }, exceptionFactory);
+#pragma warning restore CA2025
     }
 
     public static Task RaiseExceptionAndOrCancellationAsync<TException>(this AsyncPolicy policy, ExceptionAndOrCancellationScenario scenario, CancellationTokenSource cancellationTokenSource, Action onExecute)


### PR DESCRIPTION
Suppress new CA2025 analyzer warnings in test code from the .NET 10 preview 5 SDK.
