### PR TITLE
Add support for getting/setting the retry attempt number on the context

### DIFF
--- a/src/Polly.Core/.PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Polly.Core/.PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 ﻿#nullable enable
+Polly.RetryResilienceContextExtensions
+static Polly.RetryResilienceContextExtensions.GetRetryAttemptNumber(this Polly.ResilienceContext! context) -> int
+static Polly.RetryResilienceContextExtensions.SetRetryAttemptNumber(this Polly.ResilienceContext! context, int attemptNumber) -> void

--- a/src/Polly.Core/Retry/RetryResilienceContextExtensions.cs
+++ b/src/Polly.Core/Retry/RetryResilienceContextExtensions.cs
@@ -1,0 +1,45 @@
+namespace Polly;
+
+/// <summary>
+///   Extension methods for <see cref="ResilienceContext"/> to store and retrieve properties related to the Retry strategy.
+/// </summary>
+public static class RetryResilienceContextExtensions
+{
+    internal static readonly ResiliencePropertyKey<int> AttemptNumberPropertyKey = new("Retry.AttemptNumber");
+
+    /// <summary>
+    /// Gets the current attempt number from the <see cref="ResilienceContext"/> (starting with <c>0</c> for the first attempt).
+    /// </summary>
+    /// <param name="context">The <see cref="ResilienceContext"/> instance.</param>
+    /// <returns>The current attempt number.</returns>
+    public static int GetRetryAttemptNumber(this ResilienceContext context)
+    {
+        Guard.NotNull(context);
+
+        return context.Properties.TryGetValue(AttemptNumberPropertyKey, out var value)
+            ? value
+            : 0;
+    }
+
+    /// <summary>
+    /// Sets the attempt number in the <see cref="ResilienceContext"/>.
+    /// </summary>
+    /// <param name="context">The <see cref="ResilienceContext"/> instance.</param>
+    /// <param name="attemptNumber">The attempt number to set.</param>
+    /// <remarks>
+    /// Application code can use this method to set the initial attempt number when executing a retry strategy.
+    /// The strategy will update the attempt number on each retry, and it can be retrieved using <see cref="GetRetryAttemptNumber"/>.
+    /// The strategy will overwrite the attempt number on each retry, so any value set inside callbacks may be lost or cause inconsistent behavior.
+    /// </remarks>
+    public static void SetRetryAttemptNumber(this ResilienceContext context, int attemptNumber)
+    {
+        Guard.NotNull(context);
+
+        if (attemptNumber < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(attemptNumber), attemptNumber, "Attempt number must be non-negative.");
+        }
+
+        context.Properties.Set(AttemptNumberPropertyKey, attemptNumber);
+    }
+}

--- a/src/Polly.Core/Retry/RetryResilienceContextExtensions.cs
+++ b/src/Polly.Core/Retry/RetryResilienceContextExtensions.cs
@@ -25,7 +25,7 @@ public static class RetryResilienceContextExtensions
     /// Sets the attempt number in the <see cref="ResilienceContext"/>.
     /// </summary>
     /// <param name="context">The <see cref="ResilienceContext"/> instance.</param>
-    /// <param name="attemptNumber">The attempt number to set.</param>
+    /// <param name="attemptNumber">The non-negative attempt number to set.</param>
     /// <remarks>
     /// Application code can use this method to set the initial attempt number when executing a retry strategy.
     /// The strategy will update the attempt number on each retry, and it can be retrieved using <see cref="GetRetryAttemptNumber"/>.

--- a/src/Polly.Core/Retry/RetryResilienceStrategy.cs
+++ b/src/Polly.Core/Retry/RetryResilienceStrategy.cs
@@ -47,7 +47,7 @@ internal sealed class RetryResilienceStrategy<T> : ResilienceStrategy<T>
     {
         double retryState = 0;
 
-        int attempt = 0;
+        var attempt = Math.Max(0, context.GetRetryAttemptNumber());
 
         while (true)
         {
@@ -131,6 +131,8 @@ internal sealed class RetryResilienceStrategy<T> : ResilienceStrategy<T>
             {
                 attempt++;
             }
+
+            context.SetRetryAttemptNumber(attempt);
         }
     }
 

--- a/test/Polly.Core.Tests/Retry/RetryResilienceStrategyTests.cs
+++ b/test/Polly.Core.Tests/Retry/RetryResilienceStrategyTests.cs
@@ -207,6 +207,29 @@ public class RetryResilienceStrategyTests
     }
 
     [Fact]
+    public void Retry_RetryAttemptNumberSet_RetryCount_Respected()
+    {
+        int calls = 0;
+
+        _options.OnRetry = _ =>
+        {
+            calls++;
+            return default;
+        };
+
+        _options.ShouldHandle = args => args.Outcome.ResultPredicateAsync(0);
+        _options.MaxRetryAttempts = 12;
+        SetupNoDelay();
+        var sut = CreateSut();
+
+        var context = new ResilienceContext();
+        context.SetRetryAttemptNumber(5);
+        sut.Execute(_ => 0, context);
+
+        calls.ShouldBe(7);
+    }
+
+    [Fact]
     public void RetryException_RetryCount_Respected()
     {
         int calls = 0;
@@ -225,6 +248,29 @@ public class RetryResilienceStrategyTests
         Assert.Throws<InvalidOperationException>(() => sut.Execute<int>(() => throw new InvalidOperationException()));
 
         calls.ShouldBe(3);
+    }
+
+    [Fact]
+    public void RetryException_RetryAttemptNumberSet_RetryCount_Respected()
+    {
+        int calls = 0;
+        _options.OnRetry = args =>
+        {
+            args.Outcome.Exception.ShouldBeOfType<InvalidOperationException>();
+            calls++;
+            return default;
+        };
+
+        _options.ShouldHandle = args => args.Outcome.ExceptionPredicateAsync<InvalidOperationException>();
+        _options.MaxRetryAttempts = 3;
+        SetupNoDelay();
+        var sut = CreateSut();
+
+        var context = new ResilienceContext();
+        context.SetRetryAttemptNumber(1);
+        Assert.Throws<InvalidOperationException>(() => sut.Execute<int>(_ => throw new InvalidOperationException(), context));
+
+        calls.ShouldBe(2);
     }
 
     [Fact]
