### PR TITLE
Adds caller cancellation token propagation in hedging and timeout strategies

### DIFF
--- a/src/Polly.Core/Hedging/HedgingResilienceStrategy.cs
+++ b/src/Polly.Core/Hedging/HedgingResilienceStrategy.cs
@@ -1,5 +1,6 @@
 using Polly.Hedging.Utils;
 using Polly.Telemetry;
+using Polly.Utils;
 
 namespace Polly.Hedging;
 
@@ -57,7 +58,7 @@ internal sealed class HedgingResilienceStrategy<T> : ResilienceStrategy<T>
 
                 if (loadedExecution.Outcome is Outcome<T> outcome)
                 {
-                    return outcome;
+                    return outcome.WithCallerCancellationToken(cancellationToken);
                 }
 
                 var delay = await GetHedgingDelayAsync(context, hedgingContext.LoadedTasks).ConfigureAwait(continueOnCapturedContext);
@@ -72,7 +73,7 @@ internal sealed class HedgingResilienceStrategy<T> : ResilienceStrategy<T>
                 if (!execution.IsHandled)
                 {
                     execution.AcceptOutcome();
-                    return outcome;
+                    return outcome.WithCallerCancellationToken(cancellationToken);
                 }
             }
         }

--- a/src/Polly.Core/Timeout/TimeoutResilienceStrategy.cs
+++ b/src/Polly.Core/Timeout/TimeoutResilienceStrategy.cs
@@ -1,4 +1,5 @@
 using Polly.Telemetry;
+using Polly.Utils;
 
 namespace Polly.Timeout;
 
@@ -89,7 +90,7 @@ internal sealed class TimeoutResilienceStrategy : ResilienceStrategy
             return Outcome.FromException<TResult>(timeoutException.TrySetStackTrace());
         }
 
-        return outcome;
+        return outcome.WithCallerCancellationToken(previousToken);
     }
 
     private static CancellationTokenRegistration CreateRegistration(CancellationTokenSource cancellationSource, CancellationToken previousToken)

--- a/src/Polly.Core/Utils/OutcomeUtilities.cs
+++ b/src/Polly.Core/Utils/OutcomeUtilities.cs
@@ -12,7 +12,8 @@ internal static class OutcomeUtilities
     /// <param name="callerToken">The cancellation token that was associated with the execution before the strategy substituted it.</param>
     /// <returns>
     /// An outcome whose <see cref="OperationCanceledException"/> carries <paramref name="callerToken"/> when the caller
-    /// requested cancellation; otherwise the original <paramref name="outcome"/> unchanged.
+    /// requested cancellation, preserving the original exception as its <see cref="Exception.InnerException"/>;
+    /// otherwise the original <paramref name="outcome"/> unchanged.
     /// </returns>
     /// <remarks>
     /// The rewrite happens only when <paramref name="callerToken"/> actually requested cancellation. This preserves
