### PR TITLE
Fix XML doc comment on PipelineExecutedArguments

### DIFF
--- a/src/Polly.Core/Telemetry/PipelineExecutedArguments.cs
+++ b/src/Polly.Core/Telemetry/PipelineExecutedArguments.cs
@@ -3,7 +3,7 @@
 #pragma warning disable CA1815 // Override equals and operator equals on value types
 
 /// <summary>
-/// Arguments that indicate the pipeline execution started.
+/// Arguments that indicate the pipeline execution finished.
 /// </summary>
 /// <remarks>
 /// Always use the constructor when creating this struct, otherwise we do not guarantee binary compatibility.


### PR DESCRIPTION
## Problem

The XML doc comment on `Polly.Telemetry.PipelineExecutedArguments` says:

> Arguments that indicate the pipeline execution **started**.

However this struct is the payload of the `TelemetryUtil.PipelineExecuted` event, which is raised by `CompositeComponent` when the pipeline execution **completes**, and it carries the execution `Duration`:

```csharp
// src/Polly.Core/Utils/Pipeline/CompositeComponent.cs
resilienceContext ... new PipelineExecutedArguments(_timeProvider.GetElapsedTime(timeStamp))
```

Its sibling `PipelineExecutingArguments` (the actual "started" event payload) has the same summary text, so one of them is clearly a copy-paste mistake.

## Solution

One-word fix: `started` → `finished` in the summary of `PipelineExecutedArguments`.

## Verification

- `dotnet build src/Polly.Core/Polly.Core.csproj` — 0 warnings, 0 errors.

Co-authored-by: FirmamentalSpring <287222957+FirmaSpring@users.noreply.github.com>
