### PR TITLE
Use collection expressions

### DIFF
--- a/bench/Polly.Core.Benchmarks/Utils/Helper.StrategyPipeline.cs
+++ b/bench/Polly.Core.Benchmarks/Utils/Helper.StrategyPipeline.cs
@@ -4,7 +4,7 @@ internal static partial class Helper
 {
     public static object CreatePipeline(PollyVersion technology, int count) => technology switch
     {
-        PollyVersion.V7 => count == 1 ? Policy.NoOpAsync<string>() : Policy.WrapAsync(Enumerable.Repeat(0, count).Select(_ => Policy.NoOpAsync<string>()).ToArray()),
+        PollyVersion.V7 => count == 1 ? Policy.NoOpAsync<string>() : Policy.WrapAsync([.. Enumerable.Repeat(0, count).Select(_ => Policy.NoOpAsync<string>())]),
 
         PollyVersion.V8 => CreateStrategy(builder =>
         {

--- a/bench/Polly.Core.Benchmarks/Utils/Helper.StrategyPipeline.cs
+++ b/bench/Polly.Core.Benchmarks/Utils/Helper.StrategyPipeline.cs
@@ -10,7 +10,7 @@ internal static partial class Helper
         {
             for (var i = 0; i < count; i++)
             {
-                builder.AddStrategy(_ => new EmptyResilienceStrategy(), new EmptyResilienceOptions());
+                builder.AddStrategy(static _ => new EmptyResilienceStrategy(), new EmptyResilienceOptions());
             }
         }),
         _ => throw new NotSupportedException()

--- a/exclusion.dic
+++ b/exclusion.dic
@@ -1,1 +1,2 @@
+simmy
 stryker

--- a/src/Polly.Core/CircuitBreaker/CircuitBreakerManualControl.cs
+++ b/src/Polly.Core/CircuitBreaker/CircuitBreakerManualControl.cs
@@ -68,7 +68,7 @@ public sealed class CircuitBreakerManualControl
         Func<ResilienceContext, Task>[] callbacks;
         lock (_lock)
         {
-            callbacks = _onIsolate.ToArray();
+            callbacks = [.. _onIsolate];
             _isolated = true;
         }
 
@@ -98,7 +98,7 @@ public sealed class CircuitBreakerManualControl
         Func<ResilienceContext, Task>[] callbacks;
         lock (_lock)
         {
-            callbacks = _onReset.ToArray();
+            callbacks = [.. _onReset];
             _isolated = false;
         }
 

--- a/src/Polly.Core/Simmy/Utils/GeneratorHelper.cs
+++ b/src/Polly.Core/Simmy/Utils/GeneratorHelper.cs
@@ -1,14 +1,12 @@
 ﻿namespace Polly.Simmy.Utils;
 
-internal sealed class GeneratorHelper<TResult>
+internal sealed class GeneratorHelper<TResult>(Func<int, int> weightGenerator)
 {
-    private readonly Func<int, int> _weightGenerator;
+    private readonly Func<int, int> _weightGenerator = weightGenerator;
 
     private readonly List<int> _weights = [];
     private readonly List<Func<ResilienceContext, Outcome<TResult>>> _factories = [];
     private int _totalWeight;
-
-    public GeneratorHelper(Func<int, int> weightGenerator) => _weightGenerator = weightGenerator;
 
     public void AddOutcome(Func<ResilienceContext, Outcome<TResult>> generator, int weight)
     {

--- a/src/Polly.Core/Utils/Pipeline/CompositeComponent.cs
+++ b/src/Polly.Core/Utils/Pipeline/CompositeComponent.cs
@@ -38,20 +38,19 @@ internal sealed class CompositeComponent : PipelineComponent
         }
 
         // convert all components to delegating ones (except the last one as it's not required)
-        var delegatingComponents = components
+        DelegatingComponent[] delegatingComponents = [.. components
             .Take(components.Count - 1)
-            .Select(strategy => new DelegatingComponent(strategy))
-            .ToList();
+            .Select(static strategy => new DelegatingComponent(strategy))];
 
 #if NET6_0_OR_GREATER
         // link the last one
         delegatingComponents[^1].Next = components[^1];
 #else
-        delegatingComponents[delegatingComponents.Count - 1].Next = components[components.Count - 1];
+        delegatingComponents[delegatingComponents.Length - 1].Next = components[components.Count - 1];
 #endif
 
         // link the remaining ones
-        for (var i = 0; i < delegatingComponents.Count - 1; i++)
+        for (var i = 0; i < delegatingComponents.Length - 1; i++)
         {
             delegatingComponents[i].Next = delegatingComponents[i + 1];
         }

--- a/src/Polly.Extensions/Telemetry/TelemetryListenerImpl.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryListenerImpl.cs
@@ -16,10 +16,10 @@ internal sealed class TelemetryListenerImpl : TelemetryListener
 
     public TelemetryListenerImpl(TelemetryOptions options)
     {
-        _enrichers = options.MeteringEnrichers.ToList();
+        _enrichers = [.. options.MeteringEnrichers];
         _logger = options.LoggerFactory.CreateLogger(TelemetryUtil.PollyDiagnosticSource);
         _resultFormatter = options.ResultFormatter;
-        _listeners = options.TelemetryListeners.ToList();
+        _listeners = [.. options.TelemetryListeners];
         _severityProvider = options.SeverityProvider;
 
         Counter = Meter.CreateCounter<int>(

--- a/src/Polly.Extensions/Telemetry/TelemetryOptions.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryOptions.cs
@@ -26,9 +26,9 @@ public class TelemetryOptions
     {
         Guard.NotNull(other);
 
-        TelemetryListeners = other.TelemetryListeners.ToList();
+        TelemetryListeners = [.. other.TelemetryListeners];
         LoggerFactory = other.LoggerFactory;
-        MeteringEnrichers = other.MeteringEnrichers.ToList();
+        MeteringEnrichers = [.. other.MeteringEnrichers];
         ResultFormatter = other.ResultFormatter;
         SeverityProvider = other.SeverityProvider;
     }

--- a/src/Polly.Extensions/Telemetry/TelemetryUtil.cs
+++ b/src/Polly.Extensions/Telemetry/TelemetryUtil.cs
@@ -6,7 +6,7 @@ internal static class TelemetryUtil
 {
     private const int MaxIntegers = 100;
 
-    private static readonly object[] Integers = Enumerable.Range(0, MaxIntegers).Select(v => (object)v).ToArray();
+    private static readonly object[] Integers = [.. Enumerable.Range(0, MaxIntegers).Select(v => (object)v)];
 
     private static readonly object True = true;
 

--- a/src/Polly.Testing/ResiliencePipelineExtensions.cs
+++ b/src/Polly.Testing/ResiliencePipelineExtensions.cs
@@ -48,7 +48,7 @@ public static class ResiliencePipelineExtensions
 
         return new ResiliencePipelineDescriptor(
             descriptors,
-            isReloadable: components.Exists(s => s is ReloadableComponent));
+            isReloadable: components.Exists(static s => s is ReloadableComponent));
     }
 
     private static object GetStrategyInstance<T>(PipelineComponent component)

--- a/src/Polly/Wrap/IAsyncPolicyPolicyWrapExtensions.cs
+++ b/src/Polly/Wrap/IAsyncPolicyPolicyWrapExtensions.cs
@@ -178,7 +178,7 @@ public partial class Policy
         {
             < MinimumPoliciesRequiredForWrap => throw new ArgumentException("The enumerable of policies to form the wrap must contain at least two policies.", nameof(policies)),
             MinimumPoliciesRequiredForWrap => new AsyncPolicyWrap((AsyncPolicy)policies[0], policies[1]),
-            _ => WrapAsync(policies[0], WrapAsync(policies.Skip(1).ToArray())),
+            _ => WrapAsync(policies[0], WrapAsync([.. policies.Skip(1)])),
         };
 #pragma warning restore S3215 // "interface" instances should not be cast to concrete types
     }
@@ -202,7 +202,7 @@ public partial class Policy
         {
             < MinimumPoliciesRequiredForWrap => throw new ArgumentException("The enumerable of policies to form the wrap must contain at least two policies.", nameof(policies)),
             MinimumPoliciesRequiredForWrap => new AsyncPolicyWrap<TResult>((AsyncPolicy<TResult>)policies[0], policies[1]),
-            _ => WrapAsync(policies[0], WrapAsync(policies.Skip(1).ToArray())),
+            _ => WrapAsync(policies[0], WrapAsync([.. policies.Skip(1)])),
         };
 #pragma warning restore S3215 // "interface" instances should not be cast to concrete types
     }

--- a/src/Polly/Wrap/ISyncPolicyPolicyWrapExtensions.cs
+++ b/src/Polly/Wrap/ISyncPolicyPolicyWrapExtensions.cs
@@ -202,7 +202,7 @@ public partial class Policy
             < MinimumPoliciesRequiredForWrap => throw new ArgumentException(
                 "The enumerable of policies to form the wrap must contain at least two policies.", nameof(policies)),
             MinimumPoliciesRequiredForWrap => new PolicyWrap<TResult>((Policy<TResult>)policies[0], policies[1]),
-            _ => Wrap(policies[0], Wrap(policies.Skip(1).ToArray())),
+            _ => Wrap(policies[0], Wrap([.. policies.Skip(1)])),
         };
 #pragma warning restore S3215 // "interface" instances should not be cast to concrete types
     }

--- a/src/Snippets/Docs/Retry.cs
+++ b/src/Snippets/Docs/Retry.cs
@@ -187,9 +187,7 @@ internal static class Retry
             typeof(RateLimitRejectedException),
         ];
 