@@ -23,7 +24,7 @@ internal static class OutcomeUtilities
     {
         if (callerToken.IsCancellationRequested && outcome.Exception is OperationCanceledException oce && oce.CancellationToken != callerToken)
         {
-            return Outcome.FromException<T>(new OperationCanceledException(callerToken).TrySetStackTrace());
+            return Outcome.FromException<T>(new OperationCanceledException(oce.Message, oce, callerToken).TrySetStackTrace());
         }
 
         return outcome;

--- a/src/Polly.Core/Utils/OutcomeUtilities.cs
+++ b/src/Polly.Core/Utils/OutcomeUtilities.cs
@@ -1,0 +1,31 @@
+namespace Polly.Utils;
+
+internal static class OutcomeUtilities
+{
+    /// <summary>
+    /// Ensures that an <see cref="OperationCanceledException"/> escaping a strategy that substituted the
+    /// execution <see cref="CancellationToken"/> (e.g. timeout or hedging) carries the caller's token when
+    /// the cancellation was caused by that token.
+    /// </summary>
+    /// <typeparam name="T">The result type of the outcome.</typeparam>
+    /// <param name="outcome">The outcome produced by the strategy.</param>
+    /// <param name="callerToken">The cancellation token that was associated with the execution before the strategy substituted it.</param>
+    /// <returns>
+    /// An outcome whose <see cref="OperationCanceledException"/> carries <paramref name="callerToken"/> when the caller
+    /// requested cancellation; otherwise the original <paramref name="outcome"/> unchanged.
+    /// </returns>
+    /// <remarks>
+    /// The rewrite happens only when <paramref name="callerToken"/> actually requested cancellation. This preserves
+    /// the contract that a real timeout, or an unrelated <see cref="OperationCanceledException"/> thrown while the
+    /// caller's token was not cancelled, is left untouched.
+    /// </remarks>
+    public static Outcome<T> WithCallerCancellationToken<T>(this Outcome<T> outcome, CancellationToken callerToken)
+    {
+        if (callerToken.IsCancellationRequested && outcome.Exception is OperationCanceledException oce && oce.CancellationToken != callerToken)
+        {
+            return Outcome.FromException<T>(new OperationCanceledException(callerToken).TrySetStackTrace());
+        }
+
+        return outcome;
+    }
+}

--- a/test/Polly.Core.Tests/Hedging/HedgingResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Hedging/HedgingResilienceStrategyTests.cs
@@ -935,6 +935,36 @@ public class HedgingResilienceStrategyTests : IDisposable
         _events.Select(v => v.Event.EventName).Distinct().Count().ShouldBe(2);
     }
 
+    [Fact]
+    public async Task ExecuteCore_CallerCancellation_EnsureExceptionCarriesCallerToken()
+    {
+        // arrange
+        using var cancellationSource = new CancellationTokenSource();
+        _options.MaxHedgedAttempts = 1;
+        _options.Delay = LongDelay; // ensure no secondary attempt starts before the primary completes
+        ConfigureHedging(); // ShouldHandle returns false, so the primary's outcome is accepted as-is
+
+        var strategy = (HedgingResilienceStrategy<string>)Create().GetPipelineDescriptor().FirstStrategy.StrategyInstance;
+
+        var context = ResilienceContextPool.Shared.Get(CancellationToken);
+        context.CancellationToken = cancellationSource.Token;
+
+        // act
+        var outcome = await strategy.ExecuteCore(
+            (ctx, _) =>
+            {
+                cancellationSource.Cancel();
+                ctx.CancellationToken.ThrowIfCancellationRequested();
+                return Outcome.FromResultAsValueTask("unreachable");
+            },
+            context,
+            "state");
+
+        // assert
+        var exception = outcome.Exception.ShouldBeOfType<OperationCanceledException>();
+        exception.CancellationToken.ShouldBe(cancellationSource.Token);
+    }
+
     private void ConfigureHedging() =>
         ConfigureHedging(_ => false, _actions.Generator);
 

--- a/test/Polly.Core.Tests/Issues/IssuesTests.CancellationTokenPropagation_3086.cs
+++ b/test/Polly.Core.Tests/Issues/IssuesTests.CancellationTokenPropagation_3086.cs
@@ -77,12 +77,17 @@ public partial class IssuesTests
     [Fact]
     public async Task NestedTimeouts_CallerCancellation_ExceptionCarriesCallerToken_3086()
     {
-        var inner = new ResiliencePipelineBuilder()
+        var innermost = new ResiliencePipelineBuilder()
             .AddTimeout(TimeSpan.FromMinutes(1))
             .Build();
 
-        var pipeline = new ResiliencePipelineBuilder()
+        var inner = new ResiliencePipelineBuilder()
             .AddTimeout(TimeSpan.FromMinutes(2))
+            .AddPipeline(innermost)
+            .Build();
+
+        var pipeline = new ResiliencePipelineBuilder()
+            .AddTimeout(TimeSpan.FromMinutes(3))
             .AddPipeline(inner)
             .Build();
 

--- a/test/Polly.Core.Tests/Issues/IssuesTests.CancellationTokenPropagation_3086.cs
+++ b/test/Polly.Core.Tests/Issues/IssuesTests.CancellationTokenPropagation_3086.cs
@@ -22,7 +22,7 @@ public partial class IssuesTests
             pipeline.ExecuteAsync(
                 async token =>
                 {
-                    await cts.CancelAsync(); // simulate cancellation request from upstream caller
+                    cts.Cancel(); // simulate cancellation request from upstream caller
                     token.ThrowIfCancellationRequested(); // simulate cancellation response from downstream code
                 },
                 cts.Token).AsTask());
