### PR TITLE
Update deprecated action input

### DIFF
--- a/.github/workflows/after-release.yml
+++ b/.github/workflows/after-release.yml
@@ -28,7 +28,7 @@ jobs:
         id: generate-application-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.POLLY_UPDATER_BOT_APP_ID }}
+          client-id: ${{ secrets.POLLY_UPDATER_BOT_APP_ID }}
           private-key: ${{ secrets.POLLY_UPDATER_BOT_KEY }}
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -444,7 +444,7 @@ jobs:
       id: generate-application-token
       uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       with:
-        app-id: ${{ secrets.POLLY_UPDATER_BOT_APP_ID }}
+        client-id: ${{ secrets.POLLY_UPDATER_BOT_APP_ID }}
         private-key: ${{ secrets.POLLY_UPDATER_BOT_KEY }}
         permission-contents: write
 

--- a/.github/workflows/dependabot-approve.yml
+++ b/.github/workflows/dependabot-approve.yml
@@ -22,7 +22,7 @@ jobs:
         id: generate-application-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.POLLY_REVIEWER_BOT_APP_ID }}
+          client-id: ${{ secrets.POLLY_REVIEWER_BOT_APP_ID }}
           private-key: ${{ secrets.POLLY_REVIEWER_BOT_KEY }}
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/on-push-do-docs.yml
+++ b/.github/workflows/on-push-do-docs.yml
@@ -20,7 +20,7 @@ jobs:
         id: generate-application-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.POLLY_UPDATER_BOT_APP_ID }}
+          client-id: ${{ secrets.POLLY_UPDATER_BOT_APP_ID }}
           private-key: ${{ secrets.POLLY_UPDATER_BOT_KEY }}
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/updater-approve.yml
+++ b/.github/workflows/updater-approve.yml
@@ -24,7 +24,7 @@ jobs:
       id: generate-application-token
       uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       with:
-        app-id: ${{ secrets.POLLY_REVIEWER_BOT_APP_ID }}
+        client-id: ${{ secrets.POLLY_REVIEWER_BOT_APP_ID }}
         private-key: ${{ secrets.POLLY_REVIEWER_BOT_KEY }}
         permission-contents: write
         permission-pull-requests: write


### PR DESCRIPTION
`app-id` was deprecated in 3.1.0 in favour of `client-id`.
