### PR TITLE
feat(extensions): add EnableReloads overload accepting custom IOptionsMonitor

### DIFF
--- a/src/Polly.Extensions/.PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Polly.Extensions/.PublicAPI/PublicAPI.Unshipped.txt
@@ -1,3 +1,2 @@
 ﻿#nullable enable
-Polly.DependencyInjection.AddResiliencePipelineContext<TKey>.EnableReloads<TOptions>(Microsoft.Extensions.Options.IOptionsMonitor<TOptions>! monitor) -> void
-Polly.DependencyInjection.AddResiliencePipelineContext<TKey>.EnableReloads<TOptions>(Microsoft.Extensions.Options.IOptionsMonitor<TOptions>! monitor, string? name) -> void
+Polly.DependencyInjection.AddResiliencePipelineContext<TKey>.EnableReloadsWithMonitor<TOptions>(Microsoft.Extensions.Options.IOptionsMonitor<TOptions>! monitor, string? name = null) -> void

--- a/src/Polly.Extensions/.PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Polly.Extensions/.PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 ﻿#nullable enable
+Polly.DependencyInjection.AddResiliencePipelineContext<TKey>.EnableReloads<TOptions>(Microsoft.Extensions.Options.IOptionsMonitor<TOptions>! monitor, string? name = null) -> void

--- a/src/Polly.Extensions/.PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Polly.Extensions/.PublicAPI/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 ﻿#nullable enable
-Polly.DependencyInjection.AddResiliencePipelineContext<TKey>.EnableReloads<TOptions>(Microsoft.Extensions.Options.IOptionsMonitor<TOptions>! monitor, string? name = null) -> void
+Polly.DependencyInjection.AddResiliencePipelineContext<TKey>.EnableReloads<TOptions>(Microsoft.Extensions.Options.IOptionsMonitor<TOptions>! monitor) -> void
+Polly.DependencyInjection.AddResiliencePipelineContext<TKey>.EnableReloads<TOptions>(Microsoft.Extensions.Options.IOptionsMonitor<TOptions>! monitor, string? name) -> void

--- a/src/Polly.Extensions/DependencyInjection/AddResiliencePipelineContext.cs
+++ b/src/Polly.Extensions/DependencyInjection/AddResiliencePipelineContext.cs
@@ -2,6 +2,9 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Polly.Registry;
+using Polly.Utils;
+
+#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
 
 namespace Polly.DependencyInjection;
 
@@ -47,6 +50,27 @@ public sealed class AddResiliencePipelineContext<TKey>
     /// </remarks>
     public void EnableReloads<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions>(string? name = null)
         => RegistryContext.EnableReloads(ServiceProvider.GetRequiredService<IOptionsMonitor<TOptions>>(), name);
+
+    /// <summary>
+    /// Enables dynamic reloading of the resilience pipeline whenever the options produced by <paramref name="monitor"/> are changed.
+    /// </summary>
+    /// <typeparam name="TOptions">The options type to listen to.</typeparam>
+    /// <param name="monitor">The options monitor to listen to for changes.</param>
+    /// <param name="name">The named options, if any.</param>
+    /// <remarks>
+    /// Use this overload when the <see cref="IOptionsMonitor{TOptions}"/> instance is not registered in the
+    /// dependency injection container (for example, when wrapping a custom configuration source or feature flag system).
+    /// <para>
+    /// You can listen for changes from multiple options by calling this method with different <typeparamref name="TOptions"/> types.
+    /// </para>
+    /// </remarks>
+    public void EnableReloads<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions>(
+        IOptionsMonitor<TOptions> monitor,
+        string? name = null)
+    {
+        Guard.NotNull(monitor);
+        RegistryContext.EnableReloads(monitor, name);
+    }
 
     /// <summary>
     /// Gets the options identified by <paramref name="name"/>.

--- a/src/Polly.Extensions/DependencyInjection/AddResiliencePipelineContext.cs
+++ b/src/Polly.Extensions/DependencyInjection/AddResiliencePipelineContext.cs
@@ -4,8 +4,6 @@ using Microsoft.Extensions.Options;
 using Polly.Registry;
 using Polly.Utils;
 
-#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
-
 namespace Polly.DependencyInjection;
 
 /// <summary>
@@ -48,8 +46,26 @@ public sealed class AddResiliencePipelineContext<TKey>
     /// You can listen for changes from multiple options by calling this method with different <typeparamref name="TOptions"/> types.
     /// </para>
     /// </remarks>
+#pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
     public void EnableReloads<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions>(string? name = null)
         => RegistryContext.EnableReloads(ServiceProvider.GetRequiredService<IOptionsMonitor<TOptions>>(), name);
