### PR TITLE
Use NuGet Trusted Publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -395,6 +395,9 @@ jobs:
       name: NuGet.org
       url: https://www.nuget.org/profiles/Polly
 
+    permissions:
+      id-token: write
+
     steps:
 
     - name: Download signed packages
@@ -407,9 +410,15 @@ jobs:
       with:
         dotnet-version: ${{ needs.build.outputs.dotnet-sdk-version }}
 
+    - name: NuGet log in
+      uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # v1.1.0
+      id: nuget-login
+      with:
+        user: ${{ secrets.NUGET_USER }}
+
     - name: Push signed NuGet packages to NuGet.org
       env:
-        API_KEY: ${{ secrets.NUGET_TOKEN }}
+        API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
         PACKAGE_VERSION: ${{ needs.build.outputs.package-version }}
         SOURCE: https://api.nuget.org/v3/index.json
       run: dotnet nuget push "*.nupkg" --api-key "${API_KEY}" --skip-duplicate --source "${SOURCE}" && echo "::notice title=nuget.org::Published version ${PACKAGE_VERSION} to NuGet.org."


### PR DESCRIPTION
Switch to using GitHub OIDC for pushing packages to NuGet.org with Trusted Publishing.

Resolves #2742.
