### PR TITLE
Performance tweaks

### DIFF
--- a/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.BridgeBenchmark-report-github.md
+++ b/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.BridgeBenchmark-report-github.md
@@ -1,15 +1,15 @@
 ```
 
-BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4602/23H2/2023Update/SunValley3)
-12th Gen Intel Core i7-1280P, 1 CPU, 20 logical and 14 physical cores
-.NET SDK 9.0.101
-  [Host] : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2
+BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.4351)
+13th Gen Intel Core i7-13700H, 1 CPU, 20 logical and 14 physical cores
+.NET SDK 9.0.301
+  [Host] : .NET 9.0.6 (9.0.625.26613), X64 RyuJIT AVX2
 
 Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
 LaunchCount=2  WarmupCount=10  
 
 ```
-| Method                 | Mean      | Error    | StdDev    | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
-|----------------------- |----------:|---------:|----------:|------:|--------:|-------:|----------:|------------:|
-| NoOpAsync              |  84.05 ns | 4.660 ns |  6.830 ns |  1.01 |    0.11 | 0.0242 |     304 B |        1.00 |
-| NullResiliencePipeline | 241.69 ns | 8.178 ns | 12.240 ns |  2.89 |    0.27 | 0.0296 |     376 B |        1.24 |
+| Method                 | Mean      | Error    | StdDev   | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
+|----------------------- |----------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
+| NoOpAsync              |  42.79 ns | 1.119 ns | 1.604 ns |  1.00 |    0.05 | 0.0242 |     304 B |        1.00 |
+| NullResiliencePipeline | 167.35 ns | 2.640 ns | 3.786 ns |  3.92 |    0.17 | 0.0298 |     376 B |        1.24 |

--- a/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.CircuitBreakerBenchmark-report-github.md
+++ b/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.CircuitBreakerBenchmark-report-github.md
@@ -1,9 +1,9 @@
 ```
 
-BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4602/23H2/2023Update/SunValley3)
-12th Gen Intel Core i7-1280P, 1 CPU, 20 logical and 14 physical cores
-.NET SDK 9.0.101
-  [Host] : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2
+BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.4351)
+13th Gen Intel Core i7-13700H, 1 CPU, 20 logical and 14 physical cores
+.NET SDK 9.0.301
+  [Host] : .NET 9.0.6 (9.0.625.26613), X64 RyuJIT AVX2
 
 Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
 LaunchCount=2  WarmupCount=10  
@@ -11,5 +11,5 @@ LaunchCount=2  WarmupCount=10
 ```
 | Method                   | Mean     | Error   | StdDev  | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
 |------------------------- |---------:|--------:|--------:|------:|--------:|-------:|----------:|------------:|
-| ExecuteCircuitBreaker_V7 | 207.1 ns | 3.68 ns | 5.50 ns |  1.00 |    0.04 | 0.0370 |     464 B |        1.00 |
-| ExecuteCircuitBreaker_V8 | 335.3 ns | 6.30 ns | 9.43 ns |  1.62 |    0.06 |      - |         - |        0.00 |
+| ExecuteCircuitBreaker_V7 | 141.6 ns | 2.25 ns | 3.23 ns |  1.00 |    0.03 | 0.0370 |     464 B |        1.00 |
+| ExecuteCircuitBreaker_V8 | 237.4 ns | 0.31 ns | 0.46 ns |  1.68 |    0.04 |      - |         - |        0.00 |

--- a/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.CircuitBreakerOpenedBenchmark-report-github.md
+++ b/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.CircuitBreakerOpenedBenchmark-report-github.md
@@ -1,16 +1,16 @@
 ```
 
-BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4602/23H2/2023Update/SunValley3)
-12th Gen Intel Core i7-1280P, 1 CPU, 20 logical and 14 physical cores
-.NET SDK 9.0.101
-  [Host] : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2
+BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.4351)
+13th Gen Intel Core i7-13700H, 1 CPU, 20 logical and 14 physical cores
+.NET SDK 9.0.301
+  [Host] : .NET 9.0.6 (9.0.625.26613), X64 RyuJIT AVX2
 
 Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
 LaunchCount=2  WarmupCount=10  
 
 ```
-| Method                    | Mean        | Error     | StdDev    | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
-|-------------------------- |------------:|----------:|----------:|------:|--------:|-------:|----------:|------------:|
-| ExecuteAsync_Exception_V7 | 14,295.0 ns | 418.44 ns | 600.11 ns | 27.37 |    1.33 | 0.1526 |    2056 B |       10.28 |
-| ExecuteAsync_Exception_V8 |  9,178.8 ns | 114.83 ns | 171.88 ns | 17.57 |    0.55 | 0.0916 |    1312 B |        6.56 |
-| ExecuteAsync_Outcome_V8   |    522.6 ns |   9.15 ns |  13.70 ns |  1.00 |    0.04 | 0.0153 |     200 B |        1.00 |
+| Method                    | Mean        | Error    | StdDev   | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
+|-------------------------- |------------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
+| ExecuteAsync_Exception_V7 | 10,446.3 ns | 39.89 ns | 59.71 ns | 22.30 |    0.82 | 0.1526 |    2056 B |       10.28 |
+| ExecuteAsync_Exception_V8 |  6,791.6 ns | 42.75 ns | 61.31 ns | 14.50 |    0.54 | 0.0992 |    1312 B |        6.56 |
+| ExecuteAsync_Outcome_V8   |    469.0 ns | 10.24 ns | 15.33 ns |  1.00 |    0.05 | 0.0157 |     200 B |        1.00 |

