### PR TITLE
Return null from FaultGenerator when no fault is generated

### DIFF
--- a/src/Polly.Core/Simmy/Fault/FaultGenerator.cs
+++ b/src/Polly.Core/Simmy/Fault/FaultGenerator.cs
@@ -78,6 +78,6 @@ public sealed class FaultGenerator
 
         var generatorDelegate = generator._helper.CreateGenerator();
 
-        return args => new ValueTask<Exception?>(generatorDelegate(args.Context)!.Value.Exception);
+        return args => new ValueTask<Exception?>(generatorDelegate(args.Context)?.Exception);
     }
 }

--- a/test/Polly.Core.Tests/Simmy/Fault/FaultGeneratorTests.cs
+++ b/test/Polly.Core.Tests/Simmy/Fault/FaultGeneratorTests.cs
@@ -39,6 +39,24 @@ public class FaultGeneratorTests
         Generate(generator).ShouldBeOfType<InvalidOperationException>();
     }
 
+    [Fact]
+    public void NoExceptionRegistered_ShouldReturnNull()
+    {
+        var generator = new FaultGenerator();
+
+        Generate(generator).ShouldBeNull();
+    }
+
+    [Fact]
+    public void AllWeightsZero_ShouldReturnNull()
+    {
+        var generator = new FaultGenerator();
+
+        generator.AddException<InvalidOperationException>(weight: 0);
+
+        Generate(generator).ShouldBeNull();
+    }
+
     private static Exception? Generate(FaultGenerator generator)
     {
         Func<FaultGeneratorArguments, ValueTask<Exception?>> func = generator;


### PR DESCRIPTION

## The issue or feature being addressed

`FaultGenerator` throws `InvalidOperationException` ("Nullable object must have a
value.") instead of injecting no fault when its underlying generator yields no
outcome.

The implicit conversion operator on `FaultGenerator`
(`src/Polly.Core/Simmy/Fault/FaultGenerator.cs`) builds its delegate as:

```csharp
return args => new ValueTask<Exception?>(generatorDelegate(args.Context)!.Value.Exception);
```

`generatorDelegate` is a `Func<ResilienceContext, Outcome<VoidResult>?>` produced by
`GeneratorHelper<VoidResult>.CreateGenerator()`. It legitimately returns `null` when:

- no exception has been registered (an empty `FaultGenerator`), in which case
  `CreateGenerator()` returns `_ => null`; or
- the registered weights sum to zero (for example `AddException<T>(weight: 0)`), in
  which case the selection loop matches no factory and returns `null`.

Because `Outcome<TResult>` is a `readonly struct`, `Outcome<VoidResult>?` is a
`Nullable<Outcome<VoidResult>>`. The null-forgiving `!` operator has no runtime effect,
so the subsequent `.Value` dereferences an empty nullable and throws
`InvalidOperationException`.

`ChaosFaultStrategy.ExecuteCore` explicitly treats a `null` fault as "do not inject"
(`if (fault is not null)`), and its `try` block only catches
`OperationCanceledException`, so the exception escapes and fails the user's execution
that the strategy was meant to leave untouched.

The sibling `OutcomeGenerator<TResult>` handles the same situation correctly by
propagating the nullable value unchanged
(`src/Polly.Core/Simmy/Outcomes/OutcomeGenerator.cs`):

```csharp
return args => new ValueTask<Outcome<TResult>?>(generatorDelegate(args.Context));
```

## Details on the issue fix or feature implementation

Propagate `null` from the generator instead of dereferencing it, mirroring
`OutcomeGenerator<TResult>`:

```csharp
return args => new ValueTask<Exception?>(generatorDelegate(args.Context)?.Exception);
```

When a fault is produced, `Outcome<VoidResult>.Exception` returns the same exception as
before; when the generator yields no outcome, the delegate now returns `null` and
`ChaosFaultStrategy` proceeds without injecting a fault.

Added two unit tests to `test/Polly.Core.Tests/Simmy/Fault/FaultGeneratorTests.cs`:

- `NoExceptionRegistered_ShouldReturnNull` - an empty `FaultGenerator` returns `null`.
- `AllWeightsZero_ShouldReturnNull` - a generator whose weights sum to zero returns `null`.

Both tests fail on the unmodified code with
`System.InvalidOperationException : Nullable object must have a value.` at
`FaultGenerator.cs:81`, and pass after the fix.

## Confirm the following

- [x] I started this PR by branching from the head of the default branch
- [x] I have targeted the PR to merge into the default branch
- [x] I have included unit tests for the issue/feature
- [x] I have successfully run a local build