-        ImmutableArray<Type> retryableExceptions = networkExceptions
-            .Union(strategyExceptions)
-            .ToImmutableArray();
+        ImmutableArray<Type> retryableExceptions = [.. networkExceptions.Union(strategyExceptions)];
 
         var retry = new ResiliencePipelineBuilder()
             .AddRetry(new()

--- a/test/Polly.Core.Tests/ResiliencePipelineTests.cs
+++ b/test/Polly.Core.Tests/ResiliencePipelineTests.cs
@@ -181,5 +181,5 @@ public partial class ResiliencePipelineTests
         public override string ToString() => Caption;
     }
 
-    public static IEnumerable<object[]> ConvertExecuteParameters(Func<IEnumerable<ExecuteParameters>> parameters) => parameters().Select(p => new object[] { p }).ToArray();
+    public static IEnumerable<object[]> ConvertExecuteParameters(Func<IEnumerable<ExecuteParameters>> parameters) => [.. parameters().Select(p => new object[] { p })];
 }

--- a/test/Polly.Core.Tests/Retry/RetryHelperTests.cs
+++ b/test/Polly.Core.Tests/Retry/RetryHelperTests.cs
@@ -265,7 +265,7 @@ public class RetryHelperTests
     {
         if (contrib)
         {
-            return Backoff.DecorrelatedJitterBackoffV2(baseDelay, retryCount, 0, false).Take(retryCount).ToArray();
+            return [.. Backoff.DecorrelatedJitterBackoffV2(baseDelay, retryCount, 0, false).Take(retryCount)];
         }
 
         var random = randomizer ?? new Random(0).NextDouble;

--- a/test/Polly.Extensions.Tests/Telemetry/TelemetryListenerImplTests.cs
+++ b/test/Polly.Extensions.Tests/Telemetry/TelemetryListenerImplTests.cs
@@ -363,7 +363,7 @@ public class TelemetryListenerImplTests : IDisposable
         var messages = _logger.GetRecords(new EventId(1, "StrategyExecuting")).ToList();
         messages.Count.ShouldBe(1);
         messages[0].Message.ShouldBe("Resilience pipeline executing. Source: 'my-pipeline/my-instance', Operation Key: 'op-key'");
-        messages = _logger.GetRecords(new EventId(2, "StrategyExecuted")).ToList();
+        messages = [.. _logger.GetRecords(new EventId(2, "StrategyExecuted"))];
         messages.Count.ShouldBe(1);
         messages[0].Message.ShouldMatch($"Resilience pipeline executed. Source: 'my-pipeline/my-instance', Operation Key: 'op-key', Result: '{result}', Execution Time: 10000ms");
         messages[0].LogLevel.ShouldBe(LogLevel.Debug);
@@ -489,7 +489,7 @@ public class TelemetryListenerImplTests : IDisposable
         called.ShouldBeTrue();
     }
 