--- a/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.CompositeComponentBenchmark-report-github.md
+++ b/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.CompositeComponentBenchmark-report-github.md
@@ -1,9 +1,9 @@
 ```
 
-BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4602/23H2/2023Update/SunValley3)
-12th Gen Intel Core i7-1280P, 1 CPU, 20 logical and 14 physical cores
-.NET SDK 9.0.101
-  [Host] : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2
+BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.4351)
+13th Gen Intel Core i7-13700H, 1 CPU, 20 logical and 14 physical cores
+.NET SDK 9.0.301
+  [Host] : .NET 9.0.6 (9.0.625.26613), X64 RyuJIT AVX2
 
 Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
 LaunchCount=2  WarmupCount=10  
@@ -11,4 +11,4 @@ LaunchCount=2  WarmupCount=10
 ```
 | Method                         | Mean     | Error    | StdDev   | Allocated |
 |------------------------------- |---------:|---------:|---------:|----------:|
-| CompositeComponent_ExecuteCore | 40.70 ns | 0.574 ns | 0.823 ns |         - |
+| CompositeComponent_ExecuteCore | 27.45 ns | 0.106 ns | 0.155 ns |         - |

--- a/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.CreationBenchmark-report-github.md
+++ b/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.CreationBenchmark-report-github.md
@@ -1,15 +1,15 @@
 ```
 
-BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4602/23H2/2023Update/SunValley3)
-12th Gen Intel Core i7-1280P, 1 CPU, 20 logical and 14 physical cores
-.NET SDK 9.0.101
-  [Host] : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2
+BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.4351)
+13th Gen Intel Core i7-13700H, 1 CPU, 20 logical and 14 physical cores
+.NET SDK 9.0.301
+  [Host] : .NET 9.0.6 (9.0.625.26613), X64 RyuJIT AVX2
 
 Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
 LaunchCount=2  WarmupCount=10  
 
 ```
-| Method      | Mean        | Error     | StdDev    | Gen0   | Allocated |
-|------------ |------------:|----------:|----------:|-------:|----------:|
-| Fallback_V7 |    63.30 ns |  1.058 ns |  1.583 ns | 0.0305 |     384 B |
-| Fallback_V8 | 2,689.59 ns | 34.384 ns | 50.400 ns | 0.4082 |    5136 B |
+| Method      | Mean        | Error    | StdDev    | Gen0   | Allocated |
+|------------ |------------:|---------:|----------:|-------:|----------:|
+| Fallback_V7 |    45.45 ns | 2.165 ns |  3.241 ns | 0.0306 |     384 B |
+| Fallback_V8 | 1,705.23 ns | 8.115 ns | 12.146 ns | 0.4025 |    5064 B |

--- a/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.DelegatingComponentBenchmark-report-github.md
+++ b/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.DelegatingComponentBenchmark-report-github.md
@@ -1,9 +1,9 @@
 ```
 
-BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4602/23H2/2023Update/SunValley3)
-12th Gen Intel Core i7-1280P, 1 CPU, 20 logical and 14 physical cores
-.NET SDK 9.0.101
-  [Host] : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2
+BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.4351)
+13th Gen Intel Core i7-13700H, 1 CPU, 20 logical and 14 physical cores
+.NET SDK 9.0.301
+  [Host] : .NET 9.0.6 (9.0.625.26613), X64 RyuJIT AVX2
 
 Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
 LaunchCount=2  WarmupCount=10  
@@ -11,5 +11,5 @@ LaunchCount=2  WarmupCount=10
 ```
 | Method                              | Mean     | Error    | StdDev   | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
 |------------------------------------ |---------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
-| DelegatingComponent_ExecuteCore_Jit | 29.17 ns | 0.613 ns | 0.899 ns |  1.00 |    0.04 |      - |         - |          NA |
-| DelegatingComponent_ExecuteCore_Aot | 43.48 ns | 0.584 ns | 0.873 ns |  1.49 |    0.05 | 0.0019 |      24 B |          NA |
+| DelegatingComponent_ExecuteCore_Jit | 23.38 ns | 2.049 ns | 2.805 ns |  1.01 |    0.17 |      - |         - |          NA |
+| DelegatingComponent_ExecuteCore_Aot | 30.32 ns | 0.042 ns | 0.060 ns |  1.32 |    0.15 | 0.0019 |      24 B |          NA |

--- a/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.GenericOverheadBenchmark-report-github.md
+++ b/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.GenericOverheadBenchmark-report-github.md
@@ -1,15 +1,15 @@
 ```
 
-BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4602/23H2/2023Update/SunValley3)
-12th Gen Intel Core i7-1280P, 1 CPU, 20 logical and 14 physical cores
-.NET SDK 9.0.101
-  [Host] : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2
+BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.4351)
+13th Gen Intel Core i7-13700H, 1 CPU, 20 logical and 14 physical cores
+.NET SDK 9.0.301
+  [Host] : .NET 9.0.6 (9.0.625.26613), X64 RyuJIT AVX2
 
 Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
 LaunchCount=2  WarmupCount=10  
 
 ```
