### PR TITLE
Refactor project dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
 - package-ecosystem: nuget
   directory: "/"
   groups:
+    polly:
+      patterns:
+        - Polly*
     xunit:
       patterns:
         - xunit*

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <UseArtifactsOutput>true</UseArtifactsOutput>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(CI)' == 'true' ">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,12 +1,4 @@
 <Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <PollyVersion>8.6.2</PollyVersion>
-    <MicrosoftExtensionsVersion>8.0.0</MicrosoftExtensionsVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net9.0'))">
-    <MicrosoftExtensionsVersion>9.0.0</MicrosoftExtensionsVersion>
-  </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.2" />
     <PackageVersion Include="Cake.FileHelpers" Version="7.0.0" />
@@ -17,29 +9,25 @@
     <PackageVersion Include="IcedTasks" Version="0.11.4" />
     <PackageVersion Include="JunitXml.TestLogger" Version="6.1.0" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.14.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.10.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.7.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.7.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="Polly" Version="$(PollyVersion)" />
+    <PackageVersion Include="Polly" Version="8.6.2" />
     <PackageVersion Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
-    <PackageVersion Include="Polly.Core" Version="$(PollyVersion)" />
-    <PackageVersion Include="Polly.Extensions" Version="$(PollyVersion)" />
-    <PackageVersion Include="Polly.RateLimiting" Version="$(PollyVersion)" />
-    <PackageVersion Include="Polly.Testing" Version="$(PollyVersion)" />
+    <PackageVersion Include="Polly.Core" Version="8.6.2" />
+    <PackageVersion Include="Polly.Extensions" Version="8.6.2" />
+    <PackageVersion Include="Polly.RateLimiting" Version="8.6.2" />
+    <PackageVersion Include="Polly.Testing" Version="8.6.2" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="8.0.0" />
     <PackageVersion Include="ReportGenerator" Version="5.4.8" />
     <PackageVersion Include="RestSharp" Version="112.1.0" />
@@ -47,12 +35,27 @@
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.12.0.118525" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="4.5.0" />
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="System.Text.Json" Version="9.0.7" />
-    <PackageVersion Include="System.Threading.RateLimiting" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />
+  </ItemGroup>
+  <!-- Dependencies below are pinned for the libraries we ship to NuGet.org -->
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.0" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
+    <PackageVersion Include="System.Threading.RateLimiting" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net9.0'))">
+    <PackageVersion Update="Microsoft.Bcl.TimeProvider" Version="9.0.0" />
+    <PackageVersion Update="Microsoft.Extensions.Logging" Version="9.0.0" />
+    <PackageVersion Update="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageVersion Update="Microsoft.Extensions.Options" Version="9.0.0" />
+    <PackageVersion Update="System.Diagnostics.DiagnosticSource" Version="9.0.0" />
+    <PackageVersion Update="System.Threading.RateLimiting" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/samples/Chaos/Chaos.csproj
+++ b/samples/Chaos/Chaos.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Chaos</RootNamespace>
   </PropertyGroup>
 

--- a/samples/DependencyInjection/DependencyInjection.csproj
+++ b/samples/DependencyInjection/DependencyInjection.csproj
@@ -3,13 +3,11 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="Polly.Extensions" />
   </ItemGroup>
 

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -1,14 +1,17 @@
 <Project>
 
   <PropertyGroup>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <EnablePackageValidation>false</EnablePackageValidation>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <NoWarn>$(NoWarn);SA1123;SA1515;CA2000;CA2007;CA1303;IDE0021;RS0037;RS0016;CS1591</NoWarn>
+    <Nullable>enable</Nullable>
+    <ProjectType>Library</ProjectType>
     <RunAnalyzers>true</RunAnalyzers>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <AnalysisLevel>latest</AnalysisLevel>
-    <ProjectType>Library</ProjectType>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);SA1123;SA1515;CA2000;CA2007;CA1303;IDE0021;RS0037;RS0016;CS1591</NoWarn>
-    <EnablePackageValidation>false</EnablePackageValidation>
   </PropertyGroup>
 
   <Import Project="$(MsBuildThisFileDirectory)..\eng\Library.targets" />

--- a/samples/Extensibility/Extensibility.csproj
+++ b/samples/Extensibility/Extensibility.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/GenericPipelines/GenericPipelines.csproj
+++ b/samples/GenericPipelines/GenericPipelines.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Intro.FSharp/Intro.FSharp.fsproj
+++ b/samples/Intro.FSharp/Intro.FSharp.fsproj
@@ -2,9 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Intro.FSharp/Program.fs
+++ b/samples/Intro.FSharp/Program.fs
@@ -18,7 +18,7 @@ let demo () =
         // and for both void and result-returning user-callbacks.
         let pipeline =
             ResiliencePipelineBuilder()
-                .AddTimeout(TimeSpan.FromSeconds(5))
+                .AddTimeout(TimeSpan.FromSeconds(5.0))
                 .Build()
 
         let token = CancellationToken.None

--- a/samples/Intro.VisualBasic/Intro.VisualBasic.vbproj
+++ b/samples/Intro.VisualBasic/Intro.VisualBasic.vbproj
@@ -2,9 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Intro/Intro.csproj
+++ b/samples/Intro/Intro.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Retries/Retries.csproj
+++ b/samples/Retries/Retries.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Polly.Core.Tests/Retry/RetryResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Retry/RetryResilienceStrategyTests.cs
@@ -2,7 +2,6 @@ using Microsoft.Extensions.Time.Testing;
 using Polly.Retry;
 using Polly.Telemetry;
 using Polly.Testing;
-using Xunit.Sdk;
 
 namespace Polly.Core.Tests.Retry;
 
@@ -256,7 +255,7 @@ public class RetryResilienceStrategyTests
         int generatedValues = 0;
 
         var delay = TimeSpan.Zero;
-        var provider = new ThrowingFakeTimeProvider();
+        var provider = new FakeTimeProvider();
 
         _options.ShouldHandle = _ => PredicateResult.True();
         _options.MaxRetryAttempts = 3;
@@ -287,14 +286,6 @@ public class RetryResilienceStrategyTests
 
         sut.IsLastAttempt(int.MaxValue, out var increment).ShouldBeFalse();
         increment.ShouldBeFalse();
-    }
-
-    private sealed class ThrowingFakeTimeProvider : FakeTimeProvider
-    {
-        public override DateTimeOffset GetUtcNow() => throw new XunitException("TimeProvider should not be used.");
-
-        public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
-            => throw new XunitException("TimeProvider should not be used.");
     }
 
     [Fact]


### PR DESCRIPTION
- Split dependencies into groups to make management easier.
- Remove MSBuild variables for versions.
- Fix samples using .NET 8 instead of 9.
- Remove redundant properties.
- Sort some properties.
- Update test behaviour for Microsoft.Extensions.TimeProvider.Testing upgrade due to changes in https://github.com/dotnet/extensions/pull/5783.

Resolves dependabot alerts for CVE-2024-30105 and CVE-2024-43485 in the [DependencyInjection sample](https://github.com/App-vNext/Polly/tree/main/samples/DependencyInjection).