@@ -329,6 +375,36 @@ public class RetryResilienceStrategyTests
         delays[0].ShouldBe(TimeSpan.FromSeconds(2));
         delays[1].ShouldBe(TimeSpan.FromSeconds(4));
         delays[2].ShouldBe(TimeSpan.FromSeconds(6));
+    }
+
+    [Fact]
+    public async Task OnRetry_RetryAttemptNumberSet_EnsureCorrectArguments()
+    {
+        var attempts = new List<int>();
+        var delays = new List<TimeSpan>();
+
+        _options.OnRetry = args =>
+        {
+            attempts.Add(args.AttemptNumber);
+            delays.Add(args.RetryDelay);
+
+            args.Outcome.Exception.ShouldBeNull();
+            args.Outcome.Result.ShouldBe(0);
+            return default;
+        };
+
+        _options.ShouldHandle = args => PredicateResult.True();
+        _options.MaxRetryAttempts = 3;
+        _options.BackoffType = DelayBackoffType.Linear;
+
+        var sut = CreateSut();
+
+        var executing = ExecuteAndAdvanceWithRetryAttemptNumber(sut, 1);
+
+        await executing;
+
+        attempts.ShouldBe([1, 2]);
+        delays.ShouldBe([TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(6)]);
     }
 
     [Fact]
@@ -485,6 +561,28 @@ public class RetryResilienceStrategyTests
     }
 
     [Fact]
+    public void Execute_RetryAttemptNumberSet_AttemptNumberAccessibleFromContext()
+    {
+        var attempts = new List<int>();
+
+        _options.ShouldHandle = args => args.Outcome.ResultPredicateAsync(0);
+        _options.MaxRetryAttempts = 7;
+        SetupNoDelay();
+        var sut = CreateSut();
+
+        var context = new ResilienceContext();
+        context.SetRetryAttemptNumber(3);
+
+        sut.Execute(_ =>
+        {
+            attempts.Add(context.GetRetryAttemptNumber());
+            return 0;
+        }, context);
+
+        attempts.ShouldBe([3, 4, 5, 6, 7]);
+    }
+
+    [Fact]
     public async Task OnRetry_EnsureTelemetry()
     {
         var attempts = new List<int>();
@@ -531,6 +629,34 @@ public class RetryResilienceStrategyTests
     }
 
     [Fact]
+    public void RetryDelayGenerator_RetryAttemptNumberSet_EnsureCorrectArguments()
+    {
+        var attempts = new List<int>();
+
+        _options.DelayGenerator = args =>
+        {
+            attempts.Add(args.AttemptNumber);
+
+            args.Outcome.Exception.ShouldBeNull();
+            args.Outcome.Result.ShouldBe(0);
+
+            return new ValueTask<TimeSpan?>(TimeSpan.Zero);
+        };
+
+        _options.ShouldHandle = args => args.Outcome.ResultPredicateAsync(0);
+        _options.MaxRetryAttempts = 3;
+        _options.BackoffType = DelayBackoffType.Linear;
+
+        var sut = CreateSut();
+
+        var context = new ResilienceContext();
+        context.SetRetryAttemptNumber(2);
+        sut.Execute(_ => 0, context);
+
+        attempts.ShouldBe([2]);
+    }
+
+    [Fact]
     public void RetryDelayGenerator_ReturnsNull_EnsureDefaultRetry()
     {
         var delays = new List<TimeSpan>();
@@ -559,6 +685,20 @@ public class RetryResilienceStrategyTests
     private async ValueTask<int> ExecuteAndAdvance(ResiliencePipeline<object> sut)
     {
         var executing = sut.ExecuteAsync(_ => new ValueTask<int>(0)).AsTask();
+
+        while (!executing.IsCompleted)
+        {
+            _timeProvider.Advance(TimeSpan.FromMinutes(1));
+        }
+
+        return await executing;
+    }
+
+    private async ValueTask<int> ExecuteAndAdvanceWithRetryAttemptNumber(ResiliencePipeline<object> sut, int retryAttemptNumber)
+    {
+        var context = new ResilienceContext();
+        context.SetRetryAttemptNumber(retryAttemptNumber);
+        var executing = sut.ExecuteAsync(_ => new ValueTask<int>(0), context).AsTask();
 
         while (!executing.IsCompleted)
         {


### PR DESCRIPTION
Added `RetryResilienceContextExtensions` with methods for getting/setting the current retry attempt number.
Changed `RetryResilienceStrategy` to respect and update this property on the context.
Closes #3095