-| Method                  | Mean     | Error    | StdDev   | Ratio | RatioSD | Allocated | Alloc Ratio |
-|------------------------ |---------:|---------:|---------:|------:|--------:|----------:|------------:|
-| ExecuteAsync_Generic    | 14.67 ns | 0.266 ns | 0.390 ns |  1.00 |    0.04 |         - |          NA |
-| ExecuteAsync_NonGeneric | 24.89 ns | 0.581 ns | 0.870 ns |  1.70 |    0.07 |         - |          NA |
+| Method                  | Mean     | Error    | StdDev   | Median    | Ratio | RatioSD | Allocated | Alloc Ratio |
+|------------------------ |---------:|---------:|---------:|----------:|------:|--------:|----------:|------------:|
+| ExecuteAsync_Generic    | 12.53 ns | 2.430 ns | 3.244 ns |  9.500 ns |  1.07 |    0.39 |         - |          NA |
+| ExecuteAsync_NonGeneric | 15.28 ns | 0.272 ns | 0.407 ns | 15.133 ns |  1.30 |    0.33 |         - |          NA |

--- a/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.HedgingBenchmark-report-github.md
+++ b/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.HedgingBenchmark-report-github.md
@@ -1,17 +1,17 @@
 ```
 
-BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4602/23H2/2023Update/SunValley3)
-12th Gen Intel Core i7-1280P, 1 CPU, 20 logical and 14 physical cores
-.NET SDK 9.0.101
-  [Host] : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2
+BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.4351)
+13th Gen Intel Core i7-13700H, 1 CPU, 20 logical and 14 physical cores
+.NET SDK 9.0.301
+  [Host] : .NET 9.0.6 (9.0.625.26613), X64 RyuJIT AVX2
 
 Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
 LaunchCount=2  WarmupCount=10  
 
 ```
-| Method                      | Mean       | Error     | StdDev    | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
-|---------------------------- |-----------:|----------:|----------:|------:|--------:|-------:|----------:|------------:|
-| Hedging_Primary             |   684.6 ns |  25.04 ns |  36.71 ns |  1.00 |    0.07 |      - |         - |          NA |
-| Hedging_Secondary           | 1,192.5 ns |  24.41 ns |  34.21 ns |  1.75 |    0.10 | 0.0191 |     240 B |          NA |
-| Hedging_Primary_AsyncWork   | 5,504.3 ns | 313.47 ns | 449.58 ns |  8.06 |    0.77 | 0.1831 |    2338 B |          NA |
-| Hedging_Secondary_AsyncWork | 6,123.1 ns |  98.34 ns | 144.15 ns |  8.97 |    0.50 | 0.2060 |    2577 B |          NA |
+| Method                      | Mean       | Error    | StdDev    | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
+|---------------------------- |-----------:|---------:|----------:|------:|--------:|-------:|----------:|------------:|
+| Hedging_Primary             |   579.2 ns | 12.50 ns |  18.71 ns |  1.00 |    0.05 |      - |         - |          NA |
+| Hedging_Secondary           |   983.2 ns | 28.67 ns |  42.03 ns |  1.70 |    0.09 | 0.0191 |     240 B |          NA |
+| Hedging_Primary_AsyncWork   | 4,149.2 ns | 38.23 ns |  56.04 ns |  7.17 |    0.25 | 0.1831 |    2347 B |          NA |
+| Hedging_Secondary_AsyncWork | 5,138.5 ns | 95.25 ns | 142.57 ns |  8.88 |    0.37 | 0.2060 |    2579 B |          NA |

--- a/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.MultipleStrategiesBenchmark-report-github.md
+++ b/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.MultipleStrategiesBenchmark-report-github.md
@@ -1,18 +1,18 @@
 ```
 
-BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4602/23H2/2023Update/SunValley3)
-12th Gen Intel Core i7-1280P, 1 CPU, 20 logical and 14 physical cores
-.NET SDK 9.0.101
-  [Host] : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2
+BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.4351)
+13th Gen Intel Core i7-13700H, 1 CPU, 20 logical and 14 physical cores
+.NET SDK 9.0.301
+  [Host] : .NET 9.0.6 (9.0.625.26613), X64 RyuJIT AVX2
 
 Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
 LaunchCount=2  WarmupCount=10  
 
 ```