@@ -44,7 +44,7 @@ public partial class IssuesTests
             pipeline.ExecuteAsync(
                 async token =>
                 {
-                    await cts.CancelAsync();
+                    cts.Cancel();
                     token.ThrowIfCancellationRequested();
                 },
                 cts.Token).AsTask());
@@ -66,7 +66,7 @@ public partial class IssuesTests
             pipeline.ExecuteAsync(
                 async token =>
                 {
-                    await cts.CancelAsync();
+                    cts.Cancel();
                     token.ThrowIfCancellationRequested();
                 },
                 cts.Token).AsTask());
@@ -97,7 +97,7 @@ public partial class IssuesTests
             pipeline.ExecuteAsync(
                 async token =>
                 {
-                    await cts.CancelAsync();
+                    cts.Cancel();
                     token.ThrowIfCancellationRequested();
                 },
                 cts.Token).AsTask());
@@ -123,7 +123,7 @@ public partial class IssuesTests
             pipeline.ExecuteAsync(
                 async token =>
                 {
-                    await cts.CancelAsync();
+                    cts.Cancel();
                     token.ThrowIfCancellationRequested();
                     return "unreachable";
                 },
@@ -147,7 +147,7 @@ public partial class IssuesTests
             pipeline.ExecuteAsync(
                 async token =>
                 {
-                    await cts.CancelAsync();
+                    cts.Cancel();
                     token.ThrowIfCancellationRequested();
                 },
                 cts.Token).AsTask());
@@ -186,7 +186,8 @@ public partial class IssuesTests
 
         using var callerCts = new CancellationTokenSource();
         using var unrelatedCts = new CancellationTokenSource();
