### PR TITLE
Bump Refit to 10.2.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,7 +29,7 @@
     <PackageVersion Include="Polly.Extensions" Version="8.6.2" />
     <PackageVersion Include="Polly.RateLimiting" Version="8.6.2" />
     <PackageVersion Include="Polly.Testing" Version="8.6.2" />
-    <PackageVersion Include="Refit.HttpClientFactory" Version="10.1.6" />
+    <PackageVersion Include="Refit.HttpClientFactory" Version="10.2.0" />
     <PackageVersion Include="ReportGenerator" Version="5.5.10" />
     <PackageVersion Include="RestSharp" Version="114.0.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />


### PR DESCRIPTION
Refit revoked the signing certificate on 10.1.6.

See https://github.com/reactiveui/refit/issues/2114#issuecomment-4612074286.