-| Method                                         | Mean     | Error     | StdDev    | Median   | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
-|----------------------------------------------- |---------:|----------:|----------:|---------:|------:|--------:|-------:|----------:|------------:|
-| ExecuteStrategyPipeline_Generic_V7             | 1.180 μs | 0.0082 μs | 0.0122 μs | 1.179 μs |  1.00 |    0.01 | 0.2174 |    2744 B |        1.00 |
-| ExecuteStrategyPipeline_Generic_V8             | 1.082 μs | 0.0128 μs | 0.0180 μs | 1.078 μs |  0.92 |    0.02 | 0.0019 |      40 B |        0.01 |
-| ExecuteStrategyPipeline_GenericTelemetry_V8    | 1.566 μs | 0.0178 μs | 0.0255 μs | 1.552 μs |  1.33 |    0.03 | 0.0019 |      40 B |        0.01 |
-| ExecuteStrategyPipeline_NonGeneric_V8          | 1.150 μs | 0.0052 μs | 0.0075 μs | 1.148 μs |  0.97 |    0.01 | 0.0019 |      40 B |        0.01 |
-| ExecuteStrategyPipeline_NonGenericTelemetry_V8 | 1.672 μs | 0.0075 μs | 0.0110 μs | 1.672 μs |  1.42 |    0.02 | 0.0019 |      40 B |        0.01 |
+| Method                                         | Mean     | Error     | StdDev    | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
+|----------------------------------------------- |---------:|----------:|----------:|------:|--------:|-------:|----------:|------------:|
+| ExecuteStrategyPipeline_Generic_V7             | 1.347 μs | 0.0219 μs | 0.0328 μs |  1.00 |    0.03 | 0.2174 |    2744 B |        1.00 |
+| ExecuteStrategyPipeline_Generic_V8             | 1.179 μs | 0.0266 μs | 0.0398 μs |  0.88 |    0.04 | 0.0019 |      40 B |        0.01 |
+| ExecuteStrategyPipeline_GenericTelemetry_V8    | 1.653 μs | 0.0277 μs | 0.0415 μs |  1.23 |    0.04 | 0.0019 |      40 B |        0.01 |
+| ExecuteStrategyPipeline_NonGeneric_V8          | 1.285 μs | 0.0184 μs | 0.0276 μs |  0.96 |    0.03 | 0.0019 |      40 B |        0.01 |
+| ExecuteStrategyPipeline_NonGenericTelemetry_V8 | 1.739 μs | 0.0475 μs | 0.0711 μs |  1.29 |    0.06 | 0.0019 |      40 B |        0.01 |

--- a/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.PipelineBenchmark-report-github.md
+++ b/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.PipelineBenchmark-report-github.md
@@ -1,24 +1,24 @@
 ```
 
-BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4602/23H2/2023Update/SunValley3)
-12th Gen Intel Core i7-1280P, 1 CPU, 20 logical and 14 physical cores
-.NET SDK 9.0.101
-  [Host] : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2
+BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.4351)
+13th Gen Intel Core i7-13700H, 1 CPU, 20 logical and 14 physical cores
+.NET SDK 9.0.301
+  [Host] : .NET 9.0.6 (9.0.625.26613), X64 RyuJIT AVX2
 
 Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
 LaunchCount=2  WarmupCount=10  
 
 ```
-| Method             | Components | Mean      | Error    | StdDev    | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
-|------------------- |----------- |----------:|---------:|----------:|------:|--------:|-------:|----------:|------------:|
-| **ExecutePipeline_V7** | **1**          |  **69.79 ns** | **0.588 ns** |  **0.880 ns** |  **1.00** |    **0.02** | **0.0242** |     **304 B** |        **1.00** |
-| ExecutePipeline_V8 | 1          |  69.75 ns | 0.290 ns |  0.406 ns |  1.00 |    0.01 |      - |         - |        0.00 |
-|                    |            |           |          |           |       |         |        |           |             |
-| **ExecutePipeline_V7** | **2**          | **151.17 ns** | **1.092 ns** |  **1.566 ns** |  **1.00** |    **0.01** | **0.0439** |     **552 B** |        **1.00** |
-| ExecutePipeline_V8 | 2          |  99.85 ns | 0.617 ns |  0.884 ns |  0.66 |    0.01 |      - |         - |        0.00 |
-|                    |            |           |          |           |       |         |        |           |             |
-| **ExecutePipeline_V7** | **5**          | **409.27 ns** | **3.791 ns** |  **5.314 ns** |  **1.00** |    **0.02** | **0.1030** |    **1296 B** |        **1.00** |
-| ExecutePipeline_V8 | 5          | 208.08 ns | 0.874 ns |  1.280 ns |  0.51 |    0.01 |      - |         - |        0.00 |
-|                    |            |           |          |           |       |         |        |           |             |
-| **ExecutePipeline_V7** | **10**         | **822.12 ns** | **6.901 ns** | **10.115 ns** |  **1.00** |    **0.02** | **0.2012** |    **2536 B** |        **1.00** |
-| ExecutePipeline_V8 | 10         | 399.00 ns | 1.668 ns |  2.393 ns |  0.49 |    0.01 |      - |         - |        0.00 |
+| Method             | Components | Mean        | Error     | StdDev    | Median      | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
+|------------------- |----------- |------------:|----------:|----------:|------------:|------:|--------:|-------:|----------:|------------:|
+| **ExecutePipeline_V7** | **1**          |    **59.65 ns** |  **2.963 ns** |  **4.250 ns** |    **58.39 ns** |  **1.00** |    **0.10** | **0.0242** |     **304 B** |        **1.00** |
+| ExecutePipeline_V8 | 1          |    52.51 ns |  0.093 ns |  0.133 ns |    52.49 ns |  0.88 |    0.06 |      - |         - |        0.00 |
+|                    |            |             |           |           |             |       |         |        |           |             |
+| **ExecutePipeline_V7** | **2**          |   **125.93 ns** |  **0.674 ns** |  **0.988 ns** |   **125.59 ns** |  **1.00** |    **0.01** | **0.0439** |     **552 B** |        **1.00** |
+| ExecutePipeline_V8 | 2          |    74.07 ns |  0.207 ns |  0.303 ns |    73.91 ns |  0.59 |    0.01 |      - |         - |        0.00 |
+|                    |            |             |           |           |             |       |         |        |           |             |
+| **ExecutePipeline_V7** | **5**          |   **517.61 ns** | **20.857 ns** | **31.218 ns** |   **525.89 ns** |  **1.00** |    **0.10** | **0.1030** |    **1296 B** |        **1.00** |
+| ExecutePipeline_V8 | 5          |   229.02 ns |  8.340 ns | 12.483 ns |   232.35 ns |  0.44 |    0.04 |      - |         - |        0.00 |
+|                    |            |             |           |           |             |       |         |        |           |             |
+| **ExecutePipeline_V7** | **10**         | **1,175.56 ns** | **56.978 ns** | **85.282 ns** | **1,206.15 ns** |  **1.01** |    **0.11** | **0.2003** |    **2536 B** |        **1.00** |
+| ExecutePipeline_V8 | 10         |   550.37 ns | 12.148 ns | 17.806 ns |   558.74 ns |  0.47 |    0.04 |      - |         - |        0.00 |