-        await unrelatedCts.CancelAsync();
+
+        unrelatedCts.Cancel();
 
         var exception = await Should.ThrowAsync<OperationCanceledException>(() =>
             pipeline.ExecuteAsync(

--- a/test/Polly.Core.Tests/Issues/IssuesTests.CancellationTokenPropagation_3086.cs
+++ b/test/Polly.Core.Tests/Issues/IssuesTests.CancellationTokenPropagation_3086.cs
@@ -1,0 +1,197 @@
+using Polly.Hedging;
+using Polly.Timeout;
+
+namespace Polly.Core.Tests.Issues;
+
+public partial class IssuesTests
+{
+    // https://github.com/App-vNext/Polly/issues/3086
+    // When a strategy substitutes the caller's CancellationToken with an internal one (timeout, hedging),
+    // a caller-initiated cancellation must still surface an OperationCanceledException carrying the
+    // caller's token, so that callers can distinguish caller cancellation from other failures.
+    [Fact]
+    public async Task Timeout_CallerCancellation_ExceptionCarriesCallerToken_3086()
+    {
+        var pipeline = new ResiliencePipelineBuilder()
+            .AddTimeout(TimeSpan.FromMinutes(1))
+            .Build();
+
+        using var cts = new CancellationTokenSource();
+
+        var exception = await Should.ThrowAsync<OperationCanceledException>(() =>
+            pipeline.ExecuteAsync(
+                async token =>
+                {
+                    await cts.CancelAsync(); // simulate cancellation request from upstream caller
+                    token.ThrowIfCancellationRequested(); // simulate cancellation response from downstream code
+                },
+                cts.Token).AsTask());
+
+        exception.CancellationToken.ShouldBe(cts.Token);
+    }
+
+    [Fact]
+    public async Task TimeoutThenRetry_CallerCancellation_ExceptionCarriesCallerToken_3086()
+    {
+        var pipeline = new ResiliencePipelineBuilder()
+            .AddTimeout(TimeSpan.FromMinutes(1))
+            .AddRetry(new() { MaxRetryAttempts = 3, Delay = TimeSpan.Zero })
+            .Build();
+
+        using var cts = new CancellationTokenSource();
+
+        var exception = await Should.ThrowAsync<OperationCanceledException>(() =>
+            pipeline.ExecuteAsync(
+                async token =>
+                {
+                    await cts.CancelAsync();
+                    token.ThrowIfCancellationRequested();
+                },
+                cts.Token).AsTask());
+
+        exception.CancellationToken.ShouldBe(cts.Token);
+    }
+
+    [Fact]
+    public async Task RetryThenTimeout_CallerCancellation_ExceptionCarriesCallerToken_3086()
+    {
+        var pipeline = new ResiliencePipelineBuilder()
+            .AddRetry(new() { MaxRetryAttempts = 3, Delay = TimeSpan.Zero })
+            .AddTimeout(TimeSpan.FromMinutes(1))
+            .Build();
+
+        using var cts = new CancellationTokenSource();
+
+        var exception = await Should.ThrowAsync<OperationCanceledException>(() =>
+            pipeline.ExecuteAsync(
+                async token =>
+                {
+                    await cts.CancelAsync();
+                    token.ThrowIfCancellationRequested();
+                },
+                cts.Token).AsTask());
+
+        exception.CancellationToken.ShouldBe(cts.Token);
+    }
+
+    [Fact]
+    public async Task NestedTimeouts_CallerCancellation_ExceptionCarriesCallerToken_3086()
+    {
+        var inner = new ResiliencePipelineBuilder()
+            .AddTimeout(TimeSpan.FromMinutes(1))
+            .Build();
+
+        var pipeline = new ResiliencePipelineBuilder()
+            .AddTimeout(TimeSpan.FromMinutes(2))
+            .AddPipeline(inner)
+            .Build();
+
+        using var cts = new CancellationTokenSource();
+
+        var exception = await Should.ThrowAsync<OperationCanceledException>(() =>
+            pipeline.ExecuteAsync(
+                async token =>
+                {
+                    await cts.CancelAsync();
+                    token.ThrowIfCancellationRequested();
+                },
+                cts.Token).AsTask());
+
+        exception.CancellationToken.ShouldBe(cts.Token);
+    }
+
+    [Fact]
+    public async Task Hedging_CallerCancellation_ExceptionCarriesCallerToken_3086()
+    {
+        var pipeline = new ResiliencePipelineBuilder<string>()
+            .AddHedging(new HedgingStrategyOptions<string>
+            {
+                MaxHedgedAttempts = 1,
+                Delay = TimeSpan.FromMinutes(1), // ensure only the primary attempt runs before cancellation
+                ShouldHandle = _ => PredicateResult.False(), // accept the primary outcome as-is
+            })
+            .Build();
+
+        using var cts = new CancellationTokenSource();
+
+        var exception = await Should.ThrowAsync<OperationCanceledException>(() =>
+            pipeline.ExecuteAsync(
+                async token =>
+                {
+                    await cts.CancelAsync();
+                    token.ThrowIfCancellationRequested();
+                    return "unreachable";
+                },
+                cts.Token).AsTask());
+
+        exception.CancellationToken.ShouldBe(cts.Token);
+    }
+
+    [Fact]
+    public async Task WithoutTokenSubstitution_CallerCancellation_ExceptionCarriesCallerToken_3086()
+    {
+        // A pipeline that does not substitute the token has always surfaced the caller's token
+        // and this case simply guards against regressions for the common path.
+        var pipeline = new ResiliencePipelineBuilder()
+            .AddRetry(new() { MaxRetryAttempts = 3, Delay = TimeSpan.Zero })
+            .Build();
+
+        using var cts = new CancellationTokenSource();
+
+        var exception = await Should.ThrowAsync<OperationCanceledException>(() =>
+            pipeline.ExecuteAsync(
+                async token =>
+                {
+                    await cts.CancelAsync();
+                    token.ThrowIfCancellationRequested();
+                },
+                cts.Token).AsTask());
+
+        exception.CancellationToken.ShouldBe(cts.Token);
+    }
+
+    [Fact]
+    public async Task Timeout_RealTimeout_StillThrowsTimeoutRejectedException_3086()
+    {
+        // "only if": a real timeout (caller token not cancelled) must remain a TimeoutRejectedException,
+        // and must not be rewritten into a caller-cancellation.
+        var pipeline = new ResiliencePipelineBuilder { TimeProvider = TimeProvider }
+            .AddTimeout(TimeSpan.FromSeconds(1))
+            .Build();
+
+        await Should.ThrowAsync<TimeoutRejectedException>(() =>
+            pipeline.ExecuteAsync(
+                async token =>
+                {
+                    var delay = Task.Delay(TimeSpan.FromSeconds(10), TimeProvider, token);
+                    TimeProvider.Advance(TimeSpan.FromSeconds(2));
+                    await delay;
+                },
+                CancellationToken.None).AsTask());
+    }
+
+    [Fact]
+    public async Task Timeout_UnrelatedCancellation_ExceptionPreserved_3086()
+    {
+        // "only if": when the caller token is not cancelled, an unrelated OperationCanceledException
+        // thrown by user code must propagate unchanged (its own token must be preserved).
+        var pipeline = new ResiliencePipelineBuilder()
+            .AddTimeout(TimeSpan.FromMinutes(1))
+            .Build();
+
+        using var callerCts = new CancellationTokenSource();
+        using var unrelatedCts = new CancellationTokenSource();
+        await unrelatedCts.CancelAsync();
+
+        var exception = await Should.ThrowAsync<OperationCanceledException>(() =>
+            pipeline.ExecuteAsync(
+                async token =>
+                {
+                    await Task.Yield();
+                    throw new OperationCanceledException(unrelatedCts.Token);
+                },
+                callerCts.Token).AsTask());
+
+        exception.CancellationToken.ShouldBe(unrelatedCts.Token);
+    }
+}

--- a/test/Polly.Core.Tests/Issues/IssuesTests.CancellationTokenPropagation_3086.cs
+++ b/test/Polly.Core.Tests/Issues/IssuesTests.CancellationTokenPropagation_3086.cs
@@ -168,7 +168,7 @@ public partial class IssuesTests
             pipeline.ExecuteAsync(
                 async token =>
                 {
-                    var delay = Task.Delay(TimeSpan.FromSeconds(10), TimeProvider, token);
+                    var delay = TimeProvider.Delay(TimeSpan.FromSeconds(10), token);
                     TimeProvider.Advance(TimeSpan.FromSeconds(2));
                     await delay;
                 },

--- a/test/Polly.Core.Tests/Timeout/TimeoutResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Timeout/TimeoutResilienceStrategyTests.cs
@@ -226,6 +226,28 @@ public class TimeoutResilienceStrategyTests : IDisposable
     }
 
     [Fact]
+    public async Task Execute_CallerCancellation_EnsureExceptionCarriesCallerToken()
+    {
+        var delay = TimeSpan.FromSeconds(10);
+
+        using var cts = new CancellationTokenSource();
+        SetTimeout(TimeSpan.FromSeconds(10));
+
+        var sut = CreateSut();
+
+        var exception = await Should.ThrowAsync<OperationCanceledException>(
+            () => sut.ExecuteAsync(async token =>
+            {
+                var task = _timeProvider.Delay(delay, token);
+                cts.Cancel();
+                await task;
+            },
+            cts.Token).AsTask());
+
+        exception.CancellationToken.ShouldBe(cts.Token);
+    }
+
+    [Fact]
     public async Task Execute_NoTimeoutOrCancellation_EnsureCancellationTokenRestored()
     {
         var delay = TimeSpan.FromSeconds(10);

--- a/test/Polly.Core.Tests/Utils/OutcomeUtilitiesTests.cs
+++ b/test/Polly.Core.Tests/Utils/OutcomeUtilitiesTests.cs
@@ -10,12 +10,14 @@ public class OutcomeUtilitiesTests
         using var caller = new CancellationTokenSource();
         using var other = new CancellationTokenSource();
         caller.Cancel();
-        var outcome = Outcome.FromException<int>(new OperationCanceledException(other.Token));
+        var original = new OperationCanceledException(other.Token);
+        var outcome = Outcome.FromException<int>(original);
 
         var result = outcome.WithCallerCancellationToken(caller.Token);
 
         var exception = result.Exception.ShouldBeOfType<OperationCanceledException>();
         exception.CancellationToken.ShouldBe(caller.Token);
+        exception.InnerException.ShouldBeSameAs(original);
         exception.StackTrace.ShouldNotBeNull();
     }
 

--- a/test/Polly.Core.Tests/Utils/OutcomeUtilitiesTests.cs
+++ b/test/Polly.Core.Tests/Utils/OutcomeUtilitiesTests.cs
@@ -1,0 +1,74 @@
+using Polly.Utils;
+
+namespace Polly.Core.Tests.Utils;
+
+public class OutcomeUtilitiesTests
+{
+    [Fact]
+    public void WithCallerCancellation_CallerCancelled_DifferentToken_RewritesToCallerToken()
+    {
+        using var caller = new CancellationTokenSource();
+        using var other = new CancellationTokenSource();
+        caller.Cancel();
+        var outcome = Outcome.FromException<int>(new OperationCanceledException(other.Token));
+
+        var result = outcome.WithCallerCancellationToken(caller.Token);
+
+        var exception = result.Exception.ShouldBeOfType<OperationCanceledException>();
+        exception.CancellationToken.ShouldBe(caller.Token);
+        exception.StackTrace.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void WithCallerCancellation_CallerCancelled_SameToken_ReturnsOriginal()
+    {
+        using var caller = new CancellationTokenSource();
+        caller.Cancel();
+        var original = new OperationCanceledException(caller.Token);
+        var outcome = Outcome.FromException<int>(original);
+
+        var result = outcome.WithCallerCancellationToken(caller.Token);
+
+        result.Exception.ShouldBeSameAs(original);
+    }
+
+    [Fact]
+    public void WithCallerCancellation_CallerCancelled_NonCancellationException_ReturnsOriginal()
+    {
+        using var caller = new CancellationTokenSource();
+        caller.Cancel();
+        var original = new InvalidOperationException();
+        var outcome = Outcome.FromException<int>(original);
+
+        var result = outcome.WithCallerCancellationToken(caller.Token);
+
+        result.Exception.ShouldBeSameAs(original);
+    }
+
+    [Fact]
+    public void WithCallerCancellation_CallerCancelled_SuccessOutcome_ReturnsOriginal()
+    {
+        using var caller = new CancellationTokenSource();
+        caller.Cancel();
+        var outcome = Outcome.FromResult(42);
+
+        var result = outcome.WithCallerCancellationToken(caller.Token);
+
+        result.Exception.ShouldBeNull();
+        result.Result.ShouldBe(42);
+    }
+
+    [Fact]
+    public void WithCallerCancellation_CallerNotCancelled_ReturnsOriginal()
+    {
+        using var caller = new CancellationTokenSource();
+        using var other = new CancellationTokenSource();
+        other.Cancel();
+        var original = new OperationCanceledException(other.Token);
+        var outcome = Outcome.FromException<int>(original);
+
+        var result = outcome.WithCallerCancellationToken(caller.Token);
+
+        result.Exception.ShouldBeSameAs(original);
+    }
+}


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed

Fixes #3086 (Timeout strategy does not propagate the caller's `CancellationToken`)

When a resilience pipeline contains a strategy that substitutes the execution `CancellationToken` with an internal one (timeout, and also hedging), a caller-initiated cancellation surfaces an `OperationCanceledException` whose `CancellationToken` is Polly's *internal* token rather than the caller's. This breaks the common pattern of letting caller cancellation pass through unchanged while wrapping other failures, because callers cannot reliably compare `OperationCanceledException.CancellationToken` to their own token.

## Details on the issue fix or feature implementation

### Goal

Polly should throw an `OperationCanceledException` carrying the caller's token **if and only if** the cancellation was actually caused by a cancellation request on that token — for any pipeline, regardless of which strategies it is composed of or how they are nested.

### Approach

A repo-wide audit shows that within `Polly.Core` exactly two strategies substitute the execution token: **timeout** (`TimeoutResilienceStrategy`) and **hedging** (`TaskExecution` via `ResilienceContext.InitializeFrom`). Every other strategy and the pipeline plumbing only *read* `context.CancellationToken`, so they already emit the correct token at their own level.

The fix therefore lives in those two strategies, via a small shared helper:

```csharp
// Polly.Core/Utils/OutcomeUtilities.cs
public static Outcome<T> WithCallerCancellation<T>(this Outcome<T> outcome, CancellationToken callerToken)
{
    if (callerToken.IsCancellationRequested
        && outcome.Exception is OperationCanceledException oce
        && oce.CancellationToken != callerToken)
    {
        return Outcome.FromException<T>(new OperationCanceledException(callerToken).TrySetStackTrace());
    }

    return outcome;
}
```

- **Timeout** applies it to the outcome it returns, using the token that was on the context *before* it substituted its own. The existing timeout-detection branch (which produces `TimeoutRejectedException`) is unchanged.
- **Hedging** applies it at its accepted-outcome return sites, using the upstream token it already captures for the duration of the hedged execution.

Because each substituting strategy normalizes back to *its own* previous token, the behavior composes correctly through arbitrary nesting: an inner timeout rewrites to the mid-level token, the outer timeout rewrites that to the caller's token, and so on. The simplest case (`AddTimeout` only) and deeply nested cases both end up with the caller's token.

### Design decisions and trade-offs

- **Surgical fix** We considered normalizing the exception once at the outermost pipeline execution boundary. That would also cover hypothetical third-party strategies that substitute the token, but it adds work to the universal execution hot path. We chose the surgical approach because it adds **zero overhead** to the common path (work happens only inside the two strategies, only on the cancellation branch) and provably covers every composition of the built-in strategies. The trade-off is that a custom strategy that substitutes the token would remain responsible for its own token handling.
- **Exception shape** When the token must be corrected we create a bare `new OperationCanceledException(callerToken).TrySetStackTrace()`, matching the existing convention in `DelegatingComponent`, `CompositeComponent`, and hedging's pre-execution cancellation check. We deliberately did not chain the original exception as an `InnerException`; it keeps the behavior consistent with the rest of the codebase, at the cost of not preserving the original deep stack trace in this specific path.
- **Scope: v8 (`Polly.Core`) only.** The legacy v7 `Policy` API uses a combined linked token and already documents (in `AsyncTimeoutEngine`/`TimeoutEngine`) that the token on the exception is not reliable for this determination. We left v7 untouched to avoid changing long-stable behavior.
- **Deliberately ignoring a benign race** Detection relies on `callerToken.IsCancellationRequested`, read after the exception has been produced. Because a `CancellationToken` is a monotonic latch with no record of *when* or *why* it fired, there is an inherent, unavoidable race: if a non-caller cause produces the exception and the caller then cancels within the small window before we inspect the token, the cancellation is attributed to the caller. We chose not to add machinery to fight this, for three reasons:
  1. The timeout-vs-caller variant of this race is **pre-existing** — Polly's existing timeout classification already uses the same `previousToken.IsCancellationRequested` proxy, so this change does not make it worse (it only makes the resulting token more coherent).
  2. It cannot be fully eliminated: the token model exposes no causal/temporal information after the fact.
  3. In every misfire the caller's token genuinely *is* cancelled, so attributing the cancellation to the caller is defensible rather than harmful. The "only if" guarantee that matters in practice — *not* claiming caller cancellation when the caller's token was never cancelled — is fully preserved.

### Tests

- A regression test file under `Issues` (`IssuesTests.CancellationTokenPropagation_3086.cs`) with end-to-end coverage: the exact issue repro, timeout±retry in both orders, hedging, nested timeouts, a no-substitution baseline, and two "only if" guards (a real timeout still throws `TimeoutRejectedException`; an unrelated `OperationCanceledException` is preserved when the caller token is not cancelled)
- Unit tests for the new helper covering all branches
- Focused token-identity assertions added to the timeout and hedging strategy tests

All `Polly.Core.Tests` pass; branch and method coverage remain at 100% and the new code is fully covered.

## Confirm the following

- [X]  I started this PR by branching from the head of the default branch
- [X]  I have targeted the PR to merge into the default branch
- [X]  I have included unit tests for the issue/feature
- [X]  I have successfully run a local build