### PR TITLE
Assert nullable has result

### DIFF
--- a/test/Polly.Core.Tests/CircuitBreaker/Controller/CircuitStateControllerTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/Controller/CircuitStateControllerTests.cs
@@ -53,7 +53,10 @@ public class CircuitStateControllerTests
         called.ShouldBeTrue();
 
         var outcome = await controller.OnActionPreExecuteAsync(context);
-        var exception = outcome.Value.Exception.ShouldBeOfType<IsolatedCircuitException>();
+
+        Assert.True(outcome.HasValue);
+
+        var exception = outcome.GetValueOrDefault().Exception.ShouldBeOfType<IsolatedCircuitException>();
         exception.RetryAfter.ShouldBeNull();
         exception.TelemetrySource.ShouldNotBeNull();
 
@@ -125,7 +128,12 @@ public class CircuitStateControllerTests
         using var controller = CreateController();
 
         await OpenCircuit(controller, Outcome.FromResult(99));
-        var exception = (BrokenCircuitException)(await controller.OnActionPreExecuteAsync(context)).Value.Exception!;
+
+        var outcome = await controller.OnActionPreExecuteAsync(context);
+
+        Assert.True(outcome.HasValue);
+
+        var exception = outcome.GetValueOrDefault().Exception.ShouldBeOfType<BrokenCircuitException>();
         exception.RetryAfter.ShouldNotBeNull();
         exception.TelemetrySource.ShouldNotBeNull();
 
@@ -149,7 +157,9 @@ public class CircuitStateControllerTests
         {
             try
             {
-                (await controller.OnActionPreExecuteAsync(context)).Value.ThrowIfException();
+                var outcome = await controller.OnActionPreExecuteAsync(context);
+                Assert.True(outcome.HasValue);
+                (await controller.OnActionPreExecuteAsync(context)).GetValueOrDefault().ThrowIfException();
             }
             catch (BrokenCircuitException e)
             {
@@ -217,7 +227,12 @@ public class CircuitStateControllerTests
         using var controller = CreateController();
 
         await OpenCircuit(controller, Outcome.FromException<int>(new InvalidOperationException()));
-        var exception = (BrokenCircuitException)(await controller.OnActionPreExecuteAsync(context)).Value.Exception!;
+
+        var outcome = await controller.OnActionPreExecuteAsync(context);
+
+        Assert.True(outcome.HasValue);
+
+        var exception = outcome.GetValueOrDefault().Exception.ShouldBeOfType<BrokenCircuitException>();
         exception.InnerException.ShouldBeOfType<InvalidOperationException>();
         exception.RetryAfter.ShouldNotBeNull();
         exception.TelemetrySource.ShouldNotBeNull();
@@ -276,10 +291,13 @@ public class CircuitStateControllerTests
 
         // act
         await controller.OnActionPreExecuteAsync(context);
-        var error = (await controller.OnActionPreExecuteAsync(context)).Value.Exception;
+
+        var outcome = await controller.OnActionPreExecuteAsync(context);
 
         // assert
-        var exception = error.ShouldBeOfType<BrokenCircuitException>();
+        Assert.True(outcome.HasValue);
+
+        var exception = outcome.GetValueOrDefault().Exception.ShouldBeOfType<BrokenCircuitException>();
         exception.RetryAfter.ShouldNotBeNull();
         exception.TelemetrySource.ShouldNotBeNull();
         controller.CircuitState.ShouldBe(CircuitState.HalfOpen);
@@ -489,7 +507,10 @@ public class CircuitStateControllerTests
         // assert
         controller.LastException.ShouldBeNull();
         var outcome = await controller.OnActionPreExecuteAsync(context);
-        var exception = outcome.Value.Exception.ShouldBeOfType<BrokenCircuitException>();
+
+        Assert.True(outcome.HasValue);
+
+        var exception = outcome.GetValueOrDefault().Exception.ShouldBeOfType<BrokenCircuitException>();
         exception.RetryAfter.ShouldNotBeNull();
         exception.TelemetrySource.ShouldNotBeNull();
     }
@@ -530,7 +551,10 @@ public class CircuitStateControllerTests
         TimeSpan advanceTimeRejected = TimeSpan.FromMilliseconds(1);
         AdvanceTime(advanceTimeRejected);
         var outcome = await controller.OnActionPreExecuteAsync(context);
-        var exception = outcome.Value.Exception.ShouldBeOfType<BrokenCircuitException>();
+
+        Assert.True(outcome.HasValue);
+
+        var exception = outcome.GetValueOrDefault().Exception.ShouldBeOfType<BrokenCircuitException>();
         exception.RetryAfter.ShouldBe(_options.BreakDuration - advanceTimeRejected);
         exception.TelemetrySource.ShouldNotBeNull();
 

--- a/test/Polly.Core.Tests/CircuitBreaker/Controller/CircuitStateControllerTests.cs
+++ b/test/Polly.Core.Tests/CircuitBreaker/Controller/CircuitStateControllerTests.cs
@@ -158,8 +158,10 @@ public class CircuitStateControllerTests
             try
             {
                 var outcome = await controller.OnActionPreExecuteAsync(context);
+
                 Assert.True(outcome.HasValue);
-                (await controller.OnActionPreExecuteAsync(context)).GetValueOrDefault().ThrowIfException();
+
+                outcome.GetValueOrDefault().ThrowIfException();
             }
             catch (BrokenCircuitException e)
             {


### PR DESCRIPTION
Cherry-pick fix from #2931 for new compiler warning when accessing `Nullable<T>.Value`.