--- a/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.PredicateBenchmark-report-github.md
+++ b/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.PredicateBenchmark-report-github.md
@@ -1,15 +1,15 @@
 ```
 
-BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4602/23H2/2023Update/SunValley3)
-12th Gen Intel Core i7-1280P, 1 CPU, 20 logical and 14 physical cores
-.NET SDK 9.0.101
-  [Host] : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2
+BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.4351)
+13th Gen Intel Core i7-13700H, 1 CPU, 20 logical and 14 physical cores
+.NET SDK 9.0.301
+  [Host] : .NET 9.0.6 (9.0.625.26613), X64 RyuJIT AVX2
 
 Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
 LaunchCount=2  WarmupCount=10  
 
 ```
-| Method                     | Mean     | Error    | StdDev   | Median   | Ratio | RatioSD | Allocated | Alloc Ratio |
-|--------------------------- |---------:|---------:|---------:|---------:|------:|--------:|----------:|------------:|
-| Predicate_SwitchExpression | 11.82 ns | 0.234 ns | 0.343 ns | 12.08 ns |  1.00 |    0.04 |         - |          NA |
-| Predicate_PredicateBuilder | 21.52 ns | 0.077 ns | 0.108 ns | 21.51 ns |  1.82 |    0.05 |         - |          NA |
+| Method                     | Mean      | Error     | StdDev    | Median    | Ratio | RatioSD | Allocated | Alloc Ratio |
+|--------------------------- |----------:|----------:|----------:|----------:|------:|--------:|----------:|------------:|
+| Predicate_SwitchExpression |  9.687 ns | 0.1908 ns | 0.2797 ns |  9.940 ns |  1.00 |    0.04 |         - |          NA |
+| Predicate_PredicateBuilder | 17.365 ns | 0.0545 ns | 0.0816 ns | 17.369 ns |  1.79 |    0.05 |         - |          NA |

--- a/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.RateLimiterBenchmark-report-github.md
+++ b/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.RateLimiterBenchmark-report-github.md
@@ -1,15 +1,15 @@
 ```
 
-BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4602/23H2/2023Update/SunValley3)
-12th Gen Intel Core i7-1280P, 1 CPU, 20 logical and 14 physical cores
-.NET SDK 9.0.101
-  [Host] : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2
+BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.4351)
+13th Gen Intel Core i7-13700H, 1 CPU, 20 logical and 14 physical cores
+.NET SDK 9.0.301
+  [Host] : .NET 9.0.6 (9.0.625.26613), X64 RyuJIT AVX2
 
 Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
 LaunchCount=2  WarmupCount=10  
 
 ```
-| Method                | Mean     | Error   | StdDev  | Ratio | Gen0   | Allocated | Alloc Ratio |
-|---------------------- |---------:|--------:|--------:|------:|-------:|----------:|------------:|
-| ExecuteRateLimiter_V7 | 178.3 ns | 0.79 ns | 1.16 ns |  1.00 | 0.0298 |     376 B |        1.00 |
-| ExecuteRateLimiter_V8 | 188.2 ns | 0.89 ns | 1.34 ns |  1.06 | 0.0031 |      40 B |        0.11 |
+| Method                | Mean     | Error   | StdDev  | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
+|---------------------- |---------:|--------:|--------:|------:|--------:|-------:|----------:|------------:|
+| ExecuteRateLimiter_V7 | 156.3 ns | 2.29 ns | 3.35 ns |  1.00 |    0.03 | 0.0298 |     376 B |        1.00 |
+| ExecuteRateLimiter_V8 | 159.2 ns | 0.44 ns | 0.65 ns |  1.02 |    0.02 | 0.0031 |      40 B |        0.11 |

