### PR TITLE
Disable Azure deployments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,6 +215,7 @@ jobs:
 
     environment:
       name: Azure
+      deployment: false
 
     permissions:
       id-token: write


### PR DESCRIPTION
Do not create a GitHub deployment when the Azure environment is used to sign the NuGet packages.
