### PR TITLE
Add convenience overload for ExecuteOutcomeAsync and fixed documentation

### DIFF
--- a/docs/advanced/performance.md
+++ b/docs/advanced/performance.md
@@ -104,18 +104,7 @@ ResilienceContext context = ResilienceContextPool.Shared.Get(cancellationToken);
 // Instead of wrapping pipeline execution with try-catch, use ExecuteOutcomeAsync(...).
 // Certain strategies are optimized for this method, returning an exception instance without actually throwing it.
 Outcome<Member> outcome = await pipeline.ExecuteOutcomeAsync(
-    static async (context, state) =>
-    {
-        // The callback for ExecuteOutcomeAsync must return an Outcome<T> instance. Hence, some wrapping is needed.
-        try
-        {
-            return Outcome.FromResult(await GetMemberAsync(state, context.CancellationToken));
-        }
-        catch (Exception e)
-        {
-            return Outcome.FromException<Member>(e);
-        }
-    },
+    static async (context, state) => await GetMemberAsync(state, context.CancellationToken),
     context,
     id);
 

--- a/docs/migration-v8.md
+++ b/docs/migration-v8.md
@@ -937,7 +937,9 @@ ResiliencePipeline<int> pipeline = new ResiliencePipelineBuilder<int>()
 // Asynchronous execution
 var context = ResilienceContextPool.Shared.Get();
 Outcome<int> pipelineResult = await pipeline.ExecuteOutcomeAsync(
-    static async (ctx, state) => Outcome.FromResult(await MethodAsync(ctx.CancellationToken)), context, "state");
+    static async (ctx, state) => await MethodAsync(ctx.CancellationToken),
+    context,
+    "state");
 ResilienceContextPool.Shared.Return(context);
 
 // Assess policy result
@@ -973,7 +975,9 @@ ResiliencePipeline<int> pipelineWithContext = new ResiliencePipelineBuilder<int>
 
 context = ResilienceContextPool.Shared.Get();
 pipelineResult = await pipelineWithContext.ExecuteOutcomeAsync(
-    static async (ctx, state) => Outcome.FromResult(await MethodAsync(ctx.CancellationToken)), context, "state");
+    static async (ctx, state) => await MethodAsync(ctx.CancellationToken),
+    context,
+    "state");
 
 context.Properties.TryGetValue(contextKey, out var ctxValue);
 ResilienceContextPool.Shared.Return(context);