-    private List<Dictionary<string, object?>> GetEvents(string eventName) => _events.Where(e => e.Name == eventName).Select(v => v.Tags).ToList();
+    private List<Dictionary<string, object?>> GetEvents(string eventName) => [.. _events.Where(e => e.Name == eventName).Select(v => v.Tags)];
 
     private TelemetryListenerImpl Create(IEnumerable<MeteringEnricher>? enrichers = null, Action<TelemetryOptions>? configure = null)
     {

--- a/test/Polly.Specs/Helpers/ContextualPolicyTResultExtensions.cs
+++ b/test/Polly.Specs/Helpers/ContextualPolicyTResultExtensions.cs
@@ -2,12 +2,14 @@
 
 public static class ContextualPolicyTResultExtensions
 {
-    public static TResult RaiseResultSequence<TResult>(this Policy<TResult> policy,
+    public static TResult RaiseResultSequence<TResult>(
+        this Policy<TResult> policy,
         IDictionary<string, object> contextData,
         params TResult[] resultsToRaise) =>
         policy.RaiseResultSequence(contextData, resultsToRaise.ToList());
 
-    public static TResult RaiseResultSequence<TResult>(this Policy<TResult> policy,
+    public static TResult RaiseResultSequence<TResult>(
+        this Policy<TResult> policy,
         IDictionary<string, object> contextData,
         IEnumerable<TResult> resultsToRaise)
     {
@@ -24,12 +26,14 @@ public static class ContextualPolicyTResultExtensions
         }, contextData);
     }
 
-    public static PolicyResult<TResult> RaiseResultSequenceOnExecuteAndCapture<TResult>(this Policy<TResult> policy,
-      IDictionary<string, object> contextData,
-      params TResult[] resultsToRaise) =>
+    public static PolicyResult<TResult> RaiseResultSequenceOnExecuteAndCapture<TResult>(
+        this Policy<TResult> policy,
+        IDictionary<string, object> contextData,
+        params TResult[] resultsToRaise) =>
         policy.RaiseResultSequenceOnExecuteAndCapture(contextData, resultsToRaise.ToList());
 
-    public static PolicyResult<TResult> RaiseResultSequenceOnExecuteAndCapture<TResult>(this Policy<TResult> policy,
+    public static PolicyResult<TResult> RaiseResultSequenceOnExecuteAndCapture<TResult>(
+        this Policy<TResult> policy,
         IDictionary<string, object> contextData,
         IEnumerable<TResult> resultsToRaise)
     {

--- a/test/Polly.Specs/Helpers/PolicyTResultExtensions.cs
+++ b/test/Polly.Specs/Helpers/PolicyTResultExtensions.cs
@@ -24,8 +24,7 @@ public static class PolicyTResultExtensions
     public static TResult RaiseResultAndOrExceptionSequence<TResult>(this Policy<TResult> policy, params object[] resultsOrExceptionsToRaise) =>
         policy.RaiseResultAndOrExceptionSequence(resultsOrExceptionsToRaise.ToList());
 
-    public static TResult RaiseResultAndOrExceptionSequence<TResult>(this Policy<TResult> policy,
-        IEnumerable<object> resultsOrExceptionsToRaise)
+    public static TResult RaiseResultAndOrExceptionSequence<TResult>(this Policy<TResult> policy, IEnumerable<object> resultsOrExceptionsToRaise)
     {
         using var enumerator = resultsOrExceptionsToRaise.GetEnumerator();
         return policy.Execute(() =>
@@ -58,13 +57,24 @@ public static class PolicyTResultExtensions
         public bool ActionObservesCancellation = true;
     }
 
-    public static TResult RaiseResultSequenceAndOrCancellation<TResult>(this Policy<TResult> policy,
-        Scenario scenario, CancellationTokenSource cancellationTokenSource, Action onExecute,
+    public static TResult RaiseResultSequenceAndOrCancellation<TResult>(
+        this Policy<TResult> policy,
+        Scenario scenario,
+        CancellationTokenSource cancellationTokenSource,
+        Action onExecute,
         params TResult[] resultsToRaise) =>
-        policy.RaiseResultSequenceAndOrCancellation(scenario, cancellationTokenSource, onExecute,
+        policy.RaiseResultSequenceAndOrCancellation(
+            scenario,
+            cancellationTokenSource,
+            onExecute,
             resultsToRaise.ToList());
 
-    public static TResult RaiseResultSequenceAndOrCancellation<TResult>(this Policy<TResult> policy, Scenario scenario, CancellationTokenSource cancellationTokenSource, Action onExecute, IEnumerable<TResult> resultsToRaise)
+    public static TResult RaiseResultSequenceAndOrCancellation<TResult>(
+        this Policy<TResult> policy,
+        Scenario scenario,
+        CancellationTokenSource cancellationTokenSource,
+        Action onExecute,
+        IEnumerable<TResult> resultsToRaise)
     {
         int counter = 0;
 

--- a/test/Polly.Specs/Helpers/PolicyTResultExtensionsAsync.cs
+++ b/test/Polly.Specs/Helpers/PolicyTResultExtensionsAsync.cs
@@ -10,8 +10,10 @@ public static class PolicyTResultExtensionsAsync
     public static Task<TResult> RaiseResultSequenceAsync<TResult>(this AsyncPolicy<TResult> policy, IEnumerable<TResult> resultsToRaise) =>
         policy.RaiseResultSequenceAsync(default, resultsToRaise);
 
-    public static async Task<TResult> RaiseResultSequenceAsync<TResult>(this AsyncPolicy<TResult> policy,
-        CancellationToken cancellationToken, IEnumerable<TResult> resultsToRaise)
+    public static async Task<TResult> RaiseResultSequenceAsync<TResult>(
+        this AsyncPolicy<TResult> policy,
+        CancellationToken cancellationToken,
+        IEnumerable<TResult> resultsToRaise)
     {
         using var enumerator = resultsToRaise.GetEnumerator();
         return await policy.ExecuteAsync(_ =>
@@ -28,12 +30,13 @@ public static class PolicyTResultExtensionsAsync
     public static Task<TResult> RaiseResultAndOrExceptionSequenceAsync<TResult>(this AsyncPolicy<TResult> policy, params object[] resultsOrExceptionsToRaise) =>
         policy.RaiseResultAndOrExceptionSequenceAsync(resultsOrExceptionsToRaise.ToList());
 
-    public static Task<TResult> RaiseResultAndOrExceptionSequenceAsync<TResult>(this AsyncPolicy<TResult> policy,
-        IEnumerable<object> resultsOrExceptionsToRaise) =>
+    public static Task<TResult> RaiseResultAndOrExceptionSequenceAsync<TResult>(this AsyncPolicy<TResult> policy, IEnumerable<object> resultsOrExceptionsToRaise) =>
         policy.RaiseResultAndOrExceptionSequenceAsync(CancellationToken.None, resultsOrExceptionsToRaise);
 
-    public static async Task<TResult> RaiseResultAndOrExceptionSequenceAsync<TResult>(this AsyncPolicy<TResult> policy,
-        CancellationToken cancellationToken, IEnumerable<object> resultsOrExceptionsToRaise)
+    public static async Task<TResult> RaiseResultAndOrExceptionSequenceAsync<TResult>(
+        this AsyncPolicy<TResult> policy,
+        CancellationToken cancellationToken,
+        IEnumerable<object> resultsOrExceptionsToRaise)
     {
         using var enumerator = resultsOrExceptionsToRaise.GetEnumerator();
         return await policy.ExecuteAsync(_ =>
@@ -67,15 +70,21 @@ public static class PolicyTResultExtensionsAsync
         public bool ActionObservesCancellation = true;
     }
 
-    public static Task<TResult> RaiseResultSequenceAndOrCancellationAsync<TResult>(this AsyncPolicy<TResult> policy,
-        Scenario scenario, CancellationTokenSource cancellationTokenSource, Action onExecute,
+    public static Task<TResult> RaiseResultSequenceAndOrCancellationAsync<TResult>(
+        this AsyncPolicy<TResult> policy,
+        Scenario scenario,
+        CancellationTokenSource cancellationTokenSource,
+        Action onExecute,
         params TResult[] resultsToRaise) =>
         policy.RaiseResultSequenceAndOrCancellationAsync(scenario, cancellationTokenSource, onExecute,
             resultsToRaise.ToList());
 
     public static async Task<TResult> RaiseResultSequenceAndOrCancellationAsync<TResult>(
-        this AsyncPolicy<TResult> policy, Scenario scenario, CancellationTokenSource cancellationTokenSource,
-        Action onExecute, IEnumerable<TResult> resultsToRaise)
+        this AsyncPolicy<TResult> policy,
+        Scenario scenario,
+        CancellationTokenSource cancellationTokenSource,
+        Action onExecute,
+        IEnumerable<TResult> resultsToRaise)
     {
         int counter = 0;
 

--- a/test/Polly.Specs/Wrap/IPolicyWrapExtensionSpecs.cs
+++ b/test/Polly.Specs/Wrap/IPolicyWrapExtensionSpecs.cs
@@ -20,7 +20,7 @@ public class IPolicyWrapExtensionSpecs
 
         PolicyWrap policyWrap = Policy.Wrap(policy0, policy1, policy2);
 
-        List<IsPolicy> policies = policyWrap.GetPolicies().ToList();
+        List<IsPolicy> policies = [.. policyWrap.GetPolicies()];
         policies.Count.ShouldBe(3);
         policies[0].ShouldBe(policy0);
         policies[1].ShouldBe(policy1);


### PR DESCRIPTION
- Replace `ToArray()` and `ToList()` calls with collection expressions, where relevant.
- Make a few lambdas `static`.
- Add "Simmy" to the custom dictionary for the Visual Studio spellchecker.
- Use primary constructor in `GeneratorHelper`.
- Tidy up formatting of parameters.
