### PR TITLE
Remove ZIZMOR_VERSION

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,6 @@ jobs:
       POWERSHELL_YAML_VERSION: '0.4.12'
       PSSCRIPTANALYZER_VERSION: '1.24.0'
       TERM: xterm
-      ZIZMOR_VERSION: '1.23.1'
 
     permissions:
       actions: read
@@ -51,7 +50,6 @@ jobs:
       uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
       with:
         persona: pedantic
-        version: ${{ env.ZIZMOR_VERSION }}
 
     - name: Lint PowerShell in workflows
       uses: martincostello/lint-actions-powershell@e088367ebeb113cd7c1ebee5c541175d93e945b7 # v1.0.1


### PR DESCRIPTION
Rely on the built-in default pinned version instead.