--- a/src/Polly.Core/PublicAPI.Shipped.txt
+++ b/src/Polly.Core/PublicAPI.Shipped.txt
@@ -252,6 +252,7 @@ Polly.ResiliencePipeline.ExecuteAsync<TResult>(System.Func<System.Threading.Canc
 Polly.ResiliencePipeline.ExecuteAsync<TState>(System.Func<Polly.ResilienceContext!, TState, System.Threading.Tasks.ValueTask>! callback, Polly.ResilienceContext! context, TState state) -> System.Threading.Tasks.ValueTask
 Polly.ResiliencePipeline.ExecuteAsync<TState>(System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! callback, TState state, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
 Polly.ResiliencePipeline.ExecuteOutcomeAsync<TResult, TState>(System.Func<Polly.ResilienceContext!, TState, System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>>! callback, Polly.ResilienceContext! context, TState state) -> System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>
+Polly.ResiliencePipeline.ExecuteOutcomeAsync<TResult, TState>(System.Func<Polly.ResilienceContext!, TState, System.Threading.Tasks.ValueTask<TResult>>! callback, Polly.ResilienceContext! context, TState state) -> System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>
 Polly.ResiliencePipeline<T>
 Polly.ResiliencePipeline<T>.Execute<TResult, TState>(System.Func<Polly.ResilienceContext!, TState, TResult>! callback, Polly.ResilienceContext! context, TState state) -> TResult
 Polly.ResiliencePipeline<T>.Execute<TResult, TState>(System.Func<TState, System.Threading.CancellationToken, TResult>! callback, TState state, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> TResult
@@ -264,6 +265,7 @@ Polly.ResiliencePipeline<T>.ExecuteAsync<TResult, TState>(System.Func<TState, Sy
 Polly.ResiliencePipeline<T>.ExecuteAsync<TResult>(System.Func<Polly.ResilienceContext!, System.Threading.Tasks.ValueTask<TResult>>! callback, Polly.ResilienceContext! context) -> System.Threading.Tasks.ValueTask<TResult>
 Polly.ResiliencePipeline<T>.ExecuteAsync<TResult>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! callback, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<TResult>
 Polly.ResiliencePipeline<T>.ExecuteOutcomeAsync<TResult, TState>(System.Func<Polly.ResilienceContext!, TState, System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>>! callback, Polly.ResilienceContext! context, TState state) -> System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>
+Polly.ResiliencePipeline<T>.ExecuteOutcomeAsync<TResult, TState>(System.Func<Polly.ResilienceContext!, TState, System.Threading.Tasks.ValueTask<TResult>>! callback, Polly.ResilienceContext! context, TState state) -> System.Threading.Tasks.ValueTask<Polly.Outcome<TResult>>
 Polly.ResiliencePipelineBuilder
 Polly.ResiliencePipelineBuilder.Build() -> Polly.ResiliencePipeline!
 Polly.ResiliencePipelineBuilder.ResiliencePipelineBuilder() -> void

--- a/src/Polly.Core/ResiliencePipeline.AsyncT.cs
+++ b/src/Polly.Core/ResiliencePipeline.AsyncT.cs
@@ -33,6 +33,48 @@ public partial class ResiliencePipeline
     }
 
     /// <summary>
+    /// Executes the specified callback and wraps the result in an <see cref="Outcome{TResult}"/>.
+    /// </summary>
+    /// <typeparam name="TResult">The type of result returned by the callback.</typeparam>
+    /// <typeparam name="TState">The type of state associated with the callback.</typeparam>
+    /// <param name="callback">The user-provided callback.</param>
+    /// <param name="context">The context associated with the callback.</param>
+    /// <param name="state">The state associated with the callback.</param>
+    /// <returns>The instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> or <paramref name="context"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// This is a convenience method that automatically handles exception-to-outcome conversion. The <paramref name="callback"/>
+    /// can throw exceptions, which will be automatically converted to <see cref="Outcome{TResult}"/>.
+    /// For advanced scenarios requiring custom exception handling, use <see cref="ExecuteOutcomeAsync{TResult, TState}(Func{ResilienceContext, TState, ValueTask{Outcome{TResult}}}, ResilienceContext, TState)"/>.
+    /// </remarks>
+    public ValueTask<Outcome<TResult>> ExecuteOutcomeAsync<TResult, TState>(
+        Func<ResilienceContext, TState, ValueTask<TResult>> callback,
+        ResilienceContext context,
+        TState state)
+    {
+        Guard.NotNull(callback);
+        Guard.NotNull(context);
+
+        InitializeAsyncContext<TResult>(context);
+
+        return Component.ExecuteCore(
+            [DebuggerDisableUserUnhandledExceptions] static async (context, state) =>
+            {
+                try
+                {
+                    var result = await state.callback(context, state.state).ConfigureAwait(context.ContinueOnCapturedContext);
+                    return Outcome.FromResult(result);
+                }
+                catch (Exception e)
+                {
+                    return Outcome.FromException<TResult>(e);
+                }
+            },
+            context,
+            (callback, state));
+    }
+
+    /// <summary>
     /// Executes the specified callback.
     /// </summary>
     /// <typeparam name="TResult">The type of result returned by the callback.</typeparam>

--- a/src/Polly.Core/ResiliencePipelineT.Async.cs
+++ b/src/Polly.Core/ResiliencePipelineT.Async.cs
@@ -86,4 +86,26 @@ public partial class ResiliencePipeline<T>
         TState state)
         where TResult : T
         => Pipeline.ExecuteOutcomeAsync(callback, context, state);
+
+    /// <summary>
+    /// Executes the specified callback and wraps the result in an <see cref="Outcome{TResult}"/>.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
+    /// <typeparam name="TState">The type of state associated with the callback.</typeparam>
+    /// <param name="callback">The user-provided callback.</param>
+    /// <param name="context">The context associated with the callback.</param>
+    /// <param name="state">The state associated with the callback.</param>
+    /// <returns>The instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> or <paramref name="context"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// This is a convenience method that automatically handles exception-to-outcome conversion. The <paramref name="callback"/>
+    /// can throw exceptions, which will be automatically converted to <see cref="Outcome{TResult}"/>.
+    /// For advanced scenarios requiring custom exception handling, use <see cref="ExecuteOutcomeAsync{TResult, TState}(Func{ResilienceContext, TState, ValueTask{Outcome{TResult}}}, ResilienceContext, TState)"/>.
+    /// </remarks>
+    public ValueTask<Outcome<TResult>> ExecuteOutcomeAsync<TResult, TState>(
+        Func<ResilienceContext, TState, ValueTask<TResult>> callback,
+        ResilienceContext context,
+        TState state)
+        where TResult : T
+        => Pipeline.ExecuteOutcomeAsync(callback, context, state);
 }

--- a/src/Snippets/Docs/CircuitBreaker.cs
+++ b/src/Snippets/Docs/CircuitBreaker.cs
@@ -278,11 +278,10 @@ internal static class CircuitBreaker
             })
             .Build();
 
