### PR TITLE
Restrict System.Threading.RateLimiting dependency to pre .net 8

### DIFF
--- a/src/Polly.RateLimiting/Polly.RateLimiting.csproj
+++ b/src/Polly.RateLimiting/Polly.RateLimiting.csproj
@@ -27,6 +27,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Polly.Core\Polly.Core.csproj" />
-    <PackageReference Include="System.Threading.RateLimiting" />
+    <PackageReference Include="System.Threading.RateLimiting" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed

Closes #3073

## Details on the issue fix or feature implementation

I've followed the same convention as used for other framework specific dependencies

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
~- [ ]  I have included unit tests for the issue/feature~ n/a
- [ ]  I have successfully run a local build
