### PR TITLE
Fix flaky test

### DIFF
--- a/src/Polly.Core/Utils/CancellationTokenSourcePool.Pooled.cs
+++ b/src/Polly.Core/Utils/CancellationTokenSourcePool.Pooled.cs
@@ -3,7 +3,7 @@ namespace Polly.Utils;
 internal abstract partial class CancellationTokenSourcePool
 {
 #if NET6_0_OR_GREATER
-    private sealed class PooledCancellationTokenSourcePool : CancellationTokenSourcePool
+    internal sealed class PooledCancellationTokenSourcePool : CancellationTokenSourcePool
     {
         public static readonly PooledCancellationTokenSourcePool SystemInstance = new(TimeProvider.System);
 

--- a/test/Polly.Core.Tests/Utils/CancellationTokenSourcePoolTests.cs
+++ b/test/Polly.Core.Tests/Utils/CancellationTokenSourcePoolTests.cs
@@ -30,7 +30,15 @@ public class CancellationTokenSourcePoolTests
     [Theory]
     public void RentReturn_Reusable_EnsureProperBehavior(object timeProvider)
     {
+        // Use a dedicated pool instance instead of CancellationTokenSourcePool.Create(...), which
+        // returns a process-wide shared singleton for TimeProvider.System. Using the shared singleton
+        // makes this test flaky, as other tests running in parallel can rent/return CancellationTokenSource
+        // instances from the same pool concurrently, changing which instance is returned by Get().
+#if NET6_0_OR_GREATER
+        var pool = new CancellationTokenSourcePool.PooledCancellationTokenSourcePool(GetTimeProvider(timeProvider));
+#else
         var pool = CancellationTokenSourcePool.Create(GetTimeProvider(timeProvider));
+#endif
         var cts = pool.Get(System.Threading.Timeout.InfiniteTimeSpan);
         pool.Return(cts);
 


### PR DESCRIPTION
Fix [flaky test](https://github.com/App-vNext/Polly/actions/runs/34688183530/job/103538756598#step:7:489) if there's a race in the shared pool between parallel test executions.