-        Outcome<HttpResponseMessage> outcome = await circuitBreaker.ExecuteOutcomeAsync(static async (ctx, state) =>
-        {
-            var response = await IssueRequest();
-            return Outcome.FromResult(response);
-        }, context, "state");
+        Outcome<HttpResponseMessage> outcome = await circuitBreaker.ExecuteOutcomeAsync(
+            static async (ctx, state) => await IssueRequest(),
+            context,
+            "state");
 
         ResilienceContextPool.Shared.Return(context);
 

--- a/src/Snippets/Docs/Fallback.cs
+++ b/src/Snippets/Docs/Fallback.cs
@@ -119,11 +119,9 @@ internal static class Fallback
     {
         var context = ResilienceContextPool.Shared.Get();
         var outcome = await WhateverPipeline.ExecuteOutcomeAsync<HttpResponseMessage, string>(
-            async (ctx, state) =>
-            {
-                var result = await ActionCore();
-                return Outcome.FromResult(result);
-            }, context, "state");
+            async (ctx, state) => await ActionCore(),
+            context,
+            "state");
 
         if (outcome.Exception is HttpRequestException requestException)
         {
@@ -164,11 +162,9 @@ internal static class Fallback
 
         var context = ResilienceContextPool.Shared.Get();
         var outcome = await fallback.ExecuteOutcomeAsync<HttpResponseMessage, string>(
-            async (ctx, state) =>
-            {
-                var result = await CallPrimary(ctx.CancellationToken);
-                return Outcome.FromResult(result);
-            }, context, "none");
+            async (ctx, state) => await CallPrimary(ctx.CancellationToken),
+            context,
+            "none");
 
         var result = outcome.Result is not null
             ? outcome.Result

--- a/src/Snippets/Docs/Migration.Execute.cs
+++ b/src/Snippets/Docs/Migration.Execute.cs
@@ -60,7 +60,9 @@ internal static partial class Migration
         // Asynchronous execution
         var context = ResilienceContextPool.Shared.Get();
         Outcome<int> pipelineResult = await pipeline.ExecuteOutcomeAsync(
-            static async (ctx, state) => Outcome.FromResult(await MethodAsync(ctx.CancellationToken)), context, "state");
+            static async (ctx, state) => await MethodAsync(ctx.CancellationToken),
+            context,
+            "state");
         ResilienceContextPool.Shared.Return(context);
 
         // Assess policy result
@@ -96,7 +98,9 @@ internal static partial class Migration
 
         context = ResilienceContextPool.Shared.Get();
         pipelineResult = await pipelineWithContext.ExecuteOutcomeAsync(
-            static async (ctx, state) => Outcome.FromResult(await MethodAsync(ctx.CancellationToken)), context, "state");
+            static async (ctx, state) => await MethodAsync(ctx.CancellationToken),
+            context,
+            "state");
 
         context.Properties.TryGetValue(contextKey, out var ctxValue);
         ResilienceContextPool.Shared.Return(context);

--- a/src/Snippets/Docs/Performance.cs
+++ b/src/Snippets/Docs/Performance.cs
@@ -92,18 +92,7 @@ internal static class Performance
         // Instead of wrapping pipeline execution with try-catch, use ExecuteOutcomeAsync(...).
         // Certain strategies are optimized for this method, returning an exception instance without actually throwing it.
         Outcome<Member> outcome = await pipeline.ExecuteOutcomeAsync(
-            static async (context, state) =>
-            {
-                // The callback for ExecuteOutcomeAsync must return an Outcome<T> instance. Hence, some wrapping is needed.
-                try
-                {
-                    return Outcome.FromResult(await GetMemberAsync(state, context.CancellationToken));
-                }
-                catch (Exception e)
-                {
-                    return Outcome.FromException<Member>(e);
-                }
-            },
+            static async (context, state) => await GetMemberAsync(state, context.CancellationToken),
             context,
             id);
 


### PR DESCRIPTION

- Add new ExecuteOutcomeAsync overload that automatically handles exception-to-outcome conversion
- Update PublicAPI.Shipped.txt with new method signatures
- Fix problematic documentation examples that violated the 'no exceptions' rule
- Update performance documentation to use the new safer pattern
- Fix circuit breaker and fallback examples to demonstrate correct usage
- Update migration guide examples to show proper ExecuteOutcomeAsync usage


<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

<!-- Please include the existing GitHub issue number where relevant -->

## Details on the issue fix or feature implementation
 #2680


## Confirm the following

- [ √]  I started this PR by branching from the head of the default branch
- [ √]  I have targeted the PR to merge into the default branch
- [ √]  I have included unit tests for the issue/feature
- [ √]  I have successfully run a local build
