### PR TITLE
Avoid test flakiness

### DIFF
--- a/src/Polly.Core/Utils/ObjectPool.cs
+++ b/src/Polly.Core/Utils/ObjectPool.cs
@@ -4,6 +4,7 @@ namespace Polly.Utils;
 internal sealed class ObjectPool<T>
     where T : class
 {
+    // Stryker disable once arithmetic : no means to test this
     internal static readonly int MaxCapacity = (Environment.ProcessorCount * 2) - 1; // the - 1 is to account for _fastItem
 
     private readonly Func<T> _createFunc;

--- a/test/Polly.Extensions.Tests/Issues/IssuesTests.StrategiesPerEndpoint_1365.cs
+++ b/test/Polly.Extensions.Tests/Issues/IssuesTests.StrategiesPerEndpoint_1365.cs
@@ -14,7 +14,11 @@ public partial class IssuesTests
     public void StrategiesPerEndpoint_1365()
     {
         var events = new List<MeteringEvent>(1024);
-        using var listener = TestUtilities.EnablePollyMetering(events);
+
+        using var listener = TestUtilities.EnablePollyMetering(
+            events,
+            shouldRecord: TestUtilities.ForPipelines("endpoint-pipeline", "rate-limiter/Endpoint 1"));
+
         var services = new ServiceCollection();
 
         services.AddResiliencePipelineRegistry<string>();

--- a/test/Polly.Extensions.Tests/Telemetry/TelemetryListenerImplTests.cs
+++ b/test/Polly.Extensions.Tests/Telemetry/TelemetryListenerImplTests.cs
@@ -9,6 +9,8 @@ namespace Polly.Extensions.Tests.Telemetry;
 [Collection(nameof(NonParallelizableCollection))]
 public class TelemetryListenerImplTests : IDisposable
 {
+    private const string PipelineName = "my-pipeline";
+
     private readonly FakeLogger _logger;
     private readonly ILoggerFactory _loggerFactory;
     private readonly List<MeteringEvent> _events = new(1024);
@@ -101,7 +103,7 @@ public class TelemetryListenerImplTests : IDisposable
     [Theory]
     public void WriteEvent_EnsureSeverityRespected(ResilienceEventSeverity severity, LogLevel logLevel)
     {
-        using var metering = TestUtilities.EnablePollyMetering(_events);
+        using var metering = EnableMetering();
 
         var telemetry = Create();
         ReportEvent(telemetry, null, severity: severity);
@@ -174,7 +176,7 @@ public class TelemetryListenerImplTests : IDisposable
     [Theory]
     public void WriteEvent_MeteringWithoutEnrichers_Ok(bool noOutcome, bool exception)
     {
-        using var metering = TestUtilities.EnablePollyMetering(_events);
+        using var metering = EnableMetering();
         var telemetry = Create();
         Outcome<object>? outcome = noOutcome switch
         {
@@ -221,7 +223,7 @@ public class TelemetryListenerImplTests : IDisposable
     [Theory]
     public void WriteExecutionAttemptEvent_Metering_Ok(bool noOutcome, bool exception)
     {
-        using var metering = TestUtilities.EnablePollyMetering(_events);
+        using var metering = EnableMetering();
         var telemetry = Create();
         var attemptArg = new ExecutionAttemptArguments(5, TimeSpan.FromSeconds(50), true);
         Outcome<object>? outcome = noOutcome switch
@@ -284,7 +286,7 @@ public class TelemetryListenerImplTests : IDisposable
     [Theory]
     public void WriteEvent_MeteringWithEnrichers_Ok(int count)
     {
-        using var metering = TestUtilities.EnablePollyMetering(_events);
+        using var metering = EnableMetering();
 
         const int DefaultDimensions = 6;
 
@@ -320,7 +322,7 @@ public class TelemetryListenerImplTests : IDisposable
     [Fact]
     public void WriteEvent_MeteringWithoutBuilderInstance_Ok()
     {
-        using var metering = TestUtilities.EnablePollyMetering(_events);
+        using var metering = EnableMetering();
         var telemetry = Create();
         ReportEvent(telemetry, null, instanceName: null);
         GetEvents("resilience.polly.strategy.events")[0].ShouldNotContainKey("pipeline.instance");
@@ -396,7 +398,7 @@ public class TelemetryListenerImplTests : IDisposable
     [Theory]
     public void PipelineExecution_Metered(bool exception)
     {
-        using var metering = TestUtilities.EnablePollyMetering(_events);
+        using var metering = EnableMetering();
 
         var context = ResilienceContextPool.Shared.Get("op-key", TestCancellation.Token).WithResultType<int>();
         var outcome = exception ? Outcome.FromException<object>(new InvalidOperationException("dummy message")) : Outcome.FromResult((object)10);
@@ -540,6 +542,11 @@ public class TelemetryListenerImplTests : IDisposable
         _logger.GetRecords(new EventId(3, "ExecutionAttempt")).Single().LogLevel.ShouldBe(expectedLogLevel);
     }
 
+    // Only capture metering events emitted by this test's pipeline, as the "Polly" meter is process-wide
+    // and other tests running concurrently can emit events into the same listener.
+    private IDisposable EnableMetering() =>
+        TestUtilities.EnablePollyMetering(_events, shouldRecord: TestUtilities.ForPipelines(PipelineName));
+
     private List<Dictionary<string, object?>> GetEvents(string eventName) => [.. _events.Where(e => e.Name == eventName).Select(v => v.Tags)];
 
     private TelemetryListenerImpl Create(IEnumerable<MeteringEnricher>? enrichers = null, Action<TelemetryOptions>? configure = null)
@@ -587,7 +594,7 @@ public class TelemetryListenerImplTests : IDisposable
         string eventName = "my-event") =>
         telemetry.Write(
             new TelemetryEventArguments<object, TArgs>(
-                new ResilienceTelemetrySource("my-pipeline", instanceName, "my-strategy"),
+                new ResilienceTelemetrySource(PipelineName, instanceName, "my-strategy"),
                 new ResilienceEvent(severity, eventName),
                 context ?? ResilienceContextPool.Shared.Get("op-key"),
                 arg!,

--- a/test/Polly.TestUtils/TestUtilities.cs
+++ b/test/Polly.TestUtils/TestUtilities.cs
@@ -52,7 +52,10 @@ public static class TestUtilities
         return loggerFactory;
     }
 
-    public static IDisposable EnablePollyMetering(ICollection<MeteringEvent> events, Predicate<Instrument>? shouldListen = null)
+    public static IDisposable EnablePollyMetering(
+        ICollection<MeteringEvent> events,
+        Predicate<Instrument>? shouldListen = null,
+        Predicate<MeteringEvent>? shouldRecord = null)
     {
         var stateStr = Guid.NewGuid().ToString();
         var meterListener = new MeterListener
@@ -78,12 +81,24 @@ public static class TestUtilities
         {
             if (stateObj is string str && str == stateStr)
             {
-                events.Add(new MeteringEvent(measurement!, instrument.Name, tags.ToArray().ToDictionary(v => v.Key, v => v.Value)));
+                var @event = new MeteringEvent(measurement!, instrument.Name, tags.ToArray().ToDictionary(v => v.Key, v => v.Value));
+
+                if (shouldRecord is null || shouldRecord(@event))
+                {
+                    events.Add(@event);
+                }
             }
         }
 
         return meterListener;
     }
+
+    /// <summary>
+    /// Creates a <see cref="Predicate{MeteringEvent}"/> that matches metering events emitted by the
+    /// pipelines with the specified <paramref name="pipelineNames"/>, for use with <see cref="EnablePollyMetering"/>.
+    /// </summary>
+    public static Predicate<MeteringEvent> ForPipelines(params string[] pipelineNames) =>
+        (p) => p.Tags.TryGetValue("pipeline.name", out var name) && name is string actual && pipelineNames.Contains(actual);
 
     public static ResilienceContext WithResultType<T>(this ResilienceContext context)
     {


### PR DESCRIPTION
Cherry-pick changes from #3131:

- Suppress mutant uncovered by MTP.
- Scope assertions to events emitted by the tests, rather than accidentally including those from parallel tests.