--- a/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.ResiliencePipelineBenchmark-report-github.md
+++ b/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.ResiliencePipelineBenchmark-report-github.md
@@ -1,20 +1,20 @@
 ```
 
-BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4602/23H2/2023Update/SunValley3)
-12th Gen Intel Core i7-1280P, 1 CPU, 20 logical and 14 physical cores
-.NET SDK 9.0.101
-  [Host] : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2
+BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.4351)
+13th Gen Intel Core i7-13700H, 1 CPU, 20 logical and 14 physical cores
+.NET SDK 9.0.301
+  [Host] : .NET 9.0.6 (9.0.625.26613), X64 RyuJIT AVX2
 
 Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
 LaunchCount=2  WarmupCount=10  
 
 ```
-| Method                                         | Mean     | Error    | StdDev   | Ratio | RatioSD | Allocated | Alloc Ratio |
-|----------------------------------------------- |---------:|---------:|---------:|------:|--------:|----------:|------------:|
-| ExecuteOutcomeAsync                            | 45.69 ns | 0.443 ns | 0.635 ns |  1.00 |    0.02 |         - |          NA |
-| ExecuteAsync_ResilienceContextAndState         | 80.17 ns | 0.672 ns | 1.006 ns |  1.76 |    0.03 |         - |          NA |
-| ExecuteAsync_CancellationToken                 | 84.26 ns | 0.285 ns | 0.381 ns |  1.84 |    0.03 |         - |          NA |
-| ExecuteAsync_GenericStrategy_CancellationToken | 87.55 ns | 3.675 ns | 5.030 ns |  1.92 |    0.11 |         - |          NA |
-| Execute_ResilienceContextAndState              | 59.59 ns | 0.610 ns | 0.894 ns |  1.30 |    0.03 |         - |          NA |
-| Execute_CancellationToken                      | 66.67 ns | 0.542 ns | 0.794 ns |  1.46 |    0.03 |         - |          NA |
-| Execute_GenericStrategy_CancellationToken      | 67.05 ns | 0.632 ns | 0.906 ns |  1.47 |    0.03 |         - |          NA |
+| Method                                         | Mean     | Error    | StdDev   | Median   | Ratio | RatioSD | Allocated | Alloc Ratio |
+|----------------------------------------------- |---------:|---------:|---------:|---------:|------:|--------:|----------:|------------:|
+| ExecuteOutcomeAsync                            | 35.40 ns | 0.084 ns | 0.113 ns | 35.35 ns |  1.00 |    0.00 |         - |          NA |
+| ExecuteAsync_ResilienceContextAndState         | 65.38 ns | 0.426 ns | 0.569 ns | 65.77 ns |  1.85 |    0.02 |         - |          NA |
+| ExecuteAsync_CancellationToken                 | 69.33 ns | 0.112 ns | 0.154 ns | 69.33 ns |  1.96 |    0.01 |         - |          NA |
+| ExecuteAsync_GenericStrategy_CancellationToken | 71.03 ns | 0.947 ns | 1.388 ns | 71.47 ns |  2.01 |    0.04 |         - |          NA |
+| Execute_ResilienceContextAndState              | 50.61 ns | 0.136 ns | 0.190 ns | 50.69 ns |  1.43 |    0.01 |         - |          NA |
+| Execute_CancellationToken                      | 55.46 ns | 0.737 ns | 1.080 ns | 54.51 ns |  1.57 |    0.03 |         - |          NA |
+| Execute_GenericStrategy_CancellationToken      | 56.74 ns | 0.107 ns | 0.146 ns | 56.68 ns |  1.60 |    0.01 |         - |          NA |

--- a/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.ResiliencePipelineProviderBenchmark-report-github.md
+++ b/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.ResiliencePipelineProviderBenchmark-report-github.md
@@ -1,15 +1,15 @@
 ```
 
-BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4602/23H2/2023Update/SunValley3)
-12th Gen Intel Core i7-1280P, 1 CPU, 20 logical and 14 physical cores
-.NET SDK 9.0.101
-  [Host] : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2
+BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.4351)
+13th Gen Intel Core i7-13700H, 1 CPU, 20 logical and 14 physical cores
+.NET SDK 9.0.301
+  [Host] : .NET 9.0.6 (9.0.625.26613), X64 RyuJIT AVX2
 
 Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
 LaunchCount=2  WarmupCount=10  
 
 ```
-| Method                 | Mean     | Error    | StdDev   | Allocated |
-|----------------------- |---------:|---------:|---------:|----------:|
-| GetPipeline_Ok         | 11.51 ns | 0.046 ns | 0.068 ns |         - |
-| GetPipeline_Generic_Ok | 43.64 ns | 0.146 ns | 0.214 ns |         - |
+| Method                 | Mean      | Error     | StdDev    | Allocated |
+|----------------------- |----------:|----------:|----------:|----------:|
+| GetPipeline_Ok         |  9.383 ns | 0.1542 ns | 0.2308 ns |         - |
+| GetPipeline_Generic_Ok | 31.460 ns | 0.1564 ns | 0.2293 ns |         - |

