### PR TITLE
Add environments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,6 +200,9 @@ jobs:
       github.event.repository.fork == false &&
       startsWith(github.ref, 'refs/tags/')
 
+    environment:
+      name: Azure
+
     permissions:
       id-token: write
 
@@ -393,6 +396,10 @@ jobs:
   publish-nuget:
     needs: [ build, validate-signed-packages ]
     runs-on: ubuntu-latest
+
+    environment:
+      name: NuGet.org
+      url: https://www.nuget.org/profiles/Polly
 
     steps:
 


### PR DESCRIPTION
Add environments to certain jobs so we can scope permissions, such as for Azure for signing.

This should allow the code signing certificate federated credential to be scoped to the `Azure` environment instead of a tag, as we can't wildcard match the tags for that.
