### PR TITLE
fix documentation for ExecuteOutcomeAsync (#2680)

### DIFF
--- a/docs/migration-v8.md
+++ b/docs/migration-v8.md
@@ -936,8 +936,23 @@ ResiliencePipeline<int> pipeline = new ResiliencePipelineBuilder<int>()
 
 // Asynchronous execution
 var context = ResilienceContextPool.Shared.Get();
-Outcome<int> pipelineResult = await pipeline.ExecuteOutcomeAsync(
-    static async (ctx, state) => Outcome.FromResult(await MethodAsync(ctx.CancellationToken)), context, "state");
+
+Outcome<int> pipelineResult =
+    await pipeline.ExecuteOutcomeAsync<int, string>(
+        static async (ctx, state) =>
+        {
+            try
+            {
+                return Outcome.FromResult(await MethodAsync(ctx.CancellationToken));
+            }
+            catch (Exception e)
+            {
+                return Outcome.FromException<int>(e);
+            }
+        },
+        context,
+        "state");
+
 ResilienceContextPool.Shared.Return(context);
 
 // Assess policy result
@@ -950,7 +965,6 @@ if (pipelineResult.Exception is null)
 else
 {
     Exception exception = pipelineResult.Exception;
-
     // Process failure
 
     // If needed you can rethrow the exception
@@ -972,8 +986,22 @@ ResiliencePipeline<int> pipelineWithContext = new ResiliencePipelineBuilder<int>
     .Build();
 
 context = ResilienceContextPool.Shared.Get();
-pipelineResult = await pipelineWithContext.ExecuteOutcomeAsync(
-    static async (ctx, state) => Outcome.FromResult(await MethodAsync(ctx.CancellationToken)), context, "state");
+
+pipelineResult =
+    await pipelineWithContext.ExecuteOutcomeAsync<int, string>(
+        static async (ctx, state) =>
+        {
+            try
+            {
+                return Outcome.FromResult(await MethodAsync(ctx.CancellationToken));
+            }
+            catch (Exception e)
+            {
+                return Outcome.FromException<int>(e);
+            }
+        },
+        context,
+        "state");
 
 context.Properties.TryGetValue(contextKey, out var ctxValue);
 ResilienceContextPool.Shared.Return(context);

--- a/docs/strategies/circuit-breaker.md
+++ b/docs/strategies/circuit-breaker.md
@@ -675,6 +675,7 @@ Use `ExecuteOutcomeAsync` to avoid throwing exception:
 <!-- snippet: circuit-breaker-pattern-reduce-thrown-exceptions -->
 ```cs
 var context = ResilienceContextPool.Shared.Get();
+
 var circuitBreaker = new ResiliencePipelineBuilder()
     .AddCircuitBreaker(new()
     {
@@ -683,11 +684,22 @@ var circuitBreaker = new ResiliencePipelineBuilder()
     })
     .Build();
 
-Outcome<HttpResponseMessage> outcome = await circuitBreaker.ExecuteOutcomeAsync(static async (ctx, state) =>
-{
-    var response = await IssueRequest();
-    return Outcome.FromResult(response);
-}, context, "state");
+Outcome<HttpResponseMessage> outcome =
+    await circuitBreaker.ExecuteOutcomeAsync<HttpResponseMessage, string>(
+        static async (ctx, state) =>
+        {
+            try
+            {
+                var response = await IssueRequest(ctx.CancellationToken);
+                return Outcome.FromResult(response);
+            }
+            catch (Exception e)
+            {
+                return Outcome.FromException<HttpResponseMessage>(e);
+            }
+        },
+        context,
+        "state");
 
 ResilienceContextPool.Shared.Return(context);
 

--- a/docs/strategies/fallback.md
+++ b/docs/strategies/fallback.md
@@ -239,12 +239,22 @@ This method lets you execute the strategy or pipeline smoothly, without unexpect
 public static async ValueTask<HttpResponseMessage> Action()
 {
     var context = ResilienceContextPool.Shared.Get();
+
     var outcome = await WhateverPipeline.ExecuteOutcomeAsync<HttpResponseMessage, string>(
-        async (ctx, state) =>
+        static async (ctx, state) =>
         {
-            var result = await ActionCore();
-            return Outcome.FromResult(result);
-        }, context, "state");
+            try
+            {
+                var result = await ActionCore(ctx.CancellationToken);
+                return Outcome.FromResult(result);
+            }
+            catch (Exception e)
+            {
+                return Outcome.FromException<HttpResponseMessage>(e);
+            }
+        },
+        context,
+        "state");
 
     if (outcome.Exception is HttpRequestException requestException)
     {

--- a/src/Polly.Core/ResiliencePipeline.AsyncT.cs
+++ b/src/Polly.Core/ResiliencePipeline.AsyncT.cs
@@ -16,8 +16,11 @@ public partial class ResiliencePipeline
     /// <returns>The instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> or <paramref name="context"/> is <see langword="null"/>.</exception>
     /// <remarks>
-    /// This method is for advanced and high performance scenarios. The caller must make sure that the <paramref name="callback"/>
-    /// does not throw any exceptions. Instead, it converts them to <see cref="Outcome{TResult}"/>.
+    /// <para><strong>Important:</strong> This API targets advanced, low-allocation scenarios. The user callback
+    /// must not throw an exception. Wrap your code and return <see cref="Outcome{TResult}"/>:
+    /// use <see cref="Outcome.FromResult{TResult}(TResult)"/> on success, or <see cref="Outcome.FromException{TResult}(System.Exception)"/> on failure.
+    /// Do not rely on strategies to catch your exceptions; any such behavior is an implementation detail and is not
+    /// guaranteed across strategies or future versions.</para>
     /// </remarks>
     public ValueTask<Outcome<TResult>> ExecuteOutcomeAsync<TResult, TState>(
         Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,

--- a/src/Polly.Core/ResiliencePipelineT.Async.cs
+++ b/src/Polly.Core/ResiliencePipelineT.Async.cs
@@ -77,8 +77,11 @@ public partial class ResiliencePipeline<T>
     /// <returns>The instance of <see cref="ValueTask"/> that represents the asynchronous execution.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> or <paramref name="context"/> is <see langword="null"/>.</exception>
     /// <remarks>
-    /// This method is for advanced and high performance scenarios. The caller must make sure that the <paramref name="callback"/>
-    /// does not throw any exceptions. Instead, it converts them to <see cref="Outcome{TResult}"/>.
+    /// <para><strong>Important:</strong> This method targets advanced, low-allocation scenarios. The user callback
+    /// must not throw an exception. Wrap your code and return <see cref="Outcome{TResult}"/>:
+    /// use <see cref="Outcome.FromResult{TResult}(TResult)"/> on success, or <see cref="Outcome.FromException{TResult}(System.Exception)"/> on failure.
+    /// Do not rely on strategies to catch your exceptions; any such behavior is an implementation detail and
+    /// is not guaranteed across strategies or future versions.</para>
     /// </remarks>
     public ValueTask<Outcome<TResult>> ExecuteOutcomeAsync<TResult, TState>(
         Func<ResilienceContext, TState, ValueTask<Outcome<TResult>>> callback,

--- a/src/Snippets/Docs/Fallback.cs
+++ b/src/Snippets/Docs/Fallback.cs
@@ -118,12 +118,22 @@ internal static class Fallback
     public static async ValueTask<HttpResponseMessage> Action()
     {
         var context = ResilienceContextPool.Shared.Get();
+
         var outcome = await WhateverPipeline.ExecuteOutcomeAsync<HttpResponseMessage, string>(
-            async (ctx, state) =>
+            static async (ctx, state) =>
             {
-                var result = await ActionCore();
-                return Outcome.FromResult(result);
-            }, context, "state");
+                try
+                {
+                    var result = await ActionCore();
+                    return Outcome.FromResult(result);
+                }
+                catch (Exception e)
+                {
+                    return Outcome.FromException<HttpResponseMessage>(e);
+                }
+            },
+            context,
+            "state");
 
         if (outcome.Exception is HttpRequestException requestException)
         {


### PR DESCRIPTION
<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

Fix the Documentation that has incorrect examples for ExecuteOutcomeAsync #2680

## Details on the issue fix or feature implementation

 - Markdown documentation fixes:

  1. Migration Guide (migration-v8.md)
Replaced example that passed a throwing callback with the safe pattern: wrapping the MethodAsync call in try/catch and returning either Outcome.FromResult(...) or Outcome.FromException<T>(...).

  2. Fallback Strategy (fallback.md)
Updated the “✅ DO” snippet to wrap user code in try/catch and properly return Outcome<T>, enabling exception remapping logic without throwing from the callback.

  3. Circuit Breaker Strategy (circuit-breaker.md)
Rewrote the “✅ DO” example to include exception capture via Outcome<T>, and updated post-execution logic to correctly handle both BrokenCircuitException and other errors.




 - XML documentation updates. Strengthened the <remarks> section on ExecuteOutcomeAsync<TResult, TState> to emphasize that the callback must not throw; users must wrap their code and return an Outcome<TResult>. This clarifies the contract and prevents accidental misuse that relies on internal implementation details. Files affected:

  1. ResiliencePipeline.AsyncT.cs
  2. ResiliencePipelineT.Async.cs

 - Snippet corrections:

1. Migration.Execute.cs (snippets used in docs)
Updated the V8 example (SafeExecute_V8) to use the correct, safe callback pattern: wrapping in try/catch and returning an Outcome<T>. This ensures consistency across sample code and real documentation.


## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