--- a/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.RetryBenchmark-report-github.md
+++ b/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.RetryBenchmark-report-github.md
@@ -1,15 +1,15 @@
 ```
 
-BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4602/23H2/2023Update/SunValley3)
-12th Gen Intel Core i7-1280P, 1 CPU, 20 logical and 14 physical cores
-.NET SDK 9.0.101
-  [Host] : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2
+BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.4351)
+13th Gen Intel Core i7-13700H, 1 CPU, 20 logical and 14 physical cores
+.NET SDK 9.0.301
+  [Host] : .NET 9.0.6 (9.0.625.26613), X64 RyuJIT AVX2
 
 Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
 LaunchCount=2  WarmupCount=10  
 
 ```
-| Method          | Mean     | Error   | StdDev  | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
-|---------------- |---------:|--------:|--------:|------:|--------:|-------:|----------:|------------:|
-| ExecuteRetry_V7 | 125.4 ns | 0.84 ns | 1.20 ns |  1.00 |    0.01 | 0.0408 |     512 B |        1.00 |
-| ExecuteRetry_V8 | 179.7 ns | 0.61 ns | 0.87 ns |  1.43 |    0.02 |      - |         - |        0.00 |
+| Method          | Mean      | Error    | StdDev   | Ratio | Gen0   | Allocated | Alloc Ratio |
+|---------------- |----------:|---------:|---------:|------:|-------:|----------:|------------:|
+| ExecuteRetry_V7 |  99.64 ns | 0.373 ns | 0.510 ns |  1.00 | 0.0408 |     512 B |        1.00 |
+| ExecuteRetry_V8 | 149.93 ns | 0.600 ns | 0.821 ns |  1.50 |      - |         - |        0.00 |

--- a/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.TelemetryBenchmark-report-github.md
+++ b/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.TelemetryBenchmark-report-github.md
@@ -1,17 +1,17 @@
 ```
 
-BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4602/23H2/2023Update/SunValley3)
-12th Gen Intel Core i7-1280P, 1 CPU, 20 logical and 14 physical cores
-.NET SDK 9.0.101
-  [Host] : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2
+BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.4351)
+13th Gen Intel Core i7-13700H, 1 CPU, 20 logical and 14 physical cores
+.NET SDK 9.0.301
+  [Host] : .NET 9.0.6 (9.0.625.26613), X64 RyuJIT AVX2
 
 Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
 LaunchCount=2  WarmupCount=10  
 
 ```
-| Method  | Telemetry | Enrichment | Mean      | Error    | StdDev   | Allocated |
-|-------- |---------- |----------- |----------:|---------:|---------:|----------:|
-| **Execute** | **False**     | **False**      |  **60.58 ns** | **0.178 ns** | **0.256 ns** |         **-** |
-| **Execute** | **False**     | **True**       |  **62.53 ns** | **1.442 ns** | **2.159 ns** |         **-** |
-| **Execute** | **True**      | **False**      | **443.92 ns** | **1.736 ns** | **2.434 ns** |         **-** |
-| **Execute** | **True**      | **True**       | **612.90 ns** | **2.974 ns** | **4.359 ns** |         **-** |
+| Method  | Telemetry | Enrichment | Mean      | Error    | StdDev    | Median    | Allocated |
+|-------- |---------- |----------- |----------:|---------:|----------:|----------:|----------:|
+| **Execute** | **False**     | **False**      |  **50.75 ns** | **1.532 ns** |  **2.246 ns** |  **49.73 ns** |         **-** |
+| **Execute** | **False**     | **True**       |  **49.42 ns** | **0.135 ns** |  **0.189 ns** |  **49.36 ns** |         **-** |
+| **Execute** | **True**      | **False**      | **382.94 ns** | **9.059 ns** | **12.992 ns** | **394.03 ns** |         **-** |
+| **Execute** | **True**      | **True**       | **526.66 ns** | **1.216 ns** |  **1.783 ns** | **526.85 ns** |         **-** |

--- a/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.TimeoutBenchmark-report-github.md
+++ b/bench/BenchmarkDotNet.Artifacts/results/Polly.Core.Benchmarks.TimeoutBenchmark-report-github.md
@@ -1,9 +1,9 @@
 ```
 
-BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4602/23H2/2023Update/SunValley3)
-12th Gen Intel Core i7-1280P, 1 CPU, 20 logical and 14 physical cores
-.NET SDK 9.0.101
-  [Host] : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2
+BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.4351)
+13th Gen Intel Core i7-13700H, 1 CPU, 20 logical and 14 physical cores
+.NET SDK 9.0.301
+  [Host] : .NET 9.0.6 (9.0.625.26613), X64 RyuJIT AVX2
 
 Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15  
 LaunchCount=2  WarmupCount=10  
@@ -11,5 +11,5 @@ LaunchCount=2  WarmupCount=10
 ```
 | Method            | Mean     | Error   | StdDev  | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
 |------------------ |---------:|--------:|--------:|------:|--------:|-------:|----------:|------------:|