+#pragma warning restore RS0027
+
+    /// <summary>
+    /// Enables dynamic reloading of the resilience pipeline whenever the options produced by <paramref name="monitor"/> are changed.
+    /// </summary>
+    /// <typeparam name="TOptions">The options type to listen to.</typeparam>
+    /// <param name="monitor">The options monitor to listen to for changes.</param>
+    /// <remarks>
+    /// Use this overload when the <see cref="IOptionsMonitor{TOptions}"/> instance is not registered in the
+    /// dependency injection container (for example, when wrapping a custom configuration source or feature flag system).
+    /// <para>
+    /// You can listen for changes from multiple options by calling this method with different <typeparamref name="TOptions"/> types.
+    /// </para>
+    /// </remarks>
+    public void EnableReloads<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions>(
+        IOptionsMonitor<TOptions> monitor)
+        => EnableReloads(monitor, name: null);
 
     /// <summary>
     /// Enables dynamic reloading of the resilience pipeline whenever the options produced by <paramref name="monitor"/> are changed.
@@ -66,7 +82,7 @@ public sealed class AddResiliencePipelineContext<TKey>
     /// </remarks>
     public void EnableReloads<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions>(
         IOptionsMonitor<TOptions> monitor,
-        string? name = null)
+        string? name)
     {
         Guard.NotNull(monitor);
         RegistryContext.EnableReloads(monitor, name);

--- a/src/Polly.Extensions/DependencyInjection/AddResiliencePipelineContext.cs
+++ b/src/Polly.Extensions/DependencyInjection/AddResiliencePipelineContext.cs
@@ -47,7 +47,7 @@ public sealed class AddResiliencePipelineContext<TKey>
     /// </para>
     /// </remarks>
     public void EnableReloads<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions>(string? name = null)
-        => RegistryContext.EnableReloads(ServiceProvider.GetRequiredService<IOptionsMonitor<TOptions>>(), name);
+        => EnableReloadsWithMonitor(ServiceProvider.GetRequiredService<IOptionsMonitor<TOptions>>(), name);
 
     /// <summary>
     /// Enables dynamic reloading of the resilience pipeline whenever the options produced by <paramref name="monitor"/> are changed.

--- a/src/Polly.Extensions/DependencyInjection/AddResiliencePipelineContext.cs
+++ b/src/Polly.Extensions/DependencyInjection/AddResiliencePipelineContext.cs
@@ -46,26 +46,8 @@ public sealed class AddResiliencePipelineContext<TKey>
     /// You can listen for changes from multiple options by calling this method with different <typeparamref name="TOptions"/> types.
     /// </para>
     /// </remarks>
-#pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
     public void EnableReloads<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions>(string? name = null)
         => RegistryContext.EnableReloads(ServiceProvider.GetRequiredService<IOptionsMonitor<TOptions>>(), name);
-#pragma warning restore RS0027
-
-    /// <summary>
-    /// Enables dynamic reloading of the resilience pipeline whenever the options produced by <paramref name="monitor"/> are changed.
-    /// </summary>
-    /// <typeparam name="TOptions">The options type to listen to.</typeparam>
-    /// <param name="monitor">The options monitor to listen to for changes.</param>
-    /// <remarks>
-    /// Use this overload when the <see cref="IOptionsMonitor{TOptions}"/> instance is not registered in the
-    /// dependency injection container (for example, when wrapping a custom configuration source or feature flag system).
-    /// <para>
-    /// You can listen for changes from multiple options by calling this method with different <typeparamref name="TOptions"/> types.
-    /// </para>
-    /// </remarks>
-    public void EnableReloads<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions>(
-        IOptionsMonitor<TOptions> monitor)
-        => EnableReloads(monitor, name: null);
 
     /// <summary>
     /// Enables dynamic reloading of the resilience pipeline whenever the options produced by <paramref name="monitor"/> are changed.
@@ -74,15 +56,15 @@ public sealed class AddResiliencePipelineContext<TKey>
     /// <param name="monitor">The options monitor to listen to for changes.</param>
     /// <param name="name">The named options, if any.</param>
     /// <remarks>
-    /// Use this overload when the <see cref="IOptionsMonitor{TOptions}"/> instance is not registered in the
+    /// Use this method when the <see cref="IOptionsMonitor{TOptions}"/> instance is not registered in the
     /// dependency injection container (for example, when wrapping a custom configuration source or feature flag system).
     /// <para>
     /// You can listen for changes from multiple options by calling this method with different <typeparamref name="TOptions"/> types.
     /// </para>
     /// </remarks>
-    public void EnableReloads<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions>(
+    public void EnableReloadsWithMonitor<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions>(
         IOptionsMonitor<TOptions> monitor,
-        string? name)
+        string? name = null)
     {
         Guard.NotNull(monitor);
         RegistryContext.EnableReloads(monitor, name);

--- a/test/Polly.Extensions.Tests/ReloadableResiliencePipelineTests.cs
+++ b/test/Polly.Extensions.Tests/ReloadableResiliencePipelineTests.cs
@@ -109,7 +109,7 @@ public class ReloadableResiliencePipelineTests
         var services = new ServiceCollection();
         services.AddResiliencePipeline("my-pipeline", (builder, context) =>
         {
-            context.EnableReloads(monitor, name);
+            context.EnableReloadsWithMonitor(monitor, name);
 
             var options = monitor.Get(name);
             builder.AddStrategy(_ =>
@@ -148,7 +148,7 @@ public class ReloadableResiliencePipelineTests
         services.AddResiliencePipeline("my-pipeline", (_, context) =>
         {
             Assert.Throws<ArgumentNullException>("monitor",
-                () => context.EnableReloads((IOptionsMonitor<ReloadableStrategyOptions>)null!));
+                () => context.EnableReloadsWithMonitor((IOptionsMonitor<ReloadableStrategyOptions>)null!));
         });
 
         services.BuildServiceProvider()

--- a/test/Polly.Extensions.Tests/ReloadableResiliencePipelineTests.cs
+++ b/test/Polly.Extensions.Tests/ReloadableResiliencePipelineTests.cs
@@ -100,7 +100,7 @@ public class ReloadableResiliencePipelineTests
     [InlineData("custom-name")]
     [InlineData("")]
     [Theory]
-    public void EnableReloads_WithCustomMonitor_EnsureReloadable(string? name)
+    public void EnableReloadsWithMonitor_EnsureReloadable(string? name)
     {
         var resList = new List<IDisposable>();
         var monitor = new FakeOptionsMonitor<ReloadableStrategyOptions>(
@@ -142,7 +142,7 @@ public class ReloadableResiliencePipelineTests
     }
 
     [Fact]
-    public void EnableReloads_WithCustomMonitor_NullMonitor_Throws()
+    public void EnableReloadsWithMonitor_NullMonitor_Throws()
     {
         var services = new ServiceCollection();
         services.AddResiliencePipeline("my-pipeline", (_, context) =>

--- a/test/Polly.Extensions.Tests/ReloadableResiliencePipelineTests.cs
+++ b/test/Polly.Extensions.Tests/ReloadableResiliencePipelineTests.cs
@@ -138,15 +138,18 @@ public class ReloadableResiliencePipelineTests
         resList[1].Received(0).Dispose();
 
         serviceProvider.Dispose();
+        resList[0].Received(1).Dispose();
         resList[1].Received(1).Dispose();
     }
 
     [Fact]
     public void EnableReloadsWithMonitor_NullMonitor_Throws()
     {
+        var called = false;
         var services = new ServiceCollection();
         services.AddResiliencePipeline("my-pipeline", (_, context) =>
         {
+            called = true;
             Assert.Throws<ArgumentNullException>("monitor",
                 () => context.EnableReloadsWithMonitor((IOptionsMonitor<ReloadableStrategyOptions>)null!));
         });
@@ -154,6 +157,8 @@ public class ReloadableResiliencePipelineTests
         services.BuildServiceProvider()
             .GetRequiredService<ResiliencePipelineProvider<string>>()
             .GetPipeline("my-pipeline");
+
+        called.ShouldBeTrue();
     }
 
     public class ReloadableStrategy(string tag, IDisposable disposableResource) : ResilienceStrategy, IDisposable

--- a/test/Polly.Extensions.Tests/ReloadableResiliencePipelineTests.cs
+++ b/test/Polly.Extensions.Tests/ReloadableResiliencePipelineTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using Polly.Registry;
 using Polly.Telemetry;
@@ -95,6 +96,66 @@ public class ReloadableResiliencePipelineTests
         }
     }
 
+    [InlineData(null)]
+    [InlineData("custom-name")]
+    [InlineData("")]
+    [Theory]
+    public void EnableReloads_WithCustomMonitor_EnsureReloadable(string? name)
+    {
+        var resList = new List<IDisposable>();
+        var monitor = new FakeOptionsMonitor<ReloadableStrategyOptions>(
+            new ReloadableStrategyOptions { Tag = "initial-tag", OptionsName = name });
+
+        var services = new ServiceCollection();
+        services.AddResiliencePipeline("my-pipeline", (builder, context) =>
+        {
+            context.EnableReloads(monitor, name);
+
+            var options = monitor.Get(name);
+            builder.AddStrategy(_ =>
+            {
+                var res = Substitute.For<IDisposable>();
+                resList.Add(res);
+                return new ReloadableStrategy(options.Tag, res);
+            },
+            options);
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var pipeline = serviceProvider.GetRequiredService<ResiliencePipelineProvider<string>>().GetPipeline("my-pipeline");
+        var ctx = ResilienceContextPool.Shared.Get(TestCancellation.Token);
+
+        pipeline.Execute(_ => "dummy", ctx);
+        ctx.Properties.GetValue(TagKey, string.Empty).ShouldBe("initial-tag");
+
+        monitor.TriggerChange(new ReloadableStrategyOptions { Tag = "reloaded-tag", OptionsName = name }, name ?? string.Empty);
+
+        pipeline.Execute(_ => "dummy", ctx);
+        ctx.Properties.GetValue(TagKey, string.Empty).ShouldBe("reloaded-tag");
+
+        resList.Count.ShouldBe(2);
+        resList[0].Received(1).Dispose();
+        resList[1].Received(0).Dispose();
+
+        serviceProvider.Dispose();
+        resList[1].Received(1).Dispose();
+    }
+
+    [Fact]
+    public void EnableReloads_WithCustomMonitor_NullMonitor_Throws()
+    {
+        var services = new ServiceCollection();
+        services.AddResiliencePipeline("my-pipeline", (_, context) =>
+        {
+            Assert.Throws<ArgumentNullException>("monitor",
+                () => context.EnableReloads((IOptionsMonitor<ReloadableStrategyOptions>)null!));
+        });
+
+        services.BuildServiceProvider()
+            .GetRequiredService<ResiliencePipelineProvider<string>>()
+            .GetPipeline("my-pipeline");
+    }
+
     public class ReloadableStrategy(string tag, IDisposable disposableResource) : ResilienceStrategy, IDisposable
     {
         public string Tag { get; } = tag;
@@ -128,6 +189,37 @@ public class ReloadableResiliencePipelineTests
         {
             Data = new Dictionary<string, string?>(data, StringComparer.OrdinalIgnoreCase);
             OnReload();
+        }
+    }
+
+    private sealed class FakeOptionsMonitor<TOptions> : IOptionsMonitor<TOptions>
+    {
+        private readonly List<Action<TOptions, string?>> _listeners = [];
+
+        public FakeOptionsMonitor(TOptions initialValue) => CurrentValue = initialValue;
+
+        public TOptions CurrentValue { get; private set; }
+
+        public TOptions Get(string? name) => CurrentValue;
+
+        public IDisposable? OnChange(Action<TOptions, string?> listener)
+        {
+            _listeners.Add(listener);
+            return new CallbackDisposable(() => _listeners.Remove(listener));
+        }
+
+        public void TriggerChange(TOptions newValue, string? name = null)
+        {
+            CurrentValue = newValue;
+            foreach (var listener in _listeners.ToList())
+            {
+                listener(newValue, name);
+            }
+        }
+
+        private sealed class CallbackDisposable(Action callback) : IDisposable
+        {
+            public void Dispose() => callback();
         }
     }
 }

--- a/test/Polly.Extensions.Tests/ReloadableResiliencePipelineTests.cs
+++ b/test/Polly.Extensions.Tests/ReloadableResiliencePipelineTests.cs
@@ -96,10 +96,10 @@ public class ReloadableResiliencePipelineTests
         }
     }
 
-    [InlineData(null)]
-    [InlineData("custom-name")]
-    [InlineData("")]
     [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("custom-name")]
     public void EnableReloadsWithMonitor_EnsureReloadable(string? name)
     {
         var resList = new List<IDisposable>();


### PR DESCRIPTION
closes #3050 

Adds a new public overload of AddResiliencePipelineContext<TKey>.EnableReloads<TOptions> that accepts a caller-supplied IOptionsMonitor<TOptions> directly, instead of resolving it from the DI container.

The underlying ConfigureBuilderContextExtensions.EnableReloads already accepts the monitor directly - this change surfaces that path through the public API.

Use cases enabled:
- Custom options systems outside Microsoft.Extensions.Options
- Wrapping alternative configuration sources (feature flags, remote configs)
- Sharing monitor instances across pipelines without DI registration

<!-- Thank you for contributing to Polly!  Open source is only as strong as its contributors. -->

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
