### PR TITLE
Move dependabot to Friday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     default-days: 3
   schedule:
     interval: weekly
-    day: thursday
+    day: friday
     time: "12:00"
     timezone: "America/New_York"
 - package-ecosystem: nuget
@@ -28,7 +28,7 @@ updates:
         - xunit*
   schedule:
     interval: weekly
-    day: thursday
+    day: friday
     time: "12:00"
     timezone: "America/New_York"
   ignore:


### PR DESCRIPTION
Move to Friday so that the 3 day cooldown from Patch Tuesday should have completed.