-| ExecuteTimeout_V7 | 259.3 ns | 4.25 ns | 6.24 ns |  1.00 |    0.03 | 0.0577 |     728 B |        1.00 |
-| ExecuteTimeout_V8 | 241.1 ns | 1.48 ns | 2.17 ns |  0.93 |    0.02 |      - |         - |        0.00 |
+| ExecuteTimeout_V7 | 219.0 ns | 2.43 ns | 3.40 ns |  1.00 |    0.02 | 0.0579 |     728 B |        1.00 |
+| ExecuteTimeout_V8 | 191.9 ns | 0.21 ns | 0.31 ns |  0.88 |    0.01 |      - |         - |        0.00 |

--- a/src/Polly.Core/ResiliencePipelineBuilderBase.cs
+++ b/src/Polly.Core/ResiliencePipelineBuilderBase.cs
@@ -121,7 +121,7 @@ public abstract class ResiliencePipelineBuilderBase
 
         _used = true;
 
-        var components = _entries.Select(CreateComponent).ToList();
+        var components = _entries.ConvertAll(CreateComponent);
 
         if (components.Count == 0)
         {

--- a/src/Polly.Core/Simmy/Outcomes/ChaosOutcomeStrategy.cs
+++ b/src/Polly.Core/Simmy/Outcomes/ChaosOutcomeStrategy.cs
@@ -20,8 +20,8 @@ internal sealed class ChaosOutcomeStrategy<T> : ChaosStrategy<T>
     {
         try
         {
-            if (await ShouldInjectAsync(context).ConfigureAwait(context.ContinueOnCapturedContext)
-                && await _outcomeGenerator(new(context)).ConfigureAwait(context.ContinueOnCapturedContext) is Outcome<T> outcome)
+            if (await ShouldInjectAsync(context).ConfigureAwait(context.ContinueOnCapturedContext) &&
+                await _outcomeGenerator(new(context)).ConfigureAwait(context.ContinueOnCapturedContext) is Outcome<T> outcome)
             {
                 var args = new OnOutcomeInjectedArguments<T>(context, outcome);
                 _telemetry.Report(new(ResilienceEventSeverity.Information, ChaosOutcomeConstants.OnOutcomeInjectedEvent), context, args);
@@ -31,12 +31,7 @@ internal sealed class ChaosOutcomeStrategy<T> : ChaosStrategy<T>
                     await _onOutcomeInjected(args).ConfigureAwait(context.ContinueOnCapturedContext);
                 }
 
-                if (outcome.HasResult)
-                {
-                    return new Outcome<T>(outcome.Result);
-                }
-
-                return new Outcome<T>(outcome.Exception!);
+                return outcome;
             }
 
             return await StrategyHelper.ExecuteCallbackSafeAsync(callback, context, state).ConfigureAwait(context.ContinueOnCapturedContext);

--- a/src/Polly.Core/Utils/DefaultPredicates.cs
+++ b/src/Polly.Core/Utils/DefaultPredicates.cs
@@ -3,10 +3,5 @@
 internal static class DefaultPredicates<TArgs, TResult>
     where TArgs : IOutcomeArguments<TResult>
 {
-    public static readonly Func<TArgs, ValueTask<bool>> HandleOutcome = args => args.Outcome.Exception switch
-    {
-        OperationCanceledException => PredicateResult.False(),
-        Exception => PredicateResult.True(),
-        _ => PredicateResult.False(),
-    };
+    public static readonly Func<TArgs, ValueTask<bool>> HandleOutcome = args => new(args.Outcome.Exception is { } and not OperationCanceledException);
 }

--- a/src/Polly.Core/Utils/Guard.cs
+++ b/src/Polly.Core/Utils/Guard.cs
@@ -9,10 +9,14 @@ internal static class Guard
     public static T NotNull<T>(T value, [CallerArgumentExpression("value")] string argumentName = "")
         where T : class
     {
+#if NET8_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(value, argumentName);
+#else
         if (value is null)
         {
             throw new ArgumentNullException(argumentName);
         }
+#endif
 
         return value;
     }

--- a/src/Polly.Core/Utils/Pipeline/ComponentDisposeHelper.cs
+++ b/src/Polly.Core/Utils/Pipeline/ComponentDisposeHelper.cs
@@ -26,9 +26,11 @@ internal sealed class ComponentDisposeHelper : IAsyncDisposable
     {
         if (_disposed)
         {
-            throw new ObjectDisposedException("ResiliencePipeline", "This resilience pipeline has been disposed and cannot be used anymore.");
+            ThrowDisposed();
         }
     }
+
+    private static void ThrowDisposed() => throw new ObjectDisposedException("ResiliencePipeline", "This resilience pipeline has been disposed and cannot be used anymore.");
 
     public ValueTask ForceDisposeAsync()
     {


### PR DESCRIPTION
- Avoid LINQ to create components.
- Do not recreate `Outcome<T>` for chaos.
- Avoid predicate allocation.
- Use `ArgumentNullException.ThrowIfNull()` where possible.
- Add throw helper for `ObjectDisposedException`.
- Remove unused `Stopwatch`.
- Use `Volatile.Read` instead of `Interlocked.CompareExchange()`.

Cherry-picked from #2664.
