### PR TITLE
Add zizmor

### DIFF
--- a/.github/workflows/after-release.yml
+++ b/.github/workflows/after-release.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           filter: 'tree:0'
+          persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
           show-progress: false
           token: ${{ steps.generate-application-token.outputs.token }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,7 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
+        persist-credentials: false
         show-progress: false
 
     - name: Setup .NET SDKs
@@ -87,13 +88,6 @@ jobs:
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
       id: setup-dotnet
-
-    - name: Setup NuGet cache
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-      with:
-        path: ${{ env.NUGET_PACKAGES }}
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props') }}
-        restore-keys: ${{ runner.os }}-nuget-
 
     - name: Build, Test and Package
       id: build

--- a/.github/workflows/code-ql.yml
+++ b/.github/workflows/code-ql.yml
@@ -35,6 +35,7 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         filter: 'tree:0'
+        persist-credentials: false
         show-progress: false
 
     - name: Initialize CodeQL

--- a/.github/workflows/dependabot-approve.yml
+++ b/.github/workflows/dependabot-approve.yml
@@ -1,6 +1,6 @@
 name: dependabot-approve
 
-on: pull_request_target
+on: pull_request_target # zizmor: ignore[dangerous-triggers] Workflow is gated on pull request triggering account and only checks out main
 
 permissions: {}
 
@@ -32,6 +32,8 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           filter: 'tree:0'
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
           show-progress: false
 
       - name: Approve pull request and enable auto-merge

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           filter: 'tree:0'
+          persist-credentials: false
           show-progress: false
 
       - name: Review dependencies

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -29,6 +29,7 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         filter: 'tree:0'
+        persist-credentials: false
         show-progress: false
 
     - name: Lint Markdown files

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,11 +25,14 @@ jobs:
     env:
       FORCE_COLOR: 3
       POWERSHELL_YAML_VERSION: '0.4.12'
-      PSSCRIPTANALYZER_VERSION: '1.23.0'
+      PSSCRIPTANALYZER_VERSION: '1.24.0'
       TERM: xterm
+      ZIZMOR_VERSION: '1.11.0'
 
     permissions:
+      actions: read
       contents: read
+      security-events: write
 
     steps:
 
@@ -37,15 +40,22 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         filter: 'tree:0'
+        persist-credentials: false
         show-progress: false
 
     - name: Add actionlint problem matcher
       run: echo "::add-matcher::.github/actionlint-matcher.json"
 
-    - name: Lint workflows
+    - name: Lint workflows with actionlint
       uses: docker://rhysd/actionlint@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9 # v1.7.7
       with:
         args: -color
+
+    - name: Lint workflows with zizmor
+      uses: zizmorcore/zizmor-action@f52a838cfabf134edcbaa7c8b3677dde20045018 # v0.1.1
+      with:
+        persona: pedantic
+        version: ${{ env.ZIZMOR_VERSION }}
 
     - name: Lint PowerShell in workflows
       uses: martincostello/lint-actions-powershell@5942e3350ee5bd8f8933cec4e1185d13f0ea688f # v1.0.0

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -46,6 +46,7 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
+        persist-credentials: false
         show-progress: false
 
     - name: Setup .NET SDKs

--- a/.github/workflows/nuget-packages-published.yml
+++ b/.github/workflows/nuget-packages-published.yml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           filter: 'tree:0'
+          persist-credentials: false
           show-progress: false
 
       - name: Setup .NET SDK

--- a/.github/workflows/on-push-do-docs.yml
+++ b/.github/workflows/on-push-do-docs.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           filter: 'tree:0'
+          persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
           show-progress: false
           token: ${{ steps.generate-application-token.outputs.token }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           filter: 'tree:0'
+          persist-credentials: false
           show-progress: false
 
       - name: Create release

--- a/.github/workflows/updater-approve.yml
+++ b/.github/workflows/updater-approve.yml
@@ -106,6 +106,7 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         filter: 'tree:0'
+        persist-credentials: false
         show-progress: false
 
     - name: Approve pull request and enable auto-merge


### PR DESCRIPTION
- Use zizmor to scan the GitHub Actions workflows for vulnerabilities.
- Resolve zizmor findings.
- Bump PSScriptAnalyzer to v1.24.0.
