### PR TITLE
Fix after-release and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 <!-- next-release -->
 
+## 8.6.3
+
+* Add release notes configuration by [@martincostello](https://github.com/martincostello) in https://github.com/App-vNext/Polly/pull/2678
+* Simplify release workflow by [@martincostello](https://github.com/martincostello) in https://github.com/App-vNext/Polly/pull/2679
+* Sign-off commits by [@martincostello](https://github.com/martincostello) in https://github.com/App-vNext/Polly/pull/2694
+* Add GitHub sponsorship by [@martincostello](https://github.com/martincostello) in https://github.com/App-vNext/Polly/pull/2695
+* Refactor project dependencies by [@martincostello](https://github.com/martincostello) in https://github.com/App-vNext/Polly/pull/2696
+* Add zizmor by [@martincostello](https://github.com/martincostello) in https://github.com/App-vNext/Polly/pull/2698
+* Update benchmarks by [@martincostello](https://github.com/martincostello) in https://github.com/App-vNext/Polly/pull/2712
+* Reduce async overhead by [@pentp](https://github.com/pentp) in https://github.com/App-vNext/Polly/pull/2664
+* Update benchmarks by [@martincostello](https://github.com/martincostello) in https://github.com/App-vNext/Polly/pull/2713
+
 ## 8.6.2
 
 * Performance tweaks by [@martincostello](https://github.com/martincostello) in https://github.com/App-vNext/Polly/pull/2667

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="Polly" Version="8.6.2" />
+    <PackageVersion Include="Polly" Version="8.6.3" />
     <PackageVersion Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageVersion Include="Polly.Core" Version="8.6.2" />
     <PackageVersion Include="Polly.Extensions" Version="8.6.2" />

--- a/eng/bump-version.ps1
+++ b/eng/bump-version.ps1
@@ -9,7 +9,7 @@ $repo = Join-Path $PSScriptRoot ".."
 $properties = Join-Path $repo "Directory.Packages.props"
 
 $xml = [xml](Get-Content $properties)
-$pollyVersion = $xml.SelectSingleNode('Project/PropertyGroup/PollyVersion')
+$pollyVersion = $xml.SelectSingleNode("//PackageVersion[@Include='Polly']/@Version")
 
 if ($ReleaseVersion.StartsWith("v")) {
     $ReleaseVersion = $ReleaseVersion.Substring(1)
@@ -18,7 +18,7 @@ if ($ReleaseVersion.StartsWith("v")) {
 $version = [System.Version]::new($ReleaseVersion)
 $releasedVersion = $version.ToString()
 
-Write-Output "Bumping version from $($pollyVersion.InnerText) to $releasedVersion"
+Write-Output "Bumping version from $($pollyVersion.Value) to $releasedVersion"
 
 $pollyVersion.InnerText = $releasedVersion
 


### PR DESCRIPTION
- Fix xpath to get the previous release veresion broken by https://github.com/App-vNext/Polly/pull/2696.
- Update CHANGELOG and samples for v8.6.3.
