### PR TITLE
Fix dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
   groups:
     dotnet:
       patterns:
+        - Microsoft.Extensions.Configuration
         - Microsoft.Extensions.DependencyInjection
         - Microsoft.Extensions.Http.Resilience
         - Microsoft.Extensions.Logging.Console


### PR DESCRIPTION
Add missing entry to include `Microsoft.Extensions.Configuration`.
