### PR TITLE
Simplify release workflow

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,4 +2,5 @@ changelog:
   exclude:
     authors:
       - dependabot[bot]
+      - github-actions[bot]
       - polly-updater-bot[bot]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,30 +45,15 @@ jobs:
               version = version.slice(1);
             }
 
-            const tag_name = version;
-            const name = tag_name;
-
-            const { data: notes } = await github.rest.repos.generateReleaseNotes({
-              owner,
-              repo,
-              tag_name,
-              target_commitish: process.env.DEFAULT_BRANCH,
-            });
-
-            const body = notes.body
-              .split('\n')
-              .filter((line) => !line.includes(' @dependabot '))
-              .filter((line) => !line.includes(' @github-actions '))
-              .filter((line) => !line.includes(' @polly-updater-bot '))
-              .join('\n');
-
             const { data: release } = await github.rest.repos.createRelease({
               owner,
               repo,
-              tag_name,
-              name,
+              tag_name: version,
+              target_commitish: process.env.DEFAULT_BRANCH,
+              name: tag_name,
               body,
               draft,
+              generate_release_notes: true,
             });
 
             core.notice(`Created release ${release.name}: ${release.html_url}`);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
               repo,
               tag_name: version,
               target_commitish: process.env.DEFAULT_BRANCH,
-              name: tag_name,
+              name: version,
               body,
               draft,
               generate_release_notes: true,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,6 @@ jobs:
               tag_name: version,
               target_commitish: process.env.DEFAULT_BRANCH,
               name: version,
-              body,
               draft,
               generate_release_notes: true,
             });


### PR DESCRIPTION
With #2678, the release draft can be created in one request, rather than generating the notes and then manually editing them first.
